### PR TITLE
feat: add worker progress reporting

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -132,7 +132,7 @@
 - [x] Task: `render_styled_subtitles(video_asset_id, subtitle_asset_id, style, options) -> video_asset_id`.
 - [x] Task: `generate_shorts(video_asset_id, options) -> list[clip_asset_id]`.
 - [x] Task: `merge_video_audio(video_asset_id, audio_asset_id, options) -> video_asset_id`.
-- [ ] Implement job status updates & progress reporting.
+- [x] Implement job status updates & progress reporting.
 
 ---
 

--- a/services/worker/test_worker_progress.py
+++ b/services/worker/test_worker_progress.py
@@ -1,0 +1,18 @@
+from services.worker.worker import _progress
+
+
+class DummyTask:
+    def __init__(self):
+        self.calls = []
+
+    def update_state(self, state, meta):
+        self.calls.append((state, meta))
+
+
+def test_progress_updates_state():
+    dummy = DummyTask()
+    meta = _progress(dummy, "running", 0.5, job_id="123")
+    assert dummy.calls[0][0] == "PROGRESS"
+    assert dummy.calls[0][1]["progress"] == 0.5
+    assert dummy.calls[0][1]["job_id"] == "123"
+    assert meta["status"] == "running"

--- a/services/worker/worker.py
+++ b/services/worker/worker.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from celery import Celery
 
@@ -7,56 +8,87 @@ RESULT_BACKEND = os.getenv("RESULT_BACKEND", BROKER_URL)
 celery_app = Celery("reframe_worker", broker=BROKER_URL, backend=RESULT_BACKEND)
 celery_app.conf.task_default_queue = "default"
 
+logger = logging.getLogger(__name__)
 
-@celery_app.task(name="tasks.ping")
-def ping() -> str:
+
+def _progress(task, status: str, progress: float = 0.0, **meta):
+    payload = {"status": status, "progress": progress, **meta}
+    try:
+        task.update_state(state="PROGRESS", meta=payload)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Progress update failed: %s", exc)
+    return payload
+
+
+@celery_app.task(bind=True, name="tasks.ping")
+def ping(self) -> str:
+    _progress(self, "started", 0.0)
     return "pong"
 
 
-@celery_app.task(name="tasks.echo")
-def echo(message: str) -> str:
+@celery_app.task(bind=True, name="tasks.echo")
+def echo(self, message: str) -> str:
+    _progress(self, "started", 0.0, message=message)
     return message
 
 
-@celery_app.task(name="tasks.transcribe_video")
-def transcribe_video(video_asset_id: str, config: dict | None = None) -> dict:
-    return {"video_asset_id": video_asset_id, "status": "transcribed", "config": config or {}}
+@celery_app.task(bind=True, name="tasks.transcribe_video")
+def transcribe_video(self, video_asset_id: str, config: dict | None = None) -> dict:
+    _progress(self, "started", 0.0, video_asset_id=video_asset_id)
+    result = {"video_asset_id": video_asset_id, "status": "transcribed", "config": config or {}}
+    _progress(self, "completed", 1.0, video_asset_id=video_asset_id)
+    return result
 
 
-@celery_app.task(name="tasks.generate_captions")
-def generate_captions(video_asset_id: str, options: dict | None = None) -> dict:
-    return {"video_asset_id": video_asset_id, "status": "captions_generated", "options": options or {}}
+@celery_app.task(bind=True, name="tasks.generate_captions")
+def generate_captions(self, video_asset_id: str, options: dict | None = None) -> dict:
+    _progress(self, "started", 0.0, video_asset_id=video_asset_id)
+    result = {"video_asset_id": video_asset_id, "status": "captions_generated", "options": options or {}}
+    _progress(self, "completed", 1.0, video_asset_id=video_asset_id)
+    return result
 
 
-@celery_app.task(name="tasks.translate_subtitles")
-def translate_subtitles(subtitle_asset_id: str, options: dict | None = None) -> dict:
-    return {"subtitle_asset_id": subtitle_asset_id, "status": "translated", "options": options or {}}
+@celery_app.task(bind=True, name="tasks.translate_subtitles")
+def translate_subtitles(self, subtitle_asset_id: str, options: dict | None = None) -> dict:
+    _progress(self, "started", 0.0, subtitle_asset_id=subtitle_asset_id)
+    result = {"subtitle_asset_id": subtitle_asset_id, "status": "translated", "options": options or {}}
+    _progress(self, "completed", 1.0, subtitle_asset_id=subtitle_asset_id)
+    return result
 
 
-@celery_app.task(name="tasks.render_styled_subtitles")
-def render_styled_subtitles(video_asset_id: str, subtitle_asset_id: str, style: dict | None = None, options: dict | None = None) -> dict:
-    return {
+@celery_app.task(bind=True, name="tasks.render_styled_subtitles")
+def render_styled_subtitles(self, video_asset_id: str, subtitle_asset_id: str, style: dict | None = None, options: dict | None = None) -> dict:
+    _progress(self, "started", 0.0, video_asset_id=video_asset_id, subtitle_asset_id=subtitle_asset_id)
+    result = {
         "video_asset_id": video_asset_id,
         "subtitle_asset_id": subtitle_asset_id,
         "style": style or {},
         "options": options or {},
         "status": "styled_render",
     }
+    _progress(self, "completed", 1.0, video_asset_id=video_asset_id, subtitle_asset_id=subtitle_asset_id)
+    return result
 
 
-@celery_app.task(name="tasks.generate_shorts")
-def generate_shorts(video_asset_id: str, options: dict | None = None) -> dict:
-    return {"video_asset_id": video_asset_id, "status": "shorts_generated", "options": options or {}}
+@celery_app.task(bind=True, name="tasks.generate_shorts")
+def generate_shorts(self, video_asset_id: str, options: dict | None = None) -> dict:
+    _progress(self, "started", 0.0, video_asset_id=video_asset_id)
+    result = {"video_asset_id": video_asset_id, "status": "shorts_generated", "options": options or {}}
+    _progress(self, "completed", 1.0, video_asset_id=video_asset_id)
+    return result
 
 
-@celery_app.task(name="tasks.merge_video_audio")
-def merge_video_audio(video_asset_id: str, audio_asset_id: str, options: dict | None = None) -> dict:
-    return {
+@celery_app.task(bind=True, name="tasks.merge_video_audio")
+def merge_video_audio(self, video_asset_id: str, audio_asset_id: str, options: dict | None = None) -> dict:
+    _progress(self, "started", 0.0, video_asset_id=video_asset_id, audio_asset_id=audio_asset_id)
+    result = {
         "video_asset_id": video_asset_id,
         "audio_asset_id": audio_asset_id,
         "options": options or {},
         "status": "merged",
     }
+    _progress(self, "completed", 1.0, video_asset_id=video_asset_id, audio_asset_id=audio_asset_id)
+    return result
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
**Summary**
- Add progress reporting helper and bind Celery tasks to emit PROGRESS updates.
- Provide basic task stubs (transcribe, captions, translate, render styled, shorts, merge) with start/complete progress updates.
- Add a small test for the progress helper and update TODO for worker progress.

**Changes**
- `services/worker/worker.py`: bind tasks, add `_progress` helper, emit PROGRESS state with meta for job IDs.
- `services/worker/test_worker_progress.py`: verifies `update_state` is called with progress/status meta.
- `TODO.md`: mark job status/progress reporting as done.

**Testing**
- `python3 -m compileall services/worker packages/media-core/src/media_core packages/media-core/tests`

**Risk & Impact**
- Low; progress is purely metadata updates via Celery. Tasks remain stubs.

**Related TODO items**
- [x] Implement job status updates & progress reporting.
