### PR TITLE
feat: improve styling flow and shorts progress

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -224,6 +224,7 @@
 - [x] “Render full video” button -> create styled subtitle job and display/poll result asset (depends on backend producing asset).
 - [x] Show progress/status for styling jobs (polling, errors).
 - [ ] Auto-generate captions when absent and chain into styling; fetch/present preview/render assets reliably.
+- [x] Auto-generate captions when absent and chain into styling; fetch/present preview/render assets reliably.
 
 ---
 
@@ -239,7 +240,8 @@
   - [x] “Prompt to guide selection” textarea.
 - [ ] Submit:
   - [x] Create shorts job.
-  - [ ] Show a progress view with step-level feedback (beyond static steps list).
+- [ ] Show a progress view with step-level feedback (beyond static steps list).
+- [x] Show a progress view with dynamic step feedback (progress bar).
 - [ ] Result view:
   - [ ] Render real clip assets from backend (thumbnail/GIF, duration, score).
   - [ ] Enable per-clip download buttons (video + subtitles) when backend provides URIs.

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -229,6 +229,24 @@ h2, h3 { margin: 0; }
   border: 1px solid var(--border);
 }
 
+.progress-bar {
+  width: 100%;
+}
+
+.progress-track {
+  width: 100%;
+  height: 8px;
+  background: var(--panel-alt);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.progress-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-blue), var(--accent-coral));
+}
+
 .preset-list {
   list-style: none;
   margin: 0;


### PR DESCRIPTION
- **Summary**
  - Auto-generate captions when styling if no subtitles are provided, and poll translate jobs to surface download/preview assets automatically.
  - Add dynamic progress feedback for shorts jobs and a styled progress bar.
- **Changes**
  - Added helpers to generate captions on-demand for styling actions, wait for outputs, and reuse resulting subtitle assets; Style buttons now work without a pre-set subtitle id.
  - Translate jobs are tracked with polling and a download/preview panel.
  - Shorts progress card shows a progress bar using job.progress; added CSS for the bar.
  - TODO updated to reflect completed items.
- **Testing**
  - `cd apps/web && npm run build`
- **Risk & Impact**
  - Frontend-only changes; polling interval remains 5s.
- **Related TODO items**
  - [x] Auto-generate captions when absent and chain into styling; fetch/present preview/render assets reliably.
  - [x] Show a progress view with dynamic step feedback (progress bar).