### PR TITLE
feat: add transcription models skeleton

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,16 +23,17 @@
 
 ## 2. Media Core – Transcription
 
-- [ ] Create `packages/media-core/transcribe/__init__.py`.
-- [ ] Implement `TranscriptionConfig` (model, language, device, backend).
-- [ ] Implement `Word` and `TranscriptionResult` models.
+- [x] Create `packages/media-core/transcribe/__init__.py`.
+- [x] Implement `TranscriptionConfig` (model, language, device, backend).
+- [x] Implement `Word` and `TranscriptionResult` models.
 - [ ] Backend: `openai_whisper` (simple baseline).
 - [ ] Backend: `faster_whisper` (GPU‑friendly).
 - [ ] Backend: `whisper_cpp` integration (via `pywhispercpp` or subprocess).
 - [ ] Optional: support `whisper-timestamped` or `whisperX` for more accurate word timings.
 - [ ] Normalize outputs to `List[Word]` regardless of backend.
 - [ ] Add CLI entrypoint (`python -m media_core.transcribe`) for quick testing.
-- [ ] Unit tests: transcription result normalization (words sorted, no overlaps, correct lengths).
+- [x] Add CLI entrypoint (`python -m media_core.transcribe`) for quick testing.
+- [x] Unit tests: transcription result normalization (words sorted, no overlaps, correct lengths).
 
 ---
 

--- a/packages/media-core/src/media_core/transcribe/__init__.py
+++ b/packages/media-core/src/media_core/transcribe/__init__.py
@@ -1,0 +1,11 @@
+"""Transcription utilities and models for Reframe."""
+
+from .config import TranscriptionBackend, TranscriptionConfig
+from .models import TranscriptionResult, Word
+
+__all__ = [
+    "TranscriptionBackend",
+    "TranscriptionConfig",
+    "TranscriptionResult",
+    "Word",
+]

--- a/packages/media-core/src/media_core/transcribe/__main__.py
+++ b/packages/media-core/src/media_core/transcribe/__main__.py
@@ -1,0 +1,42 @@
+"""CLI entrypoint for quick transcription checks.
+
+Note: Backend execution is not yet wired. This serves as a placeholder to show
+the expected interface and to verify that the package imports cleanly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from .config import TranscriptionConfig
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Transcribe an audio/video file.")
+    parser.add_argument("input", help="Path to the media file.")
+    parser.add_argument("--language", help="ISO language code (optional).")
+    parser.add_argument("--backend", default="openai_whisper", help="Backend name.")
+    parser.add_argument("--model", default="whisper-1", help="Model name.")
+    parser.add_argument("--device", help="Device hint (e.g., cpu, cuda).")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    config = TranscriptionConfig(
+        backend=args.backend,
+        model=args.model,
+        language=args.language,
+        device=args.device,
+    )
+    print(
+        "Transcription CLI placeholder. No backend wired yet.\n"
+        f"Input: {args.input}\n"
+        f"Config: {config.model_dump_json(indent=2)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/media-core/src/media_core/transcribe/config.py
+++ b/packages/media-core/src/media_core/transcribe/config.py
@@ -1,0 +1,41 @@
+from enum import Enum
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TranscriptionBackend(str, Enum):
+    OPENAI_WHISPER = "openai_whisper"
+    FASTER_WHISPER = "faster_whisper"
+    WHISPER_CPP = "whisper_cpp"
+
+
+class TranscriptionConfig(BaseModel):
+    """Config describing how audio should be transcribed."""
+
+    backend: TranscriptionBackend = Field(
+        default=TranscriptionBackend.OPENAI_WHISPER,
+        description="Which backend to use for transcription.",
+    )
+    model: str = Field(
+        default="whisper-1",
+        description="Model name used by the selected backend.",
+    )
+    language: Optional[str] = Field(
+        default=None,
+        description="Optional ISO language code. None means auto-detect.",
+    )
+    device: Optional[str] = Field(
+        default=None,
+        description="Device hint for local backends (e.g., 'cpu', 'cuda').",
+    )
+    temperature: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=1.0,
+        description="Sampling temperature for stochastic backends that support it.",
+    )
+
+    class Config:
+        validate_assignment = True
+        extra = "forbid"

--- a/packages/media-core/src/media_core/transcribe/models.py
+++ b/packages/media-core/src/media_core/transcribe/models.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import Iterable, List, Optional
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class Word(BaseModel):
+    text: str = Field(..., description="The transcribed word text.")
+    start: float = Field(..., ge=0.0, description="Start time in seconds.")
+    end: float = Field(..., gt=0.0, description="End time in seconds.")
+    probability: Optional[float] = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="Optional confidence score.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_order(self) -> "Word":
+        if self.end <= self.start:
+            msg = f"Word '{self.text}' has non-positive duration: start={self.start}, end={self.end}"
+            raise ValueError(msg)
+        return self
+
+    @property
+    def duration(self) -> float:
+        return self.end - self.start
+
+
+class TranscriptionResult(BaseModel):
+    words: List[Word] = Field(default_factory=list, description="Ordered list of words.")
+    text: Optional[str] = Field(default=None, description="Full transcript if provided.")
+    model: Optional[str] = Field(default=None, description="Model identifier.")
+    language: Optional[str] = Field(default=None, description="Detected or provided language code.")
+
+    @model_validator(mode="after")
+    def _validate_monotonic(self) -> "TranscriptionResult":
+        if not self.words:
+            return self
+        sorted_words = sorted(self.words, key=lambda w: w.start)
+        for prev, curr in zip(sorted_words, sorted_words[1:]):
+            if curr.start < prev.end:
+                msg = (
+                    f"Words overlap: '{prev.text}' [{prev.start}, {prev.end}) "
+                    f"and '{curr.text}' [{curr.start}, {curr.end})"
+                )
+                raise ValueError(msg)
+        # maintain sorted order
+        self.words = sorted_words
+        return self
+
+    @property
+    def duration(self) -> float:
+        if not self.words:
+            return 0.0
+        return self.words[-1].end - self.words[0].start
+
+    @classmethod
+    def from_iterable(cls, words: Iterable[Word], **metadata: object) -> "TranscriptionResult":
+        """Build a result from an iterable of words, sorting and validating."""
+        return cls(words=list(words), **metadata)

--- a/packages/media-core/tests/test_transcribe_models.py
+++ b/packages/media-core/tests/test_transcribe_models.py
@@ -1,0 +1,21 @@
+from media_core.transcribe import TranscriptionResult, Word
+from pydantic import ValidationError
+
+
+def test_words_are_sorted_and_non_overlapping():
+    w1 = Word(text="hello", start=0.0, end=0.5)
+    w2 = Word(text="world", start=0.6, end=1.0)
+    result = TranscriptionResult.from_iterable([w2, w1])
+    assert [w.text for w in result.words] == ["hello", "world"]
+    assert result.duration == 1.0
+
+
+def test_overlapping_words_raise():
+    w1 = Word(text="first", start=0.0, end=1.0)
+    w2 = Word(text="second", start=0.5, end=1.5)
+    try:
+        TranscriptionResult(words=[w1, w2])
+    except ValidationError as exc:
+        assert "overlap" in str(exc).lower()
+    else:
+        raise AssertionError("Expected ValidationError for overlapping words")


### PR DESCRIPTION
**Summary**
- Introduce transcription config/models scaffolding for media-core.
- Add a CLI entrypoint placeholder for `python -m media_core.transcribe`.
- Add unit tests to ensure word ordering and overlap validation.

**Changes**
- Added `media_core.transcribe` package (__init__, config, models, __main__).
- Implemented `TranscriptionConfig`, `Word`, and `TranscriptionResult` with validation and duration helpers.
- Added tests under `packages/media-core/tests` for sorting and overlap detection.

**Testing**
- `python3 -m compileall packages/media-core/src/media_core/transcribe packages/media-core/tests`

**Risk & Impact**
- Low; no runtime backend integration yet (CLI is placeholder-only).

**Related TODO items**
- [x] Create `packages/media-core/transcribe/__init__.py`.
- [x] Implement `TranscriptionConfig` (model, language, device, backend).
- [x] Implement `Word` and `TranscriptionResult` models.
- [x] Add CLI entrypoint (`python -m media_core.transcribe`) for quick testing.
- [x] Unit tests: transcription result normalization (words sorted, no overlaps, correct lengths).
