### PR TITLE
chore: add pre-commit tooling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,54 @@
+minimum_pre_commit_version: '3.0.0'
+
+default_language_version:
+  python: python3
+
+exclude: |-
+  (^Inspirations & Former Attempts/|
+   ^node_modules/|
+   ^apps/web/node_modules/)
+
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.4
+    hooks:
+      - id: ruff
+        name: ruff (lint)
+        args: ["--fix"]
+        files: "^(apps|services|packages)/.*\\.py$"
+      - id: ruff-format
+        name: ruff (format)
+        files: "^(apps|services|packages)/.*\\.py$"
+
+  - repo: https://github.com/psf/black
+    rev: 24.8.0
+    hooks:
+      - id: black
+        files: "^(apps|services|packages)/.*\\.py$"
+
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        files: "^(apps|services|packages)/.*\\.py$"
+
+  - repo: https://github.com/pre-commit/mirrors-eslint
+    rev: v9.12.0
+    hooks:
+      - id: eslint
+        name: eslint (web)
+        files: "^apps/web/src/.*\\.(ts|tsx|js|jsx)$"
+        args: ["--config", "apps/web/.eslintrc.cjs"]
+        additional_dependencies:
+          - eslint@9.12.0
+          - "@typescript-eslint/parser@7.18.0"
+          - "@typescript-eslint/eslint-plugin@7.18.0"
+          - eslint-plugin-react@7.34.3
+          - eslint-plugin-react-hooks@4.6.2
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v3.3.3
+    hooks:
+      - id: prettier
+        name: prettier (web)
+        files: "^apps/web/.*\\.(ts|tsx|js|jsx|css|json|md)$"

--- a/TODO.md
+++ b/TODO.md
@@ -16,7 +16,7 @@
   - [x] API: `DATABASE_URL`, `MEDIA_ROOT`, `BROKER_URL`, `RESULT_BACKEND`, `OPENAI_API_KEY`, `GROQ_API_KEY`, `TRANSLATOR_*`.
   - [x] Web: `VITE_API_BASE_URL`.
 - [x] Add basic `Makefile` or task runner (`justfile`) for common commands.
-- [ ] Add pre‑commit config (ruff/black/isort, eslint/prettier).
+- [x] Add pre‑commit config (ruff/black/isort, eslint/prettier).
 - [x] Add GitHub Actions CI for API/worker checks and web build.
 
 ---

--- a/apps/web/.eslintrc.cjs
+++ b/apps/web/.eslintrc.cjs
@@ -1,0 +1,27 @@
+module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    ecmaVersion: "latest",
+    sourceType: "module",
+  },
+  settings: {
+    react: {
+      version: "detect",
+    },
+  },
+  plugins: ["react", "react-hooks", "@typescript-eslint"],
+  extends: [
+    "eslint:recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
+    "plugin:@typescript-eslint/recommended",
+  ],
+  rules: {
+    "react/react-in-jsx-scope": "off",
+  },
+};


### PR DESCRIPTION
**Summary**
- Add pre-commit configuration with Python lint/format (ruff, black, isort) and web lint/format (eslint, prettier).
- Introduce a scoped ESLint config for the Vite React TypeScript app.
- Update TODO backlog to mark the pre-commit task complete.

**Changes**
- Added `.pre-commit-config.yaml` excluding legacy assets and targeting project Python and web sources.
- Added `apps/web/.eslintrc.cjs` with TS/React recommended rules and React JSX scope override.
- Updated `TODO.md` to reflect pre-commit completion.

**Testing**
- Not run (config-only change; hooks not executed here).

**Risk & Impact**
- Low; hooks are scoped to new app/service/package paths and exclude legacy inspirations.

**Related TODO items**
- [x] Add pre-commit config (ruff/black/isort, eslint/prettier).
