### PR TITLE
feat: add api settings management

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -138,7 +138,7 @@
 
 ## 9. API – Core
 
-- [ ] Implement settings management using `pydantic-settings`.
+- [x] Implement settings management using `pydantic-settings`.
 - [ ] Add DB models (SQLModel or SQLAlchemy) for:
   - [ ] `Job`,
   - [ ] `MediaAsset`,

--- a/apps/api/app/config.py
+++ b/apps/api/app/config.py
@@ -1,0 +1,27 @@
+from functools import lru_cache
+from pydantic import BaseModel, Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class DatabaseSettings(BaseModel):
+    url: str = Field(default="sqlite:///./reframe.db")
+
+
+class BrokerSettings(BaseModel):
+    broker_url: str = Field(default="redis://redis:6379/0")
+    result_backend: str = Field(default="redis://redis:6379/0")
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(env_file=".env", env_file_encoding="utf-8", env_prefix="REFRAME_")
+
+    database: DatabaseSettings = Field(default_factory=DatabaseSettings)
+    broker: BrokerSettings = Field(default_factory=BrokerSettings)
+    media_root: str = Field(default="./media")
+    api_title: str = Field(default="Reframe API")
+    api_version: str = Field(default="0.1.0")
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> Settings:
+    return Settings()

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,12 +1,15 @@
 from fastapi import FastAPI
 
+from app.config import get_settings
+
 
 def create_app() -> FastAPI:
-    app = FastAPI(title="Reframe API", version="0.1.0")
+    settings = get_settings()
+    app = FastAPI(title=settings.api_title, version=settings.api_version)
 
     @app.get("/health", tags=["health"])
     def health() -> dict[str, str]:
-        return {"status": "ok"}
+        return {"status": "ok", "version": settings.api_version}
 
     return app
 


### PR DESCRIPTION
**Summary**
- Added pydantic-settings configuration module for the API and wired settings into FastAPI metadata and health reporting.

**Changes**
- Introduced `apps/api/app/config.py` with application, database, and broker settings using `pydantic-settings` plus a `get_settings` accessor.
- Applied settings to FastAPI title/version and the health endpoint now returns the configured version.
- Updated `TODO.md` to mark settings management as complete.

**Testing**
- `python3 -m compileall apps/api`

**Risk & Impact**
- No breaking changes expected; ensure environment variables match the new settings names.

**Related TODO items**
- [x] Implement settings management using pydantic-settings