### PR TITLE
feat: improve media probing, downloads, and worker assets

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -101,6 +101,8 @@
 - [x] Function: `merge_video_audio(video_path, audio_path, output_path, offset, ducking, normalize)`.
 - [x] Function: `burn_subtitles(video_path, srt_or_ass_path, output_path, extra_filters=None)`.
 - [x] Tests: basic FFmpeg invocation works and outputs exist.
+- [x] Return ffprobe metadata (duration/resolution/codec) from `probe_media` instead of path-only.
+- [x] Add `blur_bg` strategy to `reframe` for blurred letterboxing.
 
 ---
 
@@ -130,6 +132,7 @@
 - [x] Task: `generate_shorts(video_asset_id, options) -> list[clip_asset_id]`.
 - [x] Task: `merge_video_audio(video_asset_id, audio_asset_id, options) -> video_asset_id`.
 - [x] Implement job status updates & progress reporting.
+- [x] Create real `MediaAsset` rows (and stub files) for worker outputs and attach to jobs/clip payloads.
 
 ---
 
@@ -150,6 +153,7 @@
 - [x] Endpoint: `GET /api/v1/assets/{asset_id}` (download).
 - [x] Endpoint: `GET /api/v1/presets/styles`.
 - [x] Add OpenAPI docs with tags & examples.
+- [x] Add asset download endpoint that streams the underlying file (not just metadata).
 
 ---
 

--- a/apps/api/app/api.py
+++ b/apps/api/app/api.py
@@ -16,6 +16,7 @@ from app.config import get_settings
 from app.errors import ErrorResponse, conflict, not_found, server_error
 from app.models import Job, JobStatus, MediaAsset, SubtitleStylePreset
 from app.rate_limit import enforce_rate_limit
+from fastapi.responses import FileResponse
 
 
 router = APIRouter(prefix="/api/v1")
@@ -402,6 +403,26 @@ def get_asset(asset_id: UUID, session: SessionDep) -> MediaAsset:
     if not asset:
         raise not_found("Asset not found", details={"asset_id": str(asset_id)})
     return asset
+
+
+@router.get(
+    "/assets/{asset_id}/download",
+    response_class=FileResponse,
+    tags=["Assets"],
+    responses={404: {"model": ErrorResponse}},
+)
+def download_asset(asset_id: UUID, session: SessionDep) -> FileResponse:
+    asset = session.get(MediaAsset, asset_id)
+    if not asset:
+        raise not_found("Asset not found", details={"asset_id": str(asset_id)})
+    settings = get_settings()
+    uri_path = Path(asset.uri.lstrip("/"))
+    if uri_path.parts and uri_path.parts[0] == "media":
+        uri_path = Path(*uri_path.parts[1:])
+    file_path = Path(settings.media_root) / uri_path
+    if not file_path.exists():
+        raise not_found("Asset file missing", details={"asset_id": str(asset_id), "path": str(file_path)})
+    return FileResponse(path=file_path, media_type=asset.mime_type or "application/octet-stream", filename=file_path.name)
 
 
 @router.get("/presets/styles", response_model=List[SubtitleStylePreset], tags=["Presets"])

--- a/packages/media-core/src/media_core/video_edit/ffmpeg.py
+++ b/packages/media-core/src/media_core/video_edit/ffmpeg.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import shutil
 import subprocess
 from pathlib import Path
@@ -28,13 +29,30 @@ def probe_media(path: str | Path, runner=None) -> dict:
         "-v",
         "error",
         "-show_entries",
-        "format=duration:stream=width,height,codec_name",
+        "format=duration",
+        "-show_entries",
+        "stream=index,codec_name,width,height,codec_type",
         "-of",
-        "default=noprint_wrappers=1",
+        "json",
         str(media_path),
     ]
-    _run(cmd, runner=runner)
-    return {"path": str(media_path)}
+    completed = _run(cmd, runner=runner)
+    info = json.loads(completed.stdout.decode() if completed.stdout else "{}")
+    format_info = info.get("format", {}) or {}
+    streams = info.get("streams", []) or []
+    video_streams = [s for s in streams if s.get("codec_type") == "video"]
+    audio_streams = [s for s in streams if s.get("codec_type") == "audio"]
+    first_video = video_streams[0] if video_streams else {}
+    return {
+        "path": str(media_path),
+        "duration": float(format_info.get("duration")) if format_info.get("duration") else None,
+        "video": {
+            "codec": first_video.get("codec_name"),
+            "width": first_video.get("width"),
+            "height": first_video.get("height"),
+        },
+        "audio_codecs": [s.get("codec_name") for s in audio_streams if s.get("codec_name")],
+    }
 
 
 def extract_audio(video_path: str | Path, audio_path: str | Path, runner=None) -> None:
@@ -66,6 +84,14 @@ def reframe(video_path: str | Path, output_path: str | Path, aspect_ratio: str, 
     ffmpeg = _ensure_binary("ffmpeg")
     if strategy == "crop":
         filter_chain = f"scale=-1:ih, crop=iw:iw/{aspect_ratio.replace(':', '/')}"
+    elif strategy == "blur_bg":
+        ratio = aspect_ratio.replace(":", "/")
+        filter_chain = (
+            f"split=2[main][bg];"
+            f"[bg]scale=-1:ih,boxblur=20:1[bgblur];"
+            f"[main]scale='if(gt(a,{ratio}),iw/{ratio},{ratio}*ih)':'if(gt(a,{ratio}),ih,iw/{ratio})':force_original_aspect_ratio=decrease[fg];"
+            f"[bgblur][fg]overlay=(W-w)/2:(H-h)/2"
+        )
     else:
         filter_chain = (
             f"scale=-1:ih, pad=ceil(iw*{aspect_ratio.replace(':', '/')}/2)*2:"

--- a/packages/media-core/tests/test_video_edit_ffmpeg.py
+++ b/packages/media-core/tests/test_video_edit_ffmpeg.py
@@ -13,8 +13,9 @@ from media_core.video_edit.ffmpeg import (
 
 
 class DummyCompleted:
-    def __init__(self):
+    def __init__(self, stdout=b""):
         self.returncode = 0
+        self.stdout = stdout
 
 
 def dummy_run(expected_cmds):
@@ -22,7 +23,8 @@ def dummy_run(expected_cmds):
 
     def _runner(cmd, check=True, capture_output=True):
         calls.append(cmd)
-        return DummyCompleted()
+        sample = b'{"format": {"duration": "1.5"}, "streams": [{"codec_type": "video", "codec_name": "h264", "width": 1920, "height": 1080}, {"codec_type": "audio", "codec_name": "aac"}]}'
+        return DummyCompleted(stdout=sample)
 
     return _runner, calls
 

--- a/services/worker/worker.py
+++ b/services/worker/worker.py
@@ -2,7 +2,7 @@ import logging
 import os
 import sys
 from pathlib import Path
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from sqlmodel import Session, create_engine
 
@@ -13,7 +13,7 @@ if str(API_PATH) not in sys.path:
     sys.path.append(str(API_PATH))
 
 from app.config import get_settings
-from app.models import Job, JobStatus
+from app.models import Job, JobStatus, MediaAsset
 from celery import Celery
 
 BROKER_URL = os.getenv("BROKER_URL", "redis://redis:6379/0")
@@ -25,6 +25,7 @@ celery_app.conf.task_default_queue = "default"
 logger = logging.getLogger(__name__)
 
 _engine = None
+_media_tmp: Path | None = None
 
 
 def get_engine():
@@ -33,6 +34,31 @@ def get_engine():
         settings = get_settings()
         _engine = create_engine(settings.database.url, echo=False)
     return _engine
+
+
+def get_media_tmp() -> Path:
+    global _media_tmp
+    if _media_tmp is None:
+        settings = get_settings()
+        root = Path(settings.media_root)
+        tmp = root / "tmp"
+        tmp.mkdir(parents=True, exist_ok=True)
+        _media_tmp = tmp
+    return _media_tmp
+
+
+def create_asset(kind: str, mime_type: str, suffix: str, contents: bytes | str = b"") -> MediaAsset:
+    tmp = get_media_tmp()
+    filename = f"{uuid4()}{suffix}"
+    target = tmp / filename
+    data = contents.encode() if isinstance(contents, str) else contents
+    target.write_bytes(data)
+    asset = MediaAsset(kind=kind, uri=f"/media/tmp/{filename}", mime_type=mime_type)
+    with Session(get_engine()) as session:
+        session.add(asset)
+        session.commit()
+        session.refresh(asset)
+        return asset
 
 
 def update_job(job_id: str, *, status: JobStatus | None = None, progress: float | None = None, error: str | None = None, payload: dict | None = None, output_asset_id: str | None = None) -> None:
@@ -84,8 +110,10 @@ def echo(self, message: str) -> str:
 def transcribe_video(self, job_id: str, video_asset_id: str, config: dict | None = None) -> dict:
     update_job(job_id, status=JobStatus.running, progress=0.1)
     _progress(self, "started", 0.0, video_asset_id=video_asset_id)
-    result = {"video_asset_id": video_asset_id, "status": "transcribed", "config": config or {}}
-    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result)
+    transcript_text = f"Transcription for asset {video_asset_id}"
+    asset = create_asset(kind="transcription", mime_type="text/plain", suffix=".txt", contents=transcript_text)
+    result = {"video_asset_id": video_asset_id, "status": "transcribed", "config": config or {}, "output_asset_id": str(asset.id)}
+    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result, output_asset_id=str(asset.id))
     _progress(self, "completed", 1.0, video_asset_id=video_asset_id)
     return result
 
@@ -94,8 +122,10 @@ def transcribe_video(self, job_id: str, video_asset_id: str, config: dict | None
 def generate_captions(self, job_id: str, video_asset_id: str, options: dict | None = None) -> dict:
     update_job(job_id, status=JobStatus.running, progress=0.1)
     _progress(self, "started", 0.0, video_asset_id=video_asset_id)
-    result = {"video_asset_id": video_asset_id, "status": "captions_generated", "options": options or {}}
-    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result)
+    captions = "1\n00:00:00,000 --> 00:00:02,000\nCaption placeholder\n"
+    asset = create_asset(kind="subtitle", mime_type="text/vtt", suffix=".vtt", contents=captions)
+    result = {"video_asset_id": video_asset_id, "status": "captions_generated", "options": options or {}, "output_asset_id": str(asset.id)}
+    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result, output_asset_id=str(asset.id))
     _progress(self, "completed", 1.0, video_asset_id=video_asset_id)
     return result
 
@@ -104,8 +134,10 @@ def generate_captions(self, job_id: str, video_asset_id: str, options: dict | No
 def translate_subtitles(self, job_id: str, subtitle_asset_id: str, options: dict | None = None) -> dict:
     update_job(job_id, status=JobStatus.running, progress=0.1)
     _progress(self, "started", 0.0, subtitle_asset_id=subtitle_asset_id)
-    result = {"subtitle_asset_id": subtitle_asset_id, "status": "translated", "options": options or {}}
-    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result)
+    translated = "1\n00:00:00,000 --> 00:00:02,000\nTranslated placeholder\n"
+    asset = create_asset(kind="subtitle", mime_type="text/vtt", suffix=".vtt", contents=translated)
+    result = {"subtitle_asset_id": subtitle_asset_id, "status": "translated", "options": options or {}, "output_asset_id": str(asset.id)}
+    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result, output_asset_id=str(asset.id))
     _progress(self, "completed", 1.0, subtitle_asset_id=subtitle_asset_id)
     return result
 
@@ -114,14 +146,17 @@ def translate_subtitles(self, job_id: str, subtitle_asset_id: str, options: dict
 def render_styled_subtitles(self, job_id: str, video_asset_id: str, subtitle_asset_id: str, style: dict | None = None, options: dict | None = None) -> dict:
     update_job(job_id, status=JobStatus.running, progress=0.1)
     _progress(self, "started", 0.0, video_asset_id=video_asset_id, subtitle_asset_id=subtitle_asset_id)
+    rendered_marker = "styled-render-placeholder"
+    asset = create_asset(kind="video", mime_type="text/plain", suffix=".txt", contents=rendered_marker)
     result = {
         "video_asset_id": video_asset_id,
         "subtitle_asset_id": subtitle_asset_id,
         "style": style or {},
         "options": options or {},
         "status": "styled_render",
+        "output_asset_id": str(asset.id),
     }
-    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result)
+    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result, output_asset_id=str(asset.id))
     _progress(self, "completed", 1.0, video_asset_id=video_asset_id, subtitle_asset_id=subtitle_asset_id)
     return result
 
@@ -132,19 +167,29 @@ def generate_shorts(self, job_id: str, video_asset_id: str, options: dict | None
     _progress(self, "started", 0.0, video_asset_id=video_asset_id)
     clips = []
     max_clips = int(options.get("max_clips") or 3) if options else 3
+    min_dur = options.get("min_duration") if options else None
     for idx in range(max_clips):
+        clip_asset = create_asset(kind="video", mime_type="text/plain", suffix=".txt", contents=f"clip {idx+1} for {video_asset_id}")
         clips.append(
             {
                 "id": f"{job_id}-clip-{idx+1}",
-                "duration": options.get("min_duration") if options else None,
+                "asset_id": str(clip_asset.id),
+                "duration": min_dur,
                 "score": 0.5 + idx * 0.1,
-                "uri": None,
+                "uri": clip_asset.uri,
                 "subtitle_uri": None,
                 "thumbnail_uri": None,
             }
         )
-    result = {"video_asset_id": video_asset_id, "status": "shorts_generated", "options": options or {}, "clip_assets": clips}
-    update_job(job_id, status=JobStatus.completed, progress=1.0, payload={"clip_assets": clips, **(options or {})})
+    summary_asset = create_asset(kind="video", mime_type="text/plain", suffix=".txt", contents="shorts package placeholder")
+    result = {
+        "video_asset_id": video_asset_id,
+        "status": "shorts_generated",
+        "options": options or {},
+        "clip_assets": clips,
+        "output_asset_id": str(summary_asset.id),
+    }
+    update_job(job_id, status=JobStatus.completed, progress=1.0, payload={"clip_assets": clips, **(options or {})}, output_asset_id=str(summary_asset.id))
     _progress(self, "completed", 1.0, video_asset_id=video_asset_id)
     return result
 
@@ -153,13 +198,15 @@ def generate_shorts(self, job_id: str, video_asset_id: str, options: dict | None
 def merge_video_audio(self, job_id: str, video_asset_id: str, audio_asset_id: str, options: dict | None = None) -> dict:
     update_job(job_id, status=JobStatus.running, progress=0.1)
     _progress(self, "started", 0.0, video_asset_id=video_asset_id, audio_asset_id=audio_asset_id)
+    merged_asset = create_asset(kind="video", mime_type="text/plain", suffix=".txt", contents="merged av placeholder")
     result = {
         "video_asset_id": video_asset_id,
         "audio_asset_id": audio_asset_id,
         "options": options or {},
         "status": "merged",
+        "output_asset_id": str(merged_asset.id),
     }
-    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result)
+    update_job(job_id, status=JobStatus.completed, progress=1.0, payload=result, output_asset_id=str(merged_asset.id))
     _progress(self, "completed", 1.0, video_asset_id=video_asset_id, audio_asset_id=audio_asset_id)
     return result
 


### PR DESCRIPTION
- **Summary**
  - Enhance media probing and reframe blur handling, serve asset downloads, and have worker tasks create MediaAsset records with URIs for outputs and shorts clips.
- **Changes**
  - `probe_media` now parses ffprobe JSON and returns duration, codec, and resolution details; `reframe` supports a `blur_bg` strategy.
  - Added `/assets/{id}/download` to stream underlying files; worker tasks now create stub files and MediaAsset rows for transcribe/captions/translate/render/merge/shorts, wiring `output_asset_id` and clip URIs.
  - Updated video_edit ffmpeg tests for new probe response.
- **Testing**
  - Not run (not requested).
- **Risk & Impact**
  - Worker generates placeholder text assets in `/media/tmp`; adjust paths or MIME types later when real processing is wired.
- **Related TODO items**
  - [x] Return ffprobe metadata (duration/resolution/codec) from `probe_media` instead of path-only.
  - [x] Add `blur_bg` strategy to `reframe` for blurred letterboxing.
  - [x] Create real `MediaAsset` rows (and stub files) for worker outputs and attach to jobs/clip payloads.
  - [x] Add asset download endpoint that streams the underlying file (not just metadata).