### PR TITLE
docs(desktop): add v0.1.8 release evidence and QA sheet

### DIFF
--- a/docs/plans/2026-03-03-desktop-v0.1.8-release-evidence.md
+++ b/docs/plans/2026-03-03-desktop-v0.1.8-release-evidence.md
@@ -1,0 +1,44 @@
+# Desktop v0.1.8 Test Prerelease Evidence (2026-03-03)
+
+## Release metadata
+- tag: `desktop-v0.1.8`
+- release url: https://github.com/Prekzursil/Reframe/releases/tag/desktop-v0.1.8
+- published_at_utc: `2026-03-03T00:41:30Z`
+- prerelease: `true`
+
+## Desktop Release workflow evidence
+- workflow run: https://github.com/Prekzursil/Reframe/actions/runs/22602528982
+- workflow status: `completed`
+- workflow conclusion: `success`
+- run window: `2026-03-03T00:35:39Z` -> `2026-03-03T00:42:39Z`
+
+Per-platform publish jobs:
+- macOS aarch64: https://github.com/Prekzursil/Reframe/actions/runs/22602528982/job/65487427346 (`success`)
+- macOS x64: https://github.com/Prekzursil/Reframe/actions/runs/22602528982/job/65487427353 (`success`)
+- Windows x64: https://github.com/Prekzursil/Reframe/actions/runs/22602528982/job/65487427368 (`success`)
+- Linux x64: https://github.com/Prekzursil/Reframe/actions/runs/22602528982/job/65487427374 (`success`)
+
+## Windows installer artifacts
+- EXE: https://github.com/Prekzursil/Reframe/releases/download/desktop-v0.1.8/Reframe_0.1.8_x64-setup.exe
+- MSI: https://github.com/Prekzursil/Reframe/releases/download/desktop-v0.1.8/Reframe_0.1.8_x64_en-US.msi
+
+## Updater manifest verification
+Command:
+
+```bash
+python3 scripts/verify_desktop_updater_release.py
+```
+
+Observed output summary:
+- endpoint checked: `https://github.com/Prekzursil/Reframe/releases/latest/download/latest.json`
+- resolved version: `0.1.7`
+- validation result: `OK`
+
+Important note:
+- `desktop-v0.1.8` is intentionally marked as a **prerelease** for testing.
+- GitHub's `releases/latest` endpoint resolves to the latest non-prerelease release, so updater validation still resolves to `0.1.7` while `0.1.8` remains prerelease.
+- This is expected behavior and does not block direct EXE/MSI testing of `0.1.8`.
+
+## Test handoff
+Use the EXE above for hands-on QA and record findings in:
+- `docs/plans/2026-03-03-windows-desktop-polish-findings.md`

--- a/docs/plans/2026-03-03-windows-desktop-polish-findings.md
+++ b/docs/plans/2026-03-03-windows-desktop-polish-findings.md
@@ -1,0 +1,51 @@
+# Windows Desktop Polish Findings (v0.1.8)
+
+## Build under test
+- desktop tag: `desktop-v0.1.8`
+- EXE: https://github.com/Prekzursil/Reframe/releases/download/desktop-v0.1.8/Reframe_0.1.8_x64-setup.exe
+- MSI: https://github.com/Prekzursil/Reframe/releases/download/desktop-v0.1.8/Reframe_0.1.8_x64_en-US.msi
+- release page: https://github.com/Prekzursil/Reframe/releases/tag/desktop-v0.1.8
+
+## Environment
+- OS/version:
+- GPU/CPU:
+- Docker Desktop version:
+- ffmpeg availability shown in desktop diagnostics:
+
+## Objective run log
+- install method used: `EXE` or `MSI`
+- app version shown in desktop UI:
+- stack start result (`Start stack (build)`):
+- `Open UI` result:
+
+### Functional scenario outputs
+- captions job id:
+- captions duration/runtime:
+- caption output assets generated (`.srt/.vtt/.ass`):
+- translate subtitles job id:
+- translation target language(s):
+- shorts job id:
+- shorts runtime:
+- clip count generated:
+- styled subtitle render job id (optional):
+- retry attempts needed (if any):
+- output download integrity check:
+
+## Subjective quality notes
+- segment relevance quality:
+- caption timing/accuracy quality:
+- subtitle readability/style quality:
+- UX friction points:
+
+## Triage
+### Blocking defects
+- [ ]
+
+### Medium UX issues
+- [ ]
+
+### Polish improvements
+- [ ]
+
+## Follow-up issues
+List created GitHub issues with reproducible steps and expected vs actual behavior.


### PR DESCRIPTION
## Summary
- add `2026-03-03-desktop-v0.1.8-release-evidence.md` with Desktop Release run/result and Windows artifact links
- add `2026-03-03-windows-desktop-polish-findings.md` as the structured extended QA capture sheet
- document prerelease/latest-manifest behavior for `desktop-v0.1.8`

## Verification
- `gh run view 22602528982` (Desktop Release success)
- `gh release view desktop-v0.1.8` (Windows EXE/MSI present, prerelease=true)
- `python3 scripts/verify_desktop_updater_release.py` (latest manifest currently resolves to 0.1.7 as expected for prerelease state)
