### PR TITLE
fix: harden residual security findings in scripts and frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
   python:
     name: Python API & worker checks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Install ffmpeg
@@ -49,6 +51,8 @@ jobs:
   web:
     name: Web build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Set up Node

--- a/.github/workflows/desktop-release.yml
+++ b/.github/workflows/desktop-release.yml
@@ -39,7 +39,7 @@ jobs:
           cache-dependency-path: apps/desktop/package-lock.json
 
       - name: Install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7
         with:
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
@@ -55,7 +55,7 @@ jobs:
         run: npm ci
 
       - name: Build + upload release artifacts
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@73fb865345c54760d875b94642314f8c0c894afa
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}

--- a/TODO.md
+++ b/TODO.md
@@ -477,5 +477,8 @@ Goal: offer Reframe as a paid hosted service (multi-tenant web app) while keepin
 - [x] Add transcription input path guard and route CLI/backends through centralized validation.
 - [x] Replace iframe/window-open text preview flows with sanitized URL handling and text-only previews in web UI.
 - [x] Resolve active npm advisories in web/desktop lockfiles (rollup path traversal advisory).
+- [x] Dismiss legacy code-scanning alerts tied to archived `Inspirations & Former Attempts/` paths with documented rationale.
+- [x] Merge/clear active Dependabot security PR queue on maintained paths.
+- [ ] Fix remaining active-path CodeQL findings (currently concentrated in scripts + frontend preview sinks).
 - [ ] Validate that GitHub security alert counts converge to zero on `main` after post-merge re-analysis completes.
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1482,6 +1482,9 @@ function StyleEditor({
   };
   const outputAssetUrl = toSafeMediaHref(outputAsset?.uri);
   const subtitlePreviewUrl = toSafeUrl(subtitlePreview);
+  const safeUploadedPreview = toSafeUrl(uploadedPreview);
+  const safeMergeVideoPreview = toSafeUrl(mergeVideoPreview);
+  const safeMergeAudioPreview = toSafeUrl(mergeAudioPreview);
 
   const dismissQuickStart = () => {
     setShowQuickStart(false);
@@ -2154,8 +2157,8 @@ function StyleEditor({
 	        {active === "shorts" && (
 	          <section className="grid two-col">
             <Card title="Upload or link video">
-              <UploadPanel onAssetId={(id) => setUploadedVideoId(id)} onPreview={(url) => setUploadedPreview(url)} />
-              {uploadedPreview && <video className="preview" controls src={uploadedPreview} />}
+              <UploadPanel onAssetId={(id) => setUploadedVideoId(id)} onPreview={(url) => setUploadedPreview(toSafeUrl(url))} />
+              {safeUploadedPreview && <video className="preview" controls src={safeUploadedPreview} />}
             </Card>
             <Card title="Shorts maker">
               <ShortsForm
@@ -2461,8 +2464,8 @@ function StyleEditor({
         {active === "captions" && (
           <section className="grid two-col">
             <Card title="Upload video">
-              <UploadPanel onAssetId={(id) => setUploadedVideoId(id)} onPreview={(url) => setUploadedPreview(url)} />
-              {uploadedPreview && <video className="preview" controls src={uploadedPreview} />}
+              <UploadPanel onAssetId={(id) => setUploadedVideoId(id)} onPreview={(url) => setUploadedPreview(toSafeUrl(url))} />
+              {safeUploadedPreview && <video className="preview" controls src={safeUploadedPreview} />}
             </Card>
             <Card title="Captions & Translate">
               <p className="muted">Create caption jobs with backend/model and format options.</p>
@@ -2608,8 +2611,8 @@ function StyleEditor({
                 </Button>
                 {captionJob && <JobStatusPill status={captionJob.status} />}
               </div>
-              <UploadPanel onAssetId={(id) => setUploadedVideoId(id)} onPreview={(url) => setUploadedPreview(url)} />
-              {uploadedPreview && <video className="preview" controls src={uploadedPreview} />}
+              <UploadPanel onAssetId={(id) => setUploadedVideoId(id)} onPreview={(url) => setUploadedPreview(toSafeUrl(url))} />
+              {safeUploadedPreview && <video className="preview" controls src={safeUploadedPreview} />}
 	              {subtitlePreviewUrl && (
 	                <div className="output-card">
                     <TextPreview url={subtitlePreviewUrl} title={`Subtitle preview ${subtitleFileName ? `(${subtitleFileName})` : ""}`} />
@@ -2702,10 +2705,10 @@ function StyleEditor({
 
             <Card title="Video / Audio merge">
               <p className="muted">Merge audio into a video with optional offset, ducking, and normalization.</p>
-              <UploadPanel onAssetId={(id) => setMergeVideoId(id)} onPreview={(url) => setMergeVideoPreview(url)} />
-              {mergeVideoPreview && <video className="preview" controls src={mergeVideoPreview} />}
-              <AudioUploadPanel onAssetId={(id) => setMergeAudioId(id)} onPreview={(url) => setMergeAudioPreview(url)} />
-              {mergeAudioPreview && <audio controls src={mergeAudioPreview} />}
+              <UploadPanel onAssetId={(id) => setMergeVideoId(id)} onPreview={(url) => setMergeVideoPreview(toSafeUrl(url))} />
+              {safeMergeVideoPreview && <video className="preview" controls src={safeMergeVideoPreview} />}
+              <AudioUploadPanel onAssetId={(id) => setMergeAudioId(id)} onPreview={(url) => setMergeAudioPreview(toSafeUrl(url))} />
+              {safeMergeAudioPreview && <audio controls src={safeMergeAudioPreview} />}
               <MergeAvForm
                 onCreated={(job) => {
                   setMergeJob(job);

--- a/scripts/benchmark_diarization.py
+++ b/scripts/benchmark_diarization.py
@@ -44,7 +44,8 @@ def _extract_wav_16k_mono(input_path: Path, output_path: Path) -> None:
         "pcm_s16le",
         str(output_path),
     ]
-    subprocess.run(cmd, check=True, capture_output=True)
+    # Command is provided as an argv list (not shell-interpreted).
+    subprocess.run(cmd, check=True, capture_output=True, shell=False)
 
 
 def _get_peak_rss_mb() -> float:
@@ -54,6 +55,7 @@ def _get_peak_rss_mb() -> float:
 
 def main(argv: list[str]) -> int:
     repo_root = _ensure_repo_paths()
+    from media_core.transcribe.path_guard import validate_media_input_path
 
     parser = argparse.ArgumentParser(description="Benchmark diarization wall time and peak RSS.")
     parser.add_argument("input", help="Path to an audio/video file.")
@@ -81,9 +83,7 @@ def main(argv: list[str]) -> int:
     )
     args = parser.parse_args(argv)
 
-    input_path = Path(args.input)
-    if not input_path.is_file():
-        raise FileNotFoundError(input_path)
+    input_path = validate_media_input_path(args.input)
 
     backend_raw = str(args.backend or "pyannote").strip().lower()
     token = None

--- a/scripts/download_whispercpp_model.py
+++ b/scripts/download_whispercpp_model.py
@@ -3,11 +3,17 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import shutil
 import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
+
+from security_helpers import normalize_https_url
+
+
+ALLOWED_MODEL_HOSTS = {"huggingface.co", "www.huggingface.co"}
 
 
 def _default_output_dir() -> Path:
@@ -34,6 +40,9 @@ def _normalize_filename(model: str) -> str:
         name = f"{name}.bin"
     if not name.startswith("ggml-"):
         name = f"ggml-{name}"
+    name = Path(name).name
+    if not re.fullmatch(r"[A-Za-z0-9._-]+", name):
+        raise ValueError(f"Model filename contains unsupported characters: {model!r}")
     return name
 
 
@@ -50,6 +59,12 @@ def _download(url: str, dest_path: Path) -> None:
         raise RuntimeError(f"Failed to download {url}: {exc}") from exc
 
     tmp_path.replace(dest_path)
+
+
+def _resolve_output_dir(raw_output_dir: str) -> Path:
+    if raw_output_dir:
+        return Path(raw_output_dir).expanduser().resolve(strict=False)
+    return _default_output_dir().expanduser().resolve(strict=False)
 
 
 def main(argv: list[str]) -> int:
@@ -69,15 +84,21 @@ def main(argv: list[str]) -> int:
     parser.add_argument(
         "--base-url",
         default="https://huggingface.co/ggerganov/whisper.cpp/resolve/main",
-        help="Base URL for model downloads. Default: %(default)s",
+        help="Base URL for model downloads. Must be HTTPS and hosted on Hugging Face. Default: %(default)s",
     )
     parser.add_argument("--force", action="store_true", help="Re-download even if the file already exists.")
     args = parser.parse_args(argv)
 
-    filename = _normalize_filename(args.model)
-    output_dir = Path(args.output_dir) if args.output_dir else _default_output_dir()
+    try:
+        filename = _normalize_filename(args.model)
+        output_dir = _resolve_output_dir(args.output_dir)
+        base_url = normalize_https_url(args.base_url, allowed_hosts=ALLOWED_MODEL_HOSTS)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 2
+
     dest_path = output_dir / filename
-    url = f"{args.base_url.rstrip('/')}/{filename}"
+    url = f"{base_url.rstrip('/')}/{filename}"
 
     if dest_path.exists() and not args.force:
         print(f"Already present: {dest_path}")
@@ -102,4 +123,3 @@ def main(argv: list[str]) -> int:
 
 if __name__ == "__main__":
     raise SystemExit(main(sys.argv[1:]))
-

--- a/scripts/security_helpers.py
+++ b/scripts/security_helpers.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import ipaddress
+from urllib.parse import urlparse, urlunparse
+
+
+def normalize_https_url(raw_url: str, *, allowed_hosts: set[str] | None = None) -> str:
+    """Validate user-provided URLs for CLI scripts.
+
+    Rules:
+    - https scheme only,
+    - no embedded credentials,
+    - reject localhost/private/link-local IP targets,
+    - optional hostname allowlist.
+    """
+
+    parsed = urlparse((raw_url or "").strip())
+    if parsed.scheme != "https":
+        raise ValueError(f"Only https URLs are allowed: {raw_url!r}")
+    if not parsed.hostname:
+        raise ValueError(f"URL is missing a hostname: {raw_url!r}")
+    if parsed.username or parsed.password:
+        raise ValueError(f"URL credentials are not allowed: {raw_url!r}")
+
+    hostname = parsed.hostname.lower().strip(".")
+    if allowed_hosts is not None and hostname not in {host.lower().strip(".") for host in allowed_hosts}:
+        raise ValueError(f"URL host is not in allowlist: {hostname}")
+
+    try:
+        ip_value = ipaddress.ip_address(hostname)
+    except ValueError:
+        ip_value = None
+
+    if ip_value is not None and (
+        ip_value.is_private
+        or ip_value.is_loopback
+        or ip_value.is_link_local
+        or ip_value.is_reserved
+        or ip_value.is_multicast
+    ):
+        raise ValueError(f"Private or local addresses are not allowed: {hostname}")
+
+    if hostname in {"localhost", "localhost.localdomain"}:
+        raise ValueError("Localhost URLs are not allowed.")
+
+    sanitized = parsed._replace(fragment="", params="", query="")
+    return urlunparse(sanitized)

--- a/scripts/verify_desktop_updater_release.py
+++ b/scripts/verify_desktop_updater_release.py
@@ -8,18 +8,22 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+from security_helpers import normalize_https_url
+
 
 DEFAULT_CONFIG_PATH = Path("apps/desktop/src-tauri/tauri.conf.json")
 
 
 def _fetch_bytes(url: str) -> bytes:
-    request = urllib.request.Request(url, headers={"User-Agent": "reframe-updater-verify"})
+    safe_url = normalize_https_url(url)
+    request = urllib.request.Request(safe_url, headers={"User-Agent": "reframe-updater-verify"})
     with urllib.request.urlopen(request, timeout=30) as response:
         return response.read()
 
 
 def _head(url: str) -> int:
-    request = urllib.request.Request(url, method="HEAD", headers={"User-Agent": "reframe-updater-verify"})
+    safe_url = normalize_https_url(url)
+    request = urllib.request.Request(safe_url, method="HEAD", headers={"User-Agent": "reframe-updater-verify"})
     with urllib.request.urlopen(request, timeout=30) as response:
         return getattr(response, "status", 200)
 
@@ -31,7 +35,7 @@ def _load_default_endpoint(config_path: Path) -> str:
         raise ValueError(f"No updater endpoints found in {config_path}")
     if not isinstance(endpoints[0], str) or not endpoints[0]:
         raise ValueError(f"Invalid updater endpoint: {endpoints[0]!r}")
-    return endpoints[0]
+    return normalize_https_url(endpoints[0])
 
 
 def _require_field(obj: dict, key: str) -> str:
@@ -53,6 +57,8 @@ def main(argv: list[str]) -> int:
         if not config_path.is_file():
             raise FileNotFoundError(config_path)
         endpoint = _load_default_endpoint(config_path)
+    else:
+        endpoint = normalize_https_url(endpoint)
 
     print(f"Fetching updater JSON: {endpoint}")
     latest_bytes = _fetch_bytes(endpoint)
@@ -75,7 +81,7 @@ def main(argv: list[str]) -> int:
             failures.append(f"{platform_key}: invalid platform object: {platform_meta!r}")
             continue
         try:
-            url = _require_field(platform_meta, "url")
+            url = normalize_https_url(_require_field(platform_meta, "url"))
             signature = _require_field(platform_meta, "signature")
             if len(signature) < 20:
                 failures.append(f"{platform_key}: signature looks too short")
@@ -106,4 +112,3 @@ if __name__ == "__main__":
     except urllib.error.URLError as exc:
         print(f"Network error: {exc.reason}", file=sys.stderr)
         raise SystemExit(2)
-


### PR DESCRIPTION
## Summary
This PR addresses a second batch of active-path security findings after the archive-path cleanup. It hardens URL handling in frontend preview sinks and operational scripts, and tightens GitHub Actions workflow hygiene.

## Changes
- Web UI hardening:
  - sanitize uploaded/media preview URLs before rendering `<video>`/`<audio>` sources in `apps/web/src/App.tsx`.
- Script/network hardening:
  - added `scripts/security_helpers.py` with `normalize_https_url` (https-only, no creds, no localhost/private IPs, optional host allowlist).
  - wired URL validation into:
    - `scripts/verify_desktop_updater_release.py`
    - `scripts/download_whispercpp_model.py` (plus model filename sanitization)
  - improved benchmark input handling in `scripts/benchmark_diarization.py` by reusing centralized media path validation and explicit non-shell subprocess execution.
- Workflow hardening:
  - added per-job `permissions: contents: read` in `.github/workflows/ci.yml`.
  - pinned unpinned desktop release actions to immutable SHAs in `.github/workflows/desktop-release.yml`.
- Backlog update:
  - updated `TODO.md` section `24. Security Hardening & Supply Chain Baseline` with completed archive-dismissal/dependabot-queue steps and remaining active-path CodeQL follow-ups.

## Testing
- Python:
  - `PYTHONPATH=.:apps/api:packages/media-core/src .venv/bin/python -m pytest -s apps/api/tests services/worker packages/media-core/tests -k 'not system_status'`
  - Result: `62 passed, 6 skipped, 1 deselected`.
- Web:
  - `cd apps/web && npm test` -> `18 passed`.
  - `cd apps/web && npm run build` -> success.

## Risk & Impact
- No intentional API contract changes.
- Changes in scripts are stricter by design (invalid/non-HTTPS/local URLs now fail fast).
- Desktop release workflow now uses immutable action SHAs, reducing supply-chain tag drift risk.

## Related TODO items
- [x] Dismiss legacy code-scanning alerts tied to archived `Inspirations & Former Attempts/` paths with documented rationale.
- [x] Merge/clear active Dependabot security PR queue on maintained paths.
- [ ] Fix remaining active-path CodeQL findings (currently concentrated in scripts + frontend preview sinks).
- [ ] Validate that GitHub security alert counts converge to zero on `main` after post-merge re-analysis completes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow permissions structure
  * Pinned desktop release workflow action versions
  * Updated project roadmap with security alert status

* **Bug Fixes**
  * Enhanced URL validation and sanitization across scripts
  * Improved input path validation in benchmark tool
  * Added safety wrappers for preview URLs in web app
  * Strengthened validation and error handling in model download script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->