### PR TITLE
feat: add caption and translate job endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -136,8 +136,8 @@
   - [x] `MediaAsset`,
   - [x] (Optional) `SubtitleStylePreset`.
 - [x] Add migration tooling (Alembic) if using SQLAlchemy.
-- [ ] Endpoint: `POST /api/v1/captions/jobs`.
-- [ ] Endpoint: `POST /api/v1/subtitles/translate`.
+- [x] Endpoint: `POST /api/v1/captions/jobs`.
+- [x] Endpoint: `POST /api/v1/subtitles/translate`.
 - [ ] Endpoint: `POST /api/v1/shorts/jobs`.
 - [ ] Endpoint: `POST /api/v1/utilities/merge-av`.
 - [ ] Endpoint: `GET /api/v1/jobs/{job_id}`.

--- a/apps/api/alembic/versions/2024092602_add_job_payload.py
+++ b/apps/api/alembic/versions/2024092602_add_job_payload.py
@@ -1,0 +1,27 @@
+"""add job payload
+
+Revision ID: 2024092602
+Revises: 2024092601
+Create Date: 2024-09-26 00:15:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2024092602"
+down_revision = "2024092601"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "job",
+        sa.Column("payload", sa.JSON(), nullable=False, server_default=sa.text("'{}'")),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("job", "payload")

--- a/apps/api/app/api.py
+++ b/apps/api/app/api.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from typing import Annotated, List, Optional
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlmodel import Session, SQLModel, select
+
+from app.database import get_session
+from app.models import Job
+
+router = APIRouter(prefix="/api/v1")
+
+
+SessionDep = Annotated[Session, Depends(get_session)]
+
+
+class CaptionJobRequest(SQLModel):
+    video_asset_id: UUID
+    options: Optional[dict] = None
+
+
+class TranslateJobRequest(SQLModel):
+    subtitle_asset_id: UUID
+    target_language: str
+    options: Optional[dict] = None
+
+
+@router.post("/captions/jobs", response_model=Job, status_code=status.HTTP_201_CREATED)
+def create_caption_job(payload: CaptionJobRequest, session: SessionDep) -> Job:
+    job = Job(
+        job_type="captions",
+        status="queued",
+        progress=0.0,
+        input_asset_id=payload.video_asset_id,
+        payload=payload.options or {},
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+@router.post("/subtitles/translate", response_model=Job, status_code=status.HTTP_201_CREATED)
+def create_translate_job(payload: TranslateJobRequest, session: SessionDep) -> Job:
+    job = Job(
+        job_type="translate_subtitles",
+        status="queued",
+        progress=0.0,
+        input_asset_id=payload.subtitle_asset_id,
+        payload={"target_language": payload.target_language, **(payload.options or {})},
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+@router.get("/jobs/{job_id}", response_model=Job)
+def get_job(job_id: UUID, session: SessionDep) -> Job:
+    job = session.get(Job, job_id)
+    if not job:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Job not found")
+    return job
+
+
+@router.get("/jobs", response_model=List[Job])
+def list_jobs(status_filter: Optional[str] = None, session: SessionDep = Depends(get_session)) -> List[Job]:
+    query = select(Job)
+    if status_filter:
+        query = query.where(Job.status == status_filter)
+    results = session.exec(query).all()
+    return results

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI
 
 from app.config import get_settings
 from app.database import create_db_and_tables
+from app.api import router as api_router
 
 
 def create_app() -> FastAPI:
@@ -11,6 +12,8 @@ def create_app() -> FastAPI:
     @app.on_event("startup")
     def startup() -> None:
         create_db_and_tables()
+
+    app.include_router(api_router)
 
     @app.get("/health", tags=["health"])
     def health() -> dict[str, str]:

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -24,6 +24,7 @@ class Job(SQLModel, table=True):
     status: str = Field(default="pending", index=True)
     progress: float = Field(default=0.0, description="0-1.0 progress fraction")
     error: Optional[str] = Field(default=None, description="Error message if failed")
+    payload: dict = Field(default_factory=dict, sa_column=Column(JSON), description="Options or parameters for the job")
 
     input_asset_id: Optional[UUID] = Field(default=None, foreign_key="mediaasset.id")
     output_asset_id: Optional[UUID] = Field(default=None, foreign_key="mediaasset.id")


### PR DESCRIPTION
**Summary**
- Add initial job creation endpoints for captions and subtitle translation backed by SQLModel.

**Changes**
- Introduced API router with `POST /api/v1/captions/jobs` and `POST /api/v1/subtitles/translate` plus basic job retrieval/list endpoints.
- Extended `Job` model with a JSON payload field and added Alembic migration to persist it.
- Wired the router into FastAPI app startup and updated TODO backlog items.

**Testing**
- `python3 -m compileall apps/api`

**Risk & Impact**
- Migration adds a `payload` column to `job`; ensure Alembic is run against the target database.

**Related TODO items**
- [x] Endpoint: `POST /api/v1/captions/jobs`.
- [x] Endpoint: `POST /api/v1/subtitles/translate`.