### PR TITLE
feat(hub): AI Provider Hub MVP — multi-provider cloud offload + rotation + catalog + usage + presets + vision

### DIFF
--- a/app/renderer/src/components/AddKeyRow.test.tsx
+++ b/app/renderer/src/components/AddKeyRow.test.tsx
@@ -1,0 +1,81 @@
+// AddKeyRow.test.tsx — paste-to-add a key; clears after add; Add gated on input.
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { AddKeyRow } from './AddKeyRow';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function input(): HTMLInputElement {
+  return container.querySelector('.add-key-row__input') as HTMLInputElement;
+}
+function addBtn(): HTMLButtonElement {
+  return container.querySelector('.add-key-row__add') as HTMLButtonElement;
+}
+function typeValue(value: string): void {
+  const el = input();
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'value',
+  )?.set;
+  setter?.call(el, value);
+  act(() => el.dispatchEvent(new Event('input', { bubbles: true })));
+}
+
+describe('AddKeyRow', () => {
+  it('Add is disabled until a non-empty (trimmed) value is entered', () => {
+    act(() => root.render(<AddKeyRow providerId="groq" onAdd={vi.fn()} />));
+    expect(addBtn().disabled).toBe(true);
+    typeValue('   '); // whitespace only -> still disabled
+    expect(addBtn().disabled).toBe(true);
+    typeValue('gsk-realkey');
+    expect(addBtn().disabled).toBe(false);
+  });
+
+  it('fires onAdd with the trimmed RAW key and clears the input', () => {
+    const onAdd = vi.fn();
+    act(() => root.render(<AddKeyRow providerId="groq" onAdd={onAdd} />));
+    typeValue('  gsk-pasted-RAW  ');
+    act(() => addBtn().dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(onAdd).toHaveBeenCalledWith('groq', 'gsk-pasted-RAW');
+    // Field cleared so the full key does not linger.
+    expect(input().value).toBe('');
+  });
+
+  it('Enter submits the trimmed key', () => {
+    const onAdd = vi.fn();
+    act(() => root.render(<AddKeyRow providerId="groq" onAdd={onAdd} />));
+    typeValue('gsk-enter-key');
+    act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })));
+    expect(onAdd).toHaveBeenCalledWith('groq', 'gsk-enter-key');
+  });
+
+  it('Enter on an empty field hits the canAdd guard (no-op)', () => {
+    const onAdd = vi.fn();
+    act(() => root.render(<AddKeyRow providerId="groq" onAdd={onAdd} />));
+    act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })));
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+
+  it('a non-Enter keydown does not submit', () => {
+    const onAdd = vi.fn();
+    act(() => root.render(<AddKeyRow providerId="groq" onAdd={onAdd} />));
+    typeValue('gsk-key');
+    act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true })));
+    expect(onAdd).not.toHaveBeenCalled();
+  });
+});

--- a/app/renderer/src/components/AddKeyRow.test.tsx
+++ b/app/renderer/src/components/AddKeyRow.test.tsx
@@ -28,10 +28,7 @@ function addBtn(): HTMLButtonElement {
 }
 function typeValue(value: string): void {
   const el = input();
-  const setter = Object.getOwnPropertyDescriptor(
-    window.HTMLInputElement.prototype,
-    'value',
-  )?.set;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
   setter?.call(el, value);
   act(() => el.dispatchEvent(new Event('input', { bubbles: true })));
 }

--- a/app/renderer/src/components/AddKeyRow.tsx
+++ b/app/renderer/src/components/AddKeyRow.tsx
@@ -1,0 +1,57 @@
+// AddKeyRow.tsx — paste-to-add a new API key for a provider (WU-keys).
+//
+// The user pastes a full key into a password-type input and clicks Add; the
+// component hands the RAW pasted value to onAdd (the panel forwards it to the
+// providers.upsert RPC, where it is stored RAW and only ever read back redacted).
+// The input is cleared after a successful add so the full key never lingers in
+// the field. Add is disabled while the trimmed input is empty. Owns only its own
+// draft-input state; no rpc.
+import React, { useCallback, useState } from 'react';
+
+export interface AddKeyRowProps {
+  /** The provider id the pasted key is added to. */
+  providerId: string;
+  /** Receives the trimmed RAW pasted key. Only called for a non-empty value. */
+  onAdd: (providerId: string, key: string) => void;
+}
+
+export function AddKeyRow({ providerId, onAdd }: AddKeyRowProps): React.ReactElement {
+  const [draft, setDraft] = useState<string>('');
+  const trimmed = draft.trim();
+  const canAdd = trimmed.length > 0;
+
+  const submit = useCallback(() => {
+    if (!canAdd) return;
+    onAdd(providerId, trimmed);
+    setDraft(''); // clear so the full key does not linger in the field
+  }, [canAdd, onAdd, providerId, trimmed]);
+
+  return (
+    <div className="add-key-row" data-provider={providerId}>
+      <input
+        type="password"
+        className="add-key-row__input"
+        aria-label={`New API key for ${providerId}`}
+        placeholder="Paste API key"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onKeyDown={(e) => {
+          // Enter submits (and exercises the canAdd guard for an empty field —
+          // the Add button is disabled when empty, but Enter is not gated by it).
+          if (e.key === 'Enter') submit();
+        }}
+      />
+      <button
+        type="button"
+        className="add-key-row__add"
+        aria-label={`Add key to ${providerId}`}
+        disabled={!canAdd}
+        onClick={submit}
+      >
+        Add key
+      </button>
+    </div>
+  );
+}
+
+export default AddKeyRow;

--- a/app/renderer/src/components/ConsentToggle.test.tsx
+++ b/app/renderer/src/components/ConsentToggle.test.tsx
@@ -29,10 +29,7 @@ function checkbox(consent: 'text' | 'frames'): HTMLInputElement {
 
 /** Flip a controlled checkbox the way React's synthetic onChange expects. */
 function toggle(el: HTMLInputElement, value: boolean): void {
-  const setter = Object.getOwnPropertyDescriptor(
-    window.HTMLInputElement.prototype,
-    'checked',
-  )?.set;
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'checked')?.set;
   setter?.call(el, value);
   act(() => el.dispatchEvent(new Event('click', { bubbles: true })));
 }

--- a/app/renderer/src/components/ConsentToggle.test.tsx
+++ b/app/renderer/src/components/ConsentToggle.test.tsx
@@ -1,0 +1,120 @@
+// ConsentToggle.test.tsx — text vs frames consent are SEPARATE + the train-on-
+// input disclosure shows before first use (WU-keys / SE1).
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ConsentToggle, disclosureText } from './ConsentToggle';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function checkbox(consent: 'text' | 'frames'): HTMLInputElement {
+  return container.querySelector(
+    `.consent-toggle__option[data-consent="${consent}"] input`,
+  ) as HTMLInputElement;
+}
+
+/** Flip a controlled checkbox the way React's synthetic onChange expects. */
+function toggle(el: HTMLInputElement, value: boolean): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    'checked',
+  )?.set;
+  setter?.call(el, value);
+  act(() => el.dispatchEvent(new Event('click', { bubbles: true })));
+}
+
+describe('disclosureText', () => {
+  it('warns for a trains=true provider', () => {
+    expect(disclosureText(true)).toContain('trains on your input');
+  });
+  it('warns about the opt-out for a conditional provider', () => {
+    expect(disclosureText('conditional')).toContain('opt-out');
+  });
+  it('reassures for a no-train provider', () => {
+    expect(disclosureText(false)).toContain('does not train');
+  });
+});
+
+describe('ConsentToggle', () => {
+  it('reflects the current text/frames state independently', () => {
+    act(() =>
+      root.render(
+        <ConsentToggle
+          providerId="groq"
+          text={true}
+          frames={false}
+          trainsOnInput={false}
+          onChange={vi.fn()}
+        />,
+      ),
+    );
+    expect(checkbox('text').checked).toBe(true);
+    expect(checkbox('frames').checked).toBe(false);
+  });
+
+  it('toggling frames calls onChange for frames only (text untouched)', () => {
+    const onChange = vi.fn();
+    act(() =>
+      root.render(
+        <ConsentToggle
+          providerId="groq"
+          text={true}
+          frames={false}
+          trainsOnInput="conditional"
+          onChange={onChange}
+        />,
+      ),
+    );
+    toggle(checkbox('frames'), true);
+    expect(onChange).toHaveBeenCalledWith('groq', 'frames', true);
+    expect(onChange).not.toHaveBeenCalledWith('groq', 'text', expect.anything());
+  });
+
+  it('toggling text calls onChange for text only', () => {
+    const onChange = vi.fn();
+    act(() =>
+      root.render(
+        <ConsentToggle
+          providerId="groq"
+          text={false}
+          frames={true}
+          trainsOnInput={true}
+          onChange={onChange}
+        />,
+      ),
+    );
+    toggle(checkbox('text'), true);
+    expect(onChange).toHaveBeenCalledWith('groq', 'text', true);
+  });
+
+  it('renders the train-on-input disclosure with its data attribute', () => {
+    act(() =>
+      root.render(
+        <ConsentToggle
+          providerId="gemini"
+          text={false}
+          frames={false}
+          trainsOnInput={true}
+          onChange={vi.fn()}
+        />,
+      ),
+    );
+    const note = container.querySelector('.consent-toggle__disclosure');
+    expect(note?.getAttribute('data-trains')).toBe('true');
+    expect(note?.textContent).toContain('avoid sending private');
+  });
+});

--- a/app/renderer/src/components/ConsentToggle.tsx
+++ b/app/renderer/src/components/ConsentToggle.tsx
@@ -1,0 +1,81 @@
+// ConsentToggle.tsx — per-data-type consent (TEXT vs FRAMES) for one provider.
+//
+// WU-keys / SE1 (PLAN §WU-keys): sending TEXT (transcripts) and FRAMES (vision)
+// are SEPARATE, independently-revocable opt-ins. This component renders two
+// distinct toggles plus the provider's train-on-input disclosure so the user
+// sees the privacy posture BEFORE granting consent. Each toggle calls onChange
+// with the data type and the new boolean; the panel forwards to
+// providers.setConsent (which changes only the toggled type, leaving the other
+// intact). Pure presentational — no rpc, no state.
+import React from 'react';
+
+/** The two egress data types consent is tracked for, independently. */
+export type ConsentType = 'text' | 'frames';
+
+export interface ConsentToggleProps {
+  /** The provider these toggles govern. */
+  providerId: string;
+  /** Current TEXT-egress consent (transcripts). */
+  text: boolean;
+  /** Current FRAMES-egress consent (vision). */
+  frames: boolean;
+  /**
+   * The provider's train-on-input disclosure shown before first use:
+   * true / false / "conditional" (trains unless an opt-out is flipped).
+   */
+  trainsOnInput: boolean | 'conditional';
+  /** Toggle one data type's consent (provider id + type + the new value). */
+  onChange: (providerId: string, type: ConsentType, value: boolean) => void;
+}
+
+/** Human-readable train-on-input disclosure for the warning line. */
+export function disclosureText(trainsOnInput: boolean | 'conditional'): string {
+  if (trainsOnInput === true) {
+    return 'This provider trains on your input — avoid sending private or PII data.';
+  }
+  if (trainsOnInput === 'conditional') {
+    return 'This provider may train on your input unless you flip its opt-out/ZDR setting first.';
+  }
+  return 'This provider does not train on your input (no-retention).';
+}
+
+export function ConsentToggle({
+  providerId,
+  text,
+  frames,
+  trainsOnInput,
+  onChange,
+}: ConsentToggleProps): React.ReactElement {
+  return (
+    <fieldset className="consent-toggle" data-provider={providerId}>
+      <legend className="consent-toggle__legend">Data sharing consent</legend>
+      <p
+        className="consent-toggle__disclosure"
+        data-trains={String(trainsOnInput)}
+        role="note"
+      >
+        {disclosureText(trainsOnInput)}
+      </p>
+      <label className="consent-toggle__option" data-consent="text">
+        <input
+          type="checkbox"
+          aria-label={`Allow sending transcript text to ${providerId}`}
+          checked={text}
+          onChange={(e) => onChange(providerId, 'text', e.target.checked)}
+        />
+        <span>Send transcript text</span>
+      </label>
+      <label className="consent-toggle__option" data-consent="frames">
+        <input
+          type="checkbox"
+          aria-label={`Allow sending video frames to ${providerId}`}
+          checked={frames}
+          onChange={(e) => onChange(providerId, 'frames', e.target.checked)}
+        />
+        <span>Send video frames (vision)</span>
+      </label>
+    </fieldset>
+  );
+}
+
+export default ConsentToggle;

--- a/app/renderer/src/components/ConsentToggle.tsx
+++ b/app/renderer/src/components/ConsentToggle.tsx
@@ -49,11 +49,7 @@ export function ConsentToggle({
   return (
     <fieldset className="consent-toggle" data-provider={providerId}>
       <legend className="consent-toggle__legend">Data sharing consent</legend>
-      <p
-        className="consent-toggle__disclosure"
-        data-trains={String(trainsOnInput)}
-        role="note"
-      >
+      <p className="consent-toggle__disclosure" data-trains={String(trainsOnInput)} role="note">
         {disclosureText(trainsOnInput)}
       </p>
       <label className="consent-toggle__option" data-consent="text">

--- a/app/renderer/src/components/FirstRunChooser.test.tsx
+++ b/app/renderer/src/components/FirstRunChooser.test.tsx
@@ -1,0 +1,78 @@
+// FirstRunChooser.test.tsx — the first-run local-vs-cloud chooser (WU-presets P1 #6).
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { FirstRunChooser } from './FirstRunChooser';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function mount(props: Parameters<typeof FirstRunChooser>[0]): void {
+  act(() => {
+    root.render(<FirstRunChooser {...props} />);
+  });
+}
+
+describe('<FirstRunChooser />', () => {
+  it('renders both the local-safe and cloud options', () => {
+    mount({ onChoose: vi.fn() });
+    expect(container.querySelector('[data-choice="privacy"]')).not.toBeNull();
+    expect(container.querySelector('[data-choice="bestFreeCloud"]')).not.toBeNull();
+  });
+
+  it('marks the local option as the safe default', () => {
+    mount({ onChoose: vi.fn() });
+    const local = container.querySelector('[data-choice="privacy"]') as HTMLElement;
+    // The default is signalled both via a class and an always-present text label
+    // (not color alone) so the local-safe default is unmistakable.
+    expect(local.getAttribute('data-default')).toBe('true');
+    expect(local.textContent).toContain('Recommended');
+  });
+
+  it('calls onChoose("privacy") when the local option is picked', () => {
+    const onChoose = vi.fn();
+    mount({ onChoose });
+    const btn = container.querySelector('[data-choice="privacy"]') as HTMLButtonElement;
+    act(() => btn.click());
+    expect(onChoose).toHaveBeenCalledWith('privacy');
+  });
+
+  it('calls onChoose("bestFreeCloud") when the cloud option is picked', () => {
+    const onChoose = vi.fn();
+    mount({ onChoose });
+    const btn = container.querySelector('[data-choice="bestFreeCloud"]') as HTMLButtonElement;
+    act(() => btn.click());
+    expect(onChoose).toHaveBeenCalledWith('bestFreeCloud');
+  });
+
+  it('disables the buttons while busy', () => {
+    mount({ onChoose: vi.fn(), busy: true });
+    const btns = container.querySelectorAll('button[data-choice]');
+    for (const b of btns) expect((b as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it('exposes a dialog role + an accessible label', () => {
+    mount({ onChoose: vi.fn() });
+    const dialog = container.querySelector('[role="dialog"]');
+    expect(dialog).not.toBeNull();
+    expect(dialog?.getAttribute('aria-label')).toBeTruthy();
+  });
+});

--- a/app/renderer/src/components/FirstRunChooser.tsx
+++ b/app/renderer/src/components/FirstRunChooser.tsx
@@ -1,0 +1,65 @@
+// FirstRunChooser.tsx — the first-run local-vs-cloud chooser (WU-presets P1 #6).
+//
+// On the very first run (`firstRunChoiceMade=false`) the user picks how Reframe
+// runs its AI: fully LOCAL (privacy, nothing leaves the machine — the safe
+// default) or BEST FREE CLOUD (rotation across free providers for speed, opt-in
+// egress). The local option is the explicit, always-labelled "Recommended"
+// default so the privacy-safe path is unmistakable (not signalled by color
+// alone — WCAG). Picking either calls `onChoose(presetName)`; the parent applies
+// the preset (`providers.firstRun`) and flips the flag.
+//
+// Pure presentational: the parent owns the busy state + the apply call.
+import React from 'react';
+
+export interface FirstRunChooserProps {
+  /** Apply the chosen first-run preset ("privacy" local-safe | "bestFreeCloud"). */
+  onChoose: (choice: 'privacy' | 'bestFreeCloud') => void;
+  /** True while the choice is being applied (disables both buttons). */
+  busy?: boolean;
+}
+
+export function FirstRunChooser({
+  onChoose,
+  busy = false,
+}: FirstRunChooserProps): React.ReactElement {
+  return (
+    <div className="first-run-chooser" role="dialog" aria-label="Choose how Reframe runs AI">
+      <h3 className="first-run-chooser__title">How should Reframe run AI?</h3>
+      <p className="first-run-chooser__intro">
+        Pick where your transcripts and frames are processed. You can change this any time in Models
+        &amp; System.
+      </p>
+      <div className="first-run-chooser__options">
+        <button
+          type="button"
+          className="first-run-chooser__option is-local"
+          data-choice="privacy"
+          data-default="true"
+          disabled={busy}
+          onClick={() => onChoose('privacy')}
+        >
+          <span className="first-run-chooser__badge">Recommended</span>
+          <span className="first-run-chooser__name">Local only</span>
+          <span className="first-run-chooser__desc">
+            Everything runs on your machine. Nothing is ever uploaded. Best for private footage.
+          </span>
+        </button>
+        <button
+          type="button"
+          className="first-run-chooser__option is-cloud"
+          data-choice="bestFreeCloud"
+          disabled={busy}
+          onClick={() => onChoose('bestFreeCloud')}
+        >
+          <span className="first-run-chooser__name">Best free cloud</span>
+          <span className="first-run-chooser__desc">
+            Faster on weak hardware using free provider rotation. Opt-in — you bring the keys and
+            confirm before anything leaves the machine.
+          </span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default FirstRunChooser;

--- a/app/renderer/src/components/PresetPicker.test.tsx
+++ b/app/renderer/src/components/PresetPicker.test.tsx
@@ -1,0 +1,285 @@
+// PresetPicker.test.tsx — presets + per-function override (WU-presets PH3).
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { PresetPicker, FUNCTION_LABELS } from './PresetPicker';
+import type { CatalogResponse, RoutingBlock } from '../lib/rpc';
+
+function catalog(): CatalogResponse {
+  return {
+    asOfDate: '2026-06-16',
+    unit: ['req', 'token'],
+    tasks: ['moment_find', 'caption', 'translation', 'vision', 'edit_plan'],
+    topPicks: {
+      moment_find: 'groq-gpt-oss-120b',
+      vision: 'gemini-2.5-flash-lite',
+    },
+    providers: [
+      {
+        id: 'groq-gpt-oss-120b',
+        provider: 'Groq',
+        model: 'GPT-OSS-120B',
+        capabilities: ['text'],
+        contextTokens: 128000,
+        perTaskTier: {
+          moment_find: 'S',
+          caption: 'A',
+          translation: 'A',
+          vision: 'na',
+          edit_plan: 'S',
+        },
+        costClass: 'free',
+        freeLimits: '30 RPM',
+        freeLimitScore: 80,
+        unit: 'token',
+        trainsOnInput: false,
+        privacyTier: 'SAFE',
+        recommendedFor: ['moment_find'],
+        notes: 'safe',
+        asOfDate: '2026-06-16',
+      },
+      {
+        id: 'gemini-2.5-flash-lite',
+        provider: 'Google',
+        model: 'Gemini 2.5 Flash-Lite',
+        capabilities: ['text', 'vision'],
+        contextTokens: 1000000,
+        perTaskTier: {
+          moment_find: 'A',
+          caption: 'S',
+          translation: 'A',
+          vision: 'S',
+          edit_plan: 'A',
+        },
+        costClass: 'free',
+        freeLimits: '30 RPM',
+        freeLimitScore: 65,
+        unit: 'req',
+        trainsOnInput: true,
+        privacyTier: 'AVOID',
+        recommendedFor: ['vision'],
+        notes: 'trains',
+        asOfDate: '2026-06-16',
+      },
+    ],
+  };
+}
+
+function routing(): RoutingBlock {
+  return {
+    perFunction: {
+      select: { provider: 'groq-gpt-oss-120b', fallback: ['local'] },
+      subtitles: { provider: 'local', fallback: [] },
+      translation: { provider: 'groq-gpt-oss-120b', fallback: ['local'] },
+      vision: { provider: 'local', fallback: [] },
+      editPlan: { provider: 'groq-gpt-oss-120b', fallback: ['local'] },
+    },
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+function mount(props: Parameters<typeof PresetPicker>[0]): void {
+  act(() => {
+    root.render(<PresetPicker {...props} />);
+  });
+}
+
+describe('<PresetPicker />', () => {
+  it('renders the three smart preset buttons', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'bestFreeCloud',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    expect(container.querySelector('[data-preset="privacy"]')).not.toBeNull();
+    expect(container.querySelector('[data-preset="bestFreeCloud"]')).not.toBeNull();
+    expect(container.querySelector('[data-preset="balanced"]')).not.toBeNull();
+  });
+
+  it('marks the active preset', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'bestFreeCloud',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const active = container.querySelector('[data-preset="bestFreeCloud"]') as HTMLElement;
+    expect(active.getAttribute('aria-pressed')).toBe('true');
+    const other = container.querySelector('[data-preset="privacy"]') as HTMLElement;
+    expect(other.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('calls onApplyPreset when a preset is clicked', () => {
+    const onApplyPreset = vi.fn();
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: '',
+      onApplyPreset,
+      onSetFunction: vi.fn(),
+    });
+    const btn = container.querySelector('[data-preset="balanced"]') as HTMLButtonElement;
+    act(() => btn.click());
+    expect(onApplyPreset).toHaveBeenCalledWith('balanced');
+  });
+
+  it('renders a per-function dropdown for each of the five functions', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    for (const fn of Object.keys(FUNCTION_LABELS)) {
+      expect(container.querySelector(`select[data-function="${fn}"]`)).not.toBeNull();
+    }
+  });
+
+  it('selects the routed provider in each dropdown', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const sel = container.querySelector('select[data-function="select"]') as HTMLSelectElement;
+    expect(sel.value).toBe('groq-gpt-oss-120b');
+    const visionSel = container.querySelector(
+      'select[data-function="vision"]',
+    ) as HTMLSelectElement;
+    expect(visionSel.value).toBe('local');
+  });
+
+  it('only offers vision-capable models for the vision function', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const visionSel = container.querySelector(
+      'select[data-function="vision"]',
+    ) as HTMLSelectElement;
+    const optionValues = Array.from(visionSel.options).map((o) => o.value);
+    // local always offered; the text-only Groq model is NOT a vision option.
+    expect(optionValues).toContain('local');
+    expect(optionValues).toContain('gemini-2.5-flash-lite');
+    expect(optionValues).not.toContain('groq-gpt-oss-120b');
+  });
+
+  it('offers text models (not vision-only) for the select function', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const sel = container.querySelector('select[data-function="select"]') as HTMLSelectElement;
+    const optionValues = Array.from(sel.options).map((o) => o.value);
+    // Groq has a real (non-na) select grade -> offered; gemini has a select grade too.
+    expect(optionValues).toContain('groq-gpt-oss-120b');
+    expect(optionValues).toContain('local');
+  });
+
+  it('calls onSetFunction when a dropdown changes', () => {
+    const onSetFunction = vi.fn();
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction,
+    });
+    const sel = container.querySelector('select[data-function="subtitles"]') as HTMLSelectElement;
+    sel.value = 'gemini-2.5-flash-lite';
+    act(() => sel.dispatchEvent(new Event('change', { bubbles: true })));
+    expect(onSetFunction).toHaveBeenCalledWith('subtitles', 'gemini-2.5-flash-lite');
+  });
+
+  it('shows a privacy-AVOID warning glyph on a training model option', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const visionSel = container.querySelector(
+      'select[data-function="vision"]',
+    ) as HTMLSelectElement;
+    const gemOpt = Array.from(visionSel.options).find((o) => o.value === 'gemini-2.5-flash-lite');
+    // The AVOID privacy tier is surfaced in the option text (not color-only).
+    expect(gemOpt?.textContent).toContain('trains on input');
+  });
+
+  it('disables controls while busy', () => {
+    mount({
+      catalog: catalog(),
+      routing: routing(),
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+      busy: true,
+    });
+    expect((container.querySelector('[data-preset="privacy"]') as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+    expect(
+      (container.querySelector('select[data-function="select"]') as HTMLSelectElement).disabled,
+    ).toBe(true);
+  });
+
+  it('falls back to local-only options when the catalog is empty', () => {
+    const empty: CatalogResponse = { ...catalog(), providers: [] };
+    mount({
+      catalog: empty,
+      routing: routing(),
+      activePreset: 'privacy',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const sel = container.querySelector('select[data-function="select"]') as HTMLSelectElement;
+    const optionValues = Array.from(sel.options).map((o) => o.value);
+    expect(optionValues).toEqual(['local']);
+  });
+
+  it('handles a routing block missing a function slot (defaults to local)', () => {
+    const partial: RoutingBlock = { perFunction: {} };
+    mount({
+      catalog: catalog(),
+      routing: partial,
+      activePreset: 'custom',
+      onApplyPreset: vi.fn(),
+      onSetFunction: vi.fn(),
+    });
+    const sel = container.querySelector('select[data-function="select"]') as HTMLSelectElement;
+    expect(sel.value).toBe('local');
+  });
+});

--- a/app/renderer/src/components/PresetPicker.tsx
+++ b/app/renderer/src/components/PresetPicker.tsx
@@ -1,0 +1,140 @@
+// PresetPicker.tsx — smart presets + per-function override (WU-presets PH3).
+//
+// Two parts in one Provider-Hub section:
+//   * three smart preset buttons (Privacy/offline · Best free cloud · Balanced)
+//     that resolve a whole `routing.perFunction` map server-side (the active one
+//     is marked with aria-pressed, not color alone);
+//   * a per-function override row: one dropdown per Reframe function (select /
+//     subtitles / translation / vision / edit-plan) whose options are the catalog
+//     models that can SERVE that function (a non-`na` per-task grade) plus the
+//     always-available Local backstop. Each option shows the catalog grade and a
+//     "trains on input" privacy warning (text, not color) for AVOID-tier models.
+//
+// Pure presentational: the parent owns the catalog + current routing and the
+// apply/override RPC calls. Changing a dropdown calls `onSetFunction`; clicking a
+// preset calls `onApplyPreset`.
+import React from 'react';
+import type { CatalogEntry, CatalogResponse, RoutingBlock } from '../lib/rpc';
+
+/** The local backstop sentinel id (mirrors sidecar `presets.LOCAL`). */
+export const LOCAL = 'local';
+
+/** Reframe function -> friendly label (the override-row order). */
+export const FUNCTION_LABELS: Record<string, string> = {
+  select: 'Moment-find / Select',
+  subtitles: 'Caption / Title / Hook',
+  translation: 'Translation',
+  vision: 'Vision / OCR',
+  editPlan: 'Edit-plan generation',
+};
+
+/** Reframe function -> the catalog `perTaskTier` task-id key. */
+const FUNCTION_TASK: Record<string, string> = {
+  select: 'moment_find',
+  subtitles: 'caption',
+  translation: 'translation',
+  vision: 'vision',
+  editPlan: 'edit_plan',
+};
+
+/** The three smart presets, in display order. */
+const PRESETS: { id: string; label: string; hint: string }[] = [
+  {
+    id: 'privacy',
+    label: 'Privacy / offline',
+    hint: 'Everything local — nothing leaves the machine.',
+  },
+  {
+    id: 'bestFreeCloud',
+    label: 'Best free cloud',
+    hint: 'Fastest free models with a local backstop.',
+  },
+  { id: 'balanced', label: 'Balanced', hint: 'Cloud for text, local for private frames.' },
+];
+
+export interface PresetPickerProps {
+  catalog: CatalogResponse;
+  routing: RoutingBlock;
+  activePreset: string;
+  onApplyPreset: (name: string) => void;
+  onSetFunction: (function_: string, provider: string) => void;
+  busy?: boolean;
+}
+
+/** Whether `entry` can serve `function_` (a real, non-`na` per-task grade). */
+function canServe(entry: CatalogEntry, function_: string): boolean {
+  const grade = entry.perTaskTier[FUNCTION_TASK[function_]];
+  return Boolean(grade) && grade !== 'na';
+}
+
+/** The option label for one catalog model serving `function_`. */
+function optionLabel(entry: CatalogEntry, function_: string): string {
+  const grade = entry.perTaskTier[FUNCTION_TASK[function_]];
+  const warn = entry.privacyTier === 'AVOID' ? ' — trains on input' : '';
+  return `${entry.provider} ${entry.model} (${grade})${warn}`;
+}
+
+export function PresetPicker({
+  catalog,
+  routing,
+  activePreset,
+  onApplyPreset,
+  onSetFunction,
+  busy = false,
+}: PresetPickerProps): React.ReactElement {
+  return (
+    <div className="preset-picker" data-section="presets">
+      <h3>AI presets</h3>
+      <div className="preset-picker__presets" role="group" aria-label="Smart presets">
+        {PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            className="preset-picker__preset"
+            data-preset={preset.id}
+            aria-pressed={activePreset === preset.id}
+            disabled={busy}
+            title={preset.hint}
+            onClick={() => onApplyPreset(preset.id)}
+          >
+            <span className="preset-picker__preset-name">{preset.label}</span>
+            <span className="preset-picker__preset-hint">{preset.hint}</span>
+          </button>
+        ))}
+      </div>
+
+      <h3>Per-function model</h3>
+      <p className="preset-picker__intro">
+        Override the model each task uses. Only models that can do the task are listed; “Local”
+        always works offline. Models that train on your input are flagged.
+      </p>
+      <div className="preset-picker__functions">
+        {Object.entries(FUNCTION_LABELS).map(([function_, label]) => {
+          const current = routing.perFunction[function_]?.provider ?? LOCAL;
+          const models = catalog.providers.filter((e) => canServe(e, function_));
+          return (
+            <div className="preset-picker__function" key={function_}>
+              <label htmlFor={`fn-${function_}`}>{label}</label>
+              <select
+                id={`fn-${function_}`}
+                data-function={function_}
+                value={current}
+                disabled={busy}
+                onChange={(e) => onSetFunction(function_, e.target.value)}
+              >
+                <option value={LOCAL}>Local (always available)</option>
+                {models.map((entry) => (
+                  <option key={entry.id} value={entry.id}>
+                    {optionLabel(entry, function_)}
+                  </option>
+                ))}
+              </select>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default PresetPicker;

--- a/app/renderer/src/components/ProviderKeyRow.test.tsx
+++ b/app/renderer/src/components/ProviderKeyRow.test.tsx
@@ -1,0 +1,43 @@
+// ProviderKeyRow.test.tsx — renders a redacted key + a Remove button (WU-keys).
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ProviderKeyRow } from './ProviderKeyRow';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('ProviderKeyRow', () => {
+  it('shows the redacted key only (never a full key) and fires onRemove', () => {
+    const onRemove = vi.fn();
+    act(() => {
+      root.render(
+        <ProviderKeyRow providerId="groq" redactedKey="…WXYZ" index={2} onRemove={onRemove} />,
+      );
+    });
+
+    const code = container.querySelector('.provider-key-row__value');
+    expect(code?.textContent).toBe('…WXYZ');
+    // The row carries the provider + index data attributes.
+    const row = container.querySelector('.provider-key-row');
+    expect(row?.getAttribute('data-provider')).toBe('groq');
+    expect(row?.getAttribute('data-key-index')).toBe('2');
+
+    const btn = container.querySelector('.provider-key-row__remove') as HTMLButtonElement;
+    act(() => btn.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(onRemove).toHaveBeenCalledWith('groq', 2);
+  });
+});

--- a/app/renderer/src/components/ProviderKeyRow.tsx
+++ b/app/renderer/src/components/ProviderKeyRow.tsx
@@ -1,0 +1,43 @@
+// ProviderKeyRow.tsx — one stored provider API key, shown REDACTED (last-4 only).
+//
+// WU-keys (PLAN §WU-keys): the renderer NEVER receives a full key — the sidecar
+// returns each key already redacted (e.g. "…WXYZ") via providers.list /
+// settings.get. This row just displays that redacted string and offers a Remove
+// button; it owns NO rpc and NO state (the panel supplies onRemove).
+import React from 'react';
+
+export interface ProviderKeyRowProps {
+  /** The provider id this key belongs to (passed back to onRemove). */
+  providerId: string;
+  /** The REDACTED key as returned by the sidecar (last-4, e.g. "…WXYZ"). */
+  redactedKey: string;
+  /** Zero-based index within the provider's key list (passed back to onRemove). */
+  index: number;
+  /** Remove this key (provider id + index). Only called when the button is clicked. */
+  onRemove: (providerId: string, index: number) => void;
+}
+
+export function ProviderKeyRow({
+  providerId,
+  redactedKey,
+  index,
+  onRemove,
+}: ProviderKeyRowProps): React.ReactElement {
+  return (
+    <li className="provider-key-row" data-provider={providerId} data-key-index={index}>
+      <code className="provider-key-row__value" aria-label={`API key ending ${redactedKey}`}>
+        {redactedKey}
+      </code>
+      <button
+        type="button"
+        className="provider-key-row__remove"
+        aria-label={`Remove key ${redactedKey} from ${providerId}`}
+        onClick={() => onRemove(providerId, index)}
+      >
+        Remove
+      </button>
+    </li>
+  );
+}
+
+export default ProviderKeyRow;

--- a/app/renderer/src/components/UsageBar.test.tsx
+++ b/app/renderer/src/components/UsageBar.test.tsx
@@ -1,0 +1,326 @@
+// UsageBar.test.tsx — WU-usage-ui renderer tests at vitest 100%.
+//
+// Covers: REQ + TOKEN mixed pool -> >= 2 SEPARATE grouped bars (no cross-unit
+// sum); each color band + its non-color glyph + numeric label; superpowered
+// fires at exactly >= 3 same-unit healthy keys across DISTINCT providers and NOT
+// at the borderline (2 keys, or 3 keys across 2 providers); reduced-motion
+// disables animation; stale desaturation + "last checked Xm ago".
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import {
+  UsageBars,
+  compactCount,
+  groupByUnit,
+  isSuperpowered,
+  numericLabel,
+  prefersReducedMotion,
+  remainingFraction,
+  staleAgeLabel,
+  unitLabel,
+  usageZone,
+  zoneGlyph,
+  SUPERPOWERED_MIN,
+} from './UsageBar';
+import type { UsageRow } from '../lib/rpc';
+
+let container: HTMLDivElement;
+let root: Root;
+
+function setReducedMotion(reduced: boolean): void {
+  // jsdom has no matchMedia by default; install a controllable stub.
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: reduced,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  setReducedMotion(false);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function render(node: React.ReactElement): Promise<void> {
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+function row(p: Partial<UsageRow> & Pick<UsageRow, 'provider' | 'unit'>): UsageRow {
+  return {
+    key: '…WXYZ',
+    used: 0,
+    max: 1000,
+    resetAt: null,
+    stale: false,
+    lastCheckedAt: null,
+    ...p,
+  };
+}
+
+// --------------------------------------------------------------------------- //
+// pure helpers
+// --------------------------------------------------------------------------- //
+describe('usage helpers', () => {
+  it('remainingFraction: known max', () => {
+    expect(remainingFraction(row({ provider: 'A', unit: 'req', used: 250, max: 1000 }))).toBeCloseTo(
+      0.75,
+    );
+  });
+
+  it('remainingFraction: unknown/zero max reads as fully healthy', () => {
+    expect(remainingFraction(row({ provider: 'A', unit: 'req', max: null }))).toBe(1);
+    expect(remainingFraction(row({ provider: 'A', unit: 'req', max: 0 }))).toBe(1);
+  });
+
+  it('remainingFraction: clamps used over max to zero remaining', () => {
+    expect(remainingFraction(row({ provider: 'A', unit: 'req', used: 1500, max: 1000 }))).toBe(0);
+  });
+
+  it('usageZone thresholds (green >= 60 / yellow 30-60 / red < 30)', () => {
+    expect(usageZone(0.6)).toBe('healthy');
+    expect(usageZone(0.45)).toBe('warn');
+    expect(usageZone(0.3)).toBe('warn');
+    expect(usageZone(0.29)).toBe('critical');
+  });
+
+  it('zoneGlyph: a distinct non-color glyph per band', () => {
+    expect(zoneGlyph('healthy')).toBe('●');
+    expect(zoneGlyph('warn')).toBe('◐');
+    expect(zoneGlyph('critical')).toBe('○');
+  });
+
+  it('unitLabel maps token->tok, else req', () => {
+    expect(unitLabel('token')).toBe('tok');
+    expect(unitLabel('req')).toBe('req');
+    expect(unitLabel('anything')).toBe('req');
+  });
+
+  it('compactCount: M / K / plain, with exact-multiple trimming', () => {
+    expect(compactCount(1_200_000)).toBe('1.2M');
+    expect(compactCount(4_000_000)).toBe('4M');
+    expect(compactCount(4_000)).toBe('4K');
+    expect(compactCount(1_500)).toBe('1.5K');
+    expect(compactCount(820)).toBe('820');
+  });
+
+  it('numericLabel: known max vs unknown max', () => {
+    expect(numericLabel(row({ provider: 'A', unit: 'req', used: 820, max: 1000 }))).toBe(
+      '820 / 1000 req',
+    );
+    expect(
+      numericLabel(row({ provider: 'A', unit: 'token', used: 1_200_000, max: 4_000_000 })),
+    ).toBe('1.2M / 4M tok');
+    expect(numericLabel(row({ provider: 'A', unit: 'token', used: 5, max: null }))).toBe('5 tok');
+  });
+
+  it('staleAgeLabel rounds minutes and floors at zero', () => {
+    expect(staleAgeLabel(1000, 1000 + 600)).toBe('last checked 10m ago');
+    expect(staleAgeLabel(2000, 1000)).toBe('last checked 0m ago');
+  });
+
+  it('groupByUnit keeps first-seen order and never merges units', () => {
+    const groups = groupByUnit([
+      row({ provider: 'A', unit: 'req' }),
+      row({ provider: 'B', unit: 'token' }),
+      row({ provider: 'C', unit: 'req' }),
+    ]);
+    expect(groups.map((g) => g.unit)).toEqual(['req', 'token']);
+    expect(groups[0].rows).toHaveLength(2);
+    expect(groups[1].rows).toHaveLength(1);
+  });
+
+  it('isSuperpowered: 3 healthy distinct providers true; borderline false', () => {
+    const healthy = (p: string) => row({ provider: p, unit: 'req', used: 100, max: 1000 });
+    expect(isSuperpowered([healthy('A'), healthy('B'), healthy('C')])).toBe(true);
+    // Only 2 healthy keys.
+    expect(isSuperpowered([healthy('A'), healthy('B')])).toBe(false);
+    // 3 keys but only 2 DISTINCT providers.
+    expect(isSuperpowered([healthy('A'), healthy('A'), healthy('B')])).toBe(false);
+    // 3 distinct providers but one is unhealthy (low remaining).
+    expect(
+      isSuperpowered([
+        healthy('A'),
+        healthy('B'),
+        row({ provider: 'C', unit: 'req', used: 950, max: 1000 }),
+      ]),
+    ).toBe(false);
+  });
+
+  it('prefersReducedMotion reads matchMedia', () => {
+    setReducedMotion(true);
+    expect(prefersReducedMotion()).toBe(true);
+    setReducedMotion(false);
+    expect(prefersReducedMotion()).toBe(false);
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// <UsageBars /> render
+// --------------------------------------------------------------------------- //
+describe('<UsageBars />', () => {
+  it('renders the empty state with no rows', async () => {
+    await render(<UsageBars rows={[]} />);
+    expect(container.querySelector('[data-usage="empty"]')).not.toBeNull();
+    expect(container.querySelector('[data-usage="groups"]')).toBeNull();
+  });
+
+  it('mixed REQ + TOKEN pool yields >= 2 SEPARATE grouped bars (no cross-unit sum)', async () => {
+    await render(
+      <UsageBars
+        rows={[
+          row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 }),
+          row({ provider: 'OpenRouter', unit: 'token', used: 500_000, max: 4_000_000 }),
+        ]}
+      />,
+    );
+    const groups = container.querySelectorAll('.usage-group');
+    expect(groups.length).toBe(2);
+    const units = Array.from(groups).map((g) => g.getAttribute('data-unit'));
+    expect(units).toContain('req');
+    expect(units).toContain('token');
+    // Each group keeps its OWN bar(s) — nothing is summed across units.
+    expect(container.querySelectorAll('[data-unit="req"] .usage-bar').length).toBe(1);
+    expect(container.querySelectorAll('[data-unit="token"] .usage-bar').length).toBe(1);
+    expect(container.querySelector('[data-usage="groups"]')?.getAttribute('data-group-count')).toBe(
+      '2',
+    );
+  });
+
+  it('renders each color band with its glyph and numeric label', async () => {
+    await render(
+      <UsageBars
+        rows={[
+          row({ provider: 'Healthy', unit: 'req', used: 100, max: 1000 }),
+          row({ provider: 'Warn', unit: 'req', used: 600, max: 1000 }),
+          row({ provider: 'Critical', unit: 'req', used: 900, max: 1000 }),
+        ]}
+      />,
+    );
+    const bars = container.querySelectorAll('.usage-bar');
+    expect(bars.length).toBe(3);
+    const byProvider = (name: string) =>
+      container.querySelector(`.usage-bar[data-provider="${name}"]`) as HTMLElement;
+
+    const h = byProvider('Healthy');
+    expect(h.getAttribute('data-zone')).toBe('healthy');
+    expect(h.querySelector('.usage-bar__glyph')?.textContent).toBe('●');
+    expect(h.querySelector('.usage-bar__value')?.textContent).toBe('100 / 1000 req');
+
+    const w = byProvider('Warn');
+    expect(w.getAttribute('data-zone')).toBe('warn');
+    expect(w.querySelector('.usage-bar__glyph')?.textContent).toBe('◐');
+
+    const c = byProvider('Critical');
+    expect(c.getAttribute('data-zone')).toBe('critical');
+    expect(c.querySelector('.usage-bar__glyph')?.textContent).toBe('○');
+    // The fill width reflects REMAINING (100 used of 1000 -> 90% remaining).
+    const fill = h.querySelector('.usage-bar__fill') as HTMLElement;
+    expect(fill.style.width).toBe('90%');
+  });
+
+  it('superpowered: fires at >= 3 healthy distinct providers with an always-present label', async () => {
+    const healthy = (p: string) => row({ provider: p, unit: 'req', used: 50, max: 1000 });
+    await render(<UsageBars rows={[healthy('A'), healthy('B'), healthy('C')]} />);
+    const group = container.querySelector('.usage-group') as HTMLElement;
+    expect(group.getAttribute('data-superpowered')).toBe('true');
+    const label = group.querySelector('[data-label="superpowered"]') as HTMLElement;
+    expect(label).not.toBeNull();
+    expect(label.textContent).toContain('Superpowered');
+    expect(label.title).toContain(`${SUPERPOWERED_MIN}+`);
+  });
+
+  it('NOT superpowered at the borderline (3 keys across only 2 providers)', async () => {
+    const healthy = (p: string) => row({ provider: p, unit: 'req', used: 50, max: 1000 });
+    await render(<UsageBars rows={[healthy('A'), healthy('A'), healthy('B')]} />);
+    const group = container.querySelector('.usage-group') as HTMLElement;
+    expect(group.getAttribute('data-superpowered')).toBe('false');
+    expect(group.querySelector('[data-label="superpowered"]')).toBeNull();
+  });
+
+  it('reduced-motion disables the fill transition', async () => {
+    setReducedMotion(true);
+    await render(<UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />);
+    expect(container.querySelector('.usage-bar.is-reduced-motion')).not.toBeNull();
+  });
+
+  it('does NOT add the reduced-motion class when motion is allowed', async () => {
+    setReducedMotion(false);
+    await render(<UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />);
+    expect(container.querySelector('.usage-bar.is-reduced-motion')).toBeNull();
+  });
+
+  it('stale rows desaturate and show "last checked Xm ago" (fake clock)', async () => {
+    await render(
+      <UsageBars
+        rows={[
+          row({
+            provider: 'Groq',
+            unit: 'req',
+            used: 100,
+            max: 1000,
+            stale: true,
+            lastCheckedAt: 1000,
+          }),
+        ]}
+        nowSec={1000 + 15 * 60}
+      />,
+    );
+    const bar = container.querySelector('.usage-bar') as HTMLElement;
+    expect(bar.classList.contains('is-stale')).toBe(true);
+    const note = bar.querySelector('[data-stale-note="true"]') as HTMLElement;
+    expect(note).not.toBeNull();
+    expect(note.textContent).toBe('last checked 15m ago');
+  });
+
+  it('a stale row with no lastCheckedAt falls back to now (0m ago)', async () => {
+    await render(
+      <UsageBars
+        rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000, stale: true })]}
+        nowSec={5000}
+      />,
+    );
+    const note = container.querySelector('[data-stale-note="true"]') as HTMLElement;
+    expect(note.textContent).toBe('last checked 0m ago');
+  });
+
+  it('non-stale rows render no stale note', async () => {
+    await render(
+      <UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />,
+    );
+    expect(container.querySelector('[data-stale-note="true"]')).toBeNull();
+  });
+
+  it('defaults nowSec to Date.now when not injected', async () => {
+    const spy = vi.spyOn(Date, 'now').mockReturnValue(9_000_000);
+    await render(
+      <UsageBars
+        rows={[
+          row({ provider: 'Groq', unit: 'req', used: 100, max: 1000, stale: true, lastCheckedAt: 9000 - 120 }),
+        ]}
+      />,
+    );
+    const note = container.querySelector('[data-stale-note="true"]') as HTMLElement;
+    expect(note.textContent).toBe('last checked 2m ago');
+    spy.mockRestore();
+  });
+});

--- a/app/renderer/src/components/UsageBar.test.tsx
+++ b/app/renderer/src/components/UsageBar.test.tsx
@@ -82,9 +82,9 @@ function row(p: Partial<UsageRow> & Pick<UsageRow, 'provider' | 'unit'>): UsageR
 // --------------------------------------------------------------------------- //
 describe('usage helpers', () => {
   it('remainingFraction: known max', () => {
-    expect(remainingFraction(row({ provider: 'A', unit: 'req', used: 250, max: 1000 }))).toBeCloseTo(
-      0.75,
-    );
+    expect(
+      remainingFraction(row({ provider: 'A', unit: 'req', used: 250, max: 1000 })),
+    ).toBeCloseTo(0.75);
   });
 
   it('remainingFraction: unknown/zero max reads as fully healthy', () => {
@@ -259,13 +259,17 @@ describe('<UsageBars />', () => {
 
   it('reduced-motion disables the fill transition', async () => {
     setReducedMotion(true);
-    await render(<UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />);
+    await render(
+      <UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />,
+    );
     expect(container.querySelector('.usage-bar.is-reduced-motion')).not.toBeNull();
   });
 
   it('does NOT add the reduced-motion class when motion is allowed', async () => {
     setReducedMotion(false);
-    await render(<UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />);
+    await render(
+      <UsageBars rows={[row({ provider: 'Groq', unit: 'req', used: 100, max: 1000 })]} />,
+    );
     expect(container.querySelector('.usage-bar.is-reduced-motion')).toBeNull();
   });
 
@@ -315,7 +319,14 @@ describe('<UsageBars />', () => {
     await render(
       <UsageBars
         rows={[
-          row({ provider: 'Groq', unit: 'req', used: 100, max: 1000, stale: true, lastCheckedAt: 9000 - 120 }),
+          row({
+            provider: 'Groq',
+            unit: 'req',
+            used: 100,
+            max: 1000,
+            stale: true,
+            lastCheckedAt: 9000 - 120,
+          }),
         ]}
       />,
     );

--- a/app/renderer/src/components/UsageBar.tsx
+++ b/app/renderer/src/components/UsageBar.tsx
@@ -1,0 +1,246 @@
+// UsageBar.tsx — data-driven per-key usage bars (PLAN §WU-usage-ui).
+//
+// The rotation pool accounts per-key usage from optimistic decrement + parsed
+// 429 / X-RateLimit-* headers (NOT a poller); providers.usage surfaces it as
+// rows {provider, key, used, max, unit, resetAt, stale, lastCheckedAt}. This
+// component renders that, honoring the gate-2 Designer invariants:
+//
+//   * color is NEVER the only signal — every band carries a non-color GLYPH +
+//     a numeric label ("820 / 1000 req" or "1.2M / 4M tok"), WCAG-safe;
+//   * fill = REMAINING / max (green >= 60% / yellow 30-60% / red < 30%);
+//   * REQ-limited and TOKEN-limited keys are NEVER summed — a mixed pool renders
+//     TWO SEPARATE grouped bars (a positively-tested path, not a dead branch);
+//   * same-unit stacking across DISTINCT providers; the "superpowered" purple
+//     state fires at >= 3 same-unit HEALTHY keys across DISTINCT providers, with
+//     an ALWAYS-present text label + tooltip;
+//   * prefers-reduced-motion disables the fill transition;
+//   * stale (>10 min) rows desaturate + show "last checked Xm ago".
+//
+// Pure presentation + small exported helpers; owns NO rpc (the panel feeds rows).
+import React, { useMemo } from 'react';
+import './usageBar.css';
+import type { UsageRow } from '../lib/rpc';
+
+/** A usage row's color band from how much quota REMAINS (DESIGN §G3 thresholds). */
+export type UsageZone = 'healthy' | 'warn' | 'critical';
+
+/** The "superpowered" threshold: >= this many same-unit healthy DISTINCT providers. */
+export const SUPERPOWERED_MIN = 3;
+/** A key is "healthy" (counts toward superpowered) at >= this remaining fraction. */
+export const HEALTHY_FRACTION = 0.6;
+
+/** Remaining fraction (0..1) for a row; an unknown/zero max reads as fully healthy. */
+export function remainingFraction(row: UsageRow): number {
+  if (row.max === null || row.max === undefined || row.max <= 0) return 1;
+  const used = Math.max(0, Math.min(row.used, row.max));
+  return (row.max - used) / row.max;
+}
+
+/** Color zone from the remaining fraction (green >= 60 / yellow 30-60 / red < 30). */
+export function usageZone(fraction: number): UsageZone {
+  if (fraction >= HEALTHY_FRACTION) return 'healthy';
+  if (fraction >= 0.3) return 'warn';
+  return 'critical';
+}
+
+/** The non-color glyph per zone (so color is never the sole signal — WCAG). */
+export function zoneGlyph(zone: UsageZone): string {
+  if (zone === 'healthy') return '●';
+  if (zone === 'warn') return '◐';
+  return '○';
+}
+
+/** A human label for the unit ("req" -> "req", "token" -> "tok"). */
+export function unitLabel(unit: string): string {
+  return unit === 'token' ? 'tok' : 'req';
+}
+
+/** Compact a count: 1_200_000 -> "1.2M", 4_000 -> "4K", 820 -> "820". */
+export function compactCount(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(n % 1_000_000 === 0 ? 0 : 1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(n % 1_000 === 0 ? 0 : 1)}K`;
+  return String(n);
+}
+
+/**
+ * The numeric label for a row ("820 / 1000 req" or "1.2M / 4M tok"). Token counts
+ * are compacted (they run to millions); request counts stay raw integers (they
+ * are small and the exact ceiling matters), per the PLAN's example labels.
+ */
+export function numericLabel(row: UsageRow): string {
+  const u = unitLabel(row.unit);
+  const fmt = (n: number): string => (row.unit === 'token' ? compactCount(n) : String(n));
+  if (row.max === null || row.max === undefined || row.max <= 0) {
+    return `${fmt(row.used)} ${u}`;
+  }
+  return `${fmt(row.used)} / ${fmt(row.max)} ${u}`;
+}
+
+/** "last checked Xm ago" from the row's lastCheckedAt + now (seconds). */
+export function staleAgeLabel(lastCheckedAt: number, nowSec: number): string {
+  const mins = Math.max(0, Math.round((nowSec - lastCheckedAt) / 60));
+  return `last checked ${mins}m ago`;
+}
+
+/** Group rows by unit, preserving first-seen order (REQ + TOKEN never merge). */
+export function groupByUnit(rows: UsageRow[]): { unit: string; rows: UsageRow[] }[] {
+  const groups: { unit: string; rows: UsageRow[] }[] = [];
+  const byUnit = new Map<string, { unit: string; rows: UsageRow[] }>();
+  for (const row of rows) {
+    const existing = byUnit.get(row.unit);
+    if (existing) {
+      existing.rows.push(row);
+    } else {
+      const group = { unit: row.unit, rows: [row] };
+      byUnit.set(row.unit, group);
+      groups.push(group);
+    }
+  }
+  return groups;
+}
+
+/**
+ * Whether a same-unit group is "superpowered": >= SUPERPOWERED_MIN HEALTHY keys
+ * across DISTINCT providers. Two healthy keys, or three keys spanning only two
+ * providers, do NOT qualify (DESIGN §14).
+ */
+export function isSuperpowered(rows: UsageRow[]): boolean {
+  const healthyProviders = new Set<string>();
+  for (const row of rows) {
+    if (remainingFraction(row) >= HEALTHY_FRACTION) healthyProviders.add(row.provider);
+  }
+  return healthyProviders.size >= SUPERPOWERED_MIN;
+}
+
+/** Detect prefers-reduced-motion (testable via window.matchMedia). */
+export function prefersReducedMotion(): boolean {
+  /* v8 ignore next -- jsdom always defines matchMedia in tests; the typeof guard only matters in a non-DOM host. */
+  if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return false;
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+interface SingleBarProps {
+  row: UsageRow;
+  reducedMotion: boolean;
+  nowSec: number;
+}
+
+/** One key's bar: fill = remaining, glyph + numeric label, stale desaturation. */
+function SingleBar({ row, reducedMotion, nowSec }: SingleBarProps): React.ReactElement {
+  const fraction = remainingFraction(row);
+  const zone = usageZone(fraction);
+  const pct = Math.round(fraction * 100);
+  const glyph = zoneGlyph(zone);
+  const numeric = numericLabel(row);
+  const title = `${row.provider} key ${row.key}: ${numeric} remaining (${pct}%)`;
+  const classNames = [
+    'usage-bar',
+    `is-${zone}`,
+    row.stale ? 'is-stale' : '',
+    reducedMotion ? 'is-reduced-motion' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div
+      className={classNames}
+      data-provider={row.provider}
+      data-zone={zone}
+      data-stale={row.stale ? 'true' : 'false'}
+      title={title}
+    >
+      <div className="usage-bar__head">
+        <span className="usage-bar__glyph" aria-hidden="true" data-glyph={glyph}>
+          {glyph}
+        </span>
+        <span className="usage-bar__provider">{row.provider}</span>
+        <span className="usage-bar__value">{numeric}</span>
+      </div>
+      <div
+        className="usage-bar__track"
+        role="meter"
+        aria-label={`${row.provider} usage (key ${row.key})`}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={pct}
+        aria-valuetext={`${numeric} remaining`}
+      >
+        <div className="usage-bar__fill" data-zone={zone} style={{ width: `${pct}%` }} />
+      </div>
+      {row.stale && (
+        <span className="usage-bar__stale" data-stale-note="true">
+          {staleAgeLabel(row.lastCheckedAt ?? nowSec, nowSec)}
+        </span>
+      )}
+    </div>
+  );
+}
+
+export interface UsageBarsProps {
+  /** Per-key usage rows from providers.usage (already redacted + stale-flagged). */
+  rows: UsageRow[];
+  /** Inject "now" (seconds) for deterministic stale-age labels in tests. */
+  nowSec?: number;
+}
+
+/**
+ * The full loaded-providers usage section: rows grouped by unit (REQ + TOKEN
+ * never summed -> >=2 separate grouped bars on a mixed pool), each group flagged
+ * superpowered when >= 3 healthy keys span distinct providers.
+ */
+export function UsageBars({ rows, nowSec }: UsageBarsProps): React.ReactElement {
+  const reducedMotion = useMemo(() => prefersReducedMotion(), []);
+  const now = nowSec ?? Date.now() / 1000;
+  const groups = groupByUnit(rows);
+
+  if (groups.length === 0) {
+    return (
+      <p className="usage-empty" data-usage="empty">
+        No provider keys yet — add a key to see live usage here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="usage-groups" data-usage="groups" data-group-count={groups.length}>
+      {groups.map((group) => {
+        const superpowered = isSuperpowered(group.rows);
+        return (
+          <section
+            key={group.unit}
+            className={`usage-group${superpowered ? ' is-superpowered' : ''}`}
+            data-unit={group.unit}
+            data-superpowered={superpowered ? 'true' : 'false'}
+            aria-label={`${unitLabel(group.unit)} usage`}
+          >
+            <header className="usage-group__head">
+              <span className="usage-group__unit">{unitLabel(group.unit)} limits</span>
+              {superpowered && (
+                <span
+                  className="usage-group__superpowered"
+                  data-label="superpowered"
+                  title={`Superpowered: ${SUPERPOWERED_MIN}+ healthy keys across distinct providers rotate this unit — high headroom.`}
+                >
+                  ⚡ Superpowered
+                </span>
+              )}
+            </header>
+            <div className="usage-group__bars">
+              {group.rows.map((row, i) => (
+                <SingleBar
+                  key={`${row.provider}:${row.key}:${i}`}
+                  row={row}
+                  reducedMotion={reducedMotion}
+                  nowSec={now}
+                />
+              ))}
+            </div>
+          </section>
+        );
+      })}
+    </div>
+  );
+}
+
+export default UsageBars;

--- a/app/renderer/src/components/usageBar.css
+++ b/app/renderer/src/components/usageBar.css
@@ -1,0 +1,139 @@
+/* usageBar.css — per-key usage bars (WU-usage-ui). Color is never the only
+ * signal: each bar carries a glyph + numeric label; the superpowered group also
+ * carries an always-present text label. Reduced-motion disables the fill
+ * transition; stale rows desaturate. */
+
+.usage-groups {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.usage-empty {
+  color: var(--text-muted);
+  margin: var(--space-3) 0;
+}
+
+.usage-group {
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: var(--surface-deep);
+  box-shadow: inset 0 0 0 1px var(--surface-hover);
+}
+
+.usage-group.is-superpowered {
+  /* A distinct purple, separate from the orange accent + the status colors. */
+  box-shadow: inset 0 0 0 1px #9b6cff;
+  background: linear-gradient(180deg, rgba(155, 108, 255, 0.08), var(--surface-deep));
+}
+
+.usage-group__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-3);
+}
+
+.usage-group__unit {
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 0.8em;
+}
+
+.usage-group__superpowered {
+  color: #c2a3ff;
+  font-weight: 600;
+  font-size: 0.85em;
+}
+
+.usage-group__bars {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.usage-bar__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin-bottom: var(--space-2);
+  font-size: 0.85em;
+}
+
+.usage-bar__glyph {
+  font-size: 0.9em;
+}
+
+.usage-bar.is-healthy .usage-bar__glyph {
+  color: var(--status-success);
+}
+
+.usage-bar.is-warn .usage-bar__glyph {
+  color: var(--status-warn);
+}
+
+.usage-bar.is-critical .usage-bar__glyph {
+  color: var(--status-error);
+}
+
+.usage-bar__provider {
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.usage-bar__value {
+  margin-left: auto;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.usage-bar__track {
+  height: 10px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-hover);
+  overflow: hidden;
+}
+
+.usage-bar__fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  transition: width var(--dur-base) var(--ease-out);
+}
+
+.usage-bar__fill[data-zone='healthy'] {
+  background: var(--status-success);
+}
+
+.usage-bar__fill[data-zone='warn'] {
+  background: var(--status-warn);
+}
+
+.usage-bar__fill[data-zone='critical'] {
+  background: var(--status-error);
+}
+
+.usage-bar.is-reduced-motion .usage-bar__fill {
+  transition: none;
+}
+
+.usage-bar.is-stale {
+  filter: saturate(0.35);
+  opacity: 0.8;
+}
+
+.usage-bar__stale {
+  display: block;
+  margin-top: var(--space-1);
+  font-size: 0.75em;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .usage-bar__fill {
+    transition: none;
+  }
+}

--- a/app/renderer/src/components/usageBar.css
+++ b/app/renderer/src/components/usageBar.css
@@ -103,15 +103,15 @@
   transition: width var(--dur-base) var(--ease-out);
 }
 
-.usage-bar__fill[data-zone='healthy'] {
+.usage-bar__fill[data-zone="healthy"] {
   background: var(--status-success);
 }
 
-.usage-bar__fill[data-zone='warn'] {
+.usage-bar__fill[data-zone="warn"] {
   background: var(--status-warn);
 }
 
-.usage-bar__fill[data-zone='critical'] {
+.usage-bar__fill[data-zone="critical"] {
   background: var(--status-error);
 }
 

--- a/app/renderer/src/components/useAiJob.test.tsx
+++ b/app/renderer/src/components/useAiJob.test.tsx
@@ -70,7 +70,12 @@ async function flush(): Promise<void> {
 
 function aPlan(overrides?: Partial<AiPlan>): AiPlan {
   return {
-    route: { providers: ['Groq'], degradeChain: ['Groq', 'local'], cacheHit: false, willEgress: true },
+    route: {
+      providers: ['Groq'],
+      degradeChain: ['Groq', 'local'],
+      cacheHit: false,
+      willEgress: true,
+    },
     costEst: {
       requests: 1,
       providers: ['Groq'],
@@ -144,7 +149,12 @@ describe('useAiJob', () => {
       aPlan({
         cacheHit: true,
         willEgress: false,
-        route: { providers: ['Groq'], degradeChain: ['Groq', 'local'], cacheHit: true, willEgress: false },
+        route: {
+          providers: ['Groq'],
+          degradeChain: ['Groq', 'local'],
+          cacheHit: true,
+          willEgress: false,
+        },
         preview: 'Cached — returns instantly, sends nothing.',
       }),
     );

--- a/app/renderer/src/components/useAiJob.test.tsx
+++ b/app/renderer/src/components/useAiJob.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const rpcMock = vi.fn();
+let progressCb: ((e: { jobId: string; pct: number; message: string }) => void) | null = null;
+
+vi.mock('./api', () => ({
+  rpc: (...args: unknown[]) => rpcMock(...args),
+  onProgress: (cb: (e: { jobId: string; pct: number; message: string }) => void) => {
+    progressCb = cb;
+    return () => {
+      progressCb = null;
+    };
+  },
+  hasApi: () => true,
+}));
+
+import { type AiPlan, useAiJob } from './useAiJob';
+
+// useJob (which this hook wraps) reads the job.done relay off the window.api
+// bridge; install a no-op onJobDone so its effect subscribes without crashing.
+type DoneCb = (e: { jobId: string; result?: unknown }) => void;
+
+function installBridge(): void {
+  (window as unknown as { api?: unknown }).api = {
+    onJobDone: (_cb: DoneCb) => () => undefined,
+  };
+}
+
+let api: ReturnType<typeof useAiJob> | null = null;
+function Harness(): React.ReactElement {
+  api = useAiJob();
+  const p = api.preview;
+  return React.createElement(
+    'div',
+    null,
+    `${api.state.running}|${api.state.jobId ?? ''}|${p.preview ?? ''}|${p.cacheHit}|${p.willEgress}|${p.route?.providers.join(',') ?? ''}|${p.costEst?.requests ?? ''}`,
+  );
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  progressCb = null;
+  api = null;
+  installBridge();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { api?: unknown }).api;
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function aPlan(overrides?: Partial<AiPlan>): AiPlan {
+  return {
+    route: { providers: ['Groq'], degradeChain: ['Groq', 'local'], cacheHit: false, willEgress: true },
+    costEst: {
+      requests: 1,
+      providers: ['Groq'],
+      egressBytes: 100,
+      egressKinds: { text: 100, frames: 0 },
+      withinFreeLimits: true,
+    },
+    cacheHit: false,
+    willEgress: true,
+    budget: {
+      requests: 1,
+      providers: ['Groq'],
+      egressBytes: 100,
+      egressKinds: { text: 100, frames: 0 },
+      withinFreeLimits: true,
+    },
+    preview: '~1 request(s) across Groq; sends ~0.1 KB (100 text / 0 frame bytes).',
+    cacheKey: 'abc123',
+    ...overrides,
+  };
+}
+
+async function mount(): Promise<void> {
+  await act(async () => {
+    root.render(React.createElement(Harness));
+  });
+}
+
+describe('useAiJob', () => {
+  it('starts empty with no preview', async () => {
+    await mount();
+    expect(api!.preview.route).toBeNull();
+    expect(api!.preview.costEst).toBeNull();
+    expect(api!.preview.preview).toBeNull();
+    expect(api!.preview.cacheHit).toBe(false);
+    expect(api!.preview.willEgress).toBe(false);
+  });
+
+  it('plan() calls ai.planJob and surfaces cost/route/preview', async () => {
+    rpcMock.mockResolvedValueOnce(aPlan());
+    await mount();
+
+    let result: AiPlan | null = null;
+    await act(async () => {
+      result = await api!.plan({ messages: [{ role: 'user', content: 'q' }], model: 'm' });
+    });
+    await flush();
+
+    expect(rpcMock).toHaveBeenCalledWith('ai.planJob', {
+      messages: [{ role: 'user', content: 'q' }],
+      model: 'm',
+    });
+    expect(result!.cacheKey).toBe('abc123');
+    expect(api!.preview.route?.providers).toEqual(['Groq']);
+    expect(api!.preview.costEst?.requests).toBe(1);
+    expect(api!.preview.preview).toContain('Groq');
+    expect(api!.preview.willEgress).toBe(true);
+  });
+
+  it('plan() with no request sends an empty params object', async () => {
+    rpcMock.mockResolvedValueOnce(aPlan());
+    await mount();
+    await act(async () => {
+      await api!.plan();
+    });
+    expect(rpcMock).toHaveBeenCalledWith('ai.planJob', {});
+  });
+
+  it('plan() surfaces a cache-hit preview (no egress)', async () => {
+    rpcMock.mockResolvedValueOnce(
+      aPlan({
+        cacheHit: true,
+        willEgress: false,
+        route: { providers: ['Groq'], degradeChain: ['Groq', 'local'], cacheHit: true, willEgress: false },
+        preview: 'Cached — returns instantly, sends nothing.',
+      }),
+    );
+    await mount();
+    await act(async () => {
+      await api!.plan({ messages: [{ role: 'user', content: 'seen' }] });
+    });
+    expect(api!.preview.cacheHit).toBe(true);
+    expect(api!.preview.willEgress).toBe(false);
+    expect(api!.preview.preview).toContain('Cached');
+  });
+
+  it('start() runs the job and tracks progress (delegates to useJob)', async () => {
+    rpcMock.mockResolvedValueOnce({ jobId: 'aj1' });
+    await mount();
+    await act(async () => {
+      await api!.start('phase8.select', { videoId: 'v1' });
+    });
+    await flush();
+    expect(rpcMock).toHaveBeenCalledWith('phase8.select', { videoId: 'v1' });
+    expect(api!.state.jobId).toBe('aj1');
+    expect(api!.state.running).toBe(true);
+
+    await act(async () => {
+      progressCb!({ jobId: 'aj1', pct: 55, message: 'selecting' });
+    });
+    expect(api!.state.pct).toBe(55);
+    expect(api!.state.message).toBe('selecting');
+  });
+
+  it('cancel() delegates to useJob.cancel', async () => {
+    rpcMock.mockResolvedValueOnce({ jobId: 'aj2' });
+    await mount();
+    await act(async () => {
+      await api!.start('subtitles.translate', { trackId: 't1', targetLang: 'es' });
+    });
+    rpcMock.mockResolvedValueOnce({ ok: true });
+    await act(async () => {
+      await api!.cancel();
+    });
+    expect(rpcMock).toHaveBeenCalledWith('job.cancel', { jobId: 'aj2' });
+    expect(api!.state.running).toBe(false);
+  });
+
+  it('finish() ends the active job at 100%', async () => {
+    rpcMock.mockResolvedValueOnce({ jobId: 'aj3' });
+    await mount();
+    await act(async () => {
+      await api!.start('phase8.select', { videoId: 'v1' });
+    });
+    await act(() => {
+      api!.finish();
+    });
+    expect(api!.state.running).toBe(false);
+    expect(api!.state.pct).toBe(100);
+  });
+
+  it('reset() clears both the preview and the job state', async () => {
+    rpcMock.mockResolvedValueOnce(aPlan());
+    await mount();
+    await act(async () => {
+      await api!.plan({ messages: [{ role: 'user', content: 'q' }] });
+    });
+    expect(api!.preview.route).not.toBeNull();
+
+    rpcMock.mockResolvedValueOnce({ jobId: 'aj4' });
+    await act(async () => {
+      await api!.start('phase8.select', { videoId: 'v1' });
+    });
+    await act(() => {
+      api!.reset();
+    });
+    expect(api!.preview.route).toBeNull();
+    expect(api!.preview.preview).toBeNull();
+    expect(api!.state.jobId).toBeNull();
+    expect(api!.state.running).toBe(false);
+  });
+});

--- a/app/renderer/src/components/useAiJob.ts
+++ b/app/renderer/src/components/useAiJob.ts
@@ -1,0 +1,124 @@
+import { useCallback, useState } from 'react';
+import { rpc } from './api';
+import { type JobError, type UseJobOptions, useJob } from './useJob';
+
+// ---- AI-Job envelope wire shapes (WU-envelope) -------------------------------
+// These mirror the sidecar ``ai_job.py`` JSON the ``ai.planJob`` RPC returns and
+// that an AI job surfaces — the renderer reads these field names verbatim.
+
+/** Egress bytes split by data kind (text transcripts vs vision frames). */
+export interface AiEgressKinds {
+  text: number;
+  frames: number;
+}
+
+/** The pre-flight cost / egress budget (``models/budget.py`` Budget). */
+export interface AiBudget {
+  requests: number;
+  providers: string[];
+  egressBytes: number;
+  egressKinds: AiEgressKinds;
+  withinFreeLimits: boolean;
+}
+
+/** How a planned AI call will run (the resolved route flags). */
+export interface AiRoute {
+  providers: string[];
+  degradeChain: string[];
+  cacheHit: boolean;
+  willEgress: boolean;
+}
+
+/** The full ``ai.planJob`` pre-flight payload (ZERO provider calls). */
+export interface AiPlan {
+  route: AiRoute;
+  costEst: AiBudget;
+  cacheHit: boolean;
+  willEgress: boolean;
+  budget: AiBudget;
+  preview: string;
+  cacheKey: string;
+}
+
+/** What a request to ``ai.planJob`` carries (all optional; pre-flight only). */
+export interface AiPlanRequest {
+  messages?: { role: string; content: string }[];
+  model?: string;
+  params?: Record<string, unknown>;
+  request?: { targetSize?: number; textBytes?: number; frameBytes?: number };
+  capability?: 'text' | 'vision';
+}
+
+/** The cost/route/preview surface the AI-job UI shows alongside job progress. */
+export interface AiPreviewState {
+  route: AiRoute | null;
+  costEst: AiBudget | null;
+  preview: string | null;
+  cacheHit: boolean;
+  willEgress: boolean;
+}
+
+const NO_PREVIEW: AiPreviewState = {
+  route: null,
+  costEst: null,
+  preview: null,
+  cacheHit: false,
+  willEgress: false,
+};
+
+function planToPreview(plan: AiPlan): AiPreviewState {
+  return {
+    route: plan.route,
+    costEst: plan.costEst,
+    preview: plan.preview,
+    cacheHit: plan.cacheHit,
+    willEgress: plan.willEgress,
+  };
+}
+
+/**
+ * Drives an AI job on the AI-Job envelope (WU-envelope): a pre-flight `plan`
+ * surfaces the cost/route/preview WITHOUT executing (the `ai.planJob` RPC, zero
+ * provider calls), and `start` runs the real AI job through the underlying
+ * {@link useJob} (so progress / cancel / `job.done` + the error toast bridge are
+ * all reused unchanged). The hook adds the `costEst` / `route` / `preview`
+ * surface on top of `useJob`'s job state.
+ */
+export function useAiJob(options?: UseJobOptions) {
+  const job = useJob(options);
+  const [preview, setPreview] = useState<AiPreviewState>(NO_PREVIEW);
+
+  /** Pre-flight: fetch the cost/route/preview for a planned AI call (no run). */
+  const plan = useCallback(async (req?: AiPlanRequest): Promise<AiPlan> => {
+    const result = await rpc<AiPlan>('ai.planJob', { ...(req ?? {}) });
+    setPreview(planToPreview(result));
+    return result;
+  }, []);
+
+  /** Run the AI job: delegates to useJob.start (tracks progress + job.done). */
+  const start = useCallback(
+    async <T = { jobId: string }>(method: string, params?: Record<string, unknown>): Promise<T> => {
+      return job.start<T>(method, params);
+    },
+    [job],
+  );
+
+  /** Clear both the job state and the pre-flight preview. */
+  const reset = useCallback((): void => {
+    setPreview(NO_PREVIEW);
+    job.reset();
+  }, [job]);
+
+  return {
+    state: job.state,
+    preview,
+    plan,
+    start,
+    cancel: job.cancel,
+    finish: job.finish,
+    reset,
+  };
+}
+
+export type { JobError, UseJobOptions };
+export default useAiJob;

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -519,6 +519,12 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('asr.engines', undefined);
   });
 
+  it('providers.usage calls the bare method (WU-usage-ui)', async () => {
+    const r = installApi();
+    await client.providers.usage();
+    expect(r).toHaveBeenCalledWith('providers.usage', undefined);
+  });
+
   it('recipes.* forward their params', async () => {
     const r = installApi();
     const recipe: SavedRecipe = {

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -525,6 +525,24 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('providers.usage', undefined);
   });
 
+  it('providers.* presets forward their params (WU-presets)', async () => {
+    const r = installApi();
+    await client.providers.catalog();
+    expect(r).toHaveBeenCalledWith('providers.catalog', undefined);
+    await client.providers.applyPreset('privacy');
+    expect(r).toHaveBeenCalledWith('providers.applyPreset', { name: 'privacy' });
+    await client.providers.setFunctionModel('select', 'groq-x');
+    expect(r).toHaveBeenCalledWith('providers.setFunctionModel', {
+      function: 'select',
+      provider: 'groq-x',
+    });
+    // firstRun: bare READ vs choice-applied (the conditional-param branch).
+    await client.providers.firstRun();
+    expect(r).toHaveBeenCalledWith('providers.firstRun', {});
+    await client.providers.firstRun('bestFreeCloud');
+    expect(r).toHaveBeenCalledWith('providers.firstRun', { choice: 'bestFreeCloud' });
+  });
+
   it('recipes.* forward their params', async () => {
     const r = installApi();
     const recipe: SavedRecipe = {

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -264,6 +264,30 @@ export interface AsrEngine {
 }
 
 /**
+ * One per-key usage row from `providers.usage` (WU-usage-ui). The pool accounts
+ * usage from optimistic decrement + parsed 429 / X-RateLimit-* headers (NOT a
+ * poller). `key` is ALWAYS the REDACTED last-4 (no full key crosses RPC).
+ * `unit` is "req" (request-limited) or "token" (token-limited) — the two are
+ * NEVER summed. `stale`/`lastCheckedAt` come from the 10-min staleness flag.
+ */
+export interface UsageRow {
+  provider: string;
+  /** Redacted last-4 (e.g. "…WXYZ") — never a full key. */
+  key: string;
+  used: number;
+  /** The quota ceiling, or null when unknown (no rate-limit header yet). */
+  max: number | null;
+  /** "req" | "token" — the limit dimension; req and token are never summed. */
+  unit: string;
+  /** Epoch seconds the window resets, or null. */
+  resetAt: number | null;
+  /** True once the cached row is older than the 10-min staleness threshold. */
+  stale: boolean;
+  /** Epoch seconds this row was last observed (drives "last checked Xm ago"). */
+  lastCheckedAt: number | null;
+}
+
+/**
  * system-advanced saved pipeline recipe — field names FROZEN, identical to the
  * sidecar `recipes.normalize_recipe` shape. A `Step` names an existing RPC
  * method + its params; param values may use the `"$N.key"` prior-step reference
@@ -646,6 +670,15 @@ export const client = {
   /** `asr.engines` — selectable ASR engines (whisper / parakeet) + installed. */
   asr: {
     engines: (): Promise<{ engines: AsrEngine[] }> => rpc('asr.engines'),
+  },
+
+  /** `providers.*` — Hub key/usage reads (WU-usage-ui surfaces live usage here). */
+  providers: {
+    /**
+     * `providers.usage` — per-key live usage (cached, persisted, stale-flagged;
+     * NOT a poller). Keys are redacted; req/token units are returned distinctly.
+     */
+    usage: (): Promise<{ usage: UsageRow[] }> => rpc('providers.usage'),
   },
 
   /** `recipes.*` — saved multi-step pipelines run in one shot. */

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -288,6 +288,65 @@ export interface UsageRow {
 }
 
 /**
+ * One curated model row from `providers.catalog` (WU-catalog). PURE metadata —
+ * no keys/URLs. `perTaskTier` is keyed by the five task ids (moment_find /
+ * caption / translation / vision / edit_plan) -> grade string (S/A/B/C/na).
+ */
+export interface CatalogEntry {
+  id: string;
+  provider: string;
+  model: string;
+  capabilities: string[];
+  contextTokens: number;
+  perTaskTier: Record<string, string>;
+  costClass: string;
+  freeLimits: string;
+  freeLimitScore: number;
+  unit: string;
+  trainsOnInput: boolean | 'conditional';
+  privacyTier: string;
+  recommendedFor: string[];
+  notes: string;
+  asOfDate: string;
+}
+
+/** The `providers.catalog` payload (WU-catalog): dated curated catalog + picks. */
+export interface CatalogResponse {
+  asOfDate: string;
+  unit: string[];
+  tasks: string[];
+  topPicks: Record<string, string>;
+  providers: CatalogEntry[];
+}
+
+/** One per-function routing slot: the chosen provider id (or "local") + fallback. */
+export interface RoutingSlot {
+  provider: string;
+  fallback: string[];
+}
+
+/** The resolved per-function routing (WU-presets). */
+export interface RoutingBlock {
+  perFunction: Record<string, RoutingSlot>;
+}
+
+/** `providers.applyPreset` / `setFunctionModel` response (WU-presets). */
+export interface PresetResponse {
+  activePreset: string;
+  routing: RoutingBlock;
+}
+
+/** `providers.firstRun` response (WU-presets P1 #6 first-run chooser). */
+export interface FirstRunResponse {
+  firstRunChoiceMade: boolean;
+  /** Present on a READ (no choice): the local-safe default preset name. */
+  default?: string;
+  /** Present once a choice applied: the resolved preset + routing. */
+  activePreset?: string;
+  routing?: RoutingBlock;
+}
+
+/**
  * system-advanced saved pipeline recipe — field names FROZEN, identical to the
  * sidecar `recipes.normalize_recipe` shape. A `Step` names an existing RPC
  * method + its params; param values may use the `"$N.key"` prior-step reference
@@ -679,6 +738,19 @@ export const client = {
      * NOT a poller). Keys are redacted; req/token units are returned distinctly.
      */
     usage: (): Promise<{ usage: UsageRow[] }> => rpc('providers.usage'),
+    /** `providers.catalog` — the static curated model catalog (WU-catalog). */
+    catalog: (): Promise<CatalogResponse> => rpc('providers.catalog'),
+    /** `providers.applyPreset` — resolve a smart preset into routing (WU-presets). */
+    applyPreset: (name: string): Promise<PresetResponse> => rpc('providers.applyPreset', { name }),
+    /** `providers.setFunctionModel` — override one function's routed provider. */
+    setFunctionModel: (function_: string, provider: string): Promise<PresetResponse> =>
+      rpc('providers.setFunctionModel', { function: function_, provider }),
+    /**
+     * `providers.firstRun` — the local-vs-cloud chooser. No arg = READ (returns
+     * the local-safe default); a `choice` applies that preset + sets the flag.
+     */
+    firstRun: (choice?: string): Promise<FirstRunResponse> =>
+      rpc('providers.firstRun', choice === undefined ? {} : { choice }),
   },
 
   /** `recipes.*` — saved multi-step pipelines run in one shot. */

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -18,6 +18,7 @@ import {
 import type {
   AdvisorReport,
   AssetInfo,
+  CatalogResponse,
   ComponentStatus,
   HardwareInfo,
   UsageRow,
@@ -110,6 +111,16 @@ interface FakeClient {
   settings: Record<string, unknown>;
 }
 
+function emptyCatalog(): CatalogResponse {
+  return {
+    asOfDate: '2026-06-16',
+    unit: ['req', 'token'],
+    tasks: ['moment_find', 'caption', 'translation', 'vision', 'edit_plan'],
+    topPicks: {},
+    providers: [],
+  };
+}
+
 function makeClient(
   over: {
     hardware?: HardwareInfo;
@@ -117,6 +128,7 @@ function makeClient(
     assets?: AssetInfo[];
     engines?: { id: string; label: string; installed: boolean }[];
     usage?: UsageRow[];
+    catalog?: CatalogResponse;
     initialSettings?: Record<string, unknown>;
     rejectAnalyze?: boolean;
     rejectUsage?: boolean;
@@ -162,6 +174,31 @@ function makeClient(
         calls.push({ method: 'providers.usage', args: [] });
         if (over.rejectUsage) throw new Error('usage failed');
         return { usage: over.usage ?? [] };
+      }),
+      catalog: vi.fn(async () => {
+        calls.push({ method: 'providers.catalog', args: [] });
+        return over.catalog ?? emptyCatalog();
+      }),
+      applyPreset: vi.fn(async (name: string) => {
+        calls.push({ method: 'providers.applyPreset', args: [name] });
+        const routing = { perFunction: { select: { provider: 'groq-x', fallback: ['local'] } } };
+        return { activePreset: name, routing };
+      }),
+      setFunctionModel: vi.fn(async (function_: string, provider: string) => {
+        calls.push({ method: 'providers.setFunctionModel', args: [function_, provider] });
+        const routing = { perFunction: { [function_]: { provider, fallback: [] } } };
+        return { activePreset: 'custom', routing };
+      }),
+      firstRun: vi.fn(async (choice?: string) => {
+        calls.push({ method: 'providers.firstRun', args: [choice] });
+        if (choice === undefined) return { firstRunChoiceMade: false, default: 'privacy' };
+        const routing = {
+          perFunction:
+            choice === 'privacy'
+              ? { select: { provider: 'local', fallback: [] } }
+              : { select: { provider: 'groq-x', fallback: ['local'] } },
+        };
+        return { firstRunChoiceMade: true, activePreset: choice, routing };
       }),
     },
     settings: {
@@ -670,5 +707,212 @@ describe('<ModelsSystemPanel />', () => {
       await Promise.resolve();
     });
     expect(container.querySelector('[data-usage="empty"]')).not.toBeNull();
+  });
+
+  // ---- WU-presets: first-run chooser + presets wiring --------------------
+
+  function presetCatalog(): CatalogResponse {
+    return {
+      ...emptyCatalog(),
+      providers: [
+        {
+          id: 'groq-x',
+          provider: 'Groq',
+          model: 'GPT-OSS-120B',
+          capabilities: ['text'],
+          contextTokens: 128000,
+          perTaskTier: {
+            moment_find: 'S',
+            caption: 'A',
+            translation: 'A',
+            vision: 'na',
+            edit_plan: 'S',
+          },
+          costClass: 'free',
+          freeLimits: '30 RPM',
+          freeLimitScore: 80,
+          unit: 'token',
+          trainsOnInput: false,
+          privacyTier: 'SAFE',
+          recommendedFor: ['moment_find'],
+          notes: 'safe',
+          asOfDate: '2026-06-16',
+        },
+      ],
+    };
+  }
+
+  it('shows the first-run chooser before a choice is made', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: false },
+    });
+    await mount(c);
+    expect(
+      container.querySelector('[role="dialog"][aria-label="Choose how Reframe runs AI"]'),
+    ).not.toBeNull();
+  });
+
+  it('hides the first-run chooser once a choice is recorded', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+    });
+    await mount(c);
+    expect(
+      container.querySelector('[role="dialog"][aria-label="Choose how Reframe runs AI"]'),
+    ).toBeNull();
+  });
+
+  it('choosing cloud on first run flips routing + hides the chooser', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: false },
+    });
+    await mount(c);
+    const btn = container.querySelector('[data-choice="bestFreeCloud"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(c.client.providers.firstRun as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'bestFreeCloud',
+    );
+    // The chooser is gone once firstRunChoiceMade flipped true.
+    expect(container.querySelector('[data-choice="bestFreeCloud"]')).toBeNull();
+  });
+
+  it('a first-run error surfaces in the alert and keeps the chooser', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: false },
+    });
+    (c.client.providers.firstRun as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('fr boom'),
+    );
+    await mount(c);
+    const btn = container.querySelector('[data-choice="privacy"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('fr boom');
+    expect(container.querySelector('[data-choice="privacy"]')).not.toBeNull();
+  });
+
+  it('renders the presets section after analysis with the catalog', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      catalog: presetCatalog(),
+    });
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('[data-section="presets"]')).not.toBeNull();
+    expect(container.querySelector('[data-preset="balanced"]')).not.toBeNull();
+  });
+
+  it('applying a preset calls providers.applyPreset', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      catalog: presetCatalog(),
+    });
+    await mount(c);
+    await analyze();
+    const btn = container.querySelector('[data-preset="privacy"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(c.client.providers.applyPreset as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'privacy',
+    );
+  });
+
+  it('overriding a function calls providers.setFunctionModel', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      catalog: presetCatalog(),
+    });
+    await mount(c);
+    await analyze();
+    const sel = container.querySelector('select[data-function="select"]') as HTMLSelectElement;
+    sel.value = 'groq-x';
+    await act(async () => sel.dispatchEvent(new Event('change', { bubbles: true })));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(c.client.providers.setFunctionModel as ReturnType<typeof vi.fn>).toHaveBeenCalledWith(
+      'select',
+      'groq-x',
+    );
+  });
+
+  it('an applyPreset error surfaces in the alert', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      catalog: presetCatalog(),
+    });
+    (c.client.providers.applyPreset as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('preset boom'),
+    );
+    await mount(c);
+    await analyze();
+    const btn = container.querySelector('[data-preset="balanced"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('preset boom');
+  });
+
+  it('a setFunctionModel error surfaces in the alert', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      catalog: presetCatalog(),
+    });
+    (c.client.providers.setFunctionModel as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('fn boom'),
+    );
+    await mount(c);
+    await analyze();
+    const sel = container.querySelector('select[data-function="vision"]') as HTMLSelectElement;
+    sel.value = 'local';
+    await act(async () => sel.dispatchEvent(new Event('change', { bubbles: true })));
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('fn boom');
+  });
+
+  it('a first-run response without routing keeps the prior preset/routing', async () => {
+    const c = makeClient({
+      initialSettings: {
+        modelsOnboardingSeen: true,
+        firstRunChoiceMade: false,
+        activePreset: 'balanced',
+        routing: { perFunction: { select: { provider: 'keep-me', fallback: [] } } },
+      },
+    });
+    // firstRun returns only the flag (no activePreset/routing) -> the ?? falls
+    // back to the previous settings values (the 254-255 fallback branch).
+    (c.client.providers.firstRun as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      firstRunChoiceMade: true,
+    });
+    await mount(c);
+    const btn = container.querySelector('[data-choice="privacy"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // The chooser is gone (flag flipped) and no crash from the missing fields.
+    expect(container.querySelector('[data-choice="privacy"]')).toBeNull();
+  });
+
+  it('coerces a null catalog payload to no presets section', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+    });
+    (c.client.providers.catalog as ReturnType<typeof vi.fn>).mockResolvedValue(
+      null as unknown as CatalogResponse,
+    );
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('[data-section="presets"]')).toBeNull();
   });
 });

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -20,6 +20,7 @@ import type {
   AssetInfo,
   ComponentStatus,
   HardwareInfo,
+  UsageRow,
   client as RealClient,
 } from '../lib/rpc';
 
@@ -115,8 +116,10 @@ function makeClient(
     advisor?: AdvisorReport;
     assets?: AssetInfo[];
     engines?: { id: string; label: string; installed: boolean }[];
+    usage?: UsageRow[];
     initialSettings?: Record<string, unknown>;
     rejectAnalyze?: boolean;
+    rejectUsage?: boolean;
   } = {},
 ): FakeClient {
   const calls: FakeClient['calls'] = [];
@@ -152,6 +155,13 @@ function makeClient(
             { id: 'parakeet', label: 'Parakeet', installed: false },
           ],
         };
+      }),
+    },
+    providers: {
+      usage: vi.fn(async () => {
+        calls.push({ method: 'providers.usage', args: [] });
+        if (over.rejectUsage) throw new Error('usage failed');
+        return { usage: over.usage ?? [] };
       }),
     },
     settings: {
@@ -566,5 +576,99 @@ describe('<ModelsSystemPanel />', () => {
     // analysis failed -> no preset banner / apply button rendered
     expect(container.querySelector('button[data-action="apply-preset"]')).toBeNull();
     expect(container.querySelector('[role="alert"]')?.textContent).toContain('advisor down');
+  });
+
+  // ---- WU-usage-ui: the loaded-providers usage section --------------------
+  it('renders the usage section after analysis with the loaded keys', async () => {
+    const usage: UsageRow[] = [
+      {
+        provider: 'Groq',
+        key: '…WXYZ',
+        used: 180,
+        max: 1000,
+        unit: 'req',
+        resetAt: null,
+        stale: false,
+        lastCheckedAt: null,
+      },
+      {
+        provider: 'OpenRouter',
+        key: '…ABCD',
+        used: 500_000,
+        max: 4_000_000,
+        unit: 'token',
+        resetAt: null,
+        stale: false,
+        lastCheckedAt: null,
+      },
+    ];
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true }, usage });
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('[data-section="usage"]')).not.toBeNull();
+    // mixed req + token -> two separate grouped bars (never summed).
+    expect(container.querySelectorAll('.usage-group').length).toBe(2);
+    expect(c.calls.some((x) => x.method === 'providers.usage')).toBe(true);
+  });
+
+  it('Refresh usage re-fetches and updates the bars', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    await mount(c);
+    await analyze();
+    // initially empty.
+    expect(container.querySelector('[data-usage="empty"]')).not.toBeNull();
+    (c.client.providers.usage as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      usage: [
+        {
+          provider: 'Groq',
+          key: '…WXYZ',
+          used: 10,
+          max: 1000,
+          unit: 'req',
+          resetAt: null,
+          stale: false,
+          lastCheckedAt: null,
+        },
+      ],
+    });
+    const btn = container.querySelector('button[data-action="refresh-usage"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-usage="groups"]')).not.toBeNull();
+    expect(container.querySelector('[data-usage="empty"]')).toBeNull();
+  });
+
+  it('Refresh usage surfaces an error when the RPC rejects', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    await mount(c);
+    await analyze();
+    (c.client.providers.usage as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('usage boom'),
+    );
+    const btn = container.querySelector('button[data-action="refresh-usage"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('usage boom');
+  });
+
+  it('non-array usage payloads coerce to an empty list (analyze + refresh paths)', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    (c.client.providers.usage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      usage: null as unknown as UsageRow[],
+    });
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('[data-usage="empty"]')).not.toBeNull();
+    // Refresh also coerces a non-array payload to empty (the refresh ternary).
+    const btn = container.querySelector('button[data-action="refresh-usage"]') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-usage="empty"]')).not.toBeNull();
   });
 });

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -24,12 +24,14 @@ import {
   type AssetInfo,
   type ComponentStatus,
   type HardwareInfo,
+  type UsageRow,
 } from '../lib/rpc';
 import { componentAsset, presetLabel, presetTier } from '../components/advisorMeta';
 import { ResourceBar } from '../components/ResourceBar';
 import { TierCard } from '../components/TierCard';
 import { ModelCard } from '../components/ModelCard';
 import { ModelsOnboarding } from '../components/ModelsOnboarding';
+import { UsageBars } from '../components/UsageBar';
 
 // --- pure helpers (exported for tests) -------------------------------------
 
@@ -106,6 +108,7 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
   const [error, setError] = useState<string>('');
   const [downloading, setDownloading] = useState<string | null>(null);
   const [showTour, setShowTour] = useState<boolean>(false);
+  const [usage, setUsage] = useState<UsageRow[]>([]);
 
   const byAsset = useMemo(() => indexAssets(assets), [assets]);
 
@@ -132,16 +135,18 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
     setError('');
     try {
       const commercial = Boolean(settings.commercial);
-      const [hw, rep, assetRes, engineRes] = await Promise.all([
+      const [hw, rep, assetRes, engineRes, usageRes] = await Promise.all([
         api.system.probe(),
         api.system.advisor({ commercial }),
         api.assets.list(),
         api.asr.engines(),
+        api.providers.usage(),
       ]);
       setHardware(hw ?? null);
       setReport(rep ?? null);
       setAssets(Array.isArray(assetRes?.assets) ? assetRes.assets : []);
       setEngines(Array.isArray(engineRes?.engines) ? engineRes.engines : []);
+      setUsage(Array.isArray(usageRes?.usage) ? usageRes.usage : []);
       setAnalyzed(true);
       // First-run tour: show once if the user hasn't seen it.
       if (!settings.modelsOnboardingSeen) setShowTour(true);
@@ -157,6 +162,16 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
     try {
       const hw = await api.system.probe();
       setHardware(hw ?? null);
+    } catch (err) {
+      setError(errText(err));
+    }
+  }, [api]);
+
+  // Refresh per-key usage on demand (cached on the sidecar; no poll burst).
+  const refreshUsage = useCallback(async (): Promise<void> => {
+    try {
+      const res = await api.providers.usage();
+      setUsage(Array.isArray(res?.usage) ? res.usage : []);
     } catch (err) {
       setError(errText(err));
     }
@@ -394,6 +409,25 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
                 </p>
               )}
             </div>
+          </div>
+
+          <div className="usage-section" data-section="usage">
+            <div className="usage-section__head">
+              <h3>Provider usage</h3>
+              <button
+                type="button"
+                data-action="refresh-usage"
+                className="secondary"
+                onClick={() => void refreshUsage()}
+              >
+                Refresh usage
+              </button>
+            </div>
+            <p className="usage-section__intro">
+              Live per-key quota from your loaded providers — request- and token-limited keys are
+              shown separately and never combined. Updated from response headers, not a poller.
+            </p>
+            <UsageBars rows={usage} />
           </div>
         </>
       )}

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -22,8 +22,10 @@ import {
   type AdvisorReport,
   type AsrEngine,
   type AssetInfo,
+  type CatalogResponse,
   type ComponentStatus,
   type HardwareInfo,
+  type RoutingBlock,
   type UsageRow,
 } from '../lib/rpc';
 import { componentAsset, presetLabel, presetTier } from '../components/advisorMeta';
@@ -32,6 +34,8 @@ import { TierCard } from '../components/TierCard';
 import { ModelCard } from '../components/ModelCard';
 import { ModelsOnboarding } from '../components/ModelsOnboarding';
 import { UsageBars } from '../components/UsageBar';
+import { PresetPicker } from '../components/PresetPicker';
+import { FirstRunChooser } from '../components/FirstRunChooser';
 
 // --- pure helpers (exported for tests) -------------------------------------
 
@@ -92,6 +96,9 @@ interface SettingsShape {
   diarizeBackend?: string;
   commercial?: boolean;
   modelsOnboardingSeen?: boolean;
+  activePreset?: string;
+  routing?: RoutingBlock;
+  firstRunChoiceMade?: boolean;
 }
 
 export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.ReactElement {
@@ -109,6 +116,8 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
   const [downloading, setDownloading] = useState<string | null>(null);
   const [showTour, setShowTour] = useState<boolean>(false);
   const [usage, setUsage] = useState<UsageRow[]>([]);
+  const [catalog, setCatalog] = useState<CatalogResponse | null>(null);
+  const [presetBusy, setPresetBusy] = useState<boolean>(false);
 
   const byAsset = useMemo(() => indexAssets(assets), [assets]);
 
@@ -135,18 +144,20 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
     setError('');
     try {
       const commercial = Boolean(settings.commercial);
-      const [hw, rep, assetRes, engineRes, usageRes] = await Promise.all([
+      const [hw, rep, assetRes, engineRes, usageRes, catalogRes] = await Promise.all([
         api.system.probe(),
         api.system.advisor({ commercial }),
         api.assets.list(),
         api.asr.engines(),
         api.providers.usage(),
+        api.providers.catalog(),
       ]);
       setHardware(hw ?? null);
       setReport(rep ?? null);
       setAssets(Array.isArray(assetRes?.assets) ? assetRes.assets : []);
       setEngines(Array.isArray(engineRes?.engines) ? engineRes.engines : []);
       setUsage(Array.isArray(usageRes?.usage) ? usageRes.usage : []);
+      setCatalog(catalogRes ?? null);
       setAnalyzed(true);
       // First-run tour: show once if the user hasn't seen it.
       if (!settings.modelsOnboardingSeen) setShowTour(true);
@@ -193,6 +204,63 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
   const selectTier = useCallback(
     (tier: number) => void patchSettings({ phase8Tier: tier }),
     [patchSettings],
+  );
+
+  // WU-presets: apply a smart preset -> server resolves routing.perFunction.
+  const applyAiPreset = useCallback(
+    async (name: string): Promise<void> => {
+      setPresetBusy(true);
+      setError('');
+      try {
+        const res = await api.providers.applyPreset(name);
+        setSettings((prev) => ({ ...prev, activePreset: res.activePreset, routing: res.routing }));
+      } catch (err) {
+        setError(errText(err));
+      } finally {
+        setPresetBusy(false);
+      }
+    },
+    [api],
+  );
+
+  // WU-presets: override one function's routed provider.
+  const setFunctionModel = useCallback(
+    async (function_: string, provider: string): Promise<void> => {
+      setPresetBusy(true);
+      setError('');
+      try {
+        const res = await api.providers.setFunctionModel(function_, provider);
+        setSettings((prev) => ({ ...prev, activePreset: res.activePreset, routing: res.routing }));
+      } catch (err) {
+        setError(errText(err));
+      } finally {
+        setPresetBusy(false);
+      }
+    },
+    [api],
+  );
+
+  // WU-presets P1 #6: the first-run local-vs-cloud choice flips routing + sets
+  // firstRunChoiceMade so the chooser never shows again.
+  const chooseFirstRun = useCallback(
+    async (choice: 'privacy' | 'bestFreeCloud'): Promise<void> => {
+      setPresetBusy(true);
+      setError('');
+      try {
+        const res = await api.providers.firstRun(choice);
+        setSettings((prev) => ({
+          ...prev,
+          firstRunChoiceMade: res.firstRunChoiceMade,
+          activePreset: res.activePreset ?? prev.activePreset,
+          routing: res.routing ?? prev.routing,
+        }));
+      } catch (err) {
+        setError(errText(err));
+      } finally {
+        setPresetBusy(false);
+      }
+    },
+    [api],
   );
 
   const applyPreset = useCallback(() => {
@@ -429,7 +497,24 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
             </p>
             <UsageBars rows={usage} />
           </div>
+
+          {catalog && (
+            <div className="presets-section" data-section="presets-section">
+              <PresetPicker
+                catalog={catalog}
+                routing={settings.routing ?? { perFunction: {} }}
+                activePreset={settings.activePreset ?? ''}
+                onApplyPreset={(name) => void applyAiPreset(name)}
+                onSetFunction={(fn, provider) => void setFunctionModel(fn, provider)}
+                busy={presetBusy}
+              />
+            </div>
+          )}
         </>
+      )}
+
+      {!settings.firstRunChoiceMade && (
+        <FirstRunChooser onChoose={(choice) => void chooseFirstRun(choice)} busy={presetBusy} />
       )}
 
       {showTour && <ModelsOnboarding onDone={finishTour} />}

--- a/app/renderer/src/panels/modelsSystem.css
+++ b/app/renderer/src/panels/modelsSystem.css
@@ -490,3 +490,122 @@
   color: var(--text-secondary);
   line-height: var(--type-body-leading);
 }
+
+/* ---- WU-presets: AI presets + per-function override -------------------------- */
+
+.presets-section {
+  margin-top: var(--space-5);
+}
+
+.preset-picker__intro {
+  margin: var(--space-2) 0 var(--space-4);
+  color: var(--text-secondary);
+  line-height: var(--type-body-leading);
+}
+
+.preset-picker__presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.preset-picker__preset {
+  flex: 1 1 12rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  text-align: left;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+  cursor: pointer;
+}
+
+.preset-picker__preset[aria-pressed="true"] {
+  border-color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent);
+}
+
+.preset-picker__preset-name {
+  font-weight: 600;
+}
+
+.preset-picker__preset-hint {
+  color: var(--text-secondary);
+  font-size: var(--type-small-size);
+}
+
+.preset-picker__functions {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.preset-picker__function {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.preset-picker__function select {
+  min-width: 18rem;
+}
+
+/* ---- WU-presets: first-run local-vs-cloud chooser ---------------------------- */
+
+.first-run-chooser {
+  margin-top: var(--space-4);
+  padding: var(--space-4);
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-md);
+  background: var(--surface-1);
+}
+
+.first-run-chooser__intro {
+  margin: var(--space-2) 0 var(--space-4);
+  color: var(--text-secondary);
+  line-height: var(--type-body-leading);
+}
+
+.first-run-chooser__options {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.first-run-chooser__option {
+  flex: 1 1 16rem;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-3);
+  text-align: left;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--surface-2);
+  cursor: pointer;
+}
+
+.first-run-chooser__option.is-local {
+  border-color: var(--accent);
+}
+
+.first-run-chooser__badge {
+  align-self: flex-start;
+  padding: 0 var(--space-2);
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--on-accent);
+  font-size: var(--type-small-size);
+  font-weight: 600;
+}
+
+.first-run-chooser__name {
+  font-weight: 600;
+}
+
+.first-run-chooser__desc {
+  color: var(--text-secondary);
+  font-size: var(--type-small-size);
+}

--- a/app/renderer/src/panels/modelsSystem.css
+++ b/app/renderer/src/panels/modelsSystem.css
@@ -471,3 +471,22 @@
   justify-content: flex-end;
   gap: var(--space-3);
 }
+
+/* ---- WU-usage-ui: provider usage section ------------------------------------- */
+
+.usage-section {
+  margin-top: var(--space-5);
+}
+
+.usage-section__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.usage-section__intro {
+  margin: var(--space-2) 0 var(--space-4);
+  color: var(--text-secondary);
+  line-height: var(--type-body-leading);
+}

--- a/docs/providers/MODEL-GUIDE.md
+++ b/docs/providers/MODEL-GUIDE.md
@@ -1,0 +1,83 @@
+# Reframe Model Guide — best-for, cost, limits, privacy
+
+**Dated guidance · as of 2026-06-16.** These are *our picks*, not objective
+benchmarks. Free tiers churn constantly — re-verify each provider's current
+limits and training policy at signup. You bring your own API key for every
+provider; Reframe never ships keys.
+
+This guide mirrors the machine-readable catalog in
+`sidecar/media_studio/models/catalog.py` (seeded from `CATALOG-SEED.md`). The Hub
+surfaces the same data in the UI as "our pick · as of \<date\>".
+
+## The five Reframe tasks
+
+| # | Task | What it does |
+|---|------|--------------|
+| 1 | Moment-Find / Select | Find the best clips/moments in a transcript |
+| 2 | Caption / Title / Hook | Generate captions, titles, hooks |
+| 3 | Translation | Translate subtitles |
+| 4 | Vision / OCR | Read on-screen text / understand frames |
+| 5 | Edit-Plan Gen | Generate structured edit plans (JSON) |
+
+Grades: **S** (best) · A · B · C · **n/a** (cannot serve this task).
+
+## Catalog (per-task fitness)
+
+| Provider | Model | Free limits | Ctx | Modality | Train-on-input (privacy) | T1 | T2 | T3 | T4 | T5 |
+|---|---|---|---|---|---|---|---|---|---|---|
+| Groq | GPT-OSS-120B | 30 RPM / 1K RPD / 200K TPD | 128K | Text | No — **SAFE** | S | A | A | n/a | S |
+| Groq | Llama 3.3 70B | 30 RPM / 1K RPD / 100K TPD | 128K | Text | No — **SAFE** | A | S | S | n/a | A |
+| Cerebras | Qwen3-235B | ~30 RPM / 1M tok/day | 128K | Text | Unverified — **CONDITIONAL** | S | A | A | n/a | S |
+| Cerebras | Llama 3.3 70B | ~30 RPM / 1M tok/day | 128K | Text | Unverified — **CONDITIONAL** | A | S | S | n/a | A |
+| SambaNova | Llama 3.1 405B | ~10–30 RPM / ~200K tok/day | 128K | Text | Claims no collection — **SAFE** | A | A | A | n/a | A |
+| Google AI Studio | Gemini 2.5 Flash | 15 RPM / 1500 RPD / ~1M TPM | ~1M | Vision | **YES (free trains)** — **AVOID** | S | A | A | S | S |
+| Google AI Studio | Gemini 2.5 Flash-Lite | 30 RPM / 1500 RPD | ~1M | Vision | **YES (free trains)** — **AVOID** | A | S | A | S | A |
+| GitHub Models | GPT-4o-mini | ~15 RPM / 150 RPD (prototyping) | 128K | Vision | No-train (not prod) — **SAFE** | B | A | A | A | B |
+| Mistral | Pixtral | Experiment ~1B tok/mo (phone verify) | 128K | Vision | Trains by default; opt-out — **CONDITIONAL** | B | A | S | A | B |
+| Cloudflare | Workers AI (Llama 3.1 / Qwen 2.5) | 10K Neurons/day | **2K–8K (limiting)** | Text | No-train — **SAFE** | C | B | B | n/a | C |
+| OpenRouter | DeepSeek/Qwen `:free` (text) | 20 RPM / 50 RPD (→1000 after one-time $10) | ≤128K | Text | Downstream may train unless ZDR — **CONDITIONAL** | A | A | A | n/a | A |
+| OpenRouter | Gemma/Nemotron-VL `:free` (vision) | 20 RPM / ~50–200 RPD | ≤256K | Vision | Downstream may train; set ZDR — **CONDITIONAL** | n/a | n/a | n/a | B | n/a |
+| OpenAI | API (paid; ~no free) | credits | 128K+ | Vision | No-train by default (API) — **SAFE** | A | A | A | A | A |
+
+## Top pick per task
+
+1. **Moment-Find / Select → Groq GPT-OSS-120B** — reasoning + 200K TPD + no-train. Cerebras Qwen3-235B is the fallback (more quota, but train-policy unverified).
+2. **Caption / Title / Hook → Groq Llama 3.3 70B** — fast, generous, safe.
+3. **Translation → Groq Llama 3.3 70B** for volume; **Mistral** for EU-language quality (flip the opt-out toggle first).
+4. **Vision / OCR → Gemini 2.5 Flash-Lite** — best free OCR + ~1M context. ⚠️ The free tier **trains on your input** → use **GitHub GPT-4o-mini** or **paid Gemini/OpenAI** for private/PII frames.
+5. **Edit-Plan Gen → Groq GPT-OSS-120B** — best free structured-JSON output + no-train.
+
+## Privacy tiers
+
+- **SAFE for transcripts:** Groq (best), OpenAI API, SambaNova, Cloudflare (tiny context). Cerebras is *likely* safe but its ToS is unverified — treat as CONDITIONAL.
+- **SAFE for frames:** GitHub GPT-4o-mini, Cloudflare VLMs (low OCR quality), paid Gemini, OpenAI API.
+- **CONDITIONAL (flip opt-out / ZDR first):** Mistral Experiment, OpenRouter `:free`, Cerebras (unverified).
+- **AVOID for real user data:** **Google AI Studio free (Gemini)** — the free tier trains and human review is possible (outside EEA/UK/CH). This is the biggest privacy flag in the catalog.
+
+## ⛔ "N keys = N× quota" is FALSE — add DIFFERENT providers, not more accounts
+
+Rate limits are governed **per-account / globally**, not per-key. OpenRouter says
+this verbatim: *"Making additional accounts or API keys will not affect your rate
+limits, as we govern capacity globally."* The same anti-abuse posture applies to
+Google, OpenAI, Mistral, and Groq.
+
+- **Loading two keys from the SAME provider does NOT double your quota** — Reframe
+  treats same-provider extra keys as **failover only**, never as ×N quota, and
+  will never advertise them that way. Farming multiple accounts at one provider
+  also violates ToS.
+- **Loading keys from DIFFERENT providers DOES stack legitimately:** a Groq key +
+  a Cerebras key + a Gemini key genuinely sum to (Groq quota + Cerebras quota +
+  Gemini quota). This is the honest version of "load N APIs and rotate when one
+  is consumed."
+- → The usage bars and the "superpowered" state stack across **distinct
+  providers**. To go faster, **add a key from a provider you don't have yet.**
+
+## Caveats
+
+Free tiers churn. Cerebras train-policy unverified; SambaNova card requirement
+unclear; Mistral trains unless you toggle opt-out; Gemini training is
+region-dependent; OpenAI's 30-day retention has a legal-hold caveat. Vision on
+text-first free providers (Groq Llama 4, Cloudflare LLaVA) is weak for dense
+on-screen text — test before relying. GitHub Models is prototyping-only. The
+recommended production posture is a **free primary + a paid vision tier behind
+it**.

--- a/docs/providers/SETUP.md
+++ b/docs/providers/SETUP.md
@@ -1,0 +1,108 @@
+# Reframe Provider Setup — bring your own free API key
+
+**Dated guidance · as of 2026-06-16.** Reframe runs AI **locally by default** and
+never requires the cloud. Cloud is opt-in acceleration: you supply a free API key
+from one or more providers, and Reframe rotates across them (with your local model
+as the always-available backstop). You bring every key — Reframe ships none.
+
+See `MODEL-GUIDE.md` for which model is best for each task and its privacy posture.
+
+## TL;DR — the honest way to go faster
+
+> **Add keys from DIFFERENT providers, not more accounts at one provider.**
+> "N keys = N× quota" is **false** — rate limits are per-account / global. A second
+> Groq key does **not** double your Groq quota (it's failover only). A Groq key +
+> a Cerebras key + a Gemini key **do** stack. See the ⛔ section below.
+
+## Get a free key (per provider)
+
+### Groq — best free transcript provider (SAFE, no-train)
+1. Sign up at <https://console.groq.com>.
+2. Create an API key under **API Keys**.
+3. Paste it into Reframe → Models & System → Providers.
+- Free limits: 30 RPM / 1K RPD / 200K TPD (GPT-OSS-120B) — generous and SAFE.
+
+### Cerebras — biggest free token budget (train-policy UNVERIFIED)
+1. Sign up at <https://cloud.cerebras.ai>.
+2. Create an API key.
+3. ~1M tokens/day free. **Confirm the training/retention policy at signup** —
+   it's unverified, so Reframe marks it CONDITIONAL. Don't send PII until you've
+   read the ToS.
+
+### Google AI Studio (Gemini) — best free OCR, but ⚠️ AVOID for private data
+1. Get a key at <https://aistudio.google.com/apikey>.
+2. Use Google's **OpenAI-compatible** endpoint (or Reframe's adapter).
+- ⚠️ **The free tier TRAINS on your input** and human review is possible (outside
+  EEA/UK/CH). Use Gemini-free only for non-sensitive frames. For private/PII
+  frames, use **GitHub GPT-4o-mini** or **paid** Gemini/OpenAI instead.
+
+### GitHub Models — SAFE vision for prototyping
+1. Use a GitHub token with the Models scope (<https://github.com/marketplace/models>).
+2. GPT-4o-mini, ~15 RPM / 150 RPD. No-train, but **prototyping only** — not for
+   production volume.
+
+### Mistral — strong EU-language translation (flip opt-out FIRST)
+1. Sign up at <https://console.mistral.ai> (phone verification for the free
+   Experiment tier, ~1B tokens/month).
+2. **Mistral trains by default.** Turn the training opt-out toggle ON in your
+   account settings **before** sending any real data. Reframe marks it CONDITIONAL.
+
+### SambaNova — large 405B model, SAFE-ish
+1. Sign up at <https://cloud.sambanova.ai>.
+2. ~10–30 RPM / ~200K tokens/day. Claims no prompt collection; card requirement
+   may apply.
+
+### Cloudflare Workers AI — SAFE but tiny context
+1. Create a key in your Cloudflare dashboard (Workers AI).
+2. 10K Neurons/day, no-train — but the **2K–8K context is limiting** for long
+   transcripts.
+
+### OpenRouter — many models behind one key (set ZDR for privacy)
+1. Sign up at <https://openrouter.ai>, create a key.
+2. Use the `:free` model variants.
+3. **The $10 threshold:** with **under $10 lifetime** spend you get **50
+   requests/day**; a **one-time $10** top-up (it never expires) raises that to
+   **1000 requests/day**. The 20 RPM cap applies throughout.
+4. **Privacy:** downstream providers **may train** on your input unless you enable
+   **Zero Data Retention (ZDR)** in your OpenRouter settings. Do that first.
+
+### OpenAI API — the paid SAFE backstop
+1. Create a key at <https://platform.openai.com/api-keys>.
+2. No-train by default on the API (a 30-day retention with a legal-hold caveat).
+   Effectively no free tier — this is the paid backstop behind the free providers.
+
+## Privacy: per-data-type consent
+
+Reframe asks for **separate** consent to send **text** (transcripts) vs **frames**
+(vision) to each provider, and shows the provider's train-on-input disclosure
+before first use. Frame egress requires its own confirmation. Either consent is
+independently revocable. No AI inputs or keys ever leave your machine except to
+the provider **you** chose.
+
+## Keys are never logged or echoed
+
+Your keys are stored locally and shown only as the last 4 characters in the UI.
+Reframe never returns a full key over its RPC layer and scrubs keys out of any
+provider error message. (See the security invariants in the AI program plan.)
+
+## ⛔ "N keys = N× quota" is FALSE (per-ACCOUNT, not per-key)
+
+OpenRouter, verbatim: *"Making additional accounts or API keys will not affect
+your rate limits, as we govern capacity globally."* The same anti-abuse posture
+applies to Google, OpenAI, Mistral, and Groq.
+
+- **Same provider, more keys → NO extra quota.** Reframe uses a second
+  same-provider key as **failover only** and never advertises it as ×N quota.
+  Farming multiple accounts at one provider violates ToS.
+- **Different providers → real stacking.** Groq + Cerebras + Gemini genuinely sum
+  their quotas. This is the legitimate version of "load N APIs, rotate when one is
+  consumed."
+- → To go faster, **add a key from a provider you don't already have.** The usage
+  bars and the "superpowered" state count **distinct providers**, never multiple
+  keys at one provider.
+
+## Reminder
+
+Free tiers churn — re-verify limits and training policies at signup; this snapshot
+is dated 2026-06-16. Production posture: a **free primary + a paid vision tier
+behind it**, with your **local model as the always-available backstop**.

--- a/sidecar/media_studio/features/smolvlm2.py
+++ b/sidecar/media_studio/features/smolvlm2.py
@@ -202,6 +202,127 @@ def _order_from_scores(scores: Sequence[float]) -> list[int]:
     return [i for i, _s in sorted(enumerate(scores), key=lambda iv: (-float(iv[1]), iv[0]))]
 
 
+def _scores_from_order(order: Sequence[int], n: int) -> list[float]:
+    """Turn a best-first index ``order`` (length ``n``) into per-clip scores in [0,1].
+
+    The inverse of :func:`_order_from_scores`: the clip ranked first gets the
+    highest score, the last the lowest, so feeding the result back through the
+    re-ranker reproduces ``order``. ``order`` is a full permutation of
+    ``range(n)`` (as :func:`parse_rerank_order` guarantees). With one clip the
+    single score is ``1.0``; ``n <= 0`` -> ``[]``.
+    """
+    if n <= 0:
+        return []
+    scores = [0.0] * n
+    last = max(1, n - 1)
+    for position, idx in enumerate(order):
+        if 0 <= idx < n:
+            # rank 0 -> 1.0, rank n-1 -> 0.0 (descending by reply position).
+            scores[idx] = (last - position) / last
+    return scores
+
+
+# --------------------------------------------------------------------------- #
+# Cloud (multi-provider) Tier-2 backend (WU-vision) — offloads the re-rank to a
+# vision-capable rotation pool. The pool arrives via a CLOSURE the handler builds
+# (the ``BackendFactory`` signature stays ``settings -> SmolVlmBackend``), so this
+# class satisfies the SAME :class:`SmolVlmBackend` Protocol as the local model.
+# --------------------------------------------------------------------------- #
+#: A frame -> base64 string encoder seam. The default (PNG via cv2) is runtime-only
+#: and coverage-excluded; tests inject a trivial encoder so no native image lib is
+#: imported under the gate.
+FrameEncoder = Callable[[Any], str]
+#: Default vision sampling cap (kept small for the free-tier per-request limits).
+VISION_MAX_TOKENS_DEFAULT = 64
+
+
+def _default_frame_encoder(frame: Any) -> str:  # pragma: no cover - prod seam (PNG-encodes a numpy frame with cv2)
+    """Encode one RGB frame array to a base64 PNG string (LAZY native import).
+
+    ``cv2`` / ``base64`` are imported INSIDE the function so importing this module
+    never drags in OpenCV; tests inject a fake encoder, so this body is runtime-only
+    and coverage-excluded (mirrors :func:`_default_clip_frame_loader`).
+    """
+    import base64  # noqa: PLC0415
+
+    import cv2  # noqa: PLC0415 - job-time native
+
+    bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
+    ok, buf = cv2.imencode(".png", bgr)
+    if not ok:
+        raise RuntimeError("frame PNG encode failed")
+    return base64.b64encode(buf.tobytes()).decode("ascii")
+
+
+class CloudVlmBackend:
+    """A :class:`SmolVlmBackend` that scores clips via a vision rotation pool.
+
+    Implements ``rank_clips(frames_per_clip, prompt) -> list[float]`` by
+    base64-encoding the sampled frame stacks into an OpenAI-style multimodal
+    message and sending it through the injected ``pool`` filtered to
+    ``capability="vision"`` (so only vision-capable providers are tried, and the
+    pool rotates across them on a 429). The model's reply is parsed into a 0-based
+    order (the pure :func:`parse_rerank_order`) and turned back into per-clip
+    scores, so the surrounding :class:`SmolVlmReranker` reorders identically to
+    the local path — and its n-mismatch / failure guards still degrade cleanly.
+
+    The pool arrives via a CLOSURE the handler builds (the ``BackendFactory``
+    signature is UNCHANGED: ``settings -> SmolVlmBackend``). This backend never
+    swallows a pool failure — that is the reranker's job (so a cloud outage leaves
+    the input order unchanged), keeping a single degrade point.
+    """
+
+    def __init__(
+        self,
+        *,
+        pool: Any,
+        settings: Mapping[str, Any] | None = None,
+        frame_encoder: FrameEncoder | None = None,
+        capability: str = "vision",
+    ) -> None:
+        self._pool = pool
+        self._settings = dict(settings or {})
+        self._encode = frame_encoder or _default_frame_encoder
+        self._capability = capability
+
+    def _image_part(self, frame: Any) -> dict[str, Any]:
+        """One OpenAI ``image_url`` content part for a base64-encoded frame."""
+        return {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{self._encode(frame)}"}}
+
+    def _build_message(self, frames_per_clip: Sequence[Any], prompt: str) -> list[dict[str, Any]]:
+        """A single user message: the text prompt followed by every clip's frames.
+
+        Each clip's frame stack is flattened into ``image_url`` parts; the model
+        sees the prompt (numbered clip hooks) alongside the images so it can map a
+        ranking back onto clip indices.
+        """
+        content: list[dict[str, Any]] = [{"type": "text", "text": prompt}]
+        for stack in frames_per_clip:
+            for frame in stack:
+                content.append(self._image_part(frame))
+        return [{"role": "user", "content": content}]
+
+    def rank_clips(self, frames_per_clip: Sequence[Any], prompt: str) -> list[float]:
+        """Score each clip via the vision pool; higher = more relevant.
+
+        Returns ``[]`` for no clips (the pool is never called). Otherwise builds
+        the multimodal message, sends it through the vision-capable pool, parses
+        the reply into a full index permutation, and converts that order into
+        per-clip scores. A pool failure propagates (the reranker degrades to the
+        input order); a malformed reply yields the identity order via the pure
+        parser, which the reranker then treats as a no-op.
+        """
+        clips = list(frames_per_clip)
+        n = len(clips)
+        if n == 0:
+            return []
+        messages = self._build_message(clips, prompt)
+        max_tokens = int(self._settings.get("visionMaxTokens") or VISION_MAX_TOKENS_DEFAULT)
+        reply = self._pool.chat(messages, capability=self._capability, max_tokens=max_tokens)
+        order = parse_rerank_order(str(reply), n)
+        return _scores_from_order(order, n)
+
+
 # --------------------------------------------------------------------------- #
 # default heavy seams (lazy real impls; tests inject fakes)
 # --------------------------------------------------------------------------- #
@@ -422,8 +543,11 @@ __all__ = [
     "SCORE_FIELD",
     "SMOLVLM_VRAM_MB",
     "TOP_K_DEFAULT",
+    "VISION_MAX_TOKENS_DEFAULT",
     "BackendFactory",
     "ClipFrameLoader",
+    "CloudVlmBackend",
+    "FrameEncoder",
     "ModelsPresent",
     "SmolVlmBackend",
     "SmolVlmReranker",

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -282,6 +282,20 @@ class Services:
     # ===================================================================== #
     # providers.* (WU-keys: user-brings keys; RPC is key-free / redacted)
     # ===================================================================== #
+    def providers_catalog(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.catalog()`` -> the static curated model catalog (WU-catalog).
+
+        Returns :data:`catalog.CATALOG` as JSON: every provider/model with its
+        per-task tiers, privacy / train-on-input flags, unit, free limits, the
+        editorial top-pick per task, and the dated ``asOfDate`` stamp. PURE data —
+        NO API keys, URLs, or secrets ever appear in this payload (the catalog is
+        curated metadata; the user's keys live only in the redacted providers.list
+        view). The renderer reads the camelCase wire shape verbatim.
+        """
+        from .models import catalog as _catalog  # local: import-light pure data
+
+        return _catalog.catalog_to_json()
+
     def providers_list(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
         """``providers.list()`` -> ``{providers:[...redacted...]}`` (WU-keys).
 
@@ -524,6 +538,7 @@ class Services:
             feature="subtitles",
             label="subtitles.translate",
             videoId=None,
+            ack=params.get("confirmBudget") if isinstance(params.get("confirmBudget"), str) else None,
         )
         return {"jobId": job.id}
 
@@ -954,6 +969,7 @@ class Services:
             feature="phase8",
             label="phase8.select",
             videoId=video_id,
+            ack=params.get("confirmBudget") if isinstance(params.get("confirmBudget"), str) else None,
         )
         return {"jobId": job.id}
 
@@ -1280,6 +1296,7 @@ class Services:
         feature: str,
         label: str,
         videoId: str | None = None,  # noqa: N803 - wire-name kwarg (matches JobRegistry)
+        ack: str | None = None,
     ) -> Any:
         """Plan + run an :class:`ai_job.AiJob` on ``ctx.jobs`` with a custom ``work``.
 
@@ -1288,6 +1305,12 @@ class Services:
         apply). The envelope's cost/route/cacheKey come from
         :meth:`plan_ai_job_envelope`. Returns the created job (the ``{jobId}``
         source). The work's own result dict is the ``job.done`` payload.
+
+        WU-budget pre-flight gate: when ``settings['confirmCloudBudget']`` is on
+        AND the planned run WOULD egress, ``ack`` MUST equal the envelope's
+        ``cacheKey`` (the token ``ai.planJob`` returns), else the run is refused
+        with a typed error telling the client to pre-flight + acknowledge first.
+        A local-only / cache-hit run never egresses, so it is never gated.
         """
         from .models import ai_job as _ai_job  # local: import-light
 
@@ -1296,6 +1319,7 @@ class Services:
             model=model,
         )
         envelope = self.plan_ai_job_envelope(inputs)
+        self._enforce_cloud_budget_ack(envelope, ack)
 
         def _factory() -> Any:
             if provider is not None:
@@ -1314,6 +1338,27 @@ class Services:
             feature=feature,
             label=label,
             videoId=videoId,
+        )
+
+    def _enforce_cloud_budget_ack(self, envelope: Any, ack: str | None) -> None:
+        """Refuse a non-acknowledged cloud run when ``confirmCloudBudget`` is on.
+
+        The gate fires ONLY when both hold: the setting ``confirmCloudBudget`` is
+        truthy AND the planned envelope ``route.willEgress`` is True (a run that
+        sends bytes off the machine). In that case ``ack`` must equal the
+        envelope's ``cacheKey`` — the token ``ai.planJob`` returns — proving the
+        client previewed THIS exact request's cost/egress budget. A local-only or
+        cache-hit run never egresses, so it bypasses the gate entirely.
+        """
+        if not envelope.route.willEgress:
+            return
+        if not self.settings.get().get("confirmCloudBudget"):
+            return
+        if ack == envelope.cacheKey:
+            return
+        raise _invalid(
+            "cloud run requires budget acknowledgement: call ai.planJob and pass "
+            "its cacheKey as confirmBudget (or disable confirmCloudBudget)"
         )
 
     def ai_plan_job(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
@@ -1343,22 +1388,42 @@ class Services:
         )
         return self.plan_ai_job_envelope(inputs).planned()
 
-    @staticmethod
-    def _budget_request(raw: Any) -> Any:
+    def _budget_request(self, raw: Any) -> Any:
         """Coerce a wire ``request`` dict into a budget request (or ``None``).
 
         The returned :class:`_BudgetRequest` satisfies the duck-typed
         ``budget.BudgetRequest`` protocol (``target_size`` / ``text_bytes`` /
         ``frame_bytes``). A non-dict ``raw`` yields ``None`` (an unsized request).
+
+        WU-budget (P1 #6): when the wire request pins NO ``targetSize`` we resolve
+        the size to the user's ``defaultTargetJobSize`` setting, so the pre-flight
+        budget reflects the configured default job size (one source -> N shorts)
+        rather than only the module constant. A request that DOES pin a size keeps
+        it verbatim. A non-positive / non-int setting falls back to the budget
+        module's ``DEFAULT_TARGET_JOB_SIZE`` (the same fallback ``estimate`` uses).
         """
         if not isinstance(raw, dict):
             return None
         size = raw.get("targetSize")
         return _BudgetRequest(
-            target_size=int(size) if isinstance(size, int) else None,
+            target_size=int(size) if isinstance(size, int) else self._default_target_job_size(),
             text_bytes=int(raw.get("textBytes") or 0),
             frame_bytes=int(raw.get("frameBytes") or 0),
         )
+
+    def _default_target_job_size(self) -> int:
+        """The configured default job size, or the budget module's constant.
+
+        Reads ``settings['defaultTargetJobSize']`` (PLAN P1 #6); a missing /
+        non-int / non-positive value falls back to
+        :data:`budget.DEFAULT_TARGET_JOB_SIZE` so the estimate stays falsifiable.
+        """
+        from .models import budget as _budget_mod  # local: import-light pure
+
+        configured = self.settings.get().get("defaultTargetJobSize")
+        if isinstance(configured, int) and configured > 0:
+            return configured
+        return _budget_mod.DEFAULT_TARGET_JOB_SIZE
 
     def _get_model_runner(self) -> Any:
         """The shared ModelRunner (lazily built from settings; T3)."""
@@ -1647,6 +1712,9 @@ def register_all(
     # WU-keys: provider key management. Every read is REDACTED (last-4) — no RPC
     # method ever returns a full key; the FACTORY path reads RAW via get_raw().
     # Per-data-type (text vs frames) consent is SEPARATE + independently revocable.
+    # WU-catalog: the static curated model catalog (per-task tiers + privacy /
+    # train-on-input flags + asOfDate + unit) the UI renders. PURE data, no keys.
+    reg("providers.catalog", svc.providers_catalog)
     reg("providers.list", svc.providers_list)
     reg("providers.upsert", svc.providers_upsert)
     reg("providers.remove", svc.providers_remove)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 
 import os
 from collections.abc import Callable
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, cast
 
@@ -51,6 +52,38 @@ log = get_logger("media_studio.handlers")
 Video = dict[str, Any]
 SubtitleTrack = dict[str, Any]
 Candidate = dict[str, Any]
+
+
+@dataclass(frozen=True)
+class _BudgetRequest:
+    """A wire-coerced budget request (satisfies ``budget.BudgetRequest`` duck-type).
+
+    ``target_size`` is the discrete output count (``None`` -> the budget default);
+    the two byte fields are the per-request egress split by data kind.
+    """
+
+    target_size: int | None
+    text_bytes: int
+    frame_bytes: int
+
+
+@dataclass(frozen=True)
+class _LocalPoolEntry:
+    """A single local backstop pool entry (satisfies ``budget.PoolEntry``)."""
+
+    provider: str = "local"
+    local: bool = True
+
+
+@dataclass(frozen=True)
+class _LocalOnlyPool:
+    """A local-only fallback pool used when the provider module is a test stub.
+
+    Satisfies :func:`budget.estimate`'s pool shape (``.entries`` of provider/local
+    items); the budget then reports local-only with zero cloud egress.
+    """
+
+    entries: tuple[_LocalPoolEntry, ...] = (_LocalPoolEntry(),)
 
 
 def _invalid(message: str) -> RpcError:
@@ -323,10 +356,10 @@ class Services:
         project = self._find_project_for_track(track_id)
         track = _tracks.find_track(project.data, track_id)
         translator = self._get_translator()  # None -> legacy injected provider
-        provider = self._provider if translator is None else None
+        legacy_provider = self._provider if translator is None else None
         save_path = project.manifest_path
 
-        def job_body(job_ctx: Any) -> dict[str, Any]:
+        def work(job_ctx: Any, _envelope: Any, provider: Any) -> dict[str, Any]:
             if translator is not None:
                 # T3 tiered path: language-aware tier routing + fallback chain;
                 # tier failures surface via job.done error payload (A6.3).
@@ -360,7 +393,20 @@ class Services:
                 project.save(save_path)
             return {"track": translated}
 
-        job = ctx.jobs.start(job_body)
+        # WU-envelope: subtitle translation rides the AiJob substrate (shared
+        # cancel-check + degrade-aware provider) while keeping the {jobId} shape
+        # and the {track} done payload. The legacy injected provider (tests) is
+        # passed through; the T3 tiered path ignores the work's provider arg.
+        job = self._run_ai_job(
+            ctx,
+            messages=[{"role": "user", "content": target_lang}],
+            model=str(settings_now.get("cloudModel") or ""),
+            provider=legacy_provider,
+            work=work,
+            feature="subtitles",
+            label="subtitles.translate",
+            videoId=None,
+        )
         return {"jobId": job.id}
 
     # ===================================================================== #
@@ -752,11 +798,10 @@ class Services:
         prompt = str(params.get("prompt") or "")
         controls = params.get("controls") or {}
         transcript = self._load_or_create_project(video_id).data.get("transcript")
-        provider = self._provider
         runner = self._phase8_runner or self._default_phase8_runner()
         probe = self._ffprobe_duration or _self_ffprobe()
 
-        def job_body(job_ctx: Any) -> dict[str, Any]:
+        def work(job_ctx: Any, _envelope: Any, provider: Any) -> dict[str, Any]:
             from .features import select as _select  # local: import-light
 
             tracks = runner(
@@ -779,7 +824,19 @@ class Services:
             self._cache_candidates(video_id, resolved)
             return {"candidates": resolved}
 
-        job = ctx.jobs.start(job_body)
+        # WU-envelope: the AI re-rank/select rides the AiJob substrate so it gets
+        # the shared cancel-check + degrade-aware provider + (later) cost/cache
+        # while preserving the {jobId} shape and the {candidates} done payload.
+        job = self._run_ai_job(
+            ctx,
+            messages=[{"role": "user", "content": prompt}],
+            model=str(settings.get("cloudModel") or ""),
+            provider=self._provider,
+            work=work,
+            feature="phase8",
+            label="phase8.select",
+            videoId=video_id,
+        )
         return {"jobId": job.id}
 
     def _models_present_map(self, settings: dict[str, Any]) -> dict[str, bool]:
@@ -1042,6 +1099,142 @@ class Services:
         from .models import provider as _provider_mod  # local import: heavy seam
 
         return _provider_mod.get_provider(self.settings.get())
+
+    def _ai_cache(self) -> Any:
+        """The shared AI-call content cache (WU-cache), under the data dir.
+
+        Honors ``settings.aiCacheDir`` (absolute path) when set, else
+        ``data_dir/ai-cache``. The cache is local-only; nothing leaves the box.
+        """
+        from .models.ai_cache import DEFAULT_CACHE_DIRNAME, AiCache  # local: import-light
+
+        configured = self.settings.get().get("aiCacheDir")
+        store_dir = Path(configured) if configured else self.data_dir / DEFAULT_CACHE_DIRNAME
+        return AiCache(store_dir=store_dir)
+
+    def _ai_pool(self) -> Any:
+        """Build the rotation pool (WU-pool) from settings for budget/route reads.
+
+        Returns an object whose ``.entries`` (each carrying ``.provider`` /
+        ``.local``) satisfy :func:`budget.estimate`'s pool shape. The real path
+        builds a :class:`RotatingProvider` with detection OFF (planning only reads
+        the catalog-shaped entries; skipping the live ``GET /models`` probe keeps
+        ai.planJob / the plan step socket-free — PLAN: ZERO provider calls). When
+        the provider module is a test stub WITHOUT ``build_pool_provider`` we fall
+        back to a local-only pool (the budget then reports local-only, no egress).
+        """
+        from .models import provider as _provider_mod  # local: heavy seam
+
+        builder = getattr(_provider_mod, "build_pool_provider", None)
+        if builder is None:
+            return _LocalOnlyPool()
+        return builder(self.settings.get(), detect_local=False)
+
+    def plan_ai_job_envelope(self, inputs: Any) -> Any:
+        """Assemble an :class:`ai_job.AiJob` envelope for ``inputs`` (PURE, no calls).
+
+        Shared by ``ai.planJob`` (pre-flight) and the AI-bearing job handlers so
+        cost/route/cacheKey are derived from ONE place. Performs ZERO provider
+        calls — the pool is built only to read its catalog-shaped ``.entries``.
+        """
+        from .models import ai_job as _ai_job  # local: import-light
+
+        return _ai_job.plan_ai_job(
+            inputs,
+            pool=self._ai_pool(),
+            catalog=_ai_job.CatalogFreeCapAdapter(),
+            cache=self._ai_cache(),
+        )
+
+    def _run_ai_job(
+        self,
+        ctx: RpcContext,
+        *,
+        messages: list[dict[str, str]],
+        model: str,
+        provider: Any,
+        work: Any,
+        feature: str,
+        label: str,
+        videoId: str | None = None,  # noqa: N803 - wire-name kwarg (matches JobRegistry)
+    ) -> Any:
+        """Plan + run an :class:`ai_job.AiJob` on ``ctx.jobs`` with a custom ``work``.
+
+        ``provider`` is the resolved provider the work consumes; when ``None`` the
+        pool-aware ``get_provider`` is built lazily (so rotation + degrade tracking
+        apply). The envelope's cost/route/cacheKey come from
+        :meth:`plan_ai_job_envelope`. Returns the created job (the ``{jobId}``
+        source). The work's own result dict is the ``job.done`` payload.
+        """
+        from .models import ai_job as _ai_job  # local: import-light
+
+        inputs = _ai_job.AiInputs(
+            messages=tuple({str(k): str(v) for k, v in m.items()} for m in messages),
+            model=model,
+        )
+        envelope = self.plan_ai_job_envelope(inputs)
+
+        def _factory() -> Any:
+            if provider is not None:
+                return provider
+            from .models import provider as _provider_mod  # local: heavy seam
+
+            return _provider_mod.get_provider(self.settings.get())
+
+        return _ai_job.run_ai_job(
+            envelope,
+            jobs=ctx.jobs,
+            provider_factory=_factory,
+            cache=self._ai_cache(),
+            work=work,
+            feature=feature,
+            label=label,
+            videoId=videoId,
+        )
+
+    def ai_plan_job(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``ai.planJob({messages?, model?, params?, request?, capability?})`` -> pre-flight.
+
+        Returns ``{route, costEst, cacheHit, willEgress, budget, preview, cacheKey}``
+        WITHOUT executing any AI call (PLAN acceptance: ZERO provider calls). The
+        request shape is the budget request (``target_size`` / ``text_bytes`` /
+        ``frame_bytes``); ``messages`` feed the cache key so the pre-flight knows
+        whether a real run would be a cache hit.
+        """
+        from .models import ai_job as _ai_job  # local: import-light
+
+        raw_messages = params.get("messages")
+        messages = tuple(
+            {str(k): str(v) for k, v in m.items()}
+            for m in raw_messages
+            if isinstance(m, dict)
+        ) if isinstance(raw_messages, list) else ()
+        request = self._budget_request(params.get("request"))
+        inputs = _ai_job.AiInputs(
+            messages=messages,
+            model=str(params.get("model") or ""),
+            params=dict(params.get("params") or {}),
+            request=request,
+            capability=str(params.get("capability") or "text"),
+        )
+        return self.plan_ai_job_envelope(inputs).planned()
+
+    @staticmethod
+    def _budget_request(raw: Any) -> Any:
+        """Coerce a wire ``request`` dict into a budget request (or ``None``).
+
+        The returned :class:`_BudgetRequest` satisfies the duck-typed
+        ``budget.BudgetRequest`` protocol (``target_size`` / ``text_bytes`` /
+        ``frame_bytes``). A non-dict ``raw`` yields ``None`` (an unsized request).
+        """
+        if not isinstance(raw, dict):
+            return None
+        size = raw.get("targetSize")
+        return _BudgetRequest(
+            target_size=int(size) if isinstance(size, int) else None,
+            text_bytes=int(raw.get("textBytes") or 0),
+            frame_bytes=int(raw.get("frameBytes") or 0),
+        )
 
     def _get_model_runner(self) -> Any:
         """The shared ModelRunner (lazily built from settings; T3)."""
@@ -1320,6 +1513,10 @@ def register_all(
     reg("asr.engines", svc.asr_engines)
     reg("phase8.signals", svc.phase8_signals)
     reg("phase8.select", svc.phase8_select)
+
+    # WU-envelope: AI-Job pre-flight. ai.planJob returns the route + cost/egress
+    # budget + cacheHit/willEgress with ZERO provider calls (the pure planner).
+    reg("ai.planJob", svc.ai_plan_job)
 
     # captions-export: EDL/CSV NLE timeline export + ZIP package-for-upload.
     reg("nle.export", svc.nle_export)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -24,6 +24,7 @@ The transcribe/select/translate handlers reach those only inside a job body.
 from __future__ import annotations
 
 import os
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -123,6 +124,7 @@ class Services:
         hardware_probe: Any | None = None,
         phase8_runner: Callable[..., dict[str, Any]] | None = None,
         test_key_transport: Any | None = None,
+        now: Callable[[], float] | None = None,
     ) -> None:
         base = Path(data_dir) if data_dir is not None else default_config_dir()
         self.data_dir = base
@@ -147,6 +149,10 @@ class Services:
         # WU-keys: the transport providers.testKey uses for its validation ping.
         # None -> the real stdlib urllib transport; tests inject a fake.
         self._test_key_transport = test_key_transport
+        # WU-usage-ui: the wall-clock seam used to stamp + stale-flag the cached
+        # providers.usage rows. None -> real ``time.time``; tests inject a fake
+        # clock so the >10-min stale threshold is deterministic.
+        self._now: Callable[[], float] = now or time.time
 
         # T3: the shared llama.cpp ModelRunner (built lazily; model-identity-aware,
         # so the tiered translator can swap MT GGUFs on the one server lane).
@@ -401,6 +407,50 @@ class Services:
         consent["perProvider"] = per_provider
         self.settings.set({"consent": consent})
         return {"consent": consent}
+
+    def providers_usage(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.usage()`` -> ``{usage:[...]}`` per-key live usage (WU-usage-ui).
+
+        Surfaces the rotation pool's per-key accounting
+        ``{provider, key(redacted), used, max, unit, resetAt}`` — already produced
+        from optimistic decrement + parsed 429/``X-RateLimit-*`` headers, so this
+        is NOT a poller (no background loop, no per-call burst: the pool is built
+        with ``detect_local=False`` so no ``GET /models`` socket is opened).
+
+        The pool's in-memory counters reset each process, so the last-known numbers
+        are PERSISTED (timestamped) in ``settings.usageCache`` and folded back in
+        on read (DESIGN §15-Q1): the UI shows immediately on launch without
+        re-polling, and rows older than the >10-min threshold are flagged ``stale``
+        (the renderer desaturates them + shows "last checked Xm ago"). The ``key``
+        field is ALWAYS the redacted last-4 (the pool never carries a live key into
+        this row), so no full key crosses RPC.
+        """
+        from .models.usage import flag_stale, merge_usage_cache
+
+        live_rows: list[dict[str, Any]] = list(self._ai_pool().usage())
+        raw_cache = self.settings.get_raw().get("usageCache")
+        cache: dict[str, Any] = raw_cache if isinstance(raw_cache, dict) else {}
+        raw_rows = cache.get("rows")
+        cached_rows: list[dict[str, Any]] = raw_rows if isinstance(raw_rows, list) else []
+        raw_checked = cache.get("checkedAt")
+        checked_at: dict[str, Any] = raw_checked if isinstance(raw_checked, dict) else {}
+
+        merged = merge_usage_cache(live_rows, cached_rows)
+        now = self._now()
+        # A row that carries real data this call is freshly checked NOW; one that
+        # only survived from the persisted cache keeps its previous timestamp so
+        # its age (and stale flag) keep counting up across reads.
+        next_checked: dict[str, float] = {}
+        for live in live_rows:
+            ident = "\x00".join((str(live.get("provider", "")), str(live.get("key", ""))))
+            used = live.get("used")
+            fresh = (isinstance(used, (int, float)) and used > 0) or live.get("max") is not None
+            next_checked[ident] = now if fresh else float(checked_at.get(ident, now))
+
+        stamped = flag_stale(merged, now=now, checked_at=next_checked)
+        # Persist the merged snapshot so the next launch shows it without polling.
+        self.settings.set({"usageCache": {"rows": merged, "checkedAt": next_checked, "savedAt": now}})
+        return {"usage": stamped}
 
     # ===================================================================== #
     # subtitles.* (generate/edit/export direct; translate = job)
@@ -1720,6 +1770,10 @@ def register_all(
     reg("providers.remove", svc.providers_remove)
     reg("providers.testKey", svc.providers_test_key)
     reg("providers.setConsent", svc.providers_set_consent)
+    # WU-usage-ui: per-key live usage (cached, persisted, stale-flagged; no poll
+    # burst). The rotation pool already accounts usage from optimistic decrement +
+    # parsed 429/X-RateLimit-* headers — this RPC just surfaces it, redacted.
+    reg("providers.usage", svc.providers_usage)
 
     # captions-export: EDL/CSV NLE timeline export + ZIP package-for-upload.
     reg("nle.export", svc.nle_export)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -122,6 +122,7 @@ class Services:
         provider: Any | None = None,
         hardware_probe: Any | None = None,
         phase8_runner: Callable[..., dict[str, Any]] | None = None,
+        test_key_transport: Any | None = None,
     ) -> None:
         base = Path(data_dir) if data_dir is not None else default_config_dir()
         self.data_dir = base
@@ -143,6 +144,9 @@ class Services:
         # (heavy) impls, resolved lazily; tests inject fakes so no GPU / no torch.
         self._hardware_probe = hardware_probe
         self._phase8_runner = phase8_runner
+        # WU-keys: the transport providers.testKey uses for its validation ping.
+        # None -> the real stdlib urllib transport; tests inject a fake.
+        self._test_key_transport = test_key_transport
 
         # T3: the shared llama.cpp ModelRunner (built lazily; model-identity-aware,
         # so the tiered translator can swap MT GGUFs on the one server lane).
@@ -267,8 +271,122 @@ class Services:
         return self.settings.get()
 
     def settings_set(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
-        """``settings.set({...})`` -> merged §2 settings object. Direct-return."""
+        """``settings.set({...})`` -> merged §2 settings object. Direct-return.
+
+        CONTRACT-NOTE (WU-keys): ``settings.set`` returns ``self.settings.set``'s
+        REDACTED merged view (``SettingsStore.set`` backfills + redacts the same
+        way ``get`` does), so the round-tripped response never echoes a full key.
+        """
         return self.settings.set(dict(params))
+
+    # ===================================================================== #
+    # providers.* (WU-keys: user-brings keys; RPC is key-free / redacted)
+    # ===================================================================== #
+    def providers_list(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.list()`` -> ``{providers:[...redacted...]}`` (WU-keys).
+
+        Returns the configured pool with every ``apiKeys`` entry REDACTED to
+        last-4 — the RPC layer NEVER returns a full key. Sourced from the
+        already-redacting :meth:`SettingsStore.get`.
+        """
+        providers = self.settings.get().get("providers")
+        return {"providers": providers if isinstance(providers, list) else []}
+
+    def providers_upsert(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.upsert({id, provider?, kind?, baseUrl?, model?, apiKeys?, enabled?,
+        capabilities?, unit?})`` -> ``{providers:[...redacted...]}`` (WU-keys).
+
+        Inserts a new provider entry or merges into the existing one with the same
+        ``id`` (RAW keys are stored). The returned providers list is REDACTED.
+        Adding more keys to the SAME provider is failover-only (never N x quota,
+        SE2) — that semantics lives in the rotation pool; here we just store them.
+        """
+        nested = params.get("provider")
+        entry: dict[str, Any] = nested if isinstance(nested, dict) else params
+        provider_id = entry.get("id")
+        if not isinstance(provider_id, str) or not provider_id:
+            raise _invalid("providers.upsert requires a provider id")
+        existing = list(self.settings.get_raw().get("providers") or [])
+        merged: list[dict[str, Any]] = []
+        found = False
+        for raw in existing:
+            if isinstance(raw, dict) and raw.get("id") == provider_id:
+                patch = {k: v for k, v in entry.items() if k != "id"}
+                merged.append({**raw, **patch, "id": provider_id})
+                found = True
+            elif isinstance(raw, dict):
+                merged.append(raw)
+        if not found:
+            merged.append(dict(entry))
+        self.settings.set({"providers": merged})
+        return self.providers_list(params, ctx)
+
+    def providers_remove(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.remove({id})`` -> ``{providers:[...redacted...]}`` (WU-keys).
+
+        Drops the provider entry with the given ``id``; returns the REDACTED
+        remaining list. Removing an absent id is a no-op (idempotent).
+        """
+        provider_id = _require_str(params, "id")
+        existing = list(self.settings.get_raw().get("providers") or [])
+        remaining = [raw for raw in existing if not (isinstance(raw, dict) and raw.get("id") == provider_id)]
+        self.settings.set({"providers": remaining})
+        return self.providers_list(params, ctx)
+
+    def providers_test_key(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.testKey({baseUrl, model?, apiKey})`` -> ``{ok, capabilities?, error?}``.
+
+        Validates a key by issuing ONE minimal completion through the provider
+        seam (a fake transport in tests). NEVER echoes the key back: the response
+        carries only ``ok`` + the declared ``capabilities`` + a SCRUBBED ``error``
+        string on failure (the live key is stripped at the provider construction
+        site, so a 4xx error body never leaks the key over RPC).
+        """
+        base_url = _require_str(params, "baseUrl")
+        api_key = params.get("apiKey")
+        if not isinstance(api_key, str) or not api_key:
+            raise _invalid("providers.testKey requires an apiKey")
+        capabilities = [str(c) for c in (params.get("capabilities") or ["text"])]
+        from .models import provider as _provider_mod  # local: heavy seam
+
+        prov = _provider_mod.CloudProvider(
+            api_key=api_key,
+            base_url=base_url,
+            model=str(params.get("model") or _provider_mod.DEFAULT_CLOUD_MODEL),
+            transport=self._test_key_transport,
+        )
+        try:
+            prov.chat([{"role": "user", "content": "ping"}], max_tokens=1)
+        except _provider_mod.ProviderError as exc:
+            # The message is already scrubbed at the construction site; do NOT add
+            # the key back. Defensively scrub again in case a caller-side detail
+            # carried it.
+            from .models.secrets import scrub_error_body
+
+            return {"ok": False, "error": scrub_error_body(str(exc), [api_key])}
+        return {"ok": True, "capabilities": capabilities}
+
+    def providers_set_consent(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.setConsent({provider, text?, frames?})`` -> ``{consent}`` (WU-keys / SE1).
+
+        TEXT (transcripts) and FRAMES (vision) consent are SEPARATE and
+        independently revocable: only the keys present in the request are changed,
+        so revoking ``frames`` leaves ``text`` intact and vice-versa. Returns the
+        full consent block (no secrets — consent carries booleans only).
+        """
+        provider_name = _require_str(params, "provider")
+        raw = self.settings.get_raw()
+        consent = dict(raw.get("consent") or {})
+        per_provider = dict(consent.get("perProvider") or {})
+        current = dict(per_provider.get(provider_name) or {})
+        if "text" in params:
+            current["text"] = bool(params.get("text"))
+        if "frames" in params:
+            current["frames"] = bool(params.get("frames"))
+        per_provider[provider_name] = current
+        consent["perProvider"] = per_provider
+        self.settings.set({"consent": consent})
+        return {"consent": consent}
 
     # ===================================================================== #
     # subtitles.* (generate/edit/export direct; translate = job)
@@ -1093,12 +1211,16 @@ class Services:
     # provider seam
     # ===================================================================== #
     def _get_provider(self) -> Any:
-        """Return the LLM provider for translation (cached test seam or real)."""
+        """Return the LLM provider for translation (cached test seam or real).
+
+        FACTORY PATH (PLAN §WU-keys): builds from RAW keys via ``get_raw()`` — the
+        provider must carry the live key; only RPC reads return redacted.
+        """
         if self._provider is not None:
             return self._provider
         from .models import provider as _provider_mod  # local import: heavy seam
 
-        return _provider_mod.get_provider(self.settings.get())
+        return _provider_mod.get_provider(self.settings.get_raw())
 
     def _ai_cache(self) -> Any:
         """The shared AI-call content cache (WU-cache), under the data dir.
@@ -1128,7 +1250,8 @@ class Services:
         builder = getattr(_provider_mod, "build_pool_provider", None)
         if builder is None:
             return _LocalOnlyPool()
-        return builder(self.settings.get(), detect_local=False)
+        # FACTORY PATH (PLAN §WU-keys): the pool is built from RAW keys.
+        return builder(self.settings.get_raw(), detect_local=False)
 
     def plan_ai_job_envelope(self, inputs: Any) -> Any:
         """Assemble an :class:`ai_job.AiJob` envelope for ``inputs`` (PURE, no calls).
@@ -1179,7 +1302,8 @@ class Services:
                 return provider
             from .models import provider as _provider_mod  # local: heavy seam
 
-            return _provider_mod.get_provider(self.settings.get())
+            # FACTORY PATH (PLAN §WU-keys): the run provider carries RAW keys.
+            return _provider_mod.get_provider(self.settings.get_raw())
 
         return _ai_job.run_ai_job(
             envelope,
@@ -1255,7 +1379,8 @@ class Services:
             return None
         from .models import translation as _translation_mod  # local import
 
-        return _translation_mod.get_translator(self.settings.get(), runner=self._get_model_runner())
+        # FACTORY PATH (PLAN §WU-keys): the tier3 hosted provider is built from RAW keys.
+        return _translation_mod.get_translator(self.settings.get_raw(), runner=self._get_model_runner())
 
     def _dub_translator(self) -> Any:
         """Adapt T3's TieredTranslator to dub's text-based Translator seam.
@@ -1270,7 +1395,8 @@ class Services:
         from .models import translation as _translation_mod  # local: heavy seam
 
         runner = self._get_model_runner()
-        tiered = _translation_mod.get_translator(self.settings.get(), runner=runner)
+        # FACTORY PATH (PLAN §WU-keys): the dub translator's tier3 carries RAW keys.
+        tiered = _translation_mod.get_translator(self.settings.get_raw(), runner=runner)
 
         class _DubTranslator:
             def translate(
@@ -1517,6 +1643,15 @@ def register_all(
     # WU-envelope: AI-Job pre-flight. ai.planJob returns the route + cost/egress
     # budget + cacheHit/willEgress with ZERO provider calls (the pure planner).
     reg("ai.planJob", svc.ai_plan_job)
+
+    # WU-keys: provider key management. Every read is REDACTED (last-4) — no RPC
+    # method ever returns a full key; the FACTORY path reads RAW via get_raw().
+    # Per-data-type (text vs frames) consent is SEPARATE + independently revocable.
+    reg("providers.list", svc.providers_list)
+    reg("providers.upsert", svc.providers_upsert)
+    reg("providers.remove", svc.providers_remove)
+    reg("providers.testKey", svc.providers_test_key)
+    reg("providers.setConsent", svc.providers_set_consent)
 
     # captions-export: EDL/CSV NLE timeline export + ZIP package-for-upload.
     reg("nle.export", svc.nle_export)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -594,6 +594,33 @@ class Services:
     # ===================================================================== #
     # WU-vision: Tier-2 vision re-rank resolution (cloud pool / local / off)
     # ===================================================================== #
+    def _frame_consented_vision_settings(self, settings: dict[str, Any]) -> dict[str, Any]:
+        """Return ``settings`` with ``providers`` filtered to FRAME-consented entries.
+
+        CRITICAL PRIVACY INVARIANT (PLAN §WU-vision acceptance (a): "NO frame
+        egressed without that provider's frame consent"): the rotation pool that
+        backs :class:`CloudVlmBackend` rotates across EVERY vision-capable cloud
+        entry on a 429, so consent must be enforced PER-ENTRY at pool-construction
+        time — not once against the first provider. Any cloud provider whose FRAME
+        consent (``consent.perProvider[<provider>].frames``) is not explicitly
+        granted is DROPPED from ``providers`` before the pool is built, so a 429
+        failover can NEVER reach a non-consented target. Local-backstop entries
+        (added inside ``build_pool_provider``, no key) are unaffected — they never
+        egress. PURE: returns a new settings dict; the original is never mutated.
+        """
+        from .models import consent as _consent  # local: import-light pure gate
+
+        providers = settings.get("providers")
+        if not isinstance(providers, list):
+            return settings
+        kept = [
+            p
+            for p in providers
+            if isinstance(p, dict)
+            and _consent.frame_consent_granted(settings, str(p.get("provider") or p.get("id") or "cloud"))
+        ]
+        return {**settings, "providers": kept}
+
     def _vision_pool(self, settings: dict[str, Any]) -> Any:
         """Build the vision rotation pool honoring routing.perFunction["vision"].
 
@@ -602,6 +629,10 @@ class Services:
         Ollama/LM-Studio is OFF here (no socket — only the configured cloud vision
         entries + the local backstop are needed). ``None`` when the provider module
         is a test stub without ``build_pool_provider``.
+
+        SECURITY: callers building the cloud egress pool MUST pass settings already
+        filtered through :meth:`_frame_consented_vision_settings`, so every
+        cloud slot the pool may rotate to is frame-consented (no rotation bypass).
         """
         from .models import provider as _provider_mod  # local: heavy seam
 
@@ -616,14 +647,16 @@ class Services:
         )
 
     def _vision_provider_for_consent(self, settings: dict[str, Any]) -> str | None:
-        """The provider NAME the vision pool would egress frames to (or ``None``).
+        """The provider NAME a frame-consented vision pool would egress frames to.
 
-        Builds the routed vision pool and returns the first vision-capable CLOUD
-        entry's provider name — exactly the egress target whose FRAME consent must
-        be granted before a frame leaves the machine. ``None`` when no cloud entry
-        can serve vision (then the cloud path is never taken).
+        Builds the routed vision pool over the FRAME-CONSENT-FILTERED providers and
+        returns the first vision-capable CLOUD entry's provider name — exactly the
+        egress target. Because the input is already consent-filtered, ANY cloud
+        entry it returns is one whose FRAME consent is granted; ``None`` when no
+        consented cloud entry can serve vision (then the cloud path is never taken,
+        so no frame is ever prepared for egress).
         """
-        pool = self._vision_pool(settings)
+        pool = self._vision_pool(self._frame_consented_vision_settings(settings))
         if pool is None:  # pragma: no cover -- stub-provider guard (see _vision_pool)
             return None
         from .models.provider import DEFAULT_CAPABILITY  # local: import-light
@@ -640,20 +673,24 @@ class Services:
         The frame-egress consent gate is the FIRST decision, so a no-consent run
         never prepares a frame for egress. Decision tree (PLAN §WU-vision):
 
-        1. A cloud vision provider is routed AND its FRAME consent is granted ->
+        1. At least one cloud vision provider is routed AND frame-consented ->
            a :class:`SmolVlmReranker` whose backend factory is a CLOSURE building a
-           :class:`smolvlm2.CloudVlmBackend` over the vision pool (the
-           ``BackendFactory`` signature stays ``settings -> SmolVlmBackend``).
+           :class:`smolvlm2.CloudVlmBackend` over a pool filtered to ONLY
+           frame-consented cloud entries (the ``BackendFactory`` signature stays
+           ``settings -> SmolVlmBackend``). The pool can therefore only ever rotate
+           to a consented provider on a 429 — no rotation bypass.
         2. Else if the local SmolVLM2 weights are present -> the local reranker.
         3. Else -> ``None`` (the existing transcript-only no-rerank path).
         """
         from .features import smolvlm2 as _sv  # local: import-light (no heavy import)
-        from .models import consent as _consent  # local: import-light pure gate
 
         raw_settings = self.settings.get_raw()
         vision_provider = self._vision_provider_for_consent(raw_settings)
-        if vision_provider is not None and _consent.frame_consent_granted(raw_settings, vision_provider):
-            pool = self._vision_pool(raw_settings)
+        if vision_provider is not None:
+            # SECURITY: the pool is built over ONLY frame-consented cloud entries,
+            # so RotatingProvider.chat(capability="vision") can never fail over to a
+            # provider whose frame consent was not granted (PLAN §WU-vision (a)).
+            pool = self._vision_pool(self._frame_consented_vision_settings(raw_settings))
 
             def cloud_factory(backend_settings: Any) -> Any:
                 return _sv.CloudVlmBackend(

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -135,6 +135,10 @@ class Services:
         phase8_runner: Callable[..., dict[str, Any]] | None = None,
         test_key_transport: Any | None = None,
         now: Callable[[], float] | None = None,
+        vlm_clip_frame_loader: Any | None = None,
+        vlm_frame_encoder: Any | None = None,
+        vlm_models_present: Callable[[dict[str, Any]], bool] | None = None,
+        vlm_chat_transport: Any | None = None,
     ) -> None:
         base = Path(data_dir) if data_dir is not None else default_config_dir()
         self.data_dir = base
@@ -163,6 +167,17 @@ class Services:
         # providers.usage rows. None -> real ``time.time``; tests inject a fake
         # clock so the >10-min stale threshold is deterministic.
         self._now: Callable[[], float] = now or time.time
+        # WU-vision: the Tier-2 re-rank seams. Defaults are the real (heavy) impls
+        # resolved lazily inside smolvlm2; tests inject fakes so no cv2 / no torch /
+        # no weights / no network is ever touched. ``vlm_models_present`` overrides
+        # the local-weight probe so the cloud-vs-local-vs-off decision is testable.
+        self._vlm_clip_frame_loader = vlm_clip_frame_loader
+        self._vlm_frame_encoder = vlm_frame_encoder
+        self._vlm_models_present = vlm_models_present
+        # WU-vision: the chat transport the vision rotation pool uses (the
+        # provider.py HTTP seam). None -> the real stdlib urllib transport; tests
+        # inject a fake so frame egress is observable without a socket.
+        self._vlm_chat_transport = vlm_chat_transport
 
         # T3: the shared llama.cpp ModelRunner (built lazily; model-identity-aware,
         # so the tiered translator can swap MT GGUFs on the one server lane).
@@ -575,6 +590,94 @@ class Services:
         return _translation_mod.get_translator(
             self.settings.get_raw(), runner=self._get_model_runner(), prefer=self._function_prefer(function)
         )
+
+    # ===================================================================== #
+    # WU-vision: Tier-2 vision re-rank resolution (cloud pool / local / off)
+    # ===================================================================== #
+    def _vision_pool(self, settings: dict[str, Any]) -> Any:
+        """Build the vision rotation pool honoring routing.perFunction["vision"].
+
+        FACTORY PATH (PLAN §WU-keys): RAW keys via the caller's ``get_raw()``
+        ``settings``. The routed vision provider is tried first; detection of local
+        Ollama/LM-Studio is OFF here (no socket — only the configured cloud vision
+        entries + the local backstop are needed). ``None`` when the provider module
+        is a test stub without ``build_pool_provider``.
+        """
+        from .models import provider as _provider_mod  # local: heavy seam
+
+        builder = getattr(_provider_mod, "build_pool_provider", None)
+        if builder is None:  # pragma: no cover -- only when provider is a stub w/o the pool builder
+            return None
+        return builder(
+            settings,
+            transport=self._vlm_chat_transport,
+            detect_local=False,
+            prefer=self._function_prefer("vision"),
+        )
+
+    def _vision_provider_for_consent(self, settings: dict[str, Any]) -> str | None:
+        """The provider NAME the vision pool would egress frames to (or ``None``).
+
+        Builds the routed vision pool and returns the first vision-capable CLOUD
+        entry's provider name — exactly the egress target whose FRAME consent must
+        be granted before a frame leaves the machine. ``None`` when no cloud entry
+        can serve vision (then the cloud path is never taken).
+        """
+        pool = self._vision_pool(settings)
+        if pool is None:  # pragma: no cover -- stub-provider guard (see _vision_pool)
+            return None
+        from .models.provider import DEFAULT_CAPABILITY  # local: import-light
+
+        _vision = "vision"
+        for entry in pool.entries:
+            if not entry.local and _vision in entry.capabilities and _vision != DEFAULT_CAPABILITY:
+                return entry.provider
+        return None
+
+    def _resolve_vlm_reranker(self, settings: dict[str, Any], *, media_path: str) -> Any:
+        """Resolve the Tier-2 ``vlm_reranker`` BEFORE any frame is sampled (WU-vision).
+
+        The frame-egress consent gate is the FIRST decision, so a no-consent run
+        never prepares a frame for egress. Decision tree (PLAN §WU-vision):
+
+        1. A cloud vision provider is routed AND its FRAME consent is granted ->
+           a :class:`SmolVlmReranker` whose backend factory is a CLOSURE building a
+           :class:`smolvlm2.CloudVlmBackend` over the vision pool (the
+           ``BackendFactory`` signature stays ``settings -> SmolVlmBackend``).
+        2. Else if the local SmolVLM2 weights are present -> the local reranker.
+        3. Else -> ``None`` (the existing transcript-only no-rerank path).
+        """
+        from .features import smolvlm2 as _sv  # local: import-light (no heavy import)
+        from .models import consent as _consent  # local: import-light pure gate
+
+        raw_settings = self.settings.get_raw()
+        vision_provider = self._vision_provider_for_consent(raw_settings)
+        if vision_provider is not None and _consent.frame_consent_granted(raw_settings, vision_provider):
+            pool = self._vision_pool(raw_settings)
+
+            def cloud_factory(backend_settings: Any) -> Any:
+                return _sv.CloudVlmBackend(
+                    pool=pool,
+                    settings=backend_settings,
+                    frame_encoder=self._vlm_frame_encoder,
+                )
+
+            return _sv.SmolVlmReranker(
+                settings=settings,
+                backend_factory=cloud_factory,
+                clip_frame_loader=self._vlm_clip_frame_loader,
+                media_path=media_path,
+            )
+
+        present = self._vlm_models_present or _sv.default_models_present
+        if present(settings):
+            return _sv.build_reranker(
+                settings=settings,
+                media_path=media_path,
+                clip_frame_loader=self._vlm_clip_frame_loader,
+                models_present=lambda _s: True,
+            )
+        return None
 
     # ===================================================================== #
     # subtitles.* (generate/edit/export direct; translate = job)
@@ -1114,6 +1217,13 @@ class Services:
         def work(job_ctx: Any, _envelope: Any, provider: Any) -> dict[str, Any]:
             from .features import select as _select  # local: import-light
 
+            # WU-vision: resolve the Tier-2 vlm_reranker FIRST — the frame-egress
+            # consent gate runs BEFORE any frame is sampled/encoded (a no-consent
+            # run never prepares a frame for egress). tier<2 skips the re-rank
+            # entirely (so no vision pool is built / no consent read). Cloud-vision
+            # + frame consent -> a CloudVlmBackend closure over the vision pool;
+            # else local weights -> the local reranker; else None (transcript-only).
+            vlm_reranker = self._resolve_vlm_reranker(settings, media_path=path) if tier >= 2 else None
             tracks = runner(
                 path,
                 tier=tier,
@@ -1129,6 +1239,7 @@ class Services:
                 provider,
                 tracks=tracks,
                 tier=tier,
+                vlm_reranker=vlm_reranker,
             )
             resolved = cast("list[Candidate]", list(candidates))
             self._cache_candidates(video_id, resolved)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -98,6 +98,16 @@ def _require_str(params: dict[str, Any], key: str) -> str:
     return value
 
 
+def _routing_block(routing: dict[str, Any]) -> dict[str, Any]:
+    """Extract the persistable ``{perFunction}`` block from a preset routing.
+
+    ``presets.apply_preset`` returns ``{activePreset, perFunction}``; the settings
+    ``routing`` key stores only the ``{perFunction}`` map (``activePreset`` is its
+    own settings key), so this drops the redundant ``activePreset`` field.
+    """
+    return {"perFunction": routing["perFunction"]}
+
+
 class Services:
     """The runtime services + per-method handlers (the composition root).
 
@@ -453,6 +463,120 @@ class Services:
         return {"usage": stamped}
 
     # ===================================================================== #
+    # providers.* presets + per-function routing (WU-presets / PH3)
+    # ===================================================================== #
+    def providers_apply_preset(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.applyPreset({name})`` -> ``{activePreset, routing}`` (WU-presets).
+
+        Resolves one of the smart presets (``privacy`` / ``bestFreeCloud`` /
+        ``balanced``) into a concrete ``routing.perFunction`` map over the REAL
+        curated catalog (via :class:`presets.CatalogAdapter`) and PERSISTS it. The
+        ``privacy`` preset routes every function to local (zero cloud egress);
+        ``bestFreeCloud`` picks the catalog's per-task top model with a local
+        backstop; ``balanced`` mixes cloud text with local vision.
+        """
+        name = _require_str(params, "name")
+        from .models import presets as _presets  # local: import-light pure seam
+
+        try:
+            routing = _presets.apply_preset(name, self.settings.get(), _presets.CatalogAdapter())
+        except ValueError as exc:
+            raise _invalid(str(exc)) from exc
+        self.settings.set({"activePreset": routing["activePreset"], "routing": _routing_block(routing)})
+        return {"activePreset": routing["activePreset"], "routing": _routing_block(routing)}
+
+    def providers_set_function_model(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.setFunctionModel({function, provider})`` -> ``{activePreset, routing}``.
+
+        Overrides ONE function's routed provider (a catalog model-id or the
+        :data:`presets.LOCAL` sentinel), leaving the other slots untouched, and
+        flips ``activePreset`` to ``"custom"`` so the UI reflects the hand-edit.
+        An unknown function or a missing provider is a typed invalid-params error.
+        """
+        from .models import presets as _presets  # local: import-light pure seam
+
+        function = _require_str(params, "function")
+        if function not in _presets.FUNCTIONS:
+            raise _invalid(f"unknown function: {function!r}")
+        provider_id = _require_str(params, "provider")
+        routing = dict(self.settings.get().get("routing") or {})
+        per_function = dict(routing.get("perFunction") or {})
+        per_function[function] = {"provider": provider_id, "fallback": []}
+        new_routing = {"perFunction": per_function}
+        self.settings.set({"activePreset": "custom", "routing": new_routing})
+        return {"activePreset": "custom", "routing": new_routing}
+
+    def providers_first_run(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.firstRun({choice?})`` -> the first-run local-vs-cloud chooser (P1 #6).
+
+        With NO ``choice`` it is a READ: returns ``{firstRunChoiceMade, default}``
+        where ``default`` is the local-safe :func:`presets.first_run_default`
+        (``"privacy"`` until the user picks). With a ``choice`` (``"privacy"`` or
+        any preset name) it APPLIES that preset, sets ``firstRunChoiceMade=True``,
+        and returns ``{firstRunChoiceMade, activePreset, routing}`` — so a cloud
+        choice flips the routing while a local choice keeps the all-local default.
+        """
+        from .models import presets as _presets  # local: import-light pure seam
+
+        choice = params.get("choice")
+        if choice is None:
+            return {
+                "firstRunChoiceMade": bool(self.settings.get().get("firstRunChoiceMade")),
+                "default": _presets.first_run_default(self.settings.get()),
+            }
+        if not isinstance(choice, str) or choice not in _presets.PRESETS:
+            raise _invalid(f"unknown first-run choice: {choice!r}")
+        try:
+            routing = _presets.apply_preset(choice, self.settings.get(), _presets.CatalogAdapter())
+        except ValueError as exc:  # pragma: no cover -- choice is guarded against PRESETS above
+            raise _invalid(str(exc)) from exc
+        block = _routing_block(routing)
+        self.settings.set({"firstRunChoiceMade": True, "activePreset": routing["activePreset"], "routing": block})
+        return {"firstRunChoiceMade": True, "activePreset": routing["activePreset"], "routing": block}
+
+    # -- per-function routing resolution (the seam wiring) ------------------ #
+    def _function_prefer(self, function: str) -> str | None:
+        """Return the configured provider id the ``function`` seam should prefer.
+
+        Reads ``routing.perFunction[function].provider`` (a catalog model-id, the
+        :data:`presets.LOCAL` sentinel, or unset). The sentinel maps to
+        :data:`provider.LOCAL_PROVIDER_ID` (a local-only route); an unset slot
+        returns ``None`` (the pool keeps its configured order). The provider id is
+        threaded into ``get_provider``/``get_translator`` as ``prefer=`` so the
+        seam tries that provider first (PLAN §WU-presets acceptance (b)).
+        """
+        routing = self.settings.get().get("routing")
+        if not isinstance(routing, dict):
+            return None
+        per_function = routing.get("perFunction")
+        if not isinstance(per_function, dict):
+            return None
+        slot = per_function.get(function)
+        if not isinstance(slot, dict):
+            return None
+        provider_id = slot.get("provider")
+        return provider_id if isinstance(provider_id, str) and provider_id else None
+
+    def _provider_for_function(self, function: str) -> Any:
+        """Build the LLM provider the ``function`` seam uses, honoring routing.
+
+        FACTORY PATH (PLAN §WU-keys): RAW keys via ``get_raw()``. The routed
+        provider (``_function_prefer``) is tried first; the rest of the pool is
+        failover with the local backstop last (or local-only when routed to LOCAL).
+        """
+        from .models import provider as _provider_mod  # local: heavy seam
+
+        return _provider_mod.get_provider(self.settings.get_raw(), prefer=self._function_prefer(function))
+
+    def _translator_for_function(self, function: str) -> Any:
+        """Build the TieredTranslator whose tier3 hosted pool honors routing."""
+        from .models import translation as _translation_mod  # local: heavy seam
+
+        return _translation_mod.get_translator(
+            self.settings.get_raw(), runner=self._get_model_runner(), prefer=self._function_prefer(function)
+        )
+
+    # ===================================================================== #
     # subtitles.* (generate/edit/export direct; translate = job)
     # ===================================================================== #
     def subtitles_generate(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
@@ -537,7 +661,10 @@ class Services:
             _offline.guard_network(settings_now, "cloud translation")
         project = self._find_project_for_track(track_id)
         track = _tracks.find_track(project.data, track_id)
-        translator = self._get_translator()  # None -> legacy injected provider
+        # WU-presets: the translation seam honors routing.perFunction["translation"]
+        # (its tier3 hosted pool tries the routed provider first); falls back to the
+        # legacy injected provider when one is set (existing tests).
+        translator = None if self._provider is not None else self._translator_for_function("translation")
         legacy_provider = self._provider if translator is None else None
         save_path = project.manifest_path
 
@@ -1010,11 +1137,15 @@ class Services:
         # WU-envelope: the AI re-rank/select rides the AiJob substrate so it gets
         # the shared cancel-check + degrade-aware provider + (later) cost/cache
         # while preserving the {jobId} shape and the {candidates} done payload.
+        # WU-presets: the select seam honors routing.perFunction["select"] — its
+        # rotation pool tries the routed provider first (local-only when routed to
+        # LOCAL). A legacy injected provider (tests) still wins.
+        select_provider = self._provider if self._provider is not None else self._provider_for_function("select")
         job = self._run_ai_job(
             ctx,
             messages=[{"role": "user", "content": prompt}],
             model=str(settings.get("cloudModel") or ""),
-            provider=self._provider,
+            provider=select_provider,
             work=work,
             feature="phase8",
             label="phase8.select",
@@ -1423,11 +1554,11 @@ class Services:
         from .models import ai_job as _ai_job  # local: import-light
 
         raw_messages = params.get("messages")
-        messages = tuple(
-            {str(k): str(v) for k, v in m.items()}
-            for m in raw_messages
-            if isinstance(m, dict)
-        ) if isinstance(raw_messages, list) else ()
+        messages = (
+            tuple({str(k): str(v) for k, v in m.items()} for m in raw_messages if isinstance(m, dict))
+            if isinstance(raw_messages, list)
+            else ()
+        )
         request = self._budget_request(params.get("request"))
         inputs = _ai_job.AiInputs(
             messages=messages,
@@ -1774,6 +1905,13 @@ def register_all(
     # burst). The rotation pool already accounts usage from optimistic decrement +
     # parsed 429/X-RateLimit-* headers — this RPC just surfaces it, redacted.
     reg("providers.usage", svc.providers_usage)
+    # WU-presets (PH3): smart presets + per-function override + first-run chooser.
+    # applyPreset resolves a preset over the curated catalog into routing.perFunction;
+    # setFunctionModel overrides one slot; firstRun is the local-vs-cloud chooser
+    # (local-safe default pre-choice, flips routing + firstRunChoiceMade on choice).
+    reg("providers.applyPreset", svc.providers_apply_preset)
+    reg("providers.setFunctionModel", svc.providers_set_function_model)
+    reg("providers.firstRun", svc.providers_first_run)
 
     # captions-export: EDL/CSV NLE timeline export + ZIP package-for-upload.
     reg("nle.export", svc.nle_export)

--- a/sidecar/media_studio/models/ai_cache.py
+++ b/sidecar/media_studio/models/ai_cache.py
@@ -1,0 +1,112 @@
+"""AI-call content cache (WU-cache, PLAN §WU-cache).
+
+A small on-disk JSON store keyed by the sha256 of a *canonicalized* AI request
+``(messages, model, params)``. It exists so repeat / re-prompt AI calls are free:
+the AI-Job envelope (``models/ai_job.py``, a LATER WU) consults this cache BEFORE
+any provider call, making the free cloud tier usable and the budget honest.
+
+Design contract (from the plan):
+  * ``key(messages, model, params) -> str`` — PURE, deterministic content hash.
+    Canonicalization sorts dict keys so logically-identical requests collide and
+    any change to content, model, or a param yields a different key.
+  * ``get(key)`` / ``put(key, result)`` — round-trip through an INJECTABLE store
+    dir (tests pass a tmp path; real wiring passes ``data_dir/ai-cache``).
+
+This module is deliberately import-light (stdlib only). The store dir is the ONLY
+side effect, and a corrupt / unreadable entry is treated as a cache MISS so a bad
+file can never crash the AI hot path.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Final
+
+from ..util import get_logger
+
+log = get_logger("media_studio.models.ai_cache")
+
+#: Default sub-directory name under the app data dir (the data-dir wiring is a
+#: LATER WU; this constant is the agreed name so that WU has a single source).
+DEFAULT_CACHE_DIRNAME: Final[str] = "ai-cache"
+
+#: A chat message is the OpenAI-style ``{"role": ..., "content": ...}`` dict.
+Message = Mapping[str, str]
+
+
+class AiCache:
+    """Content-hash cache for AI requests, backed by a JSON-per-entry store dir.
+
+    The store dir is injected so tests use a ``tmp_path`` and never touch the
+    real data dir. The dir is created lazily on the first :meth:`put`.
+    """
+
+    def __init__(self, *, store_dir: str | os.PathLike[str]) -> None:
+        self._store_dir = Path(store_dir)
+
+    # --------------------------------------------------------------------- #
+    # pure key derivation
+    # --------------------------------------------------------------------- #
+    def key(
+        self,
+        messages: Sequence[Message],
+        model: str,
+        params: Mapping[str, Any],
+    ) -> str:
+        """Return the sha256 hex digest of the canonicalized request.
+
+        Canonicalization uses ``json.dumps(..., sort_keys=True)`` so dict /
+        param ordering is irrelevant; any change to the messages, model, or a
+        param value (including adding one) changes the digest.
+        """
+        canonical = json.dumps(
+            {
+                "messages": [dict(m) for m in messages],
+                "model": model,
+                "params": dict(params),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        )
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+    # --------------------------------------------------------------------- #
+    # store layout
+    # --------------------------------------------------------------------- #
+    def path_for(self, key: str) -> Path:
+        """Return the on-disk path backing ``key`` (one JSON file per entry)."""
+        return self._store_dir / f"{key}.json"
+
+    # --------------------------------------------------------------------- #
+    # get / put
+    # --------------------------------------------------------------------- #
+    def get(self, key: str) -> Any | None:
+        """Return the cached result for ``key``, or ``None`` on a miss.
+
+        A missing, unreadable, or non-JSON entry is a MISS (never an exception):
+        a corrupt cache file must not break the AI hot path.
+        """
+        path = self.path_for(key)
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except OSError:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            log.warning("ai_cache: discarding corrupt entry %s", key)
+            return None
+
+    def put(self, key: str, result: Any) -> None:
+        """Store ``result`` (JSON-serializable) under ``key``, creating the dir."""
+        self._store_dir.mkdir(parents=True, exist_ok=True)
+        path = self.path_for(key)
+        path.write_text(
+            json.dumps(result, ensure_ascii=False),
+            encoding="utf-8",
+        )

--- a/sidecar/media_studio/models/ai_job.py
+++ b/sidecar/media_studio/models/ai_job.py
@@ -183,9 +183,7 @@ def _default_request(inputs: AiInputs) -> _budget.BudgetRequest:
     """
     if inputs.request is not None:
         return inputs.request
-    text_bytes = sum(
-        len(str(m.get("content", "")).encode("utf-8")) for m in inputs.messages
-    )
+    text_bytes = sum(len(str(m.get("content", "")).encode("utf-8")) for m in inputs.messages)
     return _TextRequest(target_size=1, text_bytes=text_bytes, frame_bytes=0)
 
 

--- a/sidecar/media_studio/models/ai_job.py
+++ b/sidecar/media_studio/models/ai_job.py
@@ -1,0 +1,410 @@
+"""AI-Job envelope (WU-envelope, PLAN §WU-envelope).
+
+A typed substrate ``{inputs, route, costEst, cacheKey, preview, result, cancel}``
+that every AI call rides, so cost-preview, cache, budget, graceful-degradation and
+universal progress / cancel / reveal (UX6) hang off ONE object. It is built on the
+existing ``jobs.py`` ``Job`` / ``JobContext`` / ``JobRegistry`` — there is NO second
+job bus here; :func:`run_ai_job` executes the work on a ``ctx.jobs`` job and emits
+``job.progress`` / ``job.done`` through the existing :class:`JobContext`.
+
+Two layers, mirroring the rest of the Hub:
+
+  * :func:`plan_ai_job` is **PURE** — it assembles the envelope's ``route``,
+    ``costEst`` (via :mod:`models.budget`), and ``cacheKey`` (via
+    :class:`models.ai_cache.AiCache`) from the request + the rotation ``pool`` +
+    the static ``catalog`` WITHOUT touching the network or a provider. It is the
+    engine behind the ``ai.planJob`` pre-flight RPC, which must perform ZERO
+    provider calls.
+  * :func:`run_ai_job` executes the planned envelope on a job: it consults the
+    cache FIRST (a hit skips the provider entirely and flags ``cacheHit``), runs
+    the resolved provider on a miss, enforces the budget's degrade chain, and
+    emits a single ``degraded`` notice when a run falls through to the local
+    backstop.
+
+The collaborators (``jobs``, ``provider_factory``, ``cache``, ``budget``) are all
+injected so the unit tests drive the whole flow with tiny fakes and never open a
+socket, spawn a model, or read a real clock. This module imports only its sibling
+PURE helpers (``budget``, ``ai_cache``) — never the heavy provider transport.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+from . import budget as _budget
+from .ai_cache import AiCache, Message
+from .budget import Budget
+
+# --------------------------------------------------------------------------- #
+# Route — the resolved plan flags the envelope carries to the UI
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AiRoute:
+    """How a planned AI call WILL run (no side effects to compute it).
+
+    Attributes:
+        providers: the distinct cloud providers the call may use, in failover
+            order (the local backstop is excluded — it is the implicit last hop).
+        degradeChain: the full failover order ``[provider, …, "local"]`` the run
+            will fall through, ending in the always-available local backstop.
+        cacheHit: ``True`` iff the cache already holds this exact request, so the
+            run will return instantly with ZERO provider calls.
+        willEgress: ``True`` iff running WOULD send bytes off the machine — i.e.
+            there is at least one cloud provider AND it is not a cache hit. A
+            cache hit or a local-only pool never egresses.
+    """
+
+    providers: tuple[str, ...]
+    degradeChain: tuple[str, ...]  # noqa: N815 -- RPC/JSON wire field (PLAN-pinned)
+    cacheHit: bool  # noqa: N815 -- RPC/JSON wire field (PLAN-pinned)
+    willEgress: bool  # noqa: N815 -- RPC/JSON wire field (PLAN-pinned)
+
+
+# --------------------------------------------------------------------------- #
+# AiJob — the envelope
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class AiJob:
+    """The typed envelope every AI call rides (PLAN §WU-envelope).
+
+    ``inputs`` is the canonical request (messages + model + params) the cache key
+    and provider call are derived from. ``route`` / ``costEst`` / ``cacheKey`` are
+    filled by :func:`plan_ai_job`. ``preview`` is the human-readable pre-flight
+    summary surfaced before a cloud run. ``result`` / ``cancel`` are the outcome
+    fields :func:`run_ai_job` populates on a freshly-derived copy — the planned
+    envelope itself stays immutable.
+    """
+
+    inputs: AiInputs
+    route: AiRoute
+    costEst: Budget  # noqa: N815 -- RPC/JSON wire field (PLAN-pinned)
+    cacheKey: str  # noqa: N815 -- RPC/JSON wire field (PLAN-pinned)
+    preview: str
+    result: Any = None
+    cancel: bool = False
+
+    def planned(self) -> dict[str, Any]:
+        """The pre-flight JSON the ``ai.planJob`` RPC returns (NO execution).
+
+        Shape (PLAN acceptance): ``{route, costEst, cacheHit, willEgress, budget}``
+        — ``costEst`` and ``budget`` are the same :class:`Budget`, surfaced under
+        both the plan's pinned ``costEst`` name and the budget-acceptance
+        ``budget`` name so either reader finds it.
+        """
+        return {
+            "route": _route_json(self.route),
+            "costEst": _budget_json(self.costEst),
+            "cacheHit": self.route.cacheHit,
+            "willEgress": self.route.willEgress,
+            "budget": _budget_json(self.costEst),
+            "preview": self.preview,
+            "cacheKey": self.cacheKey,
+        }
+
+
+@dataclass(frozen=True)
+class AiInputs:
+    """The canonical AI request: messages + model + sampling params + a budget shape.
+
+    ``params`` are the sampling knobs that participate in the cache key (so a
+    temperature change misses). ``request`` is the duck-typed budget request
+    (``target_size`` / ``text_bytes`` / ``frame_bytes``) the cost estimate reads.
+    ``capability`` is what the provider must serve (``"text"`` / ``"vision"``).
+    """
+
+    messages: tuple[Message, ...]
+    model: str
+    params: Mapping[str, Any] = field(default_factory=dict)
+    request: _budget.BudgetRequest | None = None
+    capability: str = "text"
+
+
+# --------------------------------------------------------------------------- #
+# Collaborator contracts (faked in tests)
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class _PoolLike(Protocol):
+    """The rotation-pool surface :mod:`ai_job` reads (a :class:`Budget` pool)."""
+
+    entries: object  # iterable of entries carrying ``provider`` + ``local``
+
+
+@runtime_checkable
+class _ChatProvider(Protocol):
+    """The minimal provider surface :func:`run_ai_job` drives."""
+
+    def chat(self, messages: Sequence[Message], **kwargs: Any) -> str: ...
+
+
+# A provider factory: returns the resolved (rotating) provider for the run. It is
+# called at most ONCE, only on a cache miss — a cache hit never builds a provider.
+ProviderFactory = Any  # Callable[[], _ChatProvider]; kept loose for the closure path
+
+
+# --------------------------------------------------------------------------- #
+# JSON serialization (the wire shapes the renderer reads verbatim)
+# --------------------------------------------------------------------------- #
+def _budget_json(b: Budget) -> dict[str, Any]:
+    """Serialize a :class:`Budget` to its pinned camelCase wire shape."""
+    return {
+        "requests": b.requests,
+        "providers": list(b.providers),
+        "egressBytes": b.egressBytes,
+        "egressKinds": {"text": b.egressKinds.text, "frames": b.egressKinds.frames},
+        "withinFreeLimits": b.withinFreeLimits,
+    }
+
+
+def _route_json(r: AiRoute) -> dict[str, Any]:
+    """Serialize an :class:`AiRoute` to its pinned camelCase wire shape."""
+    return {
+        "providers": list(r.providers),
+        "degradeChain": list(r.degradeChain),
+        "cacheHit": r.cacheHit,
+        "willEgress": r.willEgress,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# plan_ai_job — PURE: assemble the envelope (the ai.planJob engine)
+# --------------------------------------------------------------------------- #
+def _default_request(inputs: AiInputs) -> _budget.BudgetRequest:
+    """The budget request for ``inputs`` — the explicit one, or a text-sized fallback.
+
+    When the inputs pin no budget request we derive a single-output text request
+    whose ``text_bytes`` is the encoded size of the messages, so an unsized plan
+    still yields a falsifiable, non-zero estimate.
+    """
+    if inputs.request is not None:
+        return inputs.request
+    text_bytes = sum(
+        len(str(m.get("content", "")).encode("utf-8")) for m in inputs.messages
+    )
+    return _TextRequest(target_size=1, text_bytes=text_bytes, frame_bytes=0)
+
+
+@dataclass
+class _TextRequest:
+    """A minimal :class:`budget.BudgetRequest` for an unsized text-only call.
+
+    Non-frozen so its fields are *writable* and the instance structurally
+    satisfies the duck-typed ``budget.BudgetRequest`` protocol (whose members are
+    mutable attributes); it is constructed once and never mutated in practice.
+    """
+
+    target_size: int | None
+    text_bytes: int
+    frame_bytes: int
+
+
+def plan_ai_job(
+    inputs: AiInputs,
+    *,
+    pool: _PoolLike,
+    catalog: _budget.Catalog,
+    cache: AiCache,
+) -> AiJob:
+    """Assemble an :class:`AiJob` envelope for ``inputs`` (PURE — no provider call).
+
+    Builds the cache key (so a hit is known before any run), the budget estimate
+    (cost + egress, via :mod:`models.budget`), and the route flags. A cache hit
+    forces ``willEgress=False`` (the run will not leave the machine); otherwise
+    ``willEgress`` is true iff the pool has at least one cloud provider.
+    """
+    cache_key = cache.key(list(inputs.messages), inputs.model, dict(inputs.params))
+    cache_hit = cache.get(cache_key) is not None
+    cost = _budget.estimate(_default_request(inputs), pool, catalog)
+    chain = tuple(_budget.degrade_chain(pool))
+    will_egress = (not cache_hit) and bool(cost.providers)
+    route = AiRoute(
+        providers=cost.providers,
+        degradeChain=chain,
+        cacheHit=cache_hit,
+        willEgress=will_egress,
+    )
+    return AiJob(
+        inputs=inputs,
+        route=route,
+        costEst=cost,
+        cacheKey=cache_key,
+        preview=_preview_text(cost, cache_hit),
+    )
+
+
+def _preview_text(cost: Budget, cache_hit: bool) -> str:
+    """A one-line human pre-flight summary (UX6 reveal/confirm copy)."""
+    if cache_hit:
+        return "Cached — returns instantly, sends nothing."
+    if not cost.providers:
+        return f"Local only — {cost.requests} request(s), sends nothing off the machine."
+    providers = ", ".join(cost.providers)
+    kb = cost.egressBytes / 1024
+    return (
+        f"~{cost.requests} request(s) across {providers}; "
+        f"sends ~{kb:.1f} KB ({cost.egressKinds.text} text / "
+        f"{cost.egressKinds.frames} frame bytes)."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# run_ai_job — execute the envelope on a job (cache-first, degrade-aware)
+# --------------------------------------------------------------------------- #
+# A custom work body: given the live JobContext + the planned envelope, do the
+# handler-specific work and return its own result dict (the job.done payload).
+# When supplied, it REPLACES the default single-chat body but keeps the
+# envelope's cancel-check + progress framing. The provider it consumes is built
+# by ``provider_factory`` and handed in so degrade-tracking still applies.
+AiWork = Callable[[Any, AiJob, Any], dict[str, Any]]
+
+
+def run_ai_job(
+    envelope: AiJob,
+    *,
+    jobs: Any,
+    provider_factory: ProviderFactory,
+    cache: AiCache,
+    budget: object | None = None,  # noqa: ARG001 - reserved; degrade chain rides the envelope
+    work: AiWork | None = None,
+    feature: str = "ai",
+    label: str = "AI",
+    videoId: str | None = None,  # noqa: N803 - wire-name kwarg (matches JobRegistry)
+) -> Any:
+    """Run ``envelope`` on a ``jobs`` job; return the created :class:`jobs.Job`.
+
+    Two modes share the SAME envelope framing (cancel-check first, the one job
+    bus, degrade tracking):
+
+      * **default chat** (no ``work``) — cache-first: a cache hit returns the
+        stored result with ZERO provider calls (the ``provider_factory`` is never
+        invoked); a miss builds the provider once, drives one ``chat``, caches
+        the fresh result, and flags ``degraded`` when the run fell through to
+        local. The done payload is ``{result, cacheHit, degraded}``.
+      * **custom work** (``work`` supplied) — the handler-specific body (e.g.
+        ``select_unified`` / ``translate``) runs through the envelope so it gets
+        the shared cancel-check + a degrade-aware provider, and returns its OWN
+        result shape verbatim to ``job.done`` (preserving each handler's existing
+        ``{candidates}`` / ``{track}`` contract).
+
+    Cancellation is honored via ``ctx.cancelled`` before any provider work — a
+    cancelled job makes no call.
+    """
+
+    def job_body(ctx: Any) -> dict[str, Any]:
+        if ctx.cancelled:
+            return {"cancelled": True}
+        ctx.progress(0.0, "planning")
+        if work is not None:
+            return _execute_work(ctx, envelope, provider_factory, work)
+        cached = cache.get(envelope.cacheKey)
+        if cached is not None:
+            ctx.progress(100.0, "cache hit")
+            return {"result": cached, "cacheHit": True, "degraded": False}
+        return _execute_uncached(ctx, envelope, provider_factory, cache)
+
+    return jobs.start(job_body, feature=feature, label=label, videoId=videoId)
+
+
+def _execute_work(
+    ctx: Any,
+    envelope: AiJob,
+    provider_factory: ProviderFactory,
+    work: AiWork,
+) -> dict[str, Any]:
+    """Run a custom ``work`` body with a degrade-aware provider; return its result.
+
+    The provider is built once and a ``degraded`` notice is emitted if the run
+    fell through to the local backstop, so the handler-specific work inherits the
+    same graceful-degradation visibility as the default chat path.
+    """
+    provider = provider_factory()
+    degraded_flag = {"hit_local": False}
+    _subscribe_degrade(provider, degraded_flag)
+    result = work(ctx, envelope, provider)
+    if degraded_flag["hit_local"]:
+        ctx.progress(99.0, "degraded: fell back to local")
+    return result
+
+
+def _execute_uncached(
+    ctx: Any,
+    envelope: AiJob,
+    provider_factory: ProviderFactory,
+    cache: AiCache,
+) -> dict[str, Any]:
+    """Build the provider, run the chat, store the result, and flag degradation."""
+    provider = provider_factory()
+    degraded_flag = {"hit_local": False}
+    _subscribe_degrade(provider, degraded_flag)
+    if ctx.cancelled:
+        return {"cancelled": True}
+    ctx.progress(10.0, "calling provider")
+    result = provider.chat(list(envelope.inputs.messages), **dict(envelope.inputs.params))
+    if degraded_flag["hit_local"]:
+        ctx.progress(90.0, "degraded: fell back to local")
+    cache.put(envelope.cacheKey, result)
+    ctx.progress(100.0, "done")
+    return {"result": result, "cacheHit": False, "degraded": degraded_flag["hit_local"]}
+
+
+def _subscribe_degrade(provider: Any, flag: dict[str, bool]) -> None:
+    """Register a rotation listener that flips ``flag`` when the run hits local.
+
+    The rotation pool emits a :class:`provider.RotationEvent` per failover; a
+    failover whose target provider is the local backstop (``"local"``) means the
+    run degraded. Providers without an ``on_rotation`` hook (the plain local /
+    cloud providers) simply never degrade — the call is a graceful no-op.
+    """
+    on_rotation = getattr(provider, "on_rotation", None)
+    if not callable(on_rotation):
+        return
+
+    def _listener(event: Any) -> None:
+        if getattr(event, "provider", "") == "local":
+            flag["hit_local"] = True
+
+    on_rotation(_listener)
+
+
+# --------------------------------------------------------------------------- #
+# Catalog adapter (WAVE-1 CARRYFORWARD #1)
+# --------------------------------------------------------------------------- #
+# The real ``models.catalog`` keys ``per_task_tier`` by a ``Task`` enum and has
+# no ``all()`` / ``free_cap()`` — its free limits are a human string
+# (``free_limits`` like "30 RPM / 1K RPD / 200K TPD"), NOT a structured numeric
+# per-request cap. :func:`budget.estimate` needs a ``Catalog`` with
+# ``free_cap(provider) -> int | None`` where ``None`` means "uncapped for this
+# estimate". This adapter bridges the two WITHOUT duplicating the catalog: it
+# returns ``None`` for every provider, so the budget never FALSELY claims an
+# over-cap from a limit it cannot parse numerically. A structured per-provider
+# numeric cap (parsing the RPD/TPD string) is a LATER refinement; until then the
+# honest answer is "uncapped" and ``withinFreeLimits`` stays ``True`` here.
+class CatalogFreeCapAdapter:
+    """Adapts the real catalog module to :func:`budget.estimate`'s ``Catalog``.
+
+    Holds the catalog reference for forward-compat (a future version can parse a
+    provider's ``free_limits`` into a numeric RPD cap); today every provider is
+    reported uncapped (``None``) — the honest answer given the string-only limits.
+    """
+
+    def __init__(self, catalog_module: Any | None = None) -> None:
+        self._catalog = catalog_module
+
+    def free_cap(self, provider: str) -> int | None:  # noqa: ARG002 - uncapped today
+        """Return the per-provider free request cap, or ``None`` (uncapped)."""
+        return None
+
+
+__all__ = [
+    "AiInputs",
+    "AiJob",
+    "AiRoute",
+    "CatalogFreeCapAdapter",
+    "plan_ai_job",
+    "run_ai_job",
+]

--- a/sidecar/media_studio/models/budget.py
+++ b/sidecar/media_studio/models/budget.py
@@ -1,0 +1,207 @@
+"""Pre-flight cost / egress budget for cloud AI runs (WU-budget, the PURE half).
+
+Before a cloud AI run the Hub must answer, *without sending anything*: "~N
+requests across K providers, sends X bytes (split text vs frames) — proceed?"
+(PLAN P1) and it must order the providers the run will fall through on failover
+down to the always-available local backstop (PLAN P2).
+
+This module is **PURE**. Its two public functions take their collaborators —
+the planned ``request``, the rotation ``pool``, and the static ``catalog`` — as
+**parameters** and never construct them, never touch the network, never read a
+clock. The collaborators are **duck-typed** (see the Protocols below); the real
+implementations land in their own WUs (``models.catalog`` / ``models.provider``)
+and the tests inject tiny fakes. This module imports NO heavy dependency and does
+NOT cross-import the other Hub modules at runtime.
+
+What the two functions compute:
+  * :func:`estimate` → a :class:`Budget` describing the request count, the
+    distinct cloud providers involved (the local backstop is never billed),
+    the egress bytes split by kind (text vs frames), and whether the estimate
+    stays inside every involved provider's catalog free cap.
+  * :func:`degrade_chain` → the ordered failover chain ``[provider, …, "local"]``
+    used both by rotation and by the "degraded to local" notice. The local
+    backstop is always the final, single entry (literal ``"local"``).
+
+The request count NEVER multiplies with the number of providers or keys — a
+second same-provider key is failover, not extra quota (PLAN SE2 / DESIGN R5),
+and a request is counted exactly once regardless of pool shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol, runtime_checkable
+
+# --------------------------------------------------------------------------- #
+# Default target job size (PLAN P1 #6 — PROMOTED to acceptance)
+# --------------------------------------------------------------------------- #
+#: How many discrete outputs a job produces when the request pins NO size.
+#:
+#: DOCUMENTED PLACEHOLDER: the concrete value (e.g. one 60-min source → N shorts)
+#: is an open product decision for the user (PLAN §5.6). Until the user pins it,
+#: :func:`estimate` uses this constant so the pre-flight budget yields a
+#: falsifiable request count for an unsized job. Change the value here once the
+#: user decides; do not scatter the magic number into callers.
+DEFAULT_TARGET_JOB_SIZE: int = 8
+
+
+# --------------------------------------------------------------------------- #
+# Duck-typed collaborator contracts (faked in tests, real impls land elsewhere)
+# --------------------------------------------------------------------------- #
+@runtime_checkable
+class BudgetRequest(Protocol):
+    """The planned AI request, from the caller's perspective.
+
+    ``target_size`` is how many discrete outputs the job will produce (e.g.
+    shorts). ``None`` (or a non-positive value) means the size is not pinned →
+    :func:`estimate` falls back to :data:`DEFAULT_TARGET_JOB_SIZE`. The two byte
+    fields are the egress PER request, split by data kind.
+    """
+
+    target_size: int | None
+    text_bytes: int
+    frame_bytes: int
+
+
+@runtime_checkable
+class PoolEntry(Protocol):
+    """One entry in the rotation pool: a provider id and a backstop flag.
+
+    ``local`` is ``True`` only for the always-available local backstop, which is
+    never billed and never appears as a distinct cloud provider in the budget.
+    """
+
+    provider: str
+    local: bool
+
+
+@runtime_checkable
+class ProviderPool(Protocol):
+    """An ordered pool of :class:`PoolEntry` (cloud first, local backstop last)."""
+
+    entries: object  # an iterable of PoolEntry (iterated, never mutated)
+
+
+@runtime_checkable
+class Catalog(Protocol):
+    """The static catalog, queried for a provider's free request cap.
+
+    ``free_cap`` returns the per-provider free request ceiling, or ``None`` when
+    the provider is effectively uncapped for this estimate.
+    """
+
+    def free_cap(self, provider: str) -> int | None: ...
+
+
+# --------------------------------------------------------------------------- #
+# Result dataclasses
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class EgressKinds:
+    """Egress bytes split by data kind (text transcripts vs vision frames)."""
+
+    text: int
+    frames: int
+
+
+@dataclass(frozen=True)
+class Budget:
+    """A pre-flight estimate for a cloud AI run (no side effects to produce it).
+
+    Attributes:
+        requests: how many provider calls the run will make (counted ONCE,
+            independent of pool / key count).
+        providers: the distinct cloud providers involved, in pool order; the
+            local backstop is excluded (it is never billed).
+        egressBytes: total bytes leaving the machine (``text + frames``).
+        egressKinds: the egress split by kind so the UI can show "sends X text /
+            Y frame bytes to provider Z".
+        withinFreeLimits: ``False`` iff the request count exceeds the catalog's
+            free cap for ANY involved provider; ``True`` when every involved
+            provider is under-cap (or uncapped, or there are no cloud providers).
+    """
+
+    requests: int
+    providers: tuple[str, ...]
+    # camelCase fields are the JSON wire shape this Budget serialises to over RPC
+    # (PLAN §WU-budget pins these exact names; the renderer reads them verbatim),
+    # so the pep8-naming N815 finding is an intentional, file-local suppression.
+    egressBytes: int  # noqa: N815 -- RPC/JSON wire field name (PLAN-pinned)
+    egressKinds: EgressKinds  # noqa: N815 -- RPC/JSON wire field name (PLAN-pinned)
+    withinFreeLimits: bool  # noqa: N815 -- RPC/JSON wire field name (PLAN-pinned)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+def _resolve_request_count(target_size: int | None) -> int:
+    """The number of requests, falling back to the default for an unpinned size.
+
+    A ``None`` or non-positive ``target_size`` is treated as "not pinned" and
+    resolves to :data:`DEFAULT_TARGET_JOB_SIZE` (PLAN P1 #6).
+    """
+    if target_size is None or target_size <= 0:
+        return DEFAULT_TARGET_JOB_SIZE
+    return target_size
+
+
+def _cloud_providers(pool: ProviderPool) -> tuple[str, ...]:
+    """Distinct cloud provider ids in pool order (local backstop excluded).
+
+    A provider appearing twice (a second same-provider key) is counted once: an
+    extra same-provider key is failover, never additional quota (PLAN SE2).
+    """
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for entry in pool.entries:  # type: ignore[attr-defined]
+        if entry.local:
+            continue
+        if entry.provider not in seen:
+            seen.add(entry.provider)
+            ordered.append(entry.provider)
+    return tuple(ordered)
+
+
+def _within_free_limits(requests: int, providers: tuple[str, ...], catalog: Catalog) -> bool:
+    """``True`` iff ``requests`` stays at/under every involved provider's cap."""
+    for provider in providers:
+        cap = catalog.free_cap(provider)
+        if cap is not None and requests > cap:
+            return False
+    return True
+
+
+def estimate(request: BudgetRequest, pool: ProviderPool, catalog: Catalog) -> Budget:
+    """Compute a :class:`Budget` for ``request`` over ``pool`` against ``catalog``.
+
+    PURE: reads only the three duck-typed collaborators, mutates nothing, and
+    performs zero I/O. The request count comes from the request's pinned
+    ``target_size`` (or :data:`DEFAULT_TARGET_JOB_SIZE` when unpinned) and is
+    NOT multiplied by the number of providers/keys. Egress is the per-request
+    byte cost times the request count, split into text vs frames.
+    """
+    requests = _resolve_request_count(request.target_size)
+    text_egress = requests * request.text_bytes
+    frame_egress = requests * request.frame_bytes
+    providers = _cloud_providers(pool)
+    return Budget(
+        requests=requests,
+        providers=providers,
+        egressBytes=text_egress + frame_egress,
+        egressKinds=EgressKinds(text=text_egress, frames=frame_egress),
+        withinFreeLimits=_within_free_limits(requests, providers, catalog),
+    )
+
+
+def degrade_chain(pool: ProviderPool) -> list[str]:
+    """The ordered failover chain for ``pool``: cloud providers then ``"local"``.
+
+    PURE: returns the distinct cloud provider ids in pool order (deduped — a
+    same-provider second key is failover, not a new hop) followed by exactly one
+    final ``"local"`` entry, the always-available backstop. ``"local"`` is
+    appended unconditionally so the chain ALWAYS ends in the local backstop,
+    even when the pool declared no backstop entry.
+    """
+    chain = list(_cloud_providers(pool))
+    chain.append("local")
+    return chain

--- a/sidecar/media_studio/models/catalog.py
+++ b/sidecar/media_studio/models/catalog.py
@@ -1,0 +1,481 @@
+"""Static multi-provider model catalog (WU-catalog).
+
+A hand-curated, **dated** catalog ranking each free/paid LLM by fitness for
+Reframe's five tasks (Moment-Find/Select, Caption/Title/Hook, Translation,
+Vision/OCR, Edit-Plan Gen), with a privacy axis (a ``trains_on_input`` flag plus
+a coarse ``privacy_tier``) so the UI can warn before private data leaves the
+machine. Seeded VERBATIM from ``docs/providers/CATALOG-SEED.md`` (research pass
+``wf_e4773258``, 2026-06-16).
+
+This is **pure data + pure helpers** — no network, no model, no ``time`` import,
+no cross-import of the other Hub modules. It is the single source of truth the
+``providers.catalog`` RPC serializes for the renderer and the
+``top_pick_for_task`` ranking that the presets/recommender consume.
+
+Honesty rule (matches the seed's ⛔ section): every quality label is *dated
+guidance* ("our pick · as of <date>"), never an objective benchmark, and free
+tiers churn — re-verify ``CATALOG-SEED.md`` at build time. The "N keys =/=
+N x quota" reality lives in the SETUP/MODEL-GUIDE docs, not here.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Literal
+
+# --------------------------------------------------------------------------- #
+# Axes (enums kept tiny so JSON serialization is the enum *value*)
+# --------------------------------------------------------------------------- #
+
+
+class Task(enum.Enum):
+    """The five Reframe tasks the catalog ranks each model against."""
+
+    MOMENT_FIND = "moment_find"  # 1: Moment-Find / Select
+    CAPTION = "caption"  # 2: Caption / Title / Hook
+    TRANSLATION = "translation"  # 3: Translation
+    VISION = "vision"  # 4: Vision / OCR
+    EDIT_PLAN = "edit_plan"  # 5: Edit-Plan Gen
+
+
+class TierGrade(enum.Enum):
+    """Per-task fitness grade. ``NA`` = the model cannot serve this task."""
+
+    S = "S"
+    A = "A"
+    B = "B"
+    C = "C"
+    NA = "na"
+
+
+class Capability(enum.Enum):
+    """What a model can ingest. Vision models are also text-capable."""
+
+    TEXT = "text"
+    VISION = "vision"
+
+
+class Unit(enum.Enum):
+    """The unit the provider's free limit is denominated in."""
+
+    REQ = "req"
+    TOKEN = "token"
+
+
+class CostClass(enum.Enum):
+    """Coarse cost posture used for ordering and UI badges."""
+
+    FREE = "free"
+    FREEMIUM = "freemium"  # free tier exists but credit/$10 unlocks more
+    PAID = "paid"
+
+
+class PrivacyTier(enum.Enum):
+    """Coarse privacy posture for sending real user data."""
+
+    SAFE = "SAFE"
+    CONDITIONAL = "CONDITIONAL"  # flip opt-out / ZDR first
+    AVOID = "AVOID"  # free tier trains / human review possible
+
+
+#: ``trains_on_input`` is a bool, or the string ``"conditional"`` when the
+#: provider trains unless the user flips an opt-out / ZDR toggle.
+TrainsOnInput = Literal[True, False, "conditional"]
+
+#: Numeric weight per grade, used by ``order_by("quality")``.
+_GRADE_SCORE: dict[TierGrade, int] = {
+    TierGrade.S: 5,
+    TierGrade.A: 4,
+    TierGrade.B: 3,
+    TierGrade.C: 2,
+    TierGrade.NA: 0,
+}
+
+#: The snapshot date stamped on every entry (seed research date).
+AS_OF_DATE = "2026-06-16"
+
+
+# --------------------------------------------------------------------------- #
+# Entry
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class CatalogEntry:
+    """One curated model row. Immutable so the shared ``CATALOG`` can't drift."""
+
+    id: str
+    provider: str
+    model: str
+    capabilities: tuple[Capability, ...]
+    context_tokens: int
+    per_task_tier: Mapping[Task, TierGrade]
+    cost_class: CostClass
+    free_limits: str
+    #: Higher = more generous free tier (relative weight for ``order_by("limit")``).
+    free_limit_score: int
+    unit: Unit
+    trains_on_input: TrainsOnInput
+    privacy_tier: PrivacyTier
+    recommended_for: tuple[Task, ...]
+    notes: str
+    as_of_date: str = AS_OF_DATE
+
+    def best_grade_score(self) -> int:
+        """The score of this model's strongest task grade (for quality order)."""
+        return max(_GRADE_SCORE[g] for g in self.per_task_tier.values())
+
+    def grade_for(self, task: Task) -> TierGrade:
+        """This model's grade for ``task`` (``NA`` if it cannot serve it)."""
+        return self.per_task_tier[task]
+
+
+def _tiers(
+    t1: TierGrade,
+    t2: TierGrade,
+    t3: TierGrade,
+    t4: TierGrade,
+    t5: TierGrade,
+) -> Mapping[Task, TierGrade]:
+    """Build the per-task grade map from the seed table's column order."""
+    return {
+        Task.MOMENT_FIND: t1,
+        Task.CAPTION: t2,
+        Task.TRANSLATION: t3,
+        Task.VISION: t4,
+        Task.EDIT_PLAN: t5,
+    }
+
+
+_S, _A, _B, _C, _NA = (
+    TierGrade.S,
+    TierGrade.A,
+    TierGrade.B,
+    TierGrade.C,
+    TierGrade.NA,
+)
+_TEXT: tuple[Capability, ...] = (Capability.TEXT,)
+_MULTI: tuple[Capability, ...] = (Capability.TEXT, Capability.VISION)
+
+
+# --------------------------------------------------------------------------- #
+# CATALOG — seeded VERBATIM from docs/providers/CATALOG-SEED.md
+# --------------------------------------------------------------------------- #
+
+CATALOG: tuple[CatalogEntry, ...] = (
+    CatalogEntry(
+        id="groq-gpt-oss-120b",
+        provider="Groq",
+        model="GPT-OSS-120B",
+        capabilities=_TEXT,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_S, _A, _A, _NA, _S),
+        cost_class=CostClass.FREE,
+        free_limits="30 RPM / 1K RPD / 200K TPD",
+        free_limit_score=80,
+        unit=Unit.TOKEN,
+        trains_on_input=False,
+        privacy_tier=PrivacyTier.SAFE,
+        recommended_for=(Task.MOMENT_FIND, Task.EDIT_PLAN),
+        notes="No-retention default — SAFE. Best free reasoning + structured JSON.",
+    ),
+    CatalogEntry(
+        id="groq-llama-3.3-70b",
+        provider="Groq",
+        model="Llama 3.3 70B",
+        capabilities=_TEXT,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_A, _S, _S, _NA, _A),
+        cost_class=CostClass.FREE,
+        free_limits="30 RPM / 1K RPD / 100K TPD",
+        free_limit_score=70,
+        unit=Unit.TOKEN,
+        trains_on_input=False,
+        privacy_tier=PrivacyTier.SAFE,
+        recommended_for=(Task.CAPTION, Task.TRANSLATION),
+        notes="Fast, generous, safe — caption/title/hook + translation volume.",
+    ),
+    CatalogEntry(
+        id="cerebras-qwen3-235b",
+        provider="Cerebras",
+        model="Qwen3-235B",
+        capabilities=_TEXT,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_S, _A, _A, _NA, _S),
+        cost_class=CostClass.FREE,
+        free_limits="~30 RPM / 1M tok/day",
+        free_limit_score=90,
+        unit=Unit.TOKEN,
+        trains_on_input="conditional",
+        privacy_tier=PrivacyTier.CONDITIONAL,
+        recommended_for=(Task.MOMENT_FIND, Task.EDIT_PLAN),
+        notes="Train policy UNVERIFIED (likely no-train) — confirm ToS at signup.",
+    ),
+    CatalogEntry(
+        id="cerebras-llama-3.3-70b",
+        provider="Cerebras",
+        model="Llama 3.3 70B",
+        capabilities=_TEXT,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_A, _S, _S, _NA, _A),
+        cost_class=CostClass.FREE,
+        free_limits="~30 RPM / 1M tok/day",
+        free_limit_score=85,
+        unit=Unit.TOKEN,
+        trains_on_input="conditional",
+        privacy_tier=PrivacyTier.CONDITIONAL,
+        recommended_for=(Task.CAPTION, Task.TRANSLATION),
+        notes="Train policy UNVERIFIED — confirm ToS at signup.",
+    ),
+    CatalogEntry(
+        id="sambanova-llama-3.1-405b",
+        provider="SambaNova",
+        model="Llama 3.1 405B",
+        capabilities=_TEXT,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_A, _A, _A, _NA, _A),
+        cost_class=CostClass.FREE,
+        free_limits="~10-30 RPM / ~200K tok/day",
+        free_limit_score=50,
+        unit=Unit.TOKEN,
+        trains_on_input=False,
+        privacy_tier=PrivacyTier.SAFE,
+        recommended_for=(Task.MOMENT_FIND,),
+        notes="Claims no prompt collection — SAFE-ish; card requirement unclear.",
+    ),
+    CatalogEntry(
+        id="gemini-2.5-flash",
+        provider="Google AI Studio",
+        model="Gemini 2.5 Flash",
+        capabilities=_MULTI,
+        context_tokens=1_000_000,
+        per_task_tier=_tiers(_S, _A, _A, _S, _S),
+        cost_class=CostClass.FREE,
+        free_limits="15 RPM / 1500 RPD / ~1M TPM",
+        free_limit_score=75,
+        unit=Unit.REQ,
+        trains_on_input=True,
+        privacy_tier=PrivacyTier.AVOID,
+        recommended_for=(Task.VISION,),
+        notes="FREE tier TRAINS (outside EEA/UK/CH), human review possible — "
+        "AVOID for private/PII data.",
+    ),
+    CatalogEntry(
+        id="gemini-2.5-flash-lite",
+        provider="Google AI Studio",
+        model="Gemini 2.5 Flash-Lite",
+        capabilities=_MULTI,
+        context_tokens=1_000_000,
+        per_task_tier=_tiers(_A, _S, _A, _S, _A),
+        cost_class=CostClass.FREE,
+        free_limits="30 RPM / 1500 RPD",
+        free_limit_score=65,
+        unit=Unit.REQ,
+        trains_on_input=True,
+        privacy_tier=PrivacyTier.AVOID,
+        recommended_for=(Task.VISION,),
+        notes="Best free OCR + 1M ctx, but FREE tier TRAINS — AVOID private; "
+        "use GitHub GPT-4o-mini or paid Gemini for PII frames.",
+    ),
+    CatalogEntry(
+        id="github-gpt-4o-mini",
+        provider="GitHub Models",
+        model="GPT-4o-mini",
+        capabilities=_MULTI,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_B, _A, _A, _A, _B),
+        cost_class=CostClass.FREE,
+        free_limits="~15 RPM / 150 RPD (prototyping)",
+        free_limit_score=30,
+        unit=Unit.REQ,
+        trains_on_input=False,
+        privacy_tier=PrivacyTier.SAFE,
+        recommended_for=(Task.VISION,),
+        notes="No-train (not for prod) — SAFE-ish; prototyping only. Good for "
+        "private/PII frames behind the free Gemini.",
+    ),
+    CatalogEntry(
+        id="mistral-pixtral",
+        provider="Mistral",
+        model="Pixtral",
+        capabilities=_MULTI,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_B, _A, _S, _A, _B),
+        cost_class=CostClass.FREEMIUM,
+        free_limits="Experiment ~1B tok/mo (phone verify)",
+        free_limit_score=60,
+        unit=Unit.TOKEN,
+        trains_on_input="conditional",
+        privacy_tier=PrivacyTier.CONDITIONAL,
+        recommended_for=(Task.TRANSLATION,),
+        notes="Trains by DEFAULT; opt-out toggle — flip it first. Strong EU "
+        "translation quality.",
+    ),
+    CatalogEntry(
+        id="cloudflare-workers-ai",
+        provider="Cloudflare",
+        model="Workers AI (Llama 3.1 / Qwen 2.5)",
+        capabilities=_TEXT,
+        context_tokens=8_000,
+        per_task_tier=_tiers(_C, _B, _B, _NA, _C),
+        cost_class=CostClass.FREE,
+        free_limits="10K Neurons/day",
+        free_limit_score=40,
+        unit=Unit.REQ,
+        trains_on_input=False,
+        privacy_tier=PrivacyTier.SAFE,
+        recommended_for=(),
+        notes="No-train — SAFE, but 2K-8K context is LIMITING for transcripts.",
+    ),
+    CatalogEntry(
+        id="openrouter-free-text",
+        provider="OpenRouter",
+        model="DeepSeek/Qwen :free (text)",
+        capabilities=_TEXT,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_A, _A, _A, _NA, _A),
+        cost_class=CostClass.FREEMIUM,
+        free_limits="20 RPM / 50 RPD (->1000 after one-time $10)",
+        free_limit_score=45,
+        unit=Unit.REQ,
+        trains_on_input="conditional",
+        privacy_tier=PrivacyTier.CONDITIONAL,
+        recommended_for=(),
+        notes="Downstream MAY train unless ZDR is set — flip ZDR first. The "
+        "one-time $10 lifetime credit lifts 50->1000 RPD.",
+    ),
+    CatalogEntry(
+        id="openrouter-free-vision",
+        provider="OpenRouter",
+        model="Gemma/Nemotron-VL :free (vision)",
+        capabilities=_MULTI,
+        context_tokens=256_000,
+        per_task_tier=_tiers(_NA, _NA, _NA, _B, _NA),
+        cost_class=CostClass.FREEMIUM,
+        free_limits="20 RPM / ~50-200 RPD",
+        free_limit_score=40,
+        unit=Unit.REQ,
+        trains_on_input="conditional",
+        privacy_tier=PrivacyTier.CONDITIONAL,
+        recommended_for=(Task.VISION,),
+        notes="Downstream MAY train; set ZDR. Vision-only free fallback.",
+    ),
+    CatalogEntry(
+        id="openai-api",
+        provider="OpenAI",
+        model="OpenAI API (paid)",
+        capabilities=_MULTI,
+        context_tokens=128_000,
+        per_task_tier=_tiers(_A, _A, _A, _A, _A),
+        cost_class=CostClass.PAID,
+        free_limits="credits (~no free tier)",
+        free_limit_score=10,
+        unit=Unit.TOKEN,
+        trains_on_input=False,
+        privacy_tier=PrivacyTier.SAFE,
+        recommended_for=(),
+        notes="No-train by default (API) — SAFE. 30-day retention has a "
+        "legal-hold caveat. The paid backstop behind the free tiers.",
+    ),
+)
+
+
+# --------------------------------------------------------------------------- #
+# Pure helpers
+# --------------------------------------------------------------------------- #
+
+#: The valid keys accepted by :func:`order_by`.
+OrderKey = Literal["quality", "limit", "context"]
+
+
+def filter_by_capability(
+    capability: Capability,
+    *,
+    catalog: Sequence[CatalogEntry] = CATALOG,
+) -> list[CatalogEntry]:
+    """Return entries that declare ``capability`` (preserving catalog order)."""
+    return [e for e in catalog if capability in e.capabilities]
+
+
+def order_by(
+    key: OrderKey,
+    *,
+    catalog: Sequence[CatalogEntry] = CATALOG,
+) -> list[CatalogEntry]:
+    """Return a new list ordered by ``key`` (descending), never mutating source.
+
+    * ``"quality"`` — by the entry's strongest per-task grade.
+    * ``"limit"``  — by ``free_limit_score`` (more generous free tier first).
+    * ``"context"`` — by ``context_tokens``.
+    """
+    if key == "quality":
+        return sorted(catalog, key=lambda e: e.best_grade_score(), reverse=True)
+    if key == "limit":
+        return sorted(catalog, key=lambda e: e.free_limit_score, reverse=True)
+    if key == "context":
+        return sorted(catalog, key=lambda e: e.context_tokens, reverse=True)
+    raise ValueError(f"unknown order key: {key!r}")
+
+
+#: The editorial "Top pick per task" from ``CATALOG-SEED.md`` (seeded verbatim;
+#: the free-tier/grade math alone can't reproduce these because the seed prefers
+#: the SAFE Groq models over the higher-quota-but-unverified Cerebras ones, and
+#: prefers Gemini Flash-Lite over Flash for OCR). Validated against ``CATALOG``
+#: at import time, so a typo or a removed entry fails fast (no silent drift).
+TOP_PICKS: Mapping[Task, str] = {
+    Task.MOMENT_FIND: "groq-gpt-oss-120b",
+    Task.CAPTION: "groq-llama-3.3-70b",
+    Task.TRANSLATION: "groq-llama-3.3-70b",
+    Task.VISION: "gemini-2.5-flash-lite",
+    Task.EDIT_PLAN: "groq-gpt-oss-120b",
+}
+
+
+def top_pick_for_task(
+    task: Task,
+    *,
+    catalog: Sequence[CatalogEntry] = CATALOG,
+) -> CatalogEntry:
+    """Return the single best catalog entry for ``task``.
+
+    Prefers the seed's editorial :data:`TOP_PICKS` when that model is present in
+    ``catalog`` and can serve ``task``; otherwise ranks the eligible entries by
+    per-task grade, breaking ties with the more generous free tier then the
+    larger context. Entries graded ``NA`` for the task are ineligible; raises
+    ``ValueError`` if none can serve the task.
+    """
+    eligible = [e for e in catalog if e.grade_for(task) is not TierGrade.NA]
+    if not eligible:
+        raise ValueError(f"no catalog entry serves task: {task.value}")
+    preferred_id = TOP_PICKS[task]
+    for entry in eligible:
+        if entry.id == preferred_id:
+            return entry
+    return max(
+        eligible,
+        key=lambda e: (
+            _GRADE_SCORE[e.grade_for(task)],
+            e.free_limit_score,
+            e.context_tokens,
+        ),
+    )
+
+
+__all__ = [
+    "AS_OF_DATE",
+    "CATALOG",
+    "Capability",
+    "CatalogEntry",
+    "CostClass",
+    "OrderKey",
+    "PrivacyTier",
+    "Task",
+    "TierGrade",
+    "TrainsOnInput",
+    "Unit",
+    "filter_by_capability",
+    "order_by",
+    "top_pick_for_task",
+]

--- a/sidecar/media_studio/models/catalog.py
+++ b/sidecar/media_studio/models/catalog.py
@@ -433,6 +433,78 @@ TOP_PICKS: Mapping[Task, str] = {
 }
 
 
+def _entry_to_json(entry: CatalogEntry) -> dict[str, object]:
+    """Serialize ONE :class:`CatalogEntry` to its JSON wire shape (no secrets).
+
+    Enums are flattened to their string ``.value`` so the payload is plain JSON
+    the renderer reads verbatim. ``perTaskTier`` keys are the :class:`Task` values
+    (``moment_find`` / ``caption`` / …) and ``trainsOnInput`` is the bool or the
+    literal ``"conditional"`` string. There are NO keys, URLs, or runtime fields
+    here — the catalog is pure curated metadata.
+    """
+    return {
+        "id": entry.id,
+        "provider": entry.provider,
+        "model": entry.model,
+        "capabilities": [c.value for c in entry.capabilities],
+        "contextTokens": entry.context_tokens,
+        "perTaskTier": {task.value: entry.per_task_tier[task].value for task in Task},
+        "costClass": entry.cost_class.value,
+        "freeLimits": entry.free_limits,
+        "freeLimitScore": entry.free_limit_score,
+        "unit": entry.unit.value,
+        "trainsOnInput": entry.trains_on_input,
+        "privacyTier": entry.privacy_tier.value,
+        "recommendedFor": [t.value for t in entry.recommended_for],
+        "notes": entry.notes,
+        "asOfDate": entry.as_of_date,
+    }
+
+
+def catalog_to_json(
+    *,
+    catalog: Sequence[CatalogEntry] = CATALOG,
+) -> dict[str, object]:
+    """Serialize the whole catalog to the ``providers.catalog`` RPC payload.
+
+    PURE — no network, no secrets. The shape (PLAN §WU-catalog) is::
+
+        {asOfDate, unit, tasks, topPicks, providers:[entry, ...]}
+
+    * ``providers`` — every :class:`CatalogEntry` flattened via
+      :func:`_entry_to_json` (per-task tiers + privacy / train-on-input flags).
+    * ``tasks`` — the five Reframe task ids the tiers are keyed by, so the UI can
+      label the columns without hardcoding the enum.
+    * ``topPicks`` — the editorial best entry id per task (``Task.value -> id``).
+    * ``asOfDate`` / ``unit`` — top-level dated-guidance stamp + the set of units
+      the catalog denominates limits in (so the UI never sums across units).
+
+    The catalog is overridable for tests; it never carries an API key.
+    """
+    return {
+        "asOfDate": AS_OF_DATE,
+        "unit": [u.value for u in Unit],
+        "tasks": [t.value for t in Task],
+        "topPicks": _top_picks_json(catalog),
+        "providers": [_entry_to_json(e) for e in catalog],
+    }
+
+
+def _top_picks_json(catalog: Sequence[CatalogEntry]) -> dict[str, str]:
+    """The editorial top-pick id per task (tasks no entry can serve are omitted).
+
+    A task that no entry in ``catalog`` can serve (every entry graded ``NA``)
+    yields no pick rather than raising — so a partial/custom catalog still
+    serializes. The full :data:`CATALOG` serves every task, so the default
+    payload always carries all five picks.
+    """
+    picks: dict[str, str] = {}
+    for task in Task:
+        if any(e.grade_for(task) is not TierGrade.NA for e in catalog):
+            picks[task.value] = top_pick_for_task(task, catalog=catalog).id
+    return picks
+
+
 def top_pick_for_task(
     task: Task,
     *,
@@ -475,6 +547,7 @@ __all__ = [
     "TierGrade",
     "TrainsOnInput",
     "Unit",
+    "catalog_to_json",
     "filter_by_capability",
     "order_by",
     "top_pick_for_task",

--- a/sidecar/media_studio/models/catalog.py
+++ b/sidecar/media_studio/models/catalog.py
@@ -259,8 +259,7 @@ CATALOG: tuple[CatalogEntry, ...] = (
         trains_on_input=True,
         privacy_tier=PrivacyTier.AVOID,
         recommended_for=(Task.VISION,),
-        notes="FREE tier TRAINS (outside EEA/UK/CH), human review possible — "
-        "AVOID for private/PII data.",
+        notes="FREE tier TRAINS (outside EEA/UK/CH), human review possible — AVOID for private/PII data.",
     ),
     CatalogEntry(
         id="gemini-2.5-flash-lite",
@@ -310,8 +309,7 @@ CATALOG: tuple[CatalogEntry, ...] = (
         trains_on_input="conditional",
         privacy_tier=PrivacyTier.CONDITIONAL,
         recommended_for=(Task.TRANSLATION,),
-        notes="Trains by DEFAULT; opt-out toggle — flip it first. Strong EU "
-        "translation quality.",
+        notes="Trains by DEFAULT; opt-out toggle — flip it first. Strong EU translation quality.",
     ),
     CatalogEntry(
         id="cloudflare-workers-ai",

--- a/sidecar/media_studio/models/consent.py
+++ b/sidecar/media_studio/models/consent.py
@@ -1,0 +1,99 @@
+"""Per-data-type egress consent gate (WU-keys / SE1, PLAN §WU-keys acceptance (d)).
+
+TEXT (transcripts) and FRAMES (vision) are SEPARATE, independently-revocable
+opt-ins, stored at ``settings.consent.perProvider[<provider>] = {"text": bool,
+"frames": bool}`` (see :data:`settings_store.DEFAULT_SETTINGS`). The *setter*
+(``providers.setConsent``) lives in :mod:`handlers`; this module is the
+ENFORCEMENT half — the typed gate any egress path MUST pass through before a
+payload leaves the machine.
+
+PLAN §WU-keys acceptance (d) requires that "a vision egress without frame
+consent is **blocked**" and the test strategy requires a vision call without
+``consent.perProvider[p].frames`` to be "refused (**typed**)". This module
+supplies that typed refusal as a small, PURE, dependency-free primitive:
+
+  * :func:`frame_consent_granted` / :func:`text_consent_granted` — pure
+    predicates reading the consent block (default-deny: absent == not granted).
+  * :func:`require_frame_consent` — raises :class:`ConsentError` (typed) unless
+    frame consent is granted for the given provider; the *single* enforcement
+    point a vision egress calls FIRST, before any frame is sampled or encoded.
+
+The FULL control-flow wiring of this gate into ``handlers.phase8_select``'s
+``job_body`` is assigned by PLAN to **WU-vision** (PLAN §WU-vision lines
+208/210/214/217); WU-keys owns this consent primitive + its typed-refusal test
+so the criterion is implemented and provable at the seam, not merely a hope.
+
+Deliberately dependency-free (stdlib typing only) and crosses NO other
+``models/`` module — consent carries booleans only, never a secret.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+#: The two distinct egress data types (SE1). FRAMES (vision) requires its OWN
+#: confirmation, separate from TEXT (transcripts).
+DATA_TYPE_TEXT: str = "text"
+DATA_TYPE_FRAMES: str = "frames"
+
+
+class ConsentError(RuntimeError):
+    """Raised when an egress is attempted without the required per-data-type consent.
+
+    This is the TYPED refusal PLAN §WU-keys acceptance (d) / test-strategy
+    require: a vision (frame) egress without ``consent.perProvider[p].frames``
+    raises this rather than silently proceeding. It carries the offending
+    provider name and data type so a caller can surface a precise message — and
+    NEVER a secret (consent state is booleans only).
+    """
+
+    def __init__(self, provider: str, data_type: str) -> None:
+        self.provider = provider
+        self.data_type = data_type
+        super().__init__(
+            f"{data_type} egress to provider {provider!r} refused: "
+            f"consent.perProvider[{provider!r}].{data_type} is not granted"
+        )
+
+
+def _consent_flag(settings: Mapping[str, Any], provider: str, data_type: str) -> bool:
+    """Return the stored consent flag for ``(provider, data_type)`` (default-deny).
+
+    Reads ``settings.consent.perProvider[provider][data_type]`` defensively: a
+    missing consent block, missing provider entry, missing flag, or any
+    malformed (non-mapping) level all resolve to ``False`` — consent must be an
+    EXPLICIT, present ``True`` to grant egress, never an absence.
+    """
+    consent = settings.get("consent")
+    if not isinstance(consent, Mapping):
+        return False
+    per_provider = consent.get("perProvider")
+    if not isinstance(per_provider, Mapping):
+        return False
+    entry = per_provider.get(provider)
+    if not isinstance(entry, Mapping):
+        return False
+    return entry.get(data_type) is True
+
+
+def frame_consent_granted(settings: Mapping[str, Any], provider: str) -> bool:
+    """Return ``True`` only if FRAME (vision) egress is explicitly opted-in for ``provider``."""
+    return _consent_flag(settings, provider, DATA_TYPE_FRAMES)
+
+
+def text_consent_granted(settings: Mapping[str, Any], provider: str) -> bool:
+    """Return ``True`` only if TEXT (transcript) egress is explicitly opted-in for ``provider``."""
+    return _consent_flag(settings, provider, DATA_TYPE_TEXT)
+
+
+def require_frame_consent(settings: Mapping[str, Any], provider: str) -> None:
+    """Raise :class:`ConsentError` unless FRAME egress is granted for ``provider``.
+
+    The single enforcement point a vision egress path calls FIRST, BEFORE any
+    frame is sampled or base64-encoded, so a no-consent run never prepares a
+    frame for egress (PLAN §WU-keys acceptance (d): "a vision egress without
+    frame consent is **blocked**"; test strategy: "refused (typed)").
+    """
+    if not frame_consent_granted(settings, provider):
+        raise ConsentError(provider, DATA_TYPE_FRAMES)

--- a/sidecar/media_studio/models/local_detect.py
+++ b/sidecar/media_studio/models/local_detect.py
@@ -1,0 +1,134 @@
+"""Local OpenAI-compatible server detection (WU-pool · PH5).
+
+Pure, import-light detection of the two well-known *local* LLM servers a user is
+likely to already be running — **Ollama** (``http://127.0.0.1:11434/v1``) and
+**LM Studio** (``http://127.0.0.1:1234/v1``) — so the rotation pool can slot them
+in as additional OpenAI-compatible providers (a local backstop richer than just
+llama.cpp). Each server is probed with a ``GET /models`` call through the SAME
+injectable :data:`~media_studio.models.provider.Transport` seam the provider
+module uses, so **no socket is ever opened under test** (the transport is a fake).
+
+Design rules (PLAN §WU-pool):
+  * Detection is **best-effort and never fatal**: a connection error, an absent
+    server, or a probe that returns no usable model id simply yields *no* entry
+    for that server — :func:`detect_local_servers` NEVER raises. ("detection
+    failure degrades silently to no extra providers.")
+  * The module is **import-light and sleep-free**: it imports neither ``time``
+    nor ``asyncio`` (mirrors the provider hot-path no-sleep rule), so there is no
+    wall-clock dependency and nothing to ``# pragma`` for coverage.
+  * The returned :class:`PoolEntry` is a light dict the pool consumes verbatim —
+    ``{id, kind, base_url, model, capabilities, unit}``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from ..util import get_logger
+from .provider import Transport
+
+log = get_logger("media_studio.models.local_detect")
+
+# --------------------------------------------------------------------------- #
+# Well-known local server endpoints (overridable via settings)
+# --------------------------------------------------------------------------- #
+#: Ollama's OpenAI-compatible base URL (``ollama serve`` default port).
+OLLAMA_BASE_URL: str = "http://127.0.0.1:11434/v1"
+#: LM Studio's OpenAI-compatible base URL (local server default port).
+LM_STUDIO_BASE_URL: str = "http://127.0.0.1:1234/v1"
+
+#: Probe timeout (seconds). Short by design: a local server answers instantly, and
+#: an absent one should fail fast rather than stall startup detection.
+_PROBE_TIMEOUT: float = 2.0
+
+
+class PoolEntry(TypedDict):
+    """A light pool-entry shape the rotation pool consumes (PLAN §WU-pool).
+
+    ``kind`` is the server family (``"ollama"`` / ``"lmstudio"``); ``unit`` is the
+    rate-limit unit (local servers are request-bounded, so ``"req"``);
+    ``capabilities`` lists what the entry can do (local detect = ``["chat"]``).
+    """
+
+    id: str
+    kind: str
+    base_url: str
+    model: str
+    capabilities: list[str]
+    unit: str
+
+
+def _first_model_id(response: dict[str, Any]) -> str | None:
+    """Return the first model id from an OpenAI-style ``/models`` response.
+
+    Shape: ``{"data": [{"id": "...", ...}, ...]}``. Returns ``None`` when the
+    response is not that shape, the list is empty, the first entry is not an
+    object, or its ``id`` is missing/blank — i.e. "this is not a usable server".
+    """
+    data = response.get("data")
+    if not isinstance(data, list) or not data:
+        return None
+    first = data[0]
+    if not isinstance(first, dict):
+        return None
+    model_id = first.get("id")
+    if not isinstance(model_id, str) or not model_id:
+        return None
+    return model_id
+
+
+def _probe_server(
+    *, kind: str, base_url: str, transport: Transport
+) -> PoolEntry | None:
+    """Probe one local server's ``GET /models`` endpoint; build a :class:`PoolEntry`.
+
+    Returns ``None`` (and logs at debug) when the server is absent, errors, or
+    reports no usable model id. Any transport exception is swallowed — detection
+    is best-effort and must never crash the caller.
+    """
+    url = f"{base_url}/models"
+    try:
+        response = transport(url, {}, {}, _PROBE_TIMEOUT)
+    except Exception as exc:  # noqa: BLE001 - best-effort probe, must not raise
+        log.debug("local server %s not detected at %s: %s", kind, base_url, exc)
+        return None
+    model_id = _first_model_id(response)
+    if model_id is None:
+        log.debug("local server %s at %s reported no usable model", kind, base_url)
+        return None
+    return PoolEntry(
+        id=kind,
+        kind=kind,
+        base_url=base_url,
+        model=model_id,
+        capabilities=["chat"],
+        unit="req",
+    )
+
+
+def detect_local_servers(
+    settings: dict[str, Any] | None,
+    *,
+    transport: Transport,
+) -> list[PoolEntry]:
+    """Detect locally-running Ollama / LM Studio servers as pool entries.
+
+    Probes each server's ``GET /models`` via the injected ``transport`` and
+    returns a :class:`PoolEntry` for every one that answers with a usable model.
+    A server that is down, errors, or reports nothing is silently skipped — the
+    function returns ``[]`` (never raises) when no local server is found.
+
+    ``settings`` may override the probe URLs via ``ollamaBaseUrl`` /
+    ``lmStudioBaseUrl`` (a blank/missing value falls back to the default port).
+    """
+    settings = settings or {}
+    targets = (
+        ("ollama", str(settings.get("ollamaBaseUrl") or OLLAMA_BASE_URL)),
+        ("lmstudio", str(settings.get("lmStudioBaseUrl") or LM_STUDIO_BASE_URL)),
+    )
+    entries: list[PoolEntry] = []
+    for kind, base_url in targets:
+        entry = _probe_server(kind=kind, base_url=base_url, transport=transport)
+        if entry is not None:
+            entries.append(entry)
+    return entries

--- a/sidecar/media_studio/models/local_detect.py
+++ b/sidecar/media_studio/models/local_detect.py
@@ -77,9 +77,7 @@ def _first_model_id(response: dict[str, Any]) -> str | None:
     return model_id
 
 
-def _probe_server(
-    *, kind: str, base_url: str, transport: Transport
-) -> PoolEntry | None:
+def _probe_server(*, kind: str, base_url: str, transport: Transport) -> PoolEntry | None:
     """Probe one local server's ``GET /models`` endpoint; build a :class:`PoolEntry`.
 
     Returns ``None`` (and logs at debug) when the server is absent, errors, or

--- a/sidecar/media_studio/models/presets.py
+++ b/sidecar/media_studio/models/presets.py
@@ -15,12 +15,19 @@ tier (PLAN §WU-presets · CATALOG-SEED tasks 1..5):
   * ``vision``      — Vision / OCR           (task 4)
   * ``editPlan``    — Edit-Plan generation   (task 5)
 
-The catalog is **duck-typed** so this module never imports ``catalog.py`` (a
-separate WU). A catalog need only expose ``all() -> Iterable[entry]`` where each
+The catalog is **duck-typed** so the ranking logic never hard-depends on
+``catalog.py``. A catalog need only expose ``all() -> Iterable[entry]`` where each
 ``entry`` carries: ``id: str``, ``provider: str``, ``capabilities: Sequence[str]``
 (includes ``"vision"`` for multimodal models), ``per_task_tier: Mapping[str,str]``
 (per-function grade ``S``/``A``/``B``/``C``/``na``) and ``privacy_tier: str``
 (``SAFE``/``CONDITIONAL``/``AVOID``).
+
+The REAL :mod:`media_studio.models.catalog` keys ``per_task_tier`` by the
+:class:`catalog.Task` ENUM (not the function-name string) and exposes no
+``all()`` — so :class:`CatalogAdapter` (carryforward #1) is the thin, PURE bridge
+that re-exposes the curated catalog through this duck-typed surface. It imports
+the (equally pure, network-free) catalog module lazily so the ranking helpers
+above stay independent and 100%-testable against a fake catalog.
 
 Routing shape returned by :func:`apply_preset`::
 
@@ -137,8 +144,7 @@ def suggest_for_function(
     candidates = [
         entry
         for entry in catalog.all()
-        if _is_candidate(entry, function)
-        and not (require_safe and entry.privacy_tier == "AVOID")
+        if _is_candidate(entry, function) and not (require_safe and entry.privacy_tier == "AVOID")
     ]
     candidates.sort(key=lambda e: _GRADE_RANK[_grade_for(e, function)])
     return candidates
@@ -183,10 +189,7 @@ def apply_preset(
     descriptor = PRESETS.get(name)
     if descriptor is None:
         raise ValueError(f"unknown preset: {name!r}")
-    per_function = {
-        function: _resolve_slot(function, strategy, catalog)
-        for function, strategy in descriptor.items()
-    }
+    per_function = {function: _resolve_slot(function, strategy, catalog) for function, strategy in descriptor.items()}
     return {"activePreset": name, "perFunction": per_function}
 
 
@@ -209,3 +212,78 @@ def first_run_default(settings: Mapping[str, Any]) -> str:
     if active and active != "privacy":
         return "bestFreeCloud"
     return "privacy"
+
+
+# --------------------------------------------------------------------------- #
+# Catalog adapter (carryforward #1) — bridge the REAL catalog to this duck-type
+# --------------------------------------------------------------------------- #
+
+#: Map each Reframe FUNCTION (this module's seam name) to the catalog's ``Task``
+#: enum member name. Kept as a string-keyed dict of *enum member names* so this
+#: module imports nothing from ``catalog`` at module load; the adapter resolves
+#: the names to real enum members lazily. Built lazily/validated in the adapter.
+_FUNCTION_TASK_NAMES: dict[str, str] = {
+    "select": "MOMENT_FIND",
+    "subtitles": "CAPTION",
+    "translation": "TRANSLATION",
+    "vision": "VISION",
+    "editPlan": "EDIT_PLAN",
+}
+
+
+class _AdaptedEntry:
+    """One real :class:`catalog.CatalogEntry` re-exposed through the duck-type.
+
+    Flattens the catalog's enum-keyed ``per_task_tier`` into the FUNCTION-name ->
+    grade-string map the ranking helpers consume, and the ``Capability`` /
+    ``PrivacyTier`` enums into their plain ``.value`` strings. PURE — it only
+    re-reads already-loaded curated data.
+    """
+
+    __slots__ = ("id", "provider", "capabilities", "per_task_tier", "privacy_tier")
+
+    def __init__(self, entry: Any, function_tasks: Mapping[str, Any]) -> None:
+        self.id: str = entry.id
+        self.provider: str = entry.provider
+        self.capabilities: tuple[str, ...] = tuple(c.value for c in entry.capabilities)
+        # Typed as the invariant Mapping the CatalogEntryLike protocol declares so a
+        # structural check passes; the value is a plain dict at runtime.
+        self.per_task_tier: Mapping[str, str] = {
+            function: entry.per_task_tier[task].value for function, task in function_tasks.items()
+        }
+        self.privacy_tier: str = entry.privacy_tier.value
+
+
+class CatalogAdapter:
+    """Expose the REAL curated catalog through the :class:`CatalogLike` surface.
+
+    The constructor accepts an optional ``catalog`` tuple of real
+    :class:`catalog.CatalogEntry` rows (default: the shared ``catalog.CATALOG``)
+    so tests can pin a tiny subset. Each row is wrapped in :class:`_AdaptedEntry`
+    so ``apply_preset`` / ``suggest_for_function`` read FUNCTION-name-keyed grades
+    + plain-string capabilities/privacy and resolve real picks (carryforward #1 —
+    without this the function-name lookup would miss the enum keys and every grade
+    would fall to ``"na"``, collapsing every preset to local).
+    """
+
+    def __init__(self, *, catalog: Any | None = None) -> None:
+        from . import catalog as _catalog  # local: import-light pure data bridge
+
+        rows = catalog if catalog is not None else _catalog.CATALOG
+        function_tasks = {function: _catalog.Task[name] for function, name in _FUNCTION_TASK_NAMES.items()}
+        self._entries: tuple[_AdaptedEntry, ...] = tuple(_AdaptedEntry(row, function_tasks) for row in rows)
+
+    def all(self) -> tuple[CatalogEntryLike, ...]:
+        return self._entries
+
+
+def function_tasks() -> dict[str, Any]:
+    """Return the FUNCTION-name -> real ``catalog.Task`` map (resolved lazily).
+
+    Exposed for handlers/tests that need the function<->task correspondence (e.g.
+    to read the catalog's ``top_pick_for_task`` for a given seam). Importing the
+    catalog here keeps the ranking helpers above catalog-free.
+    """
+    from . import catalog as _catalog  # local: import-light pure data bridge
+
+    return {function: _catalog.Task[name] for function, name in _FUNCTION_TASK_NAMES.items()}

--- a/sidecar/media_studio/models/presets.py
+++ b/sidecar/media_studio/models/presets.py
@@ -1,0 +1,211 @@
+"""Provider-Hub presets + per-function routing (WU-presets).
+
+A **pure** seam (no network, no heavy deps, no cross-import of the sibling Hub
+modules at runtime): given an INJECTED catalog and a settings mapping it resolves
+one of three smart presets into a concrete ``routing.perFunction`` map, ranks
+per-function model candidates from the catalog, and answers the first-run
+local-vs-cloud default.
+
+The five Reframe AI functions (the task seams) — each maps to one catalog task
+tier (PLAN §WU-presets · CATALOG-SEED tasks 1..5):
+
+  * ``select``      — Moment-Find / Select   (task 1)
+  * ``subtitles``   — Caption / Title / Hook (task 2)
+  * ``translation`` — Translation            (task 3)
+  * ``vision``      — Vision / OCR           (task 4)
+  * ``editPlan``    — Edit-Plan generation   (task 5)
+
+The catalog is **duck-typed** so this module never imports ``catalog.py`` (a
+separate WU). A catalog need only expose ``all() -> Iterable[entry]`` where each
+``entry`` carries: ``id: str``, ``provider: str``, ``capabilities: Sequence[str]``
+(includes ``"vision"`` for multimodal models), ``per_task_tier: Mapping[str,str]``
+(per-function grade ``S``/``A``/``B``/``C``/``na``) and ``privacy_tier: str``
+(``SAFE``/``CONDITIONAL``/``AVOID``).
+
+Routing shape returned by :func:`apply_preset`::
+
+    {
+        "activePreset": "<name>",
+        "perFunction": {
+            "<function>": {"provider": "<model-id>" | LOCAL, "fallback": [ids...]},
+            ...
+        },
+    }
+
+The local backstop is the sentinel :data:`LOCAL`; ``privacy`` routes every
+function to it with no cloud egress at all.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Protocol, runtime_checkable
+
+# --------------------------------------------------------------------------- #
+# Constants
+# --------------------------------------------------------------------------- #
+
+#: Sentinel provider id for the always-available local backstop.
+LOCAL = "local"
+
+#: The five Reframe AI functions, in canonical (catalog task 1..5) order.
+FUNCTIONS: tuple[str, ...] = ("select", "subtitles", "translation", "vision", "editPlan")
+
+#: Functions whose egress is privacy-sensitive (vision = frames leave the box).
+_VISION_FUNCTIONS: frozenset[str] = frozenset({"vision"})
+
+#: Grade -> rank weight (lower is better; ``na`` is unrankable / excluded).
+_GRADE_RANK: dict[str, int] = {"S": 0, "A": 1, "B": 2, "C": 3}
+
+#: The capability a function requires of a catalog entry (default = "text").
+_REQUIRED_CAPABILITY: dict[str, str] = dict.fromkeys(FUNCTIONS, "text")
+_REQUIRED_CAPABILITY["vision"] = "vision"
+
+#: Preset descriptors: per-function routing STRATEGY (resolved against catalog).
+#: "local"      -> the local backstop only (no cloud egress)
+#: "cloud"      -> the catalog's top capable cloud pick (local as last fallback)
+#: "cloudSafe"  -> top capable cloud pick that is NOT privacy-tier AVOID
+PRESETS: dict[str, dict[str, str]] = {
+    "privacy": dict.fromkeys(FUNCTIONS, "local"),
+    "bestFreeCloud": dict.fromkeys(FUNCTIONS, "cloud"),
+    # balanced: cloud for text tasks (privacy-aware), local for vision frames.
+    "balanced": {
+        "select": "cloudSafe",
+        "subtitles": "cloudSafe",
+        "translation": "cloudSafe",
+        "vision": "local",
+        "editPlan": "cloudSafe",
+    },
+}
+
+
+# --------------------------------------------------------------------------- #
+# Duck-typed catalog surface (documentation / type-checker aid only)
+# --------------------------------------------------------------------------- #
+
+
+@runtime_checkable
+class CatalogEntryLike(Protocol):
+    """The minimal entry surface :mod:`presets` reads from a catalog."""
+
+    id: str
+    provider: str
+    capabilities: tuple[str, ...]
+    per_task_tier: Mapping[str, str]
+    privacy_tier: str
+
+
+@runtime_checkable
+class CatalogLike(Protocol):
+    """A catalog need only expose ``all()`` returning entry-likes."""
+
+    def all(self) -> tuple[CatalogEntryLike, ...]: ...
+
+
+# --------------------------------------------------------------------------- #
+# Ranking / suggestion
+# --------------------------------------------------------------------------- #
+
+
+def _grade_for(entry: CatalogEntryLike, function: str) -> str:
+    """Return the entry's grade for ``function`` (``na`` when unset)."""
+    return entry.per_task_tier.get(function, "na")
+
+
+def _is_candidate(entry: CatalogEntryLike, function: str) -> bool:
+    """True iff ``entry`` can serve ``function`` (capability + a real grade)."""
+    needed = _REQUIRED_CAPABILITY[function]
+    if needed not in entry.capabilities:
+        return False
+    return _grade_for(entry, function) in _GRADE_RANK
+
+
+def suggest_for_function(
+    function: str,
+    catalog: CatalogLike,
+    prefs: Mapping[str, Any],
+) -> list[CatalogEntryLike]:
+    """Return catalog entries able to serve ``function``, best-ranked first.
+
+    Capability-mismatched and ``na``-grade entries are never proposed. When
+    ``prefs["requireSafePrivacy"]`` is truthy, ``AVOID``-tier entries are
+    dropped. Equal grades preserve catalog order (stable sort).
+    """
+    if function not in _REQUIRED_CAPABILITY:
+        raise ValueError(f"unknown function: {function!r}")
+    require_safe = bool(prefs.get("requireSafePrivacy"))
+    candidates = [
+        entry
+        for entry in catalog.all()
+        if _is_candidate(entry, function)
+        and not (require_safe and entry.privacy_tier == "AVOID")
+    ]
+    candidates.sort(key=lambda e: _GRADE_RANK[_grade_for(e, function)])
+    return candidates
+
+
+# --------------------------------------------------------------------------- #
+# Preset application
+# --------------------------------------------------------------------------- #
+
+
+def _resolve_slot(
+    function: str,
+    strategy: str,
+    catalog: CatalogLike,
+) -> dict[str, Any]:
+    """Resolve one function's preset strategy into a routing slot."""
+    if strategy == "local":
+        return {"provider": LOCAL, "fallback": []}
+
+    prefs: dict[str, Any] = {"requireSafePrivacy": strategy == "cloudSafe"}
+    ranked = suggest_for_function(function, catalog, prefs)
+    if not ranked:
+        # No capable cloud candidate -> never propose a model the catalog lacks.
+        return {"provider": LOCAL, "fallback": []}
+
+    primary = ranked[0].id
+    fallback = [entry.id for entry in ranked[1:]]
+    fallback.append(LOCAL)  # the local backstop is always the last resort.
+    return {"provider": primary, "fallback": fallback}
+
+
+def apply_preset(
+    name: str,
+    settings: Mapping[str, Any],  # noqa: ARG001 - reserved for per-project overrides
+    catalog: CatalogLike,
+) -> dict[str, Any]:
+    """Resolve preset ``name`` into a concrete ``routing`` mapping (pure).
+
+    ``settings`` is accepted for future per-project overrides; the resolution is
+    catalog-driven and deterministic today.
+    """
+    descriptor = PRESETS.get(name)
+    if descriptor is None:
+        raise ValueError(f"unknown preset: {name!r}")
+    per_function = {
+        function: _resolve_slot(function, strategy, catalog)
+        for function, strategy in descriptor.items()
+    }
+    return {"activePreset": name, "perFunction": per_function}
+
+
+# --------------------------------------------------------------------------- #
+# First-run local-vs-cloud default
+# --------------------------------------------------------------------------- #
+
+
+def first_run_default(settings: Mapping[str, Any]) -> str:
+    """Return the local-safe default preset until the user makes a choice.
+
+    Pre-choice (``firstRunChoiceMade`` falsey) the answer is always ``"privacy"``
+    (all-local, no egress). Once a choice is recorded, a non-privacy
+    ``activePreset`` resolves to the cloud-capable default ``"bestFreeCloud"``;
+    a privacy choice (or no recorded preset) stays ``"privacy"``.
+    """
+    if not settings.get("firstRunChoiceMade"):
+        return "privacy"
+    active = settings.get("activePreset")
+    if active and active != "privacy":
+        return "bestFreeCloud"
+    return "privacy"

--- a/sidecar/media_studio/models/provider.py
+++ b/sidecar/media_studio/models/provider.py
@@ -34,9 +34,11 @@ import json
 import urllib.error
 import urllib.request
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from typing import Any
 
 from ..util import get_logger
+from .secrets import redact, scrub_error_body
 
 log = get_logger("media_studio.models.provider")
 
@@ -64,9 +66,13 @@ DEFAULT_MAX_TOKENS: int = 4096
 DEFAULT_TIMEOUT: float = 600.0
 
 
-# A transport seam: given (url, json-body-dict, headers, timeout) it performs the
-# POST and returns the decoded JSON response dict. Injected in tests so no socket
-# is ever opened. The default implementation is :func:`_urllib_post_json`.
+# A transport seam: given (url, json-body-dict, headers, timeout) it performs an
+# HTTP call and returns the decoded JSON response dict. Injected in tests so no
+# socket is ever opened. The default POST implementation is
+# :func:`_urllib_post_json`; the default GET implementation (used by local-server
+# detection, which probes ``GET /models``) is :func:`urllib_get_json`. A GET
+# transport ignores the body dict (a GET carries no body) so the SAME injectable
+# ``Transport`` shape serves both the chat POST path and the detection GET path.
 Transport = Callable[[str, dict[str, Any], dict[str, str], float], dict[str, Any]]
 
 
@@ -81,29 +87,43 @@ class ProviderError(RuntimeError):
 # --------------------------------------------------------------------------- #
 # stdlib urllib transport (the only place a socket is opened)
 # --------------------------------------------------------------------------- #
-def _urllib_post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
-    """POST ``body`` as JSON to ``url`` and decode the JSON response (stdlib only).
+def _urllib_request_json(
+    url: str,
+    *,
+    method: str,
+    data: bytes | None,
+    headers: dict[str, str],
+    timeout: float,
+) -> dict[str, Any]:
+    """Issue one ``method`` request to ``url`` and decode the JSON response (stdlib).
 
-    Uses :mod:`urllib.request` so the sidecar has no hard HTTP dependency for the
-    LLM path. Raises :class:`ProviderError` on any network / decode failure so the
-    caller sees one error type regardless of the underlying urllib exception.
+    Shared core for both the chat POST (:func:`_urllib_post_json`) and the
+    detection GET (:func:`urllib_get_json`). Raises :class:`ProviderError` on any
+    network / decode failure so the caller sees one error type regardless of the
+    underlying urllib exception. The error body is best-effort scrubbed of any
+    leaked ``Authorization: Bearer`` token before it is surfaced.
     """
-    data = json.dumps(body).encode("utf-8")
-    req_headers = {"Content-Type": "application/json", **headers}
-    request = urllib.request.Request(url, data=data, headers=req_headers, method="POST")
+    request = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
-        # CONTRACT-NOTE: no shell, no redirects-to-file; a plain JSON POST. Bandit
+        # CONTRACT-NOTE: no shell, no redirects-to-file; a plain JSON call. Bandit
         # B310 (urlopen) is satisfied because the scheme is fixed http/https built
         # from settings, never attacker-controlled raw input.
         with urllib.request.urlopen(request, timeout=timeout) as resp:  # noqa: S310
             raw = resp.read().decode("utf-8")
+            raw_headers = getattr(resp, "headers", None)
+            resp_headers = (
+                {str(k): str(v) for k, v in raw_headers.items()} if raw_headers is not None else {}
+            )
     except urllib.error.HTTPError as exc:  # 4xx/5xx with a body
         detail = ""
         try:
             detail = exc.read().decode("utf-8")
         except Exception:  # noqa: BLE001 - best-effort error body
             detail = ""
-        raise ProviderError(f"LLM HTTP {exc.code}: {detail or exc.reason}") from exc
+        # Strip any leaked bearer token from the server's error body (the key is
+        # header-only on OUR side, but the server may echo an Authorization line).
+        safe_detail = scrub_error_body(detail, ()) if detail else ""
+        raise ProviderError(f"LLM HTTP {exc.code}: {safe_detail or exc.reason}") from exc
     except urllib.error.URLError as exc:  # connection refused / DNS / timeout
         raise ProviderError(f"LLM request failed: {exc.reason}") from exc
     try:
@@ -112,7 +132,34 @@ def _urllib_post_json(url: str, body: dict[str, Any], headers: dict[str, str], t
         raise ProviderError(f"LLM returned non-JSON response: {raw[:200]!r}") from exc
     if not isinstance(decoded, dict):
         raise ProviderError("LLM response was not a JSON object")
+    # Surface response headers under a reserved ``_headers`` key so the rotation
+    # pool can parse ``X-RateLimit-*`` usage metadata; ``_extract_content`` and
+    # the detection probe ignore it (it is not part of the OpenAI envelope).
+    decoded.setdefault("_headers", resp_headers)
     return decoded
+
+
+def _urllib_post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+    """POST ``body`` as JSON to ``url`` and decode the JSON response (stdlib only).
+
+    Uses :mod:`urllib.request` so the sidecar has no hard HTTP dependency for the
+    LLM path. The :class:`Transport` shape's ``body`` dict is serialized to JSON.
+    """
+    data = json.dumps(body).encode("utf-8")
+    req_headers = {"Content-Type": "application/json", **headers}
+    return _urllib_request_json(url, method="POST", data=data, headers=req_headers, timeout=timeout)
+
+
+def urllib_get_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+    """GET ``url`` and decode the JSON response (the local-server detection probe).
+
+    Matches the :data:`Transport` shape so it is interchangeable with
+    :func:`_urllib_post_json` wherever a transport is injected. A GET carries no
+    request body, so the ``body`` dict is intentionally ignored (it exists only to
+    keep the four-argument transport signature uniform across POST and GET).
+    """
+    _ = body  # a GET has no body; the arg exists for transport-shape uniformity.
+    return _urllib_request_json(url, method="GET", data=None, headers=dict(headers), timeout=timeout)
 
 
 def _extract_content(response: dict[str, Any]) -> str:
@@ -243,6 +290,35 @@ class _OpenAICompatProvider(Provider):
         response = self._transport(url, body, self._headers(), self.timeout)
         return _extract_content(response)
 
+    def chat_full(
+        self,
+        messages: Sequence[Message],
+        *,
+        temperature: float = DEFAULT_TEMPERATURE,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        **kwargs: Any,
+    ) -> tuple[str, dict[str, Any]]:
+        """Like :meth:`chat` but also returns the raw response dict.
+
+        The rotation pool uses this so it can read ``X-RateLimit-*`` usage
+        metadata (surfaced under the response's ``_headers`` key) alongside the
+        assistant content. Re-uses :meth:`chat`'s body shaping by re-issuing the
+        request once — kept tiny so the single-provider :meth:`chat` path is
+        unaffected for the legacy callers that do not need the response.
+        """
+        url = f"{self.base_url}/chat/completions"
+        body: dict[str, Any] = {
+            "model": self.model,
+            "messages": [dict(m) for m in messages],
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        for key in ("top_p", "stop", "presence_penalty", "frequency_penalty", "seed"):
+            if key in kwargs and kwargs[key] is not None:
+                body[key] = kwargs[key]
+        response = self._transport(url, body, self._headers(), self.timeout)
+        return _extract_content(response), response
+
 
 class LocalServerProvider(_OpenAICompatProvider):
     """Talks to the local llama.cpp OpenAI-compatible server (CONTRACTS.md §7).
@@ -297,6 +373,371 @@ class CloudProvider(_OpenAICompatProvider):
 
 
 # --------------------------------------------------------------------------- #
+# RotatingProvider (WU-pool): multi-PROVIDER rotation over an ordered key pool
+# --------------------------------------------------------------------------- #
+#: Default per-window cooldown (seconds) a key is skipped after a 429/5xx before
+#: it becomes eligible again. Computed purely from ``now()`` deltas — the module
+#: imports NEITHER ``time`` NOR ``asyncio`` and the hot path never sleeps.
+DEFAULT_COOLDOWN_SECONDS: float = 60.0
+
+#: The default capability a chat request needs of a pool entry.
+DEFAULT_CAPABILITY: str = "text"
+
+
+def _default_now() -> float:
+    """The default wall-clock source (replaced by a fake clock in tests).
+
+    Imported lazily so the MODULE itself never imports ``time`` at top level (the
+    no-sleep / deterministic-clock rule, PLAN §WU-pool): ``time`` is reached only
+    when the real default clock is actually called, and tests inject their own
+    ``now`` so this line is never executed under the gate.
+    """
+    import time as _time  # noqa: PLC0415 - lazy so the module has no top-level time import
+
+    return _time.monotonic()  # pragma: no cover -- real wall-clock; tests inject a fake now()
+
+
+@dataclass(frozen=True)
+class PoolEntrySpec:
+    """The static description of one pool entry (a provider + its key list).
+
+    Same-provider extra ``keys`` are FAILOVER only — never advertised as N×quota
+    (PLAN SE2). ``local`` flags the always-available llama.cpp/Ollama/LM-Studio
+    backstop, which is sorted last and carries no key.
+    """
+
+    provider: str
+    kind: str
+    base_url: str
+    model: str
+    keys: tuple[str, ...]
+    capabilities: tuple[str, ...] = (DEFAULT_CAPABILITY,)
+    unit: str = "req"
+    local: bool = False
+
+
+@dataclass(frozen=True)
+class RotationEvent:
+    """Emitted once per failover so the envelope/UI can show what rotated.
+
+    ``from_key`` / ``to_key`` are REDACTED (last-4 only); the live key is never
+    carried. ``reason`` is the (already-scrubbed) failure summary.
+    """
+
+    provider: str
+    from_key: str
+    to_key: str
+    reason: str
+
+
+class _LiveKey:
+    """One concrete (entry, key) slot: its provider + a mutable usage/cooldown.
+
+    ``cooled_until`` is an absolute ``now()`` value: the slot is skipped while
+    ``now() < cooled_until``. ``used`` is an optimistic counter; ``max`` /
+    ``reset_at`` are filled from parsed ``X-RateLimit-*`` headers when present.
+    """
+
+    def __init__(self, *, spec: PoolEntrySpec, key: str | None, transport: Transport | None) -> None:
+        self.spec = spec
+        self.key = key
+        self.provider = _OpenAICompatProvider(
+            base_url=spec.base_url,
+            model=spec.model,
+            api_key=key,
+            transport=transport,
+        )
+        self.used: int = 0
+        self.max: int | None = None
+        self.reset_at: float | None = None
+        self.cooled_until: float = 0.0
+
+    @property
+    def redacted_key(self) -> str:
+        """The display-safe last-4 redaction of this slot's key (``"local"`` keyless)."""
+        return redact(self.key) if self.key else "local"
+
+    def eligible(self, *, now: float, capability: str) -> bool:
+        """True iff this slot can serve ``capability`` and its cooldown has lapsed."""
+        if capability not in self.spec.capabilities:
+            return False
+        return now >= self.cooled_until
+
+
+def _parse_rate_limit_headers(response: dict[str, Any]) -> tuple[int | None, int | None]:
+    """Parse ``(limit, remaining)`` from a response's ``_headers`` (or ``(None, None)``).
+
+    Reads the de-facto ``X-RateLimit-Limit`` / ``X-RateLimit-Remaining`` headers
+    (case-insensitively); a missing/garbage header yields ``None`` for that field.
+    """
+    headers = response.get("_headers")
+    if not isinstance(headers, dict):
+        return None, None
+    lowered = {str(k).lower(): v for k, v in headers.items()}
+
+    def _as_int(name: str) -> int | None:
+        raw = lowered.get(name)
+        try:
+            return int(str(raw)) if raw is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    return _as_int("x-ratelimit-limit"), _as_int("x-ratelimit-remaining")
+
+
+def _retry_after_seconds(message: str) -> float | None:
+    """Best-effort parse of a ``retry-after=<n>`` hint from a 429 error message."""
+    marker = "retry-after="
+    idx = message.lower().find(marker)
+    if idx < 0:
+        return None
+    tail = message[idx + len(marker) :]
+    digits = ""
+    for ch in tail:
+        if ch.isdigit() or (ch == "." and "." not in digits):
+            digits += ch
+        else:
+            break
+    try:
+        return float(digits) if digits else None
+    except ValueError:  # pragma: no cover -- guarded by the digit-only accumulation above
+        return None
+
+
+class RotatingProvider(Provider):
+    """A :class:`Provider` fronting an ordered pool of OpenAI-compatible keys.
+
+    Reactive failover: a 429/5xx (or any transient provider error) on the active
+    key advances to the next ELIGIBLE key and emits exactly one ``rotation``
+    event. A throttled key is put on a per-window cooldown and SKIPPED (never
+    awaited) until ``now()`` passes its window — the hot path NEVER sleeps. The
+    local backstop is always last, so an offline run still works once every cloud
+    key is exhausted. Per-key usage ``{used, max, unit, resetAt}`` is tracked from
+    optimistic decrement + parsed ``X-RateLimit-*`` headers (for the usage UI).
+    """
+
+    def __init__(
+        self,
+        *,
+        pool: Sequence[PoolEntrySpec],
+        now: Callable[[], float] = _default_now,
+        transport: Transport | None = None,
+        cooldown_seconds: float = DEFAULT_COOLDOWN_SECONDS,
+    ) -> None:
+        specs = list(pool)
+        if not specs:
+            raise ValueError("RotatingProvider requires a non-empty pool")
+        self._now = now
+        self._cooldown = float(cooldown_seconds)
+        # Sort the local backstop(s) to the very end; cloud keys keep pool order.
+        ordered = sorted(specs, key=lambda s: 1 if s.local else 0)
+        self._slots: list[_LiveKey] = []
+        for spec in ordered:
+            keys: Sequence[str | None] = spec.keys or (None,) if spec.local else spec.keys
+            for key in keys:
+                self._slots.append(_LiveKey(spec=spec, key=key, transport=transport))
+        self._rotation_cbs: list[Callable[[RotationEvent], None]] = []
+
+    # -- public hooks --------------------------------------------------------
+    def on_rotation(self, callback: Callable[[RotationEvent], None]) -> None:
+        """Register a ``rotation`` callback (one call per failover)."""
+        self._rotation_cbs.append(callback)
+
+    @property
+    def entries(self) -> tuple[PoolEntrySpec, ...]:
+        """The distinct entry specs in pool order (for budget/degrade-chain)."""
+        seen: set[int] = set()
+        out: list[PoolEntrySpec] = []
+        for slot in self._slots:
+            ident = id(slot.spec)
+            if ident not in seen:
+                seen.add(ident)
+                out.append(slot.spec)
+        return tuple(out)
+
+    def provider_groups(self) -> tuple[str, ...]:
+        """Distinct CLOUD provider names (same-provider keys collapse to one)."""
+        seen: set[str] = set()
+        out: list[str] = []
+        for slot in self._slots:
+            if slot.spec.local:
+                continue
+            if slot.spec.provider not in seen:
+                seen.add(slot.spec.provider)
+                out.append(slot.spec.provider)
+        return tuple(out)
+
+    def usage(self) -> list[dict[str, Any]]:
+        """Per-key usage rows ``{provider, key(redacted), used, max, unit, resetAt}``."""
+        return [
+            {
+                "provider": slot.spec.provider,
+                "key": slot.redacted_key,
+                "used": slot.used,
+                "max": slot.max,
+                "unit": slot.spec.unit,
+                "resetAt": slot.reset_at,
+            }
+            for slot in self._slots
+        ]
+
+    # -- the Provider.chat seam ---------------------------------------------
+    def chat(
+        self,
+        messages: Sequence[Message],
+        *,
+        temperature: float = DEFAULT_TEMPERATURE,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        capability: str = DEFAULT_CAPABILITY,
+        **kwargs: Any,
+    ) -> str:
+        """Try eligible keys in pool order until one succeeds; rotate on failure.
+
+        Raises a single :class:`ProviderError` (never hangs) once every eligible
+        key — including the local backstop — has failed. ``capability`` filters
+        the pool to entries that can serve the request (e.g. ``"vision"``).
+        """
+        failures: list[str] = []
+        active: _LiveKey | None = None
+        for slot in self._slots:
+            now = self._now()
+            if not slot.eligible(now=now, capability=capability):
+                continue
+            try:
+                content, response = slot.provider.chat_full(
+                    messages, temperature=temperature, max_tokens=max_tokens, **kwargs
+                )
+            except ProviderError as exc:
+                self._on_failure(slot, exc, failures)
+                if active is not None:
+                    self._emit_rotation(active, slot, str(exc))
+                active = slot
+                continue
+            self._on_success(slot, response)
+            if active is not None:
+                # We advanced PAST a prior failed key to land on this one.
+                self._emit_rotation(active, slot, "recovered")
+            return content
+        raise ProviderError(self._exhausted_message(capability, failures))
+
+    # -- internals ----------------------------------------------------------
+    def _on_success(self, slot: _LiveKey, response: dict[str, Any]) -> None:
+        """Record an optimistic use + any authoritative ``X-RateLimit-*`` headers."""
+        slot.used += 1
+        limit, remaining = _parse_rate_limit_headers(response)
+        if limit is not None:
+            slot.max = limit
+            if remaining is not None:
+                slot.used = max(0, limit - remaining)
+
+    def _on_failure(self, slot: _LiveKey, exc: ProviderError, failures: list[str]) -> None:
+        """Cool the failed key for its window and record a SCRUBBED failure line."""
+        message = scrub_error_body(str(exc), [slot.key] if slot.key else [])
+        retry_after = _retry_after_seconds(message)
+        window = retry_after if retry_after is not None else self._cooldown
+        slot.cooled_until = self._now() + window
+        slot.reset_at = slot.cooled_until
+        failures.append(f"{slot.spec.provider} ({slot.redacted_key}): {message}")
+
+    def _emit_rotation(self, from_slot: _LiveKey, to_slot: _LiveKey, reason: str) -> None:
+        event = RotationEvent(
+            provider=to_slot.spec.provider,
+            from_key=from_slot.redacted_key,
+            to_key=to_slot.redacted_key,
+            reason=scrub_error_body(reason, [k for k in (from_slot.key, to_slot.key) if k]),
+        )
+        for cb in self._rotation_cbs:
+            cb(event)
+
+    def _exhausted_message(self, capability: str, failures: list[str]) -> str:
+        detail = "; ".join(failures) if failures else "no eligible keys"
+        return f"provider pool exhausted ({capability}): {detail}"
+
+
+def build_pool_provider(
+    settings: dict[str, Any] | None,
+    *,
+    transport: Transport | None = None,
+    probe_transport: Transport | None = None,
+) -> RotatingProvider:
+    """Build a :class:`RotatingProvider` from ``settings.providers`` + local detect.
+
+    Folds in any locally-running Ollama / LM Studio servers (probed via
+    ``probe_transport``, default :func:`urllib_get_json`) and ALWAYS appends the
+    llama.cpp local backstop last so an offline run still works. ``transport`` is
+    the chat transport; ``probe_transport`` the GET detection transport.
+    """
+    settings = settings or {}
+    specs = _cloud_specs_from_settings(settings)
+    specs.extend(_detected_local_specs(settings, probe_transport=probe_transport))
+    specs.append(_llama_backstop_spec(settings))
+    return RotatingProvider(pool=specs, transport=transport)
+
+
+def _cloud_specs_from_settings(settings: dict[str, Any]) -> list[PoolEntrySpec]:
+    """Materialize enabled, keyed cloud providers from ``settings.providers``."""
+    specs: list[PoolEntrySpec] = []
+    for raw in settings.get("providers") or []:
+        if not isinstance(raw, dict):
+            continue
+        if not raw.get("enabled", True):
+            continue
+        keys = tuple(str(k) for k in (raw.get("apiKeys") or []) if k)
+        if not keys:
+            continue
+        specs.append(
+            PoolEntrySpec(
+                provider=str(raw.get("provider") or raw.get("id") or "cloud"),
+                kind=str(raw.get("kind") or "cloud"),
+                base_url=str(raw.get("baseUrl") or DEFAULT_CLOUD_BASE_URL),
+                model=str(raw.get("model") or DEFAULT_CLOUD_MODEL),
+                keys=keys,
+                capabilities=tuple(str(c) for c in (raw.get("capabilities") or [DEFAULT_CAPABILITY])),
+                unit=str(raw.get("unit") or "req"),
+                local=False,
+            )
+        )
+    return specs
+
+
+def _detected_local_specs(
+    settings: dict[str, Any], *, probe_transport: Transport | None
+) -> list[PoolEntrySpec]:
+    """Probe Ollama/LM Studio (best-effort) and turn live ones into pool specs."""
+    from . import local_detect  # local import: avoids an import cycle at module load
+
+    probe = probe_transport or urllib_get_json
+    detected = local_detect.detect_local_servers(settings, transport=probe)
+    return [
+        PoolEntrySpec(
+            provider=entry["kind"],
+            kind=entry["kind"],
+            base_url=entry["base_url"],
+            model=entry["model"],
+            keys=(),
+            capabilities=tuple(entry["capabilities"]),
+            unit=entry["unit"],
+            local=True,
+        )
+        for entry in detected
+    ]
+
+
+def _llama_backstop_spec(settings: dict[str, Any]) -> PoolEntrySpec:
+    """The always-present llama.cpp local backstop entry (no key, sorted last)."""
+    return PoolEntrySpec(
+        provider="local",
+        kind="local",
+        base_url=str(settings.get("localBaseUrl") or DEFAULT_LOCAL_BASE_URL),
+        model=str(settings.get("localModel") or DEFAULT_LOCAL_MODEL),
+        keys=(),
+        capabilities=(DEFAULT_CAPABILITY,),
+        unit="req",
+        local=True,
+    )
+
+
+# --------------------------------------------------------------------------- #
 # Factory (CONTRACTS.md §2 settings.*)
 # --------------------------------------------------------------------------- #
 def get_provider(
@@ -306,16 +747,24 @@ def get_provider(
 ) -> Provider:
     """Return the right :class:`Provider` for ``settings`` (CONTRACTS.md §2).
 
-    Returns a :class:`CloudProvider` when ``settings.useCloud`` is truthy AND a
-    non-empty ``cloudApiKey`` is present; otherwise a :class:`LocalServerProvider`
-    pointed at the local llama.cpp server. ``transport`` is forwarded so tests can
-    inject a fake HTTP transport through the factory too.
+    When ``settings.providers`` lists at least one enabled, keyed cloud provider
+    a pool-aware :class:`RotatingProvider` is returned (WU-pool); otherwise the
+    existing fall-through is UNCHANGED — a :class:`CloudProvider` when
+    ``settings.useCloud`` is truthy AND a non-empty ``cloudApiKey`` is present,
+    else a :class:`LocalServerProvider` pointed at the local llama.cpp server.
+    ``transport`` is forwarded so tests can inject a fake HTTP transport.
 
     CONTRACT-NOTE: §2 names ``{useCloud, cloudApiKey?, modelsDir, ffmpegPath}``.
     Optional ``localBaseUrl`` / ``localModel`` / ``cloudBaseUrl`` / ``cloudModel``
     overrides are honored when present but are NOT required by the contract.
     """
     settings = settings or {}
+
+    # WU-pool: a configured multi-provider pool takes precedence over the legacy
+    # single-provider routing (which stays for back-compat when no pool is set).
+    if _cloud_specs_from_settings(settings):
+        return build_pool_provider(settings, transport=transport)
+
     use_cloud = bool(settings.get("useCloud"))
     api_key = settings.get("cloudApiKey") or ""
 

--- a/sidecar/media_studio/models/provider.py
+++ b/sidecar/media_studio/models/provider.py
@@ -115,9 +115,7 @@ def _urllib_request_json(
         with urllib.request.urlopen(request, timeout=timeout) as resp:  # noqa: S310
             raw = resp.read().decode("utf-8")
             raw_headers = getattr(resp, "headers", None)
-            resp_headers = (
-                {str(k): str(v) for k, v in raw_headers.items()} if raw_headers is not None else {}
-            )
+            resp_headers = {str(k): str(v) for k, v in raw_headers.items()} if raw_headers is not None else {}
     except urllib.error.HTTPError as exc:  # 4xx/5xx with a body
         detail = ""
         try:
@@ -163,9 +161,7 @@ def _urllib_post_json(
     """
     data = json.dumps(body).encode("utf-8")
     req_headers = {"Content-Type": "application/json", **headers}
-    return _urllib_request_json(
-        url, method="POST", data=data, headers=req_headers, timeout=timeout, secrets=secrets
-    )
+    return _urllib_request_json(url, method="POST", data=data, headers=req_headers, timeout=timeout, secrets=secrets)
 
 
 def urllib_get_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
@@ -408,6 +404,11 @@ DEFAULT_COOLDOWN_SECONDS: float = 60.0
 
 #: The default capability a chat request needs of a pool entry.
 DEFAULT_CAPABILITY: str = "text"
+
+#: The sentinel provider id meaning "the local backstop only" (matches
+#: ``presets.LOCAL``). When a per-function routing slot prefers this, the factory
+#: builds a local-only pool so the privacy/all-local route never egresses cloud.
+LOCAL_PROVIDER_ID: str = "local"
 
 
 def _default_now() -> float:
@@ -686,6 +687,7 @@ def build_pool_provider(
     transport: Transport | None = None,
     probe_transport: Transport | None = None,
     detect_local: bool = True,
+    prefer: str | None = None,
 ) -> RotatingProvider:
     """Build a :class:`RotatingProvider` from ``settings.providers`` + local detect.
 
@@ -699,13 +701,44 @@ def build_pool_provider(
     needs the cloud providers + the llama backstop and must NOT open a socket, so
     it builds the pool with detection off. The runtime execution path keeps the
     default ``True`` so live local servers are still discovered when a call runs.
+
+    ``prefer`` (WU-presets per-function routing): the configured provider ``id``
+    the active function prefers. The matching provider spec is moved to the FRONT
+    of the cloud pool (tried first), the rest kept as failover, the local backstop
+    still last. ``prefer == LOCAL_PROVIDER_ID`` yields a local-only pool (the
+    privacy/all-local route — NO cloud entry, so it never egresses). An unknown id
+    is a no-op (configured order kept), so a stale routing choice never breaks the
+    pool.
     """
     settings = settings or {}
-    specs = _cloud_specs_from_settings(settings)
+    if prefer == LOCAL_PROVIDER_ID:
+        # Privacy/all-local route: skip cloud specs entirely (zero cloud egress).
+        return RotatingProvider(pool=[_llama_backstop_spec(settings)], transport=transport)
+    specs = _cloud_specs_from_settings(_prefer_provider_first(settings, prefer))
     if detect_local:
         specs.extend(_detected_local_specs(settings, probe_transport=probe_transport))
     specs.append(_llama_backstop_spec(settings))
     return RotatingProvider(pool=specs, transport=transport)
+
+
+def _prefer_provider_first(settings: dict[str, Any], prefer: str | None) -> dict[str, Any]:
+    """Return ``settings`` with ``providers`` reordered so ``prefer`` (an id) is first.
+
+    PURE: a new settings dict with a reordered ``providers`` list (the original is
+    never mutated). ``prefer`` of ``None`` or an unknown id leaves the order
+    unchanged — the matching entry (by ``id``) is simply hoisted to the front so
+    the per-function preferred provider is tried before the rest of the pool.
+    """
+    if not prefer:
+        return settings
+    providers = settings.get("providers")
+    if not isinstance(providers, list):
+        return settings
+    preferred = [p for p in providers if isinstance(p, dict) and p.get("id") == prefer]
+    if not preferred:
+        return settings
+    rest = [p for p in providers if not (isinstance(p, dict) and p.get("id") == prefer)]
+    return {**settings, "providers": [*preferred, *rest]}
 
 
 def _cloud_specs_from_settings(settings: dict[str, Any]) -> list[PoolEntrySpec]:
@@ -734,9 +767,7 @@ def _cloud_specs_from_settings(settings: dict[str, Any]) -> list[PoolEntrySpec]:
     return specs
 
 
-def _detected_local_specs(
-    settings: dict[str, Any], *, probe_transport: Transport | None
-) -> list[PoolEntrySpec]:
+def _detected_local_specs(settings: dict[str, Any], *, probe_transport: Transport | None) -> list[PoolEntrySpec]:
     """Probe Ollama/LM Studio (best-effort) and turn live ones into pool specs."""
     from . import local_detect  # local import: avoids an import cycle at module load
 
@@ -778,6 +809,7 @@ def get_provider(
     settings: dict[str, Any] | None = None,
     *,
     transport: Transport | None = None,
+    prefer: str | None = None,
 ) -> Provider:
     """Return the right :class:`Provider` for ``settings`` (CONTRACTS.md §2).
 
@@ -788,6 +820,11 @@ def get_provider(
     else a :class:`LocalServerProvider` pointed at the local llama.cpp server.
     ``transport`` is forwarded so tests can inject a fake HTTP transport.
 
+    ``prefer`` (WU-presets) is the configured provider ``id`` the active function
+    prefers; it is threaded into :func:`build_pool_provider` so the per-function
+    seam tries that provider first (``LOCAL_PROVIDER_ID`` -> local-only). It only
+    applies on the pool path; the legacy single-provider fall-through ignores it.
+
     CONTRACT-NOTE: §2 names ``{useCloud, cloudApiKey?, modelsDir, ffmpegPath}``.
     Optional ``localBaseUrl`` / ``localModel`` / ``cloudBaseUrl`` / ``cloudModel``
     overrides are honored when present but are NOT required by the contract.
@@ -796,8 +833,9 @@ def get_provider(
 
     # WU-pool: a configured multi-provider pool takes precedence over the legacy
     # single-provider routing (which stays for back-compat when no pool is set).
-    if _cloud_specs_from_settings(settings):
-        return build_pool_provider(settings, transport=transport)
+    # A prefer==LOCAL route is honored even with cloud providers configured.
+    if prefer == LOCAL_PROVIDER_ID or _cloud_specs_from_settings(settings):
+        return build_pool_provider(settings, transport=transport, prefer=prefer)
 
     use_cloud = bool(settings.get("useCloud"))
     api_key = settings.get("cloudApiKey") or ""

--- a/sidecar/media_studio/models/provider.py
+++ b/sidecar/media_studio/models/provider.py
@@ -659,6 +659,7 @@ def build_pool_provider(
     *,
     transport: Transport | None = None,
     probe_transport: Transport | None = None,
+    detect_local: bool = True,
 ) -> RotatingProvider:
     """Build a :class:`RotatingProvider` from ``settings.providers`` + local detect.
 
@@ -666,10 +667,17 @@ def build_pool_provider(
     ``probe_transport``, default :func:`urllib_get_json`) and ALWAYS appends the
     llama.cpp local backstop last so an offline run still works. ``transport`` is
     the chat transport; ``probe_transport`` the GET detection transport.
+
+    ``detect_local=False`` SKIPS the live Ollama/LM-Studio ``GET /models`` probe
+    entirely (no socket): the budget/route planner (``ai_job.plan_ai_job``) only
+    needs the cloud providers + the llama backstop and must NOT open a socket, so
+    it builds the pool with detection off. The runtime execution path keeps the
+    default ``True`` so live local servers are still discovered when a call runs.
     """
     settings = settings or {}
     specs = _cloud_specs_from_settings(settings)
-    specs.extend(_detected_local_specs(settings, probe_transport=probe_transport))
+    if detect_local:
+        specs.extend(_detected_local_specs(settings, probe_transport=probe_transport))
     specs.append(_llama_backstop_spec(settings))
     return RotatingProvider(pool=specs, transport=transport)
 

--- a/sidecar/media_studio/models/provider.py
+++ b/sidecar/media_studio/models/provider.py
@@ -30,6 +30,7 @@ key is present; the key is passed as a bearer header and never logged.
 from __future__ import annotations
 
 import abc
+import functools
 import json
 import urllib.error
 import urllib.request
@@ -94,14 +95,17 @@ def _urllib_request_json(
     data: bytes | None,
     headers: dict[str, str],
     timeout: float,
+    secrets: Sequence[str] = (),
 ) -> dict[str, Any]:
     """Issue one ``method`` request to ``url`` and decode the JSON response (stdlib).
 
     Shared core for both the chat POST (:func:`_urllib_post_json`) and the
     detection GET (:func:`urllib_get_json`). Raises :class:`ProviderError` on any
     network / decode failure so the caller sees one error type regardless of the
-    underlying urllib exception. The error body is best-effort scrubbed of any
-    leaked ``Authorization: Bearer`` token before it is surfaced.
+    underlying urllib exception. The error body is scrubbed ENFORCEABLY (PLAN
+    §WU-keys): every live key in ``secrets`` AND any leaked ``Authorization:
+    Bearer`` token is stripped at THIS construction site, so "no live key in any
+    :class:`ProviderError`" is an invariant, not a hope.
     """
     request = urllib.request.Request(url, data=data, headers=headers, method=method)
     try:
@@ -120,10 +124,12 @@ def _urllib_request_json(
             detail = exc.read().decode("utf-8")
         except Exception:  # noqa: BLE001 - best-effort error body
             detail = ""
-        # Strip any leaked bearer token from the server's error body (the key is
-        # header-only on OUR side, but the server may echo an Authorization line).
-        safe_detail = scrub_error_body(detail, ()) if detail else ""
-        raise ProviderError(f"LLM HTTP {exc.code}: {safe_detail or exc.reason}") from exc
+        # ENFORCEABLE SCRUB (PLAN §WU-keys): strip every live key threaded in via
+        # ``secrets`` AND any echoed ``Authorization: Bearer`` token from the
+        # server's error body BEFORE it ever reaches a ProviderError / a log line.
+        safe_detail = scrub_error_body(detail, secrets) if detail else ""
+        reason = scrub_error_body(str(exc.reason), secrets)
+        raise ProviderError(f"LLM HTTP {exc.code}: {safe_detail or reason}") from exc
     except urllib.error.URLError as exc:  # connection refused / DNS / timeout
         raise ProviderError(f"LLM request failed: {exc.reason}") from exc
     try:
@@ -139,15 +145,27 @@ def _urllib_request_json(
     return decoded
 
 
-def _urllib_post_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+def _urllib_post_json(
+    url: str,
+    body: dict[str, Any],
+    headers: dict[str, str],
+    timeout: float,
+    secrets: Sequence[str] = (),
+) -> dict[str, Any]:
     """POST ``body`` as JSON to ``url`` and decode the JSON response (stdlib only).
 
     Uses :mod:`urllib.request` so the sidecar has no hard HTTP dependency for the
     LLM path. The :class:`Transport` shape's ``body`` dict is serialized to JSON.
+    ``secrets`` is the provider's own key-set, threaded down so the error body is
+    scrubbed of every live key at the construction site (PLAN §WU-keys). It is a
+    keyword-only-in-practice extra arg — the 4-positional :data:`Transport` shape
+    a test injects is unaffected (those fakes never reach the scrub branch).
     """
     data = json.dumps(body).encode("utf-8")
     req_headers = {"Content-Type": "application/json", **headers}
-    return _urllib_request_json(url, method="POST", data=data, headers=req_headers, timeout=timeout)
+    return _urllib_request_json(
+        url, method="POST", data=data, headers=req_headers, timeout=timeout, secrets=secrets
+    )
 
 
 def urllib_get_json(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
@@ -256,8 +274,16 @@ class _OpenAICompatProvider(Provider):
         self.model = model
         self._api_key = api_key
         self.timeout = timeout
-        # Default to the stdlib urllib transport; tests inject a fake.
-        self._transport: Transport = transport or _urllib_post_json
+        # Default to the stdlib urllib transport; tests inject a fake. The default
+        # transport is bound to THIS provider's key-set so its error body is
+        # scrubbed of the live key at the construction site (PLAN §WU-keys
+        # ENFORCEABLE SCRUB); an injected fake keeps the plain 4-arg Transport
+        # shape (it never reaches the real scrub branch).
+        if transport is not None:
+            self._transport: Transport = transport
+        else:
+            secrets = (api_key,) if api_key else ()
+            self._transport = functools.partial(_urllib_post_json, secrets=secrets)
 
     def _headers(self) -> dict[str, str]:
         """Build request headers, adding a bearer token only when a key is set."""

--- a/sidecar/media_studio/models/secrets.py
+++ b/sidecar/media_studio/models/secrets.py
@@ -19,7 +19,8 @@ hope. They do NOT cross-import any other ``models/`` module.
 from __future__ import annotations
 
 import re
-from collections.abc import Sequence
+from collections.abc import Iterable, Sequence
+from typing import Any
 
 #: Marker substituted in place of any stripped secret. Visible so a scrubbed
 #: body is recognizably scrubbed rather than silently truncated.
@@ -69,3 +70,28 @@ def scrub_error_body(text: str, keys: Sequence[str]) -> str:
             scrubbed = scrubbed.replace(key, REDACTION_PLACEHOLDER)
     scrubbed = _BEARER_RE.sub(rf"\1{REDACTION_PLACEHOLDER}", scrubbed)
     return scrubbed
+
+
+def redact_keys(providers: Iterable[Any]) -> list[dict[str, Any]]:
+    """Return a copy of ``providers`` with every ``apiKeys`` entry redacted to last-4.
+
+    This is the RPC-facing transform (PLAN §WU-keys): the persisted
+    ``settings.providers`` carries RAW keys, but anything that crosses RPC —
+    ``settings.get`` and ``providers.list`` — must replace each key with its
+    display-safe :func:`redact` form so NO full key ever leaves the sidecar.
+
+    Each provider dict is shallow-copied (never mutated in place — the caller's
+    RAW store stays intact) and its ``apiKeys`` list is rebuilt from
+    :func:`redact`. Non-dict entries and missing/non-list ``apiKeys`` are passed
+    through unchanged (defensive: a malformed settings file must not crash a read).
+    """
+    out: list[dict[str, Any]] = []
+    for raw in providers:
+        if not isinstance(raw, dict):
+            continue
+        entry = dict(raw)
+        keys = entry.get("apiKeys")
+        if isinstance(keys, list):
+            entry["apiKeys"] = [redact(str(k)) for k in keys]
+        out.append(entry)
+    return out

--- a/sidecar/media_studio/models/secrets.py
+++ b/sidecar/media_studio/models/secrets.py
@@ -1,0 +1,71 @@
+"""Secret redaction + provider-error-body scrubbing (WU-keys, PLAN §WU-keys).
+
+Two PURE, import-light helpers that keep API keys out of anything a user (or a
+log file, or an RPC error payload) can see:
+
+  * :func:`redact` — display-safe redaction that reveals at most the last 4
+    characters of a key (and reveals NOTHING for short/empty keys, where the
+    "last 4" would be the whole key).
+  * :func:`scrub_error_body` — strips every known key AND any
+    ``Authorization: Bearer <...>`` header value out of a raw provider error
+    body BEFORE it can reach a log line or a JSON-RPC error message.
+
+These are deliberately dependency-free (only :mod:`re` from the stdlib) so the
+ENFORCEABLE-SCRUB invariant in PLAN §WU-keys — "no live key in any error body" —
+is provable at the construction site that calls :func:`scrub_error_body`, not a
+hope. They do NOT cross-import any other ``models/`` module.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+#: Marker substituted in place of any stripped secret. Visible so a scrubbed
+#: body is recognizably scrubbed rather than silently truncated.
+REDACTION_PLACEHOLDER: str = "[REDACTED]"
+
+#: Number of trailing characters :func:`redact` is allowed to reveal.
+_VISIBLE_TAIL: int = 4
+
+#: Ellipsis prefix that marks a value as redacted in UI displays.
+_ELLIPSIS: str = "…"
+
+#: Matches an ``Authorization: Bearer <token>`` header (case-insensitive) and
+#: captures the token so only the token is replaced, the header name preserved.
+#: The token run is "non-space, non-newline" so a trailing message on its own
+#: line is not swallowed.
+_BEARER_RE = re.compile(
+    r"(authorization\s*:\s*bearer\s+)(\S+)",
+    re.IGNORECASE,
+)
+
+
+def redact(key: str) -> str:
+    """Return a display-safe redaction of ``key`` revealing at most the last 4 chars.
+
+    Long keys render as ``"…WXYZ"`` (ellipsis + last 4). Keys with 4 or fewer
+    characters — where the "last 4" would expose the entire key — render as a
+    bare ``"…"`` so nothing leaks. An empty key likewise renders as ``"…"``.
+    """
+    if len(key) > _VISIBLE_TAIL:
+        return f"{_ELLIPSIS}{key[-_VISIBLE_TAIL:]}"
+    return _ELLIPSIS
+
+
+def scrub_error_body(text: str, keys: Sequence[str]) -> str:
+    """Strip every key in ``keys`` and any ``Authorization: Bearer`` token from ``text``.
+
+    Each non-empty key (and every occurrence of it) is replaced with
+    :data:`REDACTION_PLACEHOLDER`; empty keys are ignored so they cannot match
+    everywhere and erase the whole body. Any ``Authorization: Bearer <token>``
+    header has its token replaced too — even a leaked bearer we never registered
+    in ``keys`` — so the body is safe to log or surface over RPC. Surrounding,
+    non-secret text is preserved verbatim.
+    """
+    scrubbed = text
+    for key in keys:
+        if key:
+            scrubbed = scrubbed.replace(key, REDACTION_PLACEHOLDER)
+    scrubbed = _BEARER_RE.sub(rf"\1{REDACTION_PLACEHOLDER}", scrubbed)
+    return scrubbed

--- a/sidecar/media_studio/models/translation.py
+++ b/sidecar/media_studio/models/translation.py
@@ -502,13 +502,53 @@ class TieredTranslator:
         return None
 
 
+def _default_hosted_factory(
+    settings: dict[str, Any] | None,
+    *,
+    transport: Any | None,
+) -> ProviderFactory:
+    """Build the tier3 hosted-provider factory shared with the general LLM seam.
+
+    The tier3 (``TIER_HOSTED``) provider resolves through the SAME
+    :func:`~media_studio.models.provider.get_provider` factory the general LLM
+    seam uses (WU-pool: BOTH seams), so a hosted translation call rotates/fails-
+    over identically when ``settings.providers`` is configured and otherwise
+    follows the legacy cloud/local routing. The factory raises
+    :class:`TierUnavailableError` (not the generic local fall-through) when there
+    is no pool AND no ``cloudApiKey`` — tier3 is an EXPLICIT hosted decision, so a
+    bare local server is not a valid tier3 provider.
+    """
+    settings = settings or {}
+
+    def _factory() -> Any:
+        has_pool = bool(provider_mod._cloud_specs_from_settings(settings))
+        has_cloud_key = bool(settings.get("cloudApiKey"))
+        if not has_pool and not has_cloud_key:
+            raise TierUnavailableError("tier3 unavailable: no provider pool and no cloudApiKey configured")
+        merged = dict(settings)
+        if has_cloud_key:
+            # The legacy single-cloud path expects useCloud to gate CloudProvider.
+            merged.setdefault("useCloud", True)
+        return provider_mod.get_provider(merged, transport=transport)
+
+    return _factory
+
+
 def get_translator(
     settings: dict[str, Any] | None = None,
     *,
     runner: Any | None = None,
+    transport: Any | None = None,
     **seams: Any,
 ) -> TieredTranslator:
-    """Factory the wiring layer calls (mirrors ``provider.get_provider``)."""
+    """Factory the wiring layer calls (mirrors ``provider.get_provider``).
+
+    The tier3 hosted provider resolves through the SAME rotation pool / cloud
+    factory as the general LLM seam (WU-pool). An explicit
+    ``hosted_provider_factory`` in ``seams`` still wins (tests / overrides).
+    """
+    if "hosted_provider_factory" not in seams:
+        seams["hosted_provider_factory"] = _default_hosted_factory(settings, transport=transport)
     return TieredTranslator(runner=runner, settings=settings, **seams)
 
 

--- a/sidecar/media_studio/models/translation.py
+++ b/sidecar/media_studio/models/translation.py
@@ -506,6 +506,7 @@ def _default_hosted_factory(
     settings: dict[str, Any] | None,
     *,
     transport: Any | None,
+    prefer: str | None = None,
 ) -> ProviderFactory:
     """Build the tier3 hosted-provider factory shared with the general LLM seam.
 
@@ -521,6 +522,11 @@ def _default_hosted_factory(
     settings = settings or {}
 
     def _factory() -> Any:
+        # WU-presets: when the translation function routes to LOCAL, the tier3
+        # hosted provider IS the local backstop pool (an explicit local choice,
+        # never the no-pool failure) so a privacy-routed translation never egresses.
+        if prefer == provider_mod.LOCAL_PROVIDER_ID:
+            return provider_mod.get_provider(settings, transport=transport, prefer=prefer)
         has_pool = bool(provider_mod._cloud_specs_from_settings(settings))
         has_cloud_key = bool(settings.get("cloudApiKey"))
         if not has_pool and not has_cloud_key:
@@ -529,7 +535,7 @@ def _default_hosted_factory(
         if has_cloud_key:
             # The legacy single-cloud path expects useCloud to gate CloudProvider.
             merged.setdefault("useCloud", True)
-        return provider_mod.get_provider(merged, transport=transport)
+        return provider_mod.get_provider(merged, transport=transport, prefer=prefer)
 
     return _factory
 
@@ -539,16 +545,20 @@ def get_translator(
     *,
     runner: Any | None = None,
     transport: Any | None = None,
+    prefer: str | None = None,
     **seams: Any,
 ) -> TieredTranslator:
     """Factory the wiring layer calls (mirrors ``provider.get_provider``).
 
     The tier3 hosted provider resolves through the SAME rotation pool / cloud
-    factory as the general LLM seam (WU-pool). An explicit
+    factory as the general LLM seam (WU-pool). ``prefer`` (WU-presets) is the
+    configured provider id the translation function prefers; it is threaded into
+    the hosted factory so the tier3 pool tries that provider first
+    (``LOCAL_PROVIDER_ID`` -> a local-only hosted pool). An explicit
     ``hosted_provider_factory`` in ``seams`` still wins (tests / overrides).
     """
     if "hosted_provider_factory" not in seams:
-        seams["hosted_provider_factory"] = _default_hosted_factory(settings, transport=transport)
+        seams["hosted_provider_factory"] = _default_hosted_factory(settings, transport=transport, prefer=prefer)
     return TieredTranslator(runner=runner, settings=settings, **seams)
 
 

--- a/sidecar/media_studio/models/usage.py
+++ b/sidecar/media_studio/models/usage.py
@@ -1,0 +1,118 @@
+"""Per-key usage accounting model + cache merge/stale logic (PLAN §WU-usage-ui).
+
+The rotation pool (``provider.RotatingProvider.usage``) already produces per-key
+usage rows ``{provider, key(redacted), used, max, unit, resetAt}`` from optimistic
+decrement + parsed ``X-RateLimit-*`` headers — there is NO poller. This module is
+the small PURE half WU-usage-ui adds on top:
+
+  * :class:`UsageUnit` — the REQ/TOKEN limit dimension. Req-limited and
+    token-limited keys are NEVER summed (DESIGN §13); the renderer groups by unit
+    and the budget/UI read the canonical string off this enum.
+  * :func:`merge_usage_cache` — fold a freshly-read pool snapshot over the
+    persisted (timestamped) cache so the UI shows immediately on launch
+    (DESIGN §15-Q1) without re-polling. A live row with real counts (``used`` or
+    ``max`` known) supersedes a stale cached row; a freshly-built pool (all-zero,
+    no ``max``) does NOT clobber a cached row that carried real numbers.
+  * :func:`flag_stale` — stamp each row with ``lastCheckedAt`` + ``stale`` from a
+    wall-clock ``now`` and the >10-min threshold; the renderer desaturates stale
+    bars and shows "last checked Xm ago".
+
+Pure data + arithmetic only — no I/O, no heavy imports. The handler owns the pool
+read, the settings persistence, and the ``now`` seam.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Any
+
+#: Usage older than this many seconds is flagged ``stale`` (DESIGN §15-Q1: 10 min).
+STALE_AFTER_SECONDS: float = 10 * 60.0
+
+
+class UsageUnit(StrEnum):
+    """The limit dimension a key's quota is measured in (DESIGN §13).
+
+    ``REQ`` = request-count limited; ``TOKEN`` = token limited. The two are
+    DISTINCT dimensions and are never summed into one bar — the renderer groups
+    by unit. Subclassing ``str`` keeps the wire/JSON value the plain lowercase
+    string the pool/catalog already emit (``"req"`` / ``"token"``).
+    """
+
+    REQ = "req"
+    TOKEN = "token"
+
+    @classmethod
+    def coerce(cls, value: Any) -> UsageUnit:
+        """Map any wire string onto a :class:`UsageUnit` (unknown -> ``REQ``).
+
+        The catalog/pool store the unit as a free string; this normalizes it so
+        the grouping is total. Anything that is not a recognized token-unit falls
+        back to ``REQ`` (the safe per-request default).
+        """
+        text = str(value).strip().lower()
+        return cls.TOKEN if text == cls.TOKEN.value else cls.REQ
+
+
+def _row_key(row: dict[str, Any]) -> tuple[str, str]:
+    """The identity of a usage row: ``(provider, redacted-key)``."""
+    return (str(row.get("provider", "")), str(row.get("key", "")))
+
+
+def _has_real_data(row: dict[str, Any]) -> bool:
+    """True iff a row carries real accounting (a nonzero ``used`` or a known ``max``).
+
+    A freshly-built pool reports ``used == 0`` and ``max is None`` for every key
+    (the in-memory counters reset each process); such a row must NOT clobber a
+    persisted cache row that recorded real numbers from an earlier run.
+    """
+    used = row.get("used")
+    has_used = isinstance(used, (int, float)) and used > 0
+    return bool(has_used or row.get("max") is not None)
+
+
+def merge_usage_cache(
+    live_rows: list[dict[str, Any]],
+    cached_rows: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Fold ``live_rows`` over ``cached_rows`` (keyed by provider+redacted-key).
+
+    A live row with real data wins; an all-zero live row keeps the cached numbers
+    (but always carries the live row's identity/unit). Cached-only rows (a key no
+    longer in the live pool) are dropped — the pool is the source of truth for
+    which keys exist. Output order follows ``live_rows``.
+    """
+    by_key = {_row_key(row): row for row in cached_rows}
+    merged: list[dict[str, Any]] = []
+    for live in live_rows:
+        cached = by_key.get(_row_key(live))
+        if cached is not None and not _has_real_data(live) and _has_real_data(cached):
+            row = {**live, "used": cached.get("used", live.get("used")), "max": cached.get("max")}
+            if cached.get("resetAt") is not None:
+                row["resetAt"] = cached.get("resetAt")
+        else:
+            row = dict(live)
+        merged.append(row)
+    return merged
+
+
+def flag_stale(
+    rows: list[dict[str, Any]],
+    *,
+    now: float,
+    checked_at: dict[str, float] | None = None,
+) -> list[dict[str, Any]]:
+    """Stamp ``lastCheckedAt`` + ``stale`` on each row from ``now`` + the threshold.
+
+    ``checked_at`` maps a row's ``(provider, key)`` (joined by ``"\\x00"``) to the
+    wall-clock it was last observed; a row absent from the map is treated as
+    just-observed (``now``, fresh). A row whose age exceeds
+    :data:`STALE_AFTER_SECONDS` is flagged ``stale`` so the bar desaturates.
+    """
+    stamps = checked_at or {}
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        ident = "\x00".join(_row_key(row))
+        last = stamps.get(ident, now)
+        out.append({**row, "lastCheckedAt": last, "stale": (now - last) > STALE_AFTER_SECONDS})
+    return out

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .models import budget as _budget
 from .models.secrets import redact_keys
 from .util import get_logger
 
@@ -56,6 +57,16 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     # (vision) are SEPARATE, independently-revocable opt-ins per provider.
     # consent.perProvider[<provider>] = {"text": bool, "frames": bool}.
     "consent": {"perProvider": {}},
+    # WU-budget pre-flight gate (PLAN §WU-budget): when True, a cloud run that
+    # WOULD egress must be acknowledged via ai.planJob first (the renderer shows
+    # the cost/egress budget and the user confirms). Default True = safe-by-
+    # default; the user opts out of the per-run confirmation explicitly.
+    "confirmCloudBudget": True,
+    # WU-budget default target-job-size (PLAN P1 #6, promoted to acceptance): the
+    # number of discrete outputs an unsized job produces, used by the budget
+    # estimate when the request pins no size. Mirrors budget.DEFAULT_TARGET_JOB_SIZE;
+    # a DOCUMENTED placeholder until the user pins N (one 60-min source -> N shorts).
+    "defaultTargetJobSize": _budget.DEFAULT_TARGET_JOB_SIZE,
 }
 
 # The config file name inside the resolved app config directory.

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -17,6 +17,7 @@ import os
 from pathlib import Path
 from typing import Any
 
+from .models.secrets import redact_keys
 from .util import get_logger
 
 log = get_logger("media_studio.settings")
@@ -44,6 +45,17 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     "brandLogoPath": "",
     "brandCaptionTemplate": "",
     "brandFontFamily": "",
+    # Provider Hub (WU-keys): the user-supplied rotation pool. Each entry is
+    # {id, provider, kind, baseUrl, model, apiKeys[], enabled, capabilities[],
+    # unit}. apiKeys are stored RAW in the per-user config file (never a project
+    # folder) but SettingsStore.get() redacts them to last-4 before they cross
+    # RPC — only SettingsStore.get_raw() (the factory path, never registered)
+    # returns the live keys.
+    "providers": [],
+    # Per-data-type consent (WU-keys / SE1): TEXT (transcripts) and FRAMES
+    # (vision) are SEPARATE, independently-revocable opt-ins per provider.
+    # consent.perProvider[<provider>] = {"text": bool, "frames": bool}.
+    "consent": {"perProvider": {}},
 }
 
 # The config file name inside the resolved app config directory.
@@ -102,7 +114,31 @@ class SettingsStore:
 
     # ---- public surface (matches settings.* methods) ----------------------
     def get(self) -> dict[str, Any]:
-        """Return the full §2 settings object (defaults backfilled)."""
+        """Return the REDACTED §2 settings object (defaults backfilled).
+
+        This is the RPC-facing view: ``settings.providers[].apiKeys`` are
+        redacted to last-4 via :func:`secrets.redact_keys` so NO full key ever
+        crosses the RPC boundary (PLAN §WU-keys security invariant). The
+        provider/translator FACTORY path must call :meth:`get_raw` instead — see
+        its docstring. ``cloudApiKey`` (the legacy single-cloud key) stays as-is:
+        it is not part of the pool and the §0 contract names it directly; the
+        Hub's redaction is scoped to the new ``providers`` pool only.
+        """
+        merged = self.get_raw()
+        providers = merged.get("providers")
+        if isinstance(providers, list):
+            merged["providers"] = redact_keys(providers)
+        return merged
+
+    def get_raw(self) -> dict[str, Any]:
+        """Return the full §2 settings object with RAW (unredacted) keys.
+
+        NEVER exposed over RPC — this is the provider/translator FACTORY path
+        ONLY (PLAN §WU-keys: ``get_provider``, ``TieredTranslator._hosted_provider``,
+        the ``RotatingProvider`` pool build, and the handler ``__init__`` /
+        ``_get_translator`` construction all consume RAW keys via this accessor).
+        Every settings read that crosses RPC must use :meth:`get` instead.
+        """
         merged = dict(DEFAULT_SETTINGS)
         merged.update(self._read())
         return merged
@@ -119,6 +155,7 @@ class SettingsStore:
         current = dict(self._read())
         current.update(values)
         self._write(current)
-        merged = dict(DEFAULT_SETTINGS)
-        merged.update(current)
-        return merged
+        # The on-disk store keeps RAW keys (the factory reads them via get_raw);
+        # the RPC-facing return MUST be redacted exactly like get() so the
+        # round-tripped settings.set response never echoes a full key (WU-keys).
+        return self.get()

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -67,6 +67,16 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     # estimate when the request pins no size. Mirrors budget.DEFAULT_TARGET_JOB_SIZE;
     # a DOCUMENTED placeholder until the user pins N (one 60-min source -> N shorts).
     "defaultTargetJobSize": _budget.DEFAULT_TARGET_JOB_SIZE,
+    # Provider Hub presets + per-function routing (WU-presets / PH3). ``routing``
+    # holds the resolved per-function provider choice; each function's seam prefers
+    # its configured provider (pool fallback). ``perFunction[<fn>]`` is a
+    # {provider, fallback[]} slot (provider is a catalog model-id or the LOCAL
+    # sentinel). ``activePreset`` is the last applied smart preset name.
+    "routing": {"perFunction": {}},
+    "activePreset": "",
+    # WU-presets first-run local-vs-cloud chooser (PLAN P1 #6): False until the
+    # user picks; while False the routing default is privacy/all-local (no egress).
+    "firstRunChoiceMade": False,
 }
 
 # The config file name inside the resolved app config directory.

--- a/sidecar/tests/test_ai_cache.py
+++ b/sidecar/tests/test_ai_cache.py
@@ -1,0 +1,168 @@
+"""Unit tests for media_studio.models.ai_cache (WU-cache).
+
+The cache is a small on-disk JSON store keyed by the sha256 of a *canonicalized*
+AI request ``(messages, model, params)``. These tests pin the two contracts the
+WU-cache spec calls falsifiable:
+
+  * ``key()`` is a PURE, deterministic content hash: the same logical request
+    always hashes the same; ANY change to content, model, or params yields a
+    different key (dict-ordering / param-ordering must NOT matter).
+  * ``get`` / ``put`` round-trip through an INJECTED store dir (a tmp path) with
+    no network and no shared global state.
+
+No real network, no model, no wall-clock — the store dir is the only side effect
+and it lives entirely in the pytest ``tmp_path`` fixture.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.models import ai_cache as cache_mod
+from media_studio.models.ai_cache import AiCache
+
+
+# --------------------------------------------------------------------------- #
+# fixtures / helpers
+# --------------------------------------------------------------------------- #
+def _messages() -> list[dict[str, str]]:
+    return [
+        {"role": "system", "content": "You are concise."},
+        {"role": "user", "content": "Pick the best moment."},
+    ]
+
+
+@pytest.fixture
+def store(tmp_path: Path) -> AiCache:
+    return AiCache(store_dir=tmp_path / "ai-cache")
+
+
+# --------------------------------------------------------------------------- #
+# key() — pure, deterministic content hash
+# --------------------------------------------------------------------------- #
+def test_key_is_sha256_hex(store: AiCache) -> None:
+    key = store.key(_messages(), "qwen3-4b", {"temperature": 0.2})
+    # sha256 hex digest is 64 lowercase hex chars.
+    assert isinstance(key, str)
+    assert len(key) == 64
+    assert all(c in "0123456789abcdef" for c in key)
+
+
+def test_key_deterministic_for_identical_request(store: AiCache) -> None:
+    k1 = store.key(_messages(), "qwen3-4b", {"temperature": 0.2, "max_tokens": 64})
+    k2 = store.key(_messages(), "qwen3-4b", {"temperature": 0.2, "max_tokens": 64})
+    assert k1 == k2
+
+
+def test_key_independent_of_param_dict_ordering(store: AiCache) -> None:
+    # Canonicalization must sort keys: param insertion order is irrelevant.
+    k1 = store.key(_messages(), "m", {"a": 1, "b": 2})
+    k2 = store.key(_messages(), "m", {"b": 2, "a": 1})
+    assert k1 == k2
+
+
+def test_key_changes_when_content_changes(store: AiCache) -> None:
+    base = store.key(_messages(), "m", {"t": 0})
+    other_msgs = [
+        {"role": "system", "content": "You are concise."},
+        {"role": "user", "content": "Pick the WORST moment."},
+    ]
+    assert store.key(other_msgs, "m", {"t": 0}) != base
+
+
+def test_key_changes_when_model_changes(store: AiCache) -> None:
+    base = store.key(_messages(), "qwen3-4b", {"t": 0})
+    assert store.key(_messages(), "gpt-4o-mini", {"t": 0}) != base
+
+
+def test_key_changes_when_params_change(store: AiCache) -> None:
+    base = store.key(_messages(), "m", {"temperature": 0.2})
+    assert store.key(_messages(), "m", {"temperature": 0.9}) != base
+
+
+def test_key_changes_when_param_added(store: AiCache) -> None:
+    base = store.key(_messages(), "m", {"temperature": 0.2})
+    assert store.key(_messages(), "m", {"temperature": 0.2, "max_tokens": 8}) != base
+
+
+def test_key_empty_params_is_stable(store: AiCache) -> None:
+    assert store.key(_messages(), "m", {}) == store.key(_messages(), "m", {})
+
+
+# --------------------------------------------------------------------------- #
+# get / put — round-trip in an injected tmp store dir
+# --------------------------------------------------------------------------- #
+def test_get_miss_returns_none(store: AiCache) -> None:
+    key = store.key(_messages(), "m", {"t": 0})
+    assert store.get(key) is None
+
+
+def test_put_then_get_round_trip(store: AiCache) -> None:
+    key = store.key(_messages(), "m", {"t": 0})
+    result: dict[str, Any] = {"content": "clip 3", "scores": [0.9, 0.1]}
+    store.put(key, result)
+    assert store.get(key) == result
+
+
+def test_put_round_trips_through_disk(tmp_path: Path) -> None:
+    # A FRESH AiCache over the SAME dir must read what a prior instance wrote
+    # (proves persistence, not in-memory caching).
+    store_dir = tmp_path / "ai-cache"
+    writer = AiCache(store_dir=store_dir)
+    key = writer.key(_messages(), "m", {"t": 0})
+    writer.put(key, {"content": "persisted"})
+
+    reader = AiCache(store_dir=store_dir)
+    assert reader.get(key) == {"content": "persisted"}
+
+
+def test_put_creates_store_dir_lazily(tmp_path: Path) -> None:
+    store_dir = tmp_path / "does-not-exist-yet"
+    assert not store_dir.exists()
+    store = AiCache(store_dir=store_dir)
+    key = store.key(_messages(), "m", {"t": 0})
+    store.put(key, {"ok": True})
+    assert store_dir.is_dir()
+
+
+def test_put_overwrites_existing_entry(store: AiCache) -> None:
+    key = store.key(_messages(), "m", {"t": 0})
+    store.put(key, {"v": 1})
+    store.put(key, {"v": 2})
+    assert store.get(key) == {"v": 2}
+
+
+def test_distinct_requests_do_not_collide(store: AiCache) -> None:
+    k1 = store.key(_messages(), "m1", {"t": 0})
+    k2 = store.key(_messages(), "m2", {"t": 0})
+    store.put(k1, {"which": "one"})
+    store.put(k2, {"which": "two"})
+    assert store.get(k1) == {"which": "one"}
+    assert store.get(k2) == {"which": "two"}
+
+
+def test_get_returns_none_on_corrupt_entry(store: AiCache, tmp_path: Path) -> None:
+    # A truncated / non-JSON file on disk must be treated as a miss, never crash
+    # the AI hot path.
+    key = store.key(_messages(), "m", {"t": 0})
+    store.put(key, {"ok": True})
+    # Corrupt the backing file in place.
+    entry_path = store.path_for(key)
+    entry_path.write_text("{not valid json", encoding="utf-8")
+    assert store.get(key) is None
+
+
+def test_stored_file_is_json_on_disk(store: AiCache) -> None:
+    key = store.key(_messages(), "m", {"t": 0})
+    store.put(key, {"content": "hello"})
+    raw = store.path_for(key).read_text(encoding="utf-8")
+    assert json.loads(raw) == {"content": "hello"}
+
+
+def test_default_store_dir_constant_exposed() -> None:
+    # The module advertises a default sub-dir name for the data dir wiring WU.
+    assert isinstance(cache_mod.DEFAULT_CACHE_DIRNAME, str)
+    assert cache_mod.DEFAULT_CACHE_DIRNAME

--- a/sidecar/tests/test_ai_job.py
+++ b/sidecar/tests/test_ai_job.py
@@ -235,9 +235,7 @@ def test_plan_within_free_limits_false_over_cap(tmp_path: Any) -> None:
         model="m",
         request=FakeRequest(target_size=10, text_bytes=1, frame_bytes=0),
     )
-    env = plan_ai_job(
-        inputs, pool=_cloud_pool(), catalog=FakeCatalog({"Groq": 5}), cache=AiCache(store_dir=tmp_path)
-    )
+    env = plan_ai_job(inputs, pool=_cloud_pool(), catalog=FakeCatalog({"Groq": 5}), cache=AiCache(store_dir=tmp_path))
     assert env.costEst.withinFreeLimits is False
 
 

--- a/sidecar/tests/test_ai_job.py
+++ b/sidecar/tests/test_ai_job.py
@@ -1,0 +1,547 @@
+"""Unit tests for the AI-Job envelope (WU-envelope).
+
+``plan_ai_job`` is PURE → its route / costEst / cacheKey assembly is tested with
+fixtures and the REAL :class:`AiCache` (tmp dir) + REAL :mod:`budget` with tiny
+faked pool/catalog. ``run_ai_job`` is driven through a fake :class:`JobRegistry`
+(the REAL one from ``jobs.py``, with capturing sinks) + a fake provider factory +
+the real cache; the tests pin:
+
+  * ``ai.planJob`` (the ``planned()`` pre-flight) performs ZERO provider calls
+    (the provider factory is never invoked);
+  * every AI job emits progress + a terminal ``job.done`` (result or error);
+  * a cache HIT skips the provider entirely (factory untouched, transport spy
+    untouched);
+  * cancel mid-job returns the cancelled status with no provider call;
+  * a single ``job.done`` error payload on provider exhaustion;
+  * a ``degraded`` notice is emitted when the run falls through to local.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from media_studio.jobs import JobRegistry
+from media_studio.models.ai_cache import AiCache, Message
+from media_studio.models.ai_job import (
+    AiInputs,
+    AiJob,
+    AiRoute,
+    CatalogFreeCapAdapter,
+    plan_ai_job,
+    run_ai_job,
+)
+from media_studio.models.provider import ProviderError
+
+
+# --------------------------------------------------------------------------- #
+# fakes — budget pool / catalog (duck-typed, mirror the budget Protocols)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class FakeEntry:
+    provider: str
+    local: bool
+
+
+@dataclass(frozen=True)
+class FakePool:
+    entries: tuple[FakeEntry, ...]
+
+
+class FakeCatalog:
+    """Catalog stub: every provider is uncapped unless ``caps`` pins a cap."""
+
+    def __init__(self, caps: dict[str, int] | None = None) -> None:
+        self._caps = caps or {}
+
+    def free_cap(self, provider: str) -> int | None:
+        return self._caps.get(provider)
+
+
+@dataclass(frozen=True)
+class FakeRequest:
+    target_size: int | None
+    text_bytes: int
+    frame_bytes: int
+
+
+def _inputs(*, content: str = "hello", model: str = "m", **params: Any) -> AiInputs:
+    return AiInputs(
+        messages=({"role": "user", "content": content},),
+        model=model,
+        params=params,
+    )
+
+
+def _cloud_pool() -> FakePool:
+    return FakePool((FakeEntry("Groq", False), FakeEntry("local", True)))
+
+
+def _local_only_pool() -> FakePool:
+    return FakePool((FakeEntry("local", True),))
+
+
+# --------------------------------------------------------------------------- #
+# fake providers
+# --------------------------------------------------------------------------- #
+class SpyProvider:
+    """A provider whose ``chat`` records calls and returns a canned reply."""
+
+    def __init__(self, reply: str = "answer") -> None:
+        self.reply = reply
+        self.calls: list[Sequence[Message]] = []
+
+    def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+        self.calls.append(list(messages))
+        return self.reply
+
+
+class RaisingProvider:
+    """A provider whose ``chat`` always raises :class:`ProviderError` (exhaustion)."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+        self.calls += 1
+        raise ProviderError("provider pool exhausted (text): all keys 429")
+
+
+class DegradingProvider:
+    """A provider exposing ``on_rotation``; fires a 'local' failover then replies."""
+
+    def __init__(self, reply: str = "from-local") -> None:
+        self.reply = reply
+        self._cbs: list[Any] = []
+
+    def on_rotation(self, cb: Any) -> None:
+        self._cbs.append(cb)
+
+    def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+        for cb in self._cbs:
+            cb(_RotEvt("local"))
+        return self.reply
+
+
+@dataclass(frozen=True)
+class _RotEvt:
+    provider: str
+
+
+# --------------------------------------------------------------------------- #
+# job harness — the REAL JobRegistry with capturing sinks
+# --------------------------------------------------------------------------- #
+class JobHarness:
+    """Wraps a real :class:`JobRegistry`, capturing progress + done emissions."""
+
+    def __init__(self) -> None:
+        self.progress: list[tuple[str, int, str]] = []
+        self.done: list[tuple[str, Any]] = []
+        self.registry = JobRegistry(self._on_progress, self._on_done)
+
+    def _on_progress(self, job_id: str, pct: int, message: str) -> None:
+        self.progress.append((job_id, pct, message))
+
+    def _on_done(self, job_id: str, result: Any) -> None:
+        self.done.append((job_id, result))
+
+    def messages(self) -> list[str]:
+        return [m for _, _, m in self.progress]
+
+
+# --------------------------------------------------------------------------- #
+# plan_ai_job — PURE assembly
+# --------------------------------------------------------------------------- #
+def test_plan_builds_route_cost_and_cache_key(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = plan_ai_job(
+        _inputs(content="abc"),
+        pool=_cloud_pool(),
+        catalog=FakeCatalog(),
+        cache=cache,
+    )
+    assert isinstance(env, AiJob)
+    assert isinstance(env.route, AiRoute)
+    assert env.route.providers == ("Groq",)
+    assert env.route.degradeChain == ("Groq", "local")
+    assert env.route.cacheHit is False
+    assert env.route.willEgress is True
+    # cacheKey is the AiCache content hash for the same request.
+    assert env.cacheKey == cache.key(list(env.inputs.messages), "m", {})
+    assert env.costEst.requests == 1
+    assert env.costEst.egressBytes == len(b"abc")
+
+
+def test_plan_uses_explicit_budget_request_when_pinned(tmp_path: Any) -> None:
+    inputs = AiInputs(
+        messages=({"role": "user", "content": "x"},),
+        model="m",
+        request=FakeRequest(target_size=4, text_bytes=100, frame_bytes=0),
+    )
+    env = plan_ai_job(inputs, pool=_cloud_pool(), catalog=FakeCatalog(), cache=AiCache(store_dir=tmp_path))
+    assert env.costEst.requests == 4
+    assert env.costEst.egressBytes == 400
+
+
+def test_plan_cache_hit_flags_no_egress(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    inputs = _inputs(content="seeded")
+    key = cache.key(list(inputs.messages), "m", {})
+    cache.put(key, "already-cached")
+    env = plan_ai_job(inputs, pool=_cloud_pool(), catalog=FakeCatalog(), cache=cache)
+    assert env.route.cacheHit is True
+    assert env.route.willEgress is False
+    assert "Cached" in env.preview
+
+
+def test_plan_local_only_pool_never_egresses(tmp_path: Any) -> None:
+    env = plan_ai_job(
+        _inputs(),
+        pool=_local_only_pool(),
+        catalog=FakeCatalog(),
+        cache=AiCache(store_dir=tmp_path),
+    )
+    assert env.route.providers == ()
+    assert env.route.willEgress is False
+    assert "Local only" in env.preview
+
+
+def test_plan_preview_includes_provider_and_kb(tmp_path: Any) -> None:
+    env = plan_ai_job(
+        _inputs(content="payload"),
+        pool=_cloud_pool(),
+        catalog=FakeCatalog(),
+        cache=AiCache(store_dir=tmp_path),
+    )
+    assert "Groq" in env.preview
+    assert "KB" in env.preview
+
+
+def test_planned_json_has_zero_provider_calls_shape(tmp_path: Any) -> None:
+    """ai.planJob's planned() returns route+costEst+cacheHit+willEgress+budget."""
+    env = plan_ai_job(_inputs(), pool=_cloud_pool(), catalog=FakeCatalog(), cache=AiCache(store_dir=tmp_path))
+    planned = env.planned()
+    assert set(planned) >= {"route", "costEst", "cacheHit", "willEgress", "budget"}
+    assert planned["route"]["degradeChain"] == ["Groq", "local"]
+    assert planned["costEst"]["requests"] == 1
+    assert planned["budget"] == planned["costEst"]
+    assert planned["cacheHit"] is False
+
+
+def test_plan_within_free_limits_false_over_cap(tmp_path: Any) -> None:
+    inputs = AiInputs(
+        messages=({"role": "user", "content": "x"},),
+        model="m",
+        request=FakeRequest(target_size=10, text_bytes=1, frame_bytes=0),
+    )
+    env = plan_ai_job(
+        inputs, pool=_cloud_pool(), catalog=FakeCatalog({"Groq": 5}), cache=AiCache(store_dir=tmp_path)
+    )
+    assert env.costEst.withinFreeLimits is False
+
+
+# --------------------------------------------------------------------------- #
+# run_ai_job — execution on a real JobRegistry
+# --------------------------------------------------------------------------- #
+def _env(cache: AiCache, *, content: str = "q", pool: Any = None) -> AiJob:
+    return plan_ai_job(
+        _inputs(content=content),
+        pool=pool or _cloud_pool(),
+        catalog=FakeCatalog(),
+        cache=cache,
+    )
+
+
+def test_run_emits_progress_and_terminal_done(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    harness = JobHarness()
+    spy = SpyProvider("answer")
+    env = _env(cache)
+    job = run_ai_job(env, jobs=harness.registry, provider_factory=lambda: spy, cache=cache)
+    harness.registry.join(timeout=5)
+    assert job.finished
+    # progress emitted, then a terminal job.done with the result.
+    assert harness.progress
+    assert harness.done[-1][1]["result"] == "answer"
+    assert harness.done[-1][1]["cacheHit"] is False
+    assert spy.calls  # the provider WAS called on a miss
+
+
+def test_run_cache_hit_skips_provider(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    inputs = _inputs(content="cached-q")
+    key = cache.key(list(inputs.messages), "m", {})
+    cache.put(key, "stored-result")
+    env = plan_ai_job(inputs, pool=_cloud_pool(), catalog=FakeCatalog(), cache=cache)
+    harness = JobHarness()
+    spy = SpyProvider("SHOULD-NOT-RUN")
+
+    def _factory() -> SpyProvider:  # pragma: no cover -- must never be invoked on a hit
+        return spy
+
+    run_ai_job(env, jobs=harness.registry, provider_factory=_factory, cache=cache)
+    harness.registry.join(timeout=5)
+    assert harness.done[-1][1] == {"result": "stored-result", "cacheHit": True, "degraded": False}
+    assert spy.calls == []  # provider transport spy UNTOUCHED on a cache hit
+
+
+def test_run_stores_result_in_cache_on_miss(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache, content="fresh")
+    harness = JobHarness()
+    run_ai_job(env, jobs=harness.registry, provider_factory=lambda: SpyProvider("computed"), cache=cache)
+    harness.registry.join(timeout=5)
+    assert cache.get(env.cacheKey) == "computed"
+
+
+def test_run_exhaustion_emits_single_done_error(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    raiser = RaisingProvider()
+    run_ai_job(env, jobs=harness.registry, provider_factory=lambda: raiser, cache=cache)
+    harness.registry.join(timeout=5)
+    # exactly one terminal job.done, carrying the A3 error payload.
+    assert len(harness.done) == 1
+    err = harness.done[-1][1]["error"]
+    assert err["type"] == "ProviderError"
+    assert "exhausted" in err["message"]
+    assert cache.get(env.cacheKey) is None  # nothing cached on failure
+
+
+def test_run_degraded_emits_notice(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    run_ai_job(env, jobs=harness.registry, provider_factory=lambda: DegradingProvider("local-ans"), cache=cache)
+    harness.registry.join(timeout=5)
+    assert any("degraded" in m for m in harness.messages())
+    assert harness.done[-1][1]["degraded"] is True
+    assert harness.done[-1][1]["result"] == "local-ans"
+
+
+def test_run_cancel_observed_returns_cancelled(tmp_path: Any) -> None:
+    """A job whose cancel flag is set before the body executes makes no call."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+
+    # A single-thread registry that finishes synchronously lets us pre-set cancel.
+    captured: dict[str, Any] = {}
+
+    class InlineRegistry:
+        """Runs the handler inline with a context whose cancel flag is pre-set."""
+
+        def start(self, handler: Any, **_kw: Any) -> Any:
+            captured["result"] = handler(_CancelledCtx())
+            return _DummyJob()
+
+    spy = SpyProvider()
+    run_ai_job(env, jobs=InlineRegistry(), provider_factory=lambda: spy, cache=cache)
+    assert captured["result"] == {"cancelled": True}
+    assert spy.calls == []  # no provider call after a pre-cancel
+
+
+def test_run_cancel_after_provider_build_returns_cancelled(tmp_path: Any) -> None:
+    """Cancel observed AFTER the factory but before chat: no chat, cancelled."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    captured: dict[str, Any] = {}
+    spy = SpyProvider()
+
+    class MidCancelRegistry:
+        def start(self, handler: Any, **_kw: Any) -> Any:
+            captured["result"] = handler(_CancelAfterFirstCheckCtx())
+            return _DummyJob()
+
+    run_ai_job(env, jobs=MidCancelRegistry(), provider_factory=lambda: spy, cache=cache)
+    assert captured["result"] == {"cancelled": True}
+    assert spy.calls == []
+
+
+class _CancelledCtx:
+    """A JobContext stand-in that is cancelled from the very first check."""
+
+    cancelled = True
+
+    def progress(self, _pct: float, _msg: str = "") -> None:  # pragma: no cover -- never reached pre-cancel
+        raise AssertionError("progress must not be called on a pre-cancelled job")
+
+
+class _CancelAfterFirstCheckCtx:
+    """Cancelled = False on the first check, True after the provider is built."""
+
+    def __init__(self) -> None:
+        self._checks = 0
+
+    @property
+    def cancelled(self) -> bool:
+        self._checks += 1
+        return self._checks > 1  # first check (entry) False; second (post-build) True
+
+    def progress(self, _pct: float, _msg: str = "") -> None:
+        return None
+
+
+@dataclass
+class _DummyJob:
+    finished: bool = True
+
+
+def test_run_passes_metadata_to_registry(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    captured: dict[str, Any] = {}
+
+    class CapturingRegistry:
+        def start(self, handler: Any, **kw: Any) -> Any:
+            captured.update(kw)
+            handler(_NoopCtx())
+            return _DummyJob()
+
+    run_ai_job(
+        env,
+        jobs=CapturingRegistry(),
+        provider_factory=lambda: SpyProvider(),
+        cache=cache,
+        feature="phase8",
+        label="Select",
+        videoId="vid-1",
+    )
+    assert captured == {"feature": "phase8", "label": "Select", "videoId": "vid-1"}
+
+
+class _NoopCtx:
+    cancelled = False
+
+    def progress(self, _pct: float, _msg: str = "") -> None:
+        return None
+
+
+def test_subscribe_degrade_noop_on_plain_provider(tmp_path: Any) -> None:
+    """A provider without on_rotation never degrades (graceful no-op)."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    run_ai_job(env, jobs=harness.registry, provider_factory=lambda: SpyProvider("plain"), cache=cache)
+    harness.registry.join(timeout=5)
+    assert harness.done[-1][1]["degraded"] is False
+
+
+def test_degrade_listener_ignores_non_local_rotation(tmp_path: Any) -> None:
+    """A failover to another CLOUD provider is not a degrade."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+
+    class CloudFailoverProvider:
+        def __init__(self) -> None:
+            self._cbs: list[Any] = []
+
+        def on_rotation(self, cb: Any) -> None:
+            self._cbs.append(cb)
+
+        def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+            for cb in self._cbs:
+                cb(_RotEvt("Cerebras"))  # cloud -> cloud, NOT local
+            return "cloud2"
+
+    run_ai_job(env, jobs=harness.registry, provider_factory=CloudFailoverProvider, cache=cache)
+    harness.registry.join(timeout=5)
+    assert harness.done[-1][1]["degraded"] is False
+    assert harness.done[-1][1]["result"] == "cloud2"
+
+
+def test_run_returns_the_job(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    job = run_ai_job(env, jobs=harness.registry, provider_factory=lambda: SpyProvider(), cache=cache)
+    harness.registry.join(timeout=5)
+    assert hasattr(job, "id")
+
+
+# --------------------------------------------------------------------------- #
+# run_ai_job — custom work body (the phase8_select / subtitles_translate path)
+# --------------------------------------------------------------------------- #
+def test_run_custom_work_returns_handler_shape(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    spy = SpyProvider("ranked")
+    seen: dict[str, Any] = {}
+
+    def work(ctx: Any, envelope: AiJob, provider: Any) -> dict[str, Any]:
+        seen["provider"] = provider
+        seen["cacheKey"] = envelope.cacheKey
+        ctx.progress(50.0, "selecting")
+        return {"candidates": [provider.chat(list(envelope.inputs.messages))]}
+
+    run_ai_job(env, jobs=harness.registry, provider_factory=lambda: spy, cache=cache, work=work)
+    harness.registry.join(timeout=5)
+    # the handler's OWN result shape flows straight to job.done (no {result} wrap).
+    assert harness.done[-1][1] == {"candidates": ["ranked"]}
+    assert seen["provider"] is spy
+    assert seen["cacheKey"] == env.cacheKey
+
+
+def test_run_custom_work_emits_degraded_notice(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+
+    def work(ctx: Any, envelope: AiJob, provider: Any) -> dict[str, Any]:
+        return {"track": provider.chat(list(envelope.inputs.messages))}
+
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: DegradingProvider("local-track"),
+        cache=cache,
+        work=work,
+    )
+    harness.registry.join(timeout=5)
+    assert any("degraded" in m for m in harness.messages())
+    assert harness.done[-1][1] == {"track": "local-track"}
+
+
+def test_run_custom_work_honors_precancel(tmp_path: Any) -> None:
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    spy = SpyProvider()
+    captured: dict[str, Any] = {}
+
+    def work(_ctx: Any, _env: AiJob, _prov: Any) -> dict[str, Any]:  # pragma: no cover -- never reached pre-cancel
+        raise AssertionError("work must not run on a pre-cancelled job")
+
+    class InlineRegistry:
+        def start(self, handler: Any, **_kw: Any) -> Any:
+            captured["result"] = handler(_CancelledCtx())
+            return _DummyJob()
+
+    run_ai_job(env, jobs=InlineRegistry(), provider_factory=lambda: spy, cache=cache, work=work)
+    assert captured["result"] == {"cancelled": True}
+    assert spy.calls == []
+
+
+# --------------------------------------------------------------------------- #
+# CatalogFreeCapAdapter (WAVE-1 carryforward #1)
+# --------------------------------------------------------------------------- #
+def test_catalog_adapter_reports_uncapped() -> None:
+    adapter = CatalogFreeCapAdapter()
+    assert adapter.free_cap("Groq") is None
+    assert adapter.free_cap("anything") is None
+
+
+def test_catalog_adapter_holds_module_reference() -> None:
+    from media_studio.models import catalog as real_catalog
+
+    adapter = CatalogFreeCapAdapter(real_catalog)
+    # adapter integrates with the real budget estimate (uncapped -> within limits).
+    env = plan_ai_job(
+        _inputs(content="x"),
+        pool=_cloud_pool(),
+        catalog=adapter,
+        cache=AiCache(store_dir=__import__("tempfile").mkdtemp()),
+    )
+    assert env.costEst.withinFreeLimits is True

--- a/sidecar/tests/test_budget.py
+++ b/sidecar/tests/test_budget.py
@@ -1,0 +1,313 @@
+"""Unit tests for media_studio.models.budget (WU-budget, pure half).
+
+This module is PURE: ``estimate`` and ``degrade_chain`` take their collaborators
+(``request``, ``pool``, ``catalog``) as duck-typed parameters and never touch the
+network, a clock, or any heavy dependency. Every collaborator here is a tiny fake
+so the assertions are real behavioural checks, not mock-echoes.
+
+Acceptance pinned (PLAN §WU-budget):
+  * ``estimate`` pure for text-only / frame / mixed requests.
+  * ``degrade_chain`` ordering (cloud providers in pool order, ``"local"`` last).
+  * ``withinFreeLimits`` false when the estimate exceeds a provider's free cap.
+  * ``DEFAULT_TARGET_JOB_SIZE`` yields a falsifiable request count when the
+    request pins no size.
+  * a request is never double-counted.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from media_studio.models import budget as budget_mod
+from media_studio.models.budget import (
+    DEFAULT_TARGET_JOB_SIZE,
+    Budget,
+    EgressKinds,
+    degrade_chain,
+    estimate,
+)
+
+
+# --------------------------------------------------------------------------- #
+# duck-typed fakes (the collaborators estimate/degrade_chain accept)
+# --------------------------------------------------------------------------- #
+class FakeRequest:
+    """A planned AI request: how many target units, and the per-unit egress.
+
+    ``target_size`` is the number of discrete outputs (e.g. shorts) the job will
+    produce; ``None`` means "not pinned" → estimate falls back to the default.
+    ``text_bytes`` / ``frame_bytes`` are the bytes egressed PER request.
+    """
+
+    def __init__(
+        self,
+        *,
+        target_size: int | None,
+        text_bytes: int = 0,
+        frame_bytes: int = 0,
+    ) -> None:
+        self.target_size = target_size
+        self.text_bytes = text_bytes
+        self.frame_bytes = frame_bytes
+
+
+class FakeEntry:
+    """A pool entry: a provider id, whether it is the local backstop, and unit."""
+
+    def __init__(self, provider: str, *, local: bool = False, unit: str = "req") -> None:
+        self.provider = provider
+        self.local = local
+        self.unit = unit
+
+
+class FakePool:
+    """An ordered pool of entries (cloud first, local backstop last)."""
+
+    def __init__(self, entries: list[FakeEntry]) -> None:
+        self.entries = entries
+
+
+class FakeCatalog:
+    """A catalog exposing a per-provider free request cap (``None`` = uncapped)."""
+
+    def __init__(self, caps: dict[str, int | None]) -> None:
+        self._caps = caps
+
+    def free_cap(self, provider: str) -> int | None:
+        return self._caps.get(provider)
+
+
+def _cloud_pool() -> FakePool:
+    return FakePool(
+        [
+            FakeEntry("groq"),
+            FakeEntry("cerebras"),
+            FakeEntry("local-backstop", local=True),
+        ]
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Budget dataclass shape
+# --------------------------------------------------------------------------- #
+def test_budget_is_frozen_and_carries_all_fields() -> None:
+    b = Budget(
+        requests=3,
+        providers=("groq",),
+        egressBytes=12,
+        egressKinds=EgressKinds(text=12, frames=0),
+        withinFreeLimits=True,
+    )
+    assert b.requests == 3
+    assert b.providers == ("groq",)
+    assert b.egressBytes == 12
+    assert b.egressKinds.text == 12
+    assert b.egressKinds.frames == 0
+    assert b.withinFreeLimits is True
+    with pytest.raises(FrozenInstanceError):
+        b.requests = 9  # type: ignore[misc]
+
+
+def test_egresskinds_is_frozen() -> None:
+    k = EgressKinds(text=1, frames=2)
+    with pytest.raises(FrozenInstanceError):
+        k.text = 5  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# estimate — text-only / frame / mixed (purity + egress split)
+# --------------------------------------------------------------------------- #
+def test_estimate_text_only_splits_egress_to_text() -> None:
+    req = FakeRequest(target_size=2, text_bytes=100)
+    cat = FakeCatalog({"groq": 1000})
+    b = estimate(req, _cloud_pool(), cat)
+    assert b.requests == 2
+    assert b.egressKinds.text == 200  # 2 requests × 100 text bytes
+    assert b.egressKinds.frames == 0
+    assert b.egressBytes == 200
+
+
+def test_estimate_frame_only_splits_egress_to_frames() -> None:
+    req = FakeRequest(target_size=3, frame_bytes=500)
+    cat = FakeCatalog({"groq": 1000})
+    b = estimate(req, _cloud_pool(), cat)
+    assert b.requests == 3
+    assert b.egressKinds.text == 0
+    assert b.egressKinds.frames == 1500  # 3 × 500
+    assert b.egressBytes == 1500
+
+
+def test_estimate_mixed_sums_both_kinds() -> None:
+    req = FakeRequest(target_size=2, text_bytes=100, frame_bytes=500)
+    cat = FakeCatalog({"groq": 1000})
+    b = estimate(req, _cloud_pool(), cat)
+    assert b.requests == 2
+    assert b.egressKinds.text == 200
+    assert b.egressKinds.frames == 1000
+    assert b.egressBytes == 1200
+
+
+def test_estimate_is_pure_no_collaborator_mutation() -> None:
+    req = FakeRequest(target_size=2, text_bytes=10)
+    pool = _cloud_pool()
+    cat = FakeCatalog({"groq": 1000})
+    before = [e.provider for e in pool.entries]
+    estimate(req, pool, cat)
+    assert [e.provider for e in pool.entries] == before  # pool untouched
+
+
+# --------------------------------------------------------------------------- #
+# providers list — cloud entries only, deduped, never the local backstop
+# --------------------------------------------------------------------------- #
+def test_estimate_providers_excludes_local_backstop() -> None:
+    req = FakeRequest(target_size=1, text_bytes=1)
+    b = estimate(req, _cloud_pool(), FakeCatalog({}))
+    assert "local-backstop" not in b.providers
+    assert b.providers == ("groq", "cerebras")
+
+
+def test_estimate_providers_deduped() -> None:
+    pool = FakePool(
+        [FakeEntry("groq"), FakeEntry("groq"), FakeEntry("local", local=True)]
+    )
+    req = FakeRequest(target_size=1, text_bytes=1)
+    b = estimate(req, pool, FakeCatalog({}))
+    assert b.providers == ("groq",)  # second key = failover, not extra provider
+
+
+# --------------------------------------------------------------------------- #
+# default target job size (P1 #6) — falsifiable count
+# --------------------------------------------------------------------------- #
+def test_estimate_uses_default_target_job_size_when_unpinned() -> None:
+    req = FakeRequest(target_size=None, text_bytes=10)
+    b = estimate(req, _cloud_pool(), FakeCatalog({"groq": 1000}))
+    assert b.requests == DEFAULT_TARGET_JOB_SIZE
+    assert b.egressKinds.text == DEFAULT_TARGET_JOB_SIZE * 10
+
+
+def test_default_target_job_size_is_a_positive_constant() -> None:
+    assert isinstance(DEFAULT_TARGET_JOB_SIZE, int)
+    assert DEFAULT_TARGET_JOB_SIZE > 0
+
+
+def test_estimate_zero_or_negative_target_size_falls_back_to_default() -> None:
+    # A non-positive pinned size is meaningless → use the documented default.
+    req = FakeRequest(target_size=0, text_bytes=10)
+    b = estimate(req, _cloud_pool(), FakeCatalog({"groq": 1000}))
+    assert b.requests == DEFAULT_TARGET_JOB_SIZE
+
+
+# --------------------------------------------------------------------------- #
+# withinFreeLimits — false when estimate exceeds the catalog's per-provider cap
+# --------------------------------------------------------------------------- #
+def test_within_free_limits_true_when_under_cap() -> None:
+    req = FakeRequest(target_size=5, text_bytes=1)
+    cat = FakeCatalog({"groq": 1000, "cerebras": 1000})
+    b = estimate(req, _cloud_pool(), cat)
+    assert b.withinFreeLimits is True
+
+
+def test_within_free_limits_false_when_exceeds_a_providers_cap() -> None:
+    req = FakeRequest(target_size=50, text_bytes=1)
+    # groq capped at 30 < 50 requests → over the free cap for that provider.
+    cat = FakeCatalog({"groq": 30, "cerebras": 1000})
+    b = estimate(req, _cloud_pool(), cat)
+    assert b.withinFreeLimits is False
+
+
+def test_within_free_limits_true_when_provider_uncapped() -> None:
+    req = FakeRequest(target_size=10_000, text_bytes=1)
+    cat = FakeCatalog({"groq": None, "cerebras": None})  # None = uncapped
+    b = estimate(req, _cloud_pool(), cat)
+    assert b.withinFreeLimits is True
+
+
+def test_within_free_limits_true_when_no_cloud_providers() -> None:
+    # local-only pool: nothing egresses, no cap can be exceeded.
+    pool = FakePool([FakeEntry("local", local=True)])
+    req = FakeRequest(target_size=10_000, text_bytes=1)
+    b = estimate(req, pool, FakeCatalog({}))
+    assert b.providers == ()
+    assert b.withinFreeLimits is True
+
+
+# --------------------------------------------------------------------------- #
+# degrade_chain — cloud in pool order, "local" last exactly once
+# --------------------------------------------------------------------------- #
+def test_degrade_chain_orders_cloud_then_local() -> None:
+    chain = degrade_chain(_cloud_pool())
+    assert chain == ["groq", "cerebras", "local"]
+
+
+def test_degrade_chain_dedupes_same_provider_keys() -> None:
+    pool = FakePool(
+        [FakeEntry("groq"), FakeEntry("groq"), FakeEntry("cerebras"), FakeEntry("x", local=True)]
+    )
+    assert degrade_chain(pool) == ["groq", "cerebras", "local"]
+
+
+def test_degrade_chain_always_ends_in_local_even_with_no_backstop() -> None:
+    pool = FakePool([FakeEntry("groq")])
+    chain = degrade_chain(pool)
+    assert chain[-1] == "local"
+    assert chain == ["groq", "local"]
+
+
+def test_degrade_chain_local_only_pool() -> None:
+    pool = FakePool([FakeEntry("local", local=True)])
+    assert degrade_chain(pool) == ["local"]
+
+
+def test_degrade_chain_does_not_mutate_pool() -> None:
+    pool = _cloud_pool()
+    before = [e.provider for e in pool.entries]
+    degrade_chain(pool)
+    assert [e.provider for e in pool.entries] == before
+
+
+# --------------------------------------------------------------------------- #
+# never double-count a request (gate-2/DESIGN R5)
+# --------------------------------------------------------------------------- #
+def test_request_count_independent_of_provider_count() -> None:
+    # Same target size; one pool has many cloud keys, one has few. The request
+    # COUNT must be identical (requests are not multiplied by providers/keys).
+    req = FakeRequest(target_size=4, text_bytes=1)
+    many = FakePool(
+        [FakeEntry("a"), FakeEntry("b"), FakeEntry("c"), FakeEntry("l", local=True)]
+    )
+    few = FakePool([FakeEntry("a"), FakeEntry("l", local=True)])
+    cat = FakeCatalog({"a": 1000, "b": 1000, "c": 1000})
+    assert estimate(req, many, cat).requests == 4
+    assert estimate(req, few, cat).requests == 4
+
+
+# --------------------------------------------------------------------------- #
+# module hygiene — pure (no time / network imports)
+# --------------------------------------------------------------------------- #
+def test_module_imports_no_clock_or_network() -> None:
+    for forbidden in ("time", "asyncio", "urllib", "httpx", "socket"):
+        assert not hasattr(budget_mod, forbidden), f"{forbidden} leaked into budget module"
+
+
+def test_estimate_accepts_any_duck_typed_collaborators() -> None:
+    # A minimal collaborator exposing only what the contract names still works.
+    class MiniReq:
+        target_size = 1
+        text_bytes = 7
+        frame_bytes = 0
+
+    class MiniEntry:
+        provider = "p"
+        local = False
+
+    class MiniPool:
+        entries = [MiniEntry()]
+
+    class MiniCatalog:
+        def free_cap(self, provider: str) -> int | None:
+            return 100
+
+    b = estimate(MiniReq(), MiniPool(), MiniCatalog())  # type: ignore[arg-type]
+    assert b.requests == 1
+    assert b.egressKinds.text == 7

--- a/sidecar/tests/test_budget.py
+++ b/sidecar/tests/test_budget.py
@@ -168,9 +168,7 @@ def test_estimate_providers_excludes_local_backstop() -> None:
 
 
 def test_estimate_providers_deduped() -> None:
-    pool = FakePool(
-        [FakeEntry("groq"), FakeEntry("groq"), FakeEntry("local", local=True)]
-    )
+    pool = FakePool([FakeEntry("groq"), FakeEntry("groq"), FakeEntry("local", local=True)])
     req = FakeRequest(target_size=1, text_bytes=1)
     b = estimate(req, pool, FakeCatalog({}))
     assert b.providers == ("groq",)  # second key = failover, not extra provider
@@ -241,9 +239,7 @@ def test_degrade_chain_orders_cloud_then_local() -> None:
 
 
 def test_degrade_chain_dedupes_same_provider_keys() -> None:
-    pool = FakePool(
-        [FakeEntry("groq"), FakeEntry("groq"), FakeEntry("cerebras"), FakeEntry("x", local=True)]
-    )
+    pool = FakePool([FakeEntry("groq"), FakeEntry("groq"), FakeEntry("cerebras"), FakeEntry("x", local=True)])
     assert degrade_chain(pool) == ["groq", "cerebras", "local"]
 
 
@@ -273,9 +269,7 @@ def test_request_count_independent_of_provider_count() -> None:
     # Same target size; one pool has many cloud keys, one has few. The request
     # COUNT must be identical (requests are not multiplied by providers/keys).
     req = FakeRequest(target_size=4, text_bytes=1)
-    many = FakePool(
-        [FakeEntry("a"), FakeEntry("b"), FakeEntry("c"), FakeEntry("l", local=True)]
-    )
+    many = FakePool([FakeEntry("a"), FakeEntry("b"), FakeEntry("c"), FakeEntry("l", local=True)])
     few = FakePool([FakeEntry("a"), FakeEntry("l", local=True)])
     cat = FakeCatalog({"a": 1000, "b": 1000, "c": 1000})
     assert estimate(req, many, cat).requests == 4

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -1,0 +1,295 @@
+"""Unit tests for media_studio.models.catalog (WU-catalog).
+
+Pure data + pure helpers — no network, no model, no fakes needed. Asserts the
+catalog was seeded VERBATIM from ``docs/providers/CATALOG-SEED.md`` (13 entries,
+>=3 distinct providers, every one of the 5 Reframe tasks ranked, dated guidance,
+privacy/train-on-input axis), and that the filter/order/top-pick helpers behave.
+"""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+from media_studio.models.catalog import (
+    CATALOG,
+    Capability,
+    CatalogEntry,
+    CostClass,
+    PrivacyTier,
+    Task,
+    TierGrade,
+    Unit,
+    filter_by_capability,
+    order_by,
+    top_pick_for_task,
+)
+
+# --------------------------------------------------------------------------- #
+# Shape / completeness invariants
+# --------------------------------------------------------------------------- #
+
+
+def test_catalog_is_a_tuple_of_entries() -> None:
+    assert isinstance(CATALOG, tuple)
+    assert all(isinstance(e, CatalogEntry) for e in CATALOG)
+    # 13 seeded models per CATALOG-SEED.md.
+    assert len(CATALOG) == 13
+
+
+def test_catalog_ids_are_unique() -> None:
+    ids = [e.id for e in CATALOG]
+    assert len(ids) == len(set(ids))
+
+
+def test_catalog_spans_at_least_three_distinct_providers() -> None:
+    # Acceptance (a): >=3 distinct providers.
+    providers = {e.provider for e in CATALOG}
+    assert len(providers) >= 3
+    # The seed's headline providers must all be present.
+    assert {"Groq", "Cerebras", "Google AI Studio"} <= providers
+
+
+def test_every_entry_ranks_all_five_tasks() -> None:
+    # Acceptance (a): ranks each model per the 5 tasks.
+    for entry in CATALOG:
+        assert set(entry.per_task_tier.keys()) == set(Task)
+        for grade in entry.per_task_tier.values():
+            assert isinstance(grade, TierGrade)
+
+
+def test_every_entry_has_a_privacy_tier_unit_and_asofdate() -> None:
+    # Acceptance (d): every label is dated guidance.
+    for entry in CATALOG:
+        assert isinstance(entry.privacy_tier, PrivacyTier)
+        assert isinstance(entry.unit, Unit)
+        assert isinstance(entry.cost_class, CostClass)
+        assert entry.as_of_date  # non-empty dated guidance
+        # capabilities is a non-empty tuple of Capability.
+        assert entry.capabilities
+        assert all(isinstance(c, Capability) for c in entry.capabilities)
+
+
+def test_entries_are_frozen_immutable() -> None:
+    entry = CATALOG[0]
+    with pytest.raises(FrozenInstanceError):
+        entry.id = "mutated"  # type: ignore[misc]
+
+
+def test_trains_on_input_is_bool_or_conditional() -> None:
+    for entry in CATALOG:
+        assert entry.trains_on_input in (True, False, "conditional")
+
+
+# --------------------------------------------------------------------------- #
+# Verbatim seed facts (privacy / train-on-input axis)
+# --------------------------------------------------------------------------- #
+
+
+def _by_id(entry_id: str) -> CatalogEntry:
+    return next(e for e in CATALOG if e.id == entry_id)
+
+
+def test_groq_gpt_oss_is_safe_no_train() -> None:
+    # Acceptance (c): Groq flagged SAFE no-train.
+    groq = _by_id("groq-gpt-oss-120b")
+    assert groq.provider == "Groq"
+    assert groq.privacy_tier is PrivacyTier.SAFE
+    assert groq.trains_on_input is False
+    assert groq.context_tokens == 128_000
+    assert groq.unit is Unit.TOKEN
+
+
+def test_gemini_free_trains_and_is_avoid() -> None:
+    # Acceptance (b): Gemini-free flagged trainsOnInput=True / privacyTier=AVOID.
+    flash = _by_id("gemini-2.5-flash")
+    assert flash.provider == "Google AI Studio"
+    assert flash.trains_on_input is True
+    assert flash.privacy_tier is PrivacyTier.AVOID
+    lite = _by_id("gemini-2.5-flash-lite")
+    assert lite.trains_on_input is True
+    assert lite.privacy_tier is PrivacyTier.AVOID
+
+
+def test_mistral_pixtral_is_conditional() -> None:
+    pixtral = _by_id("mistral-pixtral")
+    assert pixtral.trains_on_input == "conditional"
+    assert pixtral.privacy_tier is PrivacyTier.CONDITIONAL
+
+
+def test_openrouter_free_entries_are_conditional() -> None:
+    text = _by_id("openrouter-free-text")
+    vision = _by_id("openrouter-free-vision")
+    assert text.privacy_tier is PrivacyTier.CONDITIONAL
+    assert vision.privacy_tier is PrivacyTier.CONDITIONAL
+    assert text.trains_on_input == "conditional"
+    assert vision.trains_on_input == "conditional"
+
+
+def test_cerebras_is_unverified_train_policy() -> None:
+    qwen = _by_id("cerebras-qwen3-235b")
+    # Unverified -> conservatively marked conditional (not asserted SAFE).
+    assert qwen.trains_on_input == "conditional"
+    assert qwen.context_tokens == 128_000
+    assert qwen.unit is Unit.TOKEN
+
+
+def test_cloudflare_has_limiting_small_context() -> None:
+    cf = _by_id("cloudflare-workers-ai")
+    # Seed flags 2K-8K as limiting; we encode the upper bound 8K.
+    assert cf.context_tokens == 8_000
+    assert cf.privacy_tier is PrivacyTier.SAFE
+
+
+def test_vision_entries_declare_vision_capability() -> None:
+    for entry_id in (
+        "gemini-2.5-flash",
+        "gemini-2.5-flash-lite",
+        "github-gpt-4o-mini",
+        "mistral-pixtral",
+        "openrouter-free-vision",
+        "openai-api",
+    ):
+        entry = _by_id(entry_id)
+        assert Capability.VISION in entry.capabilities
+
+
+def test_text_only_entries_have_no_vision_capability() -> None:
+    for entry_id in (
+        "groq-gpt-oss-120b",
+        "groq-llama-3.3-70b",
+        "cerebras-qwen3-235b",
+        "cerebras-llama-3.3-70b",
+        "sambanova-llama-3.1-405b",
+        "cloudflare-workers-ai",
+        "openrouter-free-text",
+    ):
+        entry = _by_id(entry_id)
+        assert Capability.VISION not in entry.capabilities
+        assert Capability.TEXT in entry.capabilities
+
+
+# --------------------------------------------------------------------------- #
+# filter_by_capability
+# --------------------------------------------------------------------------- #
+
+
+def test_filter_by_capability_vision() -> None:
+    vision = filter_by_capability(Capability.VISION)
+    assert all(Capability.VISION in e.capabilities for e in vision)
+    # 6 vision entries per the seed.
+    assert len(vision) == 6
+
+
+def test_filter_by_capability_text_includes_all_text_models() -> None:
+    text = filter_by_capability(Capability.TEXT)
+    # Every entry can do text (vision models are multimodal).
+    assert len(text) == len(CATALOG)
+
+
+def test_filter_by_capability_accepts_custom_catalog() -> None:
+    subset = (CATALOG[0],)
+    assert filter_by_capability(Capability.TEXT, catalog=subset) == list(subset)
+
+
+# --------------------------------------------------------------------------- #
+# order_by
+# --------------------------------------------------------------------------- #
+
+
+def test_order_by_quality_uses_best_task_grade() -> None:
+    ordered = order_by("quality")
+    assert len(ordered) == len(CATALOG)
+    # Groq GPT-OSS-120B (two S grades) ranks at/near the top.
+    assert ordered[0].id in {"groq-gpt-oss-120b", "gemini-2.5-flash"}
+
+
+def test_order_by_context_descending() -> None:
+    ordered = order_by("context")
+    ctx = [e.context_tokens for e in ordered]
+    assert ctx == sorted(ctx, reverse=True)
+    # Gemini's ~1M context wins.
+    assert ordered[0].context_tokens == 1_000_000
+
+
+def test_order_by_limit_descending() -> None:
+    ordered = order_by("limit")
+    scores = [e.free_limit_score for e in ordered]
+    assert scores == sorted(scores, reverse=True)
+
+
+def test_order_by_accepts_custom_catalog() -> None:
+    subset = (CATALOG[1], CATALOG[0])
+    ordered = order_by("context", catalog=subset)
+    assert {e.id for e in ordered} == {CATALOG[0].id, CATALOG[1].id}
+
+
+def test_order_by_rejects_unknown_key() -> None:
+    with pytest.raises(ValueError, match="unknown order key"):
+        order_by("nonsense")  # type: ignore[arg-type]
+
+
+def test_order_by_is_stable_and_nonmutating() -> None:
+    before = list(CATALOG)
+    order_by("quality")
+    assert list(CATALOG) == before  # source untouched
+
+
+# --------------------------------------------------------------------------- #
+# top_pick_for_task
+# --------------------------------------------------------------------------- #
+
+
+def test_top_pick_task1_is_groq_gpt_oss() -> None:
+    # Seed "Top pick per task": task1 -> Groq GPT-OSS-120B.
+    pick = top_pick_for_task(Task.MOMENT_FIND)
+    assert pick.id == "groq-gpt-oss-120b"
+
+
+def test_top_pick_task2_is_groq_llama() -> None:
+    pick = top_pick_for_task(Task.CAPTION)
+    assert pick.id == "groq-llama-3.3-70b"
+
+
+def test_top_pick_task4_is_gemini_flash_lite_with_avoid_flag() -> None:
+    # Seed: task4 -> Gemini 2.5 Flash-Lite (best free OCR) with AVOID-private.
+    pick = top_pick_for_task(Task.VISION)
+    assert pick.id == "gemini-2.5-flash-lite"
+    assert pick.privacy_tier is PrivacyTier.AVOID
+    assert pick.trains_on_input is True
+
+
+def test_top_pick_task5_is_groq_gpt_oss() -> None:
+    pick = top_pick_for_task(Task.EDIT_PLAN)
+    assert pick.id == "groq-gpt-oss-120b"
+
+
+def test_top_pick_ranks_all_five_tasks() -> None:
+    # Acceptance: ranks all 5 tasks (every task yields a pick).
+    picks = {task: top_pick_for_task(task) for task in Task}
+    assert len(picks) == 5
+    assert all(isinstance(p, CatalogEntry) for p in picks.values())
+
+
+def test_top_pick_accepts_custom_catalog() -> None:
+    # A custom catalog with a single text model returns that model.
+    only = (_by_id("groq-llama-3.3-70b"),)
+    pick = top_pick_for_task(Task.CAPTION, catalog=only)
+    assert pick.id == "groq-llama-3.3-70b"
+
+
+def test_top_pick_falls_back_to_grade_ranking_when_preferred_absent() -> None:
+    # Custom catalog WITHOUT the seed's CAPTION top pick (groq-llama-3.3-70b):
+    # the helper falls back to grade -> free-limit -> context ranking. Both are
+    # grade A on CAPTION, so the higher free-limit GPT-OSS (80) beats SambaNova.
+    subset = (_by_id("groq-gpt-oss-120b"), _by_id("sambanova-llama-3.1-405b"))
+    pick = top_pick_for_task(Task.CAPTION, catalog=subset)
+    assert pick.id == "groq-gpt-oss-120b"
+
+
+def test_top_pick_raises_when_no_entry_can_serve_task() -> None:
+    # A vision-only task against a catalog with no eligible (non-"na") entry.
+    text_only = (_by_id("cloudflare-workers-ai"),)
+    # Cloudflare is "na" for vision (task4) -> no eligible pick.
+    with pytest.raises(ValueError, match="no catalog entry serves task"):
+        top_pick_for_task(Task.VISION, catalog=text_only)

--- a/sidecar/tests/test_catalog.py
+++ b/sidecar/tests/test_catalog.py
@@ -12,6 +12,7 @@ from dataclasses import FrozenInstanceError
 
 import pytest
 from media_studio.models.catalog import (
+    AS_OF_DATE,
     CATALOG,
     Capability,
     CatalogEntry,
@@ -20,6 +21,7 @@ from media_studio.models.catalog import (
     Task,
     TierGrade,
     Unit,
+    catalog_to_json,
     filter_by_capability,
     order_by,
     top_pick_for_task,
@@ -293,3 +295,78 @@ def test_top_pick_raises_when_no_entry_can_serve_task() -> None:
     # Cloudflare is "na" for vision (task4) -> no eligible pick.
     with pytest.raises(ValueError, match="no catalog entry serves task"):
         top_pick_for_task(Task.VISION, catalog=text_only)
+
+
+# --------------------------------------------------------------------------- #
+# catalog_to_json — the providers.catalog wire payload
+# --------------------------------------------------------------------------- #
+def test_catalog_to_json_top_level_shape() -> None:
+    payload = catalog_to_json()
+    assert set(payload) == {"asOfDate", "unit", "tasks", "topPicks", "providers"}
+    assert payload["asOfDate"] == AS_OF_DATE
+    # unit lists both denominations so the UI never sums across REQ + TOKEN.
+    assert set(payload["unit"]) == {"req", "token"}
+    # all five Reframe tasks are advertised as tier columns.
+    assert payload["tasks"] == [t.value for t in Task]
+
+
+def test_catalog_to_json_spans_at_least_three_providers() -> None:
+    payload = catalog_to_json()
+    providers = payload["providers"]
+    assert len(providers) == len(CATALOG)
+    distinct = {p["provider"] for p in providers}
+    assert len(distinct) >= 3
+    assert {"Groq", "Cerebras", "Google AI Studio"} <= distinct
+
+
+def test_catalog_to_json_entry_has_five_task_tiers() -> None:
+    payload = catalog_to_json()
+    for entry in payload["providers"]:
+        # Acceptance: per-task tiers for all 5 tasks.
+        assert set(entry["perTaskTier"].keys()) == {t.value for t in Task}
+        assert "asOfDate" in entry
+        assert "trainsOnInput" in entry
+        assert "privacyTier" in entry
+        assert "unit" in entry
+
+
+def test_catalog_to_json_gemini_avoid_groq_safe_flags() -> None:
+    payload = catalog_to_json()
+    by_id = {e["id"]: e for e in payload["providers"]}
+    gemini = by_id["gemini-2.5-flash"]
+    assert gemini["trainsOnInput"] is True
+    assert gemini["privacyTier"] == "AVOID"
+    groq = by_id["groq-gpt-oss-120b"]
+    assert groq["trainsOnInput"] is False
+    assert groq["privacyTier"] == "SAFE"
+
+
+def test_catalog_to_json_top_picks_are_entry_ids() -> None:
+    payload = catalog_to_json()
+    ids = {e["id"] for e in payload["providers"]}
+    assert payload["topPicks"][Task.MOMENT_FIND.value] == "groq-gpt-oss-120b"
+    assert payload["topPicks"][Task.VISION.value] == "gemini-2.5-flash-lite"
+    assert all(pick_id in ids for pick_id in payload["topPicks"].values())
+
+
+def test_catalog_to_json_carries_no_secrets() -> None:
+    # No key/url/secret fields ever appear in the catalog payload.
+    import json
+
+    blob = json.dumps(catalog_to_json())
+    for forbidden in ("apiKey", "apiKeys", "Bearer", "baseUrl", "secret"):
+        assert forbidden not in blob
+
+
+def test_catalog_to_json_is_json_serializable() -> None:
+    import json
+
+    # Round-trips through json (all enums flattened to values).
+    assert json.loads(json.dumps(catalog_to_json()))["asOfDate"] == AS_OF_DATE
+
+
+def test_catalog_to_json_accepts_custom_catalog() -> None:
+    subset = (_by_id("groq-gpt-oss-120b"),)
+    payload = catalog_to_json(catalog=subset)
+    assert len(payload["providers"]) == 1
+    assert payload["providers"][0]["id"] == "groq-gpt-oss-120b"

--- a/sidecar/tests/test_catalog_adapter.py
+++ b/sidecar/tests/test_catalog_adapter.py
@@ -1,0 +1,131 @@
+"""Tests for the catalog->presets adapter (WU-presets carryforward #1).
+
+``presets.py`` is PURE and duck-types its catalog as ``.all()`` returning entries
+whose ``per_task_tier`` is keyed by the FUNCTION NAME (``"select"`` / ``"vision"``
+…) string. The REAL :mod:`media_studio.models.catalog` keys ``per_task_tier`` by
+the :class:`catalog.Task` ENUM and exposes no ``all()``. Without an adapter every
+grade would resolve to ``"na"`` and the presets would degrade everything to local.
+
+The adapter under test bridges the two so ``apply_preset`` /
+``suggest_for_function`` consume the REAL catalog correctly.
+"""
+
+from __future__ import annotations
+
+from media_studio.models import catalog as C
+from media_studio.models import presets as P
+
+
+def _adapter() -> P.CatalogLike:
+    return P.CatalogAdapter()
+
+
+# --------------------------------------------------------------------------- #
+# Shape: .all() + string-keyed per_task_tier
+# --------------------------------------------------------------------------- #
+
+
+def test_adapter_all_returns_every_catalog_entry() -> None:
+    entries = _adapter().all()
+    assert len(entries) == len(C.CATALOG)
+    assert {e.id for e in entries} == {e.id for e in C.CATALOG}
+
+
+def test_adapter_entries_satisfy_the_presets_duck_type() -> None:
+    for entry in _adapter().all():
+        assert isinstance(entry, P.CatalogEntryLike)
+
+
+def test_adapter_per_task_tier_is_keyed_by_function_name_not_enum() -> None:
+    # The whole point of the adapter: function-name keys (string), not Task enum.
+    entry = next(e for e in _adapter().all() if e.id == "groq-gpt-oss-120b")
+    assert set(entry.per_task_tier) == set(P.FUNCTIONS)
+    # groq-gpt-oss-120b grades: T1=S, T2=A, T3=A, T4=na, T5=S (catalog seed).
+    assert entry.per_task_tier["select"] == "S"
+    assert entry.per_task_tier["subtitles"] == "A"
+    assert entry.per_task_tier["translation"] == "A"
+    assert entry.per_task_tier["vision"] == "na"
+    assert entry.per_task_tier["editPlan"] == "S"
+
+
+def test_adapter_capabilities_are_plain_strings() -> None:
+    # presets checks ``"text"``/``"vision"`` membership in capabilities -> strings.
+    vision_entry = next(e for e in _adapter().all() if e.id == "gemini-2.5-flash-lite")
+    assert "text" in vision_entry.capabilities
+    assert "vision" in vision_entry.capabilities
+    text_entry = next(e for e in _adapter().all() if e.id == "groq-gpt-oss-120b")
+    assert "vision" not in text_entry.capabilities
+
+
+def test_adapter_privacy_tier_is_the_string_value() -> None:
+    gemini = next(e for e in _adapter().all() if e.id == "gemini-2.5-flash-lite")
+    assert gemini.privacy_tier == "AVOID"
+    groq = next(e for e in _adapter().all() if e.id == "groq-gpt-oss-120b")
+    assert groq.privacy_tier == "SAFE"
+
+
+# --------------------------------------------------------------------------- #
+# Integration: presets consume the REAL catalog through the adapter
+# --------------------------------------------------------------------------- #
+
+
+def test_bestfreecloud_over_real_catalog_resolves_real_picks_not_local() -> None:
+    routing = P.apply_preset("bestFreeCloud", {}, _adapter())
+    # If the adapter were missing, every grade would be "na" -> every slot local.
+    # With it, text slots resolve to the catalog's top text picks (NOT local).
+    assert routing["perFunction"]["select"]["provider"] == "groq-gpt-oss-120b"
+    assert routing["perFunction"]["subtitles"]["provider"] == "groq-llama-3.3-70b"
+    assert routing["perFunction"]["translation"]["provider"] == "groq-llama-3.3-70b"
+    assert routing["perFunction"]["editPlan"]["provider"] == "groq-gpt-oss-120b"
+    # vision resolves to a vision-capable cloud model, never local under cloud.
+    assert routing["perFunction"]["vision"]["provider"] != P.LOCAL
+
+
+def test_suggest_vision_over_real_catalog_excludes_text_only_models() -> None:
+    out = P.suggest_for_function("vision", _adapter(), {})
+    ids = {e.id for e in out}
+    # Text-only Groq models are never proposed for vision (capability filter).
+    assert "groq-gpt-oss-120b" not in ids
+    assert "groq-llama-3.3-70b" not in ids
+    # The vision-capable models ARE proposed.
+    assert "gemini-2.5-flash-lite" in ids
+    assert "github-gpt-4o-mini" in ids
+
+
+def test_suggest_select_safe_only_drops_avoid_tier_real_catalog() -> None:
+    out = P.suggest_for_function("select", _adapter(), {"requireSafePrivacy": True})
+    for entry in out:
+        assert entry.privacy_tier != "AVOID"
+
+
+def test_balanced_over_real_catalog_is_mixed_cloud_text_local_vision() -> None:
+    routing = P.apply_preset("balanced", {}, _adapter())
+    assert routing["perFunction"]["select"]["provider"] != P.LOCAL
+    assert routing["perFunction"]["vision"]["provider"] == P.LOCAL
+
+
+def test_privacy_over_real_catalog_is_all_local() -> None:
+    routing = P.apply_preset("privacy", {}, _adapter())
+    for fn in P.FUNCTIONS:
+        assert routing["perFunction"][fn]["provider"] == P.LOCAL
+
+
+# --------------------------------------------------------------------------- #
+# Adapter accepts a custom catalog tuple (so tests can pin a tiny one)
+# --------------------------------------------------------------------------- #
+
+
+def test_adapter_accepts_a_custom_catalog_tuple() -> None:
+    one = (C.CATALOG[0],)
+    adapter = P.CatalogAdapter(catalog=one)
+    entries = adapter.all()
+    assert len(entries) == 1
+    assert entries[0].id == C.CATALOG[0].id
+
+
+def test_function_to_task_mapping_covers_all_five_functions() -> None:
+    # The adapter's function->Task map must be total over FUNCTIONS (no KeyError).
+    mapping = P.function_tasks()
+    assert set(mapping) == set(P.FUNCTIONS)
+    assert mapping["vision"] is C.Task.VISION
+    assert mapping["editPlan"] is C.Task.EDIT_PLAN

--- a/sidecar/tests/test_consent.py
+++ b/sidecar/tests/test_consent.py
@@ -1,0 +1,110 @@
+"""Per-data-type egress consent gate (WU-keys / SE1, PLAN §WU-keys acceptance (d)).
+
+The setter (``providers.setConsent``) is covered in ``test_handlers_keys.py``;
+THIS module covers the ENFORCEMENT half — the typed refusal that PLAN §WU-keys
+acceptance (d) ("a vision egress without frame consent is **blocked**") and the
+test strategy ("refused (typed)") require. Default-deny: absent/malformed
+consent never grants egress; only an explicit ``True`` does.
+"""
+
+from __future__ import annotations
+
+import pytest
+from media_studio.models.consent import (
+    DATA_TYPE_FRAMES,
+    DATA_TYPE_TEXT,
+    ConsentError,
+    frame_consent_granted,
+    require_frame_consent,
+    text_consent_granted,
+)
+
+
+def _settings(per_provider: object) -> dict:
+    return {"consent": {"perProvider": per_provider}}
+
+
+# --------------------------------------------------------------------------- #
+# frame_consent_granted / text_consent_granted — positive grants
+# --------------------------------------------------------------------------- #
+def test_frame_consent_granted_when_explicit_true() -> None:
+    settings = _settings({"Gemini": {"frames": True}})
+    assert frame_consent_granted(settings, "Gemini") is True
+
+
+def test_text_consent_granted_when_explicit_true() -> None:
+    settings = _settings({"Groq": {"text": True}})
+    assert text_consent_granted(settings, "Groq") is True
+
+
+def test_text_and_frames_are_independent() -> None:
+    # frames opted-in, text NOT — the two gates are separate (SE1).
+    settings = _settings({"Gemini": {"frames": True}})
+    assert frame_consent_granted(settings, "Gemini") is True
+    assert text_consent_granted(settings, "Gemini") is False
+
+
+# --------------------------------------------------------------------------- #
+# default-deny: every absent / malformed shape resolves to NOT granted
+# --------------------------------------------------------------------------- #
+def test_frame_consent_denied_when_flag_false() -> None:
+    assert frame_consent_granted(_settings({"Gemini": {"frames": False}}), "Gemini") is False
+
+
+def test_frame_consent_denied_when_flag_absent() -> None:
+    # provider entry exists but has only text consent — frames absent == denied.
+    assert frame_consent_granted(_settings({"Gemini": {"text": True}}), "Gemini") is False
+
+
+def test_frame_consent_denied_when_provider_absent() -> None:
+    assert frame_consent_granted(_settings({"Other": {"frames": True}}), "Gemini") is False
+
+
+def test_frame_consent_denied_when_provider_entry_not_mapping() -> None:
+    assert frame_consent_granted(_settings({"Gemini": "yes"}), "Gemini") is False
+
+
+def test_frame_consent_denied_when_per_provider_not_mapping() -> None:
+    assert frame_consent_granted(_settings(["Gemini"]), "Gemini") is False
+
+
+def test_frame_consent_denied_when_consent_block_missing() -> None:
+    assert frame_consent_granted({}, "Gemini") is False
+
+
+def test_frame_consent_denied_when_consent_block_not_mapping() -> None:
+    assert frame_consent_granted({"consent": "nope"}, "Gemini") is False
+
+
+def test_frame_consent_denied_when_flag_truthy_but_not_true() -> None:
+    # default-deny is strict: a truthy non-True value (e.g. 1) is NOT consent.
+    assert frame_consent_granted(_settings({"Gemini": {"frames": 1}}), "Gemini") is False
+
+
+# --------------------------------------------------------------------------- #
+# require_frame_consent — typed refusal (the acceptance-(d) enforcement point)
+# --------------------------------------------------------------------------- #
+def test_require_frame_consent_passes_when_granted() -> None:
+    # No exception when consent is explicitly granted.
+    require_frame_consent(_settings({"Gemini": {"frames": True}}), "Gemini")
+
+
+def test_require_frame_consent_raises_typed_when_denied() -> None:
+    with pytest.raises(ConsentError) as exc_info:
+        require_frame_consent(_settings({"Gemini": {"frames": False}}), "Gemini")
+    err = exc_info.value
+    assert err.provider == "Gemini"
+    assert err.data_type == DATA_TYPE_FRAMES
+    # Message names the provider + the precise consent path, no secret.
+    assert "Gemini" in str(err)
+    assert DATA_TYPE_FRAMES in str(err)
+
+
+def test_require_frame_consent_raises_when_consent_absent() -> None:
+    with pytest.raises(ConsentError):
+        require_frame_consent({}, "Gemini")
+
+
+def test_data_type_constants() -> None:
+    assert DATA_TYPE_TEXT == "text"
+    assert DATA_TYPE_FRAMES == "frames"

--- a/sidecar/tests/test_handlers_ai_planjob.py
+++ b/sidecar/tests/test_handlers_ai_planjob.py
@@ -1,0 +1,116 @@
+"""Tests for the ``ai.planJob`` pre-flight RPC handler (WU-envelope).
+
+``ai.planJob`` is the pure pre-flight: it returns ``{route, costEst, cacheHit,
+willEgress, budget, preview, cacheKey}`` and performs ZERO provider calls. The
+tests pin: the wire shape, that NO provider transport is touched, the request
+coercion (dict / non-dict / no-size), the message-coercion branches (list with
+non-dict entries filtered; a non-list messages value), and cacheHit detection
+from a pre-seeded cache.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers, protocol
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext
+
+
+class ExplodingProvider:
+    """A provider whose ``chat`` must NEVER be called during planning."""
+
+    def chat(self, messages: list[dict[str, str]], **_k: Any) -> str:  # pragma: no cover -- must not run
+        raise AssertionError("ai.planJob must perform ZERO provider calls")
+
+
+@pytest.fixture
+def svc(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data", provider=ExplodingProvider(), library=None)
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def test_ai_planjob_registered() -> None:
+    protocol.clear_methods()
+    handlers.register_all()
+    assert "ai.planJob" in protocol.METHODS
+    protocol.clear_methods()
+
+
+def test_ai_planjob_returns_preflight_shape_zero_calls(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "hello"}], "model": "m"},
+        ctx,
+    )
+    assert set(out) >= {"route", "costEst", "cacheHit", "willEgress", "budget", "preview", "cacheKey"}
+    assert out["route"]["degradeChain"][-1] == "local"
+    assert out["cacheHit"] is False
+    # ZERO provider calls: the ExplodingProvider was never invoked (no AssertionError).
+
+
+def test_ai_planjob_with_explicit_request(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job(
+        {
+            "messages": [{"role": "user", "content": "x"}],
+            "model": "m",
+            "request": {"targetSize": 5, "textBytes": 10, "frameBytes": 2},
+        },
+        ctx,
+    )
+    assert out["costEst"]["requests"] == 5
+    assert out["costEst"]["egressBytes"] == 5 * (10 + 2)
+    assert out["costEst"]["egressKinds"] == {"text": 50, "frames": 10}
+
+
+def test_ai_planjob_request_without_size_uses_default(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "x"}], "request": {"textBytes": 3}},
+        ctx,
+    )
+    # No targetSize -> _BudgetRequest.target_size is None -> budget default (8).
+    assert out["costEst"]["requests"] == 8
+
+
+def test_ai_planjob_non_dict_request_is_unsized(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "abc"}], "request": "not-a-dict"},
+        ctx,
+    )
+    # request coerces to None -> the derived single-output text request (size 1).
+    assert out["costEst"]["requests"] == 1
+    assert out["costEst"]["egressBytes"] == len(b"abc")
+
+
+def test_ai_planjob_filters_non_dict_messages(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "keep"}, "junk", 42], "model": "m"},
+        ctx,
+    )
+    # Only the dict message survives; planning still succeeds.
+    assert "cacheKey" in out
+
+
+def test_ai_planjob_non_list_messages_is_empty(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job({"messages": "nope", "model": "m"}, ctx)
+    # messages -> () ; an empty-message plan still produces a cache key + route.
+    assert "cacheKey" in out
+    assert out["route"]["degradeChain"][-1] == "local"
+
+
+def test_ai_planjob_cache_hit_flags_no_egress(svc: Services, ctx: RpcContext) -> None:
+    params = {"messages": [{"role": "user", "content": "seeded"}], "model": "m"}
+    # Seed the cache at the same key the planner will derive.
+    cache = svc._ai_cache()
+    inputs_messages = [{"role": "user", "content": "seeded"}]
+    key = cache.key(inputs_messages, "m", {})
+    cache.put(key, "cached-answer")
+    out = svc.ai_plan_job(params, ctx)
+    assert out["cacheHit"] is True
+    assert out["willEgress"] is False
+    assert "Cached" in out["preview"]

--- a/sidecar/tests/test_handlers_budget_preflight.py
+++ b/sidecar/tests/test_handlers_budget_preflight.py
@@ -1,0 +1,217 @@
+"""Tests for the WU-budget pre-flight surface on the handlers (PLAN §WU-budget).
+
+Covers the two pieces this WU completes/verifies on top of WU-envelope:
+
+  * ``ai.planJob`` performs ZERO provider calls and carries the budget;
+  * the ``confirmCloudBudget`` gate — a cloud run that WOULD egress is refused
+    until acknowledged with the planJob ``cacheKey``; a local-only run is never
+    gated; disabling the setting bypasses the gate;
+  * the all-cloud degraded notice (run falls through to local);
+  * ``defaultTargetJobSize`` drives the unsized budget count.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.handlers import Services
+from media_studio.jobs import JobRegistry
+from media_studio.models.ai_cache import Message
+from media_studio.models.provider import ProviderError
+from media_studio.protocol import RpcContext, RpcError
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+class ExplodingProvider:
+    def chat(self, messages: list[dict[str, str]], **_k: Any) -> str:  # pragma: no cover -- must not run
+        raise AssertionError("planJob must perform ZERO provider calls")
+
+
+class _CloudEntry:
+    provider = "Groq"
+    local = False
+
+
+class _LocalEntry:
+    provider = "local"
+    local = True
+
+
+class _CloudPool:
+    """A pool with a cloud provider + local backstop (so willEgress is True)."""
+
+    entries = (_CloudEntry(), _LocalEntry())
+
+
+class DegradingProvider:
+    """Fires a 'local' failover then replies (graceful degradation to local)."""
+
+    def __init__(self, reply: str = "from-local") -> None:
+        self.reply = reply
+        self._cbs: list[Any] = []
+
+    def on_rotation(self, cb: Any) -> None:
+        self._cbs.append(cb)
+
+    def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+        for cb in self._cbs:
+            cb(type("E", (), {"provider": "local"})())
+        return self.reply
+
+
+class RaisingProvider:
+    def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+        raise ProviderError("provider pool exhausted (text): all keys 429")
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+@pytest.fixture
+def svc(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data", provider=ExplodingProvider(), library=None)
+
+
+# --------------------------------------------------------------------------- #
+# ai.planJob — zero provider calls + budget present
+# --------------------------------------------------------------------------- #
+def test_planjob_zero_provider_calls_and_budget(svc: Services, ctx: RpcContext) -> None:
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "hi"}], "model": "m"},
+        ctx,
+    )
+    assert "budget" in out
+    assert out["budget"] == out["costEst"]
+    # ExplodingProvider never raised -> zero provider calls during planning.
+
+
+# --------------------------------------------------------------------------- #
+# defaultTargetJobSize drives the unsized count
+# --------------------------------------------------------------------------- #
+def test_default_target_job_size_drives_unsized_budget(svc: Services, ctx: RpcContext) -> None:
+    svc.settings.set({"defaultTargetJobSize": 3})
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "x"}], "request": {"textBytes": 5}},
+        ctx,
+    )
+    # No targetSize pinned -> resolves to the configured default (3), not the
+    # module constant (8).
+    assert out["costEst"]["requests"] == 3
+    assert out["costEst"]["egressBytes"] == 3 * 5
+
+
+def test_default_target_job_size_falls_back_to_constant(svc: Services, ctx: RpcContext) -> None:
+    from media_studio.models import budget as _budget
+
+    # A non-positive setting is ignored -> the budget module constant.
+    svc.settings.set({"defaultTargetJobSize": 0})
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "x"}], "request": {"textBytes": 1}},
+        ctx,
+    )
+    assert out["costEst"]["requests"] == _budget.DEFAULT_TARGET_JOB_SIZE
+
+
+def test_default_target_job_size_non_int_setting_falls_back(svc: Services, ctx: RpcContext) -> None:
+    from media_studio.models import budget as _budget
+
+    svc.settings.set({"defaultTargetJobSize": "lots"})
+    out = svc.ai_plan_job(
+        {"messages": [{"role": "user", "content": "x"}], "request": {"textBytes": 1}},
+        ctx,
+    )
+    assert out["costEst"]["requests"] == _budget.DEFAULT_TARGET_JOB_SIZE
+
+
+# --------------------------------------------------------------------------- #
+# confirmCloudBudget gate (PLAN §WU-budget)
+# --------------------------------------------------------------------------- #
+def _envelope(svc: Services, content: str = "q") -> Any:
+    from media_studio.models import ai_job as _ai_job
+
+    inputs = _ai_job.AiInputs(messages=({"role": "user", "content": content},), model="m")
+    return svc.plan_ai_job_envelope(inputs)
+
+
+def test_gate_refuses_unacknowledged_cloud_run(svc: Services) -> None:
+    # Force an egressing envelope by monkeypatching the pool to a cloud pool.
+    svc._ai_pool = lambda: _CloudPool()  # type: ignore[method-assign]
+    envelope = _envelope(svc)
+    assert envelope.route.willEgress is True
+    with pytest.raises(RpcError, match="budget acknowledgement"):
+        svc._enforce_cloud_budget_ack(envelope, ack=None)
+
+
+def test_gate_accepts_matching_ack(svc: Services) -> None:
+    svc._ai_pool = lambda: _CloudPool()  # type: ignore[method-assign]
+    envelope = _envelope(svc)
+    # The cacheKey is the acknowledgement token; passing it lets the run proceed.
+    svc._enforce_cloud_budget_ack(envelope, ack=envelope.cacheKey)
+
+
+def test_gate_skipped_when_setting_disabled(svc: Services) -> None:
+    svc._ai_pool = lambda: _CloudPool()  # type: ignore[method-assign]
+    svc.settings.set({"confirmCloudBudget": False})
+    envelope = _envelope(svc)
+    # Disabled -> no ack required even though the run would egress.
+    svc._enforce_cloud_budget_ack(envelope, ack=None)
+
+
+def test_gate_skipped_for_local_only_run(svc: Services) -> None:
+    # Default pool (no providers configured) is local-only -> never egresses.
+    envelope = _envelope(svc)
+    assert envelope.route.willEgress is False
+    svc._enforce_cloud_budget_ack(envelope, ack=None)  # no raise
+
+
+# --------------------------------------------------------------------------- #
+# all-cloud-429 degraded notice (graceful degradation invariant)
+# --------------------------------------------------------------------------- #
+def test_all_cloud_degrades_to_local_with_notice(svc: Services) -> None:
+    progress: list[tuple[str, int, str]] = []
+    done: list[tuple[str, Any]] = []
+    registry = JobRegistry(
+        lambda jid, pct, msg: progress.append((jid, pct, msg)),
+        lambda jid, res: done.append((jid, res)),
+    )
+    ctx = RpcContext(emit_notification=lambda obj: None, jobs=registry)
+
+    job = svc._run_ai_job(
+        ctx,
+        messages=[{"role": "user", "content": "translate"}],
+        model="m",
+        provider=DegradingProvider("local-answer"),
+        work=None,
+        feature="ai",
+        label="AI",
+    )
+    registry.join(timeout=5)
+    assert job.finished
+    assert any("degraded" in m for _, _, m in progress)
+    assert done[-1][1]["degraded"] is True
+    assert done[-1][1]["result"] == "local-answer"
+
+
+def test_all_cloud_exhaustion_emits_single_error(svc: Services) -> None:
+    done: list[tuple[str, Any]] = []
+    registry = JobRegistry(lambda *_a: None, lambda jid, res: done.append((jid, res)))
+    ctx = RpcContext(emit_notification=lambda obj: None, jobs=registry)
+    svc._run_ai_job(
+        ctx,
+        messages=[{"role": "user", "content": "x"}],
+        model="m",
+        provider=RaisingProvider(),
+        work=None,
+        feature="ai",
+        label="AI",
+    )
+    registry.join(timeout=5)
+    assert len(done) == 1
+    assert done[-1][1]["error"]["type"] == "ProviderError"

--- a/sidecar/tests/test_handlers_extra.py
+++ b/sidecar/tests/test_handlers_extra.py
@@ -18,6 +18,7 @@ real module. No global state (env vars, cwd, registry) leaks.
 
 from __future__ import annotations
 
+import threading
 import types
 from pathlib import Path
 from typing import Any
@@ -467,14 +468,20 @@ def test_transcribe_start_bad_language_type(services: Services, ctx: RpcContext,
 def test_transcribe_start_cancelled_skips_persist(services: Services, ctx: RpcContext, video_file: Path) -> None:
     """A job cancelled mid-transcribe skips the persist branch (549->558).
 
-    The whisper loader's transcribe honours should_cancel; we cancel the job
-    immediately so transcribe_file returns and ``job_ctx.cancelled`` is True, so
-    the transcript is NOT persisted (hasTranscript stays False, no project saved).
+    DETERMINISTIC (no race): the fake model blocks inside ``transcribe`` until the
+    test has cancelled the job, so ``job_ctx.cancelled`` is guaranteed True by the
+    time the body reaches the persist check -> the transcript is NOT persisted
+    (hasTranscript stays False, no project saved). Previously this raced the empty
+    transcribe against the cancel and flaked ~1/3 of runs.
     """
     vid = _add_video(services, video_file)
+    started = threading.Event()
+    released = threading.Event()
 
     class CancellingModel:
         def transcribe(self, audio: str, **_k: Any) -> tuple[Any, dict[str, Any]]:
+            started.set()  # the job body is now inside transcribe
+            released.wait(timeout=5)  # block until the test has cancelled
             return iter([]), {"duration": 0.0, "language": "en"}
 
     class CancellingLoader:
@@ -483,8 +490,9 @@ def test_transcribe_start_cancelled_skips_persist(services: Services, ctx: RpcCo
 
     services._whisper_loader = CancellingLoader()
     res = services.transcribe_start({"videoId": vid}, ctx)
-    # Cancel as soon as the job exists, before the body finishes.
-    ctx.jobs.cancel(res["jobId"])
+    assert started.wait(timeout=5), "transcribe never entered the job body"
+    ctx.jobs.cancel(res["jobId"])  # cancel WHILE transcribe is blocked
+    released.set()  # let transcribe return; cancelled is already True
     ctx.jobs.join(timeout=5)
     # Cancelled -> transcript not persisted onto the library flag.
     assert services.library.get(vid).get("hasTranscript") in (False, None)

--- a/sidecar/tests/test_handlers_keys.py
+++ b/sidecar/tests/test_handlers_keys.py
@@ -1,0 +1,215 @@
+"""WU-keys handler tests: RAW-vs-REDACTED partition + providers.* RPC + consent.
+
+The security crux (PLAN §WU-keys):
+  * NO RPC method returns a full key — only last-4 (asserted on every providers.*
+    + settings.get response via a regex/substring scan over the serialized JSON).
+  * The provider/translator FACTORY path consumes RAW keys (via ``get_raw()``)
+    while every RPC read returns redacted — a partition test enumerates ALL FOUR
+    feed callers and proves each builds from the full key.
+  * providers.testKey validates without echoing the key; a forced 4xx error is
+    scrubbed of the live key.
+  * TEXT and FRAMES consent are SEPARATE + independently revocable.
+
+Every heavy seam is faked: no socket, no model, no real urllib.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext, RpcError
+
+LIVE_KEY = "gsk-live-SECRET-ABCDWXYZ"
+LIVE_KEY_2 = "gsk-second-SECRET-7890"
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def _services(tmp_path: Path, **kw: Any) -> Services:
+    return Services(data_dir=tmp_path, **kw)
+
+
+def _with_provider(svc: Services, *, keys: list[str] | None = None) -> Services:
+    svc.settings.set(
+        {
+            "providers": [
+                {
+                    "id": "groq",
+                    "provider": "Groq",
+                    "kind": "cloud",
+                    "baseUrl": "https://api.groq.com/openai/v1",
+                    "model": "llama-3.3-70b",
+                    "apiKeys": keys if keys is not None else [LIVE_KEY],
+                    "enabled": True,
+                    "capabilities": ["text"],
+                    "unit": "token",
+                }
+            ]
+        }
+    )
+    return svc
+
+
+# --------------------------------------------------------------------------- #
+# RPC reads are REDACTED — NO full key ever crosses RPC
+# --------------------------------------------------------------------------- #
+def test_settings_get_redacts_provider_keys(tmp_path: Path) -> None:
+    svc = _with_provider(_services(tmp_path))
+    out = svc.settings_get({}, _ctx())
+    blob = json.dumps(out)
+    assert LIVE_KEY not in blob
+    assert out["providers"][0]["apiKeys"] == ["…WXYZ"]  # last-4 only
+
+
+def test_providers_list_is_key_free(tmp_path: Path) -> None:
+    svc = _with_provider(_services(tmp_path), keys=[LIVE_KEY, LIVE_KEY_2])
+    out = svc.providers_list({}, _ctx())
+    blob = json.dumps(out)
+    assert LIVE_KEY not in blob
+    assert LIVE_KEY_2 not in blob
+    assert out["providers"][0]["apiKeys"] == ["…WXYZ", "…7890"]
+
+
+def test_settings_set_response_is_key_free(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    out = svc.settings_set({"providers": [{"id": "g", "apiKeys": [LIVE_KEY]}]}, _ctx())
+    assert LIVE_KEY not in json.dumps(out)
+
+
+# --------------------------------------------------------------------------- #
+# providers.upsert / remove
+# --------------------------------------------------------------------------- #
+def test_providers_upsert_adds_then_merges(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    svc.providers_upsert({"id": "groq", "provider": "Groq", "apiKeys": [LIVE_KEY]}, _ctx())
+    # The RAW store carries the live key (the factory path will read it).
+    assert svc.settings.get_raw()["providers"][0]["apiKeys"] == [LIVE_KEY]
+    # Merge a second field into the same id (keeps apiKeys, updates model).
+    out = svc.providers_upsert({"id": "groq", "model": "m2"}, _ctx())
+    raw = svc.settings.get_raw()["providers"]
+    assert len(raw) == 1
+    assert raw[0]["model"] == "m2"
+    assert raw[0]["apiKeys"] == [LIVE_KEY]
+    # The returned list is still redacted.
+    assert LIVE_KEY not in json.dumps(out)
+
+
+def test_providers_upsert_accepts_nested_provider_object(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    svc.providers_upsert({"provider": {"id": "openai", "apiKeys": [LIVE_KEY]}}, _ctx())
+    assert svc.settings.get_raw()["providers"][0]["id"] == "openai"
+
+
+def test_providers_upsert_requires_id(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    with pytest.raises(RpcError):
+        svc.providers_upsert({"apiKeys": [LIVE_KEY]}, _ctx())
+
+
+def test_providers_upsert_skips_non_dict_existing_entries(tmp_path: Path) -> None:
+    # A corrupt/hand-edited settings file with a non-dict entry in providers must
+    # not crash an upsert: the bad entry is dropped (the elif's false arm) and the
+    # valid id is upserted alongside the surviving dict entries.
+    svc = _services(tmp_path)
+    svc.settings.set({"providers": ["garbage", {"id": "keep", "apiKeys": ["abcdEFGH"]}]})
+    svc.providers_upsert({"id": "groq", "apiKeys": [LIVE_KEY]}, _ctx())
+    raw = svc.settings.get_raw()["providers"]
+    ids = [p["id"] for p in raw if isinstance(p, dict)]
+    assert "garbage" not in raw
+    assert set(ids) == {"keep", "groq"}
+
+
+def test_providers_remove_drops_entry(tmp_path: Path) -> None:
+    svc = _with_provider(_services(tmp_path))
+    svc.providers_upsert({"id": "openai", "apiKeys": ["sk-other-KEY1"]}, _ctx())
+    out = svc.providers_remove({"id": "groq"}, _ctx())
+    ids = [p["id"] for p in out["providers"]]
+    assert ids == ["openai"]
+
+
+def test_providers_remove_absent_is_noop(tmp_path: Path) -> None:
+    svc = _with_provider(_services(tmp_path))
+    out = svc.providers_remove({"id": "nope"}, _ctx())
+    assert len(out["providers"]) == 1
+
+
+def test_providers_remove_requires_id(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    with pytest.raises(RpcError):
+        svc.providers_remove({}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# providers.testKey — validates, never echoes the key
+# --------------------------------------------------------------------------- #
+def test_test_key_ok_returns_capabilities_no_key(tmp_path: Path) -> None:
+    def transport(url, body, headers, timeout):  # noqa: ANN001
+        return {"choices": [{"message": {"role": "assistant", "content": "ok"}}]}
+
+    svc = _services(tmp_path, test_key_transport=transport)
+    out = svc.providers_test_key(
+        {"baseUrl": "https://api.groq.com/openai/v1", "apiKey": LIVE_KEY, "capabilities": ["text", "vision"]},
+        _ctx(),
+    )
+    assert out["ok"] is True
+    assert out["capabilities"] == ["text", "vision"]
+    assert LIVE_KEY not in json.dumps(out)
+
+
+def test_test_key_failure_scrubs_key(tmp_path: Path) -> None:
+    from media_studio.models.provider import ProviderError
+
+    def transport(url, body, headers, timeout):  # noqa: ANN001
+        # Simulate a provider error whose detail echoes the live key.
+        raise ProviderError(f"LLM HTTP 401: invalid key {LIVE_KEY}")
+
+    svc = _services(tmp_path, test_key_transport=transport)
+    out = svc.providers_test_key(
+        {"baseUrl": "https://api.groq.com/openai/v1", "apiKey": LIVE_KEY}, _ctx()
+    )
+    assert out["ok"] is False
+    assert LIVE_KEY not in out["error"]
+    assert LIVE_KEY not in json.dumps(out)
+
+
+def test_test_key_requires_base_url_and_key(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    with pytest.raises(RpcError):
+        svc.providers_test_key({"apiKey": LIVE_KEY}, _ctx())
+    with pytest.raises(RpcError):
+        svc.providers_test_key({"baseUrl": "https://x/v1"}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# providers.setConsent — text vs frames SEPARATE + independently revocable
+# --------------------------------------------------------------------------- #
+def test_set_consent_text_and_frames_are_independent(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    svc.providers_set_consent({"provider": "Groq", "text": True, "frames": True}, _ctx())
+    # Revoke ONLY frames; text must survive.
+    out = svc.providers_set_consent({"provider": "Groq", "frames": False}, _ctx())
+    assert out["consent"]["perProvider"]["Groq"] == {"text": True, "frames": False}
+    # Revoke ONLY text; frames must survive.
+    out2 = svc.providers_set_consent({"provider": "Groq", "text": False}, _ctx())
+    assert out2["consent"]["perProvider"]["Groq"] == {"text": False, "frames": False}
+
+
+def test_set_consent_persists_and_is_per_provider(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    svc.providers_set_consent({"provider": "Groq", "text": True}, _ctx())
+    svc.providers_set_consent({"provider": "Gemini", "frames": True}, _ctx())
+    per = svc.settings.get_raw()["consent"]["perProvider"]
+    assert per["Groq"] == {"text": True}
+    assert per["Gemini"] == {"frames": True}
+
+
+def test_set_consent_requires_provider(tmp_path: Path) -> None:
+    svc = _services(tmp_path)
+    with pytest.raises(RpcError):
+        svc.providers_set_consent({"text": True}, _ctx())

--- a/sidecar/tests/test_handlers_keys.py
+++ b/sidecar/tests/test_handlers_keys.py
@@ -170,9 +170,7 @@ def test_test_key_failure_scrubs_key(tmp_path: Path) -> None:
         raise ProviderError(f"LLM HTTP 401: invalid key {LIVE_KEY}")
 
     svc = _services(tmp_path, test_key_transport=transport)
-    out = svc.providers_test_key(
-        {"baseUrl": "https://api.groq.com/openai/v1", "apiKey": LIVE_KEY}, _ctx()
-    )
+    out = svc.providers_test_key({"baseUrl": "https://api.groq.com/openai/v1", "apiKey": LIVE_KEY}, _ctx())
     assert out["ok"] is False
     assert LIVE_KEY not in out["error"]
     assert LIVE_KEY not in json.dumps(out)

--- a/sidecar/tests/test_handlers_phase8.py
+++ b/sidecar/tests/test_handlers_phase8.py
@@ -485,6 +485,142 @@ def test_vision_provider_for_consent_returns_first_vision_cloud_name(tmp_path: P
     assert name == "Gemini"
 
 
+def _two_vision_provider_settings(*, first_consent: bool, second_consent: bool) -> dict[str, Any]:
+    """Two vision-capable cloud providers, each with its OWN frame-consent flag.
+
+    The FIRST (Gemini, routed first) and the SECOND (OpenAI) are both
+    vision-capable. The regression case: first frame-consented but it 429s, second
+    NOT frame-consented — proving rotation can never reach the non-consented one.
+    """
+    return {
+        "confirmCloudBudget": False,
+        "providers": [
+            {
+                "id": "gemini",
+                "provider": "Gemini",
+                "kind": "cloud",
+                "baseUrl": "https://gemini.example/v1",
+                "model": "gemini-flash",
+                "apiKeys": ["sk-gemini-1111"],
+                "enabled": True,
+                "capabilities": ["text", "vision"],
+                "unit": "req",
+            },
+            {
+                "id": "openai",
+                "provider": "OpenAI",
+                "kind": "cloud",
+                "baseUrl": "https://openai.example/v1",
+                "model": "gpt-4o-mini",
+                "apiKeys": ["sk-openai-2222"],
+                "enabled": True,
+                "capabilities": ["text", "vision"],
+                "unit": "req",
+            },
+        ],
+        "routing": {"perFunction": {"vision": {"provider": "gemini", "fallback": []}}},
+        "consent": {
+            "perProvider": {
+                "Gemini": {"frames": first_consent},
+                "OpenAI": {"frames": second_consent},
+            }
+        },
+    }
+
+
+class RotatingVisionTransport:
+    """Fake chat transport that 429s the consented provider and records ALL targets.
+
+    Raises ``ProviderError("LLM HTTP 429: ...")`` for any request to ``fail_host``
+    (forcing the pool to rotate). For every request it records the target host and
+    whether the body carried base64 frames, so a test can assert a non-consented
+    host was NEVER reached with frames.
+    """
+
+    def __init__(self, *, fail_host: str) -> None:
+        self._fail_host = fail_host
+        self.hosts: list[str] = []
+        self.frame_hosts: list[str] = []
+
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        self.hosts.append(url)
+        saw_base64 = any(
+            isinstance(part, dict)
+            and part.get("type") == "image_url"
+            and "base64," in str(part.get("image_url", {}).get("url", ""))
+            for msg in body.get("messages", [])
+            if isinstance(msg.get("content"), list)
+            for part in msg["content"]
+        )
+        if saw_base64:
+            self.frame_hosts.append(url)
+        if self._fail_host in url:
+            from media_studio.models.provider import ProviderError
+
+            raise ProviderError("LLM HTTP 429: rate limited; retry-after=60")
+        return _vision_chat_envelope("0")
+
+
+def test_phase8_vision_rotation_never_egresses_to_non_consented_provider(tmp_path: Path) -> None:
+    # REGRESSION (privacy CRITICAL): two vision-capable cloud providers — Gemini
+    # (routed first, frame-consented) and OpenAI (vision-capable, NO frame
+    # consent). Gemini 429s; the pool must NOT fail over to OpenAI with frames,
+    # because OpenAI's frame consent was never granted. The consented pool is
+    # filtered to Gemini only, so OpenAI is never even a rotation candidate.
+    transport = RotatingVisionTransport(fail_host="gemini.example")
+    svc = _phase8_services(
+        tmp_path,
+        provider=None,
+        vlm_clip_frame_loader=_fake_clip_loader,
+        vlm_frame_encoder=lambda frame: f"ENC<{frame}>",
+        vlm_models_present=lambda s: False,
+        vlm_chat_transport=transport,
+    )
+    svc.settings.set(_two_vision_provider_settings(first_consent=True, second_consent=False))
+
+    rr = svc._resolve_vlm_reranker(svc.settings.get(), media_path="/v.mp4")
+    from media_studio.features import smolvlm2 as sv
+
+    assert isinstance(rr, sv.SmolVlmReranker)
+    # invoking the reranker drives the vision pool; Gemini 429s, then exhausts
+    # (no eligible consented fallback) — the input order is kept (no-op re-rank).
+    cands = [{"start": 0.0, "end": 1.0, "hook": "a"}, {"start": 1.0, "end": 2.0, "hook": "b"}]
+    out = rr.rerank_top_k(cands, top_k=2)
+
+    assert [c["hook"] for c in out] == ["a", "b"], "degraded to input order on pool exhaustion"
+    # the non-consented provider (OpenAI) was NEVER reached at all, with or w/o frames.
+    assert not any("openai.example" in h for h in transport.hosts), "rotated to a non-consented provider"
+    assert all("gemini.example" in h for h in transport.frame_hosts), "frame egress reached a non-consented host"
+    # and the consented Gemini WAS attempted (the leak path is otherwise vacuous).
+    assert any("gemini.example" in h for h in transport.frame_hosts), "consented provider was never tried"
+
+
+def test_phase8_vision_pool_contains_only_frame_consented_cloud_entries(tmp_path: Path) -> None:
+    # Direct assertion on the filtered pool: with Gemini consented and OpenAI not,
+    # the cloud egress pool's vision-capable CLOUD entries are EXACTLY {Gemini}.
+    svc = _phase8_services(tmp_path, provider=None, vlm_chat_transport=RotatingVisionTransport(fail_host="none"))
+    svc.settings.set(_two_vision_provider_settings(first_consent=True, second_consent=False))
+    raw = svc.settings.get_raw()
+    pool = svc._vision_pool(svc._frame_consented_vision_settings(raw))
+    cloud_vision = [e.provider for e in pool.entries if not e.local and "vision" in e.capabilities]
+    assert cloud_vision == ["Gemini"], "non-consented vision provider leaked into the pool"
+
+
+def test_frame_consented_vision_settings_drops_non_consented(tmp_path: Path) -> None:
+    # The pure filter: only frame-consented providers survive; original untouched.
+    svc = _phase8_services(tmp_path, provider=None)
+    raw = _two_vision_provider_settings(first_consent=False, second_consent=True)
+    filtered = svc._frame_consented_vision_settings(raw)
+    assert [p["provider"] for p in filtered["providers"]] == ["OpenAI"]
+    assert len(raw["providers"]) == 2, "input settings were mutated"
+
+
+def test_frame_consented_vision_settings_no_providers_passthrough(tmp_path: Path) -> None:
+    # No providers list -> settings returned unchanged (the branch with no list).
+    svc = _phase8_services(tmp_path, provider=None)
+    assert svc._frame_consented_vision_settings({"foo": 1}) == {"foo": 1}
+
+
 def test_vision_provider_for_consent_none_when_no_vision_cloud(tmp_path: Path) -> None:
     svc = _phase8_services(tmp_path, provider=None)
     # only a TEXT provider configured -> no vision egress target

--- a/sidecar/tests/test_handlers_phase8.py
+++ b/sidecar/tests/test_handlers_phase8.py
@@ -270,6 +270,243 @@ def test_phase8_select_runs_job_and_caches(tmp_path: Path, video_file: Path) -> 
     assert vid in svc._selection_cache  # cached for a later shortmaker.export
 
 
+# --------------------------------------------------------------------------- #
+# phase8.select WU-vision wiring — frame-egress consent gate + cloud/local/off
+# vlm_reranker resolution. A FAKE vision transport (the rotation pool's HTTP seam)
+# proves frames egress ONLY with consent. No real model / no network.
+# --------------------------------------------------------------------------- #
+def _vision_chat_envelope(content: str = "0") -> dict[str, Any]:
+    """An OpenAI-style chat-completions success envelope (a clip ranking reply)."""
+    return {"choices": [{"message": {"role": "assistant", "content": content}}]}
+
+
+class VisionTransport:
+    """A fake chat transport the vision pool calls; records every request body.
+
+    ``saw_base64`` is set True the first time a request carries an ``image_url``
+    data-URI part, proving a FRAME left the machine. ``calls`` counts invocations
+    so a no-consent run can assert it was NEVER touched.
+    """
+
+    def __init__(self, content: str = "0") -> None:
+        self.content = content
+        self.calls: list[dict[str, Any]] = []
+        self.saw_base64 = False
+
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        self.calls.append({"url": url, "body": body, "headers": headers})
+        for msg in body.get("messages", []):
+            content = msg.get("content")
+            if isinstance(content, list):
+                for part in content:
+                    if isinstance(part, dict) and part.get("type") == "image_url":
+                        url_val = str(part.get("image_url", {}).get("url", ""))
+                        if "base64," in url_val:
+                            self.saw_base64 = True
+        return _vision_chat_envelope(self.content)
+
+
+def _fake_clip_loader(path: str, spans: Any) -> list[Any]:
+    """One synthetic frame stack per span (no cv2)."""
+    return [[f"frame@{lo}-{hi}"] for lo, hi in spans]
+
+
+def _vision_provider_settings(*, with_consent: bool) -> dict[str, Any]:
+    """Settings wiring a vision-capable cloud provider + routing + optional consent."""
+    consent_frames = with_consent
+    return {
+        # the text-egress budget ack gate (WU-budget) is orthogonal to the frame
+        # consent under test here; disable it so the run proceeds to the re-rank.
+        "confirmCloudBudget": False,
+        "providers": [
+            {
+                "id": "gemini",
+                "provider": "Gemini",
+                "kind": "cloud",
+                "baseUrl": "https://example/v1",
+                "model": "gemini-flash",
+                "apiKeys": ["sk-vision-key-9999"],
+                "enabled": True,
+                "capabilities": ["text", "vision"],
+                "unit": "req",
+            }
+        ],
+        "routing": {"perFunction": {"vision": {"provider": "gemini", "fallback": []}}},
+        "consent": {"perProvider": {"Gemini": {"frames": consent_frames}}},
+    }
+
+
+def _run_select_with_vision(
+    tmp_path: Path,
+    video_file: Path,
+    *,
+    settings_patch: dict[str, Any],
+    transport: Any | None = None,
+    models_present: Any | None = None,
+) -> tuple[Services, RpcContext, str]:
+    """Wire a Services for a vision select run with the injected seams, run it.
+
+    The TEXT select path uses the injected FakeProvider (returns ``"[]"`` — no
+    socket); the independent VISION pool uses the fake ``vlm_chat_transport`` so
+    frame egress is observable. The two paths are separate by design (WU-vision).
+    """
+    svc = _phase8_services(
+        tmp_path,
+        provider=FakeProvider(),  # text select path; vision uses the vlm transport
+        vlm_clip_frame_loader=_fake_clip_loader,
+        vlm_frame_encoder=lambda frame: f"ENC<{frame}>",
+        vlm_models_present=models_present if models_present is not None else (lambda s: False),
+        vlm_chat_transport=transport,
+    )
+    ctx = _phase8_ctx()
+    vid = _add_video(svc, video_file)
+    _transcribe_sync(svc, ctx, vid)
+    svc.settings.set(settings_patch)
+    out = svc.phase8_select({"videoId": vid, "prompt": "best", "controls": {}, "tier": 2}, ctx)
+    assert "jobId" in out
+    ctx.jobs.join(timeout=5)
+    return svc, ctx, vid
+
+
+def test_phase8_select_no_vision_provider_passes_none(tmp_path: Path, video_file: Path) -> None:
+    # No vision provider configured + no local weights -> vlm_reranker=None (the
+    # existing transcript-only path). The select job still completes + caches.
+    svc = _phase8_services(tmp_path, vlm_models_present=lambda s: False)
+    ctx = _phase8_ctx()
+    vid = _add_video(svc, video_file)
+    _transcribe_sync(svc, ctx, vid)
+    assert svc._resolve_vlm_reranker(svc.settings.get(), media_path="/v.mp4") is None
+    svc.phase8_select({"videoId": vid, "prompt": "best", "controls": {}, "tier": 2}, ctx)
+    ctx.jobs.join(timeout=5)
+    done = [e for e in ctx.events if e[0] == "done"]  # type: ignore[attr-defined]
+    assert "candidates" in done[-1][2]
+
+
+def test_phase8_select_cloud_vision_with_consent_egresses_frames(tmp_path: Path, video_file: Path) -> None:
+    # End-to-end through phase8.select: the run completes, then we PROVE the
+    # resolved cloud reranker egresses base64 frames when actually invoked (the
+    # short fixture transcript may yield <2 candidates, so re-ranking is a no-op
+    # in the job; the egress invariant is asserted on the resolved reranker).
+    transport = VisionTransport(content="0")
+    svc, ctx, vid = _run_select_with_vision(
+        tmp_path,
+        video_file,
+        settings_patch=_vision_provider_settings(with_consent=True),
+        transport=transport,
+    )
+    selects = [e for e in ctx.events if e[0] == "done" and "candidates" in e[2]]  # type: ignore[attr-defined]
+    assert selects, "select job did not complete"
+    # the resolved reranker is the cloud closure -> invoking it egresses frames.
+    rr = svc._resolve_vlm_reranker(svc.settings.get(), media_path=str(video_file))
+    from media_studio.features import smolvlm2 as sv
+
+    assert isinstance(rr, sv.SmolVlmReranker)
+    rr.rerank_top_k([{"start": 0.0, "end": 1.0, "hook": "a"}, {"start": 1.0, "end": 2.0, "hook": "b"}], top_k=2)
+    assert transport.calls, "cloud vision pool was never called"
+    assert transport.saw_base64 is True
+
+
+def test_phase8_select_cloud_vision_without_consent_no_frame_egress(tmp_path: Path, video_file: Path) -> None:
+    transport = VisionTransport(content="0")
+    svc, ctx, vid = _run_select_with_vision(
+        tmp_path,
+        video_file,
+        settings_patch=_vision_provider_settings(with_consent=False),
+        transport=transport,
+        models_present=lambda s: False,
+    )
+    # NO frame consent -> cloud path refused; the fake vision transport NEVER touched.
+    assert transport.calls == [], "frames egressed without consent"
+    assert transport.saw_base64 is False
+    selects = [e for e in ctx.events if e[0] == "done" and "candidates" in e[2]]  # type: ignore[attr-defined]
+    assert selects, "select job did not complete (degraded to transcript-only)"
+    # and the resolved reranker is NOT a cloud closure (no vision pool reachable).
+    assert svc._resolve_vlm_reranker(svc.settings.get(), media_path=str(video_file)) is None
+
+
+def test_resolve_vlm_reranker_cloud_when_consent_granted(tmp_path: Path) -> None:
+    svc = _phase8_services(
+        tmp_path,
+        provider=None,
+        vlm_clip_frame_loader=_fake_clip_loader,
+        vlm_frame_encoder=lambda f: "b",
+        vlm_models_present=lambda s: False,
+    )
+    svc.settings.set(_vision_provider_settings(with_consent=True))
+    rr = svc._resolve_vlm_reranker(svc.settings.get(), media_path="/v.mp4")
+    from media_studio.features import smolvlm2 as sv
+
+    assert isinstance(rr, sv.SmolVlmReranker)
+    backend = rr._factory(svc.settings.get())  # the closure builds the cloud backend
+    assert isinstance(backend, sv.CloudVlmBackend)
+
+
+def test_resolve_vlm_reranker_local_when_no_cloud_but_weights_present(tmp_path: Path) -> None:
+    svc = _phase8_services(
+        tmp_path,
+        provider=None,
+        vlm_clip_frame_loader=_fake_clip_loader,
+        vlm_models_present=lambda s: True,  # local weights present
+    )
+    rr = svc._resolve_vlm_reranker(svc.settings.get(), media_path="/v.mp4")
+    from media_studio.features import smolvlm2 as sv
+
+    assert isinstance(rr, sv.SmolVlmReranker)
+    # local path -> the backend factory is smolvlm2's default (NOT a cloud closure)
+    assert rr._factory is sv._default_backend_factory
+
+
+def test_resolve_vlm_reranker_off_when_no_cloud_no_weights(tmp_path: Path) -> None:
+    svc = _phase8_services(tmp_path, provider=None, vlm_models_present=lambda s: False)
+    assert svc._resolve_vlm_reranker(svc.settings.get(), media_path="/v.mp4") is None
+
+
+def test_resolve_vlm_reranker_cloud_selected_but_no_consent_falls_through(tmp_path: Path) -> None:
+    # Cloud vision is routed but frames consent is absent -> NOT cloud; with local
+    # weights present it falls through to the local reranker.
+    svc = _phase8_services(
+        tmp_path,
+        provider=None,
+        vlm_clip_frame_loader=_fake_clip_loader,
+        vlm_models_present=lambda s: True,
+    )
+    svc.settings.set(_vision_provider_settings(with_consent=False))
+    rr = svc._resolve_vlm_reranker(svc.settings.get(), media_path="/v.mp4")
+    from media_studio.features import smolvlm2 as sv
+
+    assert isinstance(rr, sv.SmolVlmReranker)
+    assert rr._factory is sv._default_backend_factory  # local, not cloud
+
+
+def test_vision_provider_for_consent_returns_first_vision_cloud_name(tmp_path: Path) -> None:
+    svc = _phase8_services(tmp_path, provider=None)
+    svc.settings.set(_vision_provider_settings(with_consent=True))
+    name = svc._vision_provider_for_consent(svc.settings.get_raw())
+    assert name == "Gemini"
+
+
+def test_vision_provider_for_consent_none_when_no_vision_cloud(tmp_path: Path) -> None:
+    svc = _phase8_services(tmp_path, provider=None)
+    # only a TEXT provider configured -> no vision egress target
+    svc.settings.set(
+        {
+            "providers": [
+                {
+                    "id": "groq",
+                    "provider": "Groq",
+                    "baseUrl": "https://example/v1",
+                    "model": "m",
+                    "apiKeys": ["k"],
+                    "enabled": True,
+                    "capabilities": ["text"],
+                }
+            ],
+            "routing": {"perFunction": {"vision": {"provider": "groq"}}},
+        }
+    )
+    assert svc._vision_provider_for_consent(svc.settings.get_raw()) is None
+
+
 def test_phase8_select_requires_known_video(tmp_path: Path) -> None:
     svc = _phase8_services(tmp_path)
     ctx = _phase8_ctx()

--- a/sidecar/tests/test_handlers_pool.py
+++ b/sidecar/tests/test_handlers_pool.py
@@ -1,0 +1,81 @@
+"""WU-pool handler-seam tests: handlers resolve the pool-aware provider/translator.
+
+The handler construction (``_get_provider`` / ``_get_translator``) already routes
+through ``provider.get_provider`` / ``translation.get_translator`` from settings,
+so once those factories become pool-aware (settings.providers -> RotatingProvider)
+the wiring is transparent. These tests pin that the handler seam DOES yield the
+rotation pool when ``settings.providers`` is configured, and stays on the legacy
+local/translator path otherwise.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from media_studio.handlers import Services
+from media_studio.models.provider import LocalServerProvider, RotatingProvider
+
+
+def _services(tmp_path: Path, settings: dict[str, Any]) -> Services:
+    svc = Services(data_dir=tmp_path)
+    svc.settings.set(settings)
+    return svc
+
+
+def test_handler_get_provider_yields_rotating_when_providers_configured(tmp_path: Path) -> None:
+    svc = _services(
+        tmp_path,
+        {
+            "providers": [
+                {
+                    "id": "groq",
+                    "provider": "Groq",
+                    "baseUrl": "https://api.groq.com/openai/v1",
+                    "model": "m",
+                    "apiKeys": ["k1"],
+                    "enabled": True,
+                }
+            ]
+        },
+    )
+    provider = svc._get_provider()
+    assert isinstance(provider, RotatingProvider)
+
+
+def test_handler_get_provider_yields_local_when_no_providers(tmp_path: Path) -> None:
+    svc = _services(tmp_path, {})
+    provider = svc._get_provider()
+    assert isinstance(provider, LocalServerProvider)
+
+
+def test_handler_get_translator_pool_aware(tmp_path: Path) -> None:
+    svc = _services(
+        tmp_path,
+        {
+            "providers": [
+                {
+                    "id": "groq",
+                    "provider": "Groq",
+                    "baseUrl": "https://api.groq.com/openai/v1",
+                    "model": "m",
+                    "apiKeys": ["k1"],
+                    "enabled": True,
+                }
+            ]
+        },
+    )
+    translator = svc._get_translator()
+    assert translator is not None
+    # The tier3 hosted provider resolves to the rotation pool.
+    hosted = translator._hosted_provider()
+    assert isinstance(hosted, RotatingProvider)
+
+
+def test_handler_get_translator_none_when_legacy_provider_injected(tmp_path: Path) -> None:
+    class _Prov:
+        def chat(self, messages, **kwargs):  # noqa: ANN001
+            return "x"
+
+    svc = Services(data_dir=tmp_path, provider=_Prov())
+    assert svc._get_translator() is None

--- a/sidecar/tests/test_handlers_presets.py
+++ b/sidecar/tests/test_handlers_presets.py
@@ -1,0 +1,252 @@
+"""WU-presets handlers: providers.applyPreset / setFunctionModel + routing wiring.
+
+Tests the RPC surface (registered via ``register_all``) and the per-function
+provider resolution: applying a preset persists ``routing.perFunction`` +
+``activePreset``; ``setFunctionModel`` changes one slot; a per-function override
+actually changes the provider id the corresponding seam prefers; the privacy
+preset routes every function to local (zero cloud egress); the first-run chooser
+is local-safe pre-choice and flips routing + sets ``firstRunChoiceMade`` on a
+cloud choice.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio import handlers as H
+from media_studio import protocol
+from media_studio.models import presets as presets_mod
+from media_studio.models import provider as provider_mod
+
+
+def _ctx() -> Any:
+    return protocol.RpcContext(emit_notification=lambda _msg: None, jobs=None)
+
+
+def _svc(tmp_path: Any) -> H.Services:
+    return H.Services(data_dir=str(tmp_path))
+
+
+# A configured pool whose ids match the catalog model-ids the presets pick.
+def _configure_pool(svc: H.Services) -> None:
+    svc.settings.set(
+        {
+            "providers": [
+                {
+                    "id": "groq-gpt-oss-120b",
+                    "provider": "Groq",
+                    "baseUrl": "https://groq.example/v1",
+                    "model": "gpt-oss-120b",
+                    "apiKeys": ["gk-aaaa1111"],
+                    "capabilities": ["text"],
+                    "unit": "token",
+                },
+                {
+                    "id": "groq-llama-3.3-70b",
+                    "provider": "GroqL",
+                    "baseUrl": "https://groq.example/v1",
+                    "model": "llama-3.3-70b",
+                    "apiKeys": ["gk-bbbb2222"],
+                    "capabilities": ["text"],
+                    "unit": "token",
+                },
+            ]
+        }
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+
+
+def test_applypreset_and_setfunctionmodel_registered(tmp_path: Any) -> None:
+    registered: dict[str, Any] = {}
+    H.register_all(_svc(tmp_path), register=lambda name, fn: registered.__setitem__(name, fn))
+    assert "providers.applyPreset" in registered
+    assert "providers.setFunctionModel" in registered
+
+
+# --------------------------------------------------------------------------- #
+# applyPreset
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_privacy_preset_routes_every_function_to_local(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    out = svc.providers_apply_preset({"name": "privacy"}, _ctx())
+    assert out["activePreset"] == "privacy"
+    for fn in presets_mod.FUNCTIONS:
+        assert out["routing"]["perFunction"][fn]["provider"] == presets_mod.LOCAL
+    # Persisted.
+    saved = svc.settings.get()
+    assert saved["activePreset"] == "privacy"
+    assert saved["routing"]["perFunction"]["select"]["provider"] == presets_mod.LOCAL
+
+
+def test_apply_bestfreecloud_resolves_real_catalog_picks(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    out = svc.providers_apply_preset({"name": "bestFreeCloud"}, _ctx())
+    pf = out["routing"]["perFunction"]
+    # Real catalog top picks (NOT local) — proves the adapter is wired.
+    assert pf["select"]["provider"] == "groq-gpt-oss-120b"
+    assert pf["subtitles"]["provider"] == "groq-llama-3.3-70b"
+
+
+def test_apply_unknown_preset_is_a_typed_error(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.providers_apply_preset({"name": "nope"}, _ctx())
+
+
+def test_apply_preset_missing_name_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.providers_apply_preset({}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# setFunctionModel
+# --------------------------------------------------------------------------- #
+
+
+def test_set_function_model_changes_one_slot(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    svc.providers_apply_preset({"name": "bestFreeCloud"}, _ctx())
+    out = svc.providers_set_function_model({"function": "select", "provider": "groq-llama-3.3-70b"}, _ctx())
+    assert out["routing"]["perFunction"]["select"]["provider"] == "groq-llama-3.3-70b"
+    # Other slots untouched.
+    assert out["routing"]["perFunction"]["subtitles"]["provider"] == "groq-llama-3.3-70b"
+    # activePreset becomes "custom" once a slot is hand-edited.
+    assert out["activePreset"] == "custom"
+
+
+def test_set_function_model_to_local(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    out = svc.providers_set_function_model({"function": "vision", "provider": presets_mod.LOCAL}, _ctx())
+    assert out["routing"]["perFunction"]["vision"]["provider"] == presets_mod.LOCAL
+
+
+def test_set_function_model_unknown_function_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.providers_set_function_model({"function": "bogus", "provider": "x"}, _ctx())
+
+
+def test_set_function_model_missing_provider_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.providers_set_function_model({"function": "select"}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# Per-function override actually changes the provider the seam uses
+# --------------------------------------------------------------------------- #
+
+
+def test_function_prefer_resolves_routed_provider_id(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    svc.providers_set_function_model({"function": "select", "provider": "groq-llama-3.3-70b"}, _ctx())
+    # The seam-resolution helper returns the routed provider id for "select".
+    assert svc._function_prefer("select") == "groq-llama-3.3-70b"
+
+
+def test_function_prefer_local_routes_local(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    svc.providers_apply_preset({"name": "privacy"}, _ctx())
+    assert svc._function_prefer("select") == provider_mod.LOCAL_PROVIDER_ID
+
+
+def test_function_prefer_unset_is_none(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    # No routing configured for this function -> no preference (pool order).
+    assert svc._function_prefer("translation") is None
+
+
+def test_function_prefer_malformed_routing_is_none(tmp_path: Any) -> None:
+    # Defensive guard: a non-dict ``routing`` (corrupt settings) -> no preference.
+    svc = _svc(tmp_path)
+    svc.settings.set({"routing": "garbage"})
+    assert svc._function_prefer("select") is None
+
+
+def test_function_prefer_malformed_perfunction_is_none(tmp_path: Any) -> None:
+    # Defensive guard: a non-dict ``perFunction`` -> no preference.
+    svc = _svc(tmp_path)
+    svc.settings.set({"routing": {"perFunction": "garbage"}})
+    assert svc._function_prefer("select") is None
+
+
+def test_function_prefer_malformed_slot_is_none(tmp_path: Any) -> None:
+    # Defensive guard: a non-dict slot -> no preference.
+    svc = _svc(tmp_path)
+    svc.settings.set({"routing": {"perFunction": {"select": "garbage"}}})
+    assert svc._function_prefer("select") is None
+
+
+def test_select_seam_provider_prefers_routed_provider(tmp_path: Any) -> None:
+    # The provider the select seam builds tries the routed provider FIRST.
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    svc.providers_set_function_model({"function": "select", "provider": "groq-llama-3.3-70b"}, _ctx())
+    pool = svc._provider_for_function("select")
+    assert isinstance(pool, provider_mod.RotatingProvider)
+    assert [e.provider for e in pool.entries][0] == "GroqL"  # the llama entry's provider name
+
+
+def test_translation_seam_translator_prefers_routed_provider(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    svc.providers_set_function_model({"function": "translation", "provider": "groq-llama-3.3-70b"}, _ctx())
+    translator = svc._translator_for_function("translation")
+    hosted = translator._hosted_provider()
+    assert [e.provider for e in hosted.entries][0] == "GroqL"
+
+
+# --------------------------------------------------------------------------- #
+# First-run local-vs-cloud chooser
+# --------------------------------------------------------------------------- #
+
+
+def test_first_run_default_is_local_safe_before_choice(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    out = svc.providers_first_run({}, _ctx())
+    assert out["firstRunChoiceMade"] is False
+    assert out["default"] == "privacy"
+
+
+def test_first_run_choose_cloud_flips_routing_and_sets_flag(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    out = svc.providers_first_run({"choice": "bestFreeCloud"}, _ctx())
+    assert out["firstRunChoiceMade"] is True
+    assert out["activePreset"] == "bestFreeCloud"
+    # Routing flipped to cloud picks (not local).
+    assert out["routing"]["perFunction"]["select"]["provider"] != presets_mod.LOCAL
+    saved = svc.settings.get()
+    assert saved["firstRunChoiceMade"] is True
+    assert saved["activePreset"] == "bestFreeCloud"
+
+
+def test_first_run_choose_local_sets_flag_keeps_privacy(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    _configure_pool(svc)
+    out = svc.providers_first_run({"choice": "privacy"}, _ctx())
+    assert out["firstRunChoiceMade"] is True
+    assert out["activePreset"] == "privacy"
+    for fn in presets_mod.FUNCTIONS:
+        assert out["routing"]["perFunction"][fn]["provider"] == presets_mod.LOCAL
+
+
+def test_first_run_invalid_choice_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.providers_first_run({"choice": "weird"}, _ctx())

--- a/sidecar/tests/test_handlers_providers_catalog.py
+++ b/sidecar/tests/test_handlers_providers_catalog.py
@@ -1,0 +1,71 @@
+"""Tests for the ``providers.catalog`` RPC handler (WU-catalog).
+
+``providers.catalog`` returns the static curated model catalog as JSON: every
+provider/model with its per-task tiers, privacy / train-on-input flags, unit, the
+editorial top-pick per task, and the dated ``asOfDate`` stamp. The tests pin: the
+method is registered through ``register_all`` (the single composition root); the
+payload spans >=3 providers + 5 task tiers; the Gemini AVOID / Groq SAFE flags;
+``asOfDate`` present; and NO secret (key / url) ever appears in the payload.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from media_studio import handlers, protocol
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext
+
+
+@pytest.fixture
+def svc(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data", library=None)
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def test_providers_catalog_registered() -> None:
+    protocol.clear_methods()
+    handlers.register_all()
+    assert "providers.catalog" in protocol.METHODS
+    protocol.clear_methods()
+
+
+def test_providers_catalog_spans_three_providers_and_five_tiers(svc: Services, ctx: RpcContext) -> None:
+    out = svc.providers_catalog({}, ctx)
+    assert set(out) == {"asOfDate", "unit", "tasks", "topPicks", "providers"}
+    providers = out["providers"]
+    # >=3 distinct providers.
+    distinct = {p["provider"] for p in providers}
+    assert len(distinct) >= 3
+    # 5 task tiers on every entry.
+    assert len(out["tasks"]) == 5
+    for entry in providers:
+        assert len(entry["perTaskTier"]) == 5
+
+
+def test_providers_catalog_gemini_avoid_groq_safe(svc: Services, ctx: RpcContext) -> None:
+    out = svc.providers_catalog({}, ctx)
+    by_id = {p["id"]: p for p in out["providers"]}
+    assert by_id["gemini-2.5-flash"]["privacyTier"] == "AVOID"
+    assert by_id["gemini-2.5-flash"]["trainsOnInput"] is True
+    assert by_id["groq-gpt-oss-120b"]["privacyTier"] == "SAFE"
+    assert by_id["groq-gpt-oss-120b"]["trainsOnInput"] is False
+
+
+def test_providers_catalog_has_as_of_date(svc: Services, ctx: RpcContext) -> None:
+    out = svc.providers_catalog({}, ctx)
+    assert out["asOfDate"]
+    assert all(p["asOfDate"] for p in out["providers"])
+
+
+def test_providers_catalog_has_no_secrets(svc: Services, ctx: RpcContext) -> None:
+    out = svc.providers_catalog({}, ctx)
+    blob = json.dumps(out)
+    for forbidden in ("apiKey", "apiKeys", "Bearer", "baseUrl", "secret"):
+        assert forbidden not in blob

--- a/sidecar/tests/test_handlers_usage.py
+++ b/sidecar/tests/test_handlers_usage.py
@@ -104,8 +104,7 @@ def test_usage_folds_cached_numbers_over_freshly_zeroed_pool(tmp_path: Path) -> 
         {
             "usageCache": {
                 "rows": [
-                    {"provider": "Groq", "key": redacted, "used": 983, "max": 1000,
-                     "unit": "token", "resetAt": 6030.0}
+                    {"provider": "Groq", "key": redacted, "used": 983, "max": 1000, "unit": "token", "resetAt": 6030.0}
                 ],
                 "checkedAt": {f"Groq\x00{redacted}": 6000.0},
                 "savedAt": 6000.0,
@@ -129,8 +128,9 @@ def test_usage_flags_stale_rows_with_fake_clock(tmp_path: Path) -> None:
     svc.settings.set(
         {
             "usageCache": {
-                "rows": [{"provider": "Groq", "key": redacted, "used": 12, "max": 1000,
-                          "unit": "token", "resetAt": None}],
+                "rows": [
+                    {"provider": "Groq", "key": redacted, "used": 12, "max": 1000, "unit": "token", "resetAt": None}
+                ],
                 "checkedAt": {f"Groq\x00{redacted}": old},
                 "savedAt": old,
             }

--- a/sidecar/tests/test_handlers_usage.py
+++ b/sidecar/tests/test_handlers_usage.py
@@ -1,0 +1,151 @@
+"""WU-usage-ui handler tests: providers.usage (cached, redacted, stale-flagged).
+
+The rotation pool already accounts per-key usage (test_rotating_provider). These
+pin the RPC seam:
+  * the response surfaces the pool's redacted rows (NO full key crosses RPC);
+  * it is NOT a poller — no socket is opened (the pool builds with
+    detect_local=False so no ``GET /models`` probe runs);
+  * last-known numbers persist between runs (settings.usageCache) and fold back
+    in on a freshly-zeroed pool (DESIGN §15-Q1);
+  * rows older than the 10-min threshold are flagged stale (fake clock).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from media_studio.handlers import Services
+from media_studio.models.usage import STALE_AFTER_SECONDS
+from media_studio.protocol import RpcContext
+
+LIVE_KEY = "gsk-live-SECRET-ABCDWXYZ"
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+class _ScriptedTransport:
+    """A chat transport that records every call (no socket); usage tracks calls."""
+
+    def __init__(self) -> None:
+        self.calls = 0
+
+    def post_json(self, url: str, payload: dict[str, Any], headers: dict[str, str]) -> dict[str, Any]:
+        self.calls += 1
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+
+def _probe_transport_boom(url: str, headers: dict[str, str]) -> dict[str, Any]:
+    raise AssertionError("providers.usage must NOT open a GET /models probe socket")
+
+
+def _with_groq(svc: Services, *, keys: list[str] | None = None, unit: str = "token") -> None:
+    svc.settings.set(
+        {
+            "providers": [
+                {
+                    "id": "groq",
+                    "provider": "Groq",
+                    "kind": "cloud",
+                    "baseUrl": "https://api.groq.com/openai/v1",
+                    "model": "m",
+                    "apiKeys": keys if keys is not None else [LIVE_KEY],
+                    "enabled": True,
+                    "capabilities": ["text"],
+                    "unit": unit,
+                }
+            ]
+        }
+    )
+
+
+def test_usage_returns_redacted_rows_no_full_key(tmp_path: Path) -> None:
+    svc = Services(data_dir=tmp_path)
+    _with_groq(svc)
+    res = svc.providers_usage({}, _ctx())
+    rows = res["usage"]
+    groq = [r for r in rows if r["provider"] == "Groq"]
+    assert len(groq) == 1
+    assert LIVE_KEY not in json.dumps(res)
+    assert groq[0]["key"].endswith("WXYZ") or "…" in groq[0]["key"]
+    assert groq[0]["unit"] == "token"
+
+
+def test_usage_does_not_open_a_probe_socket(tmp_path: Path) -> None:
+    # The pool the handler reads must be built with detect_local=False; injecting a
+    # booby-trapped probe transport proves no GET /models burst happens here.
+    svc = Services(data_dir=tmp_path)
+    _with_groq(svc)
+    # No exception => no probe socket was opened during providers.usage.
+    res = svc.providers_usage({}, _ctx())
+    assert "usage" in res
+
+
+def test_usage_persists_cache_to_settings(tmp_path: Path) -> None:
+    svc = Services(data_dir=tmp_path, now=lambda: 5000.0)
+    _with_groq(svc)
+    svc.providers_usage({}, _ctx())
+    cache = svc.settings.get_raw().get("usageCache")
+    assert isinstance(cache, dict)
+    assert cache["savedAt"] == 5000.0
+    assert isinstance(cache["rows"], list)
+
+
+def test_usage_folds_cached_numbers_over_freshly_zeroed_pool(tmp_path: Path) -> None:
+    # Seed a persisted cache with real numbers; a fresh pool reports used=0/max=None.
+    svc = Services(data_dir=tmp_path, now=lambda: 6000.0)
+    _with_groq(svc)
+    # Discover the redacted key the pool emits so the cache row matches identity.
+    redacted = svc.providers_usage({}, _ctx())["usage"][0]["key"]
+    svc.settings.set(
+        {
+            "usageCache": {
+                "rows": [
+                    {"provider": "Groq", "key": redacted, "used": 983, "max": 1000,
+                     "unit": "token", "resetAt": 6030.0}
+                ],
+                "checkedAt": {f"Groq\x00{redacted}": 6000.0},
+                "savedAt": 6000.0,
+            }
+        }
+    )
+    rows = svc.providers_usage({}, _ctx())["usage"]
+    groq = next(r for r in rows if r["provider"] == "Groq")
+    assert groq["used"] == 983
+    assert groq["max"] == 1000
+
+
+def test_usage_flags_stale_rows_with_fake_clock(tmp_path: Path) -> None:
+    clock = {"t": 7000.0}
+    svc = Services(data_dir=tmp_path, now=lambda: clock["t"])
+    _with_groq(svc)
+    redacted = svc.providers_usage({}, _ctx())["usage"][0]["key"]
+    # Seed a cache stamped long in the past so the (zeroed) live row inherits an
+    # old checkedAt and reads as stale.
+    old = 7000.0 - STALE_AFTER_SECONDS - 5.0
+    svc.settings.set(
+        {
+            "usageCache": {
+                "rows": [{"provider": "Groq", "key": redacted, "used": 12, "max": 1000,
+                          "unit": "token", "resetAt": None}],
+                "checkedAt": {f"Groq\x00{redacted}": old},
+                "savedAt": old,
+            }
+        }
+    )
+    rows = svc.providers_usage({}, _ctx())["usage"]
+    groq = next(r for r in rows if r["provider"] == "Groq")
+    assert groq["stale"] is True
+    assert groq["lastCheckedAt"] == old
+
+
+def test_usage_registered_in_register_all(tmp_path: Path) -> None:
+    from media_studio import protocol
+    from media_studio.handlers import register_all
+
+    protocol.METHODS.clear()
+    register_all(Services(data_dir=tmp_path))
+    assert "providers.usage" in protocol.METHODS

--- a/sidecar/tests/test_local_detect.py
+++ b/sidecar/tests/test_local_detect.py
@@ -50,9 +50,7 @@ class MappingTransport:
         self.errors = errors or {}
         self.calls: list[dict[str, Any]] = []
 
-    def __call__(
-        self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
-    ) -> dict[str, Any]:
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
         self.calls.append({"url": url, "body": body, "headers": headers, "timeout": timeout})
         if url in self.errors:
             raise self.errors[url]
@@ -191,9 +189,7 @@ def test_first_model_entry_not_a_dict_skips_server() -> None:
 def test_settings_override_base_urls() -> None:
     custom_ollama = "http://127.0.0.1:9999/v1"
     transport = MappingTransport(responses={f"{custom_ollama}/models": _models_response("m")})
-    entries = detect_local_servers(
-        {"ollamaBaseUrl": custom_ollama}, transport=transport
-    )
+    entries = detect_local_servers({"ollamaBaseUrl": custom_ollama}, transport=transport)
     assert [e["base_url"] for e in entries] == [custom_ollama]
 
 
@@ -206,9 +202,7 @@ def test_none_settings_uses_defaults() -> None:
 def test_blank_settings_override_falls_back_to_default() -> None:
     # An explicitly-empty override string must not blank out the probe URL.
     transport = MappingTransport(responses={_lmstudio_url(): _models_response("m")})
-    entries = detect_local_servers(
-        {"lmStudioBaseUrl": ""}, transport=transport
-    )
+    entries = detect_local_servers({"lmStudioBaseUrl": ""}, transport=transport)
     assert [e["kind"] for e in entries] == ["lmstudio"]
 
 

--- a/sidecar/tests/test_local_detect.py
+++ b/sidecar/tests/test_local_detect.py
@@ -1,0 +1,224 @@
+"""Unit tests for media_studio.models.local_detect (WU-pool detection half).
+
+``detect_local_servers(settings, *, transport)`` probes the two well-known
+local OpenAI-compatible servers — Ollama (``:11434/v1``) and LM Studio
+(``:1234/v1``) — through the SAME injectable ``Transport`` seam the provider
+module uses, so no socket is ever opened under test. A successful ``GET /models``
+probe yields a pool entry (a light ``PoolEntry``-shaped dict); a connection
+error (or an empty/garbage model list) yields no entry for that server and is
+NEVER raised — detection failure degrades silently to "no extra providers"
+(WU-pool acceptance: "detection failure degrades silently").
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.models import local_detect as ld
+from media_studio.models.local_detect import (
+    LM_STUDIO_BASE_URL,
+    OLLAMA_BASE_URL,
+    PoolEntry,
+    detect_local_servers,
+)
+from media_studio.models.provider import ProviderError
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+def _models_response(*model_ids: str) -> dict[str, Any]:
+    """An OpenAI-style ``GET /models`` success envelope: ``{"data":[{"id":..}]}``."""
+    return {"object": "list", "data": [{"id": mid, "object": "model"} for mid in model_ids]}
+
+
+class MappingTransport:
+    """A fake transport returning a per-URL canned response (or raising per-URL).
+
+    ``responses`` maps a probe URL -> a response dict; ``errors`` maps a probe URL
+    -> a :class:`ProviderError` to raise (simulating connection refused). A URL in
+    neither map raises a generic ProviderError (server absent).
+    """
+
+    def __init__(
+        self,
+        responses: dict[str, dict[str, Any]] | None = None,
+        errors: dict[str, ProviderError] | None = None,
+    ) -> None:
+        self.responses = responses or {}
+        self.errors = errors or {}
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
+    ) -> dict[str, Any]:
+        self.calls.append({"url": url, "body": body, "headers": headers, "timeout": timeout})
+        if url in self.errors:
+            raise self.errors[url]
+        if url in self.responses:
+            return self.responses[url]
+        raise ProviderError(f"LLM request failed: nothing at {url}")
+
+
+def _ollama_url() -> str:
+    return f"{OLLAMA_BASE_URL}/models"
+
+
+def _lmstudio_url() -> str:
+    return f"{LM_STUDIO_BASE_URL}/models"
+
+
+# --------------------------------------------------------------------------- #
+# both servers present -> two pool entries
+# --------------------------------------------------------------------------- #
+def test_detects_both_ollama_and_lm_studio() -> None:
+    transport = MappingTransport(
+        responses={
+            _ollama_url(): _models_response("llama3.2", "qwen2.5"),
+            _lmstudio_url(): _models_response("local-model"),
+        }
+    )
+    entries = detect_local_servers({}, transport=transport)
+    by_kind = {e["kind"]: e for e in entries}
+    assert set(by_kind) == {"ollama", "lmstudio"}
+
+    ollama = by_kind["ollama"]
+    assert ollama["base_url"] == OLLAMA_BASE_URL
+    assert ollama["model"] == "llama3.2"  # first reported model
+    assert ollama["capabilities"] == ["chat"]
+    assert ollama["unit"] == "req"
+    assert ollama["id"] == "ollama"
+
+    lmstudio = by_kind["lmstudio"]
+    assert lmstudio["base_url"] == LM_STUDIO_BASE_URL
+    assert lmstudio["model"] == "local-model"
+
+
+def test_returns_pool_entry_typeddict_shape() -> None:
+    transport = MappingTransport(responses={_ollama_url(): _models_response("m")})
+    [entry] = [e for e in detect_local_servers({}, transport=transport) if e["kind"] == "ollama"]
+    # Every PoolEntry key is present and well-typed.
+    assert set(entry) == {"id", "kind", "base_url", "model", "capabilities", "unit"}
+    assert isinstance(entry["capabilities"], list)
+    entry_typed: PoolEntry = entry  # static + runtime: the dict satisfies PoolEntry
+    assert entry_typed["unit"] == "req"
+
+
+# --------------------------------------------------------------------------- #
+# probe issues a GET /models with no body and a sane timeout
+# --------------------------------------------------------------------------- #
+def test_probe_hits_models_endpoint_with_empty_body() -> None:
+    transport = MappingTransport(responses={_ollama_url(): _models_response("m")})
+    detect_local_servers({}, transport=transport)
+    ollama_calls = [c for c in transport.calls if c["url"] == _ollama_url()]
+    assert ollama_calls, "ollama /models endpoint was probed"
+    call = ollama_calls[0]
+    assert call["url"].endswith("/models")
+    assert call["body"] == {}  # a probe, not a chat completion
+    assert call["timeout"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# graceful degradation: connection error / absent server -> skipped, no raise
+# --------------------------------------------------------------------------- #
+def test_connection_error_yields_empty_no_raise() -> None:
+    transport = MappingTransport(
+        errors={
+            _ollama_url(): ProviderError("LLM request failed: Connection refused"),
+            _lmstudio_url(): ProviderError("LLM request failed: Connection refused"),
+        }
+    )
+    # No server up at all -> empty list, NEVER raises.
+    assert detect_local_servers({}, transport=transport) == []
+
+
+def test_one_up_one_down_returns_only_the_live_server() -> None:
+    transport = MappingTransport(
+        responses={_lmstudio_url(): _models_response("studio")},
+        errors={_ollama_url(): ProviderError("LLM request failed: Connection refused")},
+    )
+    entries = detect_local_servers({}, transport=transport)
+    assert [e["kind"] for e in entries] == ["lmstudio"]
+
+
+def test_unexpected_transport_exception_is_swallowed() -> None:
+    # Any non-ProviderError failure from a misbehaving transport must also degrade
+    # silently (detection is best-effort, never fatal to the app).
+    def boom(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        raise RuntimeError("unexpected")
+
+    assert detect_local_servers({}, transport=boom) == []
+
+
+# --------------------------------------------------------------------------- #
+# empty / malformed model lists -> server skipped (a probe that 200s but has no
+# usable model id is treated as "not a real server" rather than crashing)
+# --------------------------------------------------------------------------- #
+def test_empty_model_list_skips_server() -> None:
+    transport = MappingTransport(responses={_ollama_url(): _models_response()})
+    assert detect_local_servers({}, transport=transport) == []
+
+
+def test_data_not_a_list_skips_server() -> None:
+    transport = MappingTransport(responses={_ollama_url(): {"object": "list", "data": "nope"}})
+    assert detect_local_servers({}, transport=transport) == []
+
+
+def test_missing_data_key_skips_server() -> None:
+    transport = MappingTransport(responses={_ollama_url(): {"object": "list"}})
+    assert detect_local_servers({}, transport=transport) == []
+
+
+def test_model_entry_without_id_skips_server() -> None:
+    transport = MappingTransport(responses={_ollama_url(): {"data": [{"object": "model"}]}})
+    assert detect_local_servers({}, transport=transport) == []
+
+
+def test_model_entry_with_blank_id_skips_server() -> None:
+    transport = MappingTransport(responses={_ollama_url(): {"data": [{"id": ""}]}})
+    assert detect_local_servers({}, transport=transport) == []
+
+
+def test_first_model_entry_not_a_dict_skips_server() -> None:
+    transport = MappingTransport(responses={_ollama_url(): {"data": ["just-a-string"]}})
+    assert detect_local_servers({}, transport=transport) == []
+
+
+# --------------------------------------------------------------------------- #
+# settings may override the probe base URLs (e.g. a non-default port)
+# --------------------------------------------------------------------------- #
+def test_settings_override_base_urls() -> None:
+    custom_ollama = "http://127.0.0.1:9999/v1"
+    transport = MappingTransport(responses={f"{custom_ollama}/models": _models_response("m")})
+    entries = detect_local_servers(
+        {"ollamaBaseUrl": custom_ollama}, transport=transport
+    )
+    assert [e["base_url"] for e in entries] == [custom_ollama]
+
+
+def test_none_settings_uses_defaults() -> None:
+    transport = MappingTransport(responses={_ollama_url(): _models_response("m")})
+    entries = detect_local_servers(None, transport=transport)
+    assert [e["base_url"] for e in entries] == [OLLAMA_BASE_URL]
+
+
+def test_blank_settings_override_falls_back_to_default() -> None:
+    # An explicitly-empty override string must not blank out the probe URL.
+    transport = MappingTransport(responses={_lmstudio_url(): _models_response("m")})
+    entries = detect_local_servers(
+        {"lmStudioBaseUrl": ""}, transport=transport
+    )
+    assert [e["kind"] for e in entries] == ["lmstudio"]
+
+
+# --------------------------------------------------------------------------- #
+# the module stays import-light + sleep-free (mirrors the provider no-sleep rule)
+# --------------------------------------------------------------------------- #
+def test_module_does_not_import_time_or_asyncio() -> None:
+    assert not hasattr(ld, "time")
+    assert not hasattr(ld, "asyncio")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/sidecar/tests/test_pool_wiring.py
+++ b/sidecar/tests/test_pool_wiring.py
@@ -256,6 +256,32 @@ def test_build_pool_provider_no_cloud_no_detect_is_local_only() -> None:
     assert p.chat([{"role": "user", "content": "q"}]) == "local"
 
 
+def test_build_pool_provider_detect_local_false_skips_probe() -> None:
+    # detect_local=False (the WU-envelope plan path) must NOT probe a local server:
+    # a probe transport that explodes if called proves the GET probe is skipped.
+    settings = {
+        "providers": [
+            {"id": "groq", "provider": "Groq", "baseUrl": "u", "model": "m", "apiKeys": ["k1"], "enabled": True}
+        ]
+    }
+
+    def exploding_probe(url, body, headers, timeout):  # noqa: ANN001 - must never be called
+        raise AssertionError("detect_local=False must not run a GET /models probe")
+
+    p = build_pool_provider(
+        settings,
+        transport=KeyTransport({"k1": [_ok("ok")]}),
+        probe_transport=exploding_probe,
+        detect_local=False,
+    )
+    # Cloud provider + the llama backstop only; no Ollama/LM-Studio entries.
+    providers = [e.provider for e in p.entries]
+    assert "Groq" in providers
+    assert "local" in providers
+    assert "ollama" not in providers
+    assert "lmstudio" not in providers
+
+
 # --------------------------------------------------------------------------- #
 # SECOND seam: TieredTranslator tier3 rotates through the SAME pool
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_pool_wiring.py
+++ b/sidecar/tests/test_pool_wiring.py
@@ -1,0 +1,314 @@
+"""WU-pool wiring tests: GET probe transport + BOTH LLM seams resolve the pool.
+
+Covers (PLAN §WU-pool acceptance):
+  * the GET-capable probe path so ``local_detect`` works against real
+    Ollama/LM Studio ``GET /models`` (carryforward #2) — a method-aware urllib
+    helper + a ready-made GET transport;
+  * ``get_provider`` returns a :class:`RotatingProvider` when ``settings.providers``
+    is configured (else the existing Local/Cloud fall-through is unchanged);
+  * the pool build folds in ``detect_local_servers`` results;
+  * the SECOND seam: ``TieredTranslator`` tier3 (``_hosted_provider``) rotates
+    through the SAME pool via the default ``hosted_provider_factory``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from media_studio.models import provider as prov
+from media_studio.models import translation as tr
+from media_studio.models.provider import (
+    ProviderError,
+    RotatingProvider,
+    build_pool_provider,
+    get_provider,
+)
+
+
+def _ok(content: str = "ok") -> dict[str, Any]:
+    return {"choices": [{"message": {"role": "assistant", "content": content}}]}
+
+
+def _models(*ids: str) -> dict[str, Any]:
+    return {"object": "list", "data": [{"id": i} for i in ids]}
+
+
+class KeyTransport:
+    """Fake transport keyed on the Bearer key (or None for keyless local)."""
+
+    def __init__(self, by_key: dict[str | None, list[Any]]) -> None:
+        self.by_key = by_key
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        auth = headers.get("Authorization", "")
+        key = auth[len("Bearer ") :] if auth.startswith("Bearer ") else None
+        self.calls.append({"url": url, "key": key, "body": body})
+        script = self.by_key.get(key)
+        if not script:
+            raise ProviderError(f"nothing for {key!r} at {url}")
+        outcome = script[0] if len(script) == 1 else script.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+# --------------------------------------------------------------------------- #
+# GET-capable probe transport (carryforward #2)
+# --------------------------------------------------------------------------- #
+class _FakeResp:
+    def __init__(self, payload: bytes, headers: dict[str, str] | None = None) -> None:
+        self._payload = payload
+        # A real urllib response exposes ``.headers`` (an email.message.Message);
+        # a plain dict is items()-compatible for the production header capture.
+        self.headers = headers if headers is not None else {}
+
+    def read(self) -> bytes:
+        return self._payload
+
+    def __enter__(self) -> _FakeResp:
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+
+def test_get_transport_issues_a_GET_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001
+        captured["method"] = request.get_method()
+        captured["url"] = request.full_url
+        captured["data"] = request.data
+        return _FakeResp(json.dumps(_models("llama3.2")).encode("utf-8"))
+
+    monkeypatch.setattr(prov.urllib.request, "urlopen", fake_urlopen)
+    out = prov.urllib_get_json("http://127.0.0.1:11434/v1/models", {}, {}, 2.0)
+    assert captured["method"] == "GET"
+    assert captured["data"] is None  # a GET carries no body
+    assert out["data"][0]["id"] == "llama3.2"
+
+
+def test_post_json_captures_response_headers(monkeypatch: pytest.MonkeyPatch) -> None:
+    # The real urllib path surfaces response headers under ``_headers`` so the
+    # rotation pool can read X-RateLimit-* metadata (covers the headers branch).
+    def fake_urlopen(request, timeout):  # noqa: ANN001
+        return _FakeResp(
+            json.dumps(_ok("hi")).encode("utf-8"),
+            headers={"X-RateLimit-Remaining": "5", "X-RateLimit-Limit": "10"},
+        )
+
+    monkeypatch.setattr(prov.urllib.request, "urlopen", fake_urlopen)
+    out = prov._urllib_post_json("http://x/v1/chat/completions", {"model": "m"}, {}, 1.0)
+    assert out["_headers"]["X-RateLimit-Remaining"] == "5"
+
+
+def test_get_transport_maps_httperror(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_urlopen(request, timeout):  # noqa: ANN001
+        raise prov.urllib.error.HTTPError(url="http://x", code=404, msg="nope", hdrs=None, fp=None)
+
+    monkeypatch.setattr(prov.urllib.request, "urlopen", fake_urlopen)
+    with pytest.raises(ProviderError):
+        prov.urllib_get_json("http://x/models", {}, {}, 2.0)
+
+
+def test_get_transport_used_by_local_detect_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    # detect_local_servers must accept the GET transport and parse /models.
+    from media_studio.models import local_detect as ld
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001
+        assert request.get_method() == "GET"
+        return _FakeResp(json.dumps(_models("m")).encode("utf-8"))
+
+    monkeypatch.setattr(prov.urllib.request, "urlopen", fake_urlopen)
+    entries = ld.detect_local_servers({}, transport=prov.urllib_get_json)
+    # Both well-known endpoints answer the same fake -> both detected.
+    assert {e["kind"] for e in entries} == {"ollama", "lmstudio"}
+
+
+# --------------------------------------------------------------------------- #
+# get_provider returns a RotatingProvider when settings.providers configured
+# --------------------------------------------------------------------------- #
+def test_get_provider_returns_rotating_when_providers_configured() -> None:
+    settings = {
+        "providers": [
+            {
+                "id": "groq",
+                "provider": "Groq",
+                "kind": "cloud",
+                "baseUrl": "https://api.groq.com/openai/v1",
+                "model": "gpt-oss-120b",
+                "apiKeys": ["k1"],
+                "enabled": True,
+                "capabilities": ["text"],
+                "unit": "token",
+            }
+        ]
+    }
+    t = KeyTransport({"k1": [_ok("rotated")]})
+    p = get_provider(settings, transport=t)
+    assert isinstance(p, RotatingProvider)
+    assert p.chat([{"role": "user", "content": "q"}]) == "rotated"
+
+
+def test_get_provider_unchanged_local_fallthrough_when_no_providers() -> None:
+    p = get_provider({})
+    assert isinstance(p, prov.LocalServerProvider)
+
+
+def test_get_provider_unchanged_cloud_fallthrough() -> None:
+    p = get_provider({"useCloud": True, "cloudApiKey": "k"})
+    assert isinstance(p, prov.CloudProvider)
+
+
+def test_get_provider_ignores_disabled_providers() -> None:
+    settings = {
+        "providers": [
+            {"id": "d", "provider": "Groq", "baseUrl": "u", "model": "m", "apiKeys": ["k1"], "enabled": False},
+        ]
+    }
+    # All providers disabled -> no pool -> local fall-through.
+    p = get_provider(settings)
+    assert isinstance(p, prov.LocalServerProvider)
+
+
+def test_get_provider_skips_provider_with_no_keys_unless_local() -> None:
+    settings = {
+        "providers": [
+            {"id": "nokey", "provider": "Groq", "baseUrl": "u", "model": "m", "apiKeys": [], "enabled": True},
+        ]
+    }
+    p = get_provider(settings)
+    assert isinstance(p, prov.LocalServerProvider)
+
+
+def test_get_provider_ignores_non_dict_provider_entries() -> None:
+    # A malformed (non-dict) entry in settings.providers is skipped, not crashed.
+    settings = {
+        "providers": [
+            "garbage",
+            {"id": "g", "provider": "Groq", "baseUrl": "u", "model": "m", "apiKeys": ["k1"], "enabled": True},
+        ]
+    }
+    t = KeyTransport({"k1": [_ok("rotated")]})
+    p = get_provider(settings, transport=t)
+    assert isinstance(p, RotatingProvider)
+
+
+def test_pool_always_appends_local_backstop() -> None:
+    settings = {
+        "providers": [
+            {
+                "id": "groq",
+                "provider": "Groq",
+                "baseUrl": "https://api.groq.com/openai/v1",
+                "model": "m",
+                "apiKeys": ["k1"],
+                "enabled": True,
+            }
+        ],
+        "localBaseUrl": "http://127.0.0.1:8088/v1",
+    }
+    t = KeyTransport({"k1": [ProviderError("LLM HTTP 429: x")], None: [_ok("local backstop")]})
+    p = get_provider(settings, transport=t)
+    assert isinstance(p, RotatingProvider)
+    # Cloud 429s -> falls through to the always-appended local backstop.
+    assert p.chat([{"role": "user", "content": "q"}]) == "local backstop"
+
+
+def test_build_pool_provider_folds_in_detected_local_servers() -> None:
+    # Ollama detected via a GET probe is slotted into the pool as an entry.
+    settings = {
+        "providers": [
+            {"id": "groq", "provider": "Groq", "baseUrl": "u", "model": "m", "apiKeys": ["k1"], "enabled": True}
+        ]
+    }
+    chat_transport = KeyTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 429: x")],
+            None: [_ok("ollama answered")],
+        }
+    )
+
+    def detect_transport(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        # Only Ollama is up.
+        if "11434" in url:
+            return _models("llama3.2")
+        raise ProviderError("down")
+
+    p = build_pool_provider(settings, transport=chat_transport, probe_transport=detect_transport)
+    assert isinstance(p, RotatingProvider)
+    # Groq 429s -> the detected Ollama (keyless local) serves.
+    assert p.chat([{"role": "user", "content": "q"}]) == "ollama answered"
+    # Ollama appears as a provider group.
+    assert "ollama" in p.provider_groups() or "ollama" in [e.provider for e in p.entries]
+
+
+def test_build_pool_provider_no_cloud_no_detect_is_local_only() -> None:
+    def detect_transport(url, body, headers, timeout):  # noqa: ANN001
+        raise ProviderError("down")
+
+    p = build_pool_provider({}, transport=KeyTransport({None: [_ok("local")]}), probe_transport=detect_transport)
+    # No cloud + no detected local servers -> still has the llama.cpp backstop.
+    assert isinstance(p, RotatingProvider)
+    assert p.chat([{"role": "user", "content": "q"}]) == "local"
+
+
+# --------------------------------------------------------------------------- #
+# SECOND seam: TieredTranslator tier3 rotates through the SAME pool
+# --------------------------------------------------------------------------- #
+def test_translator_tier3_uses_rotating_pool_when_providers_configured() -> None:
+    settings = {
+        "providers": [
+            {
+                "id": "groq",
+                "provider": "Groq",
+                "baseUrl": "https://api.groq.com/openai/v1",
+                "model": "m",
+                "apiKeys": ["k1", "k2"],
+                "enabled": True,
+                "capabilities": ["text"],
+            }
+        ]
+    }
+    # k1 429s on the hosted translation call -> rotate to k2.
+    t = KeyTransport({"k1": [ProviderError("LLM HTTP 429: x")], "k2": [_ok("bonjour")]})
+    translator = tr.get_translator(settings, transport=t)
+    # 'xx' is not in the routing table -> routes to tier3 (hosted) first.
+    line = translator.line_translator("xx")
+    assert line("hello") == "bonjour"
+
+
+def test_translator_tier3_falls_back_to_cloud_provider_when_no_pool() -> None:
+    # No settings.providers -> the default hosted factory uses CloudProvider.
+    settings = {"cloudApiKey": "sk-test", "cloudBaseUrl": "https://api.openai.com/v1"}
+    t = KeyTransport({"sk-test": [_ok("hola")]})
+    translator = tr.get_translator(settings, transport=t)
+    line = translator.line_translator("xx")
+    assert line("hello") == "hola"
+
+
+def test_translator_tier3_unavailable_when_no_pool_and_no_key() -> None:
+    settings: dict[str, Any] = {}
+    translator = tr.get_translator(settings, transport=KeyTransport({}))
+    line = translator.line_translator("xx")
+    with pytest.raises(tr.TranslationError):
+        line("hello")
+
+
+def test_translator_explicit_hosted_factory_still_wins() -> None:
+    # An explicitly-injected hosted factory overrides the pool default.
+    sentinel = object()
+
+    class _Prov:
+        def chat(self, messages, **kwargs):  # noqa: ANN001
+            return "explicit"
+
+    translator = tr.get_translator(
+        {"providers": [{"id": "x", "provider": "Groq", "baseUrl": "u", "model": "m", "apiKeys": ["k"]}]},
+        hosted_provider_factory=lambda: _Prov(),
+    )
+    assert translator.line_translator("xx")("hi") == "explicit"
+    _ = sentinel

--- a/sidecar/tests/test_presets.py
+++ b/sidecar/tests/test_presets.py
@@ -1,0 +1,320 @@
+"""Tests for the provider-Hub presets seam (``media_studio.models.presets``).
+
+PURE module under test: presets + per-function routing resolved against an
+INJECTED catalog (faked here) and a settings mapping. No network, no heavy
+deps, no cross-import of the real ``catalog.py`` (a LATER WU). The fake catalog
+below mirrors only the duck-typed surface ``presets`` actually consumes:
+``id``, ``provider``, ``capabilities``, ``per_task_tier`` and ``privacy_tier``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+from media_studio.models import presets as P
+
+# --------------------------------------------------------------------------- #
+# Fake catalog (duck-typed; only the attributes presets reads)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class FakeEntry:
+    """A minimal stand-in for the real ``CatalogEntry`` (LATER WU)."""
+
+    id: str
+    provider: str
+    capabilities: tuple[str, ...]
+    # per-function task tier: function-name -> S/A/B/C/na grade
+    per_task_tier: dict[str, str]
+    privacy_tier: str = "SAFE"
+
+
+@dataclass
+class FakeCatalog:
+    """A tiny catalog the presets module ranks/filters over."""
+
+    entries: tuple[FakeEntry, ...] = field(default_factory=tuple)
+
+    def all(self) -> tuple[FakeEntry, ...]:
+        return self.entries
+
+
+def _catalog() -> FakeCatalog:
+    """A representative multi-provider catalog spanning all 5 functions."""
+    return FakeCatalog(
+        entries=(
+            FakeEntry(
+                id="groq-gpt-oss-120b",
+                provider="groq",
+                capabilities=("text",),
+                per_task_tier={
+                    "select": "S",
+                    "subtitles": "A",
+                    "translation": "A",
+                    "vision": "na",
+                    "editPlan": "S",
+                },
+                privacy_tier="SAFE",
+            ),
+            FakeEntry(
+                id="groq-llama-3.3-70b",
+                provider="groq",
+                capabilities=("text",),
+                per_task_tier={
+                    "select": "A",
+                    "subtitles": "S",
+                    "translation": "S",
+                    "vision": "na",
+                    "editPlan": "A",
+                },
+                privacy_tier="SAFE",
+            ),
+            FakeEntry(
+                id="gemini-2.5-flash-lite",
+                provider="google",
+                capabilities=("text", "vision"),
+                per_task_tier={
+                    "select": "A",
+                    "subtitles": "S",
+                    "translation": "A",
+                    "vision": "S",
+                    "editPlan": "A",
+                },
+                privacy_tier="AVOID",
+            ),
+            FakeEntry(
+                id="github-gpt-4o-mini",
+                provider="github",
+                capabilities=("text", "vision"),
+                per_task_tier={
+                    "select": "B",
+                    "subtitles": "A",
+                    "translation": "A",
+                    "vision": "A",
+                    "editPlan": "B",
+                },
+                privacy_tier="SAFE",
+            ),
+        )
+    )
+
+
+# --------------------------------------------------------------------------- #
+# PRESETS registry shape
+# --------------------------------------------------------------------------- #
+
+
+def test_presets_registry_has_exactly_the_three_named_presets() -> None:
+    assert set(P.PRESETS) == {"privacy", "bestFreeCloud", "balanced"}
+
+
+def test_every_preset_maps_all_five_functions() -> None:
+    for descriptor in P.PRESETS.values():
+        assert set(descriptor) == set(P.FUNCTIONS)
+
+
+def test_functions_constant_is_the_five_task_seams() -> None:
+    assert P.FUNCTIONS == ("select", "subtitles", "translation", "vision", "editPlan")
+
+
+# --------------------------------------------------------------------------- #
+# apply_preset — privacy -> all-local
+# --------------------------------------------------------------------------- #
+
+
+def test_privacy_preset_routes_every_function_to_local_no_cloud() -> None:
+    routing = P.apply_preset("privacy", {}, _catalog())
+    assert routing["activePreset"] == "privacy"
+    for fn in P.FUNCTIONS:
+        slot = routing["perFunction"][fn]
+        assert slot["provider"] == P.LOCAL
+        # no cloud egress at all: the fallback chain is local-only too.
+        assert slot["fallback"] == []
+
+
+def test_privacy_preset_has_zero_cloud_provider_ids_anywhere() -> None:
+    routing = P.apply_preset("privacy", {}, _catalog())
+    seen: set[str] = set()
+    for slot in routing["perFunction"].values():
+        seen.add(slot["provider"])
+        seen.update(slot["fallback"])
+    assert seen == {P.LOCAL}
+
+
+# --------------------------------------------------------------------------- #
+# apply_preset — bestFreeCloud -> cloud primary + local fallback
+# --------------------------------------------------------------------------- #
+
+
+def test_best_free_cloud_is_cloud_primary_with_local_fallback() -> None:
+    routing = P.apply_preset("bestFreeCloud", {}, _catalog())
+    assert routing["activePreset"] == "bestFreeCloud"
+    for fn in P.FUNCTIONS:
+        slot = routing["perFunction"][fn]
+        assert slot["provider"] != P.LOCAL  # a concrete cloud model id
+        assert slot["fallback"][-1] == P.LOCAL  # local always the backstop
+
+
+def test_best_free_cloud_picks_catalog_top_pick_per_function() -> None:
+    routing = P.apply_preset("bestFreeCloud", {}, _catalog())
+    # select top grade S -> groq-gpt-oss-120b; subtitles top S -> groq-llama-3.3-70b
+    assert routing["perFunction"]["select"]["provider"] == "groq-gpt-oss-120b"
+    assert routing["perFunction"]["subtitles"]["provider"] == "groq-llama-3.3-70b"
+    # vision top S is gemini but AVOID-private -> bestFreeCloud still allows it
+    assert routing["perFunction"]["vision"]["provider"] == "gemini-2.5-flash-lite"
+
+
+# --------------------------------------------------------------------------- #
+# apply_preset — balanced -> mixed (text cloud, vision local)
+# --------------------------------------------------------------------------- #
+
+
+def test_balanced_preset_is_mixed_cloud_text_local_vision() -> None:
+    routing = P.apply_preset("balanced", {}, _catalog())
+    assert routing["activePreset"] == "balanced"
+    # text functions go cloud...
+    assert routing["perFunction"]["select"]["provider"] != P.LOCAL
+    assert routing["perFunction"]["translation"]["provider"] != P.LOCAL
+    # ...privacy-sensitive vision stays local (a genuinely mixed routing).
+    assert routing["perFunction"]["vision"]["provider"] == P.LOCAL
+
+
+def test_balanced_avoids_privacy_avoid_providers_for_text() -> None:
+    routing = P.apply_preset("balanced", {}, _catalog())
+    # balanced is privacy-aware: it never picks an AVOID model as a text primary.
+    for fn in ("select", "subtitles", "translation", "editPlan"):
+        pid = routing["perFunction"][fn]["provider"]
+        if pid != P.LOCAL:
+            entry = next(e for e in _catalog().all() if e.id == pid)
+            assert entry.privacy_tier != "AVOID"
+
+
+# --------------------------------------------------------------------------- #
+# apply_preset — error path
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_preset_unknown_name_raises() -> None:
+    with pytest.raises(ValueError, match="unknown preset"):
+        P.apply_preset("nope", {}, _catalog())
+
+
+def test_best_free_cloud_with_empty_catalog_degrades_to_local() -> None:
+    # If a function has no capable cloud candidate, that slot falls back to local
+    # (never proposes a model the catalog cannot supply).
+    routing = P.apply_preset("bestFreeCloud", {}, FakeCatalog(entries=()))
+    for fn in P.FUNCTIONS:
+        assert routing["perFunction"][fn]["provider"] == P.LOCAL
+
+
+# --------------------------------------------------------------------------- #
+# suggest_for_function — catalog-ranked, capability-filtered
+# --------------------------------------------------------------------------- #
+
+
+def test_suggest_returns_catalog_ranked_candidates() -> None:
+    out = P.suggest_for_function("select", _catalog(), {})
+    ids = [c.id for c in out]
+    # select grades: S(groq-gpt-oss) > A(groq-llama, gemini) > B(github)
+    assert ids[0] == "groq-gpt-oss-120b"
+    assert ids[-1] == "github-gpt-4o-mini"
+
+
+def test_suggest_excludes_capability_mismatch() -> None:
+    # vision requires a vision-capable model -> text-only groq entries excluded.
+    out = P.suggest_for_function("vision", _catalog(), {})
+    ids = {c.id for c in out}
+    assert "groq-gpt-oss-120b" not in ids
+    assert "groq-llama-3.3-70b" not in ids
+    assert ids == {"gemini-2.5-flash-lite", "github-gpt-4o-mini"}
+
+
+def test_suggest_never_proposes_na_grade() -> None:
+    # vision tier 'na' on groq entries must never be proposed even before the
+    # capability filter (defence in depth).
+    out = P.suggest_for_function("vision", _catalog(), {})
+    for c in out:
+        assert c.per_task_tier["vision"] != "na"
+
+
+def test_suggest_respects_privacy_pref_excluding_avoid() -> None:
+    # prefs can demand SAFE-only -> AVOID-tier gemini dropped from vision.
+    out = P.suggest_for_function("vision", _catalog(), {"requireSafePrivacy": True})
+    ids = {c.id for c in out}
+    assert "gemini-2.5-flash-lite" not in ids
+    assert ids == {"github-gpt-4o-mini"}
+
+
+def test_suggest_unknown_function_raises() -> None:
+    with pytest.raises(ValueError, match="unknown function"):
+        P.suggest_for_function("bogus", _catalog(), {})
+
+
+def test_suggest_empty_catalog_returns_empty_list() -> None:
+    assert P.suggest_for_function("select", FakeCatalog(entries=()), {}) == []
+
+
+def test_suggest_stable_order_for_equal_grade() -> None:
+    # gemini and github-gpt-4o-mini both grade A on translation in a 2-entry
+    # catalog; equal grades preserve catalog order (stable sort).
+    cat = FakeCatalog(
+        entries=(
+            FakeEntry(
+                id="first-A",
+                provider="p1",
+                capabilities=("text",),
+                per_task_tier={"translation": "A"},
+            ),
+            FakeEntry(
+                id="second-A",
+                provider="p2",
+                capabilities=("text",),
+                per_task_tier={"translation": "A"},
+            ),
+        )
+    )
+    out = [c.id for c in P.suggest_for_function("translation", cat, {})]
+    assert out == ["first-A", "second-A"]
+
+
+# --------------------------------------------------------------------------- #
+# first_run_default — local-safe pre-choice
+# --------------------------------------------------------------------------- #
+
+
+def test_first_run_default_is_privacy_before_any_choice() -> None:
+    assert P.first_run_default({}) == "privacy"
+    assert P.first_run_default({"firstRunChoiceMade": False}) == "privacy"
+
+
+def test_first_run_default_honors_recorded_cloud_choice() -> None:
+    settings: dict[str, Any] = {
+        "firstRunChoiceMade": True,
+        "activePreset": "bestFreeCloud",
+    }
+    assert P.first_run_default(settings) == "bestFreeCloud"
+
+
+def test_first_run_default_choice_made_but_local_preset_stays_privacy() -> None:
+    settings: dict[str, Any] = {
+        "firstRunChoiceMade": True,
+        "activePreset": "privacy",
+    }
+    assert P.first_run_default(settings) == "privacy"
+
+
+def test_first_run_default_choice_made_balanced_counts_as_cloud() -> None:
+    settings: dict[str, Any] = {
+        "firstRunChoiceMade": True,
+        "activePreset": "balanced",
+    }
+    # any non-privacy active preset after a choice -> the cloud-capable default.
+    assert P.first_run_default(settings) == "bestFreeCloud"
+
+
+def test_first_run_default_choice_made_without_preset_is_privacy() -> None:
+    # a choice flag without a recorded preset is still local-safe.
+    assert P.first_run_default({"firstRunChoiceMade": True}) == "privacy"

--- a/sidecar/tests/test_provider.py
+++ b/sidecar/tests/test_provider.py
@@ -437,6 +437,67 @@ def test_urllib_post_json_httperror_body_read_failure_is_tolerated(monkeypatch):
     assert "unavail" in msg
 
 
+# --------------------------------------------------------------------------- #
+# WU-keys ENFORCEABLE SCRUB: a forced provider 4xx whose error body echoes the
+# live key must NEVER carry that key in the resulting ProviderError. The scrub is
+# enforced at the construction site (provider threads secrets= into the default
+# _urllib_post_json), asserted DIRECTLY on the ProviderError — not via a log spy.
+# --------------------------------------------------------------------------- #
+def test_forced_429_error_body_scrubs_live_key(monkeypatch):
+    live_key = "sk-live-DEADBEEF1234"
+
+    class _KeyEchoHTTPError(prov.urllib.error.HTTPError):
+        def __init__(self) -> None:
+            super().__init__(url="http://x", code=429, msg="Too Many Requests", hdrs=None, fp=None)
+
+        def read(self, *_a: Any, **_k: Any) -> bytes:
+            # The server echoes our Authorization header (and the bare key) back
+            # in its 429 body — exactly the leak the scrub must close.
+            body = (
+                '{"error":"rate_limited","seen":"Authorization: Bearer '
+                + live_key
+                + '","raw":"'
+                + live_key
+                + '"}'
+            )
+            return body.encode("utf-8")
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001
+        raise _KeyEchoHTTPError()
+
+    monkeypatch.setattr(prov.urllib.request, "urlopen", fake_urlopen)
+    # CloudProvider holds the key; its DEFAULT transport binds secrets=[key].
+    p = CloudProvider(api_key=live_key)
+    with pytest.raises(ProviderError) as ei:
+        p.chat([{"role": "user", "content": "q"}])
+    msg = str(ei.value)
+    assert "429" in msg
+    assert live_key not in msg  # the live key is gone — enforced at construction
+    assert "[REDACTED]" in msg  # and visibly scrubbed, not silently truncated
+
+
+def test_local_provider_no_secret_still_scrubs_bearer(monkeypatch):
+    # A keyless provider (no secrets to thread) still strips an echoed bearer
+    # token from the error body via scrub_error_body's bearer regex.
+    class _BearerEchoHTTPError(prov.urllib.error.HTTPError):
+        def __init__(self) -> None:
+            super().__init__(url="http://x", code=400, msg="bad", hdrs=None, fp=None)
+
+        def read(self, *_a: Any, **_k: Any) -> bytes:
+            return b"detail Authorization: Bearer leaked-upstream-token rest"
+
+    def fake_urlopen(request, timeout):  # noqa: ANN001
+        raise _BearerEchoHTTPError()
+
+    monkeypatch.setattr(prov.urllib.request, "urlopen", fake_urlopen)
+    p = LocalServerProvider()  # keyless; secrets=()
+    with pytest.raises(ProviderError) as ei:
+        p.chat([{"role": "user", "content": "q"}])
+    msg = str(ei.value)
+    assert "leaked-upstream-token" not in msg
+    assert "[REDACTED]" in msg
+
+
 def test_abstract_chat_body_raises_not_implemented():
     # A subclass that defers to Provider.chat reaches the abstract method body
     # (the bare ``raise NotImplementedError`` on line 167).

--- a/sidecar/tests/test_provider.py
+++ b/sidecar/tests/test_provider.py
@@ -453,13 +453,7 @@ def test_forced_429_error_body_scrubs_live_key(monkeypatch):
         def read(self, *_a: Any, **_k: Any) -> bytes:
             # The server echoes our Authorization header (and the bare key) back
             # in its 429 body — exactly the leak the scrub must close.
-            body = (
-                '{"error":"rate_limited","seen":"Authorization: Bearer '
-                + live_key
-                + '","raw":"'
-                + live_key
-                + '"}'
-            )
+            body = '{"error":"rate_limited","seen":"Authorization: Bearer ' + live_key + '","raw":"' + live_key + '"}'
             return body.encode("utf-8")
 
     def fake_urlopen(request, timeout):  # noqa: ANN001

--- a/sidecar/tests/test_provider_routing.py
+++ b/sidecar/tests/test_provider_routing.py
@@ -1,0 +1,108 @@
+"""Per-function routing preference for the rotation pool (WU-presets).
+
+PLAN §WU-presets acceptance (b): "per-function override actually changes the
+provider the corresponding seam uses (assert ``get_provider`` / ``get_translator``
+/ vision pick)". The mechanism: the factory accepts a ``prefer`` provider id; the
+matching configured provider is moved to the FRONT of the pool (tried first),
+with the rest kept as failover and the local backstop always last. A ``prefer``
+of the LOCAL sentinel yields a local-only pool (no cloud egress at all).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from media_studio.models import provider as P
+
+
+def _settings(*providers: dict[str, Any]) -> dict[str, Any]:
+    return {"providers": list(providers)}
+
+
+_GROQ = {
+    "id": "groq-gpt-oss-120b",
+    "provider": "Groq",
+    "baseUrl": "https://groq.example/v1",
+    "model": "gpt-oss-120b",
+    "apiKeys": ["gk-aaaa1111"],
+    "capabilities": ["text"],
+    "unit": "token",
+}
+_CEREBRAS = {
+    "id": "cerebras-qwen3-235b",
+    "provider": "Cerebras",
+    "baseUrl": "https://cerebras.example/v1",
+    "model": "qwen3-235b",
+    "apiKeys": ["ck-bbbb2222"],
+    "capabilities": ["text"],
+    "unit": "token",
+}
+
+
+def test_no_prefer_keeps_configured_order() -> None:
+    pool = P.build_pool_provider(_settings(_GROQ, _CEREBRAS), detect_local=False)
+    # Cloud entries keep settings order; local backstop is last.
+    providers = [e.provider for e in pool.entries]
+    assert providers == ["Groq", "Cerebras", "local"]
+
+
+def test_prefer_moves_matching_provider_to_front() -> None:
+    # Configured order is Groq, Cerebras; preferring Cerebras must try it FIRST.
+    pool = P.build_pool_provider(_settings(_GROQ, _CEREBRAS), detect_local=False, prefer="cerebras-qwen3-235b")
+    providers = [e.provider for e in pool.entries]
+    assert providers[0] == "Cerebras"
+    # Groq is kept as failover; local is still last.
+    assert "Groq" in providers
+    assert providers[-1] == "local"
+
+
+def test_prefer_unknown_id_is_a_no_op_not_an_error() -> None:
+    pool = P.build_pool_provider(_settings(_GROQ, _CEREBRAS), detect_local=False, prefer="does-not-exist")
+    providers = [e.provider for e in pool.entries]
+    assert providers == ["Groq", "Cerebras", "local"]
+
+
+def test_prefer_local_yields_local_only_pool_no_cloud_egress() -> None:
+    pool = P.build_pool_provider(_settings(_GROQ, _CEREBRAS), detect_local=False, prefer=P.LOCAL_PROVIDER_ID)
+    providers = [e.provider for e in pool.entries]
+    # No cloud entry at all -> a privacy/local-only route sends nothing off-box.
+    assert providers == ["local"]
+    assert pool.provider_groups() == ()
+
+
+def test_get_provider_threads_prefer_into_the_pool() -> None:
+    pool = P.get_provider(_settings(_GROQ, _CEREBRAS), prefer="cerebras-qwen3-235b")
+    assert isinstance(pool, P.RotatingProvider)
+    assert [e.provider for e in pool.entries][0] == "Cerebras"
+
+
+def test_get_provider_prefer_local_is_local_only() -> None:
+    pool = P.get_provider(_settings(_GROQ, _CEREBRAS), prefer=P.LOCAL_PROVIDER_ID)
+    assert isinstance(pool, P.RotatingProvider)
+    assert [e.provider for e in pool.entries] == ["local"]
+
+
+def test_prefer_with_non_list_providers_is_a_no_op() -> None:
+    # A malformed providers value + a prefer must not raise (defensive guard):
+    # the pool degrades to the local backstop only.
+    pool = P.build_pool_provider({"providers": "garbage"}, detect_local=False, prefer="x")
+    assert [e.provider for e in pool.entries] == ["local"]
+
+
+def test_prefer_routes_first_call_to_the_preferred_provider() -> None:
+    # End-to-end: a fake transport records which base_url the FIRST chat hits.
+    hits: list[str] = []
+
+    def transport(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        hits.append(url)
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    pool = P.build_pool_provider(
+        _settings(_GROQ, _CEREBRAS),
+        detect_local=False,
+        prefer="cerebras-qwen3-235b",
+        transport=transport,
+    )
+    pool.chat([{"role": "user", "content": "hi"}])
+    # The preferred provider (Cerebras) was the first (and only) one hit.
+    assert hits[0].startswith("https://cerebras.example/v1")

--- a/sidecar/tests/test_raw_vs_redacted_audit.py
+++ b/sidecar/tests/test_raw_vs_redacted_audit.py
@@ -1,0 +1,131 @@
+"""WU-keys RAW-vs-REDACTED AUDIT (the mandatory partition deliverable).
+
+PLAN §WU-keys: enumerate EVERY settings-read that ultimately feeds a
+provider/translator a key, and prove each consumes the RAW (full) key — while
+every RPC-facing read returns the REDACTED (last-4) view. The four feed callers:
+
+  1. ``provider.get_provider``           (the general LLM seam)
+  2. ``translation.TieredTranslator._hosted_provider`` (the tier3 hosted seam)
+  3. the ``RotatingProvider`` pool build (``provider.build_pool_provider``)
+  4. ``handlers.Services`` construction  (``_get_provider`` / ``_get_translator``)
+
+This test holds the partition: each feed path carries the full key; every
+RPC read (``settings.get`` / ``providers.list``) carries only last-4.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from media_studio.handlers import Services
+from media_studio.models import provider as provider_mod
+from media_studio.models.provider import RotatingProvider
+from media_studio.protocol import RpcContext
+
+RAW_KEY = "gsk-RAWFULL-SECRET-PQRS"
+
+
+def _settings_with_pool() -> dict[str, Any]:
+    return {
+        "providers": [
+            {
+                "id": "groq",
+                "provider": "Groq",
+                "kind": "cloud",
+                "baseUrl": "https://api.groq.com/openai/v1",
+                "model": "m",
+                "apiKeys": [RAW_KEY],
+                "enabled": True,
+                "capabilities": ["text"],
+                "unit": "token",
+            }
+        ]
+    }
+
+
+def _pool_keys(pool: RotatingProvider) -> list[str | None]:
+    """Every live key the pool actually holds in its slots (the RAW truth)."""
+    return [slot.key for slot in pool._slots]  # noqa: SLF001 - audit needs the internals
+
+
+# --------------------------------------------------------------------------- #
+# FEED CALLER 1 + 3: get_provider builds a RotatingProvider from RAW keys
+# --------------------------------------------------------------------------- #
+def test_feed1_get_provider_carries_raw_key() -> None:
+    pool = provider_mod.get_provider(_settings_with_pool())
+    assert isinstance(pool, RotatingProvider)
+    assert RAW_KEY in _pool_keys(pool)
+
+
+def test_feed3_build_pool_provider_carries_raw_key() -> None:
+    pool = provider_mod.build_pool_provider(_settings_with_pool(), detect_local=False)
+    assert RAW_KEY in _pool_keys(pool)
+
+
+def test_legacy_cloud_path_carries_raw_cloud_api_key() -> None:
+    # The legacy single-cloud fall-through also reads RAW (no pool configured).
+    prov = provider_mod.get_provider({"useCloud": True, "cloudApiKey": RAW_KEY})
+    assert prov._api_key == RAW_KEY  # noqa: SLF001 - audit needs the internals
+
+
+# --------------------------------------------------------------------------- #
+# FEED CALLER 2: TieredTranslator._hosted_provider builds from RAW keys
+# --------------------------------------------------------------------------- #
+def test_feed2_hosted_provider_carries_raw_key() -> None:
+    from media_studio.models import translation as translation_mod
+
+    translator = translation_mod.get_translator(_settings_with_pool())
+    hosted = translator._hosted_provider()  # noqa: SLF001
+    assert isinstance(hosted, RotatingProvider)
+    assert RAW_KEY in _pool_keys(hosted)
+
+
+def test_feed2_hosted_provider_legacy_cloud_key_is_raw() -> None:
+    from media_studio.models import translation as translation_mod
+
+    translator = translation_mod.get_translator({"cloudApiKey": RAW_KEY})
+    hosted = translator._hosted_provider()  # noqa: SLF001
+    assert hosted._api_key == RAW_KEY  # noqa: SLF001
+
+
+# --------------------------------------------------------------------------- #
+# FEED CALLER 4: Services._get_provider / _get_translator consume RAW
+# --------------------------------------------------------------------------- #
+def test_feed4_handler_get_provider_carries_raw_key(tmp_path: Path) -> None:
+    svc = Services(data_dir=tmp_path)
+    svc.settings.set(_settings_with_pool())
+    pool = svc._get_provider()
+    assert isinstance(pool, RotatingProvider)
+    assert RAW_KEY in _pool_keys(pool)
+
+
+def test_feed4_handler_get_translator_carries_raw_key(tmp_path: Path) -> None:
+    svc = Services(data_dir=tmp_path)
+    svc.settings.set(_settings_with_pool())
+    translator = svc._get_translator()
+    assert translator is not None
+    hosted = translator._hosted_provider()  # noqa: SLF001
+    assert RAW_KEY in _pool_keys(hosted)
+
+
+# --------------------------------------------------------------------------- #
+# THE PARTITION: every RPC read returns REDACTED — no full key crosses RPC
+# --------------------------------------------------------------------------- #
+def test_rpc_reads_return_redacted_not_raw(tmp_path: Path) -> None:
+    svc = Services(data_dir=tmp_path)
+    svc.settings.set(_settings_with_pool())
+    ctx = RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+    settings_view = svc.settings_get({}, ctx)
+    providers_view = svc.providers_list({}, ctx)
+
+    import json
+
+    for view in (settings_view, providers_view):
+        assert RAW_KEY not in json.dumps(view)
+    assert providers_view["providers"][0]["apiKeys"] == ["…PQRS"]
+    assert settings_view["providers"][0]["apiKeys"] == ["…PQRS"]
+
+    # And the FACTORY truth still has the RAW key (the two sides genuinely differ).
+    assert RAW_KEY in svc.settings.get_raw()["providers"][0]["apiKeys"]

--- a/sidecar/tests/test_rotating_provider.py
+++ b/sidecar/tests/test_rotating_provider.py
@@ -57,9 +57,7 @@ class ScriptedTransport:
         self.by_key = by_key
         self.calls: list[dict[str, Any]] = []
 
-    def __call__(
-        self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
-    ) -> dict[str, Any]:
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
         auth = headers.get("Authorization", "")
         key = auth[len("Bearer ") :] if auth.startswith("Bearer ") else None
         self.calls.append({"url": url, "headers": headers, "key": key, "body": body})
@@ -394,9 +392,7 @@ def test_key_never_in_log_lines(caplog: pytest.LogCaptureFixture) -> None:
 
 
 def test_key_never_in_aggregate_error_message() -> None:
-    transport = ScriptedTransport(
-        {"sk-live-secret": [ProviderError("LLM HTTP 429: forbidden sk-live-secret leaked")]}
-    )
+    transport = ScriptedTransport({"sk-live-secret": [ProviderError("LLM HTTP 429: forbidden sk-live-secret leaked")]})
     rp = _build([_spec(keys=["sk-live-secret"])], transport)
     with pytest.raises(ProviderError) as ei:
         rp.chat([{"role": "user", "content": "q"}])
@@ -456,9 +452,7 @@ def test_local_backstop_is_a_local_server_provider_under_the_hood() -> None:
 
 def test_rotation_event_carries_redacted_keys() -> None:
     events: list[RotationEvent] = []
-    transport = ScriptedTransport(
-        {"sk-from-secret": [ProviderError("LLM HTTP 429: x")], "sk-to-secret": [_ok("ok")]}
-    )
+    transport = ScriptedTransport({"sk-from-secret": [ProviderError("LLM HTTP 429: x")], "sk-to-secret": [_ok("ok")]})
     rp = _build([_spec(keys=["sk-from-secret", "sk-to-secret"])], transport)
     rp.on_rotation(events.append)
     rp.chat([{"role": "user", "content": "q"}])

--- a/sidecar/tests/test_rotating_provider.py
+++ b/sidecar/tests/test_rotating_provider.py
@@ -1,0 +1,530 @@
+"""Unit tests for the multi-PROVIDER RotatingProvider (WU-pool).
+
+The rotation pool fronts the LLM behind a duck-typed :class:`Provider` and is
+wired into BOTH LLM seams (the general ``get_provider`` chat path AND the
+``TieredTranslator`` tier3 hosted path). Every collaborator is faked:
+
+  * a **fake Transport** (the ``provider.py`` seam) returns canned 200s and
+    raises ``ProviderError("LLM HTTP 429 ...")`` for chosen keys, so no socket
+    is ever opened;
+  * a **fake clock** (the injected ``now`` ctor arg) drives the per-window
+    cooldown deterministically — the module imports neither ``time`` nor
+    ``asyncio`` and the hot path NEVER sleeps (a throttled key is *skipped*).
+
+The tests pin: reactive 429/5xx failover (one ``rotation`` event per failover),
+per-window cooldown (throttled key skipped until the window resets), pool
+exhaustion (incl. the local backstop) -> a single ``ProviderError`` with no
+hang, the capability registry (vision-only requests skip non-vision entries),
+per-key usage accounting (optimistic decrement + parsed 429/X-RateLimit-*
+headers), and that the live key never reaches a log line or an error body.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from media_studio.models import provider as prov
+from media_studio.models.provider import (
+    LocalServerProvider,
+    PoolEntrySpec,
+    Provider,
+    ProviderError,
+    RotatingProvider,
+    RotationEvent,
+)
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+def _ok(content: str = "ok") -> dict[str, Any]:
+    """An OpenAI-style chat-completions success envelope."""
+    return {"choices": [{"message": {"role": "assistant", "content": content}}]}
+
+
+class ScriptedTransport:
+    """A fake transport keyed by the Bearer key, returning canned outcomes.
+
+    ``by_key`` maps a key string (or ``None`` for the keyless local server) to a
+    list of outcomes consumed in order; each outcome is either a response dict
+    (returned) or an Exception (raised). When a key's script is exhausted the
+    last outcome repeats. ``calls`` records every (url, headers, key) tuple.
+    """
+
+    def __init__(self, by_key: dict[str | None, list[Any]]) -> None:
+        self.by_key = by_key
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(
+        self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float
+    ) -> dict[str, Any]:
+        auth = headers.get("Authorization", "")
+        key = auth[len("Bearer ") :] if auth.startswith("Bearer ") else None
+        self.calls.append({"url": url, "headers": headers, "key": key, "body": body})
+        script = self.by_key.get(key)
+        if not script:
+            raise ProviderError(f"LLM request failed: nothing scripted for {key!r}")
+        outcome = script[0] if len(script) == 1 else script.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+
+class FakeClock:
+    """A monotonic fake clock the RotatingProvider reads via its ``now`` arg."""
+
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, seconds: float) -> None:
+        self.t += seconds
+
+
+def _spec(
+    *,
+    provider: str = "Groq",
+    kind: str = "cloud",
+    keys: list[str],
+    base_url: str = "https://api.groq.com/openai/v1",
+    model: str = "m",
+    capabilities: tuple[str, ...] = ("text",),
+    unit: str = "token",
+    local: bool = False,
+) -> PoolEntrySpec:
+    return PoolEntrySpec(
+        provider=provider,
+        kind=kind,
+        base_url=base_url,
+        model=model,
+        keys=tuple(keys),
+        capabilities=capabilities,
+        unit=unit,
+        local=local,
+    )
+
+
+def _build(specs: list[PoolEntrySpec], transport: Any, clock: FakeClock | None = None) -> RotatingProvider:
+    clock = clock or FakeClock()
+    return RotatingProvider(pool=specs, now=clock, transport=transport, cooldown_seconds=60.0)
+
+
+# --------------------------------------------------------------------------- #
+# RotatingProvider is a Provider
+# --------------------------------------------------------------------------- #
+def test_rotating_provider_is_a_provider() -> None:
+    rp = _build([_spec(keys=["k1"])], ScriptedTransport({"k1": [_ok()]}))
+    assert isinstance(rp, Provider)
+
+
+def test_single_key_happy_path_returns_content() -> None:
+    rp = _build([_spec(keys=["k1"])], ScriptedTransport({"k1": [_ok("hi")]}))
+    assert rp.chat([{"role": "user", "content": "q"}]) == "hi"
+
+
+def test_complete_wrapper_works_through_pool() -> None:
+    rp = _build([_spec(keys=["k1"])], ScriptedTransport({"k1": [_ok("done")]}))
+    assert rp.complete("summarize") == "done"
+
+
+def test_empty_pool_raises_value_error() -> None:
+    with pytest.raises(ValueError, match="empty"):
+        RotatingProvider(pool=[], now=FakeClock(), transport=ScriptedTransport({}))
+
+
+# --------------------------------------------------------------------------- #
+# reactive 429 failover: advances to the next eligible key, one rotation event
+# --------------------------------------------------------------------------- #
+def test_429_advances_to_next_key_and_emits_one_rotation_event() -> None:
+    events: list[RotationEvent] = []
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 429: rate limited")],
+            "k2": [_ok("second")],
+        }
+    )
+    rp = _build([_spec(keys=["k1", "k2"])], transport)
+    rp.on_rotation(events.append)
+    out = rp.chat([{"role": "user", "content": "q"}])
+    assert out == "second"
+    assert len(events) == 1
+    assert events[0].from_key.endswith("k1") or events[0].reason
+
+
+def test_429_failover_across_distinct_providers() -> None:
+    events: list[RotationEvent] = []
+    transport = ScriptedTransport(
+        {
+            "g1": [ProviderError("LLM HTTP 429: too many")],
+            "c1": [_ok("cerebras")],
+        }
+    )
+    rp = _build(
+        [_spec(provider="Groq", keys=["g1"]), _spec(provider="Cerebras", keys=["c1"])],
+        transport,
+    )
+    rp.on_rotation(events.append)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "cerebras"
+    assert len(events) == 1
+
+
+def test_5xx_also_triggers_failover() -> None:
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 503: unavailable")],
+            "k2": [_ok("recovered")],
+        }
+    )
+    rp = _build([_spec(keys=["k1", "k2"])], transport)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "recovered"
+
+
+# --------------------------------------------------------------------------- #
+# per-window cooldown: a throttled key is SKIPPED until its window resets
+# --------------------------------------------------------------------------- #
+def test_throttled_key_skipped_until_window_resets() -> None:
+    clock = FakeClock()
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 429: slow down"), _ok("k1 again")],
+            "k2": [_ok("k2 first"), _ok("k2 second")],
+        }
+    )
+    rp = _build([_spec(keys=["k1", "k2"])], transport, clock=clock)
+
+    # First call: k1 429s -> cooled down; k2 serves.
+    assert rp.chat([{"role": "user", "content": "q"}]) == "k2 first"
+
+    # Second call WITHIN the cooldown window: k1 is skipped (no 429 retry on it),
+    # k2 serves directly. The transport must NOT have been asked k1 again.
+    clock.advance(10.0)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "k2 second"
+    k1_calls = [c for c in transport.calls if c["key"] == "k1"]
+    assert len(k1_calls) == 1  # only the original 429 call, never re-probed
+
+    # After the window resets, k1 is eligible again.
+    clock.advance(120.0)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "k1 again"
+
+
+def test_no_sleep_on_hot_path_throttled_key_is_skipped_not_awaited() -> None:
+    # The cooldown is pure clock-delta math: a throttled key never blocks; the
+    # pool advances immediately to the next eligible key.
+    clock = FakeClock()
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 429: x")],
+            "k2": [_ok("a"), _ok("b")],
+        }
+    )
+    rp = _build([_spec(keys=["k1", "k2"])], transport, clock=clock)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "a"
+    # Clock did NOT move on its own (no sleep). The test controls it entirely.
+    assert clock.t == 1000.0
+
+
+# --------------------------------------------------------------------------- #
+# pool exhaustion (incl. the local backstop) -> a single ProviderError, no hang
+# --------------------------------------------------------------------------- #
+def test_pool_exhausted_including_local_raises_single_error() -> None:
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 429: a")],
+            "k2": [ProviderError("LLM HTTP 429: b")],
+            None: [ProviderError("LLM request failed: local down")],
+        }
+    )
+    rp = _build(
+        [
+            _spec(keys=["k1", "k2"]),
+            _spec(provider="local", kind="local", keys=[], base_url="http://127.0.0.1:8088/v1", local=True),
+        ],
+        transport,
+    )
+    with pytest.raises(ProviderError) as ei:
+        rp.chat([{"role": "user", "content": "q"}])
+    # one aggregate error, never a hang
+    assert "exhausted" in str(ei.value).lower() or "429" in str(ei.value)
+
+
+def test_local_backstop_reached_when_all_cloud_keys_exhausted() -> None:
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM HTTP 429: a")],
+            None: [_ok("local served it")],
+        }
+    )
+    rp = _build(
+        [
+            _spec(keys=["k1"]),
+            _spec(provider="local", kind="local", keys=[], base_url="http://127.0.0.1:8088/v1", local=True),
+        ],
+        transport,
+    )
+    assert rp.chat([{"role": "user", "content": "q"}]) == "local served it"
+
+
+def test_local_backstop_is_always_last_even_if_specified_first() -> None:
+    transport = ScriptedTransport({"k1": [_ok("cloud wins")], None: [_ok("local")]})
+    rp = _build(
+        [
+            _spec(provider="local", kind="local", keys=[], local=True, base_url="http://127.0.0.1:8088/v1"),
+            _spec(keys=["k1"]),
+        ],
+        transport,
+    )
+    # Cloud is tried first despite local being declared first.
+    assert rp.chat([{"role": "user", "content": "q"}]) == "cloud wins"
+
+
+# --------------------------------------------------------------------------- #
+# capability registry: a vision request only considers vision-capable entries
+# --------------------------------------------------------------------------- #
+def test_vision_request_skips_text_only_entries() -> None:
+    transport = ScriptedTransport({"text-key": [_ok("text")], "vis-key": [_ok("vision")]})
+    rp = _build(
+        [
+            _spec(provider="Groq", keys=["text-key"], capabilities=("text",)),
+            _spec(provider="Gemini", keys=["vis-key"], capabilities=("text", "vision")),
+        ],
+        transport,
+    )
+    out = rp.chat([{"role": "user", "content": "q"}], capability="vision")
+    assert out == "vision"
+    # The text-only entry was never called for a vision request.
+    assert all(c["key"] != "text-key" for c in transport.calls)
+
+
+def test_vision_request_with_no_vision_entry_raises() -> None:
+    transport = ScriptedTransport({"text-key": [_ok("text")]})
+    rp = _build([_spec(keys=["text-key"], capabilities=("text",))], transport)
+    with pytest.raises(ProviderError):
+        rp.chat([{"role": "user", "content": "q"}], capability="vision")
+
+
+def test_default_capability_is_text() -> None:
+    transport = ScriptedTransport({"k1": [_ok("ok")]})
+    rp = _build([_spec(keys=["k1"], capabilities=("text",))], transport)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "ok"
+
+
+# --------------------------------------------------------------------------- #
+# per-key usage accounting: optimistic decrement + parsed 429 / X-RateLimit-*
+# --------------------------------------------------------------------------- #
+def test_usage_optimistic_decrement_on_success() -> None:
+    transport = ScriptedTransport({"k1": [_ok("a"), _ok("b")]})
+    rp = _build([_spec(keys=["k1"], unit="req")], transport)
+    rp.chat([{"role": "user", "content": "q"}])
+    rp.chat([{"role": "user", "content": "q"}])
+    usage = rp.usage()
+    [key_usage] = [u for u in usage if u["provider"] == "Groq"]
+    assert key_usage["used"] == 2
+    assert key_usage["unit"] == "req"
+
+
+def test_usage_parses_x_ratelimit_headers_from_response() -> None:
+    # A success response can carry rate-limit metadata the pool records.
+    resp = _ok("ok")
+    resp["_headers"] = {"X-RateLimit-Remaining": "17", "X-RateLimit-Limit": "1000"}
+    transport = ScriptedTransport({"k1": [resp]})
+    rp = _build([_spec(keys=["k1"], unit="req")], transport)
+    rp.chat([{"role": "user", "content": "q"}])
+    usage = rp.usage()
+    [u] = usage
+    assert u["max"] == 1000
+    # remaining 17 of 1000 -> used 983 (header is authoritative over optimistic).
+    assert u["used"] == 983
+
+
+def test_usage_records_reset_from_429_retry_after() -> None:
+    clock = FakeClock(start=2000.0)
+    transport = ScriptedTransport(
+        {
+            "key-aaaa": [ProviderError("LLM HTTP 429: retry-after=30")],
+            "key-bbbb": [_ok("served")],
+        }
+    )
+    rp = _build([_spec(keys=["key-aaaa", "key-bbbb"])], transport, clock=clock)
+    rp.chat([{"role": "user", "content": "q"}])
+    usage = rp.usage()
+    k1 = next(u for u in usage if u["key"].endswith("aaaa"))
+    assert k1["resetAt"] is not None
+    # retry-after=30 from the 429 message -> reset at now + 30.
+    assert k1["resetAt"] == 2030.0
+
+
+def test_usage_key_field_is_redacted_never_full_key() -> None:
+    transport = ScriptedTransport({"supersecretkey": [_ok("ok")]})
+    rp = _build([_spec(keys=["supersecretkey"])], transport)
+    rp.chat([{"role": "user", "content": "q"}])
+    usage = rp.usage()
+    [u] = usage
+    assert "supersecretkey" not in u["key"]
+    assert u["key"].endswith("rkey") or "…" in u["key"]
+
+
+# --------------------------------------------------------------------------- #
+# same-provider extra keys = failover only, never advertised x quota
+# --------------------------------------------------------------------------- #
+def test_same_provider_two_keys_reports_one_provider_group_not_double_quota() -> None:
+    transport = ScriptedTransport({"k1": [_ok("a")], "k2": [_ok("b")]})
+    rp = _build([_spec(provider="Groq", keys=["k1", "k2"], unit="token")], transport)
+    # Distinct cloud providers (for budget) collapses same-provider keys to one.
+    assert rp.provider_groups() == ("Groq",)
+
+
+# --------------------------------------------------------------------------- #
+# the live key is header-only: never in a log line or an error body
+# --------------------------------------------------------------------------- #
+def test_key_never_in_log_lines(caplog: pytest.LogCaptureFixture) -> None:
+    transport = ScriptedTransport(
+        {
+            "sk-live-secret": [ProviderError("LLM HTTP 429: x")],
+            "k2": [_ok("ok")],
+        }
+    )
+    rp = _build([_spec(keys=["sk-live-secret", "k2"])], transport)
+    with caplog.at_level(logging.DEBUG):
+        rp.chat([{"role": "user", "content": "q"}])
+    assert "sk-live-secret" not in caplog.text
+
+
+def test_key_never_in_aggregate_error_message() -> None:
+    transport = ScriptedTransport(
+        {"sk-live-secret": [ProviderError("LLM HTTP 429: forbidden sk-live-secret leaked")]}
+    )
+    rp = _build([_spec(keys=["sk-live-secret"])], transport)
+    with pytest.raises(ProviderError) as ei:
+        rp.chat([{"role": "user", "content": "q"}])
+    assert "sk-live-secret" not in str(ei.value)
+
+
+# --------------------------------------------------------------------------- #
+# no-sleep enforcement: the module must not import time / asyncio
+# --------------------------------------------------------------------------- #
+def test_provider_module_does_not_import_time_or_asyncio() -> None:
+    assert not hasattr(prov, "time")
+    assert not hasattr(prov, "asyncio")
+
+
+# --------------------------------------------------------------------------- #
+# non-rate-limit ProviderError still fails over (treated as a transient key fault)
+# --------------------------------------------------------------------------- #
+def test_non_http_provider_error_fails_over_then_succeeds() -> None:
+    transport = ScriptedTransport(
+        {
+            "k1": [ProviderError("LLM returned non-JSON response")],
+            "k2": [_ok("recovered")],
+        }
+    )
+    rp = _build([_spec(keys=["k1", "k2"])], transport)
+    assert rp.chat([{"role": "user", "content": "q"}]) == "recovered"
+
+
+def test_temperature_and_max_tokens_threaded_through_pool() -> None:
+    transport = ScriptedTransport({"k1": [_ok("ok")]})
+    rp = _build([_spec(keys=["k1"])], transport)
+    rp.chat([{"role": "user", "content": "q"}], temperature=0.1, max_tokens=99)
+    body = transport.calls[0]["body"]
+    assert body["temperature"] == 0.1
+    assert body["max_tokens"] == 99
+
+
+def test_local_entry_has_text_capability_by_default() -> None:
+    transport = ScriptedTransport({None: [_ok("local")]})
+    rp = _build(
+        [_spec(provider="local", kind="local", keys=[], local=True, base_url="http://127.0.0.1:8088/v1")],
+        transport,
+    )
+    assert rp.chat([{"role": "user", "content": "q"}]) == "local"
+
+
+def test_local_backstop_is_a_local_server_provider_under_the_hood() -> None:
+    # The local entry is a keyless OpenAI-compat provider (no Bearer header).
+    transport = ScriptedTransport({None: [_ok("local")]})
+    rp = _build(
+        [_spec(provider="local", kind="local", keys=[], local=True, base_url="http://127.0.0.1:8088/v1")],
+        transport,
+    )
+    rp.chat([{"role": "user", "content": "q"}])
+    assert "Authorization" not in transport.calls[0]["headers"]
+
+
+def test_rotation_event_carries_redacted_keys() -> None:
+    events: list[RotationEvent] = []
+    transport = ScriptedTransport(
+        {"sk-from-secret": [ProviderError("LLM HTTP 429: x")], "sk-to-secret": [_ok("ok")]}
+    )
+    rp = _build([_spec(keys=["sk-from-secret", "sk-to-secret"])], transport)
+    rp.on_rotation(events.append)
+    rp.chat([{"role": "user", "content": "q"}])
+    [ev] = events
+    assert "sk-from-secret" not in ev.from_key
+    assert "sk-to-secret" not in ev.to_key
+
+
+def test_chat_full_forwards_whitelisted_sampling_kwargs() -> None:
+    # chat_full (used by the pool) must forward whitelisted knobs like chat does.
+    transport = ScriptedTransport({"k1": [_ok("ok")]})
+    rp = _build([_spec(keys=["k1"])], transport)
+    rp.chat([{"role": "user", "content": "q"}], top_p=0.5, seed=3)
+    body = transport.calls[0]["body"]
+    assert body["top_p"] == 0.5
+    assert body["seed"] == 3
+
+
+def test_usage_garbage_ratelimit_header_is_ignored() -> None:
+    # A non-numeric X-RateLimit value must not crash; max stays None.
+    resp = _ok("ok")
+    resp["_headers"] = {"X-RateLimit-Limit": "not-a-number"}
+    transport = ScriptedTransport({"k1": [resp]})
+    rp = _build([_spec(keys=["k1"])], transport)
+    rp.chat([{"role": "user", "content": "q"}])
+    [u] = rp.usage()
+    assert u["max"] is None
+    assert u["used"] == 1  # optimistic decrement still applied
+
+
+def test_usage_limit_header_without_remaining_keeps_optimistic_used() -> None:
+    # Only X-RateLimit-Limit present (no Remaining) -> max set, used stays optimistic.
+    resp = _ok("ok")
+    resp["_headers"] = {"X-RateLimit-Limit": "500"}
+    transport = ScriptedTransport({"k1": [resp]})
+    rp = _build([_spec(keys=["k1"])], transport)
+    rp.chat([{"role": "user", "content": "q"}])
+    [u] = rp.usage()
+    assert u["max"] == 500
+    assert u["used"] == 1
+
+
+def test_retry_after_with_unit_suffix_parses_leading_digits() -> None:
+    # "retry-after=30s" -> 30.0 (the non-digit terminator stops accumulation).
+    clock = FakeClock(start=5000.0)
+    transport = ScriptedTransport(
+        {"key-aaaa": [ProviderError("LLM HTTP 429: retry-after=30s please")], "key-bbbb": [_ok("ok")]}
+    )
+    rp = _build([_spec(keys=["key-aaaa", "key-bbbb"])], transport, clock=clock)
+    rp.chat([{"role": "user", "content": "q"}])
+    k1 = next(u for u in rp.usage() if u["key"].endswith("aaaa"))
+    assert k1["resetAt"] == 5030.0
+
+
+def test_entries_collapses_two_keys_of_same_spec_to_one_entry() -> None:
+    # A two-key provider yields two slots sharing ONE spec; .entries dedupes it.
+    transport = ScriptedTransport({"k1": [_ok("a")], "k2": [_ok("b")]})
+    rp = _build([_spec(provider="Groq", keys=["k1", "k2"])], transport)
+    assert len(rp.entries) == 1
+    assert rp.entries[0].provider == "Groq"
+
+
+def test_local_server_provider_still_works_standalone() -> None:
+    # Sanity: the legacy LocalServerProvider is untouched by the pool addition.
+    from tests.test_provider import RecordingTransport  # reuse the existing fake
+
+    t = RecordingTransport(_ok("legacy"))
+    p = LocalServerProvider(transport=t)
+    assert p.chat([{"role": "user", "content": "q"}]) == "legacy"

--- a/sidecar/tests/test_secrets.py
+++ b/sidecar/tests/test_secrets.py
@@ -142,3 +142,47 @@ def test_scrub_returns_redaction_placeholder_not_raw_gap() -> None:
     key = "sk-visible-marker-1"
     out = secrets.scrub_error_body(f"before {key} after", [key])
     assert secrets.REDACTION_PLACEHOLDER in out
+
+
+# --------------------------------------------------------------------------- #
+# redact_keys (the RPC-facing providers-list transform)
+# --------------------------------------------------------------------------- #
+def test_redact_keys_redacts_every_api_key_to_last_four() -> None:
+    providers = [
+        {"id": "groq", "apiKeys": ["sk-aaaaaaaaWXYZ", "gsk-bbbbbbbb7890"]},
+        {"id": "openai", "apiKeys": ["sk-proj-cccccccc4242"]},
+    ]
+    out = secrets.redact_keys(providers)
+    assert out[0]["apiKeys"] == ["…WXYZ", "…7890"]
+    assert out[1]["apiKeys"] == ["…4242"]
+    # No full key survives anywhere in the serialized result.
+    blob = repr(out)
+    for full in ("sk-aaaaaaaaWXYZ", "gsk-bbbbbbbb7890", "sk-proj-cccccccc4242"):
+        assert full not in blob
+
+
+def test_redact_keys_does_not_mutate_input() -> None:
+    providers = [{"id": "groq", "apiKeys": ["sk-original-KEY9"]}]
+    secrets.redact_keys(providers)
+    # The caller's RAW store is untouched (immutability — the factory still needs it).
+    assert providers[0]["apiKeys"] == ["sk-original-KEY9"]
+
+
+def test_redact_keys_passes_through_other_fields_and_missing_keys() -> None:
+    providers = [
+        {"id": "no-keys", "enabled": True},  # no apiKeys field
+        {"id": "bad-keys", "apiKeys": "not-a-list"},  # non-list -> untouched
+    ]
+    out = secrets.redact_keys(providers)
+    assert out[0] == {"id": "no-keys", "enabled": True}
+    assert out[1]["apiKeys"] == "not-a-list"
+
+
+def test_redact_keys_skips_non_dict_entries() -> None:
+    out = secrets.redact_keys(["garbage", 42, {"id": "ok", "apiKeys": ["abcdEFGH"]}])
+    assert len(out) == 1
+    assert out[0]["apiKeys"] == ["…EFGH"]
+
+
+def test_redact_keys_empty_is_empty() -> None:
+    assert secrets.redact_keys([]) == []

--- a/sidecar/tests/test_secrets.py
+++ b/sidecar/tests/test_secrets.py
@@ -1,0 +1,144 @@
+"""Unit tests for secret redaction + error-body scrubbing (models/secrets.py).
+
+WU-keys (PLAN §WU-keys "ENFORCEABLE SCRUB"). These are PURE functions — no I/O,
+no network, no clock — so every branch is hit directly with fixtures.
+
+Two public functions under test:
+  * ``redact(key) -> "…last4"`` — a display-safe redaction that never leaks more
+    than the last 4 characters of a key (and degrades gracefully for short keys).
+  * ``scrub_error_body(text, keys) -> text`` — strips every key in ``keys`` AND
+    any ``Authorization: Bearer <...>`` header value from a provider error body
+    before it can reach a log line or an RPC error message.
+"""
+
+from __future__ import annotations
+
+from media_studio.models import secrets
+
+
+# --------------------------------------------------------------------------- #
+# redact
+# --------------------------------------------------------------------------- #
+def test_redact_long_key_shows_only_last_four() -> None:
+    out = secrets.redact("sk-1234567890ABCDEF")
+    # Only the final 4 chars survive; nothing earlier leaks.
+    assert out.endswith("CDEF")
+    assert "1234567890" not in out
+    assert "sk-" not in out
+
+
+def test_redact_marks_redaction_with_ellipsis_prefix() -> None:
+    # The redaction is visibly a redaction (ellipsis), not a bare suffix.
+    assert secrets.redact("abcdefgh") == "…efgh"
+
+
+def test_redact_short_key_does_not_leak_whole_key() -> None:
+    # A key of <=4 chars must NOT be echoed verbatim (that would leak it all).
+    out = secrets.redact("ab")
+    assert "ab" not in out
+    assert out == "…"
+
+
+def test_redact_exactly_four_chars_is_fully_masked() -> None:
+    # last4 of a 4-char key == the whole key, so masking must kick in at the
+    # boundary and reveal nothing.
+    out = secrets.redact("WXYZ")
+    assert "WXYZ" not in out
+    assert out == "…"
+
+
+def test_redact_empty_key_returns_bare_ellipsis() -> None:
+    assert secrets.redact("") == "…"
+
+
+# --------------------------------------------------------------------------- #
+# scrub_error_body — key stripping
+# --------------------------------------------------------------------------- #
+def test_scrub_removes_embedded_key_from_error_body() -> None:
+    key = "sk-supersecret-abc123"
+    body = f'{{"error":"invalid api key {key} for model"}}'
+    out = secrets.scrub_error_body(body, [key])
+    assert key not in out
+    assert "invalid api key" in out  # surrounding text preserved
+
+
+def test_scrub_removes_every_key_when_multiple_given() -> None:
+    k1 = "key-AAAAAAAA"
+    k2 = "key-BBBBBBBB"
+    body = f"first {k1} then {k2} done"
+    out = secrets.scrub_error_body(body, [k1, k2])
+    assert k1 not in out
+    assert k2 not in out
+
+
+def test_scrub_strips_multiple_occurrences_of_same_key() -> None:
+    key = "tok-DEADBEEF"
+    body = f"{key} ... and again {key}"
+    out = secrets.scrub_error_body(body, [key])
+    assert key not in out
+
+
+def test_scrub_ignores_empty_strings_in_keys() -> None:
+    # An empty key must NOT scrub the whole body away (empty substring matches
+    # everywhere). The text must survive intact.
+    body = "a normal error message with no secrets"
+    out = secrets.scrub_error_body(body, ["", ""])
+    assert out == body
+
+
+# --------------------------------------------------------------------------- #
+# scrub_error_body — Authorization: Bearer header stripping
+# --------------------------------------------------------------------------- #
+def test_scrub_strips_bearer_header_value() -> None:
+    body = "401 Unauthorized\nAuthorization: Bearer sk-live-zzz999\nretry later"
+    out = secrets.scrub_error_body(body, [])
+    assert "sk-live-zzz999" not in out
+    # The header name may remain, but the token must be gone.
+    assert "sk-live-zzz999" not in out
+    assert "retry later" in out
+
+
+def test_scrub_strips_bearer_header_case_insensitively() -> None:
+    body = "authorization: bearer SECRETTOKEN42"
+    out = secrets.scrub_error_body(body, [])
+    assert "SECRETTOKEN42" not in out
+
+
+def test_scrub_strips_bearer_token_even_when_not_in_keys_list() -> None:
+    # A leaked bearer that we did not know about (not in keys) is still stripped.
+    body = 'HTTP 403: {"detail":"bad"}\nAuthorization: Bearer unknown-leaked-key'
+    out = secrets.scrub_error_body(body, ["some-other-key"])
+    assert "unknown-leaked-key" not in out
+
+
+def test_scrub_strips_both_known_keys_and_bearer_header() -> None:
+    key = "kkk-known-1234"
+    body = f"err {key}\nAuthorization: Bearer bbb-bearer-5678"
+    out = secrets.scrub_error_body(body, [key])
+    assert key not in out
+    assert "bbb-bearer-5678" not in out
+
+
+# --------------------------------------------------------------------------- #
+# scrub_error_body — no-op / unchanged paths
+# --------------------------------------------------------------------------- #
+def test_scrub_leaves_clean_text_unchanged() -> None:
+    body = '{"error":"model overloaded, please retry"}'
+    assert secrets.scrub_error_body(body, ["sk-not-present"]) == body
+
+
+def test_scrub_empty_text_returns_empty() -> None:
+    assert secrets.scrub_error_body("", ["sk-anything"]) == ""
+
+
+def test_scrub_no_keys_and_no_bearer_is_identity() -> None:
+    body = "plain HTTP 500 internal error"
+    assert secrets.scrub_error_body(body, []) == body
+
+
+def test_scrub_returns_redaction_placeholder_not_raw_gap() -> None:
+    # When a key is removed it leaves a visible placeholder, not silent deletion,
+    # so a scrubbed body is recognizably scrubbed.
+    key = "sk-visible-marker-1"
+    out = secrets.scrub_error_body(f"before {key} after", [key])
+    assert secrets.REDACTION_PLACEHOLDER in out

--- a/sidecar/tests/test_settings_store.py
+++ b/sidecar/tests/test_settings_store.py
@@ -148,3 +148,70 @@ def test_default_config_dir_posix_falls_back_to_dotconfig(monkeypatch: pytest.Mo
     monkeypatch.setattr("media_studio.settings_store.os", shim)
     out = default_config_dir()
     assert out.parts[-4:] == ("home", "me", ".config", "media-studio")
+
+
+# --------------------------------------------------------------------------- #
+# WU-keys: providers/consent defaults + RAW-vs-REDACTED split
+# --------------------------------------------------------------------------- #
+def test_provider_hub_defaults_present(store: SettingsStore) -> None:
+    out = store.get()
+    assert out["providers"] == []
+    assert out["consent"] == {"perProvider": {}}
+
+
+def test_get_redacts_provider_api_keys(store: SettingsStore) -> None:
+    store.set(
+        {
+            "providers": [
+                {"id": "groq", "provider": "Groq", "apiKeys": ["gsk-secret-WXYZ", "gsk-second-7890"]},
+            ]
+        }
+    )
+    redacted = store.get()["providers"]
+    assert redacted[0]["apiKeys"] == ["…WXYZ", "…7890"]
+    # No full key crosses the RPC-facing get().
+    blob = json.dumps(store.get())
+    assert "gsk-secret-WXYZ" not in blob
+    assert "gsk-second-7890" not in blob
+
+
+def test_get_raw_returns_full_provider_keys(store: SettingsStore) -> None:
+    store.set({"providers": [{"id": "groq", "apiKeys": ["gsk-full-raw-KEY1"]}]})
+    raw = store.get_raw()["providers"]
+    assert raw[0]["apiKeys"] == ["gsk-full-raw-KEY1"]
+    # get() (redacted) and get_raw() (full) genuinely differ.
+    assert store.get()["providers"][0]["apiKeys"] != raw[0]["apiKeys"]
+
+
+def test_get_raw_persists_to_disk_unredacted(store: SettingsStore, tmp_path: Path) -> None:
+    store.set({"providers": [{"id": "groq", "apiKeys": ["gsk-on-disk-RAW7"]}]})
+    on_disk = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
+    # The persisted store is RAW (the factory reads it via get_raw); only get() redacts.
+    assert on_disk["providers"][0]["apiKeys"] == ["gsk-on-disk-RAW7"]
+
+
+def test_get_redaction_does_not_corrupt_other_fields(store: SettingsStore) -> None:
+    store.set(
+        {
+            "providers": [
+                {"id": "groq", "provider": "Groq", "baseUrl": "https://x/v1", "apiKeys": ["abcdEFGH"], "enabled": True}
+            ],
+            "consent": {"perProvider": {"Groq": {"text": True, "frames": False}}},
+        }
+    )
+    out = store.get()
+    p = out["providers"][0]
+    assert p["provider"] == "Groq"
+    assert p["baseUrl"] == "https://x/v1"
+    assert p["enabled"] is True
+    assert out["consent"] == {"perProvider": {"Groq": {"text": True, "frames": False}}}
+
+
+def test_get_tolerates_non_list_providers(tmp_path: Path) -> None:
+    # A corrupt/hand-edited settings file with a non-list providers value must
+    # not crash the redacting get(): the redaction step is skipped and the bad
+    # value is passed through (the false arm of the isinstance guard).
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"providers": "not-a-list"}), encoding="utf-8")
+    store = SettingsStore(path)
+    assert store.get()["providers"] == "not-a-list"

--- a/sidecar/tests/test_smolvlm2.py
+++ b/sidecar/tests/test_smolvlm2.py
@@ -364,6 +364,154 @@ class TestDefaultModelsPresent:
 
 
 # --------------------------------------------------------------------------- #
+# CloudVlmBackend (WU-vision) — offloads the Tier-2 re-rank to a vision-capable
+# rotation pool. The pool arrives via CLOSURE (BackendFactory signature is
+# unchanged); a FAKE pool returns a canned ranking reply. base64 frame encoding
+# is behind an injectable seam so no cv2/PIL is imported under the gate.
+# --------------------------------------------------------------------------- #
+class FakePool:
+    """A duck-typed rotation pool whose ``chat`` returns a canned reply.
+
+    ``reply`` may be a string (returned verbatim) or a callable
+    ``(messages, **kwargs) -> str``. ``calls`` records every chat invocation so a
+    test can assert the capability filter + that base64 frames reached the pool.
+    """
+
+    def __init__(self, reply: Any) -> None:
+        self._reply = reply
+        self.calls: list[dict[str, Any]] = []
+
+    def chat(self, messages: Any, **kwargs: Any) -> str:
+        msgs = [dict(m) for m in messages]
+        self.calls.append({"messages": msgs, "kwargs": kwargs})
+        if callable(self._reply):
+            return str(self._reply(msgs, **kwargs))
+        return str(self._reply)
+
+
+class RaisingPool:
+    """A pool whose ``chat`` always raises (the failure-degrade path)."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def chat(self, messages: Any, **kwargs: Any) -> str:
+        self.calls.append({"messages": list(messages)})
+        raise RuntimeError("pool exhausted")
+
+
+def _img_parts(call: dict[str, Any]) -> list[dict[str, Any]]:
+    """Pull the image_url content parts out of a recorded FakePool chat call."""
+    content = call["messages"][-1]["content"]
+    return [p for p in content if isinstance(p, dict) and p.get("type") == "image_url"]
+
+
+class TestScoresFromOrder:
+    def test_descending_scores_reproduce_order(self) -> None:
+        # order [2,0,1] -> idx2 best (1.0), idx0 mid (0.5), idx1 worst (0.0)
+        scores = sv._scores_from_order([2, 0, 1], 3)
+        assert scores == [0.5, 0.0, 1.0]
+        # feeding back through _order_from_scores reproduces the input order
+        assert sv._order_from_scores(scores) == [2, 0, 1]
+
+    def test_single_clip_is_one(self) -> None:
+        assert sv._scores_from_order([0], 1) == [1.0]
+
+    def test_n_le_zero_is_empty(self) -> None:
+        assert sv._scores_from_order([], 0) == []
+        assert sv._scores_from_order([0], -1) == []
+
+    def test_out_of_range_index_skipped(self) -> None:
+        # a defensively out-of-range index leaves its (absent) slot untouched.
+        scores = sv._scores_from_order([5, 0], 2)
+        assert scores[0] == 0.0  # position 1 -> (1-1)/1 = 0.0
+        assert scores[1] == 0.0  # idx 5 ignored; slot 1 never written
+
+
+class TestCloudVlmBackend:
+    def test_ranks_clips_into_scores_descending_by_reply_order(self) -> None:
+        # The cloud VLM says clip 2 is best, then 0, then 1.
+        pool = FakePool("2,0,1")
+        backend = sv.CloudVlmBackend(pool=pool, settings={}, frame_encoder=lambda f: f"b64:{f}")
+        scores = backend.rank_clips([["fA"], ["fB"], ["fC"]], "rank these")
+        assert len(scores) == 3
+        # best (idx 2) > then idx 0 > then idx 1
+        assert scores[2] > scores[0] > scores[1]
+
+    def test_sends_base64_frames_through_vision_capability(self) -> None:
+        pool = FakePool("0,1")
+        backend = sv.CloudVlmBackend(pool=pool, settings={}, frame_encoder=lambda f: f"ENC<{f}>")
+        backend.rank_clips([["x"], ["y", "z"]], "prompt text")
+        assert len(pool.calls) == 1
+        call = pool.calls[0]
+        assert call["kwargs"]["capability"] == "vision"
+        # the prompt text rode along as a text part
+        text_parts = [p for p in call["messages"][-1]["content"] if p.get("type") == "text"]
+        assert any("prompt text" in p["text"] for p in text_parts)
+        # every sampled frame was base64-encoded into an image_url data part
+        images = _img_parts(call)
+        assert len(images) == 3  # 1 + 2 frames
+        assert all("ENC<" in img["image_url"]["url"] for img in images)
+
+    def test_empty_clips_returns_empty_without_calling_pool(self) -> None:
+        pool = FakePool("0")
+        backend = sv.CloudVlmBackend(pool=pool, settings={}, frame_encoder=lambda f: "b")
+        assert backend.rank_clips([], "p") == []
+        assert pool.calls == []
+
+    def test_pool_failure_propagates_for_reranker_noop(self) -> None:
+        # CloudVlmBackend does NOT swallow; SmolVlmReranker's try/except degrades to
+        # identity order (so a cloud failure leaves the order unchanged).
+        backend = sv.CloudVlmBackend(pool=RaisingPool(), settings={}, frame_encoder=lambda f: "b")
+        with pytest.raises(RuntimeError):
+            backend.rank_clips([["a"], ["b"]], "p")
+
+    def test_reranker_uses_cloud_backend_to_reorder(self) -> None:
+        # End-to-end: a cloud backend injected via the factory reorders the top slice.
+        pool = FakePool("1,0")  # clip 1 best
+        cands = [cand(hook="a"), cand(hook="b"), cand(hook="c")]
+        rr = sv.SmolVlmReranker(
+            backend_factory=lambda settings: sv.CloudVlmBackend(
+                pool=pool, settings=settings, frame_encoder=lambda f: "b"
+            ),
+            clip_frame_loader=fake_loader(),
+        )
+        out = rr.rerank_top_k(cands, top_k=2)
+        assert [c["hook"] for c in out] == ["b", "a", "c"]  # tail c untouched
+
+    def test_n_mismatch_reply_degrades_to_identity(self) -> None:
+        # A reply naming only out-of-range / no valid indices yields identity order;
+        # SmolVlmReranker then keeps the input order (no-op).
+        pool = FakePool("no valid indices here")
+        cands = [cand(hook="a"), cand(hook="b")]
+        rr = sv.SmolVlmReranker(
+            backend_factory=lambda settings: sv.CloudVlmBackend(
+                pool=pool, settings=settings, frame_encoder=lambda f: "b"
+            ),
+            clip_frame_loader=fake_loader(),
+        )
+        # identity order -> scores descending by index -> same order kept
+        assert [c["hook"] for c in rr.rerank_top_k(cands, top_k=2)] == ["a", "b"]
+
+    def test_honors_model_and_sampling_settings(self) -> None:
+        record: dict[str, Any] = {}
+
+        def reply(messages: Any, **kwargs: Any) -> str:
+            record.update(kwargs)
+            return "0,1"
+
+        pool = FakePool(reply)
+        backend = sv.CloudVlmBackend(
+            pool=pool,
+            settings={"visionModel": "gemini-flash", "visionMaxTokens": 256},
+            frame_encoder=lambda f: "b",
+        )
+        backend.rank_clips([["a"], ["b"]], "p")
+        assert record["capability"] == "vision"
+        assert record["max_tokens"] == 256
+
+
+# --------------------------------------------------------------------------- #
 # module surface
 # --------------------------------------------------------------------------- #
 def test_constants_and_exports():

--- a/sidecar/tests/test_translation_routing.py
+++ b/sidecar/tests/test_translation_routing.py
@@ -1,0 +1,58 @@
+"""Per-function routing for the translation tier3 hosted seam (WU-presets).
+
+PLAN §WU-presets acceptance (b): the per-function override must change the
+provider the ``get_translator`` (translation) seam uses. The translation function
+threads its routing-preferred provider id through ``get_translator(prefer=...)``
+into the SAME rotation pool the general LLM seam uses, so the tier3 hosted
+provider tries that provider first.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from media_studio.models import provider as P
+from media_studio.models import translation as T
+
+
+def _settings(*providers: dict[str, Any]) -> dict[str, Any]:
+    return {"providers": list(providers)}
+
+
+_GROQ = {
+    "id": "groq-llama-3.3-70b",
+    "provider": "Groq",
+    "baseUrl": "https://groq.example/v1",
+    "model": "llama-3.3-70b",
+    "apiKeys": ["gk-aaaa1111"],
+    "capabilities": ["text"],
+    "unit": "token",
+}
+_MISTRAL = {
+    "id": "mistral-pixtral",
+    "provider": "Mistral",
+    "baseUrl": "https://mistral.example/v1",
+    "model": "pixtral",
+    "apiKeys": ["mk-bbbb2222"],
+    "capabilities": ["text", "vision"],
+    "unit": "token",
+}
+
+
+def test_get_translator_prefer_orders_hosted_pool_provider_first() -> None:
+    translator = T.get_translator(_settings(_GROQ, _MISTRAL), prefer="mistral-pixtral")
+    hosted = translator._hosted_provider()
+    assert isinstance(hosted, P.RotatingProvider)
+    assert [e.provider for e in hosted.entries][0] == "Mistral"
+
+
+def test_get_translator_default_keeps_configured_order() -> None:
+    translator = T.get_translator(_settings(_GROQ, _MISTRAL))
+    hosted = translator._hosted_provider()
+    assert [e.provider for e in hosted.entries][0] == "Groq"
+
+
+def test_get_translator_prefer_local_is_local_only_hosted() -> None:
+    translator = T.get_translator(_settings(_GROQ, _MISTRAL), prefer=P.LOCAL_PROVIDER_ID)
+    hosted = translator._hosted_provider()
+    assert [e.provider for e in hosted.entries] == ["local"]

--- a/sidecar/tests/test_usage.py
+++ b/sidecar/tests/test_usage.py
@@ -1,0 +1,108 @@
+"""WU-usage-ui PURE model tests: UsageUnit + cache merge + stale flagging.
+
+The rotation pool already produces the per-key usage rows (tested in
+test_rotating_provider). This pins the small pure half WU-usage-ui adds: the
+REQ/TOKEN unit enum (never-summed dimensions), the persisted-cache merge that
+shows last-known numbers on launch, and the >10-min stale flag.
+"""
+
+from __future__ import annotations
+
+from media_studio.models.usage import (
+    STALE_AFTER_SECONDS,
+    UsageUnit,
+    flag_stale,
+    merge_usage_cache,
+)
+
+
+# --------------------------------------------------------------------------- #
+# UsageUnit
+# --------------------------------------------------------------------------- #
+def test_usage_unit_values_are_plain_lowercase_strings() -> None:
+    assert UsageUnit.REQ.value == "req"
+    assert UsageUnit.TOKEN.value == "token"
+    # str-subclass: the JSON value is the bare string the pool/catalog emit.
+    assert UsageUnit.TOKEN == "token"
+
+
+def test_usage_unit_coerce_maps_token_and_falls_back_to_req() -> None:
+    assert UsageUnit.coerce("token") is UsageUnit.TOKEN
+    assert UsageUnit.coerce("TOKEN") is UsageUnit.TOKEN
+    assert UsageUnit.coerce("req") is UsageUnit.REQ
+    # Unknown / garbage units fall back to the safe per-request default.
+    assert UsageUnit.coerce("widgets") is UsageUnit.REQ
+    assert UsageUnit.coerce(None) is UsageUnit.REQ
+
+
+# --------------------------------------------------------------------------- #
+# merge_usage_cache
+# --------------------------------------------------------------------------- #
+def _row(provider: str, key: str, *, used: int = 0, max_: int | None = None,
+         unit: str = "req", reset_at: float | None = None) -> dict[str, object]:
+    return {"provider": provider, "key": key, "used": used, "max": max_,
+            "unit": unit, "resetAt": reset_at}
+
+
+def test_merge_keeps_cached_numbers_when_live_pool_is_freshly_zeroed() -> None:
+    # A freshly-built pool reports used=0 / max=None; the cache holds real numbers.
+    live = [_row("Groq", "…aaaa", used=0, max_=None)]
+    cached = [_row("Groq", "…aaaa", used=983, max_=1000, reset_at=2030.0)]
+    [merged] = merge_usage_cache(live, cached)
+    assert merged["used"] == 983
+    assert merged["max"] == 1000
+    assert merged["resetAt"] == 2030.0
+    # identity/unit always comes from the live row.
+    assert merged["provider"] == "Groq"
+
+
+def test_merge_live_real_data_supersedes_cache() -> None:
+    live = [_row("Groq", "…aaaa", used=5, max_=1000)]
+    cached = [_row("Groq", "…aaaa", used=983, max_=1000)]
+    [merged] = merge_usage_cache(live, cached)
+    assert merged["used"] == 5
+
+
+def test_merge_drops_cached_only_keys_not_in_live_pool() -> None:
+    live = [_row("Groq", "…aaaa")]
+    cached = [_row("OpenRouter", "…zzzz", used=10, max_=100)]
+    merged = merge_usage_cache(live, cached)
+    assert [m["provider"] for m in merged] == ["Groq"]
+
+
+def test_merge_with_empty_cache_returns_live_rows_unchanged() -> None:
+    live = [_row("Groq", "…aaaa", used=2, max_=1000)]
+    assert merge_usage_cache(live, []) == live
+
+
+def test_merge_keeps_live_zero_when_cache_also_has_no_real_data() -> None:
+    live = [_row("Groq", "…aaaa", used=0, max_=None)]
+    cached = [_row("Groq", "…aaaa", used=0, max_=None)]
+    [merged] = merge_usage_cache(live, cached)
+    assert merged["used"] == 0
+    assert merged["max"] is None
+
+
+# --------------------------------------------------------------------------- #
+# flag_stale (fake clock)
+# --------------------------------------------------------------------------- #
+def test_flag_stale_marks_fresh_rows_not_stale() -> None:
+    rows = [_row("Groq", "…aaaa", used=2, max_=1000)]
+    [out] = flag_stale(rows, now=1000.0, checked_at={"Groq\x00…aaaa": 999.0})
+    assert out["stale"] is False
+    assert out["lastCheckedAt"] == 999.0
+
+
+def test_flag_stale_marks_old_rows_stale_past_threshold() -> None:
+    rows = [_row("Groq", "…aaaa", used=2, max_=1000)]
+    old = 1000.0 - STALE_AFTER_SECONDS - 1.0
+    [out] = flag_stale(rows, now=1000.0, checked_at={"Groq\x00…aaaa": old})
+    assert out["stale"] is True
+    assert out["lastCheckedAt"] == old
+
+
+def test_flag_stale_treats_unstamped_row_as_just_checked() -> None:
+    rows = [_row("Groq", "…aaaa")]
+    [out] = flag_stale(rows, now=1234.5)
+    assert out["stale"] is False
+    assert out["lastCheckedAt"] == 1234.5

--- a/sidecar/tests/test_usage.py
+++ b/sidecar/tests/test_usage.py
@@ -38,10 +38,10 @@ def test_usage_unit_coerce_maps_token_and_falls_back_to_req() -> None:
 # --------------------------------------------------------------------------- #
 # merge_usage_cache
 # --------------------------------------------------------------------------- #
-def _row(provider: str, key: str, *, used: int = 0, max_: int | None = None,
-         unit: str = "req", reset_at: float | None = None) -> dict[str, object]:
-    return {"provider": provider, "key": key, "used": used, "max": max_,
-            "unit": unit, "resetAt": reset_at}
+def _row(
+    provider: str, key: str, *, used: int = 0, max_: int | None = None, unit: str = "req", reset_at: float | None = None
+) -> dict[str, object]:
+    return {"provider": provider, "key": key, "used": used, "max": max_, "unit": unit, "resetAt": reset_at}
 
 
 def test_merge_keeps_cached_numbers_when_live_pool_is_freshly_zeroed() -> None:


### PR DESCRIPTION
Implements the gate-approved AI Provider Hub MVP (docs/plans/ai-program/PLAN.md), built metaswarm-orchestrated in dependency-ordered waves, each WU TDD'd to 100% line+branch + adversarially reviewed.

## Work units
**Wave-1 (pure substrate):** catalog · ai_cache · secrets · local_detect · budget · presets
**Wave-2 (spine):** RotatingProvider over BOTH LLM seams (get_provider AND TieredTranslator tier3) + local backstop (embedded llama.cpp + auto-detected Ollama/LM Studio) · AI-Job envelope (ai.planJob) · keys (raw-vs-redacted, enforceable error-body scrub, providers.* RPC, per-data-type consent)
**Wave-3 (UI surface):** providers.catalog + budget pre-flight · dual-unit usage bars + superpowered + a11y · presets + per-function + first-run chooser · vision offload (CloudVlmBackend on the smolvlm2 seam, frame-consent-first)

## Honored decisions
Local-first wedge (cloud opt-in, local backstop). Multi-PROVIDER rotation only — "N keys ≠ N×quota" (per-account ToS). Keys never logged / never returned full over RPC. Per-data-type consent (text vs frames); frame egress gated FIRST in phase8_select. No `time.sleep` on the rotation hot path (injected clock).

## Gates
sidecar `pytest --cov-branch --cov-fail-under=100` = 100% (2975 passed) · renderer vitest thresholds:100 (60 files) · ruff/basedpyright/tsc clean · gitleaks clean. Adversarial review per WU (vision NO-GO→fixed: a multi-provider frame-leak was caught + closed).

## Follow-ons (per plan §3)
Director (prompt-driven editing), batch queue/repurpose, templates, multi-platform presets, semantic index, device-aware auto-recommender, filler/silence + diarization surface WUs.