### PR TITLE
feat: add shorts and utilities job endpoints

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -138,13 +138,13 @@
 - [x] Add migration tooling (Alembic) if using SQLAlchemy.
 - [x] Endpoint: `POST /api/v1/captions/jobs`.
 - [x] Endpoint: `POST /api/v1/subtitles/translate`.
-- [ ] Endpoint: `POST /api/v1/shorts/jobs`.
-- [ ] Endpoint: `POST /api/v1/utilities/merge-av`.
-- [ ] Endpoint: `GET /api/v1/jobs/{job_id}`.
-- [ ] Endpoint: `GET /api/v1/jobs` (listing/filtering).
-- [ ] Endpoint: `GET /api/v1/assets/{asset_id}` (download).
-- [ ] Endpoint: `GET /api/v1/presets/styles`.
-- [ ] Add OpenAPI docs with tags & examples.
+- [x] Endpoint: `POST /api/v1/shorts/jobs`.
+- [x] Endpoint: `POST /api/v1/utilities/merge-av`.
+- [x] Endpoint: `GET /api/v1/jobs/{job_id}`.
+- [x] Endpoint: `GET /api/v1/jobs` (listing/filtering).
+- [x] Endpoint: `GET /api/v1/assets/{asset_id}` (download).
+- [x] Endpoint: `GET /api/v1/presets/styles`.
+- [x] Add OpenAPI docs with tags & examples.
 
 ---
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -7,7 +7,18 @@ from app.api import router as api_router
 
 def create_app() -> FastAPI:
     settings = get_settings()
-    app = FastAPI(title=settings.api_title, version=settings.api_version)
+    tags_metadata = [
+        {"name": "Health", "description": "Health and readiness checks."},
+        {"name": "Captions", "description": "Create captioning jobs."},
+        {"name": "Translate", "description": "Translate subtitle assets."},
+        {"name": "Shorts", "description": "Create shorts generation jobs."},
+        {"name": "Utilities", "description": "Utility processing like merge A/V."},
+        {"name": "Jobs", "description": "Job retrieval and listings."},
+        {"name": "Assets", "description": "Manage media assets."},
+        {"name": "Presets", "description": "Subtitle style presets."},
+    ]
+
+    app = FastAPI(title=settings.api_title, version=settings.api_version, openapi_tags=tags_metadata)
 
     @app.on_event("startup")
     def startup() -> None:


### PR DESCRIPTION
**Summary**
- Add shorts generation and merge A/V job creation endpoints along with asset and preset retrieval.

**Changes**
- Introduced request schemas with examples and tags; new routes for `/api/v1/shorts/jobs`, `/api/v1/utilities/merge-av`, `/api/v1/assets/{asset_id}`, and `/api/v1/presets/styles` plus tagged job list/detail endpoints.
- Enhanced FastAPI OpenAPI metadata with tag descriptions and example payloads for major job types.
- Updated backlog to reflect completed API endpoints and documentation task.

**Testing**
- `python3 -m compileall apps/api`

**Risk & Impact**
- No breaking changes; endpoints rely on existing SQLModel tables and Alembic migrations.

**Related TODO items**
- [x] Endpoint: `POST /api/v1/shorts/jobs`.
- [x] Endpoint: `POST /api/v1/utilities/merge-av`.
- [x] Endpoint: `GET /api/v1/jobs/{job_id}`.
- [x] Endpoint: `GET /api/v1/jobs` (listing/filtering).
- [x] Endpoint: `GET /api/v1/assets/{asset_id}` (download).
- [x] Endpoint: `GET /api/v1/presets/styles`.
- [x] Add OpenAPI docs with tags & examples.