### PR TITLE
chore(ci): refresh strict preflight canonical fallback contexts

### DIFF
--- a/apps/api/tests/test_scripts_strict23_preflight.py
+++ b/apps/api/tests/test_scripts_strict23_preflight.py
@@ -142,3 +142,21 @@ def test_main_missing_token_is_inconclusive_permissions(tmp_path, monkeypatch):
     _expect(payload["required_contexts"] == ["CodeQL"], "Expected required contexts resolved from policy")
     _expect(payload["optional_contexts"] == ["DeepScan"], "Expected optional contexts resolved from policy")
     _expect("Status: `inconclusive_permissions`" in markdown, "Expected inconclusive status in markdown output")
+
+
+def test_default_canonical_contexts_drop_vercel_and_include_current_core_checks():
+    module = _load_module()
+    defaults = module.DEFAULT_CANONICAL_CONTEXTS
+
+    _expect("Vercel" not in defaults, "Vercel should not be part of strict canonical fallback contexts")
+    _expect(
+        "Vercel Preview Comments" not in defaults,
+        "Vercel Preview Comments should not be part of strict canonical fallback contexts",
+    )
+    _expect("Analyze (actions)" in defaults, "Expected Analyze (actions) in strict canonical fallback contexts")
+    _expect(
+        "Analyze (javascript-typescript)" in defaults,
+        "Expected Analyze (javascript-typescript) in strict canonical fallback contexts",
+    )
+    _expect("Analyze (python)" in defaults, "Expected Analyze (python) in strict canonical fallback contexts")
+    _expect("SonarCloud Code Analysis" in defaults, "Expected SonarCloud Code Analysis in strict canonical fallback contexts")

--- a/scripts/strict23_preflight.py
+++ b/scripts/strict23_preflight.py
@@ -23,6 +23,9 @@ DEFAULT_CANONICAL_CONTEXTS = [
     "coverage",
     "CodeQL",
     "codecov-analytics",
+    "Analyze (actions)",
+    "Analyze (javascript-typescript)",
+    "Analyze (python)",
     "CodeRabbit",
     "dependency-review",
     "compose-smoke",
@@ -31,8 +34,7 @@ DEFAULT_CANONICAL_CONTEXTS = [
     "codacy-equivalent-zero",
     "sonar-branch-zero",
     "Seer Code Review",
-    "Vercel",
-    "Vercel Preview Comments",
+    "SonarCloud Code Analysis",
 ]
 
 


### PR DESCRIPTION
## Summary
- supersedes #97 from a clean current-main base
- keeps only strict-preflight fallback context updates (no stale policy/artifact rewrites)
- drops Vercel/Vercel Preview fallback contexts
- adds Analyze (actions/js/python) and SonarCloud fallback contexts
- adds regression test coverage for fallback context inventory

## Local verification
- `/home/prekzursil/Reframe/.venv/bin/python -m pytest apps/api/tests/test_scripts_strict23_preflight.py -q -s`
- result: `6 passed`

## Supersedes
- #97
