### PR TITLE
chore(desktop): prepare v0.1.8 test prerelease

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reframe-desktop",
   "private": true,
-  "version": "0.1.7",
+  "version": "0.1.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Reframe",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "identifier": "com.reframe.reframe",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary
- bump desktop version to `0.1.8` in package + Tauri config
- prepare tag-driven desktop release assets for Windows EXE/MSI testing

## Verification
- `cd apps/desktop && npm ci`
- `cd apps/desktop && npm run build`

## Release intent
After merge, tag `desktop-v0.1.8` to trigger the Desktop Release workflow and then mark the GitHub release as prerelease for testing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Desktop application version bumped from 0.1.7 to 0.1.8

<!-- end of auto-generated comment: release notes by coderabbit.ai -->