### PR TITLE
fix(deps): modernize chatterbox voice-clone env to py3.14 + torch 2.10.0 (cu128) — clears torch alerts

### DIFF
--- a/build/python-embed-setup.ps1
+++ b/build/python-embed-setup.ps1
@@ -3,9 +3,12 @@
 # *** NETWORK SCRIPT — run MANUALLY at build prep, never from an agent session ***
 #
 # Stages the extraResources inputs electron-builder.yml expects:
-#   build/python-embed/   embeddable CPython 3.12 (+ a staged get-pip.py so the
-#                         first-run bootstrap works offline-after-install)
-#   build/ffmpeg/         ffmpeg.exe + ffprobe.exe   (with -WithFfmpeg)
+#   build/python-embed/      embeddable CPython 3.12 (+ a staged get-pip.py so the
+#                            first-run bootstrap works offline-after-install)
+#   build/python-embed-314/  embeddable CPython 3.14 (+ get-pip.py) — the DEDICATED
+#                            interpreter for the ISOLATED chatterbox voice-clone env
+#                            (torch 2.10 only resolves on py3.14; CONTRACTS.md A4)
+#   build/ffmpeg/            ffmpeg.exe + ffprobe.exe   (with -WithFfmpeg)
 #
 # Everything downloaded is PINNED by exact URL (A6 lesson 5). SHA-256 of each
 # download is printed (and optionally enforced) so the pins can be hardened:
@@ -13,12 +16,21 @@
 #
 # CONTRACT-NOTE: 3.12.10 is the FINAL 3.12 release that ships Windows binaries
 # (the branch is security-only afterwards) — the highest pinnable embed zip.
+# The chatterbox env needs py3.14 because chatterbox-tts 0.1.7 only accepts
+# torch>=2.9.0 (we pin 2.10.0) on python_version>="3.14"; py3.14 also ships a
+# Windows embed-amd64.zip (same URL shape as 3.12). The chatterbox embed's
+# python314._pth is left AS SHIPPED: that env is consumed purely via
+# PYTHONPATH/--target (never ._pth activation — it is not the sidecar runtime).
 
 [CmdletBinding()]
 param(
     [string]$PythonVersion = '3.12.10',
     [string]$Dest = (Join-Path $PSScriptRoot 'python-embed'),
     [string]$ExpectedPythonSha256 = '',   # fill in after the first verified run
+    # The dedicated py3.14 embed for the isolated chatterbox env (A4).
+    [string]$ChatterboxPythonVersion = '3.14.0',  # human pins the exact patch on first verified run
+    [string]$ChatterboxDest = (Join-Path $PSScriptRoot 'python-embed-314'),
+    [string]$ExpectedChatterboxPythonSha256 = '',  # fill in after the first verified run
     [switch]$WithFfmpeg,
     # Pinned ffmpeg build (gyan.dev essentials; ~80 MB zip). Verify on first run.
     [string]$FfmpegUrl = 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.1.1-essentials_build.zip',
@@ -71,6 +83,32 @@ try {
         Get-Download -Url $GetPipUrl -OutFile $getPip -ExpectedSha256 ''
     }
 
+    # -- dedicated embeddable CPython 3.14 (chatterbox env, A4) -----------------
+    if ((Test-Path (Join-Path $ChatterboxDest 'python.exe')) -and -not $Force) {
+        Write-Host "[embed-setup] $ChatterboxDest already staged (use -Force to redo)"
+    } else {
+        $cbUrl = "https://www.python.org/ftp/python/$ChatterboxPythonVersion/python-$ChatterboxPythonVersion-embed-amd64.zip"
+        $cbZip = Join-Path ([IO.Path]::GetTempPath()) "python-$ChatterboxPythonVersion-embed-amd64.zip"
+        Get-Download -Url $cbUrl -OutFile $cbZip -ExpectedSha256 $ExpectedChatterboxPythonSha256
+        if (Test-Path $ChatterboxDest) { Remove-Item $ChatterboxDest -Recurse -Force }
+        New-Item -ItemType Directory -Force -Path $ChatterboxDest | Out-Null
+        Expand-Archive -Path $cbZip -DestinationPath $ChatterboxDest -Force
+        Remove-Item $cbZip -Force
+        if (-not (Test-Path (Join-Path $ChatterboxDest 'python.exe'))) {
+            throw "chatterbox embed zip extracted but python.exe is missing in $ChatterboxDest"
+        }
+        # NOTE: python314._pth left AS SHIPPED — the chatterbox env is consumed via
+        # PYTHONPATH/--target only (never ._pth activation; it is not the runtime).
+    }
+
+    # -- staged get-pip.py beside the py3.14 embed (no ensurepip there either) --
+    $cbGetPip = Join-Path $ChatterboxDest 'get-pip.py'
+    if ((Test-Path $cbGetPip) -and -not $Force) {
+        Write-Host "[embed-setup] chatterbox get-pip.py already staged"
+    } else {
+        Get-Download -Url $GetPipUrl -OutFile $cbGetPip -ExpectedSha256 ''
+    }
+
     # -- ffmpeg/ffprobe ----------------------------------------------------------
     if ($WithFfmpeg) {
         if ((Test-Path (Join-Path $FfmpegDest 'ffmpeg.exe')) -and -not $Force) {
@@ -97,7 +135,7 @@ try {
         }
     }
 
-    Write-Host "SUCCESS:python-embed-setup staged python-embed$(if ($WithFfmpeg) { ' + ffmpeg' })"
+    Write-Host "SUCCESS:python-embed-setup staged python-embed + python-embed-314$(if ($WithFfmpeg) { ' + ffmpeg' })"
     exit 0
 } catch {
     Write-Host "FAILED:python-embed-setup $($_.Exception.Message)"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -56,6 +56,11 @@ extraResources:
   # Embeddable CPython 3.12 (+ staged get-pip.py) — build/python-embed-setup.ps1
   - from: ../build/python-embed
     to: python
+  # Dedicated embeddable CPython 3.14 (+ staged get-pip.py) for the ISOLATED
+  # chatterbox voice-clone env — torch 2.10 only resolves on py3.14 (A4).
+  # ChatterboxEngine + bootstrap resolve <resources>/python-chatterbox/python.exe.
+  - from: ../build/python-embed-314
+    to: python-chatterbox
   # Bundled ffmpeg/ffprobe — resolved by ffmpeg.py via MEDIA_STUDIO_FFMPEG/FFPROBE
   # env injected by the supervisor (WIRING-T5.md) — build/python-embed-setup.ps1
   - from: ../build/ffmpeg

--- a/sidecar/media_studio/assets/manager.py
+++ b/sidecar/media_studio/assets/manager.py
@@ -323,6 +323,7 @@ class AssetManager:
         run_cmd: RunCmd | None = None,
         hf_fetch: HfFetch | None = None,
         python_exe: str | None = None,
+        chatterbox_python: Callable[[], str | None] | None = None,
         usage: Callable[[str], Any] | None = None,
         env_vars: Mapping[str, str] | None = None,
     ) -> None:
@@ -332,6 +333,10 @@ class AssetManager:
         self._run_cmd: RunCmd = run_cmd or _default_run_cmd
         self._hf_fetch: HfFetch = hf_fetch or _default_hf_fetch
         self._python_exe = python_exe or sys.executable
+        # Resolver for the dedicated py3.14 chatterbox interpreter; bound lazily
+        # in _install_env (to chatterbox.default_chatterbox_python) to avoid an
+        # import cycle (chatterbox imports assets.manifest). Tests inject a fake.
+        self._chatterbox_python = chatterbox_python
         self._usage = usage or shutil.disk_usage
         self._env_vars = env_vars
 
@@ -567,16 +572,37 @@ class AssetManager:
         log.info("hf snapshot for %s at %s", entry.name, path)
         on_frac(1.0, f"{entry.name}: downloaded")
 
+    def _resolve_env_python(self, entry: AssetEntry) -> str:
+        """The interpreter that installs ``entry`` (A7+ per-entry selection).
+
+        ``python_kind="chatterbox"`` routes to the dedicated py3.14 embeddable
+        (the only interpreter ``torch==2.10`` resolves under); anything else —
+        and a chatterbox entry on a box where that embed is not staged — falls
+        back to the manager-wide host python (an honest degradation: pip then
+        fails to resolve torch 2.10 under py3.12 and the env never registers).
+        """
+        if entry.python_kind == "chatterbox":
+            resolver = self._chatterbox_python
+            if resolver is None:
+                from ..features.tts.chatterbox import default_chatterbox_python  # noqa: PLC0415 - avoid cycle
+
+                resolver = default_chatterbox_python
+            return resolver() or self._python_exe
+        return self._python_exe
+
     def _install_env(self, entry: AssetEntry, *, on_frac: FracCb, should_cancel: CancelProbe) -> None:
         """Bootstrap a ``pip --target`` env under the assets root (A7).
 
         get-pip.py is fetched once (cached under ``<root>/tools/``), then the
         two pinned argv steps from :func:`build_env_install_argvs` run through
         the drained-subprocess seam. A success sentinel records the pins so
-        ``installed`` flips false again if the requirements change.
+        ``installed`` flips false again if the requirements change. The
+        interpreter is chosen per-entry via :meth:`_resolve_env_python` so the
+        chatterbox env installs with its dedicated py3.14 embeddable.
         """
         env_dir = self.resolve_dest(entry)
         env_dir.mkdir(parents=True, exist_ok=True)
+        python_exe = self._resolve_env_python(entry)
         get_pip = self.root / "tools" / "get-pip.py"
         if not get_pip.is_file():
             on_frac(0.01, f"{entry.name}: fetching get-pip.py")
@@ -587,7 +613,7 @@ class AssetManager:
                 should_cancel=should_cancel,
                 label="get-pip.py",
             )
-        steps = build_env_install_argvs(self._python_exe, get_pip, env_dir, entry.requirements)
+        steps = build_env_install_argvs(python_exe, get_pip, env_dir, entry.requirements)
         for index, step in enumerate(steps):
             if should_cancel():
                 raise JobCancelled(entry.name)

--- a/sidecar/media_studio/assets/manifest.py
+++ b/sidecar/media_studio/assets/manifest.py
@@ -44,6 +44,13 @@ ASSET_KINDS: tuple[str, ...] = ("model", "env", "tool")
 #   "env"      — bootstrap a pip --target env under <root>/envs/<dest> (A7)
 INSTALLERS: tuple[str, ...] = ("download", "hf", "env")
 
+# Which interpreter an installer="env" entry installs with (the manager resolves
+# the marker to a concrete python). "host" = the manager-wide python (the py3.12
+# sidecar interpreter); "chatterbox" = the dedicated py3.14 embeddable (torch
+# 2.10 only resolves there). Paths are per-machine, so entries carry the MARKER,
+# never an absolute interpreter path.
+PYTHON_KINDS: tuple[str, ...] = ("host", "chatterbox")
+
 # A settings-driven existing-path probe: (settings dict) -> existing path | None.
 # Lets an entry count as installed when the user already has the artifact
 # somewhere else (e.g. the Qwen GGUF named by settings.ggufPath/modelsDir).
@@ -74,6 +81,9 @@ class AssetEntry:
     hf_revision: str | None = None
     # installer="env": PINNED "pkg==ver" requirement strings (A6 lesson 5).
     requirements: tuple[str, ...] = ()
+    # installer="env": which interpreter to install with (see PYTHON_KINDS).
+    # Default "host"; "chatterbox" routes to the dedicated py3.14 embeddable.
+    python_kind: str = "host"
     # Optional settings-driven probe for a pre-existing copy elsewhere.
     detect: DetectFn | None = field(default=None, compare=False)
 
@@ -86,6 +96,10 @@ class AssetEntry:
             raise ValueError(f"asset {self.name!r}: installer must be one of {INSTALLERS}, got {self.installer!r}")
         if not isinstance(self.size_mb, (int, float)) or self.size_mb < 0:
             raise ValueError(f"asset {self.name!r}: size_mb must be a number >= 0")
+        if self.python_kind not in PYTHON_KINDS:
+            raise ValueError(
+                f"asset {self.name!r}: python_kind must be one of {PYTHON_KINDS}, got {self.python_kind!r}"
+            )
         # Normalize requirements to a tuple (frozen dataclass => object.__setattr__).
         object.__setattr__(self, "requirements", tuple(self.requirements or ()))
         if self.installer == "download":

--- a/sidecar/media_studio/features/tts/chatterbox.py
+++ b/sidecar/media_studio/features/tts/chatterbox.py
@@ -17,11 +17,23 @@ env (A6 lesson 5). So this engine never imports it: synthesis is a
   internally — A6 lesson 2) and the call is an argv LIST (lesson 4).
 
 CONTRACT-NOTE (CUDA12 wheels): the manifest validator requires ``pkg==ver``
-pins; the ``+cu124`` local-version pins below satisfy that, but pip can only
+pins; the ``+cu128`` local-version pins below satisfy that, but pip can only
 resolve them with the PyTorch index available — the env install step needs
-``PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu124`` in the
+``PIP_EXTRA_INDEX_URL=https://download.pytorch.org/whl/cu128`` in the
 process environment (the assets manager inherits ``os.environ``). See
 WIRING-T2.md for where the wiring agent sets it.
+
+CONTRACT-NOTE (dedicated Python 3.14 interpreter): chatterbox-tts 0.1.7 pins
+``torch==2.6.0`` for ``python_version<"3.14"`` and ``torch>=2.9.0`` for
+``python_version>="3.14"``. The main sidecar env is LOCKED to py3.12
+(kokoro-onnx needs <3.14), so ``torch==2.10.0`` is only HONESTLY installable
+on its own py3.14 interpreter. A second embeddable CPython 3.14 is staged at
+build prep (``build/python-embed-setup.ps1`` -> ``build/python-embed-314`` ->
+shipped to ``<resources>/python-chatterbox``); :func:`default_chatterbox_python`
+locates it at runtime and the engine runs the runner with THAT python (not
+``sys.executable``). Without the second interpreter, pinning torch 2.10 would
+be a manifest lie: pip would refuse to resolve it against chatterbox-tts's
+``torch==2.6.0`` py<3.14 constraint.
 
 CONTRACT-NOTE (voice): for a voice-clone engine the A4 ``voice`` parameter is
 the REFERENCE SAMPLE's wav path (``tts.dub.start``'s ``sampleId`` resolves to
@@ -52,18 +64,47 @@ log = get_logger("media_studio.tts.chatterbox")
 # --------------------------------------------------------------------------- #
 CHATTERBOX_ENV_ASSET = "chatterbox-env"
 CHATTERBOX_ENV_DEST = "envs/chatterbox"
-CHATTERBOX_ENV_SIZE_MB = 6500
+# Disk-preflight headroom only (NOT a correctness pin): torch 2.10 cu128 wheels
+# are materially larger than the old 2.6 cu124 pair. Conservative bump from
+# 6500; human confirms against the real on-disk env size on first GPU install.
+CHATTERBOX_ENV_SIZE_MB = 7500
 # PINNED requirements (manifest rejects loose specifiers). torch/torchaudio
-# carry the cu124 local version — CUDA 12 wheels off download.pytorch.org
-# (PIP_EXTRA_INDEX_URL needed at install time; see module docstring).
+# carry the cu128 local version — CUDA 12.8 wheels off download.pytorch.org
+# (PIP_EXTRA_INDEX_URL needed at install time; see module docstring). torch
+# 2.10.0 is only resolvable under the dedicated py3.14 interpreter (chatterbox
+# -tts 0.1.7 pins torch>=2.9.0 only for python_version>="3.14").
 CHATTERBOX_REQUIREMENTS: tuple[str, ...] = (
-    "chatterbox-tts==0.1.2",
-    "torch==2.6.0+cu124",
-    "torchaudio==2.6.0+cu124",
+    "chatterbox-tts==0.1.7",
+    "torch==2.10.0+cu128",
+    "torchaudio==2.10.0+cu128",
 )
-#: the index pip needs for the +cu124 wheels (wiring sets it; kept here so
+#: the index pip needs for the +cu128 wheels (wiring sets it; kept here so
 #: the value is pinned next to the requirements it serves).
-TORCH_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu124"
+TORCH_EXTRA_INDEX_URL = "https://download.pytorch.org/whl/cu128"
+
+#: the extraResources ``to:`` target for the staged py3.14 embeddable (a
+#: SIBLING of the py3.12 embed dir under the packaged resources root). Kept in
+#: sync with runtime_setup.bootstrap.CHATTERBOX_EMBED_DIRNAME the same way the
+#: requirements tuple mirrors requirements-chatterbox.txt.
+CHATTERBOX_PYTHON_SUBDIR = "python-chatterbox"
+
+
+def default_chatterbox_python(resources_dir: str | None = None) -> str | None:
+    """Locate the dedicated py3.14 embeddable's ``python.exe``, or ``None``.
+
+    The py3.12 sidecar embed ships at ``<resources>/python/`` and the py3.14
+    chatterbox embed at the sibling ``<resources>/python-chatterbox/`` (the
+    ``electron-builder.yml`` ``to:`` targets). At runtime the resources root is
+    derived from the RUNNING interpreter's location
+    (``Path(sys.executable).parent.parent`` — the embed dir's parent), so this
+    has no import dependency on the packaging-layer ``runtime_setup`` module.
+
+    Returns the resolved path when the second embed is staged, else ``None``
+    (a dev box without it degrades to ``sys.executable`` — see ``__init__``).
+    """
+    base = Path(resources_dir) if resources_dir is not None else Path(sys.executable).parent.parent
+    candidate = base / CHATTERBOX_PYTHON_SUBDIR / "python.exe"
+    return str(candidate) if candidate.is_file() else None
 
 
 def _register_assets() -> None:
@@ -76,6 +117,9 @@ def _register_assets() -> None:
             label="Chatterbox voice-clone env (torch CUDA12, isolated)",
             installer="env",
             requirements=CHATTERBOX_REQUIREMENTS,
+            # A7+: this env installs with the dedicated py3.14 interpreter (the
+            # only one torch 2.10 resolves under), NOT the host py3.12.
+            python_kind="chatterbox",
         )
     )
 
@@ -178,9 +222,12 @@ class ChatterboxEngine(TtsEngine):
         assets_root: str | None = None,
     ) -> None:
         self.env_dir = env_dir or default_env_dir(assets_root)
-        # A7: the isolated env is pip --target packages run by the HOST
-        # python with PYTHONPATH pointing in — there is no second python.exe.
-        self.python_exe = python_exe or sys.executable
+        # A7+: the isolated env is pip --target packages run by the DEDICATED
+        # py3.14 embeddable (the only interpreter torch 2.10 resolves under),
+        # with PYTHONPATH pointing in. Falls back to sys.executable when that
+        # embed is not staged (dev box) — synth then fails honestly at install
+        # time rather than crashing (the env never registers as installed).
+        self.python_exe = python_exe or default_chatterbox_python() or sys.executable
         self._run_cmd: RunCmd = run_cmd or _default_run_cmd
 
     def voices(self) -> list[Voice]:
@@ -233,11 +280,13 @@ class ChatterboxEngine(TtsEngine):
 __all__ = [
     "CHATTERBOX_ENV_ASSET",
     "CHATTERBOX_ENV_DEST",
+    "CHATTERBOX_PYTHON_SUBDIR",
     "CHATTERBOX_REQUIREMENTS",
     "TORCH_EXTRA_INDEX_URL",
     "ChatterboxEngine",
     "build_job_payload",
     "build_synth_argv",
+    "default_chatterbox_python",
     "default_env_dir",
     "runner_dir",
     "runner_extra_env",

--- a/sidecar/runtime_setup/bootstrap.py
+++ b/sidecar/runtime_setup/bootstrap.py
@@ -66,6 +66,16 @@ CHATTERBOX_REQUIREMENTS = HERE / "requirements-chatterbox.txt"
 SIDECAR_ENV_NAME = "sidecar"
 CHATTERBOX_ENV_NAME = "chatterbox"
 
+# Dedicated Python 3.14 for the ISOLATED chatterbox env (A4): chatterbox-tts
+# 0.1.7 only accepts torch>=2.9.0 (we pin 2.10.0) on python_version>="3.14",
+# while the sidecar env is LOCKED to py3.12 (kokoro-onnx needs <3.14). A second
+# embeddable is staged at build prep (build/python-embed-setup.ps1 ->
+# build/python-embed-314) and shipped to <resources>/python-chatterbox.
+CHATTERBOX_PYTHON_VERSION = "3.14.0"  # human verifies the exact patch on first GPU install
+#: the electron-builder.yml extraResources ``to:`` target (mirrors
+#: media_studio.features.tts.chatterbox.CHATTERBOX_PYTHON_SUBDIR — keep in sync).
+CHATTERBOX_EMBED_DIRNAME = "python-chatterbox"
+
 #: options a requirements file may carry besides pinned requirement lines
 ALLOWED_REQ_OPTIONS: tuple[str, ...] = ("--extra-index-url", "--index-url")
 
@@ -286,6 +296,26 @@ def ensure_get_pip(
 
 
 # --------------------------------------------------------------------------- #
+# dedicated py3.14 interpreter resolution (chatterbox env)
+# --------------------------------------------------------------------------- #
+def chatterbox_python_exe(resources_dir: Path | str | None = None) -> Path | None:
+    """Locate the dedicated py3.14 embeddable's ``python.exe``, or ``None``.
+
+    The py3.12 sidecar embed ships at ``<resources>/python/`` and the py3.14
+    chatterbox embed at the sibling ``<resources>/python-chatterbox/`` (the
+    ``electron-builder.yml`` ``to:`` targets). The resources root defaults to
+    the RUNNING interpreter's grandparent (``Path(sys.executable).parent.parent``
+    — the embed dir's parent), so a packaged first run finds the sibling without
+    any extra wiring. Returns ``None`` when the second embed is not staged (a
+    dev box) — the caller then falls back to the host interpreter (honest
+    degradation: pip cannot resolve torch 2.10 under py3.12, so it fails loudly).
+    """
+    base = Path(resources_dir) if resources_dir is not None else Path(sys.executable).parent.parent
+    candidate = base / CHATTERBOX_EMBED_DIRNAME / "python.exe"
+    return candidate if candidate.is_file() else None
+
+
+# --------------------------------------------------------------------------- #
 # env install (sidecar / chatterbox)
 # --------------------------------------------------------------------------- #
 def write_env_sentinel(env_dir: Path, name: str, reqs: Requirements) -> Path:
@@ -460,6 +490,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="the embeddable python.exe to install for (default: this interpreter)",
     )
     parser.add_argument(
+        "--chatterbox-python",
+        help=(
+            "the dedicated py3.14 embeddable for the --chatterbox env "
+            "(default: auto-resolve <resources>/python-chatterbox, else host)"
+        ),
+    )
+    parser.add_argument(
         "--requirements",
         help=f"override the sidecar requirements file (default: {SIDECAR_REQUIREMENTS.name})",
     )
@@ -500,6 +537,8 @@ def main(argv: Sequence[str] | None = None) -> int:
                 _log(f"DRY-RUN argv: {step['argv']}")
             _log(f"DRY-RUN pins: {', '.join(reqs.pins)}")
             _log(f"DRY-RUN assets: {', '.join(args.assets or default_first_run_assets())}")
+            chatter_py = Path(args.chatterbox_python) if args.chatterbox_python else chatterbox_python_exe()
+            _log(f"DRY-RUN chatterbox python: {chatter_py if chatter_py is not None else '<host fallback>'}")
             print("SUCCESS:bootstrap dry-run")
             return 0
 
@@ -535,12 +574,24 @@ def main(argv: Sequence[str] | None = None) -> int:
             extract_tool_archives(root)
 
         if args.chatterbox:
+            # The chatterbox env installs with the DEDICATED py3.14 interpreter
+            # (the only one torch 2.10 resolves under): explicit override ->
+            # auto-resolved <resources>/python-chatterbox -> host fallback. Its
+            # embed dir is the py3.14 dir (get-pip.py is staged beside it); the
+            # host fallback reuses the sidecar embed dir. A host fallback fails
+            # loudly at pip-resolve time (py3.12 cannot install torch 2.10) — by
+            # design, never a silent wrong-version install.
+            chatter_py = Path(args.chatterbox_python) if args.chatterbox_python else chatterbox_python_exe()
+            if chatter_py is not None:
+                chatter_embed: Path = Path(chatter_py).parent
+            else:
+                chatter_py, chatter_embed = python_exe, embed_dir
             install_env(
-                python_exe=python_exe,
+                python_exe=chatter_py,
                 root=root,
                 env_name=CHATTERBOX_ENV_NAME,
                 req_file=CHATTERBOX_REQUIREMENTS,
-                embed_dir=embed_dir,
+                embed_dir=chatter_embed,
             )
 
         print("SUCCESS:bootstrap first-run setup complete")

--- a/sidecar/runtime_setup/requirements-chatterbox.txt
+++ b/sidecar/runtime_setup/requirements-chatterbox.txt
@@ -6,17 +6,20 @@
 #
 # pip reads the index option from THIS file, so the cu12 wheels resolve without
 # any CLI flag plumbing.
---extra-index-url https://download.pytorch.org/whl/cu124
+--extra-index-url https://download.pytorch.org/whl/cu128
 
-# CONTRACT-NOTE: pinned torch cu12 pair chosen to match chatterbox-tts 0.1.2's
-# declared torch requirement; cu124 is the newest cu12 index with 2.6.0 wheels.
-# Human verifies the trio on the first real install (no network in build
-# sessions) and bumps all three together if needed.
+# CONTRACT-NOTE: cu128 / torch 2.10.0 / py3.14 DEDICATED interpreter. chatterbox
+# -tts 0.1.7 pins torch==2.6.0 for python_version<"3.14" and torch>=2.9.0 for
+# python_version>="3.14", so torch 2.10.0 is ONLY installable under the dedicated
+# py3.14 embeddable this env is built with (bootstrap.chatterbox_python_exe ->
+# build/python-embed-314 -> <resources>/python-chatterbox). Human verifies the
+# trio AND that the py3.14 embed is staged on the first real GPU install (no
+# network in build sessions); bump all three together if the resolver needs it.
 #
 # ORDER MATTERS: these lines mirror tts/chatterbox.py's CHATTERBOX_REQUIREMENTS
 # tuple exactly — the asset manager's env sentinel compares the requirement
 # LIST, so a bootstrap-built env only counts as the installed "chatterbox-env"
 # asset when the pin order matches. Keep both in sync.
-chatterbox-tts==0.1.2
-torch==2.6.0+cu124
-torchaudio==2.6.0+cu124
+chatterbox-tts==0.1.7
+torch==2.10.0+cu128
+torchaudio==2.10.0+cu128

--- a/sidecar/tests/test_assets.py
+++ b/sidecar/tests/test_assets.py
@@ -227,6 +227,29 @@ class TestManifest:
         )
         assert pinned.requirements == ("soundfile==0.12.1",)
 
+    def test_python_kind_defaults_to_host(self):
+        entry = manifest.AssetEntry(
+            name="host-env",
+            kind="env",
+            size_mb=10,
+            dest="envs/host",
+            installer="env",
+            requirements=["soundfile==0.12.1"],
+        )
+        assert entry.python_kind == "host"
+
+    def test_invalid_python_kind_rejected(self):
+        with pytest.raises(ValueError, match="python_kind must be one of"):
+            manifest.AssetEntry(
+                name="bad-kind-env",
+                kind="env",
+                size_mb=10,
+                dest="envs/bad",
+                installer="env",
+                requirements=["soundfile==0.12.1"],
+                python_kind="py99",
+            )
+
     def test_day1_whisper_entry(self):
         entry = manifest.get_asset(manifest.WHISPER_ASSET_NAME)
         assert entry is not None
@@ -612,6 +635,113 @@ class TestEnvInstaller:
         data = json.loads(sentinel.read_text(encoding="utf-8"))
         assert data["requirements"] == list(entry.requirements)
         assert mgr.installed_path(entry) == str(env_dir)
+
+    def test_install_env_uses_chatterbox_interpreter_for_chatterbox_kind(self, tmp_path):
+        calls: list[list[str]] = []
+
+        def run_cmd(argv, extra_env=None):
+            calls.append(list(argv))
+            return 0, "ok"
+
+        (tmp_path / "tools").mkdir(parents=True)
+        (tmp_path / "tools" / "get-pip.py").write_text("# get-pip", encoding="utf-8")
+        entry = manifest.register_asset(
+            name="chatter-env",
+            kind="env",
+            size_mb=300,
+            dest="envs/chatter-env",
+            installer="env",
+            requirements=("torch==2.10.0+cu128",),
+            python_kind="chatterbox",
+        )
+        mgr = AssetManager(
+            root=tmp_path,
+            run_cmd=run_cmd,
+            python_exe="C:/host/python.exe",
+            chatterbox_python=lambda: "C:/py314/python.exe",
+            usage=big_free_usage,
+            env_vars={},
+        )
+        mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
+        assert calls and calls[0][0] == "C:/py314/python.exe"
+        assert calls[1][0] == "C:/py314/python.exe"
+
+    def test_install_env_chatterbox_kind_falls_back_when_no_dedicated(self, tmp_path):
+        calls: list[list[str]] = []
+
+        def run_cmd(argv, extra_env=None):
+            calls.append(list(argv))
+            return 0, "ok"
+
+        (tmp_path / "tools").mkdir(parents=True)
+        (tmp_path / "tools" / "get-pip.py").write_text("# get-pip", encoding="utf-8")
+        entry = manifest.register_asset(
+            name="chatter-env-fallback",
+            kind="env",
+            size_mb=300,
+            dest="envs/chatter-env-fallback",
+            installer="env",
+            requirements=("torch==2.10.0+cu128",),
+            python_kind="chatterbox",
+        )
+        mgr = AssetManager(
+            root=tmp_path,
+            run_cmd=run_cmd,
+            python_exe="C:/host/python.exe",
+            chatterbox_python=lambda: None,  # py3.14 embed not staged
+            usage=big_free_usage,
+            env_vars={},
+        )
+        mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
+        assert calls and calls[0][0] == "C:/host/python.exe"
+
+    def test_install_env_host_kind_uses_host_interpreter(self, tmp_path):
+        calls: list[list[str]] = []
+
+        def run_cmd(argv, extra_env=None):
+            calls.append(list(argv))
+            return 0, "ok"
+
+        (tmp_path / "tools").mkdir(parents=True)
+        (tmp_path / "tools" / "get-pip.py").write_text("# get-pip", encoding="utf-8")
+        entry = env_entry("host-kind-env")  # default python_kind="host"
+        # chatterbox_python would raise if consulted — a host-kind entry must not.
+        mgr = AssetManager(
+            root=tmp_path,
+            run_cmd=run_cmd,
+            python_exe="C:/host/python.exe",
+            chatterbox_python=lambda: pytest.fail("host-kind must not consult chatterbox_python"),
+            usage=big_free_usage,
+            env_vars={},
+        )
+        mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
+        assert calls and calls[0][0] == "C:/host/python.exe"
+
+    def test_install_env_chatterbox_kind_uses_default_resolver_when_unset(self, tmp_path, monkeypatch):
+        # No chatterbox_python injected -> lazy-bind to chatterbox.default_chatterbox_python.
+        import media_studio.features.tts.chatterbox as cbmod
+
+        monkeypatch.setattr(cbmod, "default_chatterbox_python", lambda: "C:/auto314/python.exe")
+        calls: list[list[str]] = []
+
+        def run_cmd(argv, extra_env=None):
+            calls.append(list(argv))
+            return 0, "ok"
+
+        (tmp_path / "tools").mkdir(parents=True)
+        (tmp_path / "tools" / "get-pip.py").write_text("# get-pip", encoding="utf-8")
+        entry = manifest.register_asset(
+            name="chatter-env-default",
+            kind="env",
+            size_mb=300,
+            dest="envs/chatter-env-default",
+            installer="env",
+            requirements=("torch==2.10.0+cu128",),
+            python_kind="chatterbox",
+        )
+        mgr = AssetManager(root=tmp_path, run_cmd=run_cmd, usage=big_free_usage, env_vars={})
+        mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
+        assert calls and calls[0][0] == "C:/auto314/python.exe"
 
     def test_step_failure_raises_with_output_tail(self, tmp_path):
         def run_cmd(argv, extra_env=None):

--- a/sidecar/tests/test_runtime_setup.py
+++ b/sidecar/tests/test_runtime_setup.py
@@ -11,6 +11,7 @@ import io
 import json
 import zipfile
 from pathlib import Path
+from typing import Any
 
 import pytest
 from media_studio import tools_resolver as tr
@@ -79,9 +80,16 @@ class TestShippedRequirementFiles:
     def test_chatterbox_file_parses_with_torch_cu12(self):
         reqs = bs.load_requirements(bs.CHATTERBOX_REQUIREMENTS)
         pins = dict(p.split("==", 1) for p in reqs.pins)
-        assert any("cu12" in v for k, v in pins.items() if k == "torch")
-        assert "chatterbox-tts" in pins
-        assert any(opt.startswith("--extra-index-url") for opt in reqs.options)
+        # The new py3.14 trio (torch 2.10 cu128).
+        assert pins["torch"] == "2.10.0+cu128"
+        assert pins["torchaudio"] == "2.10.0+cu128"
+        assert pins["chatterbox-tts"] == "0.1.7"
+        assert reqs.options == ("--extra-index-url https://download.pytorch.org/whl/cu128",)
+        # ORDER MATTERS: mirror the CHATTERBOX_REQUIREMENTS tuple order so a
+        # bootstrap-built env registers as the installed asset (sentinel match).
+        assert reqs.pins[0].startswith("chatterbox-tts==")
+        assert reqs.pins[1] == "torch==2.10.0+cu128"
+        assert reqs.pins[2] == "torchaudio==2.10.0+cu128"
 
 
 # --------------------------------------------------------------------------- #
@@ -267,6 +275,25 @@ class TestInstallEnv:
 
 
 # --------------------------------------------------------------------------- #
+# dedicated py3.14 chatterbox interpreter resolution
+# --------------------------------------------------------------------------- #
+class TestChatterboxPythonExe:
+    def test_resolves_sibling_embed(self, tmp_path):
+        res = tmp_path / "resources"
+        (res / "python").mkdir(parents=True)
+        cb_dir = res / bs.CHATTERBOX_EMBED_DIRNAME
+        cb_dir.mkdir(parents=True)
+        cb_py = cb_dir / "python.exe"
+        cb_py.write_text("", encoding="utf-8")
+        assert bs.chatterbox_python_exe(res) == cb_py
+
+    def test_none_when_unstaged(self, tmp_path):
+        res = tmp_path / "resources"
+        (res / "python").mkdir(parents=True)
+        assert bs.chatterbox_python_exe(res) is None
+
+
+# --------------------------------------------------------------------------- #
 # tool-archive extraction (zip built in tmp; zip-slip guarded; exe hoisted)
 # --------------------------------------------------------------------------- #
 def _make_zip(path: Path, members: dict[str, bytes]) -> Path:
@@ -397,3 +424,94 @@ class TestMainOrdering:
 
         assert rc == 0
         assert order == ["pth", "install"], "._pth must be written before the pip install"
+
+
+class TestMainChatterbox:
+    """The --chatterbox env installs with the DEDICATED py3.14 interpreter."""
+
+    def _fake_host(self, tmp_path: Path) -> Path:
+        fake_py = tmp_path / "py" / "python.exe"
+        fake_py.parent.mkdir(parents=True)
+        fake_py.write_text("", encoding="utf-8")
+        return fake_py
+
+    def test_main_chatterbox_uses_dedicated_interpreter(self, tmp_path, monkeypatch):
+        captured: dict[str, Any] = {}
+
+        def fake_install(**kwargs):
+            captured.update(kwargs)
+            return tmp_path / "envs" / kwargs["env_name"]
+
+        monkeypatch.setattr(bs, "install_env", fake_install)
+        dedicated = tmp_path / "python-chatterbox" / "python.exe"
+        monkeypatch.setattr(bs, "chatterbox_python_exe", lambda *a, **k: dedicated)
+        fake_py = self._fake_host(tmp_path)
+
+        rc = bs.main(["--chatterbox", "--skip-env", "--skip-assets", "--root", str(tmp_path), "--python", str(fake_py)])
+        assert rc == 0
+        assert captured["python_exe"] == dedicated
+        assert captured["env_name"] == bs.CHATTERBOX_ENV_NAME
+        assert captured["embed_dir"] == dedicated.parent
+
+    def test_main_chatterbox_falls_back_to_host_when_unstaged(self, tmp_path, monkeypatch):
+        captured: dict[str, Any] = {}
+
+        def fake_install(**kwargs):
+            captured.update(kwargs)
+            return tmp_path / "envs" / kwargs["env_name"]
+
+        monkeypatch.setattr(bs, "install_env", fake_install)
+        monkeypatch.setattr(bs, "chatterbox_python_exe", lambda *a, **k: None)
+        fake_py = self._fake_host(tmp_path)
+
+        rc = bs.main(["--chatterbox", "--skip-env", "--skip-assets", "--root", str(tmp_path), "--python", str(fake_py)])
+        assert rc == 0
+        assert captured["python_exe"] == fake_py
+        assert captured["embed_dir"] == fake_py.parent
+
+    def test_main_chatterbox_explicit_override(self, tmp_path, monkeypatch):
+        captured: dict[str, Any] = {}
+
+        def fake_install(**kwargs):
+            captured.update(kwargs)
+            return tmp_path / "envs" / kwargs["env_name"]
+
+        monkeypatch.setattr(bs, "install_env", fake_install)
+        # chatterbox_python_exe must NOT be consulted when --chatterbox-python given.
+        monkeypatch.setattr(
+            bs, "chatterbox_python_exe", lambda *a, **k: pytest.fail("override must bypass auto-resolve")
+        )
+        fake_py = self._fake_host(tmp_path)
+        override = tmp_path / "custom314" / "python.exe"
+
+        rc = bs.main(
+            [
+                "--chatterbox",
+                "--chatterbox-python",
+                str(override),
+                "--skip-env",
+                "--skip-assets",
+                "--root",
+                str(tmp_path),
+                "--python",
+                str(fake_py),
+            ]
+        )
+        assert rc == 0
+        assert captured["python_exe"] == override
+        assert captured["embed_dir"] == override.parent
+
+    def test_dry_run_prints_chatterbox_interpreter(self, tmp_path, monkeypatch, capsys):
+        dedicated = tmp_path / "python-chatterbox" / "python.exe"
+        monkeypatch.setattr(bs, "chatterbox_python_exe", lambda *a, **k: dedicated)
+        code = bs.main(["--dry-run", "--root", str(tmp_path)])
+        assert code == 0
+        err = capsys.readouterr().err
+        assert "DRY-RUN chatterbox python" in err
+        assert str(dedicated) in err
+
+    def test_dry_run_chatterbox_host_fallback_label(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(bs, "chatterbox_python_exe", lambda *a, **k: None)
+        code = bs.main(["--dry-run", "--root", str(tmp_path)])
+        assert code == 0
+        assert "<host fallback>" in capsys.readouterr().err

--- a/sidecar/tests/test_tts_engines.py
+++ b/sidecar/tests/test_tts_engines.py
@@ -408,11 +408,63 @@ class TestChatterbox:
         assert entry is not None
         assert entry.kind == "env" and entry.installer == "env"
         assert entry.dest == cb.CHATTERBOX_ENV_DEST
+        # A4+: installs with the dedicated py3.14 interpreter (torch 2.10 only
+        # resolves there), not the host py3.12.
+        assert entry.python_kind == "chatterbox"
         # A6 lesson 5: every requirement is PINNED
         assert all("==" in req for req in entry.requirements)
         torch_pins = [r for r in entry.requirements if r.startswith("torch==")]
-        assert torch_pins and "+cu124" in torch_pins[0]
-        assert any(r.startswith("chatterbox-tts==") for r in entry.requirements)
+        assert torch_pins and "+cu128" in torch_pins[0]
+        assert any(r == "chatterbox-tts==0.1.7" for r in entry.requirements)
+        # ORDER MATTERS: the env sentinel compares the requirement LIST against
+        # this tuple, so chatterbox-tts/torch/torchaudio must stay at indices
+        # 0/1/2 (the same order requirements-chatterbox.txt mirrors).
+        assert entry.requirements[0].startswith("chatterbox-tts==")
+        assert entry.requirements[1] == "torch==2.10.0+cu128"
+        assert entry.requirements[2] == "torchaudio==2.10.0+cu128"
+
+    def test_default_chatterbox_python_resolves_staged_embed(self, tmp_path):
+        # The py3.12 embed sits at <res>/python/; the py3.14 chatterbox embed at
+        # the sibling <res>/python-chatterbox/. Given the resources dir, the
+        # resolver returns the py3.14 python.exe.
+        res = tmp_path / "resources"
+        (res / "python").mkdir(parents=True)
+        (res / "python" / "python.exe").write_text("", encoding="utf-8")
+        cb_dir = res / cb.CHATTERBOX_PYTHON_SUBDIR
+        cb_dir.mkdir(parents=True)
+        cb_py = cb_dir / "python.exe"
+        cb_py.write_text("", encoding="utf-8")
+        assert cb.default_chatterbox_python(str(res)) == str(cb_py)
+
+    def test_default_chatterbox_python_none_when_absent(self, tmp_path):
+        res = tmp_path / "resources"
+        (res / "python").mkdir(parents=True)
+        # No python-chatterbox sibling staged -> None (dev-box degradation).
+        assert cb.default_chatterbox_python(str(res)) is None
+
+    def test_engine_uses_dedicated_interpreter_when_present(self, tmp_path, monkeypatch):
+        env_dir = tmp_path / "env"
+        env_dir.mkdir()
+        sample = tmp_path / "s.wav"
+        sample.write_bytes(b"RIFF")
+        out_wav = tmp_path / "o.wav"
+        monkeypatch.setattr(cb, "default_chatterbox_python", lambda: "C:/py314/python.exe")
+        seen = {}
+
+        def fake_run_cmd(argv, extra_env=None):
+            seen["argv"] = list(argv)
+            Path(json.loads(Path(argv[-1]).read_text(encoding="utf-8"))["outWav"]).write_bytes(b"RIFF")
+            return 0, "ok"
+
+        engine = cb.ChatterboxEngine(env_dir=str(env_dir), run_cmd=fake_run_cmd)
+        assert engine.python_exe == "C:/py314/python.exe"
+        engine.synth(CUES, str(sample), "en", str(out_wav))
+        assert seen["argv"][0] == "C:/py314/python.exe"
+
+    def test_engine_falls_back_to_sys_executable(self, monkeypatch):
+        monkeypatch.setattr(cb, "default_chatterbox_python", lambda: None)
+        engine = cb.ChatterboxEngine(env_dir="X")
+        assert engine.python_exe == sys.executable
 
     def test_synth_argv_shape(self):
         argv = cb.build_synth_argv("C:/py dir/python.exe", "C:/jobs/job.json")


### PR DESCRIPTION
## Why

The isolated chatterbox voice-clone env carries the last 4 open dependabot **torch** advisories on `sidecar/runtime_setup/requirements-chatterbox.txt`:

| Alert | GHSA | Patched in |
|---|---|---|
| #256 | GHSA-3749-ghw9-m3mg | 2.7.1 |
| #257 | GHSA-887c-mr87-cxwp | 2.8.0 |
| #261 | GHSA-vgrw-7cvw-pwgx | 2.9.1 |
| #263 | GHSA-qfhq-4f3w-5fph | 2.10.0 |

They clear when the env pins `torch>=2.10.0` — **but only if that pin is honestly installable**, not a manifest lie.

## The architecture blocker (verified)

`chatterbox.py` previously set `self.python_exe = sys.executable`: the chatterbox env is `pip --target` packages run by the **HOST py3.12** interpreter with `PYTHONPATH` pointing in — there was no second `python.exe`. And `chatterbox-tts==0.1.7` (latest on PyPI) declares:

- `torch==2.6.0` for `python_version < "3.14"`
- `torch>=2.9.0` for `python_version >= "3.14"` (torchaudio mirrors)

The main sidecar env is **locked to py3.12** (kokoro-onnx needs <3.14). So pinning `torch==2.10.0` under py3.12 would make pip refuse to resolve (it conflicts with chatterbox-tts's `torch==2.6.0` py<3.14 constraint) — a manifest lie.

## The change: a dedicated Python 3.14 interpreter for the chatterbox env

Give the **isolated** chatterbox env its own bundled/downloaded Python 3.14 embeddable, install `chatterbox-tts==0.1.7` + `torch==2.10.0+cu128` + `torchaudio==2.10.0+cu128` into it (cu128 index), and run the runner with **that** interpreter (not `sys.executable`). The main sidecar env stays on py3.12 — untouched.

- **`chatterbox.py`** — new trio + `whl/cu128` index; `default_chatterbox_python()` resolver (locates `<resources>/python-chatterbox/python.exe`, a sibling of the py3.12 embed); `ChatterboxEngine.__init__` uses it (falls back to `sys.executable` when unstaged, so a dev box degrades honestly rather than crashing); env asset registered with `python_kind="chatterbox"`.
- **`requirements-chatterbox.txt`** — mirrors the new trio + cu128 index, same order (the env sentinel compares the requirement list order-sensitively).
- **`manifest.py`** — `AssetEntry.python_kind` field (`host`|`chatterbox`) + validation.
- **`manager.py`** — per-entry interpreter selection in `_install_env` via a lazily-bound `chatterbox_python` seam (chatterbox kind -> dedicated py3.14, else host fallback).
- **`bootstrap.py`** — `CHATTERBOX_PYTHON_VERSION`/`EMBED_DIRNAME` consts, `chatterbox_python_exe()` resolver, `--chatterbox-python` CLI arg, and route the `--chatterbox` install to the dedicated interpreter + its embed dir.
- **`python-embed-setup.ps1` / `electron-builder.yml`** — stage `build/python-embed-314` (py3.14 embed + get-pip) and ship it to `resources/python-chatterbox`.

This makes `torch>=2.10.0` genuinely installable -> the 4 alerts clear honestly on merge + dependabot rescan.

## Tests

All new branches are covered with **injected fakes — no network, no real download/pip** (mirrors the existing chatterbox test convention):

- resolver staged/absent arcs (engine + bootstrap),
- engine dedicated/`sys.executable`-fallback arcs,
- `_install_env` host / chatterbox / fallback / default-resolver arcs,
- `manifest.python_kind` validation (valid default + invalid),
- bootstrap `--chatterbox` main routing (dedicated / host-fallback / explicit override) + dry-run interpreter print,
- shipped `requirements-chatterbox.txt` parses to the new trio in the sentinel-matching order.

**Gates:** sidecar pytest **100% line+branch**; `ruff check` + `ruff format --check` clean; `basedpyright` **0 errors**.

## REQUIRED human GPU first-install verification (before trusting the pins)

This combo is **not** offline-resolvable in CI/build sessions. On the GPU box, once:

1. Run `build/python-embed-setup.ps1` (new `-ChatterboxPythonVersion`); confirm `build/python-embed-314/python.exe` reports Python 3.14.x with `get-pip.py` staged beside it; copy the printed SHA-256 into `-ExpectedChatterboxPythonSha256`.
2. From that embed, run the two pip steps `_install_env` runs and confirm pip resolves **`chatterbox-tts==0.1.7` + `torch==2.10.0+cu128` + `torchaudio==2.10.0+cu128`** off `download.pytorch.org/whl/cu128` with **no conflict** (this is the single fact that makes the pins honest).
3. Smoke `python -m chatterbox_runner job.json` with a real reference wav; confirm `torch.cuda.is_available()` on cu128 (driver new enough for CUDA 12.8) and a WAV is produced.
4. Confirm `CHATTERBOX_ENV_SIZE_MB` (bumped 6500->7500, disk-preflight headroom only) vs the real on-disk size.
5. Confirm alerts #256/#257/#261/#263 close on the merge rescan.

**Fallback ladder if the combo does not resolve (R1):** drop to `torch==2.9.1+cu128` (clears #256/#257/#261, not #263) — re-confirm against the four alerts. If a cp314 cu128 wheel is missing (R2), pip fails the same honest way (`AssetError`/`BootstrapError`, env never registers, `synth()` raises `TtsError`) — no silent breakage.
