### PR TITLE
feat: add shorts segmentation scaffolding

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -101,16 +101,16 @@
 
 ## 7. Media Core – Shorts Segmentation
 
-- [ ] Create `packages/media-core/segment/shorts.py`.
-- [ ] Define `SegmentCandidate` model (start, end, score, reason, snippet).
-- [ ] Implement naive equal‑splits strategy (baseline, from `long_to_shorts_app`).
-- [ ] Implement sliding window candidate generator (configurable window size & stride).
+- [x] Create `packages/media-core/segment/shorts.py`.
+- [x] Define `SegmentCandidate` model (start, end, score, reason, snippet).
+- [x] Implement naive equal‑splits strategy (baseline, from `long_to_shorts_app`).
+- [x] Implement sliding window candidate generator (configurable window size & stride).
 - [ ] Implement scoring using simple heuristics (density of keywords, sentence boundaries).
 - [ ] Implement LLM scoring backend:
   - [ ] Interface: `score_segments(transcript, candidates, prompt, model)`.
   - [ ] Provider: Groq or OpenAI (whichever you prefer).
 - [ ] Implement selector: pick top N segments under min/max duration & non‑overlap rules.
-- [ ] Unit tests: segments non‑overlapping, durations within bounds.
+- [x] Unit tests: segments non‑overlapping, durations within bounds.
 
 ---
 

--- a/packages/media-core/src/media_core/segment/shorts.py
+++ b/packages/media-core/src/media_core/segment/shorts.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+
+@dataclass
+class SegmentCandidate:
+    start: float
+    end: float
+    score: float = 0.0
+    reason: Optional[str] = None
+    snippet: Optional[str] = None
+
+    @property
+    def duration(self) -> float:
+        return max(0.0, self.end - self.start)
+
+
+def equal_splits(duration: float, clip_length: float) -> List[SegmentCandidate]:
+    """Produce naive equal splits across the duration."""
+    if duration <= 0 or clip_length <= 0:
+        return []
+    segments: List[SegmentCandidate] = []
+    t = 0.0
+    while t < duration:
+        end = min(duration, t + clip_length)
+        segments.append(SegmentCandidate(start=t, end=end, score=0.0, reason="equal_split"))
+        t += clip_length
+    return segments
+
+
+def sliding_window(duration: float, window: float, stride: float) -> List[SegmentCandidate]:
+    if duration <= 0 or window <= 0 or stride <= 0:
+        return []
+    segments: List[SegmentCandidate] = []
+    t = 0.0
+    while t < duration:
+        end = min(duration, t + window)
+        segments.append(SegmentCandidate(start=t, end=end, score=0.0, reason="sliding_window"))
+        t += stride
+    return segments
+
+
+def select_top(
+    candidates: List[SegmentCandidate],
+    max_segments: int,
+    min_duration: float,
+    max_duration: float,
+) -> List[SegmentCandidate]:
+    """Select top non-overlapping segments by score within duration bounds."""
+    filtered = [
+        c
+        for c in candidates
+        if c.duration >= min_duration and c.duration <= max_duration and c.start < c.end
+    ]
+    filtered.sort(key=lambda c: c.score, reverse=True)
+    selected: List[SegmentCandidate] = []
+    for cand in filtered:
+        if len(selected) >= max_segments:
+            break
+        if any(not (cand.end <= s.start or cand.start >= s.end) for s in selected):
+            continue
+        selected.append(cand)
+    selected.sort(key=lambda c: c.start)
+    return selected

--- a/packages/media-core/tests/test_segment_shorts.py
+++ b/packages/media-core/tests/test_segment_shorts.py
@@ -1,0 +1,25 @@
+from media_core.segment.shorts import SegmentCandidate, equal_splits, select_top, sliding_window
+
+
+def test_equal_splits_produces_segments():
+    segs = equal_splits(duration=10.0, clip_length=4.0)
+    assert len(segs) == 3
+    assert segs[0].start == 0.0 and segs[1].start == 4.0
+    assert segs[-1].end == 10.0
+
+
+def test_sliding_window_stride():
+    segs = sliding_window(duration=5.0, window=2.0, stride=1.0)
+    assert len(segs) == 5
+    assert segs[0].start == 0.0 and segs[1].start == 1.0
+
+
+def test_select_top_filters_and_sorts():
+    cands = [
+        SegmentCandidate(start=0, end=2, score=0.5),
+        SegmentCandidate(start=2.1, end=4, score=0.8),
+        SegmentCandidate(start=1, end=3, score=0.9),  # overlaps
+    ]
+    selected = select_top(cands, max_segments=2, min_duration=1.0, max_duration=5.0)
+    assert len(selected) == 2
+    assert selected[0].start == 0 and selected[1].start == 2.1


### PR DESCRIPTION
**Summary**
- Add shorts segmentation scaffold with SegmentCandidate model and basic generators.
- Provide naive equal-split and sliding-window segmenters plus non-overlap selector.
- Add unit tests for splits, sliding window counts, and overlap-free selection; update TODO.

**Changes**
- Added `segment/shorts.py` with SegmentCandidate model, `equal_splits`, `sliding_window`, and `select_top` helpers.
- Added tests in `packages/media-core/tests/test_segment_shorts.py` covering splitting, windowing, and selection.
- Updated TODO to mark segmentation scaffolding tasks complete (heuristic/LLM scoring still open).

**Testing**
- `python3 -m compileall packages/media-core/src/media_core packages/media-core/tests`

**Risk & Impact**
- Low; pure-Python scaffolding, no external calls.

**Related TODO items**
- [x] Create `packages/media-core/segment/shorts.py`.
- [x] Define `SegmentCandidate` model (start, end, score, reason, snippet).
- [x] Implement naive equal-splits strategy (baseline, from `long_to_shorts_app`).
- [x] Implement sliding window candidate generator (configurable window size & stride).
- [x] Unit tests: segments non-overlapping, durations within bounds.
- [ ] Implement scoring using simple heuristics (density of keywords, sentence boundaries).
- [ ] Implement LLM scoring backend.
- [ ] Implement selector: pick top N segments under min/max duration & non-overlap rules (advanced scoring).
