### PR TITLE
fix(security): SECURITY.md + clear 3 CodeQL alerts

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,33 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the `main` branch.
+
+| Version | Supported |
+| --- | --- |
+| `main` | :white_check_mark: |
+| Other branches/tags | :x: |
+
+## Reporting a Vulnerability
+
+Please do **not** open public GitHub issues for undisclosed security findings.
+
+Use GitHub Private Vulnerability Reporting for this repository:
+<https://github.com/Prekzursil/Reframe/security/advisories/new>
+
+If private advisory reporting is unavailable, contact the maintainer privately on GitHub (`@Prekzursil`).
+
+When reporting, include:
+
+- the affected component, file, workflow, or dependency
+- the exact commit, branch, or release if known
+- clear reproduction or proof-of-concept steps
+- impact details covering confidentiality, integrity, or availability
+- any suggested mitigation if known
+
+## Disclosure Expectations
+
+- Initial acknowledgment: best effort within 3 business days.
+- Triage update: best effort within 7 business days.
+- Coordinated disclosure is expected; please allow time to investigate and patch before public disclosure.


### PR DESCRIPTION
## Summary

Adds a `SECURITY.md` security policy at the repo root and addresses the 3 open CodeQL `note`-severity alerts.

### SECURITY.md
- Supported versions table (`main` only)
- Private Vulnerability Reporting workflow + maintainer fallback
- Disclosure expectations / timelines

### CodeQL alerts — all 3 target retired code (skipped, not fabricated)
The 3 alerts point at the old SaaS surface, which no longer exists on `main` (repo is now the desktop/Electron app — `app/`, `sidecar/`, no `apps/` or `scripts/quality/`):

- **#1496** `py/unused-import` — `scripts/quality/check_visual_zero.py:6` — file absent on `main`
- **#1461** `py/unused-local-variable` — `apps/api/tests/test_project_collaboration.py:38` — file absent on `main`
- **#1456** `py/empty-except` — `apps/api/app/api.py:1675` — file absent on `main`

Verified via `git ls-files` (no match for any of the three paths, no `apps/` or `scripts/quality/` tree). These alerts are stale and should age out / be dismissed as "code removed"; there is nothing left to edit. No files deleted, no tests weakened.

## Test plan
- [ ] Quality CI (`.github/workflows/quality.yml`) green on a docs-only change