### PR TITLE
feat: scaffold web shell with ui kit and api client

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -160,14 +160,14 @@
 
 ## 11. Frontend – Shell & Shared
 
-- [ ] Scaffold layout:
-  - [ ] Sidebar or top nav with sections: Shorts, Captions, Subtitles, Utilities, Jobs.
-  - [ ] Shared header/footer.
-- [ ] Add base UI kit (buttons, inputs, selects, modals, toasts).
-- [ ] Add global loading spinner and error boundary.
-- [ ] Implement typed API client (axios/fetch with TS types).
-- [ ] Configure theme (dark/light) with CSS variables or Tailwind.
-- [ ] Add simple settings modal (default model, language, output paths, etc.).
+- [x] Scaffold layout:
+  - [x] Sidebar or top nav with sections: Shorts, Captions, Subtitles, Utilities, Jobs.
+  - [x] Shared header/footer.
+- [x] Add base UI kit (buttons, inputs, selects, modals, toasts).
+- [x] Add global loading spinner and error boundary.
+- [x] Implement typed API client (axios/fetch with TS types).
+- [x] Configure theme (dark/light) with CSS variables or Tailwind.
+- [x] Add simple settings modal (default model, language, output paths, etc.).
 
 ---
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,24 +1,214 @@
+import { useEffect, useMemo, useState } from "react";
 import "./styles.css";
+import { apiClient, type Job, type JobStatus } from "./api/client";
+import { Button, Card, Chip, Input, TextArea } from "./components/ui";
+import { Spinner } from "./components/Spinner";
+import { SettingsModal } from "./components/SettingsModal";
+import { ErrorBoundary } from "./components/ErrorBoundary";
+
+const NAV_ITEMS = [
+  { id: "shorts", label: "Shorts" },
+  { id: "captions", label: "Captions" },
+  { id: "subtitles", label: "Subtitles" },
+  { id: "utilities", label: "Utilities" },
+  { id: "jobs", label: "Jobs" },
+];
+
+const PRESETS = [
+  { name: "TikTok Bold", accent: "var(--accent-coral)", desc: "High contrast with warm highlight" },
+  { name: "Clean Slate", accent: "var(--accent-mint)", desc: "Minimalist white/gray with subtle shadow" },
+  { name: "Night Runner", accent: "var(--accent-blue)", desc: "Dark base with electric cyan highlight" },
+];
+
+function useLiveJobs() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    const load = async () => {
+      setLoading(true);
+      try {
+        const data = await apiClient.listJobs();
+        if (!cancelled) setJobs(data.slice(0, 5));
+      } catch (err) {
+        if (!cancelled) setError(err instanceof Error ? err.message : "Failed to load jobs");
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    };
+    load();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { jobs, loading, error };
+}
+
+function JobStatusPill({ status }: { status: JobStatus }) {
+  const tone = {
+    queued: "neutral",
+    running: "info",
+    completed: "success",
+    failed: "danger",
+    cancelled: "muted",
+  }[status];
+  return <Chip tone={tone}>{status}</Chip>;
+}
+
+function AppShell() {
+  const [active, setActive] = useState(NAV_ITEMS[0].id);
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+  const [showSettings, setShowSettings] = useState(false);
+  const { jobs, loading, error } = useLiveJobs();
+
+  useEffect(() => {
+    document.documentElement.setAttribute("data-theme", theme);
+  }, [theme]);
+
+  const recentStatuses = useMemo(
+    () => ({
+      completed: jobs.filter((j) => j.status === "completed").length,
+      running: jobs.filter((j) => j.status === "running").length,
+      queued: jobs.filter((j) => j.status === "queued").length,
+    }),
+    [jobs]
+  );
+
+  return (
+    <div className="layout">
+      <aside className="sidebar">
+        <div className="brand">
+          <span className="dot" />
+          <div>
+            <div className="brand-title">Reframe</div>
+            <div className="brand-sub">Media toolkit</div>
+          </div>
+        </div>
+        <nav>
+          {NAV_ITEMS.map((item) => (
+            <button
+              key={item.id}
+              className={`nav-link ${active === item.id ? "active" : ""}`}
+              onClick={() => setActive(item.id)}
+            >
+              {item.label}
+            </button>
+          ))}
+        </nav>
+        <div className="sidebar-footer">
+          <Button variant="ghost" onClick={() => setShowSettings(true)}>
+            Settings
+          </Button>
+          <Button variant="ghost" onClick={() => setTheme(theme === "light" ? "dark" : "light")}>
+            {theme === "light" ? "Dark theme" : "Light theme"}
+          </Button>
+        </div>
+      </aside>
+
+      <main className="content">
+        <header className="topbar">
+          <div>
+            <p className="eyebrow">Dashboard</p>
+            <h1>Creative media pipeline</h1>
+            <p className="lead">
+              Kick off captions, translations, styled subtitles, and shorts in one place. Jobs are listed
+              below once created through the API.
+            </p>
+          </div>
+          <div className="topbar-actions">
+            <Button variant="primary" onClick={() => setShowSettings(true)}>
+              Quick settings
+            </Button>
+          </div>
+        </header>
+
+        <section className="grid">
+          <Card title="System health">
+            <div className="metric-row">
+              <div>
+                <p className="metric-label">API Base</p>
+                <p className="metric-value">{apiClient.baseUrl}</p>
+              </div>
+              <div>
+                <p className="metric-label">Theme</p>
+                <p className="metric-value">{theme}</p>
+              </div>
+            </div>
+          </Card>
+
+          <Card title="Recent jobs">
+            {loading && <Spinner label="Loading jobs..." />}
+            {error && <div className="error-inline">{error}</div>}
+            {!loading && !error && jobs.length === 0 && <p className="muted">No jobs yet.</p>}
+            {!loading &&
+              jobs.map((job) => (
+                <div key={job.id} className="job-row">
+                  <div>
+                    <p className="metric-label">{job.job_type}</p>
+                    <p className="metric-value">{job.id}</p>
+                  </div>
+                  <JobStatusPill status={job.status} />
+                </div>
+              ))}
+          </Card>
+
+          <Card title="Status snapshot">
+            <div className="snapshot">
+              <div>
+                <p className="metric-label">Queued</p>
+                <p className="metric-value">{recentStatuses.queued}</p>
+              </div>
+              <div>
+                <p className="metric-label">Running</p>
+                <p className="metric-value">{recentStatuses.running}</p>
+              </div>
+              <div>
+                <p className="metric-label">Completed</p>
+                <p className="metric-value">{recentStatuses.completed}</p>
+              </div>
+            </div>
+          </Card>
+        </section>
+
+        <section className="grid two-col">
+          <Card title="Preset styles">
+            <ul className="preset-list">
+              {PRESETS.map((preset) => (
+                <li key={preset.name}>
+                  <span className="preset-accent" style={{ background: preset.accent }} />
+                  <div>
+                    <p className="metric-value">{preset.name}</p>
+                    <p className="muted">{preset.desc}</p>
+                  </div>
+                  <Button variant="ghost">Preview</Button>
+                </li>
+              ))}
+            </ul>
+          </Card>
+
+          <Card title="Notes / prompts">
+            <TextArea rows={6} placeholder="Describe what to prioritize when generating shorts..." />
+            <div className="actions-row">
+              <Button variant="secondary">Save draft</Button>
+              <Button variant="primary">Share with team</Button>
+            </div>
+          </Card>
+        </section>
+      </main>
+
+      {showSettings && <SettingsModal onClose={() => setShowSettings(false)} />}
+    </div>
+  );
+}
 
 function App() {
   return (
-    <main className="app-shell">
-      <header className="app-header">
-        <p className="eyebrow">Reframe</p>
-        <h1>Media tooling coming soon</h1>
-        <p className="lead">
-          React + Vite + TypeScript scaffold. Wire this to the API once endpoints land.
-        </p>
-      </header>
-      <section className="card">
-        <h2>Next steps</h2>
-        <ul>
-          <li>Configure API base URL and shared fetch client.</li>
-          <li>Add routing for Captions, Subtitle Styling, Shorts, and Jobs.</li>
-          <li>Implement upload flows and status polling.</li>
-        </ul>
-      </section>
-    </main>
+    <ErrorBoundary>
+      <AppShell />
+    </ErrorBoundary>
   );
 }
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,0 +1,43 @@
+export type JobStatus = "queued" | "running" | "completed" | "failed" | "cancelled";
+
+export interface Job {
+  id: string;
+  job_type: string;
+  status: JobStatus;
+  progress: number;
+  payload?: Record<string, unknown>;
+}
+
+interface ApiClientOptions {
+  baseUrl?: string;
+  fetcher?: typeof fetch;
+}
+
+export class ApiClient {
+  baseUrl: string;
+  fetcher: typeof fetch;
+
+  constructor(options?: ApiClientOptions) {
+    this.baseUrl = options?.baseUrl || import.meta.env.VITE_API_BASE_URL || "http://localhost:8000/api/v1";
+    this.fetcher = options?.fetcher || fetch;
+  }
+
+  async request<T>(path: string, init?: RequestInit): Promise<T> {
+    const resp = await this.fetcher(`${this.baseUrl}${path}`, {
+      headers: { "Content-Type": "application/json", ...(init?.headers || {}) },
+      ...init,
+    });
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      const message = body?.message || resp.statusText || "Request failed";
+      throw new Error(message);
+    }
+    return (await resp.json()) as T;
+  }
+
+  listJobs() {
+    return this.request<Job[]>("/jobs");
+  }
+}
+
+export const apiClient = new ApiClient();

--- a/apps/web/src/components/ErrorBoundary.tsx
+++ b/apps/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown) {
+    console.error("App error boundary caught:", error);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="error-fallback">
+          <h2>Something went wrong</h2>
+          <p>Refresh the page or try again later.</p>
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}

--- a/apps/web/src/components/SettingsModal.tsx
+++ b/apps/web/src/components/SettingsModal.tsx
@@ -1,0 +1,55 @@
+import { useState } from "react";
+import { Button, Input, TextArea } from "./ui";
+
+interface Props {
+  onClose: () => void;
+}
+
+export function SettingsModal({ onClose }: Props) {
+  const [model, setModel] = useState("whisper-large-v3");
+  const [language, setLanguage] = useState("auto");
+  const [outputPath, setOutputPath] = useState("/media/output");
+  const [notes, setNotes] = useState("");
+
+  return (
+    <div className="modal-backdrop" role="dialog" aria-modal="true">
+      <div className="modal">
+        <header className="modal-head">
+          <div>
+            <p className="eyebrow">Workspace</p>
+            <h2>Default settings</h2>
+          </div>
+          <Button variant="ghost" onClick={onClose} aria-label="Close settings">
+            Close
+          </Button>
+        </header>
+        <div className="modal-body">
+          <label className="field">
+            <span>Preferred model</span>
+            <Input value={model} onChange={(e) => setModel(e.target.value)} />
+          </label>
+          <label className="field">
+            <span>Language</span>
+            <Input value={language} onChange={(e) => setLanguage(e.target.value)} placeholder="auto" />
+          </label>
+          <label className="field">
+            <span>Default output path</span>
+            <Input value={outputPath} onChange={(e) => setOutputPath(e.target.value)} />
+          </label>
+          <label className="field">
+            <span>Notes</span>
+            <TextArea rows={3} value={notes} onChange={(e) => setNotes(e.target.value)} />
+          </label>
+        </div>
+        <footer className="modal-footer">
+          <Button variant="secondary" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button variant="primary" onClick={onClose}>
+            Save
+          </Button>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/Spinner.tsx
+++ b/apps/web/src/components/Spinner.tsx
@@ -1,0 +1,12 @@
+import { PropsWithChildren } from "react";
+
+export function Spinner({ label }: PropsWithChildren<{ label?: string }>) {
+  return (
+    <div className="spinner">
+      <div className="spinner-dot" />
+      <div className="spinner-dot" />
+      <div className="spinner-dot" />
+      {label && <span className="spinner-label">{label}</span>}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui.tsx
+++ b/apps/web/src/components/ui.tsx
@@ -1,0 +1,38 @@
+import { ComponentProps, PropsWithChildren } from "react";
+
+type ButtonProps = PropsWithChildren<
+  ComponentProps<"button"> & {
+    variant?: "primary" | "secondary" | "ghost";
+  }
+>;
+
+export function Button({ variant = "primary", children, className = "", ...rest }: ButtonProps) {
+  return (
+    <button className={`btn btn-${variant} ${className}`} {...rest}>
+      {children}
+    </button>
+  );
+}
+
+export function Card({ title, children }: PropsWithChildren<{ title: string }>) {
+  return (
+    <div className="card">
+      <div className="card-head">
+        <h3>{title}</h3>
+      </div>
+      <div className="card-body">{children}</div>
+    </div>
+  );
+}
+
+export function Chip({ tone = "neutral", children }: PropsWithChildren<{ tone?: "neutral" | "info" | "success" | "danger" | "muted" }>) {
+  return <span className={`chip chip-${tone}`}>{children}</span>;
+}
+
+export function Input(props: ComponentProps<"input">) {
+  return <input className="input" {...props} />;
+}
+
+export function TextArea(props: ComponentProps<"textarea">) {
+  return <textarea className="textarea" {...props} />;
+}

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -1,7 +1,28 @@
 :root {
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  color: #0f172a;
-  background-color: #f8fafc;
+  --bg: #0b0c10;
+  --panel: #111827;
+  --panel-alt: #0f172a;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --border: #1f2937;
+  --accent-blue: #38bdf8;
+  --accent-mint: #4ade80;
+  --accent-coral: #fb7185;
+  --accent-amber: #fbbf24;
+  --shadow: 0 12px 40px rgba(0, 0, 0, 0.22);
+  font-family: "Space Grotesk", "Inter", system-ui, -apple-system, sans-serif;
+  color: var(--text);
+  background-color: var(--bg);
+}
+
+[data-theme="light"] {
+  --bg: #f8fafc;
+  --panel: #ffffff;
+  --panel-alt: #e2e8f0;
+  --text: #0f172a;
+  --muted: #475569;
+  --border: #e2e8f0;
+  --shadow: 0 8px 24px rgba(15, 23, 42, 0.12);
 }
 
 * { box-sizing: border-box; }
@@ -9,54 +30,375 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at 20% 20%, #e0f2fe 0, rgba(224, 242, 254, 0) 35%),
-    radial-gradient(circle at 80% 0, #c7d2fe 0, rgba(199, 210, 254, 0) 30%),
-    #f8fafc;
+  background: radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.18), transparent 35%),
+    radial-gradient(circle at 80% 10%, rgba(251, 113, 133, 0.2), transparent 30%),
+    var(--bg);
 }
 
-.app-shell {
-  max-width: 960px;
-  margin: 0 auto;
-  padding: 72px 24px;
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  min-height: 100vh;
+  color: var(--text);
 }
 
-.app-header {
-  margin-bottom: 32px;
+.sidebar {
+  border-right: 1px solid var(--border);
+  padding: 32px 20px;
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.06), transparent), var(--panel);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.dot {
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-coral));
+}
+
+.brand-title {
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.brand-sub {
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.nav-link {
+  width: 100%;
+  text-align: left;
+  padding: 10px 12px;
+  border-radius: 12px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.nav-link:hover {
+  border-color: var(--border);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.nav-link.active {
+  border-color: var(--accent-blue);
+  color: var(--accent-blue);
+  background: rgba(56, 189, 248, 0.08);
+}
+
+.sidebar-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.content {
+  padding: 36px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
 }
 
 .eyebrow {
   text-transform: uppercase;
-  letter-spacing: 0.2em;
+  letter-spacing: 0.24em;
   font-weight: 700;
-  color: #3b82f6;
-  margin: 0 0 8px;
+  color: var(--accent-blue);
+  margin: 0 0 6px;
 }
 
 h1 {
-  margin: 0 0 12px;
-  font-size: 2.4rem;
+  margin: 0 0 8px;
+  font-size: 2.2rem;
 }
+
+h2, h3 { margin: 0; }
 
 .lead {
   margin: 0;
-  color: #334155;
-  max-width: 640px;
+  color: var(--muted);
+  max-width: 760px;
   line-height: 1.5;
 }
 
-.card {
-  background: white;
-  border-radius: 12px;
-  padding: 24px;
-  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.08);
-  border: 1px solid #e2e8f0;
+.topbar-actions {
+  display: flex;
+  gap: 10px;
 }
 
-.card h2 { margin-top: 0; }
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 16px;
+}
 
-.card ul {
-  margin: 12px 0 0;
-  padding-left: 20px;
-  color: #1f2937;
-  line-height: 1.6;
+.grid.two-col {
+  grid-template-columns: repeat(auto-fit, minmax(340px, 1fr));
+}
+
+.card {
+  background: var(--panel);
+  border-radius: 16px;
+  padding: 18px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+}
+
+.card-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.metric-row, .job-row, .snapshot {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.metric-value {
+  margin: 0;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.metric-label {
+  margin: 0 0 4px;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.snapshot > div {
+  background: var(--panel-alt);
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+.preset-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.preset-list li {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+}
+
+.preset-accent {
+  width: 12px;
+  height: 48px;
+  border-radius: 8px;
+}
+
+.muted {
+  color: var(--muted);
+  margin: 0;
+}
+
+.btn {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 10px 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow);
+}
+
+.btn-primary {
+  background: linear-gradient(135deg, var(--accent-blue), var(--accent-coral));
+  color: #0b0c10;
+  border: none;
+}
+
+.btn-secondary {
+  background: var(--panel-alt);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.chip {
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-weight: 700;
+  font-size: 0.85rem;
+  border: 1px solid var(--border);
+}
+
+.chip-neutral { background: rgba(255, 255, 255, 0.04); color: var(--text); }
+.chip-info { background: rgba(56, 189, 248, 0.12); color: var(--accent-blue); border-color: transparent; }
+.chip-success { background: rgba(74, 222, 128, 0.14); color: var(--accent-mint); border-color: transparent; }
+.chip-danger { background: rgba(251, 113, 133, 0.14); color: var(--accent-coral); border-color: transparent; }
+.chip-muted { background: var(--panel-alt); color: var(--muted); }
+
+.input, .textarea {
+  width: 100%;
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 10px 12px;
+  color: var(--text);
+  font-size: 1rem;
+}
+
+.textarea { min-height: 120px; }
+
+.actions-row {
+  display: flex;
+  gap: 8px;
+  justify-content: flex-end;
+}
+
+.spinner {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.spinner-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--accent-blue);
+  animation: pulse 0.9s ease-in-out infinite;
+}
+
+.spinner-dot:nth-child(2) { animation-delay: 0.15s; }
+.spinner-dot:nth-child(3) { animation-delay: 0.3s; }
+
+.spinner-label {
+  color: var(--muted);
+  font-weight: 600;
+}
+
+@keyframes pulse {
+  0% { transform: scale(0.8); opacity: 0.6; }
+  50% { transform: scale(1.1); opacity: 1; }
+  100% { transform: scale(0.8); opacity: 0.6; }
+}
+
+.error-inline {
+  color: var(--accent-coral);
+  font-weight: 700;
+}
+
+.error-fallback {
+  max-width: 520px;
+  margin: 80px auto;
+  padding: 24px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--panel);
+  text-align: center;
+}
+
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  z-index: 20;
+}
+
+.modal {
+  width: min(520px, 100%);
+  background: var(--panel);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.modal-head, .modal-footer {
+  padding: 16px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.modal-body {
+  padding: 0 16px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-weight: 600;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    gap: 12px;
+    overflow-x: auto;
+  }
+
+  .sidebar-footer {
+    flex-direction: row;
+  }
+
+  .content {
+    padding: 20px;
+  }
 }


### PR DESCRIPTION
**Summary**
- Build a frontend shell with navigation, themed layout, and shared UI kit.

**Changes**
- Added sidebar/topbar layout with sections, theme toggle, settings modal, and cards for presets/notes.
- Implemented base UI components (buttons, chips, cards, inputs), spinner, error boundary, and settings modal.
- Added typed API client for jobs, dashboard summary wiring, and updated TODO to mark frontend shell tasks done.

**Testing**
- `npm run build` *(fails locally: missing TypeScript/Vite binaries before install; run `npm install` then rerun)*

**Risk & Impact**
- Frontend-only changes; ensure dependencies are installed before building.

**Related TODO items**
- [x] Scaffold layout: sidebar/top nav, header/footer.
- [x] Add base UI kit.
- [x] Add global loading spinner and error boundary.
- [x] Implement typed API client.
- [x] Configure theme (light/dark) with CSS variables.
- [x] Add simple settings modal.