### PR TITLE
feat: add api models and db setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -139,10 +139,10 @@
 ## 9. API – Core
 
 - [x] Implement settings management using `pydantic-settings`.
-- [ ] Add DB models (SQLModel or SQLAlchemy) for:
-  - [ ] `Job`,
-  - [ ] `MediaAsset`,
-  - [ ] (Optional) `SubtitleStylePreset`.
+- [x] Add DB models (SQLModel or SQLAlchemy) for:
+  - [x] `Job`,
+  - [x] `MediaAsset`,
+  - [x] (Optional) `SubtitleStylePreset`.
 - [ ] Add migration tooling (Alembic) if using SQLAlchemy.
 - [ ] Endpoint: `POST /api/v1/captions/jobs`.
 - [ ] Endpoint: `POST /api/v1/subtitles/translate`.

--- a/apps/api/app/database.py
+++ b/apps/api/app/database.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import Generator
+
+from sqlmodel import Session, SQLModel, create_engine
+
+from app.config import get_settings
+
+
+@lru_cache(maxsize=1)
+def get_engine():
+    settings = get_settings()
+    return create_engine(settings.database.url, echo=False)
+
+
+def create_db_and_tables() -> None:
+    # Import models so SQLModel sees the metadata before creating tables.
+    from app import models  # noqa: F401
+
+    engine = get_engine()
+    SQLModel.metadata.create_all(engine)
+
+
+def get_session() -> Generator[Session, None, None]:
+    engine = get_engine()
+    with Session(engine) as session:
+        yield session

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,11 +1,16 @@
 from fastapi import FastAPI
 
 from app.config import get_settings
+from app.database import create_db_and_tables
 
 
 def create_app() -> FastAPI:
     settings = get_settings()
     app = FastAPI(title=settings.api_title, version=settings.api_version)
+
+    @app.on_event("startup")
+    def startup() -> None:
+        create_db_and_tables()
 
     @app.get("/health", tags=["health"])
     def health() -> dict[str, str]:

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+from uuid import UUID, uuid4
+
+from sqlalchemy import Column, JSON
+from sqlmodel import Field, SQLModel
+
+
+class MediaAsset(SQLModel, table=True):
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    kind: str = Field(description="Type of asset, e.g., video, audio, subtitle")
+    uri: Optional[str] = Field(default=None, description="Storage URI or path for the asset")
+    mime_type: Optional[str] = Field(default=None)
+    duration: Optional[float] = Field(default=None, description="Duration in seconds if known")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class Job(SQLModel, table=True):
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    job_type: str = Field(description="Pipeline type, e.g., transcribe, translate, shorts")
+    status: str = Field(default="pending", index=True)
+    progress: float = Field(default=0.0, description="0-1.0 progress fraction")
+    error: Optional[str] = Field(default=None, description="Error message if failed")
+
+    input_asset_id: Optional[UUID] = Field(default=None, foreign_key="mediaasset.id")
+    output_asset_id: Optional[UUID] = Field(default=None, foreign_key="mediaasset.id")
+
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class SubtitleStylePreset(SQLModel, table=True):
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    name: str
+    description: Optional[str] = Field(default=None)
+    style: dict = Field(default_factory=dict, sa_column=Column(JSON), description="Serialized style payload")
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -1,2 +1,4 @@
 fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
+pydantic-settings>=2.2.1
+sqlmodel>=0.0.22


### PR DESCRIPTION
**Summary**
- Add initial database models for jobs, media assets, and subtitle style presets using SQLModel.

**Changes**
- Introduced `Job`, `MediaAsset`, and `SubtitleStylePreset` models with UUID keys, timestamps, and basic fields.
- Added database engine/session helpers plus startup table creation wiring into the FastAPI app.
- Updated API requirements for SQLModel/pydantic-settings and marked the TODO backlog item completed.

**Testing**
- `python3 -m compileall apps/api`

**Risk & Impact**
- Creates tables on startup; ensure the configured `REFRAME_DATABASE_URL` points to the desired database.

**Related TODO items**
- [x] Add DB models (SQLModel or SQLAlchemy) for:
  - [x] Job
  - [x] MediaAsset
  - [x] (Optional) SubtitleStylePreset