### PR TITLE
chore: add env template and ci pipeline

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+# API settings
+DATABASE_URL=postgresql://reframe:reframe@localhost:5432/reframe
+MEDIA_ROOT=./media
+BROKER_URL=redis://localhost:6379/0
+RESULT_BACKEND=${BROKER_URL}
+OPENAI_API_KEY=your-openai-key
+GROQ_API_KEY=your-groq-key
+TRANSLATOR_PROVIDER=
+TRANSLATOR_API_KEY=
+
+# Web app settings
+VITE_API_BASE_URL=http://localhost:8000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  python:
+    name: Python API & worker checks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: pip
+      - name: Install dependencies
+        if: hashFiles('apps/api/requirements.txt', 'services/worker/requirements.txt') != ''
+        run: |
+          pip install --upgrade pip
+          pip install -r apps/api/requirements.txt -r services/worker/requirements.txt
+      - name: Syntax check
+        if: hashFiles('apps/api/requirements.txt', 'services/worker/requirements.txt') != ''
+        run: |
+          python -m compileall apps/api services/worker packages/media-core
+      - name: Skip notice
+        if: hashFiles('apps/api/requirements.txt', 'services/worker/requirements.txt') == ''
+        run: echo "API/worker sources not present; skipping Python job."
+
+  web:
+    name: Web build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: apps/web/package-lock.json
+      - name: Install dependencies
+        if: hashFiles('apps/web/package-lock.json') != ''
+        working-directory: apps/web
+        run: npm ci
+      - name: Build
+        if: hashFiles('apps/web/package-lock.json') != ''
+        working-directory: apps/web
+        run: npm run build
+      - name: Skip notice
+        if: hashFiles('apps/web/package-lock.json') == ''
+        run: echo "Web app not present; skipping web build."

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+.PHONY: help api-install worker-install web-install api-dev worker-dev web-dev web-build compose-up compose-down
+
+help:
+	@echo "Targets: api-install, worker-install, web-install, api-dev, worker-dev, web-dev, web-build, compose-up, compose-down"
+
+api-install:
+	pip install -r apps/api/requirements.txt
+
+worker-install:
+	pip install -r services/worker/requirements.txt
+
+web-install:
+	cd apps/web && npm install
+
+api-dev:
+	uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload --app-dir apps/api
+
+worker-dev:
+	cd services/worker && celery -A worker.celery_app worker --loglevel=info
+
+web-dev:
+	cd apps/web && npm run dev -- --host 0.0.0.0 --port 5173
+
+web-build:
+	cd apps/web && npm run build
+
+compose-up:
+	cd infra && docker compose up --build
+
+compose-down:
+	cd infra && docker compose down

--- a/TODO.md
+++ b/TODO.md
@@ -12,12 +12,12 @@
 - [x] Add `infra/docker-compose.yml` for API, worker, Redis, web.
 - [x] Add Dockerfiles: `Dockerfile.api`, `Dockerfile.worker`, `Dockerfile.web`.
 - [x] Add root `.gitignore` for Python, Node, env, media, build artifacts.
-- [ ] Add `.env.example`:
-  - [ ] API: `DATABASE_URL`, `MEDIA_ROOT`, `BROKER_URL`, `RESULT_BACKEND`, `OPENAI_API_KEY`, `GROQ_API_KEY`, `TRANSLATOR_*`.
-  - [ ] Web: `VITE_API_BASE_URL`.
-- [ ] Add basic `Makefile` or task runner (`justfile`) for common commands.
+- [x] Add `.env.example`:
+  - [x] API: `DATABASE_URL`, `MEDIA_ROOT`, `BROKER_URL`, `RESULT_BACKEND`, `OPENAI_API_KEY`, `GROQ_API_KEY`, `TRANSLATOR_*`.
+  - [x] Web: `VITE_API_BASE_URL`.
+- [x] Add basic `Makefile` or task runner (`justfile`) for common commands.
 - [ ] Add pre‑commit config (ruff/black/isort, eslint/prettier).
-- [ ] Add GitHub Actions CI for API/worker checks and web build.
+- [x] Add GitHub Actions CI for API/worker checks and web build.
 
 ---
 


### PR DESCRIPTION
**Summary**
- Add a shared .env.example covering API and web placeholders.
- Introduce GitHub Actions CI for Python (api/worker) and Node (web) with caching and skip guards.
- Provide a root Makefile for common install/dev/build/compose commands.

**Changes**
- Added .env.example with API and web config placeholders.
- Added .github/workflows/ci.yml with Python compile check and web build jobs.
- Added Makefile targets for api/worker/web dev/build and docker compose.
- Updated TODO.md to mark the new infra tasks as complete.

**Testing**
- Not run (no runtime code on default branch; workflow is new).

**Risk & Impact**
- Low; workflow steps skip when target paths aren’t present until scaffolding lands.

**Related TODO items**
- [x] Add `.env.example`: `DATABASE_URL`, `MEDIA_ROOT`, `BROKER_URL`, `RESULT_BACKEND`, `OPENAI_API_KEY`, `GROQ_API_KEY`, `TRANSLATOR_*`.
- [x] Add `.env.example`: `VITE_API_BASE_URL`.
- [x] Add basic `Makefile` or task runner (`justfile`) for common commands.
- [x] Add GitHub Actions CI for API/worker checks and web build.