### PR TITLE
feat: enhance whisper backends and moviepy renderer

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -34,7 +34,7 @@
 - [x] Add CLI entrypoint (`python -m media_core.transcribe`) for quick testing.
 - [x] Unit tests: transcription result normalization (words sorted, no overlaps, correct lengths).
 - [x] Make transcribe CLI execute chosen backend (with safe fallback) instead of placeholder.
-- [ ] Flesh out whisper.cpp / whisper-timestamped execution paths with graceful fallback if deps missing.
+- [x] Flesh out whisper.cpp / whisper-timestamped execution paths with graceful fallback if deps missing.
 - [x] Add optional dependency groups for transcription backends (openai, faster-whisper, whispercpp).
 
 ---
@@ -70,7 +70,7 @@
 - [x] Add a simple “solid background + subtitles only” mode for preview.
 - [x] Provide a few preset styles (e.g. “TikTok default”, “Yellow highlight”, “Clean white”).
 - [x] Integration test: render a 5–10 second sample with 3 lines and verify no crashes.
-- [ ] Build actual MoviePy text/highlight rendering; remove plan-only scaffold.
+- [x] Build actual MoviePy text/highlight rendering; remove plan-only scaffold.
 
 ---
 

--- a/packages/media-core/src/media_core/transcribe/__main__.py
+++ b/packages/media-core/src/media_core/transcribe/__main__.py
@@ -45,7 +45,9 @@ def main() -> int:
             result = transcribe_openai_file(str(input_path), config)
         elif backend == TranscriptionBackend.FASTER_WHISPER:
             result = transcribe_faster_whisper(str(input_path), config)
-        elif backend in (TranscriptionBackend.WHISPER_CPP, TranscriptionBackend.WHISPERX, TranscriptionBackend.WHISPER_TIMESTAMPED):
+        elif backend == TranscriptionBackend.WHISPER_CPP:
+            result = transcribe_whisper_cpp(str(input_path), config)
+        elif backend in (TranscriptionBackend.WHISPER_TIMESTAMPED, TranscriptionBackend.WHISPERX):
             result = transcribe_whisper_timestamped(str(input_path), config)
         else:
             result = transcribe_noop(str(input_path), config)


### PR DESCRIPTION
- **Summary**
  - Improve whisper.cpp and whisper-timestamped backends with real execution attempts and graceful fallbacks, and add a concrete MoviePy renderer for styled subtitles.
- **Changes**
  - whisper.cpp backend now calls pywhispercpp when available and normalizes segments; whisper-timestamped tries real transcription via the optional library or JSON inputs, else returns a stub with warnings; CLI dispatch routes whisper.cpp correctly.
  - StyledSubtitleRenderer gains a MoviePy-based `render_video` that composites base and highlight text layers, falling back to preview when MoviePy isn’t available.
  - TODO updated to mark these tasks complete.
- **Testing**
  - Not run (not requested).
- **Risk & Impact**
  - Optional dependencies required for full execution (whispercpp, whisper_timestamped, moviepy); code falls back gracefully when missing.
- **Related TODO items**
  - [x] Flesh out whisper.cpp / whisper-timestamped execution paths with graceful fallback if deps missing.
  - [x] Build actual MoviePy text/highlight rendering; remove plan-only scaffold.