### PR TITLE
chore: add alembic migrations setup

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -135,7 +135,7 @@
   - [x] `Job`,
   - [x] `MediaAsset`,
   - [x] (Optional) `SubtitleStylePreset`.
-- [ ] Add migration tooling (Alembic) if using SQLAlchemy.
+- [x] Add migration tooling (Alembic) if using SQLAlchemy.
 - [ ] Endpoint: `POST /api/v1/captions/jobs`.
 - [ ] Endpoint: `POST /api/v1/subtitles/translate`.
 - [ ] Endpoint: `POST /api/v1/shorts/jobs`.

--- a/apps/api/alembic.ini
+++ b/apps/api/alembic.ini
@@ -1,0 +1,43 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = .
+file_template = %%(rev)s_%%(slug)s
+truncate_slug_length = 40
+revision_environment = true
+version_path_separator = os
+timezone = utc
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_sqlalchemy]
+level = WARN
+handlers = console
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers = console
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+
+[alembic:runtime]
+sqlalchemy.url = sqlite:///./reframe.db

--- a/apps/api/alembic/env.py
+++ b/apps/api/alembic/env.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import sys
+from logging.config import fileConfig
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlmodel import SQLModel
+
+from app.config import get_settings
+from app import models  # noqa: F401
+
+
+# Alembic Config object provides access to values within the .ini file.
+config = context.config
+
+# Configure logging.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+settings = get_settings()
+config.set_main_option("sqlalchemy.url", settings.database.url)
+
+target_metadata = SQLModel.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(connection=connection, target_metadata=target_metadata)
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/apps/api/alembic/versions/2024092601_init_models.py
+++ b/apps/api/alembic/versions/2024092601_init_models.py
@@ -1,0 +1,58 @@
+"""init models
+
+Revision ID: 2024092601
+Revises: 
+Create Date: 2024-09-26 00:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2024092601"
+down_revision = None
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "mediaasset",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("kind", sa.String(length=255), nullable=False),
+        sa.Column("uri", sa.String(length=1024), nullable=True),
+        sa.Column("mime_type", sa.String(length=255), nullable=True),
+        sa.Column("duration", sa.Float(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        "job",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("job_type", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False, server_default=sa.text("'pending'")),
+        sa.Column("progress", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("input_asset_id", sa.String(length=36), sa.ForeignKey("mediaasset.id"), nullable=True),
+        sa.Column("output_asset_id", sa.String(length=36), sa.ForeignKey("mediaasset.id"), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+    op.create_table(
+        "subtitlestylepreset",
+        sa.Column("id", sa.String(length=36), primary_key=True, nullable=False),
+        sa.Column("name", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("style", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("subtitlestylepreset")
+    op.drop_table("job")
+    op.drop_table("mediaasset")

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -2,3 +2,4 @@ fastapi>=0.111.0
 uvicorn[standard]>=0.29.0
 pydantic-settings>=2.2.1
 sqlmodel>=0.0.22
+alembic>=1.13.2


### PR DESCRIPTION
**Summary**
- Add Alembic migration tooling for the API service with an initial schema revision.

**Changes**
- Added Alembic config and environment that load settings and SQLModel metadata from the FastAPI app.
- Created initial migration covering `mediaasset`, `job`, and `subtitlestylepreset` tables.
- Updated API requirements to include Alembic and marked the backlog item complete.

**Testing**
- `python3 -m compileall apps/api`

**Risk & Impact**
- Running migrations requires configuring `REFRAME_DATABASE_URL`; defaults to the local SQLite file.

**Related TODO items**
- [x] Add migration tooling (Alembic) if using SQLAlchemy.