### PR TITLE
feat: improve job lifecycle handling and errors

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -150,10 +150,10 @@
 
 ## 10. API – Job Lifecycle & Errors
 
-- [ ] Standardize job statuses & error codes.
-- [ ] Add structured error responses (code, message, details).
-- [ ] Add background cleanup for orphaned temp files.
-- [ ] Add endpoint to cancel a running job (best effort).
+- [x] Standardize job statuses & error codes.
+- [x] Add structured error responses (code, message, details).
+- [x] Add background cleanup for orphaned temp files.
+- [x] Add endpoint to cancel a running job (best effort).
 - [ ] Add rate limiting for heavy endpoints (optional, later).
 
 ---

--- a/apps/api/app/cleanup.py
+++ b/apps/api/app/cleanup.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import os
+import threading
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+
+def _remove_old_files(directory: Path, older_than: timedelta) -> None:
+    if not directory.exists() or not directory.is_dir():
+        return
+    cutoff = datetime.utcnow() - older_than
+    for entry in directory.iterdir():
+        try:
+            if entry.is_file():
+                mtime = datetime.utcfromtimestamp(entry.stat().st_mtime)
+                if mtime < cutoff:
+                    entry.unlink(missing_ok=True)
+        except Exception:
+            # best-effort cleanup
+            continue
+
+
+def start_cleanup_loop(root: str, interval_seconds: int = 3600, ttl_hours: int = 24) -> Optional[threading.Thread]:
+    target_dir = Path(root) / "tmp"
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    def _loop() -> None:
+        while True:
+            _remove_old_files(target_dir, timedelta(hours=ttl_hours))
+            time.sleep(interval_seconds)
+
+    thread = threading.Thread(target=_loop, daemon=True)
+    thread.start()
+    return thread

--- a/apps/api/app/errors.py
+++ b/apps/api/app/errors.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from fastapi import status
+from pydantic import BaseModel
+
+
+class ErrorCode:
+    NOT_FOUND = "NOT_FOUND"
+    CONFLICT = "CONFLICT"
+    VALIDATION_ERROR = "VALIDATION_ERROR"
+    SERVER_ERROR = "SERVER_ERROR"
+    RATE_LIMITED = "RATE_LIMITED"
+
+
+class ErrorResponse(BaseModel):
+    code: str
+    message: str
+    details: Optional[Any] = None
+
+
+class ApiError(Exception):
+    def __init__(self, *, status_code: int, code: str, message: str, details: Optional[Any] = None):
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.details = details
+        super().__init__(message)
+
+
+def not_found(message: str = "Resource not found", details: Optional[Any] = None) -> ApiError:
+    return ApiError(status_code=status.HTTP_404_NOT_FOUND, code=ErrorCode.NOT_FOUND, message=message, details=details)
+
+
+def conflict(message: str = "Conflict", details: Optional[Any] = None) -> ApiError:
+    return ApiError(status_code=status.HTTP_409_CONFLICT, code=ErrorCode.CONFLICT, message=message, details=details)
+
+
+def server_error(message: str = "Server error", details: Optional[Any] = None) -> ApiError:
+    return ApiError(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, code=ErrorCode.SERVER_ERROR, message=message, details=details)

--- a/apps/api/app/models.py
+++ b/apps/api/app/models.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from enum import Enum
 from typing import Optional
 from uuid import UUID, uuid4
 
@@ -18,10 +19,18 @@ class MediaAsset(SQLModel, table=True):
     updated_at: datetime = Field(default_factory=datetime.utcnow)
 
 
+class JobStatus(str, Enum):
+    queued = "queued"
+    running = "running"
+    completed = "completed"
+    failed = "failed"
+    cancelled = "cancelled"
+
+
 class Job(SQLModel, table=True):
     id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
     job_type: str = Field(description="Pipeline type, e.g., transcribe, translate, shorts")
-    status: str = Field(default="pending", index=True)
+    status: JobStatus = Field(default=JobStatus.queued, index=True)
     progress: float = Field(default=0.0, description="0-1.0 progress fraction")
     error: Optional[str] = Field(default=None, description="Error message if failed")
     payload: dict = Field(default_factory=dict, sa_column=Column(JSON), description="Options or parameters for the job")


### PR DESCRIPTION
**Summary**
- Standardize job statuses/error codes, add structured error responses, and introduce a cancel endpoint.

**Changes**
- Added `JobStatus` enum and JSON payload typing, plus API error helpers/handler returning structured `ErrorResponse` bodies.
- Added job cancellation endpoint, status-filtered listing, and converted existing endpoints to use standardized statuses and error responses.
- Added background temp cleanup loop on startup and tagged OpenAPI metadata/examples; updated TODO to reflect completed lifecycle tasks.

**Testing**
- `python3 -m compileall apps/api`

**Risk & Impact**
- Background cleanup runs in a daemon thread targeting `media_root/tmp`; ensure this directory is acceptable for temp files.
- Status enum stored as strings; migration not required but downstream code should use standardized values.

**Related TODO items**
- [x] Standardize job statuses & error codes.
- [x] Add structured error responses (code, message, details).
- [x] Add background cleanup for orphaned temp files.
- [x] Add endpoint to cancel a running job (best effort).