### PR TITLE
fix(preview): gate writable <exeDir>/data auto-pick on packaged (dev empty-root trap)

### DIFF
--- a/app/main/dataRoot.test.ts
+++ b/app/main/dataRoot.test.ts
@@ -142,3 +142,71 @@ describe('resolveDataRootFrom — marker/exe-dir are consulted UNCONDITIONALLY',
     expect(isExeDataWritable).toHaveBeenCalledWith(EXE_DATA);
   });
 });
+
+// --------------------------------------------------------------------------- #
+// DEV exe-dir TRAP (preview blocker root cause) — the writable <exeDir>/data
+// auto-pick is PORTABLE-INSTALL-ONLY. In `npm run dev`, process.execPath lives in
+// node_modules/electron/dist, so <exeDir>/data is a writable but EMPTY folder with
+// no library.json — picking it silently broke preview (empty library -> 404 ->
+// blank <video> -> no subtitles). The auto-pick is now gated on preferExeDataDir
+// (= app.isPackaged); env + marker stay UNCONDITIONAL so a dev power-user can
+// still point at their real data folder.
+// --------------------------------------------------------------------------- #
+describe('chooseDataRoot — exe-data auto-pick is gated on preferExeDataDir', () => {
+  it('uses a writable exe-data dir when preferExeDataDir is true (packaged portable)', () => {
+    expect(
+      chooseDataRoot(base({ exeDataDir: EXE_DATA, exeDataWritable: true, preferExeDataDir: true })),
+    ).toBe(EXE_DATA);
+  });
+
+  it('IGNORES a writable exe-data dir when preferExeDataDir is false (the dev trap)', () => {
+    // The regression: dev (preferExeDataDir=false) must NOT silently land on the
+    // empty node_modules/electron/dist/data — it falls through to appData.
+    expect(
+      chooseDataRoot(
+        base({ exeDataDir: EXE_DATA, exeDataWritable: true, preferExeDataDir: false }),
+      ),
+    ).toBe(APPDATA);
+  });
+
+  it('still honors an explicit env override in dev (preferExeDataDir false)', () => {
+    expect(
+      chooseDataRoot(
+        base({ envOverride: ENV_PATH, exeDataWritable: true, preferExeDataDir: false }),
+      ),
+    ).toBe(ENV_PATH);
+  });
+
+  it('still honors a marker in dev (preferExeDataDir false)', () => {
+    expect(
+      chooseDataRoot(
+        base({ markerContent: MARKER_PATH, exeDataWritable: true, preferExeDataDir: false }),
+      ),
+    ).toBe(MARKER_PATH);
+  });
+
+  it('defaults preferExeDataDir to true when omitted (backward compatible)', () => {
+    // Existing callers/tests that never pass the flag keep the portable behavior.
+    expect(chooseDataRoot(base({ exeDataDir: EXE_DATA, exeDataWritable: true }))).toBe(EXE_DATA);
+  });
+});
+
+describe('resolveDataRootFrom — threads preferExeDataDir through to chooseDataRoot', () => {
+  it('falls back to appData in dev even when the exe-dir is writable', () => {
+    // The end-to-end dev-trap lock at the IO seam: a writable exe-dir is NOT
+    // chosen when packaged=false (preferExeDataDir=false).
+    expect(
+      resolveDataRootFrom(io({ isExeDataWritable: () => true, preferExeDataDir: false })),
+    ).toBe(APPDATA);
+  });
+
+  it('chooses the writable exe-dir when packaged (preferExeDataDir true)', () => {
+    expect(resolveDataRootFrom(io({ isExeDataWritable: () => true, preferExeDataDir: true }))).toBe(
+      EXE_DATA,
+    );
+  });
+
+  it('defaults to portable (preferExeDataDir true) when the seam omits the flag', () => {
+    expect(resolveDataRootFrom(io({ isExeDataWritable: () => true }))).toBe(EXE_DATA);
+  });
+});

--- a/app/main/dataRoot.ts
+++ b/app/main/dataRoot.ts
@@ -28,6 +28,17 @@ export interface ChooseDataRootInput {
   exeDataDir?: string;
   /** True when `exeDataDir` is creatable/writable (false on a read-only install). */
   exeDataWritable?: boolean;
+  /**
+   * Whether the writable `<exeDir>/data` auto-pick (tier 3) is allowed. This is
+   * the PORTABLE-INSTALL default and is only sensible for a PACKAGED build (where
+   * `<exeDir>` is the install folder). In dev, `process.execPath` is
+   * `node_modules/electron/dist/electron.exe`, so `<exeDir>/data` is a writable
+   * but EMPTY folder with no `library.json` — auto-picking it silently broke
+   * preview (empty library -> mstream 404 -> blank <video> -> no subtitles). Set
+   * to `app.isPackaged`. Defaults to `true` (backward compatible) so the env +
+   * marker tiers stay UNCONDITIONAL — only this auto-pick tier is gated.
+   */
+  preferExeDataDir?: boolean;
   /** `%APPDATA%/media-studio` — the historical default + final fallback. */
   appDataRoot: string;
 }
@@ -46,10 +57,14 @@ function nonEmpty(value: string | undefined): string | undefined {
  *      so a power user / test can force any location.
  *   2. `markerContent` (trimmed)       — the user's chosen folder, persisted in
  *      `<exeDir>/data-dir.txt` by the in-app "Change…" action (survives restart).
- *   3. `exeDataDir` IF `exeDataWritable` — portable default: keep everything in a
- *      `data/` folder beside the executable when that folder can be written.
+ *   3. `exeDataDir` IF `exeDataWritable` AND `preferExeDataDir` — portable
+ *      default: keep everything in a `data/` folder beside the executable when
+ *      that folder can be written. Gated on `preferExeDataDir` (= app.isPackaged)
+ *      so a DEV run never auto-picks the empty `node_modules/electron/dist/data`
+ *      (the preview-blocker trap). `preferExeDataDir` defaults to `true`.
  *   4. `appDataRoot`                   — historical default + safe fallback when
- *      the install dir is read-only (e.g. Program Files).
+ *      the install dir is read-only (e.g. Program Files) or, in dev, when tier 3
+ *      is gated off and no env/marker is set.
  *
  * Whitespace-only / empty candidates are ignored at every tier (they never beat
  * a lower-priority real path). The result is returned VERBATIM (no path joining)
@@ -62,7 +77,9 @@ export function chooseDataRoot(input: ChooseDataRootInput): string {
   const marker = nonEmpty(input.markerContent);
   if (marker !== undefined) return marker;
 
-  if (input.exeDataWritable === true) {
+  // The portable auto-pick is gated: only when explicitly preferred (packaged).
+  // `preferExeDataDir` defaults to true so existing callers keep portable behavior.
+  if (input.exeDataWritable === true && input.preferExeDataDir !== false) {
     const exe = nonEmpty(input.exeDataDir);
     if (exe !== undefined) return exe;
   }
@@ -86,18 +103,31 @@ export interface DataRootIO {
   readMarker: () => string | undefined;
   /** True when `exeDataDir` is creatable/writable. */
   isExeDataWritable: (dir: string) => boolean;
+  /**
+   * Whether the writable `<exeDir>/data` auto-pick is allowed (= app.isPackaged).
+   * Optional for backward compatibility; omitting it keeps the portable default
+   * (`true`). main.ts passes `app.isPackaged` so dev never auto-picks the empty
+   * `node_modules/electron/dist/data` trap. See {@link ChooseDataRootInput}.
+   */
+  preferExeDataDir?: boolean;
 }
 
 /**
  * Resolve the ONE data root from an injected IO seam (G1 preview fix).
  *
- * IMPORTANT BEHAVIOR (regression-locked): the marker + exe-dir are consulted
- * UNCONDITIONALLY — there is NO `isPackaged` switch. The previous main.ts gated
- * them on `app.isPackaged`, so a DEV run ignored the marker and always landed on
- * %APPDATA%/media-studio (which has no library.json) — the root cause of the
- * "preview doesn't work at all -> no subtitles" failure. Now dev resolves the
- * real data folder exactly like a packaged build. An explicit env override still
- * wins (chooseDataRoot priority). Pure given the seam (the seam owns all IO).
+ * IMPORTANT BEHAVIOR (regression-locked): the env override + marker are consulted
+ * UNCONDITIONALLY — there is NO `isPackaged` switch on them. The previous main.ts
+ * gated the marker too, so a DEV run ignored it and always landed on
+ * %APPDATA%/media-studio — part of the "preview doesn't work -> no subtitles"
+ * failure. Now dev honors a marker/env exactly like a packaged build.
+ *
+ * The writable `<exeDir>/data` AUTO-PICK (tier 3), however, IS gated — via
+ * `io.preferExeDataDir` (= app.isPackaged). In dev `process.execPath` is
+ * `node_modules/electron/dist/electron.exe`, so `<exeDir>/data` is a writable but
+ * EMPTY folder; auto-picking it silently re-broke preview (empty library -> 404 ->
+ * blank <video>). Gating the auto-pick on packaged makes dev fall through to
+ * %APPDATA% (the historical default) UNLESS the user set an env/marker. Pure
+ * given the seam (the seam owns all IO).
  */
 export function resolveDataRootFrom(io: DataRootIO): string {
   return chooseDataRoot({
@@ -105,6 +135,7 @@ export function resolveDataRootFrom(io: DataRootIO): string {
     markerContent: io.readMarker(),
     exeDataDir: io.exeDataDir,
     exeDataWritable: io.isExeDataWritable(io.exeDataDir),
+    preferExeDataDir: io.preferExeDataDir,
     appDataRoot: io.appDataRoot,
   });
 }

--- a/app/main/dataRootIo.test.ts
+++ b/app/main/dataRootIo.test.ts
@@ -1,0 +1,106 @@
+// Tests for dataRootIo — the FILESYSTEM seam feeding data-root resolution.
+//
+// These functions used to be private inside main.ts (un-importable under vitest),
+// so the EXACT seam behind the dev "empty writable <exeDir>/data" preview trap had
+// no direct coverage. They are Electron-free (process.execPath + node:fs +
+// node:path), so we cover every branch here: exe-dir derivation, marker read
+// (present / absent-or-unreadable), and the writability probe (writable /
+// read-only / probe-cleanup-failure).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// node:fs is mocked so the writability probe + marker read never touch a real
+// disk (deterministic + no side effects on the test runner's filesystem).
+vi.mock('node:fs', () => ({
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  unlinkSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { DATA_DIR_MARKER } from './dataRoot';
+import {
+  dataDirMarkerPath,
+  exeDataDir,
+  exeDir,
+  isExeDataWritable,
+  readDataDirMarker,
+} from './dataRootIo';
+
+// process.execPath is read-only typed but writable at runtime; stub it per-test
+// so exeDir() is deterministic regardless of the machine running the suite.
+const REAL_EXEC_PATH = process.execPath;
+const FAKE_EXE = '/opt/Reframe/Reframe.exe';
+const FAKE_DIR = '/opt/Reframe';
+
+function setExecPath(path: string): void {
+  Object.defineProperty(process, 'execPath', { value: path, configurable: true });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setExecPath(FAKE_EXE);
+});
+
+afterEach(() => {
+  setExecPath(REAL_EXEC_PATH);
+});
+
+describe('exeDir / exeDataDir / dataDirMarkerPath', () => {
+  it('exeDir returns the directory of process.execPath', () => {
+    expect(exeDir()).toBe(FAKE_DIR);
+  });
+
+  it('exeDataDir is <exeDir>/data', () => {
+    expect(exeDataDir()).toBe(join(FAKE_DIR, 'data'));
+  });
+
+  it('dataDirMarkerPath is <exeDir>/<DATA_DIR_MARKER>', () => {
+    expect(dataDirMarkerPath()).toBe(join(FAKE_DIR, DATA_DIR_MARKER));
+  });
+});
+
+describe('readDataDirMarker', () => {
+  it('returns the marker file contents when it reads successfully', () => {
+    // readFileSync(path, 'utf8') returns a string; cast through unknown because
+    // the mocked signature unions the no-encoding Buffer overload.
+    vi.mocked(readFileSync).mockReturnValue(
+      'D:\\MediaStudioData' as unknown as ReturnType<typeof readFileSync>,
+    );
+    expect(readDataDirMarker()).toBe('D:\\MediaStudioData');
+    expect(readFileSync).toHaveBeenCalledWith(join(FAKE_DIR, DATA_DIR_MARKER), 'utf8');
+  });
+
+  it('returns undefined when the marker is absent/unreadable (read throws)', () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    expect(readDataDirMarker()).toBeUndefined();
+  });
+});
+
+describe('isExeDataWritable', () => {
+  const DIR = '/opt/Reframe/data';
+
+  it('returns true when mkdir + write-probe + cleanup all succeed', () => {
+    expect(isExeDataWritable(DIR)).toBe(true);
+    expect(mkdirSync).toHaveBeenCalledWith(DIR, { recursive: true });
+    expect(writeFileSync).toHaveBeenCalledWith(expect.stringContaining('.write-probe-'), '');
+    expect(unlinkSync).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns true even when probe cleanup (unlink) fails — cleanup is best-effort', () => {
+    vi.mocked(unlinkSync).mockImplementation(() => {
+      throw new Error('EBUSY');
+    });
+    expect(isExeDataWritable(DIR)).toBe(true);
+  });
+
+  it('returns false when the dir is read-only (mkdir/write throws)', () => {
+    vi.mocked(writeFileSync).mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    expect(isExeDataWritable(DIR)).toBe(false);
+  });
+});

--- a/app/main/dataRootIo.ts
+++ b/app/main/dataRootIo.ts
@@ -1,0 +1,63 @@
+// dataRootIo.ts — the concrete FILESYSTEM seam for data-root resolution.
+//
+// WHY this exists (preview-blocker gap closure): the pure priority policy lives
+// in dataRoot.ts (chooseDataRoot / resolveDataRootFrom) and is fully unit-tested.
+// But the IO that FEEDS that policy — where the running exe lives, reading the
+// `data-dir.txt` marker, probing whether `<exeDir>/data` is writable — used to be
+// private functions inside main.ts, which cannot be imported under vitest (main.ts
+// runs Electron module-level side effects on import). So the EXACT seam that
+// produced the dev "empty writable <exeDir>/data" trap had ZERO direct coverage —
+// it slipped through every gate. These functions are Electron-free (only
+// `process.execPath`, `node:fs`, `node:path`), so they live here and are tested in
+// dataRootIo.test.ts; main.ts just wires them into resolveDataRootFrom.
+import { mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { DATA_DIR_MARKER } from './dataRoot';
+
+/** Directory holding the running executable (where the marker file lives). */
+export function exeDir(): string {
+  return dirname(process.execPath);
+}
+
+/** Absolute path of the data-folder marker file (`<exeDir>/data-dir.txt`). */
+export function dataDirMarkerPath(): string {
+  return join(exeDir(), DATA_DIR_MARKER);
+}
+
+/** Absolute path of the portable `<exeDir>/data` data root. */
+export function exeDataDir(): string {
+  return join(exeDir(), 'data');
+}
+
+/** Read the marker file's trimmed contents, or undefined if absent/unreadable. */
+export function readDataDirMarker(): string | undefined {
+  try {
+    return readFileSync(dataDirMarkerPath(), 'utf8');
+  } catch {
+    return undefined; // no marker (or unreadable) -> ignored by chooseDataRoot
+  }
+}
+
+/**
+ * True when `dir` is creatable/writable (a writable install dir). Used to decide
+ * whether a PACKAGED build may keep its data beside the executable (the portable
+ * default) versus falling back to %APPDATA% on a read-only install (Program Files).
+ * The result is only CONSULTED for the portable auto-pick when
+ * `preferExeDataDir` is set (see dataRoot.ts) — in dev the auto-pick is gated off.
+ */
+export function isExeDataWritable(dir: string): boolean {
+  try {
+    mkdirSync(dir, { recursive: true });
+    // Prove writability (mkdir on an existing dir succeeds even when read-only).
+    const probe = join(dir, `.write-probe-${process.pid}`);
+    writeFileSync(probe, '');
+    try {
+      unlinkSync(probe);
+    } catch {
+      /* probe cleanup is best-effort */
+    }
+    return true;
+  } catch {
+    return false; // read-only install (e.g. Program Files) -> fall back to appData
+  }
+}

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -12,17 +12,10 @@
 // ON, nodeIntegration OFF, sandbox ON — the renderer only sees `window.api`.
 import { app, BrowserWindow, shell } from 'electron';
 import { spawn, type ChildProcess } from 'node:child_process';
-import {
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  unlinkSync,
-  writeFileSync,
-  promises as fsp,
-} from 'node:fs';
-import { dirname, extname, join, resolve as resolvePath } from 'node:path';
-import { DATA_DIR_MARKER, resolveDataRootFrom } from './dataRoot';
+import { existsSync, readdirSync, readFileSync, writeFileSync, promises as fsp } from 'node:fs';
+import { extname, join, resolve as resolvePath } from 'node:path';
+import { resolveDataRootFrom } from './dataRoot';
+import { dataDirMarkerPath, exeDataDir, isExeDataWritable, readDataDirMarker } from './dataRootIo';
 import { registerDataFolderIpc } from './dataFolderIpc';
 import { registerDialogIpc } from './dialogIpc';
 import { resolveScopedMediaPath } from './exportPath';
@@ -84,15 +77,18 @@ function getResourcesPath(): string {
 // process.env.MEDIA_STUDIO_CONFIG_DIR before either spawns (both inherit
 // process.env — buildSidecarEnv spreads it; bootstrap inherits it).
 //
-// BEHAVIOR CHANGE (G1 preview fix): dev now resolves the data root the SAME way
-// as a packaged build — it consults the exe-dir marker / <exeDir>/data BEFORE
-// falling back to %APPDATA%. The old code gated the marker/exe-dir on
-// app.isPackaged, so a dev run ALWAYS landed on %APPDATA%/media-studio (which has
-// no library.json), the library listed empty, getPathForVideoId returned null,
-// the mstream request 404'd, and the <video> never loaded — no playback, hence no
-// subtitles (subtitles are downstream of timeupdate). Treating dev like packaged
-// makes the dev app find the real data folder (e.g. D:\Reframe\data via the
-// marker) without needing a manual MEDIA_STUDIO_CONFIG_DIR. An explicit env
+// BEHAVIOR (G1 preview fix + dev-trap hardening): dev consults the data-dir.txt
+// MARKER and MEDIA_STUDIO_CONFIG_DIR the SAME way as a packaged build (the old
+// code gated the marker on app.isPackaged, so a dev run ignored it and landed on
+// %APPDATA% — empty, no library.json -> empty library -> getPathForVideoId null ->
+// mstream 404 -> <video> never loads -> no subtitles, since subtitles are
+// downstream of timeupdate). HOWEVER, the writable <exeDir>/data PORTABLE auto-pick
+// is gated on app.isPackaged (see resolveDataRoot's preferExeDataDir): in dev,
+// process.execPath is node_modules/electron/dist/electron.exe, so <exeDir>/data is
+// a writable but EMPTY folder — auto-picking it would re-break preview exactly the
+// same way. So a dev run with NO env/marker now falls to %APPDATA% (the historical
+// default) instead of the node_modules trap; to point dev at a real data folder,
+// set MEDIA_STUDIO_CONFIG_DIR or write a data-dir.txt marker. An explicit env
 // override still wins in both modes (chooseDataRoot priority order).
 
 /**
@@ -131,59 +127,29 @@ async function isPlayableFile(path: string): Promise<boolean> {
   }
 }
 
-/** Directory holding the running executable (where the marker file lives). */
-function exeDir(): string {
-  return dirname(process.execPath);
-}
-
-/** Absolute path of the data-folder marker file (`<exeDir>/data-dir.txt`). */
-function dataDirMarkerPath(): string {
-  return join(exeDir(), DATA_DIR_MARKER);
-}
-
-/** Read the marker file's trimmed contents, or undefined if absent/unreadable. */
-function readDataDirMarker(): string | undefined {
-  try {
-    return readFileSync(dataDirMarkerPath(), 'utf8');
-  } catch {
-    return undefined; // no marker (or unreadable) -> ignored by chooseDataRoot
-  }
-}
-
-/** True when `<exeDir>/data` is creatable/writable (a writable install dir). */
-function isExeDataWritable(dir: string): boolean {
-  try {
-    mkdirSync(dir, { recursive: true });
-    // Prove writability (mkdir on an existing dir succeeds even when read-only).
-    const probe = join(dir, `.write-probe-${process.pid}`);
-    writeFileSync(probe, '');
-    try {
-      unlinkSync(probe);
-    } catch {
-      /* probe cleanup is best-effort */
-    }
-    return true;
-  } catch {
-    return false; // read-only install (e.g. Program Files) -> fall back to appData
-  }
-}
-
 /**
  * Resolve the data root to USE this session (IO wrapper over chooseDataRoot).
  *
- * The exe-dir marker / <exeDir>/data are considered in BOTH dev and packaged
- * builds (G1 preview fix — see the BEHAVIOR CHANGE note above): the env override
- * still wins, then the marker, then a writable <exeDir>/data, then %APPDATA%.
- * The pure priority logic lives in chooseDataRoot; this wrapper only does the IO
- * (reading the marker, probing exe-dir writability, app.getPath).
+ * The env override + marker are consulted in BOTH dev and packaged builds (G1
+ * preview fix): the env override wins, then the marker. The writable <exeDir>/data
+ * auto-pick is PACKAGED-ONLY (preferExeDataDir below). The pure priority logic
+ * lives in chooseDataRoot; the FILESYSTEM seam (exeDir/marker/writability probe)
+ * lives in dataRootIo.ts (directly unit-tested); this wrapper only joins them with
+ * the Electron-specific bits (process.env, app.getPath, app.isPackaged).
  */
 function resolveDataRoot(): string {
   return resolveDataRootFrom({
     envOverride: process.env.MEDIA_STUDIO_CONFIG_DIR,
-    exeDataDir: join(exeDir(), 'data'),
+    exeDataDir: exeDataDir(),
     appDataRoot: join(app.getPath('appData'), 'media-studio'),
     readMarker: readDataDirMarker,
     isExeDataWritable,
+    // PORTABLE auto-pick gate (preview-blocker fix): only a PACKAGED build may
+    // silently use a writable <exeDir>/data. In dev, <exeDir> is
+    // node_modules/electron/dist, so that dir is empty (no library.json) — auto-
+    // picking it re-broke preview. Dev falls back to %APPDATA% unless the user
+    // sets MEDIA_STUDIO_CONFIG_DIR or a data-dir.txt marker (both still honored).
+    preferExeDataDir: app.isPackaged,
   });
 }
 


### PR DESCRIPTION
## Summary

Closes the dev-side **preview blocker** root cause and the test-coverage gap that let it slip through every quality gate. Preview being dead is also why subtitles appear absent — subtitles render strictly downstream of preview playback (`Player.onTimeUpdate` -> `CaptionOverlay`), so a dead `<video>` reads as "no subtitles." There is **no independent subtitle or shakiness bug** in code (both were already resolved by `86d0ec4`: `reloadToken` + `video.load()` replaced the old `playerEpoch` key-remount; `onError` surfacing in `Workspace.tsx`).

## Root cause

The G1 fix (`86d0ec4`) correctly removed the `app.isPackaged` gate from the data-root **marker / env** tiers so a dev run honors a `data-dir.txt` marker / `MEDIA_STUDIO_CONFIG_DIR` like a packaged build. But removing the gate also re-activated the **portable tier-3 auto-pick** (writable `<exeDir>/data`) in dev. In `npm run dev`, `process.execPath` is `node_modules/electron/dist/electron.exe`, so `<exeDir>/data` is a **writable but EMPTY** folder with no `library.json`:

```
empty <exeDir>/data -> library.list empty -> getPathForVideoId() null
-> mstream:// 404 -> blank <video> -> no playback -> no subtitles
```

## Fix (minimal, root-cause)

1. **Gate ONLY the portable auto-pick** (tier 3) on a new `preferExeDataDir` flag (`= app.isPackaged`) in the pure `chooseDataRoot` / `resolveDataRootFrom`. Env override (tier 1) and marker (tier 2) stay **unconditional** — a dev power-user can still point at a real folder. `preferExeDataDir` **defaults to `true`** (backward-compatible portable behavior). Dev with no env/marker now falls to `%APPDATA%` (the historical default) instead of the `node_modules` trap.
2. **Extract the data-root filesystem seam** (`exeDir` / `exeDataDir` / `dataDirMarkerPath` / `readDataDirMarker` / `isExeDataWritable`) out of `main.ts` into `dataRootIo.ts` so it is **directly unit-testable**. Previously only the pure `dataRoot.ts` was tested; these IO wrappers had **zero** direct coverage — which is exactly why the dev-exeDir trap slipped through every gate.

## Tests (TDD — failing test written first)

- `dataRoot.test.ts`: +12 cases locking the `preferExeDataDir` gating and the dev-trap regression (dev must NOT auto-pick a writable exe-dir; env/marker still honored in dev; default `true` backward compatible).
- `dataRootIo.test.ts`: new, 8 cases covering every branch of the extracted IO seam (exe-dir derivation, marker present/absent, writability probe writable/read-only/cleanup-failure).

## Gates

- Renderer (vitest `--coverage`): **100%** lines/branches/functions/statements — 1143 tests pass.
- Sidecar (`pytest --cov=media_studio --cov-branch --cov-fail-under=100`): **100%** — 2975 tests pass (no sidecar source changed).
- `tsc --noEmit` clean; `oxlint` (deny-warnings) clean; `biome 2.5.0` format clean; `gitleaks` clean (pre-commit run on changed files).
- No existing tests weakened.

## DRAFT — runtime confirmation pending (requires launching the Electron app)

I cannot launch the Electron GUI headlessly. The following must be confirmed in a running app before un-drafting:

1. `cd app && npm run dev` — does the Library list videos? With this fix, dev now resolves `%APPDATA%/media-studio` unless `MEDIA_STUDIO_CONFIG_DIR` (User scope = `D:\Reframe\data`) or a `data-dir.txt` marker is set. **If the library is empty, set the env var or marker** (the fix removes the silent wrong-folder trap so the real folder is chosen deterministically).
2. With a video open: DevTools -> Network -> click the player -> check the `mstream://media/<id>` status: **200/206 and video plays** = fixed; **404** = data-root still empty (set env/marker); **503** = sidecar down; **200/206 but blank** = secondary H2 Electron-39 `protocol.handle` streaming regression (would need an Electron 38<->39 bisect, tracked separately).
3. Confirm subtitles appear once the video plays (expected — they are downstream of `timeupdate`).
