### PR TITLE
feat: add cloud translation backend

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,7 +75,7 @@
 - [x] Create `packages/media-core/translate/__init__.py`.
 - [x] Define `Translator` interface:
   - [x] `translate_batch(texts: list[str], src: str, tgt: str) -> list[str]`.
-- [ ] Implement simple cloud translation backend (if you already use one).
+- [x] Implement simple cloud translation backend (if you already use one).
 - [x] Implement local/offline backend (e.g., Argos Translate / HF model) where feasible.
 - [x] Implement SRT translator:
   - [x] Parse SRT → list of `SubtitleLine`.
@@ -105,19 +105,11 @@
 - [x] Define `SegmentCandidate` model (start, end, score, reason, snippet).
 - [x] Implement naive equal‑splits strategy (baseline, from `long_to_shorts_app`).
 - [x] Implement sliding window candidate generator (configurable window size & stride).
-<<<<<<< HEAD
 - [x] Implement scoring using simple heuristics (density of keywords, sentence boundaries).
 - [x] Implement LLM scoring backend:
   - [x] Interface: `score_segments(transcript, candidates, prompt, model)`.
   - [x] Provider: Groq or OpenAI (whichever you prefer).
 - [x] Implement selector: pick top N segments under min/max duration & non‑overlap rules.
-=======
-- [ ] Implement scoring using simple heuristics (density of keywords, sentence boundaries).
-- [ ] Implement LLM scoring backend:
-  - [ ] Interface: `score_segments(transcript, candidates, prompt, model)`.
-  - [ ] Provider: Groq or OpenAI (whichever you prefer).
-- [x] Implement selector: pick top N segments under min/max duration & non‑overlap rules.
->>>>>>> 0758e52 (feat: improve segment selector and add tests)
 - [x] Unit tests: segments non‑overlapping, durations within bounds.
 
 ---

--- a/packages/media-core/src/media_core/translate/__init__.py
+++ b/packages/media-core/src/media_core/translate/__init__.py
@@ -1,10 +1,11 @@
 """Translation utilities for subtitles."""
 
-from .translator import Translator, NoOpTranslator
+from .translator import CloudTranslator, NoOpTranslator, Translator
 from .srt import parse_srt, translate_srt, translate_srt_bilingual
 
 __all__ = [
     "Translator",
+    "CloudTranslator",
     "NoOpTranslator",
     "parse_srt",
     "translate_srt",

--- a/packages/media-core/src/media_core/translate/translator.py
+++ b/packages/media-core/src/media_core/translate/translator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import List
+from typing import Callable, List, Optional
 
 
 class Translator(ABC):
@@ -16,3 +16,58 @@ class NoOpTranslator(Translator):
 
     def translate_batch(self, texts: List[str], src: str, tgt: str) -> List[str]:  # pragma: no cover - trivial
         return texts
+
+
+class CloudTranslator(Translator):
+    """Simple cloud-backed translator using an LLM-style chat client.
+
+    The client is expected to expose `chat.completions.create(model=..., messages=[...])`
+    similar to OpenAI or Groq SDKs. Provide a pre-configured client instance to avoid
+    importing optional dependencies directly from this package.
+    """
+
+    def __init__(
+        self,
+        client: object,
+        model: str,
+        system_prompt: Optional[str] = None,
+        temperature: float = 0.0,
+        postprocess: Optional[Callable[[str], str]] = None,
+    ) -> None:
+        if client is None:
+            raise ValueError("CloudTranslator requires a chat client instance")
+        self.client = client
+        self.model = model
+        self.system_prompt = system_prompt or (
+            "You are a translation engine. Translate user text from {src} to {tgt}. "
+            "Reply with the translated text only."
+        )
+        self.temperature = temperature
+        self.postprocess = postprocess
+
+    def translate_batch(self, texts: List[str], src: str, tgt: str) -> List[str]:
+        results: List[str] = []
+        for text in texts:
+            messages = [
+                {"role": "system", "content": self.system_prompt.format(src=src, tgt=tgt)},
+                {
+                    "role": "user",
+                    "content": f"Translate this from {src} to {tgt}. Reply with translation only: {text}",
+                },
+            ]
+
+            try:
+                resp = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    temperature=self.temperature,
+                )
+                content = getattr(resp.choices[0].message, "content", "")  # type: ignore[attr-defined]
+                cleaned = content.strip() if content else text
+                if self.postprocess:
+                    cleaned = self.postprocess(cleaned)
+                results.append(cleaned or text)
+            except Exception:
+                # Fallback to original text if the provider fails
+                results.append(text)
+        return results

--- a/packages/media-core/tests/test_translate_cloud.py
+++ b/packages/media-core/tests/test_translate_cloud.py
@@ -1,0 +1,44 @@
+from media_core.translate import CloudTranslator
+
+
+class FakeResponse:
+    def __init__(self, content: str):
+        self.choices = [type("Choice", (), {"message": type("Msg", (), {"content": content})()})()]
+
+
+class FakeChatClient:
+    def __init__(self, content: str = "translated"):
+        self.calls = []
+        self.chat = self
+        self.completions = self
+        self._content = content
+
+    def create(self, model, messages, temperature=0.0):  # pragma: no cover - trivial
+        self.calls.append({"model": model, "messages": messages, "temperature": temperature})
+        return FakeResponse(self._content)
+
+
+class FailingChatClient(FakeChatClient):
+    def create(self, *args, **kwargs):  # pragma: no cover - trivial
+        raise RuntimeError("boom")
+
+
+def test_cloud_translator_uses_chat_client_and_returns_content():
+    client = FakeChatClient(content="hola")
+    translator = CloudTranslator(client=client, model="demo", system_prompt="translate {src} to {tgt}", temperature=0.2)
+
+    out = translator.translate_batch(["hello"], src="en", tgt="es")
+
+    assert out == ["hola"]
+    assert client.calls[0]["model"] == "demo"
+    assert "en" in client.calls[0]["messages"][0]["content"]
+    assert "es" in client.calls[0]["messages"][0]["content"]
+
+
+def test_cloud_translator_falls_back_to_original_on_error():
+    client = FailingChatClient()
+    translator = CloudTranslator(client=client, model="demo")
+
+    out = translator.translate_batch(["keep me"], src="en", tgt="fr")
+
+    assert out == ["keep me"]


### PR DESCRIPTION
**Summary**
- Add a simple cloud-backed translator implementation that works with OpenAI/Groq-style chat clients.

**Changes**
- Introduced `CloudTranslator` in `media_core.translate` using a provided chat client, with safe fallbacks and optional postprocessing.
- Exported the new translator through the package init and added focused unit tests.
- Resolved the TODO backlog conflict and marked cloud translation backend as complete.

**Testing**
- `PYTHONPATH=packages/media-core/src python3 -m pytest packages/media-core/tests/test_translate.py packages/media-core/tests/test_translate_cloud.py`

**Risk & Impact**
- No breaking changes; runtime requires the caller to pass an appropriate chat client when using the cloud translator.

**Related TODO items**
- [x] Implement simple cloud translation backend (if you already use one).