### PR TITLE
feat: add subtitle builder and srt/vtt exporters

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -38,15 +38,15 @@
 
 ## 3. Media Core – Subtitle Building
 
-- [ ] Create `packages/media-core/subtitles/builder.py`.
-- [ ] Implement `SubtitleLine` model (with `words: list[Word]`).
-- [ ] Implement grouping logic:
-  - [ ] `max_chars_per_line`,
-  - [ ] `max_words_per_line`,
-  - [ ] `max_duration`,
-  - [ ] `max_gap`.
-- [ ] Export to SRT writer.
-- [ ] Export to VTT writer.
+- [x] Create `packages/media-core/subtitles/builder.py`.
+- [x] Implement `SubtitleLine` model (with `words: list[Word]`).
+- [x] Implement grouping logic:
+  - [x] `max_chars_per_line`,
+  - [x] `max_words_per_line`,
+  - [x] `max_duration`,
+  - [x] `max_gap`.
+- [x] Export to SRT writer.
+- [x] Export to VTT writer.
 - [ ] Export to ASS writer (basic).
 - [ ] Use `pysubs2` for ASS styling where helpful.
 - [ ] Unit tests: grouping for different languages & fast/slow speech.

--- a/packages/media-core/src/media_core/subtitles/builder.py
+++ b/packages/media-core/src/media_core/subtitles/builder.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterable, List, Sequence
+
+from media_core.transcribe.models import Word
+
+
+@dataclass
+class SubtitleLine:
+    start: float
+    end: float
+    words: List[Word] = field(default_factory=list)
+
+    def text(self) -> str:
+        return " ".join(w.text for w in self.words).strip()
+
+    @property
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)
+
+
+@dataclass
+class GroupingConfig:
+    max_chars_per_line: int = 40
+    max_words_per_line: int = 12
+    max_duration: float = 6.0
+    max_gap: float = 0.6
+
+
+def group_words(words: Sequence[Word], config: GroupingConfig) -> List[SubtitleLine]:
+    lines: List[SubtitleLine] = []
+    if not words:
+        return lines
+
+    current_words: List[Word] = []
+    current_start = words[0].start
+    last_end = words[0].end
+
+    def flush():
+        nonlocal current_words, current_start, last_end
+        if current_words:
+            lines.append(SubtitleLine(start=current_start, end=last_end, words=current_words.copy()))
+        current_words = []
+
+    for w in words:
+        if not current_words:
+            current_start = w.start
+            last_end = w.end
+            current_words.append(w)
+            continue
+
+        candidate_text = " ".join([*(cw.text for cw in current_words), w.text])
+        too_many_chars = len(candidate_text) > config.max_chars_per_line
+        too_many_words = len(current_words) + 1 > config.max_words_per_line
+        too_long = (w.end - current_start) > config.max_duration
+        too_far = (w.start - last_end) > config.max_gap
+
+        if too_many_chars or too_many_words or too_long or too_far:
+            flush()
+            current_start = w.start
+            last_end = w.end
+            current_words.append(w)
+            continue
+
+        current_words.append(w)
+        last_end = w.end
+
+    flush()
+    return lines
+
+
+def _format_timestamp(seconds: float) -> str:
+    millis = int(round(seconds * 1000))
+    hours, rem = divmod(millis, 3_600_000)
+    minutes, rem = divmod(rem, 60_000)
+    secs, ms = divmod(rem, 1_000)
+    return f"{hours:02d}:{minutes:02d}:{secs:02d},{ms:03d}"
+
+
+def to_srt(lines: Iterable[SubtitleLine]) -> str:
+    output = []
+    for idx, line in enumerate(lines, start=1):
+        output.append(str(idx))
+        output.append(f"{_format_timestamp(line.start)} --> {_format_timestamp(line.end)}")
+        output.append(line.text())
+        output.append("")  # blank line separator
+    return "\n".join(output)
+
+
+def to_vtt(lines: Iterable[SubtitleLine]) -> str:
+    output = ["WEBVTT", ""]
+    for line in lines:
+        output.append(f"{_format_timestamp(line.start).replace(',', '.')} --> {_format_timestamp(line.end).replace(',', '.')}")
+        output.append(line.text())
+        output.append("")
+    return "\n".join(output)

--- a/packages/media-core/tests/test_subtitle_builder.py
+++ b/packages/media-core/tests/test_subtitle_builder.py
@@ -1,0 +1,37 @@
+from media_core.subtitles.builder import (
+    GroupingConfig,
+    SubtitleLine,
+    group_words,
+    to_srt,
+    to_vtt,
+)
+from media_core.transcribe.models import Word
+
+
+def test_group_words_respects_limits_and_sorting():
+    words = [
+        Word(text="hello", start=0.0, end=0.5),
+        Word(text="world", start=0.6, end=1.1),
+        Word(text="this", start=3.0, end=3.4),
+        Word(text="is", start=3.5, end=3.7),
+        Word(text="long", start=3.8, end=4.5),
+    ]
+    cfg = GroupingConfig(max_chars_per_line=11, max_words_per_line=2, max_gap=0.7, max_duration=3.0)
+    lines = group_words(words, cfg)
+    assert len(lines) == 3
+    assert [line.text() for line in lines] == ["hello world", "this is", "long"]
+    assert lines[0].start == 0.0 and lines[0].end == 1.1
+    assert lines[1].start == 3.0 and lines[1].end == 3.7
+
+
+def test_to_srt_and_vtt_render_simple_lines():
+    line = SubtitleLine(
+        start=1.0,
+        end=2.5,
+        words=[Word(text="sample", start=1.0, end=1.5), Word(text="text", start=1.6, end=2.0)],
+    )
+    srt = to_srt([line])
+    vtt = to_vtt([line])
+    assert "00:00:01,000 --> 00:00:02,500" in srt
+    assert "00:00:01.000 --> 00:00:02.500" in vtt
+    assert "sample text" in srt and "sample text" in vtt


### PR DESCRIPTION
**Summary**
- Add subtitle builder with grouping logic and simple SRT/VTT exporters.
- Provide tests for grouping constraints and basic subtitle rendering.
- Update TODO to mark subtitle builder tasks complete (except ASS/pysubs2).

**Changes**
- Added `media_core.subtitles.builder` with `SubtitleLine`, grouping config/logic, and SRT/VTT writers.
- Added unit tests for grouping behavior and SRT/VTT output formatting.
- Updated TODO entries for subtitle building milestones.

**Testing**
- `python3 -m compileall packages/media-core/src/media_core packages/media-core/tests`

**Risk & Impact**
- Low; pure-Python logic. No external IO or media processing.

**Related TODO items**
- [x] Create `packages/media-core/subtitles/builder.py`.
- [x] Implement `SubtitleLine` model (with `words: list[Word]`).
- [x] Implement grouping logic: `max_chars_per_line`, `max_words_per_line`, `max_duration`, `max_gap`.
- [x] Export to SRT writer.
- [x] Export to VTT writer.
- [ ] Export to ASS writer (basic).
- [ ] Use `pysubs2` for ASS styling where helpful.
- [ ] Unit tests: grouping for different languages & fast/slow speech.
