### PR TITLE
feat: UX/QoL — save/resume/save-options/availability/thumbnails (15 WUs)

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -58,8 +58,9 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 
 ### Method registry (the public surface — do not rename)
 - `ping()` -> `{"pong":true,"version":str}`
-- `library.list()` -> `{"videos":[{id,path,title,addedAt,durationSec,hasTranscript}]}`
+- `library.list()` -> `{"videos":[{id,path,title,addedAt,durationSec,hasTranscript,thumbnailPath}]}`
 - `library.add({path})` -> `{video}` ; `library.remove({id})` -> `{ok:true}`
+- `library.thumbnail({id})` -> `{thumbnailPath}` (WU-2: idempotent source-video poster under `data_dir/thumbnails/<id>.jpg`)
 - `project.open({id})` -> `{project}` ; `project.save({project})` -> `{ok}` ; `project.consolidate({id})` -> `{ok,folder}`
 - `transcribe.start({videoId, language?})` -> `{jobId}` ; streams progress ; `job.done.result` = `{transcript}`
 - `subtitles.generate({videoId})` -> `{track}` ; `subtitles.edit({trackId, cues})` -> `{track}`
@@ -79,7 +80,7 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 - **Cue** `{index:int, start:float, end:float, text:str}` ; **SubtitleTrack** `{id, lang, name, format, kind:"soft"|"hard", cues:[Cue]}`
 - **Candidate** `{rank:int, start:float, end:float, durationSec:float, hook:str, why:str, score:int, sourceStart:float}`
   (`sourceStart` = the clip's start in the ORIGINAL video; captions must subtract it to re-base to the clip's local t=0)
-- **Video** `{id, path, title, addedAt, durationSec, hasTranscript}`
+- **Video** `{id, path, title, addedAt, durationSec, hasTranscript, thumbnailPath}` (thumbnailPath is additive, default `""`)
 - **Project** `{id, video, transcript?, tracks:[SubtitleTrack], clips:[{candidate, path}], settings}`
 
 ## 4. Engine interfaces (exactly ONE impl each in this build)

--- a/app/main/exportPath.test.ts
+++ b/app/main/exportPath.test.ts
@@ -45,4 +45,41 @@ describe('resolveScopedMediaPath', () => {
     expect(resolveScopedMediaPath(`dub:${inside}`, 'dub:', dubsRoot)).toBe(inside);
     expect(resolveScopedMediaPath(`dub:${resolvePath('/x.wav')}`, 'dub:', dubsRoot)).toBeNull();
   });
+
+  // WU-3 (ux-qol): the `thumb:` branch serves library posters under
+  // DATA_ROOT/thumbnails. It is prefix-agnostic so it reuses this exact helper —
+  // the security boundary is identical to short:/dub: (a poster id may only ever
+  // resolve to a path INSIDE the thumbnails root).
+  describe('thumb: branch (library posters)', () => {
+    const thumbsRoot = resolvePath('/tmp/media-studio/thumbnails');
+
+    it('resolves a poster strictly inside the thumbnails root', () => {
+      const inside = resolvePath(thumbsRoot, 'vid1.jpg');
+      expect(resolveScopedMediaPath(`thumb:${inside}`, 'thumb:', thumbsRoot)).toBe(inside);
+    });
+
+    it('allows the thumbnails root itself', () => {
+      expect(resolveScopedMediaPath(`thumb:${thumbsRoot}`, 'thumb:', thumbsRoot)).toBe(thumbsRoot);
+    });
+
+    it('returns null for a parent-traversal escape out of the thumbnails root', () => {
+      const escape = `${thumbsRoot}${sep}..${sep}escape.jpg`;
+      expect(resolveScopedMediaPath(`thumb:${escape}`, 'thumb:', thumbsRoot)).toBeNull();
+    });
+
+    it('returns null for a sibling dir sharing the thumbnails prefix string', () => {
+      const sibling = `${thumbsRoot}-evil${sep}vid1.jpg`;
+      expect(resolveScopedMediaPath(`thumb:${sibling}`, 'thumb:', thumbsRoot)).toBeNull();
+    });
+
+    it('returns null for an absolute path elsewhere on disk', () => {
+      const elsewhere = resolvePath('/etc/passwd');
+      expect(resolveScopedMediaPath(`thumb:${elsewhere}`, 'thumb:', thumbsRoot)).toBeNull();
+    });
+
+    it('returns null for a missing-prefix id', () => {
+      const inside = resolvePath(thumbsRoot, 'vid1.jpg');
+      expect(resolveScopedMediaPath(inside, 'thumb:', thumbsRoot)).toBeNull();
+    });
+  });
 });

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -458,6 +458,21 @@ function bootstrap(): void {
       const exportsRoot = resolvePath(DATA_ROOT, 'exports');
       return resolveScopedMediaPath(videoId, 'short:', exportsRoot);
     }
+    // WU-3 (ux-qol §WU-3): serve a SOURCE library video's poster frame
+    // (`<videoId>.jpg`, written by the sidecar's library.thumbnail RPC into
+    // DATA_ROOT/thumbnails) over the same traversal-guarded mstream resolver so
+    // `<img src>` can load it in the sandbox (raw fs paths cannot). The id is
+    // `thumb:<absolute path>`; resolve it ONLY inside the thumbnails root (same
+    // path-traversal guard as `dub:`/`short:`). The thumbnails root is derived
+    // from DATA_ROOT — the SAME source as `short:`/`dub:` above — so it stays in
+    // lockstep with the sidecar's data dir (see the short: cross-process
+    // invariant note above: bootstrap() propagates DATA_ROOT to the sidecar as
+    // MEDIA_STUDIO_CONFIG_DIR, and the sidecar joins `/thumbnails` onto the same
+    // root in library.thumbnail).
+    if (videoId.startsWith('thumb:')) {
+      const thumbnailsRoot = resolvePath(DATA_ROOT, 'thumbnails');
+      return resolveScopedMediaPath(videoId, 'thumb:', thumbnailsRoot);
+    }
     if (!sc) return null;
     // Distinguish a dead/throwing sidecar (transient -> SidecarUnavailableError ->
     // 503) from a genuinely-absent id (-> null -> 404). Both `request` calls go to

--- a/app/main/mediaProtocol.test.ts
+++ b/app/main/mediaProtocol.test.ts
@@ -158,6 +158,16 @@ describe('videoIdFromUrl', () => {
     const url = `mstream://media/${encodeURIComponent(`short:${path}`)}`;
     expect(videoIdFromUrl(url)).toBe(`short:${path}`);
   });
+
+  it('decodes a WU-3 thumb: prefixed id intact (library poster single-segment round-trip)', () => {
+    // The library-poster URL is mstream://media/<encodeURIComponent("thumb:"+path)>.
+    // The whole `thumb:<path>` must come back as ONE id so the resolver branch can
+    // strip the prefix and traversal-guard the absolute path it encodes — exactly
+    // like short:/dub:.
+    const path = 'C:\\data\\thumbnails\\vid1.jpg';
+    const url = `mstream://media/${encodeURIComponent(`thumb:${path}`)}`;
+    expect(videoIdFromUrl(url)).toBe(`thumb:${path}`);
+  });
 });
 
 describe('contentTypeFor', () => {

--- a/app/renderer/src/App.quality.test.tsx
+++ b/app/renderer/src/App.quality.test.tsx
@@ -29,7 +29,26 @@ vi.mock('./lib/rpc', () => ({
 
 // Stub child views/chrome so the test focuses on App's own logic.
 vi.mock('./views/Library', () => ({
-  Library: () => <div data-testid="library" />,
+  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => (
+    <div data-testid="library">
+      <button
+        type="button"
+        data-testid="open-video"
+        onClick={() =>
+          onOpen({
+            id: 'v1',
+            path: '/movies/talk.mp4',
+            title: 'Talk',
+            addedAt: '2026-06-11T00:00:00Z',
+            durationSec: 600,
+            hasTranscript: false,
+          })
+        }
+      >
+        open-video
+      </button>
+    </div>
+  ),
 }));
 vi.mock('./views/Workspace', () => ({
   Workspace: ({ video }: { video: Video }) => (
@@ -340,5 +359,30 @@ describe('App handleReexport guard branches', () => {
     expect(libraryListMock).toHaveBeenCalledTimes(1);
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+  });
+});
+
+describe('App lastOpenedVideoId — bridge-absent branches (WU-13)', () => {
+  it('does NOT read settings.get on launch when no preload bridge is present', async () => {
+    hasApiValue = false;
+    await mount();
+    // The restore effect short-circuits before any RPC; stays on the Library.
+    expect(rpcMock).not.toHaveBeenCalledWith('settings.get');
+    expect(libraryListMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+  });
+
+  it('does NOT persist lastOpenedVideoId when no preload bridge is present', async () => {
+    hasApiValue = false;
+    await mount();
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="open-video"]')!.click();
+    });
+    await flush();
+    // openVideo still navigates in-memory but skips the settings.set persist.
+    expect(rpcMock).not.toHaveBeenCalledWith('settings.set', { lastOpenedVideoId: 'v1' });
+    expect(
+      container.querySelector('[data-testid="workspace"]')!.getAttribute('data-video-id'),
+    ).toBe('v1');
   });
 });

--- a/app/renderer/src/App.test.tsx
+++ b/app/renderer/src/App.test.tsx
@@ -247,3 +247,91 @@ describe('App route switch', () => {
     expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
   });
 });
+
+// WU-13: persist `lastOpenedVideoId` on openVideo + restore it on launch.
+describe('App lastOpenedVideoId persist + restore', () => {
+  it('restores the workspace for a valid persisted lastOpenedVideoId on launch', async () => {
+    rpcMock.mockImplementation((method: string) => {
+      if (method === 'settings.get') return Promise.resolve({ lastOpenedVideoId: 'v1' });
+      return Promise.resolve({});
+    });
+    libraryListMock.mockResolvedValue({ videos: [makeVideo({ id: 'v1', title: 'Restored' })] });
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    expect(libraryListMock).toHaveBeenCalledTimes(1);
+    const ws = container.querySelector('[data-testid="workspace"]');
+    expect(ws).not.toBeNull();
+    expect(ws!.getAttribute('data-video-id')).toBe('v1');
+  });
+
+  it('stays on the Library when the persisted id is absent from library.list', async () => {
+    rpcMock.mockImplementation((method: string) => {
+      if (method === 'settings.get') return Promise.resolve({ lastOpenedVideoId: 'gone' });
+      return Promise.resolve({});
+    });
+    libraryListMock.mockResolvedValue({ videos: [makeVideo({ id: 'v1' })] });
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    expect(libraryListMock).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+  });
+
+  it('stays on the Library when no lastOpenedVideoId is persisted (empty key)', async () => {
+    rpcMock.mockImplementation((method: string) => {
+      if (method === 'settings.get') return Promise.resolve({ lastOpenedVideoId: '' });
+      return Promise.resolve({});
+    });
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    // Empty key short-circuits before resolving the library.
+    expect(libraryListMock).not.toHaveBeenCalled();
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+  });
+
+  it('stays on the Library when the restore path throws (best-effort)', async () => {
+    rpcMock.mockImplementation((method: string) => {
+      if (method === 'settings.get') return Promise.resolve({ lastOpenedVideoId: 'v1' });
+      return Promise.resolve({});
+    });
+    libraryListMock.mockRejectedValue(new Error('boom'));
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+  });
+
+  it('persists lastOpenedVideoId via settings.set exactly once when a video is opened', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    const openBtn = container.querySelector<HTMLButtonElement>('[data-testid="library"] button');
+    await act(async () => {
+      openBtn!.click();
+    });
+    await flush();
+
+    const setCalls = rpcMock.mock.calls.filter(([method]) => method === 'settings.set');
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0][1]).toEqual({ lastOpenedVideoId: 'v1' });
+  });
+});

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -106,8 +106,40 @@ export function App(): React.ReactElement {
     });
   }, []);
 
+  // WU-13: restore the last-opened video on launch. This is its own async path
+  // (NOT bolted onto the sync quality-hydrate effect above): read the persisted
+  // `lastOpenedVideoId` from settings, then resolve the Video via library.list
+  // (mirroring handleReexport). Navigate to its Workspace on a match; fall back
+  // to the Library home (the default route) when the video is gone or absent.
+  useEffect(() => {
+    if (!hasApi()) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const settings = await rpc<{ lastOpenedVideoId?: string }>('settings.get');
+        const id = settings?.lastOpenedVideoId;
+        if (cancelled || !id) return;
+        const { videos } = await client.library.list();
+        const match = videos.find((v) => v.id === id);
+        if (!cancelled && match) {
+          setRoute({ name: 'workspace', video: match });
+        }
+      } catch {
+        // Best-effort restore; stay on the Library default on any failure.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   const openVideo = useCallback((video: Video) => {
     setRoute({ name: 'workspace', video });
+    // WU-13: persist the last-opened video so launch can restore it. Best-effort.
+    if (!hasApi()) return;
+    void rpc('settings.set', { lastOpenedVideoId: video.id }).catch(() => {
+      // Persisting is best-effort; navigation already happened in-memory.
+    });
   }, []);
 
   const backToLibrary = useCallback(() => {

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -195,7 +195,9 @@ export function App(): React.ReactElement {
         );
       case 'library':
       default:
-        return <Library onOpen={openVideo} />;
+        // WU-14: a readiness fix action on the library roll-up routes to the
+        // Models & System panel, where the provider/asset flows live.
+        return <Library onOpen={openVideo} onReadinessAction={openModels} />;
     }
   }
 

--- a/app/renderer/src/components/JobQueue.test.tsx
+++ b/app/renderer/src/components/JobQueue.test.tsx
@@ -25,8 +25,10 @@ vi.mock('../lib/rpc', () => ({
 import {
   JobQueue,
   JOB_POLL_INTERVAL_MS,
+  RESUME_TITLE,
   applyProgress,
   canCancel,
+  canResume,
   canRetry,
   clampPct,
 } from './JobQueue';
@@ -116,6 +118,16 @@ describe('canCancel / canRetry', () => {
     expect(canRetry(makeJob({ status: 'error' }))).toBe(true);
     expect(canRetry(makeJob({ status: 'running' }))).toBe(false);
     expect(canRetry(makeJob({ status: 'done' }))).toBe(false);
+    expect(canRetry(makeJob({ status: 'interrupted' }))).toBe(false);
+  });
+
+  it('resume applies to interrupted only (table-test all six statuses)', () => {
+    expect(canResume(makeJob({ status: 'interrupted' }))).toBe(true);
+    expect(canResume(makeJob({ status: 'queued' }))).toBe(false);
+    expect(canResume(makeJob({ status: 'running' }))).toBe(false);
+    expect(canResume(makeJob({ status: 'done' }))).toBe(false);
+    expect(canResume(makeJob({ status: 'error' }))).toBe(false);
+    expect(canResume(makeJob({ status: 'cancelled' }))).toBe(false);
   });
 });
 
@@ -241,6 +253,46 @@ describe('JobQueue', () => {
 
     expect(rpcMock).toHaveBeenCalledWith('job.retry', { jobId: 'err-1' });
     expect(listCalls()).toBe(before + 1);
+  });
+
+  it('Resume shows for interrupted only, fires job.retry, and excludes Retry/Cancel', async () => {
+    serveJobs([makeJob({ jobId: 'int-1', status: 'interrupted', pct: 0 })]);
+    await renderQueue(true);
+
+    // Exactly one Resume button; no Retry, no Cancel (the §3.2 a11y bug — an
+    // interrupted job would otherwise render zero action buttons).
+    expect(container.querySelectorAll('.jobqueue__resume').length).toBe(1);
+    expect(container.querySelectorAll('.jobqueue__retry').length).toBe(0);
+    expect(container.querySelectorAll('.jobqueue__cancel').length).toBe(0);
+
+    const resume = container.querySelector('.jobqueue__resume') as HTMLButtonElement;
+    expect(resume.getAttribute('aria-label')).toBe('Resume Transcribe talk.mp4');
+    expect(resume.getAttribute('title')).toBe(RESUME_TITLE);
+    expect(resume.textContent).toBe('Resume');
+    // The status pill renders the interrupted label as text (not color-only).
+    expect(container.textContent).toContain('interrupted');
+    expect(container.querySelector('.jobqueue__status--interrupted')).not.toBeNull();
+
+    const before = listCalls();
+    await click('.jobqueue__resume');
+
+    // Resume re-dispatches via the existing job.retry re-dispatch.
+    expect(rpcMock).toHaveBeenCalledWith('job.retry', { jobId: 'int-1' });
+    expect(listCalls()).toBe(before + 1);
+  });
+
+  it('gives Resume and Retry distinct accessible names', async () => {
+    serveJobs([
+      makeJob({ jobId: 'int-1', label: 'Dub clip.mp4', status: 'interrupted', pct: 0 }),
+      makeJob({ jobId: 'err-1', label: 'Dub clip.mp4', status: 'error', pct: 0 }),
+    ]);
+    await renderQueue(true);
+
+    const resume = container.querySelector('.jobqueue__resume') as HTMLButtonElement;
+    const retry = container.querySelector('.jobqueue__retry') as HTMLButtonElement;
+    expect(resume.getAttribute('aria-label')).toBe('Resume Dub clip.mp4');
+    expect(retry.getAttribute('aria-label')).toBe('Retry Dub clip.mp4');
+    expect(resume.getAttribute('aria-label')).not.toBe(retry.getAttribute('aria-label'));
   });
 
   it('surfaces a job.cancel failure and still refreshes (JobQueue.tsx:100-103)', async () => {

--- a/app/renderer/src/components/JobQueue.tsx
+++ b/app/renderer/src/components/JobQueue.tsx
@@ -26,6 +26,27 @@ export function canRetry(job: JobInfo): boolean {
   return job.status === 'error';
 }
 
+/**
+ * Resume applies to `interrupted` jobs only (a job left running/queued when the
+ * sidecar last shut down — rehydrated as `interrupted`, never auto-restarted).
+ * Kept SEPARATE from canRetry so the affordance reads as crash-recovery, not a
+ * generic failure-retry, even though both re-dispatch via `job.retry`.
+ */
+export function canResume(job: JobInfo): boolean {
+  return job.status === 'interrupted';
+}
+
+/**
+ * Resume tooltip/microcopy — makes the full re-dispatch + cloud budget
+ * re-prompt visible at the point of action (DESIGN §4.3), so Resume is never a
+ * surprise spend: the job restarts at 0% and re-flows through the budget-ack
+ * gate before any cloud egress.
+ */
+export const RESUME_TITLE =
+  'Re-runs this interrupted job from the start (it restarts at 0%, not where it ' +
+  "stopped). If it uses a cloud provider, you'll be asked to confirm the budget " +
+  'again before it runs.';
+
 /** Clamp a pct into 0..100 for rendering (NaN -> 0). */
 export function clampPct(pct: number): number {
   if (!Number.isFinite(pct)) return 0;
@@ -160,7 +181,7 @@ export function JobQueue({ open, onClose }: JobQueueProps): React.ReactElement |
                 </div>
                 <span className="jobqueue__pct">{Math.round(clampPct(job.pct))}%</span>
               </div>
-              {canCancel(job) || canRetry(job) ? (
+              {canCancel(job) || canRetry(job) || canResume(job) ? (
                 <div className="jobqueue__actions">
                   {canCancel(job) ? (
                     <button
@@ -175,9 +196,21 @@ export function JobQueue({ open, onClose }: JobQueueProps): React.ReactElement |
                     <button
                       type="button"
                       className="jobqueue__retry"
+                      aria-label={`Retry ${job.label}`}
                       onClick={() => void handleRetry(job.jobId)}
                     >
                       Retry
+                    </button>
+                  ) : null}
+                  {canResume(job) ? (
+                    <button
+                      type="button"
+                      className="jobqueue__resume"
+                      aria-label={`Resume ${job.label}`}
+                      title={RESUME_TITLE}
+                      onClick={() => void handleRetry(job.jobId)}
+                    >
+                      Resume
                     </button>
                   ) : null}
                 </div>

--- a/app/renderer/src/components/PathsPanel.test.tsx
+++ b/app/renderer/src/components/PathsPanel.test.tsx
@@ -1,0 +1,290 @@
+// PathsPanel.test.tsx — show the on-disk data layout + change-root flow + per-row
+// "Open folder" (UX/QoL WU-12).
+//
+// Fake `paths.describe` payload + a fake bridge (no preload). Pins the falsifiable
+// acceptance:
+//   * each dir row exposes a real <button> named "Open <label> folder" (no
+//     icon-only control) and renders its path as selectable TEXT (queryable, not
+//     a button);
+//   * "Change data folder" calls bridge.pickDataFolder THEN bridge.setDataFolder
+//     in order, then shows the chosen path + a restart hint;
+//   * loading / unavailable-bridge / error branches all render.
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { PathsPanel, type PathsRpc, type PathsBridge, type PathsDescribe } from './PathsPanel';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function layout(): PathsDescribe {
+  return {
+    dataDir: 'C:/data',
+    projectsDir: 'C:/data/projects',
+    exportsDir: 'C:/data/exports',
+    settingsPath: 'C:/data/settings.json',
+    libraryPath: 'C:/data/library.json',
+    subDirs: {
+      dubs: 'C:/data/dubs',
+      shorts: 'C:/data/exports/shorts-*',
+      stabilized: 'C:/data/exports/stabilized',
+      audiomix: 'C:/data/exports/audiomix',
+      trimmed: 'C:/data/exports/trimmed',
+    },
+  };
+}
+
+function makeRpc(overrides: Partial<PathsRpc> = {}): PathsRpc {
+  return {
+    describe: vi.fn().mockResolvedValue(layout()),
+    ...overrides,
+  };
+}
+
+function makeBridge(overrides: Partial<PathsBridge> = {}): PathsBridge {
+  return {
+    getDataFolder: vi.fn().mockResolvedValue('C:/data'),
+    pickDataFolder: vi.fn().mockResolvedValue('D:/new-root'),
+    setDataFolder: vi.fn().mockResolvedValue({ ok: true }),
+    openInFolder: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function mount(props: Parameters<typeof PathsPanel>[0]): Promise<void> {
+  await act(async () => {
+    root.render(<PathsPanel {...props} />);
+  });
+  await flush();
+}
+
+function flush(): Promise<void> {
+  return act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function openButtons(): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>('.paths-panel__open'));
+}
+
+describe('<PathsPanel />', () => {
+  it('renders a row per dir with a path-as-text and an "Open <label> folder" button', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, bridge: makeBridge() });
+    expect(rpc.describe).toHaveBeenCalledTimes(1);
+    // One row per layout entry (5 top-level + 5 subDirs = 10).
+    const rows = container.querySelectorAll('.paths-panel__row');
+    expect(rows.length).toBe(10);
+    // The path string is rendered as TEXT, not a button.
+    const dataRow = container.querySelector('[data-path-key="dataDir"]') as HTMLElement;
+    const pathEl = dataRow.querySelector('.paths-panel__path') as HTMLElement;
+    expect(pathEl.tagName).not.toBe('BUTTON');
+    expect(pathEl.textContent).toBe('C:/data');
+    // Each DIRECTORY row's Open control is a real <button> with a row-specific
+    // accessible name (8 dirs = 3 top-level + 5 subDirs; the 2 file rows have none).
+    const buttons = openButtons();
+    expect(buttons.length).toBe(8);
+    for (const btn of buttons) {
+      expect(btn.tagName).toBe('BUTTON');
+      expect(btn.getAttribute('aria-label')).toMatch(/^Open .+ folder$/);
+    }
+  });
+
+  it("opens a dir via bridge.openInFolder with that row's path", async () => {
+    const bridge = makeBridge();
+    await mount({ rpc: makeRpc(), bridge });
+    const row = container.querySelector('[data-path-key="exportsDir"]') as HTMLElement;
+    const btn = row.querySelector('.paths-panel__open') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await flush();
+    expect(bridge.openInFolder).toHaveBeenCalledWith('C:/data/exports');
+  });
+
+  it('surfaces an open-folder failure', async () => {
+    const bridge = makeBridge({ openInFolder: vi.fn().mockRejectedValue(new Error('open boom')) });
+    await mount({ rpc: makeRpc(), bridge });
+    const row = container.querySelector('[data-path-key="dataDir"]') as HTMLElement;
+    await act(async () => (row.querySelector('.paths-panel__open') as HTMLButtonElement).click());
+    await flush();
+    expect(container.querySelector('.paths-panel__error')?.textContent).toBe('open boom');
+  });
+
+  it('shows the file-path rows as text but does NOT render an Open button for files', async () => {
+    await mount({ rpc: makeRpc(), bridge: makeBridge() });
+    const settingsRow = container.querySelector('[data-path-key="settingsPath"]') as HTMLElement;
+    expect((settingsRow.querySelector('.paths-panel__path') as HTMLElement).textContent).toBe(
+      'C:/data/settings.json',
+    );
+    // Files have no own-folder Open button (they are not directories).
+    expect(settingsRow.querySelector('.paths-panel__open')).toBeNull();
+  });
+
+  it('hydrates and shows the current data folder from the bridge', async () => {
+    const bridge = makeBridge();
+    await mount({ rpc: makeRpc(), bridge });
+    expect(bridge.getDataFolder).toHaveBeenCalledTimes(1);
+    expect((container.querySelector('.paths-panel__root-value') as HTMLElement).textContent).toBe(
+      'C:/data',
+    );
+  });
+
+  it('falls back to "Unknown" when getDataFolder resolves an empty string', async () => {
+    const bridge = makeBridge({ getDataFolder: vi.fn().mockResolvedValue('') });
+    await mount({ rpc: makeRpc(), bridge });
+    expect((container.querySelector('.paths-panel__root-value') as HTMLElement).textContent).toBe(
+      'Unknown',
+    );
+  });
+
+  it('changes the data folder: pickDataFolder THEN setDataFolder, then shows the choice + restart hint', async () => {
+    const order: string[] = [];
+    const bridge = makeBridge({
+      pickDataFolder: vi.fn(async () => {
+        order.push('pick');
+        return 'D:/new-root';
+      }),
+      setDataFolder: vi.fn(async () => {
+        order.push('set');
+        return { ok: true };
+      }),
+    });
+    await mount({ rpc: makeRpc(), bridge });
+    const change = container.querySelector('.paths-panel__change-root') as HTMLButtonElement;
+    await act(async () => change.click());
+    await flush();
+    expect(order).toEqual(['pick', 'set']);
+    expect(bridge.setDataFolder).toHaveBeenCalledWith('D:/new-root');
+    expect((container.querySelector('.paths-panel__root-value') as HTMLElement).textContent).toBe(
+      'D:/new-root',
+    );
+    expect(container.querySelector('.paths-panel__restart-hint')).not.toBeNull();
+  });
+
+  it('no-ops the change when the picker is cancelled (null) — no setDataFolder, no restart hint', async () => {
+    const bridge = makeBridge({ pickDataFolder: vi.fn().mockResolvedValue(null) });
+    await mount({ rpc: makeRpc(), bridge });
+    await act(async () =>
+      (container.querySelector('.paths-panel__change-root') as HTMLButtonElement).click(),
+    );
+    await flush();
+    expect(bridge.setDataFolder).not.toHaveBeenCalled();
+    expect(container.querySelector('.paths-panel__restart-hint')).toBeNull();
+  });
+
+  it('surfaces a save failure (setDataFolder ok:false) without flagging a restart', async () => {
+    const bridge = makeBridge({ setDataFolder: vi.fn().mockResolvedValue({ ok: false }) });
+    await mount({ rpc: makeRpc(), bridge });
+    await act(async () =>
+      (container.querySelector('.paths-panel__change-root') as HTMLButtonElement).click(),
+    );
+    await flush();
+    expect(container.querySelector('.paths-panel__error')?.textContent).toMatch(/read-only/i);
+    expect(container.querySelector('.paths-panel__restart-hint')).toBeNull();
+  });
+
+  it('surfaces a change-root exception', async () => {
+    const bridge = makeBridge({
+      pickDataFolder: vi.fn().mockRejectedValue(new Error('pick boom')),
+    });
+    await mount({ rpc: makeRpc(), bridge });
+    await act(async () =>
+      (container.querySelector('.paths-panel__change-root') as HTMLButtonElement).click(),
+    );
+    await flush();
+    expect(container.querySelector('.paths-panel__error')?.textContent).toBe('pick boom');
+  });
+
+  it('renders the loading state before the layout resolves', async () => {
+    let resolve: (v: PathsDescribe) => void = () => undefined;
+    const rpc = makeRpc({
+      describe: vi.fn(
+        () =>
+          new Promise<PathsDescribe>((r) => {
+            resolve = r;
+          }),
+      ),
+    });
+    await act(async () => {
+      root.render(<PathsPanel rpc={rpc} bridge={makeBridge()} />);
+    });
+    expect(container.querySelector('.paths-panel__loading')).not.toBeNull();
+    expect(container.querySelector('.paths-panel__row')).toBeNull();
+    await act(async () => {
+      resolve(layout());
+    });
+    await flush();
+    expect(container.querySelector('.paths-panel__loading')).toBeNull();
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(10);
+  });
+
+  it('surfaces a describe error and stops loading', async () => {
+    const rpc = makeRpc({ describe: vi.fn().mockRejectedValue(new Error('describe boom')) });
+    await mount({ rpc, bridge: makeBridge() });
+    expect(container.querySelector('.paths-panel__error')?.textContent).toBe('describe boom');
+    expect(container.querySelector('.paths-panel__loading')).toBeNull();
+  });
+
+  it('stringifies a non-Error describe rejection', async () => {
+    const rpc = makeRpc({ describe: vi.fn().mockRejectedValue('describe-bad') });
+    await mount({ rpc, bridge: makeBridge() });
+    expect(container.querySelector('.paths-panel__error')?.textContent).toBe('describe-bad');
+  });
+
+  it('shows the change-root control as unavailable when the bridge lacks the picker', async () => {
+    // Bridge with no pick/set/get — the data-root section degrades, never crashes.
+    const bridge: PathsBridge = { openInFolder: vi.fn().mockResolvedValue(true) };
+    await mount({ rpc: makeRpc(), bridge });
+    expect(container.querySelector('.paths-panel__change-root')).toBeNull();
+    expect(container.querySelector('.paths-panel__root-unavailable')).not.toBeNull();
+    // The layout rows still render (the describe RPC is independent of the bridge).
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(10);
+  });
+
+  it('keeps the Open button inert when the bridge lacks openInFolder', async () => {
+    const bridge: PathsBridge = {
+      getDataFolder: vi.fn().mockResolvedValue('C:/data'),
+      pickDataFolder: vi.fn(),
+      setDataFolder: vi.fn(),
+    };
+    await mount({ rpc: makeRpc(), bridge });
+    // No Open buttons are rendered without an openInFolder bridge (no dead control).
+    expect(openButtons().length).toBe(0);
+  });
+
+  it('tolerates a describe payload missing subDirs (defensive default)', async () => {
+    const partial = { ...layout(), subDirs: undefined } as unknown as PathsDescribe;
+    const rpc = makeRpc({ describe: vi.fn().mockResolvedValue(partial) });
+    await mount({ rpc, bridge: makeBridge() });
+    // Only the 5 top-level rows render; no crash on the absent subDirs map.
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(5);
+  });
+
+  it('tolerates a getDataFolder failure (root stays unknown, panel still renders)', async () => {
+    const bridge = makeBridge({ getDataFolder: vi.fn().mockRejectedValue(new Error('no root')) });
+    await mount({ rpc: makeRpc(), bridge });
+    // The root value falls back to the unknown placeholder; rows still render.
+    expect((container.querySelector('.paths-panel__root-value') as HTMLElement).textContent).toBe(
+      'Unknown',
+    );
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(10);
+  });
+});

--- a/app/renderer/src/components/PathsPanel.tsx
+++ b/app/renderer/src/components/PathsPanel.tsx
@@ -1,0 +1,235 @@
+// PathsPanel.tsx — show WHERE everything lives + change the data root + open a
+// folder in the OS file explorer (UX/QoL WU-12).
+//
+// Two independent sources, both INJECTED so the component unit-tests with no
+// preload bridge (mirrors SavePresetsControls' injected `savePresets` slice):
+//   * `rpc.describe()` (sidecar `paths.describe`, WU-1, read-only) -> the resolved
+//     on-disk layout. Each DIRECTORY entry renders its path as selectable text +
+//     a real <button> ("Open <label> folder") that reveals it via the bridge's
+//     `openInFolder` (the existing `shell.showItemInFolder` channel — no new
+//     channel). FILE entries (settings/library) are text-only (not directories).
+//   * `bridge` — the MAIN-process data-root flow (`dataFolder.get/pick/set`, NOT
+//     sidecar RPCs) + `openInFolder`. Each capability is optional: a missing piece
+//     degrades that control to an "Unavailable" state rather than crashing the
+//     panel (same fail-soft contract ShortMaker's data-root section uses).
+//
+// a11y: every row Open control is a real <button> with a per-row accessible name
+// ("Open <label> folder"); the path string is inert selectable text, never an
+// interactive element. Color is never the sole signal.
+import React, { useCallback, useEffect, useState } from 'react';
+import './pathsPanel.css';
+
+/** The resolved on-disk data layout (`paths.describe`, WU-1). */
+export interface PathsDescribe {
+  dataDir: string;
+  projectsDir: string;
+  exportsDir: string;
+  settingsPath: string;
+  libraryPath: string;
+  subDirs?: Record<string, string>;
+}
+
+/** The thin `paths.*` slice this component needs (injectable for tests). */
+export interface PathsRpc {
+  describe(): Promise<PathsDescribe>;
+}
+
+/**
+ * The MAIN-process bridge slice (NOT sidecar RPCs). Every member is optional so a
+ * missing preload capability degrades the matching control, never the panel.
+ */
+export interface PathsBridge {
+  /** Reveal a directory in the OS file explorer (true on success). */
+  openInFolder?(path: string): Promise<boolean>;
+  /** The data root in use this session. */
+  getDataFolder?(): Promise<string>;
+  /** Native open-DIRECTORY picker (null when cancelled). */
+  pickDataFolder?(): Promise<string | null>;
+  /** Persist the chosen data root (a restart applies it). */
+  setDataFolder?(path: string): Promise<{ ok: boolean }>;
+}
+
+export interface PathsPanelProps {
+  /** The injected `paths.*` client slice (`client.paths` in the app). */
+  rpc: PathsRpc;
+  /** The injected MAIN-process bridge (`window.api` in the app). */
+  bridge: PathsBridge;
+}
+
+/** A single layout row: a human label, its path, and whether it is a directory. */
+interface PathRow {
+  key: string;
+  label: string;
+  path: string;
+  isDir: boolean;
+}
+
+const ROOT_UNKNOWN = 'Unknown';
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Build the ordered display rows from a `paths.describe` payload. */
+function buildRows(layout: PathsDescribe): PathRow[] {
+  const dirs: PathRow[] = [
+    { key: 'dataDir', label: 'Data', path: layout.dataDir, isDir: true },
+    { key: 'projectsDir', label: 'Projects', path: layout.projectsDir, isDir: true },
+    { key: 'exportsDir', label: 'Exports', path: layout.exportsDir, isDir: true },
+  ];
+  const files: PathRow[] = [
+    { key: 'settingsPath', label: 'Settings file', path: layout.settingsPath, isDir: false },
+    { key: 'libraryPath', label: 'Library file', path: layout.libraryPath, isDir: false },
+  ];
+  const subDirs = Object.entries(layout.subDirs ?? {}).map(([name, path]) => ({
+    key: `subDir:${name}`,
+    label: name,
+    path,
+    isDir: true,
+  }));
+  return [...dirs, ...files, ...subDirs];
+}
+
+export function PathsPanel({ rpc, bridge }: PathsPanelProps): React.ReactElement {
+  const [rows, setRows] = useState<PathRow[] | null>(null);
+  const [root, setRoot] = useState<string>(ROOT_UNKNOWN);
+  const [pendingRestart, setPendingRestart] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState<boolean>(false);
+
+  // Fetch the layout (read-only; independent of the bridge).
+  useEffect(() => {
+    let alive = true;
+    rpc
+      .describe()
+      .then((layout) => {
+        if (alive) setRows(buildRows(layout));
+      })
+      .catch((err) => {
+        if (alive) {
+          setError(errText(err));
+          setRows([]);
+        }
+      });
+    return () => {
+      alive = false;
+    };
+  }, [rpc]);
+
+  // Hydrate the current data root from the bridge (fail-soft -> "Unknown").
+  const getRoot = bridge.getDataFolder;
+  useEffect(() => {
+    if (!getRoot) return undefined;
+    let alive = true;
+    getRoot()
+      .then((folder) => {
+        if (alive) setRoot(folder || ROOT_UNKNOWN);
+      })
+      .catch(() => {
+        // Bridge present but failed -> leave the placeholder, never block.
+      });
+    return () => {
+      alive = false;
+    };
+  }, [getRoot]);
+
+  // Capture the open fn once (it is passed to handleOpen only from rows that
+  // render it, so no in-handler null guard is needed).
+  const openInFolder = bridge.openInFolder;
+  const handleOpen = useCallback(async (open: (path: string) => Promise<boolean>, path: string) => {
+    try {
+      await open(path);
+    } catch (err) {
+      setError(errText(err));
+    }
+  }, []);
+
+  // Capture the pick/set fns once; handleChangeRoot is only wired to the button
+  // that renders when both exist, so it receives them as guaranteed args.
+  const pickDataFolder = bridge.pickDataFolder;
+  const setDataFolder = bridge.setDataFolder;
+  const handleChangeRoot = useCallback(
+    async (
+      pick: () => Promise<string | null>,
+      persist: (path: string) => Promise<{ ok: boolean }>,
+    ) => {
+      setBusy(true);
+      try {
+        const chosen = await pick();
+        if (!chosen) return; // cancelled
+        const res = await persist(chosen);
+        if (!res.ok) {
+          setError('Could not save the data folder (the install directory may be read-only).');
+          return;
+        }
+        setRoot(chosen);
+        setPendingRestart(true);
+        setError(null);
+      } catch (err) {
+        setError(errText(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [],
+  );
+
+  return (
+    <section className="paths-panel" data-section="paths" aria-label="Data locations">
+      <h3>Data locations</h3>
+
+      {error ? (
+        <div className="paths-panel__error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      <div className="paths-panel__root">
+        <span className="paths-panel__root-label">Data folder</span>
+        <span className="paths-panel__root-value">{root}</span>
+        {pickDataFolder && setDataFolder ? (
+          <button
+            type="button"
+            className="paths-panel__change-root"
+            disabled={busy}
+            onClick={() => void handleChangeRoot(pickDataFolder, setDataFolder)}
+          >
+            Change data folder
+          </button>
+        ) : (
+          <span className="paths-panel__root-unavailable">
+            Changing the data folder is unavailable in this build.
+          </span>
+        )}
+        {pendingRestart ? (
+          <span className="paths-panel__restart-hint">Restart to apply the new data folder.</span>
+        ) : null}
+      </div>
+
+      {rows === null ? (
+        <div className="paths-panel__loading">Loading data locations…</div>
+      ) : (
+        <ul className="paths-panel__list">
+          {rows.map((row) => (
+            <li key={row.key} className="paths-panel__row" data-path-key={row.key}>
+              <span className="paths-panel__row-label">{row.label}</span>
+              <span className="paths-panel__path">{row.path}</span>
+              {row.isDir && openInFolder ? (
+                <button
+                  type="button"
+                  className="paths-panel__open"
+                  aria-label={`Open ${row.label} folder`}
+                  onClick={() => void handleOpen(openInFolder, row.path)}
+                >
+                  Open folder
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default PathsPanel;

--- a/app/renderer/src/components/Player.test.tsx
+++ b/app/renderer/src/components/Player.test.tsx
@@ -9,6 +9,7 @@ import {
   mediaUrl,
   resolveSrc,
   shortMediaUrl,
+  thumbMediaUrl,
   windowEndReached,
   type PlayerHandle,
   type PlayerProps,
@@ -107,6 +108,16 @@ describe('shortMediaUrl (P4 §6 / C10)', () => {
     // The colon after `short` is encoded (%3A) so it cannot be mistaken for a
     // URL scheme/host boundary — proves it is one path segment, not media/short/.
     expect(url.startsWith('mstream://media/short%3A')).toBe(true);
+  });
+});
+
+describe('thumbMediaUrl (UX/QoL WU-4)', () => {
+  it('encodes the thumb: prefixed path as a single path segment', () => {
+    const url = thumbMediaUrl('C:\\data\\thumbnails\\v1.jpg');
+    expect(url).toBe(`mstream://media/${encodeURIComponent('thumb:C:\\data\\thumbnails\\v1.jpg')}`);
+    // The colon after `thumb` is encoded (%3A) so it cannot be mistaken for a
+    // URL scheme/host boundary — proves it is one path segment, not media/thumb/.
+    expect(url.startsWith('mstream://media/thumb%3A')).toBe(true);
   });
 });
 

--- a/app/renderer/src/components/Player.tsx
+++ b/app/renderer/src/components/Player.tsx
@@ -111,6 +111,17 @@ export function shortMediaUrl(path: string): string {
   return `${MEDIA_SCHEME}://${MEDIA_HOST}/${encodeURIComponent(`short:${path}`)}`;
 }
 
+/**
+ * UX/QoL (WU-4): the `<img src>` URL for a SOURCE-library poster frame. Rides
+ * the mstream:// protocol with the `thumb:<absolute path>` id form, which
+ * main.ts resolves ONLY inside the thumbnails root (traversal-guarded, WU-3).
+ * Mirrors `shortMediaUrl` exactly — the prefixed path stays a single encoded
+ * segment so `videoIdFromUrl` decodes it intact.
+ */
+export function thumbMediaUrl(path: string): string {
+  return `${MEDIA_SCHEME}://${MEDIA_HOST}/${encodeURIComponent(`thumb:${path}`)}`;
+}
+
 /** Resolve the effective <video> src: explicit `src` wins, else mstream URL. */
 export function resolveSrc(videoId?: string, src?: string): string {
   if (src) return src;

--- a/app/renderer/src/components/ReadinessBadge.test.tsx
+++ b/app/renderer/src/components/ReadinessBadge.test.tsx
@@ -1,0 +1,133 @@
+// ReadinessBadge.test.tsx — render tests for the shared readiness status pill
+// (WU-9). Mirrors advisorComponents' raw-DOM convention (createRoot + jsdom).
+// Pins the WCAG-1.4.1 guard: status is asserted by visible TEXT + role, never by
+// hue alone; every action control is a real <button> with a capability-tied name.
+
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ReadinessBadge } from './ReadinessBadge';
+import { READINESS_LABEL, READINESS_CLASS } from './readinessMeta';
+import type { ReadinessAction, ReadinessStatus } from '../lib/rpc';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function render(node: React.ReactElement): Promise<void> {
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+const STATUSES: ReadinessStatus[] = [
+  'ready',
+  'needsDownload',
+  'needsKey',
+  'needsConsent',
+  'unavailable',
+];
+
+describe('<ReadinessBadge /> — status pill', () => {
+  it.each(
+    STATUSES,
+  )('renders %s by visible text + role + data attr (not hue alone)', async (status) => {
+    await render(<ReadinessBadge status={status} capabilityLabel="Captions" />);
+    const badge = container.querySelector('[role="status"]') as HTMLElement;
+    // Visible TEXT label — the use-of-color guard (query text, not class).
+    expect(badge.textContent).toBe(READINESS_LABEL[status]);
+    expect(badge.tagName).toBe('SPAN');
+    expect(badge.getAttribute('data-readiness')).toBe(status);
+    // Reuses verdict-badge pill geometry + a parallel readiness class.
+    expect(badge.classList.contains('verdict-badge')).toBe(true);
+    expect(badge.classList.contains('readiness-badge')).toBe(true);
+    expect(badge.classList.contains(READINESS_CLASS[status])).toBe(true);
+    // Title names blocker + fix (non-empty).
+    expect(badge.title.length).toBeGreaterThan(0);
+  });
+
+  it('appends a blockedBy reason to the title when supplied', async () => {
+    await render(
+      <ReadinessBadge status="needsKey" capabilityLabel="Captions" blockedBy="No OpenAI key" />,
+    );
+    const badge = container.querySelector('[role="status"]') as HTMLElement;
+    expect(badge.title).toContain('No OpenAI key');
+  });
+});
+
+describe('<ReadinessBadge /> — action button', () => {
+  it('renders an assets.ensure action as a button naming the capability', async () => {
+    const action: ReadinessAction = { kind: 'assets.ensure', assets: ['saliency'] };
+    await render(
+      <ReadinessBadge status="needsDownload" capabilityLabel="Captions" action={action} />,
+    );
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('aria-label')).toBe('Download Captions model');
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  it('renders an openProviders action as a button', async () => {
+    const action: ReadinessAction = { kind: 'openProviders' };
+    await render(<ReadinessBadge status="needsKey" capabilityLabel="Captions" action={action} />);
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('aria-label')).toBe('Add a provider key');
+  });
+
+  it('renders a setConsent action as a button naming the provider', async () => {
+    const action: ReadinessAction = { kind: 'setConsent', provider: 'openai' };
+    await render(
+      <ReadinessBadge status="needsConsent" capabilityLabel="Captions" action={action} />,
+    );
+    const button = container.querySelector('button') as HTMLButtonElement;
+    expect(button.getAttribute('aria-label')).toBe('Grant consent for openai');
+  });
+
+  it('renders NO button when there is no action (ready / blocked-no-fix)', async () => {
+    await render(<ReadinessBadge status="ready" capabilityLabel="Captions" />);
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('invokes onAction with the action when the button is clicked', async () => {
+    const action: ReadinessAction = { kind: 'openProviders' };
+    let received: ReadinessAction | null = null;
+    await render(
+      <ReadinessBadge
+        status="needsKey"
+        capabilityLabel="Captions"
+        action={action}
+        onAction={(a) => {
+          received = a;
+        }}
+      />,
+    );
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+    expect(received).toBe(action);
+  });
+
+  it('does not throw when the button is clicked with no onAction handler', async () => {
+    const action: ReadinessAction = { kind: 'openProviders' };
+    await render(<ReadinessBadge status="needsKey" capabilityLabel="Captions" action={action} />);
+    const button = container.querySelector('button') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+    expect(button).toBeTruthy();
+  });
+});

--- a/app/renderer/src/components/ReadinessBadge.tsx
+++ b/app/renderer/src/components/ReadinessBadge.tsx
@@ -1,0 +1,62 @@
+// ReadinessBadge.tsx — the shared readiness status pill (WU-9). A thin render
+// shell over readinessMeta.ts (WU-8): it mirrors the VerdictBadge PRIMITIVE
+// (text label + role="status" + data attr + title) so status is announced by
+// TEXT and role, never by hue alone (WCAG 1.4.1). It reuses ONLY the
+// `verdict-badge` pill geometry; the tint comes from a parallel `readiness-badge`
+// class map (readinessClass), NOT the verdict color map. The optional fix action
+// is a REAL <button> with a capability-tied accessible name — never icon-only.
+import React from 'react';
+import type { ReadinessAction, ReadinessStatus } from '../lib/rpc';
+import {
+  readinessActionLabel,
+  readinessClass,
+  readinessHint,
+  readinessLabel,
+} from './readinessMeta';
+import './readinessBadge.css';
+
+export interface ReadinessBadgeProps {
+  status: ReadinessStatus;
+  /** Human-friendly capability name, woven into the action's accessible name. */
+  capabilityLabel: string;
+  /** Plain-language reason it is not ready; appended to the tooltip when set. */
+  blockedBy?: string;
+  /** The fix action; when null/absent no button renders (ready / blocked-no-fix). */
+  action?: ReadinessAction | null;
+  /** Fired with the action when the fix button is clicked. */
+  onAction?: (action: ReadinessAction) => void;
+}
+
+export function ReadinessBadge({
+  status,
+  capabilityLabel,
+  blockedBy,
+  action,
+  onAction,
+}: ReadinessBadgeProps): React.ReactElement {
+  const title = [readinessHint(status), blockedBy].filter(Boolean).join(' ');
+  return (
+    <span className="readiness-badge-group">
+      <span
+        className={`verdict-badge readiness-badge ${readinessClass(status)}`}
+        data-readiness={status}
+        role="status"
+        title={title}
+      >
+        {readinessLabel(status)}
+      </span>
+      {action ? (
+        <button
+          type="button"
+          className="readiness-badge__action"
+          aria-label={readinessActionLabel(action, capabilityLabel)}
+          onClick={() => onAction?.(action)}
+        >
+          {readinessActionLabel(action, capabilityLabel)}
+        </button>
+      ) : null}
+    </span>
+  );
+}
+
+export default ReadinessBadge;

--- a/app/renderer/src/components/ReadinessRollup.test.tsx
+++ b/app/renderer/src/components/ReadinessRollup.test.tsx
@@ -1,0 +1,240 @@
+// ReadinessRollup.test.tsx — the unified readiness roll-up consumer (WU-14).
+//
+// Wires `readiness.summary` (WU-8) into a reusable section that renders one
+// <ReadinessBadge /> (WU-9) per capability with its capability-tied action
+// button. Pins the falsifiable WU-14 acceptance: N badges for N items, each with
+// its action button; the reused in-flight skeleton shows before data resolves;
+// actions forward to the parent; failures degrade to a quiet error (never crash).
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ReadinessRollup } from './ReadinessRollup';
+import { READINESS_LABEL } from './readinessMeta';
+import type { ReadinessAction, ReadinessItem } from '../lib/rpc';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+/** A minimal typed client stub exposing only `readiness.summary`. */
+function makeClient(summary: () => Promise<{ items: ReadinessItem[] }>) {
+  return { readiness: { summary: vi.fn(summary) } } as unknown as Parameters<
+    typeof ReadinessRollup
+  >[0]['rpcClient'];
+}
+
+async function flush(turns = 4): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < turns; i += 1) await Promise.resolve();
+  });
+}
+
+function makeItem(over: Partial<ReadinessItem> = {}): ReadinessItem {
+  return {
+    capability: 'tier1-multimodal',
+    label: 'Tier 1 multimodal',
+    status: 'ready',
+    blockedBy: '',
+    action: null,
+    ...over,
+  };
+}
+
+describe('<ReadinessRollup /> — WU-14 wiring', () => {
+  it('renders one ReadinessBadge per readiness.summary item', async () => {
+    const items = [
+      makeItem({ capability: 'a', label: 'Captions', status: 'ready' }),
+      makeItem({
+        capability: 'b',
+        label: 'Vision',
+        status: 'needsDownload',
+        blockedBy: 'saliency missing',
+        action: { kind: 'assets.ensure', assets: ['saliency'] },
+      }),
+      makeItem({
+        capability: 'c',
+        label: 'Translation',
+        status: 'needsKey',
+        action: { kind: 'openProviders' },
+      }),
+    ];
+    const rpcClient = makeClient(() => Promise.resolve({ items }));
+
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    await flush();
+
+    const badges = container.querySelectorAll('[role="status"]');
+    expect(badges.length).toBe(3);
+    expect(badges[0].textContent).toBe(READINESS_LABEL.ready);
+    expect(badges[1].textContent).toBe(READINESS_LABEL.needsDownload);
+    expect(badges[2].textContent).toBe(READINESS_LABEL.needsKey);
+    // One row per item, labelled by the capability name.
+    expect(container.textContent).toContain('Captions');
+    expect(container.textContent).toContain('Vision');
+    expect(container.textContent).toContain('Translation');
+  });
+
+  it('renders an action button only for items that carry a fix action', async () => {
+    const items = [
+      makeItem({ capability: 'ready', label: 'Ready cap', status: 'ready', action: null }),
+      makeItem({
+        capability: 'fix',
+        label: 'Vision',
+        status: 'needsDownload',
+        action: { kind: 'assets.ensure', assets: ['saliency'] },
+      }),
+    ];
+    const rpcClient = makeClient(() => Promise.resolve({ items }));
+
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    await flush();
+
+    const buttons = container.querySelectorAll('button.readiness-badge__action');
+    expect(buttons.length).toBe(1);
+    expect(buttons[0].getAttribute('aria-label')).toBe('Download Vision model');
+  });
+
+  it('shows the reused in-flight skeleton before the data resolves', async () => {
+    let resolve: (v: { items: ReadinessItem[] }) => void = () => {};
+    const rpcClient = makeClient(
+      () =>
+        new Promise<{ items: ReadinessItem[] }>((res) => {
+          resolve = res;
+        }),
+    );
+
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    // Mid-flight: the reused skeleton (jobqueue empty convention) is showing.
+    expect(container.querySelector('.jobqueue__empty')).not.toBeNull();
+    expect(container.querySelectorAll('[role="status"]').length).toBe(0);
+
+    await act(async () => {
+      resolve({ items: [makeItem({ label: 'Captions' })] });
+    });
+    await flush();
+
+    expect(container.querySelector('.jobqueue__empty')).toBeNull();
+    expect(container.querySelectorAll('[role="status"]').length).toBe(1);
+  });
+
+  it('forwards a badge action click to onAction', async () => {
+    const action: ReadinessAction = { kind: 'openProviders' };
+    const items = [makeItem({ label: 'Translation', status: 'needsKey', action })];
+    const rpcClient = makeClient(() => Promise.resolve({ items }));
+    let received: ReadinessAction | null = null;
+
+    await act(async () => {
+      root.render(
+        <ReadinessRollup
+          rpcClient={rpcClient}
+          onAction={(a) => {
+            received = a;
+          }}
+        />,
+      );
+    });
+    await flush();
+
+    const button = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    await act(async () => {
+      button.click();
+    });
+    expect(received).toBe(action);
+  });
+
+  it('renders an empty-state line when there are no readiness items', async () => {
+    const rpcClient = makeClient(() => Promise.resolve({ items: [] }));
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    await flush();
+    expect(container.querySelector('.jobqueue__empty')).toBeNull();
+    expect(container.querySelectorAll('[role="status"]').length).toBe(0);
+    expect(container.textContent).toContain('Nothing to report');
+  });
+
+  it('tolerates a result with no items field (treats it as empty)', async () => {
+    const rpcClient = makeClient(() => Promise.resolve({}) as Promise<{ items: ReadinessItem[] }>);
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    await flush();
+    expect(container.querySelectorAll('[role="status"]').length).toBe(0);
+    expect(container.textContent).toContain('Nothing to report');
+  });
+
+  it('surfaces a load error without crashing (Error instance)', async () => {
+    const rpcClient = makeClient(() => Promise.reject(new Error('sidecar down')));
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('sidecar down');
+    expect(container.querySelector('.jobqueue__empty')).toBeNull();
+  });
+
+  it('stringifies a non-Error load rejection', async () => {
+    const rpcClient = makeClient(() => Promise.reject('plain failure'));
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain failure');
+  });
+
+  it('renders a custom title when provided', async () => {
+    const rpcClient = makeClient(() => Promise.resolve({ items: [makeItem()] }));
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} title="What works right now" />);
+    });
+    await flush();
+    expect(container.textContent).toContain('What works right now');
+  });
+
+  it('ignores a late resolve after unmount (no state update warning)', async () => {
+    let resolve: (v: { items: ReadinessItem[] }) => void = () => {};
+    const rpcClient = makeClient(
+      () =>
+        new Promise<{ items: ReadinessItem[] }>((res) => {
+          resolve = res;
+        }),
+    );
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} />);
+    });
+    // Unmount before the summary resolves.
+    await act(async () => {
+      root.unmount();
+    });
+    // Resolving now must be a no-op (the alive guard drops the result).
+    await act(async () => {
+      resolve({ items: [makeItem()] });
+    });
+    expect(container.querySelectorAll('[role="status"]').length).toBe(0);
+    // Re-create the root so afterEach's unmount is safe.
+    root = createRoot(container);
+  });
+});

--- a/app/renderer/src/components/ReadinessRollup.tsx
+++ b/app/renderer/src/components/ReadinessRollup.tsx
@@ -1,0 +1,94 @@
+// ReadinessRollup.tsx — the unified "what works right now" roll-up (WU-14).
+//
+// The integration join: it CONSUMES `readiness.summary` (WU-8) and renders one
+// shared <ReadinessBadge /> (WU-9) per capability, each with its capability-tied
+// fix action. It is the single roll-up surface reused on BOTH the library home
+// and the model panel (DESIGN §3.4), so neither panel re-derives readiness.
+//
+// While the summary is in flight it reuses JobQueue's existing skeleton/empty
+// convention (`jobqueue__empty`) rather than inventing a bespoke loader
+// (DESIGN §3.4 "Empty / loading states"). A load failure degrades to a quiet
+// inline alert — it never blocks the host panel. Actions are forwarded to the
+// parent via `onAction` (the parent owns navigation to the providers/assets
+// flows), keeping this component a thin, side-effect-free consumer.
+import React, { useEffect, useState } from 'react';
+import { client, type ReadinessAction, type ReadinessItem } from '../lib/rpc';
+import { ReadinessBadge } from './ReadinessBadge';
+import './readinessBadge.css';
+
+/** Error text from an unknown thrown value (mirrors the sibling panels). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface ReadinessRollupProps {
+  /** Inject the typed client for tests; defaults to the real lib/rpc client. */
+  rpcClient?: Pick<typeof client, 'readiness'>;
+  /** Section heading; defaults to a neutral label both hosts can reuse. */
+  title?: string;
+  /** Fired when a badge's fix action is clicked (parent owns the routing). */
+  onAction?: (action: ReadinessAction) => void;
+}
+
+export function ReadinessRollup({
+  rpcClient,
+  title = 'Readiness',
+  onAction,
+}: ReadinessRollupProps): React.ReactElement {
+  /* v8 ignore next -- the `?? client` default only runs in the real app; every test injects rpcClient. */
+  const api = rpcClient ?? client;
+  const [items, setItems] = useState<ReadinessItem[] | null>(null);
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    let alive = true;
+    setError('');
+    setItems(null);
+    Promise.resolve(api.readiness.summary())
+      .then((res) => {
+        if (alive) setItems(Array.isArray(res?.items) ? res.items : []);
+      })
+      .catch((err: unknown) => {
+        if (alive) setError(errText(err));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [api]);
+
+  return (
+    <section className="readiness-rollup" aria-label={title}>
+      <h3 className="readiness-rollup__title">{title}</h3>
+
+      {error ? (
+        <p className="readiness-rollup__error jobqueue__error" role="alert">
+          {error}
+        </p>
+      ) : items === null ? (
+        // Reuse JobQueue's skeleton/empty convention while in flight.
+        <div className="jobqueue__empty" aria-busy="true">
+          Checking what's ready…
+        </div>
+      ) : items.length === 0 ? (
+        <div className="readiness-rollup__empty">Nothing to report.</div>
+      ) : (
+        <ul className="readiness-rollup__list">
+          {items.map((item) => (
+            <li key={item.capability} className="readiness-rollup__row">
+              <span className="readiness-rollup__cap">{item.label}</span>
+              <ReadinessBadge
+                status={item.status}
+                capabilityLabel={item.label}
+                blockedBy={item.blockedBy || undefined}
+                action={item.action}
+                onAction={onAction}
+              />
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default ReadinessRollup;

--- a/app/renderer/src/components/SavePresetsControls.test.tsx
+++ b/app/renderer/src/components/SavePresetsControls.test.tsx
@@ -1,0 +1,224 @@
+// SavePresetsControls.test.tsx — list / apply / save / remove save-presets
+// (UX/QoL WU-11).
+//
+// Fake `savePresets.*` client slice (no preload bridge). Pins the falsifiable
+// acceptance: list renders rows with the active one tagged; Apply calls
+// `savePresets.apply` + `onApply(bundle)` + marks active; Save upserts the live
+// autosave/exportDefaults under the typed name and refreshes; Remove drops a row;
+// empty/error states render; whitespace name is a no-op.
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { SavePresetsControls, type SavePresetsRpc } from './SavePresetsControls';
+import type { AutosaveSettings, ExportDefaults, SavePreset, SavePresetsBlock } from '../lib/rpc';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+const AUTOSAVE: AutosaveSettings = { enabled: true, debounceMs: 1500 };
+const EXPORT_DEFAULTS: ExportDefaults = { subtitleFormat: 'srt', nleFormat: 'edl', nleFps: 30 };
+
+function preset(): SavePreset {
+  return { autosave: { enabled: false, debounceMs: 800 }, exportDefaults: { nleFps: 24 } };
+}
+
+function block(active = 'Fast'): SavePresetsBlock {
+  return { presets: { Fast: preset(), Slow: preset() }, active };
+}
+
+function makeRpc(overrides: Partial<SavePresetsRpc> = {}): SavePresetsRpc {
+  return {
+    list: vi.fn().mockResolvedValue(block()),
+    apply: vi.fn().mockResolvedValue({ active: 'Slow', savePreset: preset() }),
+    upsert: vi.fn().mockResolvedValue({ presets: block().presets }),
+    remove: vi.fn().mockResolvedValue({ presets: { Slow: preset() }, active: '' }),
+    ...overrides,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function mount(props: Parameters<typeof SavePresetsControls>[0]): Promise<void> {
+  await act(async () => {
+    root.render(<SavePresetsControls {...props} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function flush(): Promise<void> {
+  return act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/**
+ * Type into a controlled <input>. React tracks the value via a native setter, so
+ * a bare `el.value = x` is reverted on the synthetic event; we must call the
+ * prototype setter before dispatching `input` for React's onChange to see it.
+ */
+function typeInto(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(el, value);
+  act(() => el.dispatchEvent(new Event('input', { bubbles: true })));
+}
+
+describe('<SavePresetsControls />', () => {
+  it('lists the saved presets on mount, tagging the active one', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    expect(rpc.list).toHaveBeenCalledTimes(1);
+    expect(container.querySelector('[data-preset="Fast"]')).not.toBeNull();
+    expect(container.querySelector('[data-preset="Slow"]')).not.toBeNull();
+    const fast = container.querySelector('[data-preset="Fast"]') as HTMLElement;
+    expect(fast.getAttribute('aria-current')).toBe('true');
+    expect(fast.querySelector('.save-presets__active-tag')?.textContent).toBe('Active');
+    // The non-active row carries no aria-current and no tag.
+    const slow = container.querySelector('[data-preset="Slow"]') as HTMLElement;
+    expect(slow.getAttribute('aria-current')).toBeNull();
+    expect(slow.querySelector('.save-presets__active-tag')).toBeNull();
+  });
+
+  it('renders the empty state when there are no presets', async () => {
+    const rpc = makeRpc({ list: vi.fn().mockResolvedValue({ presets: {}, active: '' }) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    expect(container.querySelector('.save-presets__empty')).not.toBeNull();
+    expect(container.querySelector('.save-presets__list')).toBeNull();
+  });
+
+  it('tolerates a list payload missing presets/active (defensive defaults)', async () => {
+    const rpc = makeRpc({ list: vi.fn().mockResolvedValue(null) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    expect(container.querySelector('.save-presets__empty')).not.toBeNull();
+  });
+
+  it('applies a preset: calls savePresets.apply, marks active, and pre-fills via onApply', async () => {
+    const rpc = makeRpc();
+    const onApply = vi.fn();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS, onApply });
+    const applyBtn = container.querySelector(
+      '[data-preset="Slow"] .save-presets__apply',
+    ) as HTMLButtonElement;
+    await act(async () => applyBtn.click());
+    await flush();
+    expect(rpc.apply).toHaveBeenCalledWith('Slow');
+    expect(onApply).toHaveBeenCalledWith(preset());
+    // The active marker moves to Slow without a re-list.
+    expect(
+      (container.querySelector('[data-preset="Slow"]') as HTMLElement).getAttribute('aria-current'),
+    ).toBe('true');
+    expect(rpc.list).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies without an onApply callback (optional prop omitted)', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const applyBtn = container.querySelector(
+      '[data-preset="Fast"] .save-presets__apply',
+    ) as HTMLButtonElement;
+    await act(async () => applyBtn.click());
+    await flush();
+    expect(rpc.apply).toHaveBeenCalledWith('Fast');
+  });
+
+  it('saves the live settings under the typed name, then refreshes and clears it', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const input = container.querySelector('#save-presets-name') as HTMLInputElement;
+    typeInto(input, 'My preset');
+    const saveBtn = container.querySelector('.save-presets__save') as HTMLButtonElement;
+    await act(async () => saveBtn.click());
+    await flush();
+    expect(rpc.upsert).toHaveBeenCalledWith('My preset', {
+      autosave: AUTOSAVE,
+      exportDefaults: EXPORT_DEFAULTS,
+    });
+    // Refresh after save (list called twice: mount + post-save).
+    expect(rpc.list).toHaveBeenCalledTimes(2);
+    // Name field cleared.
+    expect((container.querySelector('#save-presets-name') as HTMLInputElement).value).toBe('');
+  });
+
+  it('trims the name and ignores a whitespace-only save (no RPC)', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const input = container.querySelector('#save-presets-name') as HTMLInputElement;
+    typeInto(input, '   ');
+    const saveBtn = container.querySelector('.save-presets__save') as HTMLButtonElement;
+    // The handler trims and no-ops on a blank name — no RPC fires.
+    await act(async () => saveBtn.click());
+    await flush();
+    expect(rpc.upsert).not.toHaveBeenCalled();
+  });
+
+  it('removes a preset: calls savePresets.remove and drops the row', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const removeBtn = container.querySelector(
+      '[data-preset="Fast"] .save-presets__remove',
+    ) as HTMLButtonElement;
+    await act(async () => removeBtn.click());
+    await flush();
+    expect(rpc.remove).toHaveBeenCalledWith('Fast');
+    expect(container.querySelector('[data-preset="Fast"]')).toBeNull();
+    expect(container.querySelector('[data-preset="Slow"]')).not.toBeNull();
+  });
+
+  it('surfaces a list error', async () => {
+    const rpc = makeRpc({ list: vi.fn().mockRejectedValue(new Error('list boom')) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    expect(container.querySelector('.save-presets__error')?.textContent).toBe('list boom');
+  });
+
+  it('surfaces an apply error (non-Error rejection stringified)', async () => {
+    const rpc = makeRpc({ apply: vi.fn().mockRejectedValue('apply-bad') });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const applyBtn = container.querySelector(
+      '[data-preset="Fast"] .save-presets__apply',
+    ) as HTMLButtonElement;
+    await act(async () => applyBtn.click());
+    await flush();
+    expect(container.querySelector('.save-presets__error')?.textContent).toBe('apply-bad');
+  });
+
+  it('surfaces a save error', async () => {
+    const rpc = makeRpc({ upsert: vi.fn().mockRejectedValue(new Error('save boom')) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const input = container.querySelector('#save-presets-name') as HTMLInputElement;
+    typeInto(input, 'X');
+    await act(async () =>
+      (container.querySelector('.save-presets__save') as HTMLButtonElement).click(),
+    );
+    await flush();
+    expect(container.querySelector('.save-presets__error')?.textContent).toBe('save boom');
+  });
+
+  it('surfaces a remove error', async () => {
+    const rpc = makeRpc({ remove: vi.fn().mockRejectedValue(new Error('remove boom')) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    await act(async () =>
+      (
+        container.querySelector('[data-preset="Fast"] .save-presets__remove') as HTMLButtonElement
+      ).click(),
+    );
+    await flush();
+    expect(container.querySelector('.save-presets__error')?.textContent).toBe('remove boom');
+  });
+});

--- a/app/renderer/src/components/SavePresetsControls.tsx
+++ b/app/renderer/src/components/SavePresetsControls.tsx
@@ -1,0 +1,199 @@
+// SavePresetsControls.tsx — list / apply / save / remove named save-presets
+// (UX/QoL WU-11).
+//
+// A save-preset is a named `{autosave, exportDefaults}` bundle persisted by the
+// `savePresets.*` RPCs (WU-10). This control set:
+//   * lists the saved bundles (one row each) with the last-applied one marked
+//     `aria-current` (text "Active", not color alone — WCAG 1.4.1);
+//   * APPLIES a bundle — marks it active server-side AND calls `onApply` so the
+//     parent can pre-fill export dialogs from the bundle's `exportDefaults`;
+//   * SAVES the live `autosave` + `exportDefaults` under a typed name (upsert);
+//   * REMOVES a bundle.
+//
+// Self-fetching (mirrors JobQueue's load-on-mount + error state) but with the RPC
+// surface INJECTED (mirrors useVideoThumbnail) so it unit-tests against a fake
+// client with no preload bridge. The parent owns the live settings (passed in)
+// and the post-apply pre-fill (`onApply`); this component owns only the list +
+// the three mutations.
+import React, { useCallback, useEffect, useState } from 'react';
+import type { AutosaveSettings, ExportDefaults, SavePreset, SavePresetsBlock } from '../lib/rpc';
+import './savePresetsControls.css';
+
+/** The thin `savePresets.*` slice this component needs (injectable for tests). */
+export interface SavePresetsRpc {
+  list(): Promise<SavePresetsBlock>;
+  apply(name: string): Promise<{ active: string; savePreset: SavePreset }>;
+  upsert(
+    name: string,
+    bundle: { autosave: AutosaveSettings; exportDefaults: ExportDefaults },
+  ): Promise<{ presets: Record<string, SavePreset> }>;
+  remove(name: string): Promise<{ presets: Record<string, SavePreset>; active: string }>;
+}
+
+export interface SavePresetsControlsProps {
+  /** The injected `savePresets.*` client slice (`client.savePresets` in the app). */
+  rpc: SavePresetsRpc;
+  /** Live autosave settings — bundled into the preset on Save. */
+  autosave: AutosaveSettings;
+  /** Live export defaults — bundled into the preset on Save. */
+  exportDefaults: ExportDefaults;
+  /** Called after a successful apply with the applied bundle (parent pre-fills UI). */
+  onApply?: (preset: SavePreset) => void;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function SavePresetsControls({
+  rpc,
+  autosave,
+  exportDefaults,
+  onApply,
+}: SavePresetsControlsProps): React.ReactElement {
+  const [block, setBlock] = useState<SavePresetsBlock>({ presets: {}, active: '' });
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState<string>('');
+  const [busy, setBusy] = useState<boolean>(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      const result = await rpc.list();
+      setBlock({ presets: result?.presets ?? {}, active: result?.active ?? '' });
+      setError(null);
+    } catch (err) {
+      setError(errText(err));
+    }
+  }, [rpc]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const handleApply = useCallback(
+    async (presetName: string) => {
+      setBusy(true);
+      try {
+        const result = await rpc.apply(presetName);
+        setBlock((prev) => ({ ...prev, active: result.active }));
+        setError(null);
+        if (onApply) onApply(result.savePreset);
+      } catch (err) {
+        setError(errText(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [rpc, onApply],
+  );
+
+  const handleSave = useCallback(async () => {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setBusy(true);
+    try {
+      await rpc.upsert(trimmed, { autosave, exportDefaults });
+      setName('');
+      setError(null);
+      await refresh();
+    } catch (err) {
+      setError(errText(err));
+    } finally {
+      setBusy(false);
+    }
+  }, [name, rpc, autosave, exportDefaults, refresh]);
+
+  const handleRemove = useCallback(
+    async (presetName: string) => {
+      setBusy(true);
+      try {
+        const result = await rpc.remove(presetName);
+        setBlock({ presets: result.presets, active: result.active });
+        setError(null);
+      } catch (err) {
+        setError(errText(err));
+      } finally {
+        setBusy(false);
+      }
+    },
+    [rpc],
+  );
+
+  const names = Object.keys(block.presets);
+
+  return (
+    <div className="save-presets" data-section="save-presets">
+      <h3>Saved export presets</h3>
+
+      {error ? (
+        <div className="save-presets__error" role="alert">
+          {error}
+        </div>
+      ) : null}
+
+      {names.length === 0 ? (
+        <div className="save-presets__empty">No saved presets yet.</div>
+      ) : (
+        <ul className="save-presets__list">
+          {names.map((presetName) => {
+            const isActive = block.active === presetName;
+            return (
+              <li
+                key={presetName}
+                className="save-presets__item"
+                data-preset={presetName}
+                aria-current={isActive ? 'true' : undefined}
+              >
+                <span className="save-presets__name">{presetName}</span>
+                {isActive ? <span className="save-presets__active-tag">Active</span> : null}
+                <div className="save-presets__item-actions">
+                  <button
+                    type="button"
+                    className="save-presets__apply"
+                    aria-label={`Apply ${presetName}`}
+                    disabled={busy}
+                    onClick={() => void handleApply(presetName)}
+                  >
+                    Apply
+                  </button>
+                  <button
+                    type="button"
+                    className="save-presets__remove"
+                    aria-label={`Remove ${presetName}`}
+                    disabled={busy}
+                    onClick={() => void handleRemove(presetName)}
+                  >
+                    Remove
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="save-presets__save-row">
+        <label htmlFor="save-presets-name">Save current settings as</label>
+        <input
+          id="save-presets-name"
+          type="text"
+          className="save-presets__name-input"
+          placeholder="Preset name"
+          value={name}
+          disabled={busy}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <button
+          type="button"
+          className="save-presets__save"
+          disabled={busy}
+          onClick={() => void handleSave()}
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+export default SavePresetsControls;

--- a/app/renderer/src/components/api.ts
+++ b/app/renderer/src/components/api.ts
@@ -62,6 +62,12 @@ export interface Video {
   addedAt: string;
   durationSec: number;
   hasTranscript: boolean;
+  /**
+   * WU-2/WU-4: persisted poster-frame path ("" / absent until generated). The
+   * library card serves it through the `thumb:` mstream resolver via
+   * `useVideoThumbnail`; additive + backfilled, so older payloads omit it.
+   */
+  thumbnailPath?: string;
 }
 
 export interface Project {

--- a/app/renderer/src/components/jobqueue.css
+++ b/app/renderer/src/components/jobqueue.css
@@ -163,6 +163,11 @@
   color: var(--status-success);
 }
 
+/* Interrupted: a crash-recovery state, not a failure — distinct from error. */
+.jobqueue__status--interrupted {
+  color: var(--status-warning, var(--text-secondary));
+}
+
 .jobqueue__label {
   font-size: var(--type-caption-size);
   color: var(--text-muted);
@@ -209,7 +214,8 @@
 }
 
 .jobqueue__cancel,
-.jobqueue__retry {
+.jobqueue__retry,
+.jobqueue__resume {
   appearance: none;
   padding: 3px 10px;
   border: none;

--- a/app/renderer/src/components/library-cards.css
+++ b/app/renderer/src/components/library-cards.css
@@ -58,7 +58,7 @@ li.library__item .library__item-meta {
   background: var(--surface-deep);
 }
 
-.library__thumb-video {
+.library__thumb-img {
   display: block;
   width: 100%;
   height: 100%;
@@ -68,7 +68,7 @@ li.library__item .library__item-meta {
   transition: transform var(--dur-slow) var(--ease-out);
 }
 
-li.library__item:hover .library__thumb-video {
+li.library__item:hover .library__thumb-img {
   transform: scale(1.03);
 }
 

--- a/app/renderer/src/components/pathsPanel.css
+++ b/app/renderer/src/components/pathsPanel.css
@@ -1,0 +1,110 @@
+/* pathsPanel.css — the data-layout list + change-root row (WU-12).
+ * Geometry/colors reuse the shared design tokens (space/radius/accent/status).
+ * The path string is inert selectable text; only the per-row Open control and the
+ * change-root control are interactive (real <button>s with focus rings). */
+
+.paths-panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.paths-panel__error {
+  color: var(--status-error);
+  background: var(--status-error-soft);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+
+.paths-panel__root {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding: var(--space-2);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+}
+
+.paths-panel__root-label {
+  font-weight: var(--type-body-weight);
+}
+
+.paths-panel__root-value {
+  font-family: var(--font-mono, monospace);
+  color: var(--text-secondary);
+  user-select: text;
+}
+
+.paths-panel__root-unavailable,
+.paths-panel__restart-hint {
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+}
+
+.paths-panel__loading {
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+}
+
+.paths-panel__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.paths-panel__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+}
+
+.paths-panel__row-label {
+  min-width: 7rem;
+  font-weight: var(--type-caption-weight);
+}
+
+.paths-panel__path {
+  flex: 1;
+  font-family: var(--font-mono, monospace);
+  font-size: var(--type-caption-size);
+  color: var(--text-secondary);
+  user-select: text;
+  word-break: break-all;
+}
+
+.paths-panel__change-root,
+.paths-panel__open {
+  appearance: none;
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--accent);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.paths-panel__change-root:hover,
+.paths-panel__open:hover {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+
+.paths-panel__change-root:focus-visible,
+.paths-panel__open:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.paths-panel__change-root:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}

--- a/app/renderer/src/components/readinessBadge.css
+++ b/app/renderer/src/components/readinessBadge.css
@@ -57,3 +57,46 @@
   outline: none;
   box-shadow: var(--focus-ring);
 }
+
+/* ReadinessRollup (WU-14): the shared "what works right now" section, reused on
+ * the library home + the model panel. Layout only — the badge tint/geometry come
+ * from the rules above; the in-flight skeleton reuses `.jobqueue__empty`. */
+.readiness-rollup {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.readiness-rollup__title {
+  margin: 0;
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.readiness-rollup__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.readiness-rollup__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.readiness-rollup__cap {
+  color: var(--text-primary);
+}
+
+.readiness-rollup__empty {
+  color: var(--text-faint);
+  font-size: var(--type-caption-size);
+}

--- a/app/renderer/src/components/readinessBadge.css
+++ b/app/renderer/src/components/readinessBadge.css
@@ -1,0 +1,59 @@
+/* readinessBadge.css — the parallel color map for <ReadinessBadge /> (WU-9).
+ * The pill GEOMETRY is reused from `.verdict-badge` (modelsSystem.css); this file
+ * adds ONLY the readiness-specific tint per status (a distinct map from the
+ * verdict colors) plus the inline action button. Color is decorative — the status
+ * is always conveyed by the visible text label too (WCAG 1.4.1). */
+
+.readiness-badge-group {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.readiness-badge.is-ready {
+  color: var(--status-success);
+  background: var(--status-success-soft);
+}
+
+.readiness-badge.is-needs-download {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+
+.readiness-badge.is-needs-key {
+  color: var(--status-warn);
+  background: var(--status-warn-soft);
+}
+
+.readiness-badge.is-needs-consent {
+  color: var(--status-warn);
+  background: var(--status-warn-soft);
+}
+
+.readiness-badge.is-unavailable {
+  color: var(--status-error);
+  background: var(--status-error-soft);
+}
+
+.readiness-badge__action {
+  appearance: none;
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--accent);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.readiness-badge__action:hover {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+
+.readiness-badge__action:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}

--- a/app/renderer/src/components/readinessMeta.test.ts
+++ b/app/renderer/src/components/readinessMeta.test.ts
@@ -1,0 +1,98 @@
+// readinessMeta.test.ts — WU-8 pins for the pure readiness label/class/hint map
+// + the action accessible-name builder. Status is distinguished by TEXT (the
+// label), never hue alone (WCAG 1.4.1); every status + action kind is table-tested
+// and the defensive fallbacks are exercised.
+import { describe, expect, it } from 'vitest';
+import type { ReadinessAction, ReadinessStatus } from '../lib/rpc';
+import {
+  READINESS_CLASS,
+  READINESS_HINT,
+  READINESS_LABEL,
+  readinessActionLabel,
+  readinessClass,
+  readinessHint,
+  readinessLabel,
+} from './readinessMeta';
+
+const STATUSES: ReadinessStatus[] = [
+  'ready',
+  'needsDownload',
+  'needsKey',
+  'needsConsent',
+  'unavailable',
+];
+
+describe('readinessLabel', () => {
+  it('returns the exact visible label for all five statuses', () => {
+    expect(readinessLabel('ready')).toBe('Ready');
+    expect(readinessLabel('needsDownload')).toBe('Needs download');
+    expect(readinessLabel('needsKey')).toBe('Needs key');
+    expect(readinessLabel('needsConsent')).toBe('Needs consent');
+    expect(readinessLabel('unavailable')).toBe('Unavailable');
+  });
+  it('every status maps to a non-empty text label (use-of-color guard)', () => {
+    for (const status of STATUSES) {
+      expect(readinessLabel(status).length).toBeGreaterThan(0);
+    }
+  });
+  it('falls back to the raw status for an unknown value (defensive)', () => {
+    expect(readinessLabel('mystery' as ReadinessStatus)).toBe('mystery');
+  });
+});
+
+describe('readinessClass', () => {
+  it('returns the status class for all five statuses', () => {
+    for (const status of STATUSES) {
+      expect(readinessClass(status)).toBe(READINESS_CLASS[status]);
+      expect(readinessClass(status).startsWith('is-')).toBe(true);
+    }
+  });
+  it('falls back to "" for an unknown value (defensive)', () => {
+    expect(readinessClass('mystery' as ReadinessStatus)).toBe('');
+  });
+});
+
+describe('readinessHint', () => {
+  it('returns a non-empty hint for all five statuses', () => {
+    for (const status of STATUSES) {
+      expect(readinessHint(status)).toBe(READINESS_HINT[status]);
+      expect(readinessHint(status).length).toBeGreaterThan(0);
+    }
+  });
+  it('falls back to "" for an unknown value (defensive)', () => {
+    expect(readinessHint('mystery' as ReadinessStatus)).toBe('');
+  });
+});
+
+describe('label maps are complete', () => {
+  it('every status has a label, class, and hint entry', () => {
+    for (const status of STATUSES) {
+      expect(READINESS_LABEL[status]).toBeTruthy();
+      expect(READINESS_CLASS[status]).toBeTruthy();
+      expect(READINESS_HINT[status]).toBeTruthy();
+    }
+  });
+});
+
+describe('readinessActionLabel', () => {
+  it('names the verb + capability for assets.ensure', () => {
+    const action: ReadinessAction = { kind: 'assets.ensure', assets: ['siglip2-so400m'] };
+    expect(readinessActionLabel(action, 'Multimodal')).toBe('Download Multimodal model');
+  });
+  it('names the add-key action', () => {
+    const action: ReadinessAction = { kind: 'openProviders', provider: 'gpt' };
+    expect(readinessActionLabel(action, 'AI: select')).toBe('Add a provider key');
+  });
+  it('names the provider for setConsent', () => {
+    const action: ReadinessAction = { kind: 'setConsent', provider: 'gpt' };
+    expect(readinessActionLabel(action, 'AI: vision')).toBe('Grant consent for gpt');
+  });
+  it('falls back to a generic provider name when setConsent omits the provider', () => {
+    const action = { kind: 'setConsent' } as ReadinessAction;
+    expect(readinessActionLabel(action, 'AI: vision')).toBe('Grant consent for provider');
+  });
+  it('falls back to the capability label for an unknown action kind (defensive)', () => {
+    const action = { kind: 'mystery' } as unknown as ReadinessAction;
+    expect(readinessActionLabel(action, 'Some capability')).toBe('Some capability');
+  });
+});

--- a/app/renderer/src/components/readinessMeta.ts
+++ b/app/renderer/src/components/readinessMeta.ts
@@ -1,0 +1,64 @@
+// readinessMeta.ts — pure, test-pinned helpers for the unified readiness roll-up
+// (`readiness.summary`, WU-8). Mirrors advisorMeta's shape: a status -> label /
+// status-class / plain-language hint map plus the per-action accessible-name
+// builder. No React, no I/O — keeping the branchy copy here lets ReadinessBadge
+// (WU-9) stay a thin render shell and pins the WCAG-1.4.1 "status by text, never
+// hue alone" guarantee in one covered place.
+import type { ReadinessAction, ReadinessStatus } from '../lib/rpc';
+
+/** Readiness status -> the short visible badge label (text, not color). */
+export const READINESS_LABEL: Record<ReadinessStatus, string> = {
+  ready: 'Ready',
+  needsDownload: 'Needs download',
+  needsKey: 'Needs key',
+  needsConsent: 'Needs consent',
+  unavailable: 'Unavailable',
+};
+
+/** Readiness status -> the status modifier class (drives the pill tint). */
+export const READINESS_CLASS: Record<ReadinessStatus, string> = {
+  ready: 'is-ready',
+  needsDownload: 'is-needs-download',
+  needsKey: 'is-needs-key',
+  needsConsent: 'is-needs-consent',
+  unavailable: 'is-unavailable',
+};
+
+/** Readiness status -> a one-line plain-language gloss (badge tooltip). */
+export const READINESS_HINT: Record<ReadinessStatus, string> = {
+  ready: 'Ready to use right now — nothing to install or configure.',
+  needsDownload: 'Needs a one-time model download before it can run.',
+  needsKey: 'Routed to a cloud provider that has no API key yet — add one to enable it.',
+  needsConsent: 'Has a key but needs your consent to send data to the cloud provider.',
+  unavailable: 'Not available here (download blocked offline, or no runnable path).',
+};
+
+/** Map a readiness status to its label (unknown -> the raw status, defensive). */
+export function readinessLabel(status: ReadinessStatus): string {
+  return READINESS_LABEL[status] ?? status;
+}
+
+/** Map a readiness status to its status class (unknown -> "", defensive). */
+export function readinessClass(status: ReadinessStatus): string {
+  return READINESS_CLASS[status] ?? '';
+}
+
+/** Map a readiness status to its plain-language hint (unknown -> "", defensive). */
+export function readinessHint(status: ReadinessStatus): string {
+  return READINESS_HINT[status] ?? '';
+}
+
+/**
+ * The capability-tied accessible name for a readiness fix action. Never
+ * icon-only: the returned string names BOTH the verb and the capability/provider
+ * so screen readers announce a self-describing control (WU-9 a11y requirement).
+ * An unknown action kind falls back to the capability label (defensive).
+ */
+export function readinessActionLabel(action: ReadinessAction, capabilityLabel: string): string {
+  const builders: Record<ReadinessAction['kind'], () => string> = {
+    'assets.ensure': () => `Download ${capabilityLabel} model`,
+    openProviders: () => 'Add a provider key',
+    setConsent: () => `Grant consent for ${action.provider ?? 'provider'}`,
+  };
+  return (builders[action.kind] ?? (() => capabilityLabel))();
+}

--- a/app/renderer/src/components/savePresetsControls.css
+++ b/app/renderer/src/components/savePresetsControls.css
@@ -1,0 +1,109 @@
+/* savePresetsControls.css — the named save-preset list + save row (WU-11).
+ * Geometry/colors reuse the shared design tokens (space/radius/accent/status);
+ * the "Active" state is conveyed by a TEXT tag, never color alone (WCAG 1.4.1). */
+
+.save-presets {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.save-presets__error {
+  color: var(--status-error);
+  background: var(--status-error-soft);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+}
+
+.save-presets__empty {
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+}
+
+.save-presets__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.save-presets__item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-md);
+}
+
+.save-presets__item[aria-current="true"] {
+  background: var(--accent-soft);
+}
+
+.save-presets__name {
+  font-weight: var(--type-body-weight);
+}
+
+.save-presets__active-tag {
+  color: var(--accent);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+}
+
+.save-presets__item-actions {
+  margin-left: auto;
+  display: inline-flex;
+  gap: var(--space-1);
+}
+
+.save-presets__apply,
+.save-presets__remove,
+.save-presets__save {
+  appearance: none;
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--accent);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.save-presets__apply:hover,
+.save-presets__remove:hover,
+.save-presets__save:hover {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+
+.save-presets__apply:focus-visible,
+.save-presets__remove:focus-visible,
+.save-presets__save:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.save-presets__apply:disabled,
+.save-presets__remove:disabled,
+.save-presets__save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.save-presets__save-row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.save-presets__name-input {
+  flex: 1;
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  color: var(--text-primary);
+  padding: var(--space-1) var(--space-2);
+}

--- a/app/renderer/src/components/useAutosave.test.tsx
+++ b/app/renderer/src/components/useAutosave.test.tsx
@@ -1,0 +1,121 @@
+// useAutosave.test.tsx — debounced, gated workspace autosave (UX/QoL WU-11).
+//
+// Fake timers + a fake `save` fn pin the falsifiable acceptance:
+//   * enabled + N rapid schedule()s -> EXACTLY ONE save after `debounceMs`;
+//   * disabled -> ZERO saves;
+//   * a config flip / unmount drops a pending timer (no stale, wrongly-timed save);
+//   * the trailing save runs the LATEST `save` closure (ref-tracked, not stale).
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { useAutosave, type AutosaveConfig, type AutosaveControls } from './useAutosave';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useAutosave (hook)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let controls: AutosaveControls;
+
+  function Harness(props: { save: () => void; config: AutosaveConfig }): React.ReactElement {
+    controls = useAutosave(props.save, props.config);
+    return React.createElement('div', null, null);
+  }
+
+  function render(props: { save: () => void; config: AutosaveConfig }): void {
+    act(() => {
+      root.render(React.createElement(Harness, props));
+    });
+  }
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('coalesces N rapid edits into ONE save after the debounce window', () => {
+    const save = vi.fn();
+    render({ save, config: { enabled: true, debounceMs: 1500 } });
+
+    act(() => {
+      controls.schedule();
+      controls.schedule();
+      controls.schedule();
+    });
+    // Before the window closes: nothing has fired.
+    act(() => vi.advanceTimersByTime(1499));
+    expect(save).not.toHaveBeenCalled();
+    // One tick past the window: exactly one coalesced save.
+    act(() => vi.advanceTimersByTime(1));
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-arms the timer on each edit (only the trailing edit fires)', () => {
+    const save = vi.fn();
+    render({ save, config: { enabled: true, debounceMs: 1000 } });
+
+    act(() => controls.schedule());
+    act(() => vi.advanceTimersByTime(800)); // not yet
+    act(() => controls.schedule()); // re-arm: the 800ms of waiting is discarded
+    act(() => vi.advanceTimersByTime(800));
+    expect(save).not.toHaveBeenCalled(); // would have fired at 1000 without re-arm
+    act(() => vi.advanceTimersByTime(200));
+    expect(save).toHaveBeenCalledTimes(1);
+  });
+
+  it('never saves when autosave is disabled', () => {
+    const save = vi.fn();
+    render({ save, config: { enabled: false, debounceMs: 1500 } });
+
+    act(() => {
+      controls.schedule();
+      controls.schedule();
+    });
+    act(() => vi.advanceTimersByTime(10000));
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('drops a pending save when autosave is turned off mid-window', () => {
+    const save = vi.fn();
+    render({ save, config: { enabled: true, debounceMs: 1500 } });
+    act(() => controls.schedule());
+    act(() => vi.advanceTimersByTime(500));
+    // Flip enabled -> false: the config-change effect clears the pending timer.
+    render({ save, config: { enabled: false, debounceMs: 1500 } });
+    act(() => vi.advanceTimersByTime(5000));
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('clears a pending save on unmount', () => {
+    const save = vi.fn();
+    render({ save, config: { enabled: true, debounceMs: 1500 } });
+    act(() => controls.schedule());
+    act(() => vi.advanceTimersByTime(500));
+    act(() => root.unmount());
+    act(() => vi.advanceTimersByTime(5000));
+    expect(save).not.toHaveBeenCalled();
+  });
+
+  it('runs the latest save closure, not the one captured at schedule time', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    render({ save: first, config: { enabled: true, debounceMs: 1000 } });
+    act(() => controls.schedule());
+    // Re-render with a fresh save fn before the timer fires (e.g. a new project).
+    render({ save: second, config: { enabled: true, debounceMs: 1000 } });
+    act(() => vi.advanceTimersByTime(1000));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/renderer/src/components/useAutosave.ts
+++ b/app/renderer/src/components/useAutosave.ts
@@ -1,0 +1,67 @@
+// useAutosave.ts — debounced, gated workspace autosave (UX/QoL WU-11).
+//
+// The workspace persists edits with `project.save` (handlers.py:276-287,
+// caller-driven — the sidecar never auto-persists). WU-11 wires the renderer to
+// fire that save automatically a short, COALESCED moment after the user stops
+// editing, gated on the WU-0 `autosave.enabled` setting:
+//
+//   * with `enabled=true`, N rapid edits collapse to ONE save `debounceMs` after
+//     the LAST edit (the falsifiable coalescing claim);
+//   * with `enabled=false`, edits NEVER trigger a save.
+//
+// The hook is deliberately decoupled from any specific RPC: the caller injects a
+// `save` callback (`() => client.project.save(project)` in the real workspace),
+// which keeps it pure-testable with fake timers + a fake save fn, and reusable by
+// any future caller-driven persistence surface.
+import { useCallback, useEffect, useRef } from 'react';
+
+/** The WU-0 autosave config slice this hook reads (mirrors `AutosaveSettings`). */
+export interface AutosaveConfig {
+  enabled: boolean;
+  debounceMs: number;
+}
+
+/** What `useAutosave` returns: `schedule()` arms/re-arms the debounced save. */
+export interface AutosaveControls {
+  /** Mark the document dirty — schedules ONE save `debounceMs` after the last call. */
+  schedule: () => void;
+}
+
+/**
+ * Debounce a caller-driven `save` on a per-edit `schedule()` signal.
+ *
+ * Each `schedule()` call (re)arms a single timer; only the trailing edit's timer
+ * survives, so a burst of edits coalesces into ONE `save` after the window. When
+ * `enabled` is false, `schedule()` is inert (zero saves). The pending timer is
+ * cleared on unmount and whenever `enabled`/`debounceMs` change, so a config flip
+ * can never fire a stale, wrongly-timed save. `save` is read through a ref so a
+ * changing closure (e.g. a fresh `project`) never resets the timer.
+ */
+export function useAutosave(save: () => void, config: AutosaveConfig): AutosaveControls {
+  const { enabled, debounceMs } = config;
+  const saveRef = useRef(save);
+  saveRef.current = save;
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clear = useCallback(() => {
+    if (timerRef.current !== null) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const schedule = useCallback(() => {
+    if (!enabled) return;
+    clear();
+    timerRef.current = setTimeout(() => {
+      timerRef.current = null;
+      saveRef.current();
+    }, debounceMs);
+  }, [enabled, debounceMs, clear]);
+
+  // A config change (or unmount) drops any in-flight timer so it can't fire with
+  // stale timing / after autosave was turned off.
+  useEffect(() => clear, [enabled, debounceMs, clear]);
+
+  return { schedule };
+}

--- a/app/renderer/src/components/useVideoThumbnail.test.tsx
+++ b/app/renderer/src/components/useVideoThumbnail.test.tsx
@@ -1,0 +1,118 @@
+// useVideoThumbnail.test.tsx — the pure poster-URL helper + the on-demand hook
+// (UX/QoL WU-4).
+//
+// A near-clone of useShortThumbnail's test, repointed at the SOURCE-library
+// poster engine: `library.thumbnail({id})` + the `thumb:` mstream resolver
+// (WU-2 + WU-3). The pure `videoThumbnailSrc` mapping is pinned directly; the
+// `useVideoThumbnail` hook is exercised for serve-existing, generate-on-demand,
+// the no-rpc / empty-id short-circuit, and the error/empty-result fallbacks.
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { videoThumbnailSrc, useVideoThumbnail, type VideoThumbnailRpc } from './useVideoThumbnail';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('videoThumbnailSrc', () => {
+  it('routes a poster path through the thumb: mstream resolver', () => {
+    const url = videoThumbnailSrc('/data/thumbnails/v1.jpg');
+    expect(url).toContain('mstream://media/');
+    expect(url).toContain('thumb%3A'); // encoded "thumb:"
+    expect(url).toContain('v1.jpg');
+  });
+
+  it('returns "" for an empty path (caller shows the glyph fallback)', () => {
+    expect(videoThumbnailSrc('')).toBe('');
+  });
+});
+
+describe('useVideoThumbnail (hook)', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  let resolved = '';
+
+  function Harness(props: {
+    rpc: VideoThumbnailRpc | null;
+    videoId: string;
+    thumbnailPath: string;
+  }): React.ReactElement {
+    resolved = useVideoThumbnail(props.rpc, props.videoId, props.thumbnailPath);
+    return React.createElement('div', null, resolved);
+  }
+
+  async function render(props: {
+    rpc: VideoThumbnailRpc | null;
+    videoId: string;
+    thumbnailPath: string;
+  }): Promise<void> {
+    await act(async () => {
+      root.render(React.createElement(Harness, props));
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  beforeEach(() => {
+    resolved = '';
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('serves an existing poster path immediately without an RPC call', async () => {
+    const rpc: VideoThumbnailRpc = { thumbnail: vi.fn() };
+    await render({
+      rpc,
+      videoId: 'v1',
+      thumbnailPath: '/data/thumbnails/v1.jpg',
+    });
+    expect(resolved).toBe(videoThumbnailSrc('/data/thumbnails/v1.jpg'));
+    expect(rpc.thumbnail).not.toHaveBeenCalled();
+  });
+
+  it('resolves to "" when no rpc client is available', async () => {
+    await render({ rpc: null, videoId: 'v1', thumbnailPath: '' });
+    expect(resolved).toBe('');
+  });
+
+  it('resolves to "" when the video id is empty (no RPC fired)', async () => {
+    const rpc: VideoThumbnailRpc = { thumbnail: vi.fn() };
+    await render({ rpc, videoId: '', thumbnailPath: '' });
+    expect(resolved).toBe('');
+    expect(rpc.thumbnail).not.toHaveBeenCalled();
+  });
+
+  it('generates the poster on demand and serves the returned path', async () => {
+    const rpc: VideoThumbnailRpc = {
+      thumbnail: vi.fn().mockResolvedValue({ thumbnailPath: '/data/thumbnails/gen.jpg' }),
+    };
+    await render({ rpc, videoId: 'v1', thumbnailPath: '' });
+    expect(rpc.thumbnail).toHaveBeenCalledWith('v1');
+    expect(resolved).toBe(videoThumbnailSrc('/data/thumbnails/gen.jpg'));
+  });
+
+  it('keeps "" when the generation returns an empty thumbnailPath', async () => {
+    const rpc: VideoThumbnailRpc = {
+      thumbnail: vi.fn().mockResolvedValue({ thumbnailPath: '' }),
+    };
+    await render({ rpc, videoId: 'v1', thumbnailPath: '' });
+    expect(resolved).toBe('');
+  });
+
+  it('falls back to "" when the generation RPC rejects', async () => {
+    const rpc: VideoThumbnailRpc = {
+      thumbnail: vi.fn().mockRejectedValue(new Error('no poster')),
+    };
+    await render({ rpc, videoId: 'v1', thumbnailPath: '' });
+    expect(resolved).toBe('');
+  });
+});

--- a/app/renderer/src/components/useVideoThumbnail.ts
+++ b/app/renderer/src/components/useVideoThumbnail.ts
@@ -1,0 +1,78 @@
+// useVideoThumbnail.ts — generate + serve a SOURCE-library video's poster frame
+// (UX/QoL WU-4).
+//
+// A near-clone of `useShortThumbnail` repointed at the source-library poster
+// engine. Two facts it builds on:
+//   1. `library.thumbnail({id})` (WU-2) extracts a poster from a SOURCE video by
+//      reusing the shorts ffmpeg poster engine, persists `thumbnailPath` onto the
+//      Video, and returns it. It is idempotent server-side (an existing
+//      `data_dir/thumbnails/<id>.jpg` short-circuits — the runner never re-runs).
+//   2. A raw filesystem path in `<img src>` cannot load in the sandboxed
+//      renderer — image bytes must ride the `thumb:` mstream resolver (WU-3,
+//      traversal-guarded inside the thumbnails root), so `thumbMediaUrl(path)`
+//      resolves it.
+//
+// `videoThumbnailSrc(path)` is the pure URL helper (unit-tested without React).
+// The `useVideoThumbnail` hook fetches the poster ON DEMAND (idempotent
+// server-side) when a card has no `thumbnailPath` yet, and returns the mstream
+// URL to render.
+import { useEffect, useState } from 'react';
+import { thumbMediaUrl } from './Player';
+
+/** RPC surface this hook needs (a thin slice of lib/rpc's `client.library`). */
+export interface VideoThumbnailRpc {
+  thumbnail(videoId: string): Promise<{ thumbnailPath: string }>;
+}
+
+/**
+ * The `<img src>` URL for a poster-frame path, routed through the `thumb:`
+ * mstream resolver (image bytes can't load from a raw fs path in the sandbox).
+ * Returns "" for an empty path (the caller falls back to the ▶ glyph). Pure.
+ */
+export function videoThumbnailSrc(thumbnailPath: string): string {
+  return thumbnailPath ? thumbMediaUrl(thumbnailPath) : '';
+}
+
+/**
+ * Resolve a renderable poster URL for a SOURCE-library video, generating it on
+ * demand.
+ *
+ * - If `thumbnailPath` is already set, serve it immediately (no RPC).
+ * - Otherwise call `rpc.thumbnail(videoId)` once (idempotent: the sidecar
+ *   caches `data_dir/thumbnails/<id>.jpg`) and serve the returned path.
+ * Best-effort: any failure leaves "" so the card shows the ▶ glyph fallback —
+ * a missing poster never blocks the gallery. Never mutates inputs.
+ */
+export function useVideoThumbnail(
+  rpc: VideoThumbnailRpc | null,
+  videoId: string,
+  thumbnailPath: string,
+): string {
+  const [resolved, setResolved] = useState<string>(() => videoThumbnailSrc(thumbnailPath));
+
+  useEffect(() => {
+    // An existing poster wins — serve it without an RPC round-trip.
+    if (thumbnailPath) {
+      setResolved(videoThumbnailSrc(thumbnailPath));
+      return undefined;
+    }
+    if (!rpc || !videoId) {
+      setResolved('');
+      return undefined;
+    }
+    let alive = true;
+    setResolved('');
+    Promise.resolve(rpc.thumbnail(videoId))
+      .then((res) => {
+        if (alive && res && res.thumbnailPath) setResolved(videoThumbnailSrc(res.thumbnailPath));
+      })
+      .catch(() => {
+        // No poster -> the card keeps the ▶ glyph fallback.
+      });
+    return () => {
+      alive = false;
+    };
+  }, [rpc, videoId, thumbnailPath]);
+
+  return resolved;
+}

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -217,7 +217,7 @@ describe('client.ping / library / project', () => {
     expect(r).toHaveBeenCalledWith('ping', undefined);
   });
 
-  it('library.list / add / remove forward their params', async () => {
+  it('library.list / add / remove / thumbnail forward their params', async () => {
     const r = installApi();
     await client.library.list();
     expect(r).toHaveBeenCalledWith('library.list', undefined);
@@ -225,6 +225,8 @@ describe('client.ping / library / project', () => {
     expect(r).toHaveBeenCalledWith('library.add', { path: '/a.mp4' });
     await client.library.remove('v1');
     expect(r).toHaveBeenCalledWith('library.remove', { id: 'v1' });
+    await client.library.thumbnail('v1');
+    expect(r).toHaveBeenCalledWith('library.thumbnail', { id: 'v1' });
   });
 
   it('project.open / save / consolidate forward their params', async () => {

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -548,6 +548,29 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('providers.firstRun', { choice: 'bestFreeCloud' });
   });
 
+  it('savePresets.* forward their params (WU-10/WU-11)', async () => {
+    const r = installApi();
+    await client.savePresets.list();
+    expect(r).toHaveBeenCalledWith('savePresets.list', undefined);
+    await client.savePresets.apply('Fast export');
+    expect(r).toHaveBeenCalledWith('savePresets.apply', { name: 'Fast export' });
+    // upsert WITHOUT a bundle: the conditional-spread falls back to `{}`.
+    await client.savePresets.upsert('Bare');
+    expect(r).toHaveBeenCalledWith('savePresets.upsert', { name: 'Bare' });
+    // upsert WITH a bundle: both parts ride along.
+    await client.savePresets.upsert('Full', {
+      autosave: { enabled: true, debounceMs: 1500 },
+      exportDefaults: { subtitleFormat: 'srt', nleFormat: 'edl', nleFps: 30 },
+    });
+    expect(r).toHaveBeenCalledWith('savePresets.upsert', {
+      name: 'Full',
+      autosave: { enabled: true, debounceMs: 1500 },
+      exportDefaults: { subtitleFormat: 'srt', nleFormat: 'edl', nleFps: 30 },
+    });
+    await client.savePresets.remove('Bare');
+    expect(r).toHaveBeenCalledWith('savePresets.remove', { name: 'Bare' });
+  });
+
   it('recipes.* forward their params', async () => {
     const r = installApi();
     const recipe: SavedRecipe = {

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -11,9 +11,12 @@ import {
   rpc,
   onProgress,
   onJobDone,
+  type AutosaveSettings,
   type Candidate,
   type ConvertOptions,
+  type ExportDefaults,
   type Project,
+  type SavePresetsBlock,
   type SavedRecipe,
   type ShortInfo,
   type ShortReexportHint,
@@ -558,5 +561,31 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('recipes.delete', { id: 'r1' });
     await client.recipes.run('r1');
     expect(r).toHaveBeenCalledWith('recipes.run', { id: 'r1' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// WU-0 (ux-qol): additive settings type shapes. These mirror the sidecar
+// DEFAULT_SETTINGS QoL keys; the assertions pin the field names/types so a future
+// drift breaks the typecheck (the interfaces are erased, so we assert literals).
+// ---------------------------------------------------------------------------
+describe('WU-0 QoL settings shapes (mirror sidecar DEFAULT_SETTINGS)', () => {
+  it('AutosaveSettings matches the sidecar default', () => {
+    const autosave: AutosaveSettings = { enabled: true, debounceMs: 1500 };
+    expect(autosave).toEqual({ enabled: true, debounceMs: 1500 });
+  });
+
+  it('ExportDefaults matches the sidecar default', () => {
+    const exportDefaults: ExportDefaults = {
+      subtitleFormat: 'srt',
+      nleFormat: 'edl',
+      nleFps: 30,
+    };
+    expect(exportDefaults).toEqual({ subtitleFormat: 'srt', nleFormat: 'edl', nleFps: 30 });
+  });
+
+  it('SavePresetsBlock matches the sidecar default (empty presets + no active)', () => {
+    const savePresets: SavePresetsBlock = { presets: {}, active: '' };
+    expect(savePresets).toEqual({ presets: {}, active: '' });
   });
 });

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -524,6 +524,12 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('asr.engines', undefined);
   });
 
+  it('readiness.summary calls the bare method (WU-8 roll-up)', async () => {
+    const r = installApi();
+    await client.readiness.summary();
+    expect(r).toHaveBeenCalledWith('readiness.summary', undefined);
+  });
+
   it('providers.usage calls the bare method (WU-usage-ui)', async () => {
     const r = installApi();
     await client.providers.usage();

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -264,6 +264,41 @@ export interface AsrEngine {
 }
 
 /**
+ * One capability's readiness state (`readiness.summary`, WU-8). The five states
+ * are distinguished by TEXT (the badge label), never hue alone (WCAG 1.4.1):
+ * `ready`, `needsDownload`, `needsKey`, `needsConsent`, `unavailable`.
+ */
+export type ReadinessStatus =
+  | 'ready'
+  | 'needsDownload'
+  | 'needsKey'
+  | 'needsConsent'
+  | 'unavailable';
+
+/** The actionable fix a not-ready capability offers (null when `ready`/blocked). */
+export interface ReadinessAction {
+  /** `assets.ensure` (download), `openProviders` (add a key), `setConsent`. */
+  kind: 'assets.ensure' | 'openProviders' | 'setConsent';
+  /** The asset names to ensure (only for `assets.ensure`). */
+  assets?: string[];
+  /** The provider id the action targets (key/consent actions). */
+  provider?: string;
+}
+
+/** One rolled-up capability row from `readiness.summary` (WU-8). */
+export interface ReadinessItem {
+  /** Stable capability id, e.g. `tier1-multimodal` or `ai.select`. */
+  capability: string;
+  /** Human-friendly capability name. */
+  label: string;
+  status: ReadinessStatus;
+  /** Plain-language reason it is not ready ("" when ready). */
+  blockedBy: string;
+  /** The fix action, or null when ready or blocked with no fix. */
+  action: ReadinessAction | null;
+}
+
+/**
  * One per-key usage row from `providers.usage` (WU-usage-ui). The pool accounts
  * usage from optimistic decrement + parsed 429 / X-RateLimit-* headers (NOT a
  * poller). `key` is ALWAYS the REDACTED last-4 (no full key crosses RPC).

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -528,6 +528,8 @@ export const client = {
     list: (): Promise<{ videos: Video[] }> => rpc('library.list'),
     add: (path: string): Promise<{ video: Video }> => rpc('library.add', { path }),
     remove: (id: string): Promise<{ ok: boolean }> => rpc('library.remove', { id }),
+    /** `library.thumbnail {id}` — idempotent source-video poster extraction (WU-4). */
+    thumbnail: (id: string): Promise<{ thumbnailPath: string }> => rpc('library.thumbnail', { id }),
   },
 
   project: {

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -346,6 +346,36 @@ export interface FirstRunResponse {
   routing?: RoutingBlock;
 }
 
+// ---------------------------------------------------------------------------
+// UX / QoL bundle (WU-0): additive settings shapes downstream WUs consume.
+// These mirror the sidecar DEFAULT_SETTINGS QoL keys (settings_store.py) and are
+// purely additive — they never widen or break the existing settings surface.
+// ---------------------------------------------------------------------------
+
+/** Workspace autosave config (WU-11): the renderer debounces `project.save`. */
+export interface AutosaveSettings {
+  enabled: boolean;
+  debounceMs: number;
+}
+
+/** Pre-selected export formats the export UI offers first (WU-11). */
+export interface ExportDefaults {
+  subtitleFormat: string;
+  nleFormat: string;
+  nleFps: number;
+}
+
+/**
+ * Saved export/pipeline presets (WU-10/WU-11). `presets` is a name->preset map;
+ * `active` is the last-applied preset name. NOTE: the sidecar `settings.set` is a
+ * SHALLOW top-level merge — writing `savePresets` REPLACES the whole block, so a
+ * partial update must read-modify-write the full block to preserve `presets`.
+ */
+export interface SavePresetsBlock {
+  presets: Record<string, unknown>;
+  active: string;
+}
+
 /**
  * system-advanced saved pipeline recipe — field names FROZEN, identical to the
  * sidecar `recipes.normalize_recipe` shape. A `Step` names an existing RPC

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -808,6 +808,16 @@ export const client = {
     engines: (): Promise<{ engines: AsrEngine[] }> => rpc('asr.engines'),
   },
 
+  /**
+   * `readiness.*` — the unified "what works right now" roll-up (WU-8). Strictly
+   * read-only: it derives every row from the installed-weight map + redacted
+   * settings view, so it triggers no download and opens no socket.
+   */
+  readiness: {
+    /** `readiness.summary()` -> the per-capability readiness rows (WU-8). */
+    summary: (): Promise<{ items: ReadinessItem[] }> => rpc('readiness.summary'),
+  },
+
   /** `providers.*` — Hub key/usage reads (WU-usage-ui surfaces live usage here). */
   providers: {
     /**

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -401,13 +401,23 @@ export interface ExportDefaults {
 }
 
 /**
+ * One saved bundle (WU-10/WU-11): the autosave + export-default choices a named
+ * preset carries. Both parts are `Partial` because the sidecar `upsert` stores
+ * `{}` for an omitted part (the renderer fills the gaps from live settings).
+ */
+export interface SavePreset {
+  autosave: Partial<AutosaveSettings>;
+  exportDefaults: Partial<ExportDefaults>;
+}
+
+/**
  * Saved export/pipeline presets (WU-10/WU-11). `presets` is a name->preset map;
  * `active` is the last-applied preset name. NOTE: the sidecar `settings.set` is a
  * SHALLOW top-level merge — writing `savePresets` REPLACES the whole block, so a
  * partial update must read-modify-write the full block to preserve `presets`.
  */
 export interface SavePresetsBlock {
-  presets: Record<string, unknown>;
+  presets: Record<string, SavePreset>;
   active: string;
 }
 
@@ -818,6 +828,32 @@ export const client = {
      */
     firstRun: (choice?: string): Promise<FirstRunResponse> =>
       rpc('providers.firstRun', choice === undefined ? {} : { choice }),
+  },
+
+  /**
+   * `savePresets.*` — named `{autosave, exportDefaults}` bundles (WU-10/WU-11).
+   * The sidecar `settings.set` is a SHALLOW top-level merge, so every mutating
+   * handler read-modify-writes the whole `savePresets` block server-side; the
+   * client just mirrors the frozen method names + param/result shapes.
+   */
+  savePresets: {
+    /** `savePresets.list()` -> the saved bundle map + last-applied name. */
+    list: (): Promise<SavePresetsBlock> => rpc('savePresets.list'),
+    /** `savePresets.apply({name})` -> the now-active name + its resolved bundle. */
+    apply: (name: string): Promise<{ active: string; savePreset: SavePreset }> =>
+      rpc('savePresets.apply', { name }),
+    /**
+     * `savePresets.upsert({name, autosave?, exportDefaults?})` -> the bundle map.
+     * Omitted parts default to `{}` server-side (filled from live settings).
+     */
+    upsert: (
+      name: string,
+      bundle?: { autosave?: AutosaveSettings; exportDefaults?: ExportDefaults },
+    ): Promise<{ presets: Record<string, SavePreset> }> =>
+      rpc('savePresets.upsert', { name, ...(bundle ?? {}) }),
+    /** `savePresets.remove({name})` -> the surviving bundle map + active name. */
+    remove: (name: string): Promise<{ presets: Record<string, SavePreset>; active: string }> =>
+      rpc('savePresets.remove', { name }),
   },
 
   /** `recipes.*` — saved multi-step pipelines run in one shot. */

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -440,7 +440,7 @@ export interface JobInfo {
   feature: string;
   label: string;
   videoId?: string;
-  status: 'queued' | 'running' | 'done' | 'error' | 'cancelled';
+  status: 'queued' | 'running' | 'done' | 'error' | 'cancelled' | 'interrupted';
   pct: number;
 }
 

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -21,9 +21,12 @@ import type {
   CatalogResponse,
   ComponentStatus,
   HardwareInfo,
+  ReadinessItem,
   UsageRow,
   client as RealClient,
 } from '../lib/rpc';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
 // ---- pure-helper coverage --------------------------------------------------
 
@@ -132,6 +135,8 @@ function makeClient(
     initialSettings?: Record<string, unknown>;
     rejectAnalyze?: boolean;
     rejectUsage?: boolean;
+    readiness?: ReadinessItem[];
+    rejectEnsure?: boolean;
   } = {},
 ): FakeClient {
   const calls: FakeClient['calls'] = [];
@@ -155,7 +160,14 @@ function makeClient(
       }),
       ensure: vi.fn(async (names: string[]) => {
         calls.push({ method: 'assets.ensure', args: [names] });
+        if (over.rejectEnsure) throw new Error('ensure failed');
         return { jobId: 'job-1' };
+      }),
+    },
+    readiness: {
+      summary: vi.fn(async () => {
+        calls.push({ method: 'readiness.summary', args: [] });
+        return { items: over.readiness ?? [] };
       }),
     },
     asr: {
@@ -914,5 +926,191 @@ describe('<ModelsSystemPanel />', () => {
     await mount(c);
     await analyze();
     expect(container.querySelector('[data-section="presets"]')).toBeNull();
+  });
+
+  // ---- WU-14: the readiness roll-up join ----------------------------------
+
+  it('renders the readiness roll-up (one badge per readiness.summary item)', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      readiness: [
+        { capability: 't1', label: 'Tier 1', status: 'ready', blockedBy: '', action: null },
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: 'saliency missing',
+          action: { kind: 'assets.ensure', assets: ['saliency'] },
+        },
+      ],
+    });
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const badges = container.querySelectorAll('.readiness-rollup [role="status"]');
+    expect(badges.length).toBe(2);
+    expect(c.calls.some((x) => x.method === 'readiness.summary')).toBe(true);
+  });
+
+  it('an assets.ensure roll-up action installs + re-lists + re-runs the advisor', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          action: { kind: 'assets.ensure', assets: ['saliency'] },
+        },
+      ],
+    });
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fix = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fix.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(c.calls.some((x) => x.method === 'assets.ensure')).toBe(true);
+    expect(c.calls.some((x) => x.method === 'system.advisor')).toBe(true);
+  });
+
+  it('surfaces an error when a roll-up assets.ensure action fails', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      rejectEnsure: true,
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          action: { kind: 'assets.ensure', assets: ['saliency'] },
+        },
+      ],
+    });
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fix = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fix.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.error')?.textContent).toContain('ensure failed');
+  });
+
+  it('a non-ensure roll-up action (openProviders) is a no-op install-wise', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'tr',
+          label: 'Translation',
+          status: 'needsKey',
+          blockedBy: 'no key',
+          action: { kind: 'openProviders' },
+        },
+      ],
+    });
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fix = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fix.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    // No install was attempted for a key/consent action.
+    expect(c.calls.some((x) => x.method === 'assets.ensure')).toBe(false);
+  });
+
+  it('an assets.ensure roll-up action coerces a non-array list + null advisor', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          action: { kind: 'assets.ensure', assets: ['saliency'] },
+        },
+      ],
+    });
+    // assets.list resolves a non-array -> the `: []` fallback; advisor resolves
+    // null -> the `?? null` fallback. Both arms of the post-ensure refresh.
+    (c.client.assets.list as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {} as unknown as { assets: AssetInfo[] },
+    );
+    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      null as unknown as AdvisorReport,
+    );
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fix = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fix.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(c.calls.some((x) => x.method === 'assets.ensure')).toBe(true);
+    // No crash; no error surfaced.
+    expect(container.querySelector('.error')).toBeNull();
+  });
+
+  it('an assets.ensure roll-up action with no asset names is a no-op', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          // assets.ensure with an empty list -> the guard short-circuits.
+          action: { kind: 'assets.ensure', assets: [] },
+        },
+      ],
+    });
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fix = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fix.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(c.calls.some((x) => x.method === 'assets.ensure')).toBe(false);
   });
 });

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -36,6 +36,8 @@ import { ModelsOnboarding } from '../components/ModelsOnboarding';
 import { UsageBars } from '../components/UsageBar';
 import { PresetPicker } from '../components/PresetPicker';
 import { FirstRunChooser } from '../components/FirstRunChooser';
+import { ReadinessRollup } from '../components/ReadinessRollup';
+import type { ReadinessAction } from '../lib/rpc';
 
 // --- pure helpers (exported for tests) -------------------------------------
 
@@ -302,6 +304,28 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
     [api, downloading, settings.commercial],
   );
 
+  // WU-14: the readiness roll-up surfaces a fix action per not-ready capability.
+  // A `assets.ensure` action installs the named weights then re-lists assets +
+  // re-runs the advisor (same effect as a per-model Download). Key/consent
+  // actions are handled by the provider controls already on this panel, so the
+  // roll-up just announces them — no extra navigation needed here.
+  const handleReadinessAction = useCallback(
+    async (action: ReadinessAction): Promise<void> => {
+      if (action.kind !== 'assets.ensure' || !action.assets || action.assets.length === 0) return;
+      setError('');
+      try {
+        await api.assets.ensure(action.assets);
+        const res = await api.assets.list();
+        setAssets(Array.isArray(res?.assets) ? res.assets : []);
+        const rep = await api.system.advisor({ commercial: Boolean(settings.commercial) });
+        setReport(rep ?? null);
+      } catch (err) {
+        setError(errText(err));
+      }
+    },
+    [api, settings.commercial],
+  );
+
   const currentTier = settings.phase8Tier ?? 1;
   const recommendedTier = report ? presetTier(report.recommendedPreset) : 0;
 
@@ -312,6 +336,12 @@ export function ModelsSystemPanel({ rpcClient }: ModelsSystemPanelProps): React.
         See what your machine can run, pick a quality tier for moment-finding, and download only the
         models you need. Analysis is opt-in and runs locally — nothing is uploaded.
       </p>
+
+      <ReadinessRollup
+        rpcClient={api}
+        title="What works right now"
+        onAction={(action) => void handleReadinessAction(action)}
+      />
 
       <div className="actions">
         <button type="button" data-action="analyze" onClick={() => void analyze()} disabled={busy}>

--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
@@ -11,40 +11,25 @@ vi.mock('../components/api', () => ({
   hasApi: () => true,
 }));
 
-import { Library, POSTER_SEEK_FRACTION, posterSeekTime } from './Library';
-import type { Video } from '../components/api';
-
-// ---------------------------------------------------------------------------
-// T6 thumbnails: jsdom does not implement HTMLMediaElement; back the bits the
-// poster thumbnail touches (pause/currentTime/duration) with deterministic
-// per-element stores so tests can drive them (same pattern as Player.test.tsx).
-// ---------------------------------------------------------------------------
-const pauseMock = vi.fn();
-const currentTimes = new WeakMap<HTMLMediaElement, number>();
-const durations = new WeakMap<HTMLMediaElement, number>();
-
-beforeAll(() => {
-  Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
-    configurable: true,
-    writable: true,
-    value: pauseMock,
-  });
-  Object.defineProperty(HTMLMediaElement.prototype, 'currentTime', {
-    configurable: true,
-    get(this: HTMLMediaElement) {
-      return currentTimes.get(this) ?? 0;
-    },
-    set(this: HTMLMediaElement, v: number) {
-      currentTimes.set(this, v);
-    },
-  });
-  Object.defineProperty(HTMLMediaElement.prototype, 'duration', {
-    configurable: true,
-    get(this: HTMLMediaElement) {
-      return durations.get(this) ?? Number.NaN;
-    },
-  });
+// WU-14: the library home renders <ReadinessRollup>, which loads
+// `readiness.summary` through the canonical lib/rpc `client`. Stub that client so
+// the roll-up resolves to an empty set in these tests (the roll-up has its own
+// dedicated suite); the rest of lib/rpc stays real for the type re-exports.
+const readinessSummaryMock = vi.fn(
+  async (): Promise<{ items: ReadinessItem[] }> => ({ items: [] }),
+);
+vi.mock('../lib/rpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/rpc')>();
+  return {
+    ...actual,
+    client: { ...actual.client, readiness: { summary: () => readinessSummaryMock() } },
+  };
 });
+
+import { Library } from './Library';
+import type { Video } from '../components/api';
+import type { ReadinessItem } from '../lib/rpc';
+import { videoThumbnailSrc } from '../components/useVideoThumbnail';
 
 function makeVideo(over: Partial<Video> = {}): Video {
   return {
@@ -54,6 +39,10 @@ function makeVideo(over: Partial<Video> = {}): Video {
     addedAt: '2026-06-11T00:00:00Z',
     durationSec: 605,
     hasTranscript: false,
+    // WU-14: an already-persisted poster path serves immediately via
+    // useVideoThumbnail (no on-demand `library.thumbnail` rpc), so the existing
+    // rpc-call-count assertions stay exact. Thumbnail-specific tests override it.
+    thumbnailPath: '/data/thumbnails/v1.jpg',
     ...over,
   };
 }
@@ -83,7 +72,8 @@ beforeEach(() => {
   rpcMock.mockReset();
   openVideosMock.mockReset();
   pathForFileMock.mockReset();
-  pauseMock.mockClear();
+  readinessSummaryMock.mockClear();
+  readinessSummaryMock.mockResolvedValue({ items: [] });
   installBridge();
   container = document.createElement('div');
   document.body.appendChild(container);
@@ -675,43 +665,70 @@ describe('Library', () => {
 });
 
 // ---------------------------------------------------------------------------
-// T6: poster-frame thumbnails + duration badge
+// WU-14: poster-frame thumbnails (useVideoThumbnail) + the readiness roll-up
 // ---------------------------------------------------------------------------
 
-describe('posterSeekTime', () => {
-  it('is ~10% of the duration', () => {
-    expect(POSTER_SEEK_FRACTION).toBe(0.1);
-    expect(posterSeekTime(605)).toBeCloseTo(60.5);
-    expect(posterSeekTime(20)).toBeCloseTo(2);
-  });
-
-  it('is 0 for unknown/invalid durations', () => {
-    expect(posterSeekTime(0)).toBe(0);
-    expect(posterSeekTime(-3)).toBe(0);
-    expect(posterSeekTime(Number.NaN)).toBe(0);
-  });
-});
-
-describe('Library thumbnails (T6)', () => {
-  function thumbVideo(): HTMLVideoElement {
-    return container.querySelector('video.library__thumb-video') as HTMLVideoElement;
-  }
-
-  it('renders a muted metadata-only poster <video> on the mstream URL per card', async () => {
+describe('Library thumbnails (WU-14 useVideoThumbnail wiring)', () => {
+  it('renders the thumb: <img> poster per card when a thumbnailPath exists', async () => {
     rpcMock.mockResolvedValueOnce({
-      videos: [makeVideo(), makeVideo({ id: 'v 2', title: 'Second' })],
+      videos: [makeVideo(), makeVideo({ id: 'v2', title: 'Second' })],
     });
     await renderLibrary();
 
-    const thumbs = container.querySelectorAll('video.library__thumb-video');
-    expect(thumbs.length).toBe(2);
-    const first = thumbs[0] as HTMLVideoElement;
-    // Same URL convention as components/Player.tsx (id percent-encoded).
-    expect(first.getAttribute('src')).toBe('mstream://media/v1');
-    expect((thumbs[1] as HTMLVideoElement).getAttribute('src')).toBe('mstream://media/v%202');
-    expect(first.muted).toBe(true);
-    expect(first.getAttribute('preload')).toBe('metadata');
-    // jsdom never fires loadedmetadata on its own — no playback was requested.
+    const imgs = container.querySelectorAll('img.library__thumb-img');
+    expect(imgs.length).toBe(2);
+    // Served immediately through the thumb: mstream resolver (no on-demand rpc).
+    expect(imgs[0].getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/v1.jpg'));
+    // A persisted poster short-circuits the hook -> no library.thumbnail call.
+    expect(rpcMock).not.toHaveBeenCalledWith('library.thumbnail', expect.anything());
+    // No glyph fallback while the poster resolves.
+    expect(container.querySelector('.library__thumb-fallback')).toBeNull();
+  });
+
+  it('treats an absent thumbnailPath (undefined) as no poster -> generates on demand', async () => {
+    // thumbnailPath omitted entirely -> the `video.thumbnailPath ?? ''` fallback.
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo({ thumbnailPath: undefined })] });
+    rpcMock.mockResolvedValueOnce({ thumbnailPath: '/data/thumbnails/u.jpg' });
+    await renderLibrary();
+
+    expect(rpcMock).toHaveBeenCalledWith('library.thumbnail', { id: 'v1' });
+    const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/u.jpg'));
+  });
+
+  it('generates the poster on demand when a card has no thumbnailPath', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo({ thumbnailPath: '' })] });
+    rpcMock.mockResolvedValueOnce({ thumbnailPath: '/data/thumbnails/gen.jpg' });
+    await renderLibrary();
+
+    expect(rpcMock).toHaveBeenCalledWith('library.thumbnail', { id: 'v1' });
+    const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/gen.jpg'));
+  });
+
+  it('falls back to the glyph when on-demand generation yields no poster', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo({ thumbnailPath: '' })] });
+    rpcMock.mockRejectedValueOnce(new Error('no poster'));
+    await renderLibrary();
+
+    expect(container.querySelector('img.library__thumb-img')).toBeNull();
+    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
+    // Duration badge still renders.
+    expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
+  });
+
+  it('falls back to the glyph when the poster <img> fails to load', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    await renderLibrary();
+
+    const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    await act(async () => {
+      img.dispatchEvent(new Event('error'));
+    });
+
+    expect(container.querySelector('img.library__thumb-img')).toBeNull();
+    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
+    expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
   });
 
   it('shows a duration badge formatted mm:ss from durationSec', async () => {
@@ -725,63 +742,41 @@ describe('Library thumbnails (T6)', () => {
     );
     expect(badges).toEqual(['10:05', '1:02:05']); // 605s and 3725s
   });
+});
 
-  it('pauses immediately and seeks to ~10% of the element duration on loadedmetadata', async () => {
-    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+describe('Library readiness roll-up (WU-14)', () => {
+  it('renders the ReadinessRollup section on the library home', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [] });
     await renderLibrary();
-
-    const video = thumbVideo();
-    durations.set(video, 200); // metadata-reported duration wins when finite
-    await act(async () => {
-      video.dispatchEvent(new Event('loadedmetadata'));
-    });
-
-    expect(pauseMock).toHaveBeenCalledTimes(1);
-    expect(video.currentTime).toBeCloseTo(20); // 10% of 200
+    expect(container.querySelector('.readiness-rollup')).not.toBeNull();
+    expect(readinessSummaryMock).toHaveBeenCalled();
   });
 
-  it('falls back to the library durationSec when the element duration is unknown', async () => {
-    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] }); // durationSec: 605
-    await renderLibrary();
-
-    const video = thumbVideo(); // stubbed duration stays NaN
+  it('forwards a roll-up action to the onReadinessAction prop', async () => {
+    readinessSummaryMock.mockResolvedValue({
+      items: [
+        {
+          capability: 'tr',
+          label: 'Translation',
+          status: 'needsKey',
+          blockedBy: 'no key',
+          action: { kind: 'openProviders' },
+        },
+      ],
+    });
+    rpcMock.mockResolvedValueOnce({ videos: [] });
+    const onReadinessAction = vi.fn();
     await act(async () => {
-      video.dispatchEvent(new Event('loadedmetadata'));
+      root.render(<Library onOpen={() => {}} onReadinessAction={onReadinessAction} />);
     });
+    await flush();
 
-    expect(video.currentTime).toBeCloseTo(60.5); // 10% of 605
-  });
-
-  it('falls back to the placeholder when seeking the poster frame throws', async () => {
-    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
-    await renderLibrary();
-
-    const video = thumbVideo();
-    // Make pause() throw so the onLoadedMetadata try/catch flips `failed`.
-    pauseMock.mockImplementationOnce(() => {
-      throw new Error('pause not allowed');
-    });
+    const btn = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
     await act(async () => {
-      video.dispatchEvent(new Event('loadedmetadata'));
+      btn.click();
     });
-
-    expect(container.querySelector('video.library__thumb-video')).toBeNull();
-    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
-    // duration badge still renders from durationSec
-    expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
-  });
-
-  it('replaces the video with a placeholder on media error, keeping the badge', async () => {
-    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
-    await renderLibrary();
-
-    const video = thumbVideo();
-    await act(async () => {
-      video.dispatchEvent(new Event('error'));
-    });
-
-    expect(container.querySelector('video.library__thumb-video')).toBeNull();
-    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
-    expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
+    expect(onReadinessAction).toHaveBeenCalledWith({ kind: 'openProviders' });
   });
 });

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -1,8 +1,8 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { rpc, type Video } from '../components/api';
-// T6 thumbnails: reuse the Player's frozen mstream:// URL convention (read-only
-// import of U1's exported pure helper — no new RPC methods involved).
-import { mediaUrl } from '../components/Player';
+import { useVideoThumbnail, type VideoThumbnailRpc } from '../components/useVideoThumbnail';
+import { ReadinessRollup } from '../components/ReadinessRollup';
+import type { ReadinessAction } from '../lib/rpc';
 import '../components/library-cards.css';
 
 // ---- Toasts (P2 U2) ---------------------------------------------------------
@@ -35,6 +35,13 @@ export interface LibraryProps {
    * fallback strip is not rendered.
    */
   toast?: (toast: ToastMessage) => void;
+  /**
+   * WU-14: fired when the library's readiness roll-up action button is clicked
+   * (e.g. download a model / add a provider key). The parent owns the routing
+   * to the providers/assets flows; absent -> the roll-up still renders, the
+   * action is simply a no-op.
+   */
+  onReadinessAction?: (action: ReadinessAction) => void;
 }
 
 interface ListResult {
@@ -104,61 +111,44 @@ function formatDuration(sec: number): string {
   return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
 }
 
-// ---- Poster-frame thumbnails (T6) -------------------------------------------
-
-/** Fraction of the duration the poster frame is seeked to (~10%). */
-export const POSTER_SEEK_FRACTION = 0.1;
-
-/** Source-absolute poster time: ~10% into the video (0 for unknown durations). */
-export function posterSeekTime(durationSec: number): number {
-  if (!Number.isFinite(durationSec) || durationSec <= 0) return 0;
-  return durationSec * POSTER_SEEK_FRACTION;
-}
+// ---- Poster-frame thumbnails (WU-4 wiring, WU-14) ---------------------------
 
 /**
- * Poster-frame thumbnail: a muted, metadata-only <video> on the SAME
- * `mstream://media/<id>` convention the Player uses, paused immediately and
- * seeked to ~10% of the duration so the held frame acts as the poster — no
- * new RPC methods, no frame-extraction pipeline. Falls back to a placeholder
- * div when the media errors (missing file, unsupported codec). The duration
- * badge always renders (mm:ss from the library's durationSec).
+ * `library.thumbnail({id})` adapter over the shared `rpc` bridge — the thin RPC
+ * slice `useVideoThumbnail` needs. Stable across renders so the hook's effect
+ * does not re-fire every card render.
+ */
+const thumbnailRpc: VideoThumbnailRpc = {
+  thumbnail: (videoId: string) =>
+    rpc<{ thumbnailPath: string }>('library.thumbnail', { id: videoId }),
+};
+
+/**
+ * Library-card poster: consumes `useVideoThumbnail` (WU-4) to serve the source
+ * video's `thumb:` poster as a real <img>, generating it on demand (idempotent
+ * server-side). Inherits WU-4's graceful degradation: a missing / failed poster
+ * (empty resolved URL, or an <img> load error) falls back to the ▶ glyph and
+ * NEVER blocks the gallery. The duration badge always renders (mm:ss).
  */
 function VideoThumb({ video }: { video: Video }): React.ReactElement {
-  const [failed, setFailed] = useState(false);
-
-  const handleLoadedMetadata = useCallback(
-    (event: React.SyntheticEvent<HTMLVideoElement>) => {
-      const el = event.currentTarget;
-      try {
-        el.pause(); // poster only — the element must never play
-        const duration =
-          Number.isFinite(el.duration) && el.duration > 0 ? el.duration : video.durationSec;
-        el.currentTime = posterSeekTime(duration);
-      } catch {
-        setFailed(true);
-      }
-    },
-    [video.durationSec],
-  );
+  const posterUrl = useVideoThumbnail(thumbnailRpc, video.id, video.thumbnailPath ?? '');
+  const [imgFailed, setImgFailed] = useState(false);
+  const showImg = posterUrl !== '' && !imgFailed;
 
   return (
     <div className="library__thumb">
-      {failed ? (
+      {showImg ? (
+        <img
+          className="library__thumb-img"
+          src={posterUrl}
+          alt=""
+          aria-hidden="true"
+          onError={() => setImgFailed(true)}
+        />
+      ) : (
         <div className="library__thumb-fallback" aria-hidden="true">
           ▶
         </div>
-      ) : (
-        <video
-          className="library__thumb-video"
-          src={mediaUrl(video.id)}
-          preload="metadata"
-          muted
-          playsInline
-          tabIndex={-1}
-          aria-hidden="true"
-          onLoadedMetadata={handleLoadedMetadata}
-          onError={() => setFailed(true)}
-        />
       )}
       <span className="library__thumb-duration">{formatDuration(video.durationSec)}</span>
     </div>
@@ -172,7 +162,11 @@ function VideoThumb({ video }: { video: Video }): React.ReactElement {
  * typed error toasts, de-dupe by id), removes (library.remove), and opens a
  * video into the Workspace on click.
  */
-export function Library({ onOpen, toast: externalToast }: LibraryProps): React.ReactElement {
+export function Library({
+  onOpen,
+  toast: externalToast,
+  onReadinessAction,
+}: LibraryProps): React.ReactElement {
   const [videos, setVideos] = useState<Video[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -349,6 +343,8 @@ export function Library({ onOpen, toast: externalToast }: LibraryProps): React.R
           {adding ? 'Adding…' : 'Add videos'}
         </button>
       </header>
+
+      <ReadinessRollup title="What works right now" onAction={onReadinessAction} />
 
       {dragOver ? (
         <div className="library__drophint" aria-hidden="true">

--- a/docs/plans/ux-qol/DESIGN.md
+++ b/docs/plans/ux-qol/DESIGN.md
@@ -1,0 +1,186 @@
+# Reframe — "UX / QoL" Bundle — DESIGN
+
+Branch: `feat/ux-qol-design` (off `origin/main`). DESIGN + PLAN docs only — **no feature code in this branch.**
+
+## 0. Scope (what this bundle covers)
+
+Five quality-of-life capabilities, all wiring on the shipped Hub substrate:
+
+1. **Save locations** — where projects / exports / data live, and making them configurable + visible.
+2. **Resume / pick-up** — reopen the last project on launch, and continue (re-dispatch) an in-progress job after a restart.
+3. **Save options** — autosave, export formats, and named presets for the save/export choices.
+4. **Availability indicators** — badges showing which models / features / providers are ready vs need a download / key / consent.
+5. **UI preview thumbnails** — generate, store and render poster frames for library videos and project clips.
+
+**Explicitly OUT of scope (separate bundle):** AI best-frame thumbnail *selection*. This bundle covers only the UI rendering + storage of thumbnails; frame *choice* stays the dumb "poster at offset" path that `shorts.thumbnail` already ships.
+
+---
+
+## 1. Real-code seam map (cited)
+
+Every capability below reuses already-shipped seams. Citations are `path:line` in this repo at `origin/main`.
+
+### Composition root / RPC site
+- The ONE registration site is `register_all` — `sidecar/media_studio/handlers.py:1982`, which calls `protocol.register(name, handler)` for ~30 methods and delegates to feature modules' own `register()` (`handlers.py:2072-2237`). Every new `*.*` handler MUST land here.
+- `protocol.register` raises on a duplicate name (`sidecar/media_studio/protocol.py:79-91`) — a double-wire fails loudly at startup.
+- Built-ins already present: `job.list` (JobInfo list) + `job.retry` (re-dispatch the stored request as a NEW job) + `job.cancel` / `job.status` (`protocol.py:13-14`).
+
+### Save locations (LARGELY SHIPPED — main-process IPC, NOT sidecar RPC)
+- `Services` derives **all** on-disk locations from ONE data dir: `data_dir`, `projects_dir = base/"projects"`, `exports_dir = base/"exports"`, `settings.json`, `library.json` (`handlers.py:143-148`). Per-feature out-dirs all hang off `exports_dir` (e.g. `shorts-<vid>`, `stabilized`, `audiomix`, `trimmed`, `dubs` — `handlers.py:1351,2119,2164-2182`).
+- The data root is **relocatable** via `MEDIA_STUDIO_CONFIG_DIR` (env) → `data-dir.txt` marker → `<exeDir>/data` → `%APPDATA%/media-studio`, resolved by the pure `chooseDataRoot` / `resolveDataRootFrom` (`app/main/dataRoot.ts:58-110`).
+- The user-facing "Change data folder" flow already exists as 3 main-process IPC channels: `dataFolder.get` / `dataFolder.pick` (native dir picker) / `dataFolder.set` (writes the marker, restart-applies) — `app/main/dataFolderIpc.ts:97-108`. The marker write is fail-soft (`dataFolderIpc.ts:78-90`).
+- `settings_store.py:34-40` documents the deliberate decision: there is **no per-key `outputDir`** — ONE root relocates everything (`default_config_dir()` at `settings_store.py:88-103`).
+- Scoped-media security: `resolveScopedMediaPath` traversal-guards the `short:` / `dub:` resolvers so the privileged `mstream://` scheme cannot read arbitrary disk (`app/main/exportPath.ts:20-24`). Any new served path (project thumbnails) MUST reuse this guard.
+
+### Resume / pick-up
+- Projects already persist: one manifest per video at `projects_dir/<videoId>.json` (`handlers.py:204-218`); `project.open` lazily creates one (`handlers.py:265-274`); `Project.open` / `.save` are atomic (`library.py:223-253`).
+- The library index persists videos (`library.py:120-189`), each with `hasTranscript` (`library.py:116`).
+- **Jobs do NOT persist.** `JobRegistry` holds jobs in an in-memory `self._jobs` dict; `record_request` / `get_request` store the originating `{method, params}` **in memory only** (`jobs.py:270-300`) — there is zero file I/O in `jobs.py`. After a process restart `job.list` is empty and `job.retry` has nothing to re-dispatch. **This is the central capability gap for "continue an in-progress job after restart."**
+- Renderer: `App` always starts at `route = {name:'library'}` (`app/renderer/src/App.tsx:77`); it hydrates the quality toggle from `settings.get` (`App.tsx:84-99`) but never restores the last-opened video. `handleReexport` already shows the pattern for "resolve a video id via `library.list`, then navigate" (`App.tsx:136-148`).
+
+### Save options (autosave / formats / presets)
+- Settings are a single merged JSON doc; `settings.set` blindly merges any keys (`settings_store.py:167-182`), and `DEFAULT_SETTINGS` lists keys for first-launch discoverability (`settings_store.py:41-80`). New QoL keys are pure additive merges — no schema migration needed.
+- Export formats already exist per feature: subtitles `subtitles.export({format})` (`handlers.py:763-774`), NLE `nle.export({format:edl|csv, fps})` (`handlers.py:1472-1494`), package `package.export` (`handlers.py:1499-1533`). There is **no shared "export preset"** concept and **no autosave** today — `project.save` is caller-driven (`handlers.py:276-287`).
+- A preset precedent exists for *routing*: `providers.applyPreset` resolves a named preset and persists it (`handlers.py:483-501`); the shortmaker has UI-side presets (`app/renderer/src/features/shortMakerPresets.ts`).
+
+### Availability indicators
+- **Models:** `assets.list` returns `AssetInfo {name, kind, sizeMB, installed, dest}` (`sidecar/media_studio/assets/manager.py:392-402`); `assets.ensure` downloads (`assets/rpc.py:40-63`); registered at `handlers.py:2233`. `installed_path` is the real probe (`manager.py:360-375`). Renderer `Assets.tsx` already renders install state + per-asset / install-all (`app/renderer/src/features/Assets.tsx:13-39`); `ModelCard.tsx` already renders a will-it-run badge + Installed/Download button (`ModelCard.tsx:18-107`).
+- **Features (tiers):** `system.advisor` returns per-component `present`/`verdict` + runnable tiers (`handlers.py:1152-1173`, wire shape `_advisor_report_to_wire` at `handlers.py:1902-1928`); `asr.engines` returns `[{id,label,installed}]` (`handlers.py:1175-1194`). `_models_present_map` (`handlers.py:1305-1327`) is the per-component installed probe.
+- **Providers:** `providers.list` (redacted keys, `handlers.py:330-338`), `providers.usage` (live + cached + stale-flagged, `handlers.py:436-478`), per-provider `consent.perProvider[].{text,frames}` (`handlers.py:414-434`). `routing.perFunction` says which provider each function prefers (`handlers.py:553-573`).
+- **Gap:** the three readiness sources (assets / advisor / providers) are surfaced by **three separate panels**; there is no single roll-up "is X ready, and if not, what's the one action to make it ready?" view.
+
+### UI preview thumbnails
+- **Clip thumbnails: shipped.** `shorts.thumbnail({path}) -> {thumbnailPath}` ffmpeg-extracts `<clip>.thumb.jpg` idempotently (`sidecar/media_studio/features/shorts.py:16-17,102-103,183`); ShortInfo already carries `thumbnailPath` (`shorts.py:31,267`). Renderer `useShortThumbnail` generates on demand + serves via the `short:` mstream resolver (`app/renderer/src/components/useShortThumbnail.ts:28-73`).
+- **Gap: library-video thumbnails do NOT exist.** A `Video` is `{id, path, title, addedAt, durationSec, hasTranscript}` (`library.py:108-117`) — **no `thumbnailPath`**. The library home renders cards (`library-cards.css`) with no poster; there is no RPC to extract a poster for a *source* video (only for an exported *clip*).
+
+### AI / Hub envelope (only the resume-job + budget-touching parts)
+- `plan_ai_job` (PURE) / `run_ai_job` (cache-first, degrade-aware) ride the ONE job bus (`sidecar/media_studio/models/ai_job.py:204-308`). `Services._run_ai_job` plans + enforces the budget-ack gate + runs (`handlers.py:1617-1691`); `ai.planJob` is the pre-flight returning `{route,costEst,cacheHit,willEgress,budget,preview,cacheKey}` (`handlers.py:1693-1718`).
+- The budget-ack gate fires only when `confirmCloudBudget` is on AND `route.willEgress` (`handlers.py:1672-1691`). **Implication for resume:** any resumed AI job that would egress must re-run `ai.planJob` and re-acknowledge — a stale `cacheKey` from before restart must NOT be silently trusted.
+- Rotation pool: `provider.get_provider` / `build_pool_provider` (`sidecar/media_studio/models/provider.py`), built from RAW keys via `settings.get_raw()` (`handlers.py:584,1599`).
+
+---
+
+## 2. User value + MVP cut
+
+| # | Capability | User value | MVP (this bundle) | Deferred |
+|---|------------|-----------|-------------------|----------|
+| 1 | Save locations | "I can see where my stuff lives and put it on a big drive." | Surface the resolved data root + sub-dirs (read-only display) via a new `paths.describe` RPC; the existing `dataFolder.*` IPC already changes the root. Add an "Open folder" affordance. | Per-feature output redirection (deliberately rejected by `settings_store.py:34-40`). |
+| 2 | Resume / pick-up | "Reopen where I was; finish the job the crash interrupted." | (a) Restore last-opened video on launch via a `lastOpenedVideoId` setting. (b) **Persist job records to disk** so `job.list` survives restart and `job.retry` can re-dispatch an interrupted job. | Live mid-job checkpoint/resume (re-runs the whole job, not mid-stream). |
+| 3 | Save options | "Autosave my edits; remember my export format." | (a) `autosave` setting → project auto-persist debounce in the workspace. (b) `exportDefaults` settings block (subtitle fmt, nle fmt/fps). (c) Named `savePresets` via new `savePresets.*` RPC (mirrors `providers.applyPreset`). | Cloud sync; versioned project history. |
+| 4 | Availability indicators | "One place that tells me what's ready and the one button to fix it." | A new `readiness.summary` RPC that rolls up assets + advisor + providers into `[{capability, status, blockedBy, action}]`; a renderer `ReadinessBadge` reused across panels. | Auto-remediation (one-click fix actions chain). |
+| 5 | Preview thumbnails | "See a poster on every video + clip card." | (a) NEW `library.thumbnail({videoId}) -> {thumbnailPath}` reusing the shorts ffmpeg poster path; persist `thumbnailPath` onto the Video. (b) A renderer `useVideoThumbnail` mirroring `useShortThumbnail`, served via a traversal-guarded resolver. | AI best-frame selection (separate bundle). |
+
+**MVP altitude:** capabilities 1, 4, 5(a) are mostly *surfacing* existing data (cheap, high-value). Capability 2(b) (job persistence) is the only genuinely new substrate and is the highest-risk item — it gets the most design attention below.
+
+---
+
+## 3. Architecture — reuse vs NEW
+
+### 3.1 Save locations (REUSE almost entirely)
+- **REUSE:** `dataFolder.get/pick/set` IPC (`dataFolderIpc.ts`), `chooseDataRoot` (`dataRoot.ts`), `Services.{data_dir,projects_dir,exports_dir}` (`handlers.py:143-148`).
+- **NEW (small):** one sidecar RPC `paths.describe()` → `{dataDir, projectsDir, exportsDir, settingsPath, libraryPath, subDirs:{shorts,dubs,...}}` so the renderer can *show* the layout (today it can only get the root via `dataFolder.get`). Read-only; derives from `Services` fields. Registered in `register_all`.
+- **NEW (renderer):** a `PathsPanel` (or a section in an existing Settings panel) wiring `dataFolder.*` + `paths.describe` + a shell "open folder" (reuse the existing `shellIpc` pattern referenced by `dataFolderIpc.ts`).
+
+### 3.2 Resume / pick-up (NEW substrate: job persistence)
+- **Resume project (REUSE + tiny NEW):** persist `lastOpenedVideoId` via `settings.set` on `openVideo` (`App.tsx:109-111`); on launch read it in the existing `settings.get` effect (`App.tsx:84-99`), resolve via `library.list` (same pattern as `handleReexport`, `App.tsx:136-148`), navigate to workspace. Pure settings + renderer state — **no new RPC.**
+- **Resume job (NEW — the load-bearing piece):**
+  - Add a **`JobStore`** (NEW module `sidecar/media_studio/job_store.py`) that the `JobRegistry` writes through: on `create` / `record_request` / status transitions it appends/updates a JSON-lines (or per-job JSON) record under `data_dir/jobs/` with `{jobId, feature, label, videoId, method, params, status, pct, startedAt, finishedAt}`. Reuses the atomic `_write_json` pattern (`library.py:74-79`).
+  - On sidecar startup, `JobRegistry` **rehydrates** records: any job left in `running`/`queued` at last shutdown is marked `interrupted` (a NEW terminal-ish status) — it is NOT auto-restarted (that would silently re-spend a cloud budget). Its stored `{method, params}` remains available to `job.retry`.
+  - `job.list` then includes interrupted jobs after restart; the user clicks "Resume" → `job.retry` (existing built-in, `protocol.py:13`) re-dispatches the stored request as a NEW job.
+  - **Injectability:** `JobStore` is injected into `JobRegistry.__init__` (default = real disk store under `data_dir/jobs`; tests inject an in-memory fake), preserving the existing test pattern (every `Services` collaborator is injected — `handlers.py:121-180`).
+- **Why not mid-job checkpointing:** jobs are opaque `(JobContext)->result` bodies (`jobs.py:304-326`); there is no general resumable checkpoint. Re-dispatch from the stored request is the honest, contract-safe resume. **Named gap** (§5).
+
+### 3.3 Save options (REUSE patterns; NEW keys + one RPC)
+- **Autosave (REUSE):** additive `autosave:{enabled,debounceMs}` settings block; the *workspace renderer* debounces `project.save` (`handlers.py:276-287`) on edit — **no sidecar change** beyond the default key in `DEFAULT_SETTINGS`.
+- **Export defaults (REUSE):** additive `exportDefaults:{subtitleFormat, nleFormat, nleFps}` in `DEFAULT_SETTINGS`; the export handlers already accept these per-call (`handlers.py:763,1472`) — renderer passes the stored defaults. No handler change required, but the export handlers MAY fall back to `settings.exportDefaults` when a param is omitted (small, optional).
+- **Save presets (NEW RPC, mirrors routing presets):** `savePresets.list/apply/upsert/remove` storing a named `{autosave, exportDefaults}` bundle under a `savePresets` settings key. Mirrors `providers.applyPreset` exactly (`handlers.py:483-501`) — same persist-to-settings shape, registered in `register_all`.
+
+### 3.4 Availability indicators (NEW roll-up RPC over existing data)
+- **NEW RPC `readiness.summary()`** → `{items:[{capability, status:"ready"|"needsDownload"|"needsKey"|"needsConsent"|"unavailable", blockedBy, sizeMB?, action:{kind:"assets.ensure"|"openProviders"|"setConsent", payload}}]}`.
+  - Source 1 (models/features): `_models_present_map` + `system.advisor` component verdicts (`handlers.py:1152-1327`).
+  - Source 2 (assets sizes/installed): `assets.list` via the same `AssetManager` (`manager.py:402`).
+  - Source 3 (providers/keys/consent): `providers.list` + `consent` + `routing.perFunction` (`handlers.py:330-434,553-573`).
+  - Honors Offline mode (a missing weight that needs a download counts unavailable — same rule as `system.advisor`).
+- **REUSE renderer:** `ModelCard` badge styling + `Assets.tsx` ensure flow; new shared `ReadinessBadge` component consumed by the library home + model panel.
+
+### 3.5 Preview thumbnails (REUSE the shorts poster engine)
+- **NEW RPC `library.thumbnail({videoId}) -> {thumbnailPath}`** — extracts a poster from the *source* video (not a clip) by **reusing `shorts.build_thumbnail_argv` / `thumbnail_path`** (`shorts.py:102,183`) against the resolved source path (`handlers.py:197-202`); persists `thumbnailPath` onto the Library Video and returns it. Idempotent (poster file is cached next to nothing user-owned → store under `data_dir/thumbnails/<videoId>.jpg`, inside the data root so the resolver can serve it).
+- **NEW (Video schema):** add optional `thumbnailPath` to `library._normalize` (`library.py:108-117`) — additive, backfilled to `""`; no migration.
+- **NEW (resolver):** a `thumb:` id branch for `mstream://` reusing `resolveScopedMediaPath` (`exportPath.ts:20`) rooted at `data_dir/thumbnails`. (Clips keep the existing `short:` resolver.)
+- **REUSE renderer:** new `useVideoThumbnail` hook = a near-clone of `useShortThumbnail` (`useShortThumbnail.ts:41-73`) pointed at `library.thumbnail` + the `thumb:` URL.
+
+---
+
+## 4. RPC + renderer + storage surface
+
+### 4.1 New sidecar RPC handlers (all wired in `register_all`, `handlers.py:1982`)
+| Method | Shape | Job? | Reuses |
+|--------|-------|------|--------|
+| `paths.describe` | `() -> {dataDir, projectsDir, exportsDir, settingsPath, libraryPath, subDirs}` | direct | `Services` fields |
+| `library.thumbnail` | `({videoId}) -> {thumbnailPath}` | direct (fast ffmpeg) | `shorts.build_thumbnail_argv`, `_resolve_video_path`, `library.set_*` |
+| `readiness.summary` | `() -> {items:[ReadinessItem]}` | direct | `_models_present_map`, `assets.list`, `providers.list`, `consent` |
+| `savePresets.list` | `() -> {presets, active}` | direct | settings doc |
+| `savePresets.apply` | `({name}) -> {active, savePreset}` | direct | mirrors `providers.applyPreset` |
+| `savePresets.upsert` | `({name, autosave?, exportDefaults?}) -> {presets}` | direct | settings merge |
+| `savePresets.remove` | `({name}) -> {presets}` | direct | settings merge |
+| `jobs.history` *(optional)* | `({limit?}) -> {jobs}` incl. interrupted | direct | `JobRegistry.list_info` after rehydrate |
+
+`job.list` / `job.retry` / `job.cancel` are **existing built-ins** (`protocol.py:13-14`) — resume reuses them; only the persistence-backed rehydrate is new. No new job-control RPC needed beyond the optional `jobs.history`.
+
+### 4.2 Main-process IPC (REUSE; no new channels required)
+- `dataFolder.get/pick/set` (`dataFolderIpc.ts`) — already cover changing the data root.
+- One **NEW** optional channel `paths.openFolder(path)` (shell-open, traversal-checked) if "Open folder" is in MVP; otherwise reuse the existing `shellIpc` channel referenced by `dataFolderIpc.ts:16`.
+
+### 4.3 Renderer surface
+- `useVideoThumbnail` hook (clone of `useShortThumbnail.ts`).
+- `ReadinessBadge` shared component (reuses `ModelCard` badge classes).
+- `PathsPanel` section (wires `paths.describe` + `dataFolder.*`).
+- `SavePresetsControls` (wires `savePresets.*`, mirrors `PresetPicker.tsx`).
+- App-level: `lastOpenedVideoId` persist on `openVideo` + restore in the launch `settings.get` effect (`App.tsx:84-148`).
+- JobQueue: render the `interrupted` status + a "Resume" button → `job.retry` (extend `JobQueue.tsx`).
+
+### 4.4 Storage + settings keys (all additive — `settings.set` blind-merges, `settings_store.py:167-182`)
+```
+DEFAULT_SETTINGS additions:
+  lastOpenedVideoId: ""
+  autosave: { enabled: true, debounceMs: 1500 }
+  exportDefaults: { subtitleFormat: "srt", nleFormat: "edl", nleFps: 30 }
+  savePresets: { presets: {}, active: "" }
+On-disk NEW dirs (under the ONE data root):
+  data_dir/jobs/        # persisted job records (rehydrate source)
+  data_dir/thumbnails/  # <videoId>.jpg posters
+Library Video schema:  + thumbnailPath: ""  (library._normalize)
+```
+No secrets in any new payload. `paths.describe` returns only directory paths (no keys); `readiness.summary` returns booleans + redacted provider names (never keys — reuse `providers.list` which is already redacted, `handlers.py:330-338`).
+
+---
+
+## 5. Reversibility / safety + (AI parts) consent & budget
+
+- **Save locations:** `dataFolder.set` only writes the marker; it **does not move files** (`dataFolderIpc.ts:5-13`) — a restart applies the new root; the old tree is untouched (fully reversible). `paths.describe` is read-only.
+- **Resume project:** `lastOpenedVideoId` is a single settings key; restoring is best-effort and falls back to Library when the video is gone (same fallback as `handleReexport`, `App.tsx:144-148`). Reversible (clear the key).
+- **Resume job (safety-critical):** rehydrated jobs are marked `interrupted` and **never auto-restarted** — the user must explicitly click Resume. This prevents a crash from silently re-spending a cloud budget. When a resumed job is an AI job that would egress, `job.retry` re-dispatches the original `{method, params}`, which flows back through `_run_ai_job` → `_enforce_cloud_budget_ack` (`handlers.py:1672-1691`): a stale pre-restart `confirmBudget` token will NOT match the freshly-planned `cacheKey`, so the user is correctly re-prompted to `ai.planJob` + re-acknowledge. **The budget/consent gate is preserved across resume by construction — no new bypass.**
+- **Autosave:** debounced `project.save` writes are atomic (`library.py:74-79`); disabling autosave is a settings toggle. No destructive overwrite (manifest is the single source).
+- **Thumbnails:** posters are derived artifacts under `data_dir/thumbnails`; deleting them is harmless (regenerated on demand, idempotent — same property as `shorts.thumbnail`). Served only through a traversal-guarded `thumb:` resolver rooted at `data_dir/thumbnails` (reuses `resolveScopedMediaPath`, `exportPath.ts:20`) — no arbitrary-disk read.
+- **Availability indicators:** read-only roll-up; the only *actions* it surfaces (`assets.ensure`, open-providers, set-consent) are existing user-initiated flows with their own gates. `readiness.summary` itself triggers no download and opens no socket (it must build the asset manager + read settings only, like `system.advisor` — never call a provider).
+- **Consent invariant:** `readiness.summary` reports provider/consent state by reading `consent.perProvider` (`handlers.py:414-434`) — it never grants consent and never lists a full key (reuses redacted `providers.list`).
+
+---
+
+## 6. Explicit capability gaps (no fabrication)
+
+1. **No job persistence today.** `jobs.py` is 100% in-memory (`jobs.py:270-300`, no file I/O). The `JobStore` + rehydrate is genuinely new substrate and the riskiest piece. Until built, "continue a job after restart" is impossible.
+2. **No mid-job resume.** Job bodies are opaque `(JobContext)->result` (`jobs.py:304-326`); resume = full re-dispatch, not mid-stream continuation. A long transcribe interrupted at 90% restarts from 0%. Documented limitation, not solved here.
+3. **No source-video thumbnail RPC.** `shorts.thumbnail` only posters *exported clips* (`shorts.py`); library videos have no `thumbnailPath` field (`library.py:108-117`). New `library.thumbnail` + schema field required.
+4. **No unified readiness view.** Readiness data is split across `assets.list`, `system.advisor`, `providers.list` (`handlers.py`); no single roll-up exists. `readiness.summary` is the new aggregator.
+5. **No autosave / no shared export presets.** `project.save` is caller-driven (`handlers.py:276-287`); no `autosave` or `savePresets` concept exists (only *routing* presets, `handlers.py:483`). New keys + `savePresets.*` RPC.
+6. **Deliberate non-goal preserved:** per-feature output redirection is rejected by design (`settings_store.py:34-40`) — this bundle does NOT add `outputDir` keys; it surfaces the ONE root instead. Changing that decision is out of scope.
+7. **`thumb:` resolver does not exist yet.** Only `short:` / `dub:` branches are implemented (`exportPath.ts`, main.ts resolver). A new branch (small, reuses `resolveScopedMediaPath`) is required to serve library posters.
+
+---
+
+## 7. Build gates (for the eventual implementation branch — NOT this docs branch)
+- Sidecar: `pytest --cov-branch --cov-fail-under=100` (heavy-ML bodies stay `# pragma: no cover` as elsewhere; the ffmpeg/job-store seams are injected + fully covered).
+- Renderer: `vitest` with `thresholds: 100`.
+- Lint/type: `ruff`, `oxlint`, `biome`, `basedpyright`, `tsc`.
+- Never `--no-verify`; never `git add -A` — scoped adds only.

--- a/docs/plans/ux-qol/DESIGN.md
+++ b/docs/plans/ux-qol/DESIGN.md
@@ -44,7 +44,7 @@ Every capability below reuses already-shipped seams. Citations are `path:line` i
 - A preset precedent exists for *routing*: `providers.applyPreset` resolves a named preset and persists it (`handlers.py:483-501`); the shortmaker has UI-side presets (`app/renderer/src/features/shortMakerPresets.ts`).
 
 ### Availability indicators
-- **Models:** `assets.list` returns `AssetInfo {name, kind, sizeMB, installed, dest}` (`sidecar/media_studio/assets/manager.py:392-402`); `assets.ensure` downloads (`assets/rpc.py:40-63`); registered at `handlers.py:2233`. `installed_path` is the real probe (`manager.py:360-375`). Renderer `Assets.tsx` already renders install state + per-asset / install-all (`app/renderer/src/features/Assets.tsx:13-39`); `ModelCard.tsx` already renders a will-it-run badge + Installed/Download button (`ModelCard.tsx:18-107`).
+- **Models:** `assets.list` returns `AssetInfo {name, kind, sizeMB, installed, dest}` (`sidecar/media_studio/assets/manager.py:392-402`); `assets.ensure` downloads (`assets/rpc.py:40-63`); registered at `handlers.py:2233`. `installed_path` is the real probe (`manager.py:360-375`). Renderer `Assets.tsx` already renders install state + per-asset / install-all (`app/renderer/src/features/Assets.tsx:13-39`); `ModelCard.tsx` already renders a will-it-run badge (via the `VerdictBadge` component) + Installed/Download button (`app/renderer/src/components/ModelCard.tsx:18-107`).
 - **Features (tiers):** `system.advisor` returns per-component `present`/`verdict` + runnable tiers (`handlers.py:1152-1173`, wire shape `_advisor_report_to_wire` at `handlers.py:1902-1928`); `asr.engines` returns `[{id,label,installed}]` (`handlers.py:1175-1194`). `_models_present_map` (`handlers.py:1305-1327`) is the per-component installed probe.
 - **Providers:** `providers.list` (redacted keys, `handlers.py:330-338`), `providers.usage` (live + cached + stale-flagged, `handlers.py:436-478`), per-provider `consent.perProvider[].{text,frames}` (`handlers.py:414-434`). `routing.perFunction` says which provider each function prefers (`handlers.py:553-573`).
 - **Gap:** the three readiness sources (assets / advisor / providers) are surfaced by **three separate panels**; there is no single roll-up "is X ready, and if not, what's the one action to make it ready?" view.
@@ -87,6 +87,10 @@ Every capability below reuses already-shipped seams. Citations are `path:line` i
   - Add a **`JobStore`** (NEW module `sidecar/media_studio/job_store.py`) that the `JobRegistry` writes through: on `create` / `record_request` / status transitions it appends/updates a JSON-lines (or per-job JSON) record under `data_dir/jobs/` with `{jobId, feature, label, videoId, method, params, status, pct, startedAt, finishedAt}`. Reuses the atomic `_write_json` pattern (`library.py:74-79`).
   - On sidecar startup, `JobRegistry` **rehydrates** records: any job left in `running`/`queued` at last shutdown is marked `interrupted` (a NEW terminal-ish status) — it is NOT auto-restarted (that would silently re-spend a cloud budget). Its stored `{method, params}` remains available to `job.retry`.
   - `job.list` then includes interrupted jobs after restart; the user clicks "Resume" → `job.retry` (existing built-in, `protocol.py:13`) re-dispatches the stored request as a NEW job.
+  - **JobQueue rendering path for `interrupted` (a11y-critical — without this the Resume button never appears).** `JobQueue.tsx` gates ALL per-job actions on the outer predicate `canCancel(job) || canRetry(job)` (`app/renderer/src/components/JobQueue.tsx:163`), and `canRetry` matches **only** `status === 'error'` (`JobQueue.tsx:25-27`). An `interrupted` job matches neither, so today it would render no action button at all. The two exact change points are:
+    1. **NEW predicate** `canResume(job): boolean` in `JobQueue.tsx` returning `job.status === 'interrupted'` (a sibling of `canCancel`/`canRetry`, kept separate so the Resume affordance is distinct from Retry — see copy below). It MUST stay a separate predicate rather than folding `interrupted` into `canRetry`, because the two buttons carry different labels/tooltips.
+    2. **Extend the outer action-gate** at `JobQueue.tsx:163` to `canCancel(job) || canRetry(job) || canResume(job)`, and add a third conditional button inside the `jobqueue__actions` block (alongside Cancel/Retry) that renders when `canResume(job)` and calls the existing `handleRetry(job.jobId)` (`JobQueue.tsx:108-118`) — Resume reuses the `job.retry` re-dispatch; only the label/tooltip differ.
+    The `interrupted` status string already renders correctly in the status pill (`JobQueue.tsx:150-152` renders `job.status` as **text**, not color-only) and the `JobInfo` status union (`lib/rpc`) MUST be widened to include `'interrupted'`.
   - **Injectability:** `JobStore` is injected into `JobRegistry.__init__` (default = real disk store under `data_dir/jobs`; tests inject an in-memory fake), preserving the existing test pattern (every `Services` collaborator is injected — `handlers.py:121-180`).
 - **Why not mid-job checkpointing:** jobs are opaque `(JobContext)->result` bodies (`jobs.py:304-326`); there is no general resumable checkpoint. Re-dispatch from the stored request is the honest, contract-safe resume. **Named gap** (§5).
 
@@ -101,13 +105,20 @@ Every capability below reuses already-shipped seams. Citations are `path:line` i
   - Source 2 (assets sizes/installed): `assets.list` via the same `AssetManager` (`manager.py:402`).
   - Source 3 (providers/keys/consent): `providers.list` + `consent` + `routing.perFunction` (`handlers.py:330-434,553-573`).
   - Honors Offline mode (a missing weight that needs a download counts unavailable — same rule as `system.advisor`).
-- **REUSE renderer:** `ModelCard` badge styling + `Assets.tsx` ensure flow; new shared `ReadinessBadge` component consumed by the library home + model panel.
+- **REUSE renderer:** `Assets.tsx` ensure flow + the `verdict-badge` status-pill conventions; new shared `ReadinessBadge` component consumed by the library home + model panel.
+- **`ReadinessBadge` accessibility contract (a11y-critical — follow the `VerdictBadge` *component*, not loose CSS classes):** the real reusable status-pill primitive is `VerdictBadge.tsx` (`app/renderer/src/components/VerdictBadge.tsx:19-31`), which renders a **text label** (`verdictLabel`, `advisorMeta.ts:38-40`), `role="status"`, a status-modifier `data-*` attribute, and a descriptive `title` hint — so the status is conveyed by *text + role*, never hue alone. `ReadinessBadge` MUST mirror this exactly and MUST NOT reduce to color-only class reuse (that would fail WCAG 1.4.1 use-of-color and drop status semantics). Concretely:
+  - Render a **visible text label per status** (e.g. `ready → "Ready"`, `needsDownload → "Needs download"`, `needsKey → "Needs key"`, `needsConsent → "Needs consent"`, `unavailable → "Unavailable"`) — color is decorative reinforcement, never the sole carrier.
+  - Set `role="status"` so assistive tech announces it as a live status (same as `VerdictBadge.tsx:25`).
+  - Carry a `data-readiness="<status>"` attribute and a `title` that names the blocker + the fix action (mirrors `VerdictBadge`'s `data-verdict` + `title`).
+  - Reuse only the *pill geometry* CSS conventions (the `verdict-badge` base look), not its verdict-specific color map; add a parallel readiness-status label/class/hint map in a pure `readinessMeta.ts` helper (mirroring `advisorMeta.ts:17-50`) so the label/class/hint logic is test-pinned once and the component stays a thin render shell.
+- **Roll-up action affordance (a11y):** each item's `action` (`assets.ensure` / `openProviders` / `setConsent`) MUST render as a real `<button>` with an accessible name tying the action to its capability (e.g. `aria-label="Download {capability} model"` / `"Add a provider key"` / `"Grant consent for {provider}"`), never an icon-only control. The badge conveys *state*; the button conveys *the one fix action*.
+- **Empty / loading states:** while `readiness.summary` is in flight, reuse JobQueue's existing skeleton/empty conventions (`jobqueue__empty`, the progress bar pattern, `JobQueue.tsx:142-162`) for visual consistency rather than inventing new ones.
 
 ### 3.5 Preview thumbnails (REUSE the shorts poster engine)
 - **NEW RPC `library.thumbnail({videoId}) -> {thumbnailPath}`** — extracts a poster from the *source* video (not a clip) by **reusing `shorts.build_thumbnail_argv` / `thumbnail_path`** (`shorts.py:102,183`) against the resolved source path (`handlers.py:197-202`); persists `thumbnailPath` onto the Library Video and returns it. Idempotent (poster file is cached next to nothing user-owned → store under `data_dir/thumbnails/<videoId>.jpg`, inside the data root so the resolver can serve it).
 - **NEW (Video schema):** add optional `thumbnailPath` to `library._normalize` (`library.py:108-117`) — additive, backfilled to `""`; no migration.
 - **NEW (resolver):** a `thumb:` id branch for `mstream://` reusing `resolveScopedMediaPath` (`exportPath.ts:20`) rooted at `data_dir/thumbnails`. (Clips keep the existing `short:` resolver.)
-- **REUSE renderer:** new `useVideoThumbnail` hook = a near-clone of `useShortThumbnail` (`useShortThumbnail.ts:41-73`) pointed at `library.thumbnail` + the `thumb:` URL.
+- **REUSE renderer:** new `useVideoThumbnail` hook = a near-clone of `useShortThumbnail` (`useShortThumbnail.ts:41-73`) pointed at `library.thumbnail` + the `thumb:` URL. It MUST inherit `useShortThumbnail`'s proven graceful-degradation: a missing/failed poster falls back to the ▶ glyph and **never blocks the card** (`useShortThumbnail.ts:28-39` catch path), so a thumbnail-generation failure degrades silently instead of breaking the gallery. While generation is pending, show the same placeholder rather than a layout-shifting blank.
 
 ---
 
@@ -127,17 +138,23 @@ Every capability below reuses already-shipped seams. Citations are `path:line` i
 
 `job.list` / `job.retry` / `job.cancel` are **existing built-ins** (`protocol.py:13-14`) — resume reuses them; only the persistence-backed rehydrate is new. No new job-control RPC needed beyond the optional `jobs.history`.
 
+**Renderer type change for resume:** the `JobInfo` status union in `lib/rpc` MUST be widened to add `'interrupted'` (today: `queued`/`running`/`error`/done states). This unblocks the new `canResume` predicate (§3.2) and lets the status pill render the `interrupted` label as text (`JobQueue.tsx:150-152`). It is purely additive — no existing status is removed or renamed.
+
 ### 4.2 Main-process IPC (REUSE; no new channels required)
 - `dataFolder.get/pick/set` (`dataFolderIpc.ts`) — already cover changing the data root.
 - One **NEW** optional channel `paths.openFolder(path)` (shell-open, traversal-checked) if "Open folder" is in MVP; otherwise reuse the existing `shellIpc` channel referenced by `dataFolderIpc.ts:16`.
 
 ### 4.3 Renderer surface
 - `useVideoThumbnail` hook (clone of `useShortThumbnail.ts`).
-- `ReadinessBadge` shared component (reuses `ModelCard` badge classes).
-- `PathsPanel` section (wires `paths.describe` + `dataFolder.*`).
+- `ReadinessBadge` shared component (mirrors the `VerdictBadge` primitive — text label + `role="status"` + `data-readiness` + `title`; reuses only the `verdict-badge` pill geometry, not the verdict color map — see §3.4). Backed by a pure `readinessMeta.ts` label/class/hint map.
+- `PathsPanel` section (wires `paths.describe` + `dataFolder.*`). **a11y:** each path row is read-only but its "Open folder" control MUST be a real `<button>` with a per-row accessible name (e.g. `aria-label="Open {dirLabel} folder"`), keyboard-focusable in tab order; the path string itself is presented as selectable text, not an interactive-looking-but-inert element.
 - `SavePresetsControls` (wires `savePresets.*`, mirrors `PresetPicker.tsx`).
 - App-level: `lastOpenedVideoId` persist on `openVideo` + restore in the launch `settings.get` effect (`App.tsx:84-148`).
-- JobQueue: render the `interrupted` status + a "Resume" button → `job.retry` (extend `JobQueue.tsx`).
+- JobQueue: render the `interrupted` status + a **Resume** button → `job.retry` (extend `JobQueue.tsx` per the §3.2 two change points: new `canResume` predicate + widen the `JobQueue.tsx:163` action-gate).
+  - **Resume vs Retry — distinct affordance + user-facing copy (a11y/clarity-critical).** Both buttons re-dispatch via `job.retry`, but their UX intent differs (crash-recovery vs explicit failure-retry), so they MUST read differently and the Resume copy MUST set correct expectations about cost and progress:
+    - **Button label:** `Resume` (distinct from the `Retry` label on `error` jobs). Accessible name MUST disambiguate by job, e.g. `aria-label="Resume {label}"` (Retry stays `aria-label="Retry {label}"`).
+    - **Tooltip / microcopy (`title`):** convey full re-dispatch + budget re-prompt, e.g. *"Re-runs this interrupted job from the start (it restarts at 0%, not where it stopped). If it uses a cloud provider, you'll be asked to confirm the budget again before it runs."* This makes the §5 safety reality (full re-dispatch through `_run_ai_job` → `_enforce_cloud_budget_ack`, re-prompting on cloud egress) visible at the point of action so Resume is never a surprise spend.
+    - Optionally surface a short inline note on the `interrupted` item (e.g. "Interrupted by restart — Resume to re-run from the start") so the status reads as crash-recovery, not generic failure. This note is **text**, reinforcing the already-text status pill (`JobQueue.tsx:150-152`).
 
 ### 4.4 Storage + settings keys (all additive — `settings.set` blind-merges, `settings_store.py:167-182`)
 ```

--- a/docs/plans/ux-qol/PLAN.md
+++ b/docs/plans/ux-qol/PLAN.md
@@ -28,7 +28,7 @@ Companion: [`DESIGN.md`](./DESIGN.md) (committed `86e480a`). This PLAN decompose
 | **WU-3** | `thumb:` mstream resolver branch | main process | new resolver branch | WU-2 (shape only) |
 | **WU-4** | `useVideoThumbnail` hook | renderer | no | WU-2, WU-3 (URL shape) |
 | **WU-5** | `JobStore` + atomic disk persistence | sidecar | **YES — the load-bearing piece** | WU-0 |
-| **WU-6** | `JobRegistry` write-through + rehydrate + `INTERRUPTED` status | sidecar | extends jobs.py | WU-5 |
+| **WU-6** | `JobRegistry` write-through + rehydrate + `INTERRUPTED` status + composition-root store injection | sidecar (jobs.py + rpc.py + __main__.py) | extends jobs.py; injects store at the real composition root | WU-5 |
 | **WU-7** | `JobInfo` status widening + `canResume` + Resume button | renderer | no | WU-6 (status name) |
 | **WU-8** | `readiness.summary` RPC + `readinessMeta.ts` | sidecar RPC + pure helper | RPC + pure map | WU-0 |
 | **WU-9** | `ReadinessBadge` component | renderer | no | WU-8 |
@@ -176,28 +176,35 @@ Companion: [`DESIGN.md`](./DESIGN.md) (committed `86e480a`). This PLAN decompose
 
 ### WU-6 — `JobRegistry` write-through + rehydrate + `INTERRUPTED` status
 
-**Goal:** Wire `JobStore` into `JobRegistry` (write-through on create / `record_request` / status transitions); on startup, rehydrate records and mark any `running`/`queued` (PENDING) job as a NEW terminal-ish `INTERRUPTED` status — NOT auto-restarted (§5 safety: no silent re-spend).
+**Goal:** Wire `JobStore` into `JobRegistry` (write-through on create / `record_request` / status transitions via a single status choke-point); inject the store at the **real composition root** (`__main__.main()` → `RpcServer`/`JobRegistry`), since the registry is owned by `RpcServer` and `data_dir` lives in `Services` (see "Composition-root reality" below); on startup, rehydrate records and mark any `pending`/`running` job as a NEW terminal-ish `INTERRUPTED` status — NOT auto-restarted (§5 safety: no silent re-spend).
+
+**Composition-root reality (verified — read before designing the wiring):** the `JobRegistry` is NOT owned by `handlers.py`. It is constructed in `RpcServer.__init__` (`rpc.py:55`, verified: `self.jobs = JobRegistry(emit_progress=self._emit_progress, emit_done=self._emit_done)`), and handlers reach it only as `ctx.jobs` at call time (`protocol.py:RpcContext.jobs`, verified `protocol.py:59-68`). `register_all(services=None, *, register=None)` (`handlers.py:1982`, verified signature) builds a **separate** `Services` (which is what holds `data_dir`, `handlers.py:143-148`) and registers handlers — it never constructs or touches the registry. `RpcServer` takes only optional in/out streams (`rpc.py:48-56`, verified) and has **no `data_dir`**. The real entry point wires the two **independently** and discards the `Services`: `__main__.main()` (verified `__main__.py:74-79`) calls `handlers.register_all()` (return value ignored), then `rpc.main(argv)` → `rpc.build_server()` → `RpcServer()` (verified `rpc.py:130,136,142`), which constructs the registry afresh. **There is therefore no existing seam that flows `data_dir` into the registry.** WU-6 must create that seam at the real composition root; "construct the persistent registry in handlers.py" is not buildable as such.
 
 **Files:**
 - `sidecar/media_studio/jobs.py`:
-  - Add `INTERRUPTED = "interrupted"` to `JobStatus` (`jobs.py:46-64`). **CONTRACT-NOTE update required:** the enum's existing docstring (`jobs.py:53-60`, verified) pins the wire status set to exactly five values and the `Job.info()` mapping (`jobs.py:166`). Adding a sixth member MUST update that contract-note AND any P1 `job.status` test that asserts the value-set is exactly five (search `test_jobs*.py` for that assertion — it is a real pin per the docstring). `Job.info()` (`jobs.py:159-171`) needs no mapping change (INTERRUPTED is a real value, unlike PENDING→"queued").
-  - Inject `JobStore` into `JobRegistry.__init__` (`jobs.py:192-212`, verified signature) with default `= None` → a no-op/in-memory store so all existing `JobRegistry(...)` callers keep working (the existing every-collaborator-injected pattern, `handlers.py:121-180`).
-  - Write-through in `create` (`jobs.py:220-245`), `record_request` (`jobs.py:270-292`), and the status-transition points.
-  - `rehydrate()`: load records, recreate `Job` shells with stored `request`, map any non-terminal stored status to `INTERRUPTED`. Its `{method, params}` stays available to the existing built-in `job.retry` (`protocol.py:13`, verified).
-- `sidecar/media_studio/handlers.py` — construct the registry with a `DiskJobStore` rooted at `data_dir/jobs` (default real store) and call `rehydrate()` at sidecar startup.
-- Tests: extend `sidecar/tests/test_jobs.py` (+ a new `test_jobs_persistence.py`).
+  - Add `INTERRUPTED = "interrupted"` to `JobStatus`. **Enum members are `PENDING/RUNNING/DONE/ERROR/CANCELLED`** (verified `jobs.py:60-64`) — note the internal pre-run member is named `PENDING` (not `QUEUED`); add `INTERRUPTED` alongside those names. **CONTRACT-NOTE update required:** the enum docstring (verified `jobs.py:53-60`) pins the **wire** status set to exactly the five values `queued|running|done|error|cancelled` and explains the `PENDING→"queued"` map in `Job.info()` (verified `jobs.py:166`). Adding a sixth member MUST update that contract-note AND any P1 `job.status` test that asserts the value-set is exactly five (search `test_jobs*.py` for that assertion — it is a real pin per the docstring). `Job.info()` (verified `jobs.py:159-175`) needs **no mapping change** — `INTERRUPTED` is a real wire value (unlike `PENDING`, which is the only mapped member); the `info()` line `status = "queued" if self.status is JobStatus.PENDING else self.status.value` (verified `jobs.py:166`) emits `"interrupted"` unchanged.
+  - Inject `JobStore` into `JobRegistry.__init__` (verified signature `jobs.py:192-212`: `(emit_progress, emit_done, *, id_prefix="job", max_workers=2, max_gpu_workers=1)`) as a new keyword-only `store: JobStore | None = None` defaulting to `None` → behaves as no-op/in-memory so **every existing `JobRegistry(...)` caller keeps working** unchanged, incl. the `rpc.py:55` construction (back-compat).
+  - **Introduce a single status-transition choke-point** `_set_status(job, new_status)` and route the four existing direct assignments through it — verified sinks: `jobs.py:390` (`job.status = JobStatus.RUNNING`), `jobs.py:418` (`= JobStatus.DONE`), `jobs.py:426` (`= JobStatus.CANCELLED`), `jobs.py:434` (`= JobStatus.ERROR`). There is **no existing `set_status` method** (verified — status is mutated by direct assignment at those four lines only), so the write-through has no single seam today; WU-6 must add one (or, if a choke-point is rejected, enumerate and hook all four sinks). Write-through to `store.write(...)` happens inside the choke-point so no transition is silently missed.
+  - Write-through also in `create` (verified `jobs.py:220-261`). For `record_request` (verified `jobs.py:270-292`): note its **first-write-wins guard** — it returns early when `job.request is not None` (verified `jobs.py:282`). `rehydrate()` recreates `Job` shells with `request` already populated from the stored record, so a resumed-then-rebuilt job's `request` is non-`None`; the write-through must NOT re-record or be blocked by that guard for rehydrated jobs. Pin the interaction with a falsifiable test (see acceptance).
+  - `rehydrate()`: load `store.load_all()`, recreate `Job` shells with the stored `{method, params}` set as `job.request` (so the existing built-in `job.retry` — verified `protocol.py` dispatch records the new job — can re-dispatch them), and map any non-terminal stored status (`pending`/`running`) to `INTERRUPTED`; terminal statuses (`done`/`error`/`cancelled`) are kept verbatim.
+- `sidecar/media_studio/rpc.py` (**the registry owner — added to scope per the composition-root reality above**) — give `RpcServer.__init__` an optional `store: JobStore | None = None` (default `None` = today's in-memory behavior, back-compat) and pass it into the `JobRegistry(...)` it constructs at `rpc.py:55`; thread it through `build_server(...)` (`rpc.py:130-133`) and `rpc.main(...)` (`rpc.py:136-152`) so the entry point can supply it. Optionally call `server.jobs.rehydrate()` once after construction (or expose it for the entry point to call).
+- `sidecar/media_studio/__main__.py` (**the composition root — added to scope**) — this is where `data_dir` and the registry must meet. `main()` (verified `__main__.py:74-79`) currently calls `handlers.register_all()` then `rpc.main(argv)` with no shared state. Change it to (a) capture the `Services` that `register_all()` returns (it already returns `svc`, verified `handlers.py:1993,2267`) so its `svc.data_dir` is in hand, (b) build a `DiskJobStore(svc.data_dir / "jobs")`, and (c) pass that store into `rpc.main(argv, store=store)` (or `build_server(store=store)` then `serve()`), then call `rehydrate()` once at startup. This is the **only** place `data_dir` (Services-owned) and the registry (RpcServer-owned) are both visible, so it is the correct injection seam.
+- `sidecar/media_studio/handlers.py` — **no registry construction here.** If any handler needs to surface persistence (it does not for MVP — persistence is registry-internal), it uses `ctx.jobs` as today. `register_all` is unchanged except: it already returns `svc` (verified), which `__main__.main()` now consumes.
+- Tests: extend `sidecar/tests/test_jobs.py` (+ a new `test_jobs_persistence.py`); add a focused `RpcServer(store=...)` wiring test in `sidecar/tests/test_rpc.py` (the registry-owner seam) and a `__main__.main()` composition test (fake/patched `rpc.main` + `register_all`, asserting a `DiskJobStore` rooted at `svc.data_dir/jobs` is constructed and `rehydrate()` is called — no real stdio, no real serve loop).
 
-**Test strategy:** Inject `InMemoryJobStore` (from WU-5). Assert write-through fires on each lifecycle event. Simulate restart: build registry A, create/run jobs, then build registry B sharing the same store → `rehydrate()` marks the non-terminal ones `interrupted`, terminal ones keep their status. Assert a rehydrated job's `request` survives so `job.retry` re-dispatches it (re-dispatch flows back through the dispatch layer — `protocol.py` records the new job, verified `protocol.py:11-14`). NO real ffmpeg/model — job handlers are fakes.
+**Test strategy:** Inject `InMemoryJobStore` (from WU-5) directly into `JobRegistry(store=...)`. Assert write-through fires on `create`, the chosen `record_request` path, and each of the four status transitions (drive each transition and assert one `store.write` per transition). Simulate restart: build registry A with store S, create/run jobs, then build registry B with the same store S → `rehydrate()` marks the non-terminal ones `interrupted`, terminal ones keep their status, and a rehydrated job's `request` survives so `job.retry` re-dispatches it. For the seam: a `RpcServer(store=InMemoryJobStore())` test asserts `server.jobs` carries the store; a `__main__.main()` test (patching `register_all`→fake Services with a tmp `data_dir`, and `rpc.main`→capture kwargs) asserts a `DiskJobStore` at `data_dir/jobs` is passed and `rehydrate()` invoked. NO real ffmpeg/model/stdio — all seams faked.
 
 **Falsifiable acceptance:**
-- After "restart", a job that was `running` reads `interrupted`; a job that was `done` stays `done` (the rule is falsifiable per-status).
+- After "restart" (registry B over the same store), a job that was `running` reads `interrupted`; a job that was `done` stays `done` (falsifiable per-status).
 - An `interrupted` job is **never** auto-spawned on rehydrate (assert the pool's run-count stays 0 after rehydrate with no explicit start — the §5 no-silent-spend invariant).
 - `job.retry` on a rehydrated `interrupted` job creates a NEW job from the stored `{method, params}`.
-- Existing `JobRegistry(...)` callers (no store arg) still pass every prior `test_jobs.py` test (back-compat).
-- The P1 `job.status` value-set test is updated to six and passes; the enum docstring contract-note is updated.
-- 100% line+branch.
+- **The composition seam exists and carries `data_dir`:** `__main__.main()` constructs a `DiskJobStore` rooted at the `Services.data_dir/jobs` returned by `register_all()` and passes it into the registry the `RpcServer` builds; `rehydrate()` is called once at startup (assert via patched `rpc.main`/`build_server`).
+- **`record_request` × rehydrate:** a rehydrated job (whose `request` is already populated) is not re-recorded nor blocked by the first-write-wins guard (assert the stored `{method, params}` is intact and a subsequent in-process `record_request` for a genuinely new job still works) — the guard interaction is pinned, not assumed.
+- Existing `JobRegistry(...)` callers (no `store` arg) and `RpcServer()` (no `store` arg) still pass every prior `test_jobs.py` / `test_rpc.py` test (back-compat — default `store=None` ⇒ in-memory).
+- The P1 `job.status` value-set test is updated to six and passes; the enum docstring contract-note is updated to note `interrupted` is a real wire value (no `info()` mapping change).
+- 100% line+branch (write-through choke-point, all four transitions, rehydrate terminal/non-terminal branches, the seam, the no-store default branch).
 
-**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_jobs.py tests/test_jobs_persistence.py tests/test_handlers.py`.
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_jobs.py tests/test_jobs_persistence.py tests/test_rpc.py tests/test_handlers.py`.
 
 ---
 
@@ -344,8 +351,8 @@ Companion: [`DESIGN.md`](./DESIGN.md) (committed `86e480a`). This PLAN decompose
 
 **Files:**
 - `app/renderer/src/App.tsx`:
-  - On `openVideo` (`App.tsx:109-111`, verified), `settings.set({lastOpenedVideoId: id})`.
-  - In the launch `settings.get` effect (`App.tsx:84-99`, verified — already hydrates the quality toggle), read `lastOpenedVideoId`, resolve via `library.list` (the exact pattern of `handleReexport`, `App.tsx:136-148`, verified), navigate to workspace. Fall back to Library when the video is gone (same fallback as `handleReexport`, `App.tsx:144-148`).
+  - On `openVideo` (`App.tsx:109-111`, verified — note its signature is `openVideo = useCallback((video: Video) => ...)`, it receives a **`Video` object, not an id**), persist `settings.set({lastOpenedVideoId: video.id})` (use `video.id`, not a bare `id`).
+  - Restore: do NOT bolt this onto the existing launch `settings.get` effect's body — that effect's typed call is `rpc<{ useCloud?: boolean }>('settings.get')` (verified `App.tsx:87`) and its hydration is synchronous-ish; reading `lastOpenedVideoId` requires (a) **widening that typed shape** to `rpc<{ useCloud?: boolean; lastOpenedVideoId?: string }>('settings.get')` (or a shared typed settings interface from WU-0), and (b) an **async** resolve via `library.list` — which mirrors `handleReexport` (verified `App.tsx:136-148`, which `await client.library.list()` and `.find((v) => v.id === ...)`), NOT the sync quality-hydrate. Implement the restore as its own async path (a separate effect or an async branch that awaits `library.list`), navigate to workspace on a match, and fall back to Library when the video is gone (same fallback as `handleReexport`, `App.tsx:147`). The quality-toggle hydrate stays untouched.
 - Tests: extend `app/renderer/src/App.test.tsx` (if present; else new focused test).
 
 **Test strategy:** Fake rpc. Launch with `lastOpenedVideoId` present + in `library.list` → navigates to workspace for that id. Present but absent from list → stays on Library (best-effort fallback). Empty key → stays on Library (default `route='library'`, `App.tsx:77`). `openVideo` persists the key.
@@ -353,7 +360,7 @@ Companion: [`DESIGN.md`](./DESIGN.md) (committed `86e480a`). This PLAN decompose
 **Falsifiable acceptance:**
 - A valid `lastOpenedVideoId` → route becomes workspace for that id on launch.
 - A stale id (not in `library.list`) → route stays Library, no crash (the fallback invariant).
-- `openVideo(id)` triggers exactly one `settings.set({lastOpenedVideoId:id})`.
+- `openVideo(video)` triggers exactly one `settings.set({lastOpenedVideoId: video.id})` (the persisted value is `video.id`, derived from the `Video` arg).
 - 100% line+branch (restore-success, restore-fallback, empty-key branches).
 
 **Gate:** `cd app && npx vitest run --coverage app/renderer/src/App.test.tsx`.
@@ -405,7 +412,7 @@ After WU-0 lands (it touches shared files — `settings_store.py`, `rpc.ts` — 
 
 - **Track A — Save locations:** WU-1 → WU-12.
 - **Track B — Thumbnails:** WU-2 → WU-3 → WU-4 (→ WU-14).
-- **Track C — Resume (highest risk):** WU-5 → WU-6 → WU-7. Sequence strictly; do NOT parallelize within (each extends the same `jobs.py`).
+- **Track C — Resume (highest risk):** WU-5 → WU-6 → WU-7. Sequence strictly; do NOT parallelize within (each extends the same `jobs.py`). WU-6 additionally owns the composition-root seam (`rpc.py` + `__main__.py`) — those two files are touched by no other WU, so they carry no cross-track index hazard, but they ARE the load-bearing wiring (see WU-6 "Composition-root reality").
 - **Track D — Readiness:** WU-8 → WU-9 (→ WU-14).
 - **Track E — Save options:** WU-10 → WU-11; WU-13 is independent and can run any time after WU-0.
 
@@ -426,6 +433,9 @@ After WU-0 lands (it touches shared files — `settings_store.py`, `rpc.ts` — 
 | Resumed AI job silently re-spends cloud budget | WU-6/7 | Rehydrated jobs are `interrupted`, NEVER auto-spawned (assert run-count 0). `job.retry` re-flows through `_enforce_cloud_budget_ack` (`handlers.py:1672-1691`); stale `cacheKey` ≠ fresh → re-prompt. Resume copy states the re-prompt up front. |
 | `thumb:` becomes an arbitrary-disk read | WU-3 | Reuse `resolveScopedMediaPath` (`exportPath.ts:20`); traversal tests assert ANY path outside `data_dir/thumbnails` → `null`. |
 | Adding `INTERRUPTED` breaks the P1 `job.status` value-set pin | WU-6 | The enum docstring (`jobs.py:53-60`) pins five values; update the contract-note + the test asserting exactly-five. Falsifiable: the updated test passes at six. |
+| Store injected into the wrong object — registry is `RpcServer`-owned (`rpc.py:55`), not `handlers.py`; `RpcServer` has no `data_dir` | WU-6 | Inject `store` through `RpcServer`/`build_server`/`rpc.main` and build the `DiskJobStore(svc.data_dir/jobs)` at `__main__.main()` (the only place `data_dir` and the registry both exist). Falsifiable: a patched-`rpc.main` test asserts the `DiskJobStore` at `data_dir/jobs` is passed and `rehydrate()` is called at startup. |
+| `record_request` first-write-wins guard (`jobs.py:282`) collides with rehydrate (request pre-populated) | WU-6 | Write-through must not be blocked/double-recorded for rehydrated jobs; pin the guard×rehydrate interaction with a falsifiable test (stored `{method,params}` intact, new-job recording still works). |
+| Status write-through silently misses a transition (4 scattered direct assignments, no `set_status`) | WU-6 | Route all four sinks (`jobs.py:390,418,426,434`) through one `_set_status` choke-point; falsifiable: drive each transition, assert exactly one `store.write` per transition. |
 | `ReadinessBadge` regresses to color-only (WCAG 1.4.1) | WU-9 | Query by visible TEXT label, not class; assert `role="status"` + `data-readiness`. |
 | `readiness.summary` accidentally calls a provider / triggers a download | WU-8 | Assert fakes' provider/ensure call-counts are 0 (read-only invariant). |
 | Parallel agents contaminate `handlers.py`/`rpc.ts` index | all | Serialize `register_all` edits OR isolated worktrees + scoped adds; never `git add -A`. |
@@ -434,7 +444,7 @@ After WU-0 lands (it touches shared files — `settings_store.py`, `rpc.ts` — 
 
 ## 6. Capability gaps carried from DESIGN §6 (no fabrication)
 
-1. **No job persistence today** (`jobs.py:270-300`, verified zero file I/O) — WU-5/6 is the genuinely new substrate.
+1. **No job persistence today** (`jobs.py:270-300`, verified zero file I/O) — WU-5/6 is the genuinely new substrate. NOTE: the `JobRegistry` is owned by `RpcServer` (`rpc.py:55`), not `handlers.py`, and `RpcServer` has no `data_dir`; the only place `data_dir` (Services-owned) meets the registry is `__main__.main()` (`__main__.py:74-79`). WU-6 creates that injection seam there — see WU-6 "Composition-root reality".
 2. **No mid-job resume** — job bodies are opaque `(JobContext)->result` (`jobs.py:304-326`); Resume = full re-dispatch (a 90% transcribe restarts at 0%). Documented limitation; the Resume copy (WU-7) makes it visible. NOT solved here.
 3. **No source-video thumbnail** before WU-2 (`Video` has no `thumbnailPath`, `library.py:108-117`).
 4. **No unified readiness view** before WU-8 (split across `assets.list` / `system.advisor` / `providers.list`).

--- a/docs/plans/ux-qol/PLAN.md
+++ b/docs/plans/ux-qol/PLAN.md
@@ -1,0 +1,457 @@
+# Reframe — "UX / QoL" Bundle — PLAN
+
+Branch: `feat/ux-qol-design` (off `origin/main`). **DESIGN + PLAN docs only — no feature code in this branch.** The eventual implementation lands on a separate branch `feat/ux-qol` off fresh `origin/main`.
+
+Companion: [`DESIGN.md`](./DESIGN.md) (committed `86e480a`). This PLAN decomposes that design into falsifiable Work Units. Every WU cites real code (`path:line`, verified against this checkout at `feat/ux-qol-design`). No fabrication; capability gaps are named per §5.
+
+---
+
+## 0. Ground rules for the build (apply to EVERY WU)
+
+- **TDD, 100% line+branch.** Write the test first, watch it fail, then implement. Sidecar gate: `pytest --cov-branch --cov-fail-under=100`. Renderer gate: `vitest run --coverage` (thresholds 100/100/100/100 already enforced — `app/vitest.config.ts:44-49`).
+- **Fakes at the seams.** ffmpeg (thumbnails), the model/provider pool, OCR, and the job-store disk are all injected; tests use in-memory/fake doubles. NEVER spawn real ffmpeg / open a real socket / hit a real provider in a unit test. Heavy-ML bodies stay `# pragma: no cover` (existing convention).
+- **The ONE RPC site.** Every new `*.*` handler is wired in `register_all` (`sidecar/media_studio/handlers.py:1982`); a duplicate name raises at import (`protocol.py:79-91`, verified) so a double-wire fails loudly.
+- **Additive only.** `settings.set` blind-merges (`settings_store.py:167-182`); the `Video` schema field and the new status are additive. No migration.
+- **Reuse the Hub envelope where AI is touched.** Resumed AI jobs re-flow through `Services._run_ai_job` → `_enforce_cloud_budget_ack` (`handlers.py:1672-1691`); a stale pre-restart `cacheKey` cannot match a freshly-planned one, so budget/consent re-prompt by construction. No new bypass.
+- **Scoped commits.** Never `git add -A`; add only the files a WU touches. Never `--no-verify`. Never `git push --force` without explicit approval.
+- **Per-WU gate commands** are listed under each WU; the bundle-level gate is §"Gate commands (bundle-level)".
+
+---
+
+## 1. Work-Unit overview
+
+| WU | Title | Layer | New substrate? | Depends on |
+|----|-------|-------|----------------|------------|
+| **WU-0** | Settings defaults + types scaffold | sidecar + renderer types | no (additive keys) | — |
+| **WU-1** | `paths.describe` RPC | sidecar RPC | no | WU-0 |
+| **WU-2** | `library.thumbnail` RPC + `Video.thumbnailPath` | sidecar RPC + schema | RPC + schema field | WU-0 |
+| **WU-3** | `thumb:` mstream resolver branch | main process | new resolver branch | WU-2 (shape only) |
+| **WU-4** | `useVideoThumbnail` hook | renderer | no | WU-2, WU-3 (URL shape) |
+| **WU-5** | `JobStore` + atomic disk persistence | sidecar | **YES — the load-bearing piece** | WU-0 |
+| **WU-6** | `JobRegistry` write-through + rehydrate + `INTERRUPTED` status | sidecar | extends jobs.py | WU-5 |
+| **WU-7** | `JobInfo` status widening + `canResume` + Resume button | renderer | no | WU-6 (status name) |
+| **WU-8** | `readiness.summary` RPC + `readinessMeta.ts` | sidecar RPC + pure helper | RPC + pure map | WU-0 |
+| **WU-9** | `ReadinessBadge` component | renderer | no | WU-8 |
+| **WU-10** | `savePresets.*` RPC | sidecar RPC | no (mirrors applyPreset) | WU-0 |
+| **WU-11** | `SavePresetsControls` + export-defaults wiring | renderer | no | WU-10, WU-0 |
+| **WU-12** | `PathsPanel` renderer | renderer | no | WU-1 |
+| **WU-13** | App `lastOpenedVideoId` persist + restore | renderer | no | WU-0 |
+| **WU-14** | Wire badges/thumbnails into library + model panels | renderer integration | no | WU-4, WU-9 |
+
+14 build WUs + 1 scaffold (WU-0). WU-5/WU-6/WU-7 are the resume spine and carry the most risk.
+
+---
+
+## 2. Work Units (detailed)
+
+### WU-0 — Settings defaults + shared type scaffold
+
+**Goal:** Land the additive settings keys and the renderer type changes that downstream WUs depend on, in one small foundation WU so parallel WUs don't race the same files.
+
+**Files:**
+- `sidecar/media_studio/settings_store.py` — extend `DEFAULT_SETTINGS` (currently `settings_store.py:41-80`) with: `lastOpenedVideoId: ""`, `autosave: {enabled: True, debounceMs: 1500}`, `exportDefaults: {subtitleFormat: "srt", nleFormat: "edl", nleFps: 30}`, `savePresets: {presets: {}, active: ""}`.
+- `app/renderer/src/lib/rpc.ts` — add the matching TS shapes (`AutosaveSettings`, `ExportDefaults`, `SavePresetsBlock`) as additive interfaces near the existing settings types. (The `JobInfo` status widening is deferred to WU-7 to keep this WU dependency-free.)
+- Tests: `sidecar/tests/test_settings_store.py` (extend existing), `app/renderer/src/lib/rpc.test.ts` (if present; else a focused type-shape test).
+
+**Test strategy:** Assert `DEFAULT_SETTINGS` contains the four new keys with exact default values; assert `settings.set({autosave:{enabled:False}})` round-trips through the blind-merge (`settings_store.py:167-182`) without clobbering siblings. No fakes needed (pure dict logic).
+
+**Falsifiable acceptance:**
+- `DEFAULT_SETTINGS["exportDefaults"] == {"subtitleFormat":"srt","nleFormat":"edl","nleFps":30}` exactly.
+- A merge of `{"savePresets":{"active":"x"}}` leaves `presets` untouched (deep-merge or documented shallow-merge — pin whichever `settings.set` actually does; `settings_store.py:167-182` is the source of truth — TEST the real behavior, do not assume deep).
+- Coverage 100% on the new lines.
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_settings_store.py` + `cd app && npx vitest run --coverage`.
+
+---
+
+### WU-1 — `paths.describe` RPC (read-only layout)
+
+**Goal:** A direct (non-job) sidecar RPC returning the resolved data layout so the renderer can SHOW where everything lives (today it can only fetch the root via `dataFolder.get`).
+
+**Files:**
+- `sidecar/media_studio/handlers.py` — add `Services.paths_describe(self, params, ctx) -> {dataDir, projectsDir, exportsDir, settingsPath, libraryPath, subDirs}`; derive purely from `Services.{data_dir, projects_dir, exports_dir}` (`handlers.py:143-148`) + the per-feature sub-dir names already used (`shorts-*`, `dubs`, `stabilized`, `audiomix`, `trimmed` — `handlers.py:1351,2119,2164-2182`). Register in `register_all` (`handlers.py:1982`).
+- Tests: `sidecar/tests/test_handlers_paths.py` (new).
+
+**Test strategy:** Construct `Services` with a tmp data dir (existing `Services` construction pattern, `handlers.py:121-180`); call the handler; assert all paths are children of `data_dir`. No I/O beyond path joins (pure). No fakes.
+
+**Falsifiable acceptance:**
+- `result["projectsDir"]` == `os.path.join(result["dataDir"], "projects")` and equals `Services.projects_dir`.
+- `result["subDirs"]` keys cover at least `{shorts, dubs, stabilized, audiomix, trimmed}`.
+- Response contains **no** key/secret strings (assert none of the values look like a token; assert `providers`/`keys` absent).
+- Calling it twice is identical and writes nothing to disk (mtime of data dir unchanged).
+- 100% line+branch on the handler.
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_handlers_paths.py tests/test_handlers.py`.
+
+---
+
+### WU-2 — `library.thumbnail` RPC + `Video.thumbnailPath`
+
+**Goal:** Extract a poster from a SOURCE library video (not a clip) by reusing the shorts ffmpeg poster engine; persist `thumbnailPath` onto the Video; return it. Idempotent.
+
+**Files:**
+- `sidecar/media_studio/handlers.py` — add `Services.library_thumbnail(self, params, ctx) -> {thumbnailPath}`: resolve the source path via the existing `_resolve_video_path` pattern (`handlers.py:197-202`); compute the output `data_dir/thumbnails/<videoId>.jpg`; if it exists, return it; else build argv via `shorts.build_thumbnail_argv` (`shorts.py:183`) and run through the **injected ffmpeg runner** (the same seam `shorts.thumbnail` uses — do NOT call `subprocess` directly here; reuse the injected runner so tests fake it). Persist `thumbnailPath` onto the Library Video. Register in `register_all`.
+- `sidecar/media_studio/library.py` — extend `_normalize` (`library.py:108-117`) to carry optional `thumbnailPath` (default `""`); add a setter mirroring the existing `set_*` helpers used by `handlers.py`.
+- Tests: `sidecar/tests/test_handlers_library_thumbnail.py` (new), extend `sidecar/tests/test_library.py`.
+
+**Test strategy:**
+- **Fake the ffmpeg runner** (inject a fake that "creates" the output file by touching it / records the argv) — assert the argv equals `build_thumbnail_argv(sourcePath, out, settings)` and that the output path is `data_dir/thumbnails/<videoId>.jpg`.
+- Idempotence: pre-create the poster file → assert the runner is NOT invoked and the existing path is returned.
+- Missing video id → structured error (mirror `_resolve_video_path` failure).
+- `_normalize` backfills `thumbnailPath: ""` for an old Video record with no field.
+
+**Falsifiable acceptance:**
+- First call invokes the fake runner exactly once with argv == `build_thumbnail_argv(...)`; second call invokes it zero times and returns the same path (idempotent).
+- The returned path is strictly under `data_dir/thumbnails/` (string-prefix assertion).
+- A Library Video JSON lacking `thumbnailPath` loads as `""` (no KeyError).
+- The persisted Video now carries the poster path (re-list shows it).
+- 100% line+branch (the heavy real-ffmpeg body, if any, stays behind the injected seam — no `# pragma` needed because the seam is faked).
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_handlers_library_thumbnail.py tests/test_library.py`.
+
+---
+
+### WU-3 — `thumb:` mstream resolver branch (main process)
+
+**Goal:** Serve library posters through a traversal-guarded `thumb:` id branch so `<img src>` can load them in the sandbox (raw fs paths can't load).
+
+**Files:**
+- `app/main/main.ts` — add a `thumb:` branch in `registerMediaProtocol(...)` alongside the verified `dub:` (`main.ts:436-439`) and `short:` (`main.ts:457-459`) branches: derive `const thumbnailsRoot = resolvePath(DATA_ROOT, 'thumbnails')` (mirrors the exports/dubs derivation exactly — both use `DATA_ROOT`, verified `main.ts:437,458`) and call `resolveScopedMediaPath(videoId, 'thumb:', thumbnailsRoot)` (`exportPath.ts:20`).
+- `app/main/exportPath.ts` — **no change** (the helper is prefix-agnostic, verified `exportPath.ts:20-24`); the `thumb:` form encodes an absolute path after the prefix, identical to `short:`/`dub:`.
+- Tests: extend `app/main/exportPath.test.ts` and `app/main/mediaProtocol.test.ts` (both exist).
+
+**Test strategy (pure, no Electron):**
+- `resolveScopedMediaPath('thumb:' + insideAbs, 'thumb:', root)` returns the path when inside root; returns `null` for a parent-traversal (`thumb:<root>/../escape.jpg`), for a sibling dir sharing the prefix string, and for a missing-prefix id. (These mirror the existing `short:`/`dub:` traversal tests.)
+
+**Falsifiable acceptance:**
+- An id pointing strictly inside `data_dir/thumbnails` resolves; ANY path outside returns `null` (the security boundary is the falsifiable claim).
+- The `thumb:` root is derived from `DATA_ROOT` (same source as `short:`/`dub:`) — assert the join in a unit test of the branch's root derivation (extract the derivation if needed to keep it testable without Electron, mirroring how `exportPath.ts` was extracted).
+- 100% line+branch on the new branch.
+
+**Gate:** `cd app && npx vitest run --coverage app/main/exportPath.test.ts app/main/mediaProtocol.test.ts`.
+
+---
+
+### WU-4 — `useVideoThumbnail` hook (renderer)
+
+**Goal:** A near-clone of `useShortThumbnail` (`useShortThumbnail.ts:41-73`, verified) pointed at `library.thumbnail` + the `thumb:` URL, inheriting the proven graceful-degradation (missing poster → ▶ glyph, never blocks the card).
+
+**Files:**
+- `app/renderer/src/components/useVideoThumbnail.ts` (new) — a `thumbnailSrc`-style pure URL helper (`thumb:` form) + the `useVideoThumbnail(rpc, videoId, thumbnailPath)` hook. Reuse the exact lifecycle of `useShortThumbnail`: existing path wins (no RPC), else call once (idempotent server-side), best-effort catch leaves `""`.
+- `app/renderer/src/lib/rpc.ts` — add `library.thumbnail` to the typed client surface.
+- Tests: `app/renderer/src/components/useVideoThumbnail.test.tsx` (new), mirroring `useShortThumbnail`'s test if present.
+
+**Test strategy:** Pure helper tested directly. Hook tested with a fake `rpc` (resolves / rejects / returns empty). Assert: existing `thumbnailPath` short-circuits (rpc NOT called); empty path + null rpc → `""`; rpc reject → `""` (graceful); rpc resolve → the `thumb:` URL. No real network.
+
+**Falsifiable acceptance:**
+- Given a non-empty `thumbnailPath`, the fake rpc is called **zero** times and the rendered URL is the `thumb:` form of that path.
+- Given an empty path and a rejecting rpc, the hook returns `""` and does not throw (the gallery never breaks — the §3.5 invariant).
+- The pending state never produces a layout-shifting blank (returns the placeholder URL until resolved).
+- 100% line+branch.
+
+**Gate:** `cd app && npx vitest run --coverage app/renderer/src/components/useVideoThumbnail.test.tsx`.
+
+---
+
+### WU-5 — `JobStore` + atomic disk persistence (NEW SUBSTRATE)
+
+**Goal:** A standalone, injectable store that persists job records to `data_dir/jobs/` using the atomic write pattern (`library.py:74-79`). This is the only genuinely new substrate (the §6.1 named gap: `jobs.py` is 100% in-memory, verified — no file I/O in `jobs.py:270-300`).
+
+**Files:**
+- `sidecar/media_studio/job_store.py` (new) — `JobStore` protocol + `DiskJobStore(root: Path)` (atomic per-job JSON under `root/<jobId>.json`) + `InMemoryJobStore` (test double). Methods: `write(record: dict)`, `load_all() -> list[dict]`, `delete(job_id)`. Record shape: `{jobId, feature, label, videoId, method, params, status, pct, startedAt, finishedAt}`.
+- Tests: `sidecar/tests/test_job_store.py` (new).
+
+**Test strategy:** Use a real tmp dir for `DiskJobStore` (filesystem is the unit under test here — that's legitimate, no ffmpeg/network). Assert atomic write (no partial file on crash-sim: write to temp + rename), round-trip `write` → `load_all`, `delete` removes the file, `load_all` on a missing/empty dir returns `[]`, a corrupt/garbage JSON file is skipped (not fatal). `InMemoryJobStore` parity-tested against the same contract.
+
+**Falsifiable acceptance:**
+- `write(r)` then `load_all()` returns a record equal to `r` (field-for-field).
+- A second `write` with the same `jobId` updates, not duplicates (one file).
+- A corrupt file in `root` is skipped and the rest load (a partial-write crash never bricks startup — falsifiable resilience claim).
+- `load_all()` on a non-existent root returns `[]` (no crash on first run).
+- 100% line+branch (the rename-atomicity path included).
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_job_store.py`.
+
+---
+
+### WU-6 — `JobRegistry` write-through + rehydrate + `INTERRUPTED` status
+
+**Goal:** Wire `JobStore` into `JobRegistry` (write-through on create / `record_request` / status transitions); on startup, rehydrate records and mark any `running`/`queued` (PENDING) job as a NEW terminal-ish `INTERRUPTED` status — NOT auto-restarted (§5 safety: no silent re-spend).
+
+**Files:**
+- `sidecar/media_studio/jobs.py`:
+  - Add `INTERRUPTED = "interrupted"` to `JobStatus` (`jobs.py:46-64`). **CONTRACT-NOTE update required:** the enum's existing docstring (`jobs.py:53-60`, verified) pins the wire status set to exactly five values and the `Job.info()` mapping (`jobs.py:166`). Adding a sixth member MUST update that contract-note AND any P1 `job.status` test that asserts the value-set is exactly five (search `test_jobs*.py` for that assertion — it is a real pin per the docstring). `Job.info()` (`jobs.py:159-171`) needs no mapping change (INTERRUPTED is a real value, unlike PENDING→"queued").
+  - Inject `JobStore` into `JobRegistry.__init__` (`jobs.py:192-212`, verified signature) with default `= None` → a no-op/in-memory store so all existing `JobRegistry(...)` callers keep working (the existing every-collaborator-injected pattern, `handlers.py:121-180`).
+  - Write-through in `create` (`jobs.py:220-245`), `record_request` (`jobs.py:270-292`), and the status-transition points.
+  - `rehydrate()`: load records, recreate `Job` shells with stored `request`, map any non-terminal stored status to `INTERRUPTED`. Its `{method, params}` stays available to the existing built-in `job.retry` (`protocol.py:13`, verified).
+- `sidecar/media_studio/handlers.py` — construct the registry with a `DiskJobStore` rooted at `data_dir/jobs` (default real store) and call `rehydrate()` at sidecar startup.
+- Tests: extend `sidecar/tests/test_jobs.py` (+ a new `test_jobs_persistence.py`).
+
+**Test strategy:** Inject `InMemoryJobStore` (from WU-5). Assert write-through fires on each lifecycle event. Simulate restart: build registry A, create/run jobs, then build registry B sharing the same store → `rehydrate()` marks the non-terminal ones `interrupted`, terminal ones keep their status. Assert a rehydrated job's `request` survives so `job.retry` re-dispatches it (re-dispatch flows back through the dispatch layer — `protocol.py` records the new job, verified `protocol.py:11-14`). NO real ffmpeg/model — job handlers are fakes.
+
+**Falsifiable acceptance:**
+- After "restart", a job that was `running` reads `interrupted`; a job that was `done` stays `done` (the rule is falsifiable per-status).
+- An `interrupted` job is **never** auto-spawned on rehydrate (assert the pool's run-count stays 0 after rehydrate with no explicit start — the §5 no-silent-spend invariant).
+- `job.retry` on a rehydrated `interrupted` job creates a NEW job from the stored `{method, params}`.
+- Existing `JobRegistry(...)` callers (no store arg) still pass every prior `test_jobs.py` test (back-compat).
+- The P1 `job.status` value-set test is updated to six and passes; the enum docstring contract-note is updated.
+- 100% line+branch.
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_jobs.py tests/test_jobs_persistence.py tests/test_handlers.py`.
+
+---
+
+### WU-7 — `JobInfo` status widening + `canResume` + Resume button (renderer)
+
+**Goal:** Surface `interrupted` jobs with a distinct **Resume** affordance that re-dispatches via `job.retry`, with copy that sets correct cost/progress expectations (§4.3).
+
+**Files:**
+- `app/renderer/src/lib/rpc.ts` — widen the `JobInfo.status` union (`rpc.ts:413`, verified: `'queued'|'running'|'done'|'error'|'cancelled'`) to add `'interrupted'`. Purely additive.
+- `app/renderer/src/components/JobQueue.tsx`:
+  - NEW pure predicate `canResume(job): boolean` → `job.status === 'interrupted'` (sibling of verified `canCancel` `JobQueue.tsx:20-22` and `canRetry` `:25-27`; kept SEPARATE so the button labels differ).
+  - Extend the action-gate at `JobQueue.tsx:163` (verified `canCancel(job) || canRetry(job)`) to `... || canResume(job)`.
+  - Add a third conditional `<button>` in `jobqueue__actions` that renders when `canResume(job)`, calls the existing `handleRetry(job.jobId)` (`JobQueue.tsx:108-118`, verified), label `Resume`, `aria-label="Resume {label}"`, `title` = the §4.3 microcopy ("Re-runs this interrupted job from the start (restarts at 0%)… you'll be asked to confirm the budget again before it runs.").
+  - The status pill already renders `job.status` as TEXT (`JobQueue.tsx:150-152`, verified) — `interrupted` renders correctly with no change; add the status-modifier CSS class value `interrupted`.
+- Tests: extend `app/renderer/src/components/JobQueue.test.tsx`.
+
+**Test strategy:** Render a job with `status:'interrupted'` → assert exactly one Resume button (no Cancel, no Retry); assert its `aria-label` and `title`. Render `error` → Retry only (no Resume). Render `running` → Cancel only. Click Resume → fake `rpc('job.retry', {jobId})` called once. Pure predicate `canResume` unit-tested over all six statuses.
+
+**Falsifiable acceptance:**
+- `canResume` is true ONLY for `'interrupted'` (table-test all six statuses).
+- An `interrupted` job renders a Resume button and NO Retry/Cancel button (the §3.2 a11y bug — without the gate change it would render zero buttons).
+- Resume and Retry have distinct accessible names (`Resume {label}` vs `Retry {label}`).
+- Clicking Resume invokes `job.retry` with the job's id.
+- 100% line+branch (the new button + predicate + gate branch).
+
+**Gate:** `cd app && npx vitest run --coverage app/renderer/src/components/JobQueue.test.tsx`.
+
+---
+
+### WU-8 — `readiness.summary` RPC + `readinessMeta.ts` (pure helper)
+
+**Goal:** A direct RPC rolling up the three readiness sources (assets / advisor / providers) into `[{capability, status, blockedBy, action}]`. Read-only — triggers no download, opens no socket (§5).
+
+**Files:**
+- `sidecar/media_studio/handlers.py` — add `Services.readiness_summary(self, params, ctx) -> {items:[ReadinessItem]}`. Sources (all verified):
+  - models/features: `_models_present_map` (`handlers.py:1305-1327`) + `system.advisor` component verdicts (`handlers.py:1152-1173`).
+  - assets sizes/installed: `assets.list` via the same `AssetManager` (`manager.py:392-402`).
+  - providers/keys/consent: `providers.list` (redacted, `handlers.py:330-338`) + `consent.perProvider` (`handlers.py:414-434`) + `routing.perFunction` (`handlers.py:553-573`).
+  - Honor Offline mode (a missing weight needing a download counts `unavailable` — same rule `system.advisor` uses). Register in `register_all`.
+- `app/renderer/src/components/readinessMeta.ts` (new) — pure label/class/hint map per status (mirrors `advisorMeta.ts:17-50`, verified): `ready→"Ready"`, `needsDownload→"Needs download"`, `needsKey→"Needs key"`, `needsConsent→"Needs consent"`, `unavailable→"Unavailable"`.
+- Tests: `sidecar/tests/test_handlers_readiness.py` (new), `app/renderer/src/components/readinessMeta.test.ts` (new).
+
+**Test strategy:** Build `Services` with FAKE asset manager + fake settings (no provider call ever made — assert the provider client is never invoked, the §5 "never call a provider" invariant). Drive each status: no weight + online → `needsDownload`; no key for a cloud-routed function → `needsKey`; consent off → `needsConsent`; offline + missing weight → `unavailable`; all present → `ready`. `readinessMeta` unit-tested over all five statuses.
+
+**Falsifiable acceptance:**
+- Each input scenario yields exactly the expected `status` + `blockedBy` + `action.kind` (table-test).
+- The response contains **no** full key string (assert redaction; reuse `providers.list` which is already redacted, `handlers.py:330-338`).
+- `readiness.summary` performs **zero** network/provider calls and triggers no `assets.ensure` (assert the fakes' call-counts are 0 — the read-only invariant).
+- `readinessMeta(status)` returns the exact label for all five statuses; an unknown status falls back safely (defensive branch tested).
+- 100% line+branch.
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_handlers_readiness.py` + `cd app && npx vitest run --coverage app/renderer/src/components/readinessMeta.test.ts`.
+
+---
+
+### WU-9 — `ReadinessBadge` component (renderer)
+
+**Goal:** A shared status pill mirroring the `VerdictBadge` PRIMITIVE (verified `VerdictBadge.tsx:19-31`): text label + `role="status"` + `data-readiness` + `title` — status by text+role, never hue alone (WCAG 1.4.1). Plus the per-item action `<button>` with a capability-tied accessible name.
+
+**Files:**
+- `app/renderer/src/components/ReadinessBadge.tsx` (new) — thin render shell over `readinessMeta.ts` (WU-8). Renders the visible label, `role="status"`, `data-readiness="<status>"`, a `title` naming blocker+fix. Reuses ONLY the `verdict-badge` pill geometry CSS (NOT its verdict color map); a parallel readiness class from `readinessMeta`.
+- An action `<button>` (or accept an `action` render prop): `assets.ensure` → `aria-label="Download {capability} model"`, `openProviders` → `"Add a provider key"`, `setConsent` → `"Grant consent for {provider}"`. Never icon-only.
+- Tests: `app/renderer/src/components/ReadinessBadge.test.tsx` (new).
+
+**Test strategy:** Render each status → assert the visible TEXT label is present (not color-only), `role="status"`, `data-readiness` matches, `title` non-empty. Render each action kind → assert the exact `aria-label`. Assert the badge is a `<span role="status">` and the action is a real `<button>`.
+
+**Falsifiable acceptance:**
+- Every status renders a non-empty visible text label (query by text, not by class) — the use-of-color guard.
+- `role="status"` and `data-readiness="<status>"` present for all five statuses.
+- Each action kind renders a `<button>` with the capability-specific accessible name (no icon-only control passes — query `getByRole('button', {name})`).
+- 100% line+branch (all five statuses + all three action kinds branched).
+
+**Gate:** `cd app && npx vitest run --coverage app/renderer/src/components/ReadinessBadge.test.tsx`.
+
+---
+
+### WU-10 — `savePresets.*` RPC (sidecar)
+
+**Goal:** `savePresets.list/apply/upsert/remove` storing a named `{autosave, exportDefaults}` bundle under the `savePresets` settings key — mirrors `providers.applyPreset` exactly (verified `handlers.py:483-501`: resolve → persist to settings).
+
+**Files:**
+- `sidecar/media_studio/handlers.py` — four handlers persisting to the `savePresets` settings block via `settings.set` (blind-merge, `settings_store.py:167-182`). `list → {presets, active}`; `apply({name}) → {active, savePreset}` (sets `active`); `upsert({name, autosave?, exportDefaults?}) → {presets}`; `remove({name}) → {presets}`. Register all four in `register_all`.
+- Tests: `sidecar/tests/test_handlers_save_presets.py` (new).
+
+**Test strategy:** Fake settings store; round-trip upsert → list → apply → remove. Assert `apply` on a missing name errors (structured `_invalid`, mirroring `providers_apply_preset`'s `ValueError → _invalid`, `handlers.py:494-496`). Assert `remove` of the active preset clears `active`. No I/O beyond the settings doc.
+
+**Falsifiable acceptance:**
+- `upsert("a", autosave=X)` then `list()` returns `presets["a"].autosave == X`.
+- `apply("a")` sets `active == "a"`; `apply("missing")` raises a structured error (not a crash).
+- `remove("a")` drops it from `presets`; removing the active one resets `active` to `""`.
+- Sibling settings keys are untouched (blind-merge invariant).
+- 100% line+branch (incl. the missing-name and remove-active branches).
+
+**Gate:** `cd sidecar && pytest --cov-branch --cov-fail-under=100 tests/test_handlers_save_presets.py`.
+
+---
+
+### WU-11 — `SavePresetsControls` + export-defaults wiring (renderer)
+
+**Goal:** A renderer control set wiring `savePresets.*` (mirrors `PresetPicker.tsx`, verified to exist) + reading `exportDefaults`/`autosave` from settings to pre-fill export dialogs.
+
+**Files:**
+- `app/renderer/src/components/SavePresetsControls.tsx` (new) — list/apply/upsert/remove via the typed client; pattern from `PresetPicker.tsx`.
+- `app/renderer/src/lib/rpc.ts` — add `savePresets.*` to the client surface.
+- Export call sites — pass stored `exportDefaults` (subtitle fmt, nle fmt/fps) as the default param (the handlers already accept them per-call: `subtitles.export` `handlers.py:763`, `nle.export` `handlers.py:1472`, verified). The sidecar fallback-to-`settings.exportDefaults` is OPTIONAL and out of MVP unless trivial.
+- Autosave: debounce `project.save` (`handlers.py:276-287`, verified caller-driven) in the workspace renderer, gated on `autosave.enabled`. **No sidecar change** beyond the WU-0 default key.
+- Tests: `app/renderer/src/components/SavePresetsControls.test.tsx` (new) + a focused autosave-debounce test (fake timers, fake rpc).
+
+**Test strategy:** Fake rpc + fake timers. Assert list renders presets; apply calls `savePresets.apply`; upsert/remove call their methods. Autosave: an edit triggers ONE `project.save` after `debounceMs`; rapid edits coalesce to one; `autosave.enabled=false` triggers zero.
+
+**Falsifiable acceptance:**
+- With `autosave.enabled=true, debounceMs=1500`, N rapid edits → exactly ONE `project.save` after the debounce window (coalescing is the falsifiable claim).
+- With `autosave.enabled=false`, edits trigger ZERO `project.save`.
+- Export dialog pre-fills from `exportDefaults` (assert the default value shown).
+- 100% line+branch.
+
+**Gate:** `cd app && npx vitest run --coverage app/renderer/src/components/SavePresetsControls.test.tsx`.
+
+---
+
+### WU-12 — `PathsPanel` (renderer)
+
+**Goal:** Show the data layout (`paths.describe`, WU-1) + the existing `dataFolder.*` change-root flow + an "Open folder" button. a11y: real `<button>` per row with a per-row accessible name; path string is selectable text, not inert-interactive.
+
+**Files:**
+- `app/renderer/src/components/PathsPanel.tsx` (new) — fetch `paths.describe`; render each dir row with `aria-label="Open {dirLabel} folder"`; wire `dataFolder.get/pick/set` (verified `dataFolderIpc.ts:97-108`) for changing the root; "Open folder" via the existing `shellIpc` channel (`registerShellIpc`, verified `main.ts` + `dataFolderIpc.ts:16`) — reuse, no new channel unless "open arbitrary path" needs one (then a NEW traversal-checked `paths.openFolder`; keep out of MVP if `shellIpc` covers it).
+- Tests: `app/renderer/src/components/PathsPanel.test.tsx` (new).
+
+**Test strategy:** Fake rpc returning a `paths.describe` payload. Assert each dir row renders its path as text + an "Open folder" `<button>` with the row-specific accessible name. Assert "Change data folder" calls `dataFolder.pick` then `dataFolder.set`. Loading state covered.
+
+**Falsifiable acceptance:**
+- Each dir row exposes a button via `getByRole('button', {name:/Open .* folder/})` (no icon-only control).
+- The path string is rendered as text (queryable), not as a button.
+- Change-root calls `dataFolder.pick` → `dataFolder.set` in order.
+- 100% line+branch.
+
+**Gate:** `cd app && npx vitest run --coverage app/renderer/src/components/PathsPanel.test.tsx`.
+
+---
+
+### WU-13 — App `lastOpenedVideoId` persist + restore (renderer)
+
+**Goal:** Persist the last-opened video on `openVideo` and restore it on launch — pure settings + renderer state, NO new RPC (§3.2).
+
+**Files:**
+- `app/renderer/src/App.tsx`:
+  - On `openVideo` (`App.tsx:109-111`, verified), `settings.set({lastOpenedVideoId: id})`.
+  - In the launch `settings.get` effect (`App.tsx:84-99`, verified — already hydrates the quality toggle), read `lastOpenedVideoId`, resolve via `library.list` (the exact pattern of `handleReexport`, `App.tsx:136-148`, verified), navigate to workspace. Fall back to Library when the video is gone (same fallback as `handleReexport`, `App.tsx:144-148`).
+- Tests: extend `app/renderer/src/App.test.tsx` (if present; else new focused test).
+
+**Test strategy:** Fake rpc. Launch with `lastOpenedVideoId` present + in `library.list` → navigates to workspace for that id. Present but absent from list → stays on Library (best-effort fallback). Empty key → stays on Library (default `route='library'`, `App.tsx:77`). `openVideo` persists the key.
+
+**Falsifiable acceptance:**
+- A valid `lastOpenedVideoId` → route becomes workspace for that id on launch.
+- A stale id (not in `library.list`) → route stays Library, no crash (the fallback invariant).
+- `openVideo(id)` triggers exactly one `settings.set({lastOpenedVideoId:id})`.
+- 100% line+branch (restore-success, restore-fallback, empty-key branches).
+
+**Gate:** `cd app && npx vitest run --coverage app/renderer/src/App.test.tsx`.
+
+---
+
+### WU-14 — Wire badges + thumbnails into library + model panels (integration)
+
+**Goal:** Consume `useVideoThumbnail` on library cards and `ReadinessBadge` on the library home + model panel — the surfacing payoff.
+
+**Files:**
+- `app/renderer/src/features/` library home component (the one rendering `library-cards.css` cards, per design §1) — render the poster via `useVideoThumbnail` (WU-4) with the ▶ glyph fallback; render `ReadinessBadge` (WU-9) roll-up driven by `readiness.summary` (WU-8), reusing JobQueue's skeleton/empty conventions (`jobqueue__empty`, `JobQueue.tsx:142-162`, verified) while in flight.
+- Model panel (`Assets.tsx` / `ModelCard.tsx`, verified to render install state, `Assets.tsx:13-39` / `ModelCard.tsx:18-107`) — add the `ReadinessBadge` roll-up where appropriate (reuse, don't duplicate the existing `VerdictBadge`).
+- Tests: extend the relevant feature test files.
+
+**Test strategy:** Fake rpc (`library.thumbnail`, `readiness.summary`). Assert a card renders the poster URL when available and the ▶ glyph when generation fails (graceful, inheriting WU-4). Assert the readiness roll-up renders one `ReadinessBadge` per item with its action button. Assert the in-flight skeleton shows before data resolves.
+
+**Falsifiable acceptance:**
+- A card with a resolvable thumbnail renders the `thumb:` `<img>`; a failing one renders the ▶ glyph (gallery never breaks).
+- The readiness roll-up renders N badges for N `readiness.summary` items, each with its capability-tied action button.
+- In-flight state renders the reused skeleton (no bespoke loader).
+- 100% line+branch on the wiring.
+
+**Gate:** `cd app && npx vitest run --coverage` (the affected feature test files).
+
+---
+
+## 3. Dependency graph
+
+```
+WU-0 (settings + types scaffold)
+ ├─► WU-1 (paths.describe) ─────────────► WU-12 (PathsPanel)
+ ├─► WU-2 (library.thumbnail+schema) ──► WU-3 (thumb: resolver) ──► WU-4 (useVideoThumbnail) ─┐
+ ├─► WU-5 (JobStore) ──► WU-6 (registry write-through+rehydrate+INTERRUPTED) ──► WU-7 (canResume+Resume)
+ ├─► WU-8 (readiness.summary + readinessMeta) ──► WU-9 (ReadinessBadge) ───────────────────────┤
+ ├─► WU-10 (savePresets.*) ──► WU-11 (SavePresetsControls + autosave/export-defaults)          │
+ └─► WU-13 (lastOpenedVideoId)                                                                  │
+                                                                                               ▼
+                                                          WU-14 (wire thumbnails + badges into panels)
+```
+
+Critical path (longest): `WU-0 → WU-5 → WU-6 → WU-7` (the resume spine) and `WU-0 → WU-2 → WU-3 → WU-4 → WU-14`. WU-14 is the only multi-parent join.
+
+---
+
+## 4. Parallelism notes
+
+After WU-0 lands (it touches shared files — `settings_store.py`, `rpc.ts` — so it goes FIRST, alone, to avoid index contamination), the five feature tracks are **file-disjoint and parallelizable**:
+
+- **Track A — Save locations:** WU-1 → WU-12.
+- **Track B — Thumbnails:** WU-2 → WU-3 → WU-4 (→ WU-14).
+- **Track C — Resume (highest risk):** WU-5 → WU-6 → WU-7. Sequence strictly; do NOT parallelize within (each extends the same `jobs.py`).
+- **Track D — Readiness:** WU-8 → WU-9 (→ WU-14).
+- **Track E — Save options:** WU-10 → WU-11; WU-13 is independent and can run any time after WU-0.
+
+**Shared-file hazards (one owner each):**
+- `handlers.py` (`register_all`) is touched by WU-1/2/6/8/10 — they each add a handler + one `register(...)` line. To avoid the shared-worktree index contamination noted in prior lessons: if running parallel agents, give each its OWN worktree, OR mandate scoped adds (`git add <specific files>`; `git diff --cached --name-only` before every commit) and serialize the `register_all` edits. **Recommend serializing the `handlers.py` edits** (the register block is a single one-owner hotspot).
+- `rpc.ts` is touched by WU-0/4/7/11 — additive client surface; same scoped-add discipline.
+- WU-14 is the integration join — run it LAST, after WU-4 and WU-9 (and ideally WU-8) are merged.
+
+**WU-0 and WU-14 are serialization points** (first and last); everything between fans out into 5 tracks.
+
+---
+
+## 5. Risk register (falsifiable mitigations)
+
+| Risk | WU | Mitigation (testable) |
+|------|----|----|
+| Job persistence is new substrate — could corrupt startup | WU-5/6 | Corrupt-file-skip test + `load_all([])` on empty dir + atomic rename test. A bad record never bricks rehydrate. |
+| Resumed AI job silently re-spends cloud budget | WU-6/7 | Rehydrated jobs are `interrupted`, NEVER auto-spawned (assert run-count 0). `job.retry` re-flows through `_enforce_cloud_budget_ack` (`handlers.py:1672-1691`); stale `cacheKey` ≠ fresh → re-prompt. Resume copy states the re-prompt up front. |
+| `thumb:` becomes an arbitrary-disk read | WU-3 | Reuse `resolveScopedMediaPath` (`exportPath.ts:20`); traversal tests assert ANY path outside `data_dir/thumbnails` → `null`. |
+| Adding `INTERRUPTED` breaks the P1 `job.status` value-set pin | WU-6 | The enum docstring (`jobs.py:53-60`) pins five values; update the contract-note + the test asserting exactly-five. Falsifiable: the updated test passes at six. |
+| `ReadinessBadge` regresses to color-only (WCAG 1.4.1) | WU-9 | Query by visible TEXT label, not class; assert `role="status"` + `data-readiness`. |
+| `readiness.summary` accidentally calls a provider / triggers a download | WU-8 | Assert fakes' provider/ensure call-counts are 0 (read-only invariant). |
+| Parallel agents contaminate `handlers.py`/`rpc.ts` index | all | Serialize `register_all` edits OR isolated worktrees + scoped adds; never `git add -A`. |
+
+---
+
+## 6. Capability gaps carried from DESIGN §6 (no fabrication)
+
+1. **No job persistence today** (`jobs.py:270-300`, verified zero file I/O) — WU-5/6 is the genuinely new substrate.
+2. **No mid-job resume** — job bodies are opaque `(JobContext)->result` (`jobs.py:304-326`); Resume = full re-dispatch (a 90% transcribe restarts at 0%). Documented limitation; the Resume copy (WU-7) makes it visible. NOT solved here.
+3. **No source-video thumbnail** before WU-2 (`Video` has no `thumbnailPath`, `library.py:108-117`).
+4. **No unified readiness view** before WU-8 (split across `assets.list` / `system.advisor` / `providers.list`).
+5. **No autosave / shared export presets** before WU-10/11 (`project.save` caller-driven, `handlers.py:276-287`; only routing presets exist, `handlers.py:483`).
+6. **Per-feature `outputDir` deliberately rejected** (`settings_store.py:34-40`) — OUT of scope; this bundle surfaces the ONE root only.
+7. **No `thumb:` resolver branch** before WU-3 (only `short:`/`dub:` exist, `main.ts:436-459`).
+
+---
+
+## 7. Gate commands (bundle-level — for the eventual `feat/ux-qol` impl branch, NOT this docs branch)
+
+Run from the impl branch before any commit/PR; never `--no-verify`, never `git add -A`:
+
+- **Sidecar:** `cd sidecar && pytest --cov-branch --cov-fail-under=100`
+- **Renderer:** `cd app && npx vitest run --coverage` (thresholds 100/100/100/100 enforced by `app/vitest.config.ts:44-49`)
+- **Lint/type (sidecar):** `cd sidecar && ruff check . && basedpyright`
+- **Lint/type (app):** `cd app && npx tsc --noEmit && npx oxlint && npx biome check .`
+- **Scoped adds only:** `git add <specific files>`; verify with `git diff --cached --name-only` before each commit.
+
+Heavy-ML / real-ffmpeg bodies stay `# pragma: no cover`; the ffmpeg / job-store / provider / OCR seams are injected and fully covered by fakes.

--- a/sidecar/media_studio/__main__.py
+++ b/sidecar/media_studio/__main__.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import sys
 
 from . import handlers, rpc
+from .job_store import DiskJobStore
 
 
 def _suppress_windows_error_dialogs() -> None:
@@ -72,11 +73,20 @@ def _preimport_native_modules() -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Register all feature handlers, then run the stdio JSON-RPC server."""
+    """Register all feature handlers, then run the stdio JSON-RPC server.
+
+    WU-6 composition seam: ``register_all`` returns the assembled ``Services``
+    (the only owner of ``data_dir``), and the ``JobRegistry`` is owned by the
+    ``RpcServer`` ``rpc.main`` builds. This is the ONLY place both are visible,
+    so here we build a :class:`DiskJobStore` rooted at ``svc.data_dir/jobs`` and
+    inject it — ``rpc.main`` rehydrates it once at startup so a job interrupted
+    by a prior exit reappears as INTERRUPTED (never auto-restarted, §5).
+    """
     _suppress_windows_error_dialogs()
     _preimport_native_modules()
-    handlers.register_all()
-    return rpc.main(argv)
+    svc = handlers.register_all()
+    store = DiskJobStore(svc.data_dir / "jobs")
+    return rpc.main(argv, store=store)
 
 
 if __name__ == "__main__":  # pragma: no cover - process entry

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -321,8 +321,10 @@ class Services:
         paths from the injected stores' own path attributes (robust to a custom
         settings/library location). ``subDirs`` names the per-feature derivative
         folders the sidecar writes into — ``dubs`` under the data dir; the
-        ffmpeg-derivative folders (``shorts``/``stabilized``/``audiomix``/``trimmed``)
-        under the exports root, matching ``register_all``'s wiring. NO key/secret
+        ffmpeg-derivative folders (``stabilized``/``audiomix``/``trimmed``)
+        under the exports root, matching ``register_all``'s wiring. ``shorts`` is
+        written PER-VIDEO as ``exports/shorts-<videoId>``, so it is reported as the
+        honest ``shorts-*`` pattern (no flat ``exports/shorts`` dir exists). NO key/secret
         string ever appears in this payload (it is layout-only).
         """
         return {
@@ -333,7 +335,7 @@ class Services:
             "libraryPath": str(self.library.index_path),
             "subDirs": {
                 "dubs": str(self.data_dir / "dubs"),
-                "shorts": str(self.exports_dir / "shorts"),
+                "shorts": str(self.exports_dir / "shorts-*"),
                 "stabilized": str(self.exports_dir / "stabilized"),
                 "audiomix": str(self.exports_dir / "audiomix"),
                 "trimmed": str(self.exports_dir / "trimmed"),

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -259,6 +259,36 @@ class Services:
         ok = self.library.remove(video_id)
         return {"ok": bool(ok)}
 
+    def library_thumbnail(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``library.thumbnail({id})`` -> ``{thumbnailPath}``. Direct-return.
+
+        WU-2: extract a poster from a SOURCE library video by reusing the shorts
+        ffmpeg poster engine, persist ``thumbnailPath`` onto the Video, and return
+        it. Idempotent: an existing ``data_dir/thumbnails/<id>.jpg`` short-circuits
+        (the runner is NOT invoked again). The ffmpeg ``run`` seam is the SAME
+        injectable one ``shorts.thumbnail`` uses — never ``subprocess`` directly —
+        so tests fake it (no real ffmpeg).
+        """
+        video_id = _require_str(params, "id")
+        in_path = self._resolve_video_path(video_id)
+        if not in_path:
+            raise _invalid(f"unknown video: {video_id}")
+        out = self.data_dir / "thumbnails" / f"{video_id}.jpg"
+        if out.exists():
+            self.library.set_thumbnail(video_id, str(out))
+            return {"thumbnailPath": str(out)}
+        out.parent.mkdir(parents=True, exist_ok=True)
+        run = self._ffmpeg_run or _self_ffmpeg_run()
+        argv = _shorts_meta.build_thumbnail_argv(in_path, str(out), self.settings.get())
+        code = run(argv, total_sec=0.0)
+        if code != 0:
+            raise RpcError(
+                f"ffmpeg exited with code {code} extracting a thumbnail for {video_id}",
+                ErrorCode.INTERNAL_ERROR,
+            )
+        self.library.set_thumbnail(video_id, str(out))
+        return {"thumbnailPath": str(out)}
+
     # ===================================================================== #
     # project.*
     # ===================================================================== #
@@ -2028,6 +2058,7 @@ def register_all(
     reg("library.list", svc.library_list)
     reg("library.add", svc.library_add)
     reg("library.remove", svc.library_remove)
+    reg("library.thumbnail", svc.library_thumbnail)
 
     reg("project.open", svc.project_open)
     reg("project.save", svc.project_save)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -310,6 +310,36 @@ class Services:
         """
         return self.settings.set(dict(params))
 
+    def paths_describe(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``paths.describe()`` -> the resolved on-disk data layout. Direct-return.
+
+        WU-1 (read-only): surfaces WHERE everything lives so the renderer can SHOW
+        the data layout (today it can only fetch the root via ``dataFolder.get``).
+        A PURE path-join: no I/O, nothing is created, nothing is read from disk, so
+        repeated calls are identical. Derives the dirs from
+        :attr:`data_dir`/:attr:`projects_dir`/:attr:`exports_dir` and the file
+        paths from the injected stores' own path attributes (robust to a custom
+        settings/library location). ``subDirs`` names the per-feature derivative
+        folders the sidecar writes into — ``dubs`` under the data dir; the
+        ffmpeg-derivative folders (``shorts``/``stabilized``/``audiomix``/``trimmed``)
+        under the exports root, matching ``register_all``'s wiring. NO key/secret
+        string ever appears in this payload (it is layout-only).
+        """
+        return {
+            "dataDir": str(self.data_dir),
+            "projectsDir": str(self.projects_dir),
+            "exportsDir": str(self.exports_dir),
+            "settingsPath": str(self.settings.config_path),
+            "libraryPath": str(self.library.index_path),
+            "subDirs": {
+                "dubs": str(self.data_dir / "dubs"),
+                "shorts": str(self.exports_dir / "shorts"),
+                "stabilized": str(self.exports_dir / "stabilized"),
+                "audiomix": str(self.exports_dir / "audiomix"),
+                "trimmed": str(self.exports_dir / "trimmed"),
+            },
+        }
+
     # ===================================================================== #
     # providers.* (WU-keys: user-brings keys; RPC is key-free / redacted)
     # ===================================================================== #
@@ -2003,6 +2033,9 @@ def register_all(
 
     reg("settings.get", svc.settings_get)
     reg("settings.set", svc.settings_set)
+
+    # WU-1: read-only data-layout describe (no I/O, no secrets, idempotent).
+    reg("paths.describe", svc.paths_describe)
 
     reg("transcribe.start", svc.transcribe_start)
 

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -645,6 +645,84 @@ class Services:
         self.settings.set({"firstRunChoiceMade": True, "activePreset": routing["activePreset"], "routing": block})
         return {"firstRunChoiceMade": True, "activePreset": routing["activePreset"], "routing": block}
 
+    # ===================================================================== #
+    # savePresets.* — named {autosave, exportDefaults} bundles (WU-10)
+    # ===================================================================== #
+    def _save_presets_block(self) -> dict[str, Any]:
+        """Return the current ``savePresets`` block as ``{presets, active}``.
+
+        ``settings.set`` is a SHALLOW top-level merge (``settings_store``: writing
+        ``savePresets`` REPLACES the whole block), so every mutating handler MUST
+        read this full block, modify it, and write it back whole — otherwise a
+        partial write would drop ``presets`` or ``active``. A corrupt (non-dict)
+        block, or non-dict ``presets``, is defensively treated as empty.
+        """
+        raw = self.settings.get().get("savePresets")
+        block = raw if isinstance(raw, dict) else {}
+        presets = block.get("presets")
+        active = block.get("active")
+        return {
+            "presets": dict(presets) if isinstance(presets, dict) else {},
+            "active": active if isinstance(active, str) else "",
+        }
+
+    def save_presets_list(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``savePresets.list()`` -> ``{presets, active}`` (WU-10).
+
+        READ-ONLY roll-up of the named ``{autosave, exportDefaults}`` bundles the
+        user has saved (``presets``) plus the last-applied bundle name (``active``).
+        Writes nothing.
+        """
+        return self._save_presets_block()
+
+    def save_presets_upsert(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``savePresets.upsert({name, autosave?, exportDefaults?})`` -> ``{presets}``.
+
+        Creates or replaces the named bundle. Omitted ``autosave`` / ``exportDefaults``
+        default to ``{}`` (the renderer fills them from live settings). The whole
+        ``savePresets`` block is read-modify-written so siblings (other presets +
+        ``active``) survive the shallow-merge replace.
+        """
+        name = _require_str(params, "name")
+        block = self._save_presets_block()
+        block["presets"][name] = {
+            "autosave": dict(params["autosave"]) if isinstance(params.get("autosave"), dict) else {},
+            "exportDefaults": dict(params["exportDefaults"]) if isinstance(params.get("exportDefaults"), dict) else {},
+        }
+        self.settings.set({"savePresets": block})
+        return {"presets": block["presets"]}
+
+    def save_presets_apply(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``savePresets.apply({name})`` -> ``{active, savePreset}`` (WU-10).
+
+        Marks ``name`` the active bundle (persisted) and echoes it back. An unknown
+        name is a typed invalid-params error (mirrors ``providers.applyPreset``'s
+        ``ValueError -> _invalid``) rather than a crash.
+        """
+        name = _require_str(params, "name")
+        block = self._save_presets_block()
+        if name not in block["presets"]:
+            raise _invalid(f"unknown save preset: {name!r}")
+        block["active"] = name
+        self.settings.set({"savePresets": block})
+        return {"active": name, "savePreset": block["presets"][name]}
+
+    def save_presets_remove(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``savePresets.remove({name})`` -> ``{presets, active}`` (WU-10).
+
+        Drops the named bundle. If it was the ``active`` one, ``active`` is reset to
+        ``""`` (no stale pointer). An unknown name is a typed invalid-params error.
+        """
+        name = _require_str(params, "name")
+        block = self._save_presets_block()
+        if name not in block["presets"]:
+            raise _invalid(f"unknown save preset: {name!r}")
+        del block["presets"][name]
+        if block["active"] == name:
+            block["active"] = ""
+        self.settings.set({"savePresets": block})
+        return {"presets": block["presets"], "active": block["active"]}
+
     # -- per-function routing resolution (the seam wiring) ------------------ #
     def _function_prefer(self, function: str) -> str | None:
         """Return the configured provider id the ``function`` seam should prefer.
@@ -2318,6 +2396,15 @@ def register_all(
     reg("providers.applyPreset", svc.providers_apply_preset)
     reg("providers.setFunctionModel", svc.providers_set_function_model)
     reg("providers.firstRun", svc.providers_first_run)
+
+    # WU-10 (UX/QoL): named {autosave, exportDefaults} save-presets, persisted under
+    # the ``savePresets`` settings block (read-modify-write the whole block — the
+    # settings merge is a SHALLOW top-level replace). Mirrors providers.applyPreset
+    # (resolve -> persist) but stores user-named bundles, not routing presets.
+    reg("savePresets.list", svc.save_presets_list)
+    reg("savePresets.apply", svc.save_presets_apply)
+    reg("savePresets.upsert", svc.save_presets_upsert)
+    reg("savePresets.remove", svc.save_presets_remove)
 
     # captions-export: EDL/CSV NLE timeline export + ZIP package-for-upload.
     reg("nle.export", svc.nle_export)

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -372,6 +372,40 @@ class Services:
             },
         }
 
+    def readiness_summary(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``readiness.summary()`` -> ``{items:[ReadinessItem]}``. Direct-return.
+
+        WU-8 (read-only): rolls the three otherwise-split readiness sources into
+        ONE per-capability list the renderer can SHOW as a unified "what works
+        right now" view. Two capability families:
+
+          * **Model tiers** — each runnable tier (0/1/2) is ``ready`` when all its
+            model weights are installed; ``needsDownload`` when one is missing and
+            we are online (the action targets ``assets.ensure`` with the missing
+            asset names); ``unavailable`` when one is missing AND Offline mode is on
+            (the download is blocked — same rule ``system.advisor`` uses). Tier-0 is
+            the zero-download CPU floor and is always ``ready``.
+          * **AI functions** — each routed AI function (``select``/``subtitles``/
+            ``translation``/``vision``/``editPlan``) routed to a CLOUD provider is
+            ``needsKey`` (no key for that provider), then ``needsConsent`` (key
+            present but the data-type consent — TEXT for most, FRAMES for vision —
+            is not granted), then ``ready``. A function routed to LOCAL (or unrouted
+            -> the local-safe default) needs neither and is ``ready``.
+
+        STRICTLY READ-ONLY (§5): it derives everything from the installed-weight map
+        (the :meth:`_models_present_map` seam) + the redacted settings view, so it
+        performs ZERO network/provider calls and triggers NO ``assets.ensure``. No
+        full key ever rides this payload (it reads the already-redacted
+        :meth:`providers.list <providers_list>` view for key PRESENCE only).
+        """
+        settings = self.settings.get()
+        models_present = self._models_present_map(settings)
+        offline = _offline.is_offline(settings)
+        providers = self.providers_list(params, ctx)["providers"]
+        items = _tier_readiness_items(models_present, offline=offline)
+        items.extend(_function_readiness_items(settings, providers))
+        return {"items": items}
+
     # ===================================================================== #
     # providers.* (WU-keys: user-brings keys; RPC is key-free / redacted)
     # ===================================================================== #
@@ -1961,6 +1995,160 @@ def _signals_summary(tracks: dict[str, Any]) -> dict[str, Any]:
     return {"tracks": counts, "present": present}
 
 
+#: WU-8 readiness: each runnable tier id -> (label, the advisor-component names it
+#: needs). Mirrors ``system_advisor.TIERS`` but expressed against ``_COMPONENT_ASSETS``
+#: so readiness is derived purely from installed-weight state (no hardware probe /
+#: dependency import). Tier-0 is the zero-download CPU floor (no model-backed
+#: components) and so is always ready.
+_READINESS_TIERS: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    ("tier0-numeric", "Instant numeric (no downloads)", ()),
+    (
+        "tier1-multimodal",
+        "Multimodal (visual + audio + transcript)",
+        ("saliency", "audio_saliency", "scene_transnet", "vlm_backbone", "quality_gate"),
+    ),
+    ("tier2-vlm", "Video-LLM re-rank (heavy, opt-in)", ("smolvlm2",)),
+)
+
+#: WU-8 readiness: the AI functions whose cloud-route key/consent state is rolled
+#: up. Mirrors ``presets.FUNCTIONS``; ``vision`` checks FRAME consent, the rest
+#: check TEXT consent (the §-consent data-type split).
+_READINESS_FUNCTIONS: tuple[str, ...] = ("select", "subtitles", "translation", "vision", "editPlan")
+
+#: The routing sentinel meaning "run this function locally" (mirrors
+#: ``presets.LOCAL``); an unrouted function also defaults to the local-safe route.
+_LOCAL_ROUTE = "local"
+
+
+def _missing_tier_assets(component_names: tuple[str, ...], models_present: dict[str, bool]) -> list[str]:
+    """The de-duplicated asset names a tier needs that are NOT installed.
+
+    Maps each member component to its pinned asset (``_COMPONENT_ASSETS``) and
+    keeps only the assets whose weight is not present. Components sharing an asset
+    (e.g. ``vlm_backbone``/``aesthetic`` both use SigLIP-2) collapse to one name.
+    """
+    missing: list[str] = []
+    for name in component_names:
+        if models_present.get(name, False):
+            continue
+        asset = _COMPONENT_ASSETS.get(name)
+        if asset is not None and asset not in missing:
+            missing.append(asset)
+    return missing
+
+
+def _tier_readiness_items(models_present: dict[str, bool], *, offline: bool) -> list[dict[str, Any]]:
+    """Roll each runnable tier up to a :class:`ReadinessItem` from installed state.
+
+    ``ready`` when every member weight is installed; ``needsDownload`` (with an
+    ``assets.ensure`` action over the missing names) when one is missing online;
+    ``unavailable`` when one is missing AND Offline mode is on (download blocked).
+    """
+    items: list[dict[str, Any]] = []
+    for tier_id, label, components in _READINESS_TIERS:
+        missing = _missing_tier_assets(components, models_present)
+        if not missing:
+            items.append(_readiness_item(tier_id, label, "ready", "", None))
+            continue
+        blocked = f"missing model weights: {', '.join(missing)}"
+        if offline:
+            items.append(
+                _readiness_item(tier_id, label, "unavailable", f"{blocked} (Offline mode blocks downloads)", None)
+            )
+        else:
+            action = {"kind": "assets.ensure", "assets": missing}
+            items.append(_readiness_item(tier_id, label, "needsDownload", blocked, action))
+    return items
+
+
+def _function_readiness_items(settings: dict[str, Any], providers: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Roll each AI function's CLOUD route up to a key/consent readiness item.
+
+    A function routed to LOCAL (or unrouted -> local-safe default) is ``ready``.
+    A cloud-routed one is ``needsKey`` (no key for the provider), else
+    ``needsConsent`` (key present but the data-type consent is not granted), else
+    ``ready``. Vision checks FRAME consent; every other function checks TEXT.
+    """
+    from .models import consent as _consent  # local: import-light pure gate
+
+    routing = settings.get("routing")
+    per_function = routing.get("perFunction") if isinstance(routing, dict) else None
+    per_function = per_function if isinstance(per_function, dict) else {}
+
+    items: list[dict[str, Any]] = []
+    for function in _READINESS_FUNCTIONS:
+        cap = f"ai.{function}"
+        label = f"AI: {function}"
+        provider_id = _routed_cloud_provider(per_function.get(function))
+        if provider_id is None:
+            items.append(_readiness_item(cap, label, "ready", "", None))
+            continue
+        if not _provider_has_key(provider_id, providers):
+            action = {"kind": "openProviders", "provider": provider_id}
+            items.append(_readiness_item(cap, label, "needsKey", f"no key for provider {provider_id!r}", action))
+            continue
+        granted = (
+            _consent.frame_consent_granted(settings, provider_id)
+            if function == "vision"
+            else _consent.text_consent_granted(settings, provider_id)
+        )
+        if not granted:
+            action = {"kind": "setConsent", "provider": provider_id}
+            items.append(
+                _readiness_item(cap, label, "needsConsent", f"consent not granted for {provider_id!r}", action)
+            )
+            continue
+        items.append(_readiness_item(cap, label, "ready", "", None))
+    return items
+
+
+def _routed_cloud_provider(slot: Any) -> str | None:
+    """The CLOUD provider id a routing slot points at, or None for local/unrouted.
+
+    Returns ``None`` when the slot is absent, malformed, unset, or the LOCAL
+    sentinel (those all run locally — no key/consent needed); otherwise the
+    configured cloud provider id.
+    """
+    if not isinstance(slot, dict):
+        return None
+    provider_id = slot.get("provider")
+    if not isinstance(provider_id, str) or not provider_id or provider_id == _LOCAL_ROUTE:
+        return None
+    return provider_id
+
+
+def _provider_has_key(provider_id: str, providers: list[dict[str, Any]]) -> bool:
+    """True when a configured provider matching ``provider_id`` carries a key.
+
+    Matches on either the entry ``provider`` field or its ``id`` (the routing id
+    may be a friendly id or the canonical provider name). Reads the REDACTED
+    ``providers.list`` view, so it only ever sees key PRESENCE (last-4), never a
+    full key.
+    """
+    for entry in providers:
+        if not isinstance(entry, dict):
+            continue  # pragma: no cover - providers.list yields dicts only
+        ident = {str(entry.get("provider") or ""), str(entry.get("id") or "")}
+        if provider_id in ident:
+            keys = entry.get("apiKeys")
+            if isinstance(keys, list) and any(keys):
+                return True
+    return False
+
+
+def _readiness_item(
+    capability: str, label: str, status: str, blocked_by: str, action: dict[str, Any] | None
+) -> dict[str, Any]:
+    """Build one wire :class:`ReadinessItem` dict (camelCase, JSON-safe)."""
+    return {
+        "capability": capability,
+        "label": label,
+        "status": status,
+        "blockedBy": blocked_by,
+        "action": action,
+    }
+
+
 def _advisor_report_to_wire(report: Any) -> dict[str, Any]:
     """Convert an :class:`AdvisorReport` frozen tree to the camelCase wire dict.
 
@@ -2096,6 +2284,10 @@ def register_all(
     # phase8.* are long jobs (load heavy models behind the phase8 runner seam).
     reg("system.probe", svc.system_probe)
     reg("system.advisor", svc.system_advisor)
+    # WU-8: the unified read-only readiness roll-up (model tiers + per-function
+    # provider key/consent state). Direct (no job): pure installed-state + redacted
+    # settings reads — no provider call, no assets.ensure (the read-only invariant).
+    reg("readiness.summary", svc.readiness_summary)
     reg("asr.engines", svc.asr_engines)
     reg("phase8.signals", svc.phase8_signals)
     reg("phase8.select", svc.phase8_select)

--- a/sidecar/media_studio/job_store.py
+++ b/sidecar/media_studio/job_store.py
@@ -1,0 +1,135 @@
+"""WU-5: an injectable store that persists job records to disk atomically.
+
+This is the only genuinely new substrate in the UX/QoL bundle: ``jobs.py`` is
+100% in-memory (no file I/O), so resumed-after-restart jobs need a place to
+survive a process exit. WU-6 wires this store into ``JobRegistry`` (write-through
+on every status transition) and rehydrates from it at startup; WU-5 ships the
+store alone, fully covered, with no coupling to the registry.
+
+Design:
+
+* :class:`JobStore` is a structural ``Protocol`` (duck-typed seam) so the
+  registry can take any implementation — the real :class:`DiskJobStore` or the
+  test/in-memory :class:`InMemoryJobStore`.
+* :class:`DiskJobStore` writes ONE pretty-JSON file per job under ``root/<jobId>.json``
+  using the project's atomic write pattern (temp file + :func:`os.replace`,
+  mirroring ``library.py``). A crash mid-write leaves either the old file or the
+  new one — never a half-written record — and a stray garbage file is skipped on
+  load rather than bricking startup.
+
+Record shape (the persisted JobInfo+request superset)::
+
+    {jobId, feature, label, videoId, method, params, status, pct,
+     startedAt, finishedAt}
+
+The store treats records as opaque JSON dicts: it requires only a ``jobId`` key
+(the file/identity key) and otherwise round-trips whatever the caller stored.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+from pathlib import Path
+from typing import Any, Protocol, runtime_checkable
+
+from .util import get_logger
+
+log = get_logger("media_studio.job_store")
+
+# A persisted job record. Opaque JSON dict keyed by ``jobId`` (see module docstring).
+JobRecord = dict[str, Any]
+
+
+@runtime_checkable
+class JobStore(Protocol):
+    """The persistence seam the registry depends on (structural / duck-typed).
+
+    Any object exposing these three methods is a valid store; the registry never
+    imports a concrete class, so tests inject :class:`InMemoryJobStore` and the
+    real process injects :class:`DiskJobStore`.
+    """
+
+    def write(self, record: JobRecord) -> None:
+        """Persist ``record`` (keyed by ``record["jobId"]``); a repeat id updates."""
+        ...  # pragma: no cover - Protocol method body is never executed
+
+    def load_all(self) -> list[JobRecord]:
+        """Return every persisted record (order unspecified). ``[]`` when empty."""
+        ...  # pragma: no cover - Protocol method body is never executed
+
+    def delete(self, job_id: str) -> None:
+        """Remove the record for ``job_id`` if present (a no-op when absent)."""
+        ...  # pragma: no cover - Protocol method body is never executed
+
+
+class DiskJobStore:
+    """Persists each job as an atomically-written JSON file under ``root``.
+
+    One file per job (``root/<jobId>.json``) so a single job's update never
+    rewrites the whole index and a corrupt file isolates blast radius to that
+    one job. ``load_all`` skips anything that is not a readable JSON object, so a
+    partial-write crash artifact never prevents the rest from loading.
+    """
+
+    def __init__(self, root: str | os.PathLike[str]):
+        self.root = Path(root)
+
+    def _path(self, job_id: str) -> Path:
+        return self.root / f"{job_id}.json"
+
+    def write(self, record: JobRecord) -> None:
+        """Atomically persist ``record`` to ``root/<jobId>.json`` (temp + rename)."""
+        path = self._path(str(record["jobId"]))
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(record, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, path)
+
+    def load_all(self) -> list[JobRecord]:
+        """Load every well-formed ``*.json`` record under ``root``.
+
+        A non-existent root, a non-JSON / non-object file, or a partial-write
+        artifact is skipped — never fatal — so a crashed write can never brick
+        startup (the WU-5 resilience invariant).
+        """
+        if not self.root.is_dir():
+            return []
+        records: list[JobRecord] = []
+        for path in sorted(self.root.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                log.warning("skipping unreadable job record: %s", path.name)
+                continue
+            if isinstance(data, dict):
+                records.append(data)
+            else:
+                log.warning("skipping non-object job record: %s", path.name)
+        return records
+
+    def delete(self, job_id: str) -> None:
+        """Remove ``root/<jobId>.json`` if it exists (missing id is a no-op)."""
+        self._path(job_id).unlink(missing_ok=True)
+
+
+class InMemoryJobStore:
+    """A dependency-free :class:`JobStore` for tests (parity with the disk store).
+
+    Stores deep copies on both ``write`` and ``load_all`` so callers cannot
+    mutate persisted state through a returned record — matching the disk store,
+    which always re-reads fresh dicts from JSON.
+    """
+
+    def __init__(self) -> None:
+        self._records: dict[str, JobRecord] = {}
+
+    def write(self, record: JobRecord) -> None:
+        self._records[str(record["jobId"])] = copy.deepcopy(record)
+
+    def load_all(self) -> list[JobRecord]:
+        return [copy.deepcopy(r) for r in self._records.values()]
+
+    def delete(self, job_id: str) -> None:
+        self._records.pop(job_id, None)

--- a/sidecar/media_studio/jobs.py
+++ b/sidecar/media_studio/jobs.py
@@ -31,9 +31,14 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Any
 
+from .job_store import JobRecord, JobStore
 from .util import clamp_pct, get_logger
 
 log = get_logger("media_studio.jobs")
+
+# Stored statuses that are NOT terminal — a job left in one of these when the
+# process exited was mid-flight and is rehydrated as INTERRUPTED (WU-6).
+_NON_TERMINAL_WIRE_STATUSES = frozenset({"pending", "running", "queued"})
 
 # A progress sink: receives the jobId, an integer pct (0..100), and a message.
 ProgressEmit = Callable[[str, int, str], None]
@@ -51,10 +56,16 @@ class JobStatus(enum.StrEnum):
     encoder.
 
     CONTRACT-NOTE (A3): JobInfo's wire status set is "queued"|"running"|"done"|
-    "error"|"cancelled". A pool-waiting job is internally PENDING ("pending")
-    and is *mapped* to "queued" in :meth:`Job.info`; we do not add a QUEUED
-    member because the P1 ``job.status`` surface (and its tests) pin "pending"
-    as the pre-run value and the enum's value set as exactly these five.
+    "error"|"cancelled" plus (WU-6) "interrupted". A pool-waiting job is
+    internally PENDING ("pending") and is *mapped* to "queued" in
+    :meth:`Job.info`; we do not add a QUEUED member because the P1
+    ``job.status`` surface (and its tests) pin "pending" as the pre-run value.
+
+    WU-6 widens the value set to SIX by adding INTERRUPTED ("interrupted") —
+    the status given on startup to a job that was ``pending``/``running`` when
+    the process last exited (persisted via the injected JobStore and rehydrated
+    here). Unlike PENDING, INTERRUPTED is a REAL wire value: :meth:`Job.info`
+    emits it unchanged (no mapping), and resumable-job UI keys off it.
     """
 
     PENDING = "pending"
@@ -62,6 +73,7 @@ class JobStatus(enum.StrEnum):
     DONE = "done"
     ERROR = "error"
     CANCELLED = "cancelled"
+    INTERRUPTED = "interrupted"
 
 
 class JobCancelled(Exception):
@@ -197,10 +209,16 @@ class JobRegistry:
         id_prefix: str = "job",
         max_workers: int = 2,
         max_gpu_workers: int = 1,
+        store: JobStore | None = None,
     ) -> None:
         self._emit_progress = emit_progress
         self._emit_done = emit_done
         self._id_prefix = id_prefix
+        # WU-6: optional persistence seam. When ``None`` the registry is purely
+        # in-memory (P1/P2 behavior) so every existing caller keeps working;
+        # when supplied, every create / record_request / status transition is
+        # written through, and :meth:`rehydrate` reloads it at startup.
+        self._store = store
         self._jobs: dict[str, Job] = {}
         self._counter = 0
         self._lock = threading.RLock()
@@ -216,6 +234,34 @@ class JobRegistry:
     def _next_id(self) -> str:
         self._counter += 1
         return f"{self._id_prefix}-{self._counter}"
+
+    # -- persistence write-through (WU-6) -----------------------------------
+
+    @staticmethod
+    def _record_for(job: Job) -> JobRecord:
+        """Build the persisted record for ``job`` (its JobInfo + stored request).
+
+        Superset of JobInfo: adds the originating ``method``/``params`` (the
+        ``job.retry`` source) so a rehydrated shell can re-dispatch. ``videoId``
+        is always present (``None`` when unknown) so the record shape is stable.
+        """
+        record: JobRecord = {
+            "jobId": job.id,
+            "feature": job.feature,
+            "label": job.label,
+            "videoId": job.video_id,
+            "status": job.info()["status"],
+            "pct": job.pct,
+        }
+        if job.request is not None:
+            record["method"] = job.request.get("method")
+            record["params"] = job.request.get("params")
+        return record
+
+    def _persist(self, job: Job) -> None:
+        """Write ``job``'s current record through the store (no-op when absent)."""
+        if self._store is not None:
+            self._store.write(self._record_for(job))
 
     def create(
         self,
@@ -242,6 +288,7 @@ class JobRegistry:
                 gpu=bool(gpu),
             )
             self._jobs[job.id] = job
+            self._persist(job)
             return job
 
     def get(self, job_id: str) -> Job | None:
@@ -279,6 +326,9 @@ class JobRegistry:
         """
         with self._lock:
             job = self._jobs.get(job_id)
+            # First-write-wins guard (P2): a later job.retry dispatch — and a
+            # rehydrated job whose request is already populated (WU-6) — must
+            # not overwrite the real method+params, nor re-write the store.
             if job is None or job.request is not None:
                 return
             job.request = {"method": method, "params": copy.deepcopy(dict(params))}
@@ -290,6 +340,7 @@ class JobRegistry:
                 video_id = params.get("videoId") if isinstance(params, dict) else None
                 if isinstance(video_id, str) and video_id:
                     job.video_id = video_id
+            self._persist(job)
 
     def get_request(self, job_id: str) -> dict[str, Any] | None:
         """Return a copy of the stored ``{"method", "params"}`` (or ``None``)."""
@@ -298,6 +349,68 @@ class JobRegistry:
             if job is None or job.request is None:
                 return None
             return copy.deepcopy(job.request)
+
+    # -- rehydrate (WU-6 startup) -------------------------------------------
+
+    @staticmethod
+    def _rehydrated_noop(ctx: JobContext) -> None:  # pragma: no cover - never run
+        """Placeholder handler for a rehydrated shell.
+
+        A rehydrated job is NEVER auto-spawned (§5 no-silent-spend), so this
+        body never executes; ``job.retry`` re-dispatches from the stored
+        ``request`` via a FRESH handler instead.
+        """
+
+    def rehydrate(self, *, handler: JobHandler | None = None) -> None:
+        """Reload persisted jobs at startup; mark mid-flight jobs INTERRUPTED.
+
+        Recreates a :class:`Job` shell per stored record with its metadata +
+        stored ``{method, params}`` (so the built-in ``job.retry`` can
+        re-dispatch it), maps any non-terminal stored status
+        (``pending``/``running``/``queued``) to :data:`JobStatus.INTERRUPTED`
+        and persists that re-mark, and keeps terminal statuses verbatim. NO job
+        is started here — the pool is untouched (assert run-count 0). A no-op
+        when no store was injected; a record without a ``jobId`` is skipped.
+        ``handler`` overrides the shell handler (tests use it as a tripwire).
+        """
+        if self._store is None:
+            return
+        shell_handler = handler if handler is not None else self._rehydrated_noop
+        max_seen = 0
+        for record in self._store.load_all():
+            job_id = record.get("jobId")
+            if not isinstance(job_id, str) or not job_id:
+                log.warning("rehydrate: skipping record without jobId")
+                continue
+            stored_status = str(record.get("status", ""))
+            interrupted = stored_status in _NON_TERMINAL_WIRE_STATUSES
+            status = JobStatus.INTERRUPTED if interrupted else JobStatus(stored_status)
+            method = record.get("method")
+            params = record.get("params")
+            request = None
+            if isinstance(method, str):
+                request = {"method": method, "params": copy.deepcopy(params) if params is not None else {}}
+            job = Job(
+                id=job_id,
+                handler=shell_handler,
+                status=status,
+                pct=int(record.get("pct", 0) or 0),
+                feature=str(record.get("feature", "") or ""),
+                label=str(record.get("label", "") or ""),
+                video_id=record.get("videoId"),
+                request=request,
+            )
+            with self._lock:
+                self._jobs[job_id] = job
+            if interrupted:
+                # Persist the re-mark so a SECOND restart stays consistent.
+                self._persist(job)
+            suffix = job_id.rsplit("-", 1)[-1]
+            if suffix.isdigit():
+                max_seen = max(max_seen, int(suffix))
+        # New ids must not collide with rehydrated ones.
+        with self._lock:
+            self._counter = max(self._counter, max_seen)
 
     # -- execution ---------------------------------------------------------
 
@@ -384,10 +497,21 @@ class JobRegistry:
 
         return emit
 
+    def _set_status(self, job: Job, new_status: JobStatus) -> None:
+        """The SINGLE status-transition choke-point (WU-6 write-through seam).
+
+        Every status change goes through here so no transition is silently
+        missed by persistence: mutate under the lock, then write the job's
+        record through the store. The four lifecycle sinks (running / done /
+        cancelled / error) all route through this method.
+        """
+        with self._lock:
+            job.status = new_status
+        self._persist(job)
+
     def _run(self, job: Job) -> None:
         try:
-            with self._lock:
-                job.status = JobStatus.RUNNING
+            self._set_status(job, JobStatus.RUNNING)
             ctx = JobContext(
                 job_id=job.id,
                 _cancel_event=job._cancel_event,
@@ -415,15 +539,14 @@ class JobRegistry:
 
     def _finish_done(self, job: Job, result: Any) -> None:
         with self._lock:
-            job.status = JobStatus.DONE
             job.pct = 100
             job.result = result
+        self._set_status(job, JobStatus.DONE)  # one write-through, final pct included
         job._done_event.set()
         self._emit_done(job.id, result)
 
     def _finish_cancelled(self, job: Job) -> None:
-        with self._lock:
-            job.status = JobStatus.CANCELLED
+        self._set_status(job, JobStatus.CANCELLED)
         job._done_event.set()
         # CONTRACT-NOTE: §2 only specifies job.done for *completed* long jobs.
         # We do NOT emit job.done on cancel; the caller learns the outcome via
@@ -431,8 +554,8 @@ class JobRegistry:
 
     def _finish_error(self, job: Job, exc: Exception) -> None:
         with self._lock:
-            job.status = JobStatus.ERROR
             job.error = str(exc)
+        self._set_status(job, JobStatus.ERROR)  # one write-through, error set
         job._done_event.set()
         # Phase-0 spine finding: a failed job MUST notify, or every stdio client
         # (UI panels included) waits on job.done forever and the failure reads

--- a/sidecar/media_studio/library.py
+++ b/sidecar/media_studio/library.py
@@ -114,6 +114,9 @@ class Library:
             "addedAt": v.get("addedAt") or _now_iso(),
             "durationSec": float(v.get("durationSec") or 0.0),
             "hasTranscript": bool(v.get("hasTranscript", False)),
+            # WU-2: additive source-video poster path; "" until library.thumbnail
+            # extracts one. Backfilled here so legacy records load without KeyError.
+            "thumbnailPath": str(v.get("thumbnailPath") or ""),
         }
 
     # ---- public surface (matches library.* methods) ------------------------
@@ -151,6 +154,7 @@ class Library:
             "addedAt": _now_iso(),
             "durationSec": duration,
             "hasTranscript": False,
+            "thumbnailPath": "",  # WU-2: poster filled in by library.thumbnail
         }
         videos.append(video)
         self._save(videos)
@@ -183,6 +187,21 @@ class Library:
         for v in videos:
             if v["id"] == video_id:
                 v["hasTranscript"] = bool(value)
+                result = v
+        if result is not None:
+            self._save(videos)
+        return result
+
+    def set_thumbnail(self, video_id: str, thumbnail_path: str) -> Video | None:
+        """WU-2: set a video's ``thumbnailPath`` and persist; returns the Video.
+
+        Mirrors :meth:`set_has_transcript`. Returns ``None`` for an unknown id.
+        """
+        videos = self._load()
+        result: Video | None = None
+        for v in videos:
+            if v["id"] == video_id:
+                v["thumbnailPath"] = str(thumbnail_path)
                 result = v
         if result is not None:
             self._save(videos)

--- a/sidecar/media_studio/rpc.py
+++ b/sidecar/media_studio/rpc.py
@@ -19,6 +19,7 @@ import threading
 from typing import Any, TextIO
 
 from . import protocol
+from .job_store import JobStore
 from .jobs import JobRegistry
 from .protocol import (
     ErrorCode,
@@ -48,11 +49,16 @@ class RpcServer:
         self,
         instream: TextIO | None = None,
         outstream: TextIO | None = None,
+        *,
+        store: JobStore | None = None,
     ) -> None:
         self._in: TextIO = instream if instream is not None else sys.stdin
         self._out: TextIO = outstream if outstream is not None else sys.stdout
         self._write_lock = threading.Lock()
-        self.jobs = JobRegistry(emit_progress=self._emit_progress, emit_done=self._emit_done)
+        # WU-6: the registry is RpcServer-owned, so the persistence store is
+        # injected here (default None = today's in-memory behavior, back-compat)
+        # and threaded down from the composition root via build_server/main.
+        self.jobs = JobRegistry(emit_progress=self._emit_progress, emit_done=self._emit_done, store=store)
         self.ctx = RpcContext(emit_notification=self._write_obj, jobs=self.jobs)
 
     # -- output ------------------------------------------------------------
@@ -127,21 +133,36 @@ class RpcServer:
         log.info("sidecar rpc server: stdin closed, exiting")
 
 
-def build_server(instream: TextIO | None = None, outstream: TextIO | None = None) -> RpcServer:
+def build_server(
+    instream: TextIO | None = None,
+    outstream: TextIO | None = None,
+    *,
+    store: JobStore | None = None,
+) -> RpcServer:
     """Construct an :class:`RpcServer`. Feature modules register handlers on
-    :data:`protocol.METHODS` at import time before this is called."""
-    return RpcServer(instream=instream, outstream=outstream)
+    :data:`protocol.METHODS` at import time before this is called.
+
+    WU-6: ``store`` (default ``None`` = in-memory) is forwarded to the
+    registry the server constructs so the composition root can supply disk
+    persistence."""
+    return RpcServer(instream=instream, outstream=outstream, store=store)
 
 
-def main(argv: list[str] | None = None) -> int:
+def main(argv: list[str] | None = None, *, store: JobStore | None = None) -> int:
     """Entry point: serve JSON-RPC over real stdio until stdin closes.
 
     CONTRACT-NOTE: feature handlers register themselves via import side effects.
     This core module imports none of them (to stay heavy-ML-free); the assembled
     sidecar entry point is expected to import the feature packages before calling
     ``main`` so their @method registrations land in METHODS.
+
+    WU-6: when a ``store`` is supplied, the server's registry persists through
+    it and is rehydrated once at startup (mid-flight jobs become INTERRUPTED;
+    nothing is auto-spawned — the §5 no-silent-spend invariant).
     """
-    server = build_server()
+    server = build_server(store=store)
+    if store is not None:
+        server.jobs.rehydrate()
     try:
         server.serve()
     except KeyboardInterrupt:  # pragma: no cover - interactive only

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -77,6 +77,22 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     # WU-presets first-run local-vs-cloud chooser (PLAN P1 #6): False until the
     # user picks; while False the routing default is privacy/all-local (no egress).
     "firstRunChoiceMade": False,
+    # ---- UX / QoL bundle (WU-0): additive foundation keys ------------------
+    # The renderer's last-opened source video, restored on launch (WU-13). Empty
+    # until the user opens a video; the restore path tolerates a stale/deleted id.
+    "lastOpenedVideoId": "",
+    # Workspace autosave (WU-11/§autosave): the renderer debounces ``project.save``
+    # while ``enabled``. Pure config — no sidecar behavior beyond this default key.
+    "autosave": {"enabled": True, "debounceMs": 1500},
+    # Export defaults (WU-11): the pre-selected subtitle/NLE formats + fps the
+    # export UI offers first. ``subtitleFormat`` in {srt,vtt,...}; ``nleFormat`` in
+    # {edl,fcpxml,...}; ``nleFps`` the timeline frame rate. Pure data.
+    "exportDefaults": {"subtitleFormat": "srt", "nleFormat": "edl", "nleFps": 30},
+    # Saved export/pipeline presets (WU-10/WU-11): ``presets`` is a name->preset
+    # map; ``active`` is the last-applied preset name. NOTE: ``settings.set`` is a
+    # SHALLOW top-level merge — writing ``savePresets`` REPLACES the whole block,
+    # so WU-10/WU-11 must read-modify-write the full block to preserve ``presets``.
+    "savePresets": {"presets": {}, "active": ""},
 }
 
 # The config file name inside the resolved app config directory.

--- a/sidecar/tests/test_handlers_library_thumbnail.py
+++ b/sidecar/tests/test_handlers_library_thumbnail.py
@@ -1,0 +1,180 @@
+"""WU-2 — ``library.thumbnail`` RPC tests.
+
+Extract a poster from a SOURCE library video by reusing the shorts ffmpeg poster
+engine, persist ``thumbnailPath`` onto the Video, and return it. Idempotent.
+
+The ffmpeg ``run`` seam is FAKED (records the argv + "creates" the output by
+touching it). No real ffmpeg / no subprocess is ever spawned — the heavy body
+lives behind the injected ``ffmpeg_run`` seam, so 100% line+branch needs no
+``# pragma`` here. These tests pin the §WU-2 falsifiable acceptance criteria.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers
+from media_studio.features import shorts as _shorts
+from media_studio.handlers import Services
+from media_studio.protocol import ErrorCode, RpcContext, RpcError
+
+
+class FakeRunner:
+    """A fake ffmpeg ``run`` seam: records each argv and creates the output file.
+
+    Mirrors ``ffmpeg.run(argv, total_sec=...) -> int`` (the same seam
+    ``shorts.thumbnail`` uses). The output path is the argv's LAST element (the
+    poster path), which the fake touches so an idempotence re-check sees it exist.
+    """
+
+    def __init__(self, code: int = 0) -> None:
+        self.code = code
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Any, total_sec: float = 0.0) -> int:
+        self.calls.append(list(argv))
+        if self.code == 0:
+            out = Path(argv[-1])
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_bytes(b"\xff\xd8\xff")  # minimal JPEG marker
+        return self.code
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+@pytest.fixture
+def fake_video(tmp_path: Path) -> Path:
+    p = tmp_path / "src" / "talk.mp4"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x00\x00fakebytes")
+    return p
+
+
+def _make_services(tmp_path: Path, runner: FakeRunner) -> tuple[Services, dict[str, Any]]:
+    svc = Services(
+        data_dir=tmp_path / "data",
+        ffmpeg_run=runner,
+        ffprobe_duration=lambda _p: 0.0,
+    )
+    return svc, {}
+
+
+def test_first_call_invokes_runner_once_with_build_thumbnail_argv(
+    tmp_path: Path, ctx: RpcContext, fake_video: Path
+) -> None:
+    runner = FakeRunner()
+    svc, _ = _make_services(tmp_path, runner)
+    video = svc.library.add(str(fake_video))
+
+    result = svc.library_thumbnail({"id": video["id"]}, ctx)
+
+    out = svc.data_dir / "thumbnails" / f"{video['id']}.jpg"
+    assert result["thumbnailPath"] == str(out)
+    assert len(runner.calls) == 1
+    expected = _shorts.build_thumbnail_argv(video["path"], str(out), svc.settings.get())
+    assert runner.calls[0] == expected
+
+
+def test_second_call_is_idempotent_no_runner_invocation(tmp_path: Path, ctx: RpcContext, fake_video: Path) -> None:
+    runner = FakeRunner()
+    svc, _ = _make_services(tmp_path, runner)
+    video = svc.library.add(str(fake_video))
+
+    first = svc.library_thumbnail({"id": video["id"]}, ctx)
+    second = svc.library_thumbnail({"id": video["id"]}, ctx)
+
+    assert second["thumbnailPath"] == first["thumbnailPath"]
+    assert len(runner.calls) == 1  # second call short-circuits on existing poster
+
+
+def test_returned_path_is_under_data_dir_thumbnails(tmp_path: Path, ctx: RpcContext, fake_video: Path) -> None:
+    runner = FakeRunner()
+    svc, _ = _make_services(tmp_path, runner)
+    video = svc.library.add(str(fake_video))
+
+    result = svc.library_thumbnail({"id": video["id"]}, ctx)
+
+    prefix = str(svc.data_dir / "thumbnails")
+    assert result["thumbnailPath"].startswith(prefix)
+
+
+def test_persists_thumbnail_path_onto_library_video(tmp_path: Path, ctx: RpcContext, fake_video: Path) -> None:
+    runner = FakeRunner()
+    svc, _ = _make_services(tmp_path, runner)
+    video = svc.library.add(str(fake_video))
+
+    result = svc.library_thumbnail({"id": video["id"]}, ctx)
+
+    # Re-list (fresh read from disk) shows the persisted poster path.
+    relisted = next(v for v in svc.library.list() if v["id"] == video["id"])
+    assert relisted["thumbnailPath"] == result["thumbnailPath"]
+
+
+def test_missing_video_id_raises_invalid_params(tmp_path: Path, ctx: RpcContext) -> None:
+    runner = FakeRunner()
+    svc, _ = _make_services(tmp_path, runner)
+
+    with pytest.raises(RpcError) as exc:
+        svc.library_thumbnail({"id": "does-not-exist"}, ctx)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+    assert len(runner.calls) == 0
+
+
+def test_id_param_is_required(tmp_path: Path, ctx: RpcContext) -> None:
+    runner = FakeRunner()
+    svc, _ = _make_services(tmp_path, runner)
+
+    with pytest.raises(RpcError) as exc:
+        svc.library_thumbnail({}, ctx)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+
+
+def test_runner_nonzero_exit_raises_internal_error(tmp_path: Path, ctx: RpcContext, fake_video: Path) -> None:
+    runner = FakeRunner(code=1)
+    svc, _ = _make_services(tmp_path, runner)
+    video = svc.library.add(str(fake_video))
+
+    with pytest.raises(RpcError) as exc:
+        svc.library_thumbnail({"id": video["id"]}, ctx)
+    assert exc.value.code == ErrorCode.INTERNAL_ERROR
+    # On a failed run, nothing is persisted onto the Video.
+    relisted = next(v for v in svc.library.list() if v["id"] == video["id"])
+    assert relisted["thumbnailPath"] == ""
+
+
+def test_uses_default_ffmpeg_run_seam_when_not_injected(
+    tmp_path: Path, ctx: RpcContext, fake_video: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With no injected ffmpeg_run, the handler resolves the default seam lazily.
+    # Patch the module-level default resolver so no real ffmpeg is touched.
+    calls: list[list[str]] = []
+
+    def fake_run(argv: Any, total_sec: float = 0.0) -> int:
+        calls.append(list(argv))
+        out = Path(argv[-1])
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_bytes(b"\xff\xd8\xff")
+        return 0
+
+    monkeypatch.setattr(handlers, "_self_ffmpeg_run", lambda: fake_run)
+    svc = Services(data_dir=tmp_path / "data", ffprobe_duration=lambda _p: 0.0)
+    video = svc.library.add(str(fake_video))
+
+    result = svc.library_thumbnail({"id": video["id"]}, ctx)
+
+    assert len(calls) == 1
+    assert result["thumbnailPath"].endswith(f"{video['id']}.jpg")
+
+
+def test_library_thumbnail_is_registered(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "library.thumbnail" in registered

--- a/sidecar/tests/test_handlers_paths.py
+++ b/sidecar/tests/test_handlers_paths.py
@@ -1,0 +1,97 @@
+"""WU-1 — ``paths.describe`` RPC (read-only data-layout) tests.
+
+The handler returns the resolved on-disk layout so the renderer can SHOW where
+everything lives. It is a pure path-join: no I/O, no secrets, idempotent. These
+tests pin the §WU-1 falsifiable acceptance criteria.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext
+
+
+@pytest.fixture
+def services(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data")
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def test_paths_describe_top_level_dirs_are_children_of_data_dir(services: Services, ctx: RpcContext) -> None:
+    result = services.paths_describe({}, ctx)
+    data_dir = result["dataDir"]
+    assert data_dir == str(services.data_dir)
+    for key in ("projectsDir", "exportsDir", "settingsPath", "libraryPath"):
+        assert result[key].startswith(data_dir + os.sep)
+
+
+def test_paths_describe_projects_dir_matches_services(services: Services, ctx: RpcContext) -> None:
+    result = services.paths_describe({}, ctx)
+    assert result["projectsDir"] == os.path.join(result["dataDir"], "projects")
+    assert result["projectsDir"] == str(services.projects_dir)
+    assert result["exportsDir"] == str(services.exports_dir)
+
+
+def test_paths_describe_settings_and_library_paths(services: Services, ctx: RpcContext) -> None:
+    result = services.paths_describe({}, ctx)
+    assert result["settingsPath"] == str(services.settings.config_path)
+    assert result["libraryPath"] == str(services.library.index_path)
+
+
+def test_paths_describe_subdirs_cover_required_features(services: Services, ctx: RpcContext) -> None:
+    result = services.paths_describe({}, ctx)
+    sub = result["subDirs"]
+    assert {"shorts", "dubs", "stabilized", "audiomix", "trimmed"} <= set(sub)
+    # dubs lives under the data dir; the exports-rooted ones under exports.
+    assert sub["dubs"] == str(services.data_dir / "dubs")
+    assert sub["stabilized"] == str(services.exports_dir / "stabilized")
+    assert sub["audiomix"] == str(services.exports_dir / "audiomix")
+    assert sub["trimmed"] == str(services.exports_dir / "trimmed")
+    assert sub["shorts"] == str(services.exports_dir / "shorts")
+
+
+def test_paths_describe_leaks_no_secrets(services: Services, ctx: RpcContext) -> None:
+    result = services.paths_describe({}, ctx)
+    # No provider/key surface ever rides this read-only layout payload.
+    assert "providers" not in result
+    assert "keys" not in result
+
+    def _walk(obj: Any) -> list[str]:
+        if isinstance(obj, dict):
+            return [s for v in obj.values() for s in _walk(v)]
+        if isinstance(obj, str):
+            return [obj]
+        return []  # pragma: no cover - defensive; payload is str/dict only
+
+    for value in _walk(result):
+        lowered = value.lower()
+        assert "key" not in lowered or "key" in str(services.data_dir).lower()
+        assert "token" not in lowered or "token" in str(services.data_dir).lower()
+
+
+def test_paths_describe_is_idempotent_and_writes_nothing(services: Services, ctx: RpcContext, tmp_path: Path) -> None:
+    # The data dir need not exist for a pure path-join; describe must not create it.
+    assert not services.data_dir.exists()
+    first = services.paths_describe({}, ctx)
+    second = services.paths_describe({}, ctx)
+    assert first == second
+    assert not services.data_dir.exists()
+
+
+def test_paths_describe_is_registered(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "paths.describe" in registered

--- a/sidecar/tests/test_handlers_paths.py
+++ b/sidecar/tests/test_handlers_paths.py
@@ -57,7 +57,10 @@ def test_paths_describe_subdirs_cover_required_features(services: Services, ctx:
     assert sub["stabilized"] == str(services.exports_dir / "stabilized")
     assert sub["audiomix"] == str(services.exports_dir / "audiomix")
     assert sub["trimmed"] == str(services.exports_dir / "trimmed")
-    assert sub["shorts"] == str(services.exports_dir / "shorts")
+    # Shorts are written PER-VIDEO under exports as ``shorts-<videoId>`` (see
+    # register_all's ``out_dir_for=lambda vid: exports_dir / f"shorts-{vid}"``);
+    # there is no flat ``exports_dir/shorts`` dir, so report the honest pattern.
+    assert sub["shorts"] == str(services.exports_dir / "shorts-*")
 
 
 def test_paths_describe_leaks_no_secrets(services: Services, ctx: RpcContext) -> None:

--- a/sidecar/tests/test_handlers_readiness.py
+++ b/sidecar/tests/test_handlers_readiness.py
@@ -1,0 +1,280 @@
+"""WU-8 — ``readiness.summary`` RPC (read-only readiness roll-up) tests.
+
+The handler rolls the three readiness sources (model tiers / providers / consent)
+into ``{items:[{capability, status, blockedBy, action}]}``. It is READ-ONLY: it
+triggers NO download (no ``assets.ensure``) and opens NO socket (no provider call
+ever). These tests pin the §WU-8 falsifiable acceptance criteria, driving every
+status with FAKE seams so no real ffmpeg/model/provider/network is touched.
+
+Model-tier readiness is derived purely from the installed-weight map (the
+``_models_present_map`` seam, overridden here with a pure fake) + Offline mode —
+no hardware probe / dependency-import is consulted, so the statuses are
+deterministic on any machine.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers
+from media_studio.handlers import Services, _missing_tier_assets, _provider_has_key
+from media_studio.protocol import RpcContext
+
+_ALL_MODELS = (
+    "saliency",
+    "audio_saliency",
+    "scene_transnet",
+    "vlm_backbone",
+    "quality_gate",
+    "smolvlm2",
+)
+
+
+def _services(
+    tmp_path: Path,
+    *,
+    settings: dict[str, Any] | None = None,
+    models_present: dict[str, bool] | None = None,
+) -> Services:
+    svc = Services(data_dir=tmp_path / "data")
+    if settings:
+        svc.settings.set(settings)
+    # Override the (AssetManager-backed) installed-state probe with a pure fake so
+    # the test NEVER touches the real manifest/filesystem install probe.
+    present = models_present if models_present is not None else {}
+    svc._models_present_map = lambda _s: dict(present)  # type: ignore[method-assign]
+    return svc
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def _by_cap(result: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {item["capability"]: item for item in result["items"]}
+
+
+# --------------------------------------------------------------------------- #
+# model-tier capabilities
+# --------------------------------------------------------------------------- #
+def test_tier_all_models_present_online_is_ready(tmp_path: Path, ctx: RpcContext) -> None:
+    # Every model weight installed + online -> the multimodal tier is ready.
+    svc = _services(tmp_path, models_present=dict.fromkeys(_ALL_MODELS, True))
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    tier1 = items["tier1-multimodal"]
+    assert tier1["status"] == "ready"
+    assert tier1["blockedBy"] == ""
+    assert tier1["action"] is None
+
+
+def test_tier_missing_weight_online_needs_download(tmp_path: Path, ctx: RpcContext) -> None:
+    # A missing weight + online -> needsDownload with an assets.ensure action.
+    svc = _services(tmp_path, models_present={})
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    tier1 = items["tier1-multimodal"]
+    assert tier1["status"] == "needsDownload"
+    assert tier1["blockedBy"]
+    assert tier1["action"]["kind"] == "assets.ensure"
+    # The action names the missing assets so the panel can target assets.ensure.
+    assert tier1["action"]["assets"]
+
+
+def test_tier_missing_weight_offline_is_unavailable(tmp_path: Path, ctx: RpcContext) -> None:
+    # Offline + a missing weight -> unavailable (download blocked); no action.
+    svc = _services(tmp_path, settings={"offline": True}, models_present={})
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    tier1 = items["tier1-multimodal"]
+    assert tier1["status"] == "unavailable"
+    assert tier1["action"] is None
+
+
+def test_tier0_numeric_is_always_ready(tmp_path: Path, ctx: RpcContext) -> None:
+    # Tier-0 is the zero-download CPU floor: ready even with no weights installed.
+    svc = _services(tmp_path, models_present={})
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["tier0-numeric"]["status"] == "ready"
+    assert items["tier0-numeric"]["action"] is None
+
+
+def test_tier2_only_needs_its_own_model(tmp_path: Path, ctx: RpcContext) -> None:
+    # Tier-2 (smolvlm2 only): present that one weight and it is ready even though
+    # tier-1 weights are missing (per-tier independence is the falsifiable claim).
+    svc = _services(tmp_path, models_present={"smolvlm2": True})
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["tier2-vlm"]["status"] == "ready"
+    assert items["tier1-multimodal"]["status"] == "needsDownload"
+
+
+# --------------------------------------------------------------------------- #
+# provider / function capabilities
+# --------------------------------------------------------------------------- #
+def _cloud_routing(*functions: str) -> dict[str, Any]:
+    fns = functions or ("select", "subtitles", "translation")
+    return {"routing": {"perFunction": {fn: {"provider": "gpt", "fallback": []} for fn in fns}}}
+
+
+def test_function_routed_cloud_no_key_needs_key(tmp_path: Path, ctx: RpcContext) -> None:
+    # A cloud-routed function with no provider key -> needsKey + openProviders.
+    svc = _services(tmp_path, settings=_cloud_routing())
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    sel = items["ai.select"]
+    assert sel["status"] == "needsKey"
+    assert sel["blockedBy"]
+    assert sel["action"]["kind"] == "openProviders"
+
+
+def test_function_routed_cloud_keyed_no_consent_needs_consent(tmp_path: Path, ctx: RpcContext) -> None:
+    # Key present but text consent OFF -> needsConsent + a setConsent action.
+    settings = {
+        **_cloud_routing(),
+        "providers": [{"id": "gpt", "provider": "gpt", "apiKeys": ["sk-real-key"]}],
+        "consent": {"perProvider": {"gpt": {"text": False}}},
+    }
+    svc = _services(tmp_path, settings=settings)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    sel = items["ai.select"]
+    assert sel["status"] == "needsConsent"
+    assert sel["action"]["kind"] == "setConsent"
+    assert sel["action"]["provider"] == "gpt"
+
+
+def test_function_routed_cloud_keyed_and_consented_is_ready(tmp_path: Path, ctx: RpcContext) -> None:
+    settings = {
+        **_cloud_routing(),
+        "providers": [{"id": "gpt", "provider": "gpt", "apiKeys": ["sk-real-key"]}],
+        "consent": {"perProvider": {"gpt": {"text": True}}},
+    }
+    svc = _services(tmp_path, settings=settings)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["ai.select"]["status"] == "ready"
+    assert items["ai.select"]["action"] is None
+
+
+def test_function_routed_local_is_ready_without_key(tmp_path: Path, ctx: RpcContext) -> None:
+    # A function routed to LOCAL needs neither key nor consent -> ready.
+    settings = {"routing": {"perFunction": {"select": {"provider": "local", "fallback": []}}}}
+    svc = _services(tmp_path, settings=settings)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["ai.select"]["status"] == "ready"
+
+
+def test_function_unrouted_defaults_local_ready(tmp_path: Path, ctx: RpcContext) -> None:
+    # No routing at all -> every function is the local-safe default -> ready.
+    svc = _services(tmp_path)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    for fn in ("select", "subtitles", "translation", "vision", "editPlan"):
+        assert items[f"ai.{fn}"]["status"] == "ready"
+        assert items[f"ai.{fn}"]["action"] is None
+
+
+def test_vision_function_uses_frame_consent(tmp_path: Path, ctx: RpcContext) -> None:
+    # The vision function checks FRAME consent (not text); frames OFF -> needsConsent.
+    settings = {
+        "routing": {"perFunction": {"vision": {"provider": "gpt", "fallback": []}}},
+        "providers": [{"id": "gpt", "provider": "gpt", "apiKeys": ["sk-real-key"]}],
+        "consent": {"perProvider": {"gpt": {"frames": False, "text": True}}},
+    }
+    svc = _services(tmp_path, settings=settings)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["ai.vision"]["status"] == "needsConsent"
+
+
+def test_provider_entry_keyed_by_provider_field_or_id(tmp_path: Path, ctx: RpcContext) -> None:
+    # A provider whose key match is on the "provider" field (id differs) still
+    # resolves its key + consent (the lookup tolerates either identifier).
+    settings = {
+        "routing": {"perFunction": {"select": {"provider": "gpt", "fallback": []}}},
+        "providers": [{"id": "my-openai", "provider": "gpt", "apiKeys": ["sk-real-key"]}],
+        "consent": {"perProvider": {"gpt": {"text": True}}},
+    }
+    svc = _services(tmp_path, settings=settings)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["ai.select"]["status"] == "ready"
+
+
+def test_provider_empty_keys_list_needs_key(tmp_path: Path, ctx: RpcContext) -> None:
+    # An entry present but with an empty apiKeys list still counts as no key.
+    settings = {
+        **_cloud_routing("select"),
+        "providers": [{"id": "gpt", "provider": "gpt", "apiKeys": []}],
+    }
+    svc = _services(tmp_path, settings=settings)
+    items = _by_cap(svc.readiness_summary({}, ctx))
+    assert items["ai.select"]["status"] == "needsKey"
+
+
+# --------------------------------------------------------------------------- #
+# read-only invariants + registration
+# --------------------------------------------------------------------------- #
+def test_summary_makes_no_provider_or_ensure_call(tmp_path: Path, ctx: RpcContext) -> None:
+    # The read-only invariant: a provider seam wired to EXPLODE is never invoked,
+    # and the data dir is never created (no asset ensured/downloaded).
+    def _boom(*_a: Any, **_k: Any) -> Any:  # pragma: no cover - must never run
+        raise AssertionError("readiness.summary must not call a provider")
+
+    settings = {
+        **_cloud_routing(),
+        "providers": [{"id": "gpt", "provider": "gpt", "apiKeys": ["sk-real-key"]}],
+        "consent": {"perProvider": {"gpt": {"text": True}}},
+    }
+    svc = _services(tmp_path, settings=settings)
+    svc._provider = _boom  # any provider use would explode
+    result = svc.readiness_summary({}, ctx)
+    assert result["items"]  # produced a roll-up without ever touching the provider
+    assert not (svc.data_dir / "models").exists()
+
+
+def test_summary_leaks_no_full_key(tmp_path: Path, ctx: RpcContext) -> None:
+    settings = {
+        **_cloud_routing(),
+        "providers": [{"id": "gpt", "provider": "gpt", "apiKeys": ["sk-super-secret-full-key"]}],
+        "consent": {"perProvider": {"gpt": {"text": True}}},
+    }
+    svc = _services(tmp_path, settings=settings)
+    result = svc.readiness_summary({}, ctx)
+
+    def _walk(obj: Any) -> list[str]:
+        if isinstance(obj, dict):
+            return [s for v in obj.values() for s in _walk(v)]
+        if isinstance(obj, list):
+            return [s for v in obj for s in _walk(v)]
+        if isinstance(obj, str):
+            return [obj]
+        return []  # pragma: no cover - defensive; payload is str/dict/list only
+
+    for value in _walk(result):
+        assert "sk-super-secret-full-key" not in value
+
+
+def test_missing_tier_assets_dedups_and_skips_assetless(tmp_path: Path, ctx: RpcContext) -> None:
+    # ``aesthetic`` and ``vlm_backbone`` SHARE the SigLIP-2 asset, and ``motion``
+    # is a zero-download floor with no asset: a tier mixing them collapses the
+    # shared asset to ONE name and skips the asset-less component entirely.
+    missing = _missing_tier_assets(("vlm_backbone", "aesthetic", "motion"), {})
+    assert missing == ["siglip2-so400m"]
+    # When the shared weight IS installed, nothing is reported missing.
+    assert _missing_tier_assets(("vlm_backbone", "aesthetic"), {"vlm_backbone": True, "aesthetic": True}) == []
+
+
+def test_provider_has_key_skips_non_matching_entries(tmp_path: Path, ctx: RpcContext) -> None:
+    # A list whose FIRST entry does not match the routed id: the loop must walk
+    # past it and find the key on the matching second entry.
+    providers = [
+        {"id": "other", "provider": "claude", "apiKeys": ["sk-other"]},
+        {"id": "gpt", "provider": "gpt", "apiKeys": ["sk-real-key"]},
+    ]
+    assert _provider_has_key("gpt", providers) is True
+    # No entry matches at all -> no key.
+    assert _provider_has_key("absent", providers) is False
+
+
+def test_readiness_summary_is_registered(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "readiness.summary" in registered

--- a/sidecar/tests/test_handlers_save_presets.py
+++ b/sidecar/tests/test_handlers_save_presets.py
@@ -1,0 +1,193 @@
+"""WU-10 handlers: ``savePresets.list/apply/upsert/remove``.
+
+A named ``{autosave, exportDefaults}`` bundle persisted under the ``savePresets``
+settings key. Mirrors ``providers.applyPreset`` (resolve -> persist to settings)
+but stores user-named bundles rather than routing presets.
+
+The settings ``set`` is a SHALLOW top-level merge (``settings_store.py``: writing
+``savePresets`` REPLACES the whole block), so every handler read-modify-writes the
+full ``savePresets`` block to preserve ``presets`` and ``active``. Tests pin the
+blind-merge invariant (sibling keys untouched), the missing-name error, and the
+remove-active branch.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio import handlers as H
+from media_studio import protocol
+
+
+def _ctx() -> Any:
+    return protocol.RpcContext(emit_notification=lambda _msg: None, jobs=None)
+
+
+def _svc(tmp_path: Any) -> H.Services:
+    return H.Services(data_dir=str(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# Registration
+# --------------------------------------------------------------------------- #
+
+
+def test_save_presets_handlers_registered(tmp_path: Any) -> None:
+    registered: dict[str, Any] = {}
+    H.register_all(_svc(tmp_path), register=lambda name, fn: registered.__setitem__(name, fn))
+    assert "savePresets.list" in registered
+    assert "savePresets.apply" in registered
+    assert "savePresets.upsert" in registered
+    assert "savePresets.remove" in registered
+
+
+# --------------------------------------------------------------------------- #
+# list
+# --------------------------------------------------------------------------- #
+
+
+def test_list_empty_default(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    out = svc.save_presets_list({}, _ctx())
+    assert out == {"presets": {}, "active": ""}
+
+
+# --------------------------------------------------------------------------- #
+# upsert
+# --------------------------------------------------------------------------- #
+
+
+def test_upsert_creates_named_bundle(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    autosave = {"enabled": False, "debounceMs": 500}
+    export_defaults = {"subtitleFormat": "vtt", "nleFormat": "fcpxml", "nleFps": 24}
+    out = svc.save_presets_upsert({"name": "a", "autosave": autosave, "exportDefaults": export_defaults}, _ctx())
+    assert out["presets"]["a"]["autosave"] == autosave
+    assert out["presets"]["a"]["exportDefaults"] == export_defaults
+    # Round-trips through list.
+    listed = svc.save_presets_list({}, _ctx())
+    assert listed["presets"]["a"]["autosave"] == autosave
+
+
+def test_upsert_omitted_fields_default_to_empty(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    out = svc.save_presets_upsert({"name": "bare"}, _ctx())
+    assert out["presets"]["bare"] == {"autosave": {}, "exportDefaults": {}}
+
+
+def test_upsert_updates_existing_in_place(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    svc.save_presets_upsert({"name": "a", "autosave": {"enabled": True}}, _ctx())
+    out = svc.save_presets_upsert({"name": "a", "autosave": {"enabled": False}}, _ctx())
+    # One entry, updated (not duplicated).
+    assert list(out["presets"].keys()) == ["a"]
+    assert out["presets"]["a"]["autosave"] == {"enabled": False}
+
+
+def test_upsert_preserves_siblings(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    svc.save_presets_upsert({"name": "a", "autosave": {"enabled": True}}, _ctx())
+    svc.save_presets_upsert({"name": "b", "autosave": {"enabled": False}}, _ctx())
+    out = svc.save_presets_list({}, _ctx())
+    assert set(out["presets"].keys()) == {"a", "b"}
+
+
+def test_upsert_missing_name_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.save_presets_upsert({}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# apply
+# --------------------------------------------------------------------------- #
+
+
+def test_apply_sets_active_and_returns_preset(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    autosave = {"enabled": True, "debounceMs": 1000}
+    svc.save_presets_upsert({"name": "a", "autosave": autosave}, _ctx())
+    out = svc.save_presets_apply({"name": "a"}, _ctx())
+    assert out["active"] == "a"
+    assert out["savePreset"]["autosave"] == autosave
+    # Persisted.
+    assert svc.save_presets_list({}, _ctx())["active"] == "a"
+
+
+def test_apply_missing_name_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.save_presets_apply({}, _ctx())
+
+
+def test_apply_unknown_preset_is_a_typed_error(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.save_presets_apply({"name": "missing"}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# remove
+# --------------------------------------------------------------------------- #
+
+
+def test_remove_drops_preset(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    svc.save_presets_upsert({"name": "a"}, _ctx())
+    svc.save_presets_upsert({"name": "b"}, _ctx())
+    out = svc.save_presets_remove({"name": "a"}, _ctx())
+    assert set(out["presets"].keys()) == {"b"}
+
+
+def test_remove_active_resets_active(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    svc.save_presets_upsert({"name": "a"}, _ctx())
+    svc.save_presets_apply({"name": "a"}, _ctx())
+    out = svc.save_presets_remove({"name": "a"}, _ctx())
+    assert out["active"] == ""
+    assert "a" not in out["presets"]
+
+
+def test_remove_non_active_keeps_active(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    svc.save_presets_upsert({"name": "a"}, _ctx())
+    svc.save_presets_upsert({"name": "b"}, _ctx())
+    svc.save_presets_apply({"name": "a"}, _ctx())
+    out = svc.save_presets_remove({"name": "b"}, _ctx())
+    assert out["active"] == "a"
+    assert set(out["presets"].keys()) == {"a"}
+
+
+def test_remove_missing_name_is_invalid(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.save_presets_remove({}, _ctx())
+
+
+def test_remove_unknown_preset_is_a_typed_error(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    with pytest.raises(protocol.RpcError):
+        svc.save_presets_remove({"name": "ghost"}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# Blind-merge invariant: sibling settings keys survive a savePresets write.
+# --------------------------------------------------------------------------- #
+
+
+def test_save_presets_write_preserves_sibling_settings(tmp_path: Any) -> None:
+    svc = _svc(tmp_path)
+    svc.settings.set({"lastOpenedVideoId": "vid-42"})
+    svc.save_presets_upsert({"name": "a", "autosave": {"enabled": True}}, _ctx())
+    # The unrelated sibling key is untouched by the savePresets block replace.
+    assert svc.settings.get()["lastOpenedVideoId"] == "vid-42"
+
+
+def test_save_presets_block_handles_corrupt_existing_block(tmp_path: Any) -> None:
+    # Defensive: a non-dict ``savePresets`` (corrupt settings) is treated as empty.
+    svc = _svc(tmp_path)
+    svc.settings.set({"savePresets": "garbage"})
+    out = svc.save_presets_upsert({"name": "a"}, _ctx())
+    assert out["presets"]["a"] == {"autosave": {}, "exportDefaults": {}}
+    assert svc.save_presets_list({}, _ctx())["active"] == ""

--- a/sidecar/tests/test_job_store.py
+++ b/sidecar/tests/test_job_store.py
@@ -1,0 +1,187 @@
+"""Tests for the WU-5 JobStore substrate (atomic per-job disk persistence).
+
+The store is the only genuinely new substrate in the UX/QoL bundle (jobs.py is
+100% in-memory today). These tests pin the falsifiable acceptance from
+docs/plans/ux-qol/PLAN.md WU-5:
+
+* ``write(r)`` then ``load_all()`` round-trips field-for-field;
+* a second ``write`` with the same ``jobId`` UPDATES (one file, not a duplicate);
+* a corrupt JSON file in the root is SKIPPED (a partial-write crash never bricks
+  startup) — the falsifiable resilience claim;
+* ``load_all()`` on a non-existent root returns ``[]`` (no crash on first run);
+* the write is atomic (temp file + rename, no partial file left behind);
+* ``InMemoryJobStore`` is parity-tested against the same contract.
+
+Using a REAL tmp dir for ``DiskJobStore`` is legitimate here: the filesystem IS
+the unit under test (no ffmpeg / network / provider is touched).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.job_store import DiskJobStore, InMemoryJobStore, JobStore
+
+
+def _record(job_id: str = "job-1", **overrides: Any) -> dict[str, Any]:
+    """A full WU-5 job record (the persisted shape)."""
+    rec: dict[str, Any] = {
+        "jobId": job_id,
+        "feature": "transcribe",
+        "label": "Transcribe clip",
+        "videoId": "vid-42",
+        "method": "ai.transcribe",
+        "params": {"videoId": "vid-42", "lang": "en"},
+        "status": "running",
+        "pct": 37,
+        "startedAt": "2026-06-20T04:00:00Z",
+        "finishedAt": None,
+    }
+    rec.update(overrides)
+    return rec
+
+
+# --------------------------------------------------------------------------- #
+# Parametrize across both implementations so the CONTRACT is enforced on both. #
+# --------------------------------------------------------------------------- #
+def _make_disk(tmp_path: Path) -> JobStore:
+    return DiskJobStore(tmp_path / "jobs")
+
+
+def _make_mem(tmp_path: Path) -> JobStore:  # tmp_path unused; signature parity
+    return InMemoryJobStore()
+
+
+@pytest.fixture(params=[_make_disk, _make_mem], ids=["disk", "memory"])
+def store(request: pytest.FixtureRequest, tmp_path: Path) -> JobStore:
+    return request.param(tmp_path)
+
+
+def test_write_then_load_all_round_trips_field_for_field(store: JobStore) -> None:
+    rec = _record()
+    store.write(rec)
+    loaded = store.load_all()
+    assert loaded == [rec]
+
+
+def test_second_write_same_job_id_updates_not_duplicates(store: JobStore) -> None:
+    store.write(_record(status="running", pct=10))
+    store.write(_record(status="done", pct=100, finishedAt="2026-06-20T04:05:00Z"))
+    loaded = store.load_all()
+    assert len(loaded) == 1
+    assert loaded[0]["status"] == "done"
+    assert loaded[0]["pct"] == 100
+    assert loaded[0]["finishedAt"] == "2026-06-20T04:05:00Z"
+
+
+def test_load_all_returns_all_distinct_jobs(store: JobStore) -> None:
+    store.write(_record("job-a"))
+    store.write(_record("job-b"))
+    ids = sorted(r["jobId"] for r in store.load_all())
+    assert ids == ["job-a", "job-b"]
+
+
+def test_load_all_on_empty_store_returns_empty_list(store: JobStore) -> None:
+    assert store.load_all() == []
+
+
+def test_delete_removes_the_record(store: JobStore) -> None:
+    store.write(_record("job-a"))
+    store.write(_record("job-b"))
+    store.delete("job-a")
+    ids = [r["jobId"] for r in store.load_all()]
+    assert ids == ["job-b"]
+
+
+def test_delete_missing_job_is_a_no_op(store: JobStore) -> None:
+    store.write(_record("job-a"))
+    store.delete("does-not-exist")  # must not raise
+    assert [r["jobId"] for r in store.load_all()] == ["job-a"]
+
+
+# --------------------------------------------------------------------------- #
+# DiskJobStore-specific behaviour (atomicity, corruption resilience, layout).  #
+# --------------------------------------------------------------------------- #
+def test_disk_load_all_on_nonexistent_root_returns_empty(tmp_path: Path) -> None:
+    store = DiskJobStore(tmp_path / "never-created")
+    assert store.load_all() == []
+
+
+def test_disk_write_creates_the_root_dir(tmp_path: Path) -> None:
+    root = tmp_path / "jobs"
+    assert not root.exists()
+    DiskJobStore(root).write(_record())
+    assert root.is_dir()
+
+
+def test_disk_write_leaves_no_temp_file(tmp_path: Path) -> None:
+    root = tmp_path / "jobs"
+    store = DiskJobStore(root)
+    store.write(_record("job-a"))
+    # Only the final per-job JSON file remains; no .tmp residue (atomic rename).
+    names = sorted(p.name for p in root.iterdir())
+    assert names == ["job-a.json"]
+
+
+def test_disk_corrupt_file_is_skipped_not_fatal(tmp_path: Path) -> None:
+    root = tmp_path / "jobs"
+    store = DiskJobStore(root)
+    store.write(_record("good"))
+    # Simulate a partial-write / garbage file crash artifact.
+    (root / "broken.json").write_text("{ this is not json", encoding="utf-8")
+    loaded = store.load_all()
+    assert [r["jobId"] for r in loaded] == ["good"]
+
+
+def test_disk_non_json_files_in_root_are_ignored(tmp_path: Path) -> None:
+    root = tmp_path / "jobs"
+    store = DiskJobStore(root)
+    store.write(_record("good"))
+    # A stray temp/other file must not be parsed as a record.
+    (root / "good.json.tmp").write_text("garbage", encoding="utf-8")
+    (root / "README.txt").write_text("notes", encoding="utf-8")
+    assert [r["jobId"] for r in store.load_all()] == ["good"]
+
+
+def test_disk_non_dict_json_record_is_skipped(tmp_path: Path) -> None:
+    root = tmp_path / "jobs"
+    store = DiskJobStore(root)
+    store.write(_record("good"))
+    # A syntactically-valid JSON file whose top level is not an object.
+    (root / "list.json").write_text("[1, 2, 3]", encoding="utf-8")
+    assert [r["jobId"] for r in store.load_all()] == ["good"]
+
+
+def test_disk_record_is_persisted_as_indented_json(tmp_path: Path) -> None:
+    root = tmp_path / "jobs"
+    DiskJobStore(root).write(_record("job-a"))
+    text = (root / "job-a.json").read_text(encoding="utf-8")
+    assert '"jobId": "job-a"' in text  # pretty, key-spaced (indent=2)
+
+
+def test_disk_root_accepts_str_path(tmp_path: Path) -> None:
+    # The constructor coerces str | PathLike to Path.
+    store = DiskJobStore(str(tmp_path / "jobs"))
+    store.write(_record("job-a"))
+    assert [r["jobId"] for r in store.load_all()] == ["job-a"]
+
+
+def test_in_memory_returns_independent_copies(tmp_path: Path) -> None:
+    # Mutating a returned record must not corrupt the store's state (parity with
+    # the disk store, which always re-reads from JSON).
+    store = InMemoryJobStore()
+    store.write(_record("job-a", pct=10))
+    loaded = store.load_all()
+    loaded[0]["pct"] = 999
+    assert store.load_all()[0]["pct"] == 10
+
+
+def test_in_memory_write_copies_input_record(tmp_path: Path) -> None:
+    # Mutating the caller's record after write must not change stored state.
+    store = InMemoryJobStore()
+    rec = _record("job-a", pct=10)
+    store.write(rec)
+    rec["pct"] = 999
+    assert store.load_all()[0]["pct"] == 10

--- a/sidecar/tests/test_jobs.py
+++ b/sidecar/tests/test_jobs.py
@@ -31,12 +31,14 @@ def test_jobstatus_is_str_and_values_are_stable():
     # Inherits from str so it serializes straight into JSON-RPC payloads.
     assert JobStatus.RUNNING == "running"
     assert JobStatus.DONE.value == "done"
+    # WU-6 widened the wire status set from five to six (adds "interrupted").
     assert {s.value for s in JobStatus} == {
         "pending",
         "running",
         "done",
         "error",
         "cancelled",
+        "interrupted",
     }
 
 

--- a/sidecar/tests/test_jobs_persistence.py
+++ b/sidecar/tests/test_jobs_persistence.py
@@ -1,0 +1,321 @@
+"""WU-6: JobRegistry write-through + rehydrate + INTERRUPTED status.
+
+These tests pin the persistence seam introduced in WU-6: the registry
+writes a job record through an injected :class:`JobStore` on create, on the
+chosen ``record_request`` path, and on each of the four status transitions
+(routed through one ``_set_status`` choke-point); and on startup ``rehydrate``
+re-reads the store, marking non-terminal stored jobs ``INTERRUPTED`` while
+keeping terminal statuses verbatim — never auto-spawning anything.
+
+Heavy-ML-free: handlers are plain callables; the store is the WU-5
+:class:`InMemoryJobStore`.
+"""
+
+from __future__ import annotations
+
+import threading
+
+import pytest
+from media_studio.job_store import InMemoryJobStore
+from media_studio.jobs import Job, JobRegistry, JobStatus
+
+
+@pytest.fixture()
+def store() -> InMemoryJobStore:
+    return InMemoryJobStore()
+
+
+@pytest.fixture()
+def reg(emit_sinks, store) -> JobRegistry:
+    ep, ed = emit_sinks
+    return JobRegistry(emit_progress=ep, emit_done=ed, store=store)
+
+
+# -- INTERRUPTED status / contract -----------------------------------------
+
+
+def test_jobstatus_value_set_is_exactly_six_with_interrupted():
+    # WU-6 widens the wire status set from five to six (adds "interrupted").
+    assert {s.value for s in JobStatus} == {
+        "pending",
+        "running",
+        "done",
+        "error",
+        "cancelled",
+        "interrupted",
+    }
+    assert JobStatus.INTERRUPTED.value == "interrupted"
+
+
+def test_interrupted_is_a_real_wire_value_in_info():
+    # Unlike PENDING (mapped to "queued"), INTERRUPTED emits unchanged.
+    job = Job(id="job-1", handler=lambda ctx: None, status=JobStatus.INTERRUPTED)
+    assert job.info()["status"] == "interrupted"
+    assert job.snapshot()["status"] == "interrupted"
+
+
+# -- write-through ----------------------------------------------------------
+
+
+def test_create_writes_through_to_store(reg, store):
+    job = reg.create(lambda ctx: None, feature="transcribe", label="t", videoId="v1")
+    records = store.load_all()
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["jobId"] == job.id
+    assert rec["status"] == "queued"  # PENDING maps to the wire "queued"
+    assert rec["feature"] == "transcribe"
+    assert rec["videoId"] == "v1"
+
+
+def test_record_request_writes_through_method_and_params(reg, store):
+    job = reg.create(lambda ctx: None)
+    reg.record_request(job.id, "transcribe.start", {"videoId": "v9"})
+    rec = next(r for r in store.load_all() if r["jobId"] == job.id)
+    assert rec["method"] == "transcribe.start"
+    assert rec["params"] == {"videoId": "v9"}
+
+
+def test_each_status_transition_writes_through_exactly_once(emit_sinks):
+    # One store.write per transition (the choke-point routes all four sinks).
+    writes: list[tuple[str, str]] = []
+
+    class CountingStore:
+        def write(self, record):
+            writes.append((record["jobId"], record["status"]))
+
+        def load_all(self):
+            return []
+
+        def delete(self, job_id):
+            pass
+
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=CountingStore())
+
+    # DONE transition.
+    done = reg.start(lambda ctx: "ok")
+    done.wait(2.0)
+    # ERROR transition.
+    err = reg.start(lambda ctx: (_ for _ in ()).throw(RuntimeError("boom")))
+    err.wait(2.0)
+    reg.join(2.0)
+
+    done_writes = [s for (jid, s) in writes if jid == done.id]
+    err_writes = [s for (jid, s) in writes if jid == err.id]
+    # create -> running -> done  (3 writes, exactly one "running" + one "done")
+    assert done_writes.count("running") == 1
+    assert done_writes.count("done") == 1
+    # create -> running -> error
+    assert err_writes.count("running") == 1
+    assert err_writes.count("error") == 1
+
+
+def test_cancelled_transition_writes_through(emit_sinks, store):
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store, max_workers=1)
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow(ctx):
+        started.set()
+        release.wait(2.0)
+        ctx.raise_if_cancelled()
+
+    job = reg.start(slow)
+    started.wait(2.0)
+    reg.cancel(job.id)
+    release.set()
+    reg.join(2.0)
+    rec = next(r for r in store.load_all() if r["jobId"] == job.id)
+    assert rec["status"] == "cancelled"
+
+
+def test_no_store_is_in_memory_noop(emit_sinks):
+    # Back-compat: default store=None means zero persistence side effects.
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed)  # no store
+    job = reg.start(lambda ctx: "ok")
+    job.wait(2.0)
+    reg.join(2.0)
+    assert job.status is JobStatus.DONE  # ran fine without a store
+
+
+# -- rehydrate --------------------------------------------------------------
+
+
+def test_rehydrate_marks_non_terminal_interrupted_and_keeps_terminal(emit_sinks):
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "a.x", "params": {}})
+    store.write({"jobId": "job-2", "status": "pending", "method": "b.y", "params": {}})
+    store.write({"jobId": "job-3", "status": "done", "method": "c.z", "params": {}})
+    store.write({"jobId": "job-4", "status": "error", "method": "d.w", "params": {}})
+    store.write({"jobId": "job-5", "status": "cancelled", "method": "e.v", "params": {}})
+
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+
+    assert reg.get("job-1").status is JobStatus.INTERRUPTED
+    assert reg.get("job-2").status is JobStatus.INTERRUPTED
+    assert reg.get("job-3").status is JobStatus.DONE
+    assert reg.get("job-4").status is JobStatus.ERROR
+    assert reg.get("job-5").status is JobStatus.CANCELLED
+
+
+def test_rehydrate_restores_request_for_retry(emit_sinks):
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "transcribe.start", "params": {"videoId": "v3"}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    assert reg.get_request("job-1") == {"method": "transcribe.start", "params": {"videoId": "v3"}}
+
+
+def test_rehydrate_restores_metadata(emit_sinks):
+    store = InMemoryJobStore()
+    store.write(
+        {
+            "jobId": "job-7",
+            "status": "running",
+            "feature": "convert",
+            "label": "Convert clip",
+            "videoId": "v8",
+            "method": "convert.start",
+            "params": {"videoId": "v8"},
+        }
+    )
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    info = reg.get("job-7").info()
+    assert info["feature"] == "convert"
+    assert info["label"] == "Convert clip"
+    assert info["videoId"] == "v8"
+
+
+def test_rehydrate_does_not_autospawn(emit_sinks):
+    # §5 no-silent-spend: a rehydrated interrupted job NEVER runs on rehydrate.
+    ran = threading.Event()
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "a.x", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    # Replace the handler the shell would run with a tripwire — it must NOT fire.
+    reg.rehydrate(handler=lambda ctx: ran.set())
+    reg.join(0.2)
+    assert not ran.is_set()
+    assert reg._running_count == 0  # pool never spun up
+
+
+def test_rehydrate_writes_back_interrupted_status(emit_sinks):
+    # The interrupted re-mark is persisted so a second restart stays consistent.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "a.x", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    rec = next(r for r in store.load_all() if r["jobId"] == "job-1")
+    assert rec["status"] == "interrupted"
+
+
+def test_rehydrate_terminal_not_rewritten(emit_sinks):
+    # Terminal records keep their status and are not needlessly re-written.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "done", "method": "a.x", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    rec = next(r for r in store.load_all() if r["jobId"] == "job-1")
+    assert rec["status"] == "done"
+
+
+def test_rehydrate_skips_records_without_jobid(emit_sinks):
+    # A malformed record (no jobId) is skipped, not fatal.
+    class BadStore:
+        def load_all(self):
+            return [{"status": "running"}, {"jobId": "job-9", "status": "done", "method": "a", "params": {}}]
+
+        def write(self, record):
+            pass
+
+        def delete(self, job_id):
+            pass
+
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=BadStore())
+    reg.rehydrate()
+    assert reg.get("job-9") is not None
+    assert len(reg.all()) == 1
+
+
+def test_rehydrate_record_without_method_has_no_request(emit_sinks):
+    # A record missing "method" rehydrates a shell with no stored request
+    # (job.retry has nothing to re-dispatch — get_request returns None).
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running"})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    assert reg.get("job-1").status is JobStatus.INTERRUPTED
+    assert reg.get_request("job-1") is None
+
+
+def test_rehydrate_method_without_params_defaults_to_empty(emit_sinks):
+    # A record with a method but no params rehydrates with params == {}.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "a.x"})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    assert reg.get_request("job-1") == {"method": "a.x", "params": {}}
+
+
+def test_rehydrate_non_numeric_id_does_not_advance_counter(emit_sinks):
+    # An id whose suffix is not a number is tolerated; the counter is unmoved.
+    store = InMemoryJobStore()
+    store.write({"jobId": "custom-job", "status": "done", "method": "a.x", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    assert reg.get("custom-job") is not None
+    fresh = reg.create(lambda ctx: None)
+    assert fresh.id == "job-1"  # counter never advanced past the non-numeric id
+
+
+def test_rehydrate_without_store_is_noop(emit_sinks):
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed)  # no store
+    reg.rehydrate()  # must not raise
+    assert reg.all() == {}
+
+
+def test_rehydrate_counter_skips_past_existing_ids(emit_sinks):
+    # New jobs created after rehydrate must not collide with rehydrated ids.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-5", "status": "done", "method": "a.x", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    fresh = reg.create(lambda ctx: None)
+    assert fresh.id != "job-5"
+    assert int(fresh.id.split("-")[1]) > 5
+
+
+# -- record_request x rehydrate guard interaction --------------------------
+
+
+def test_record_request_after_rehydrate_does_not_clobber_or_rewrite(emit_sinks):
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "transcribe.start", "params": {"videoId": "v3"}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    # First-write-wins guard: a rehydrated job already has request set, so a
+    # later record_request must NOT overwrite the stored {method, params}.
+    reg.record_request("job-1", "job.retry", {"jobId": "job-1"})
+    assert reg.get_request("job-1") == {"method": "transcribe.start", "params": {"videoId": "v3"}}
+    # A genuinely new job still records fine through the same path.
+    new = reg.create(lambda ctx: None)
+    reg.record_request(new.id, "convert.start", {"videoId": "v2"})
+    assert reg.get_request(new.id) == {"method": "convert.start", "params": {"videoId": "v2"}}

--- a/sidecar/tests/test_library.py
+++ b/sidecar/tests/test_library.py
@@ -46,6 +46,7 @@ def test_add_returns_full_video_schema(lib: Library, fake_video: Path):
         "addedAt",
         "durationSec",
         "hasTranscript",
+        "thumbnailPath",  # WU-2: additive Video field (default "")
     }
     assert v["durationSec"] == 123.5
     assert v["hasTranscript"] is False
@@ -169,6 +170,62 @@ def test_normalize_backfills_legacy_entries(tmp_path: Path):
     assert v["addedAt"]  # generated
     assert v["durationSec"] == 0.0
     assert v["hasTranscript"] is False
+
+
+# --------------------------------------------------------------------------- #
+# WU-2: thumbnailPath (additive Video field) + set_thumbnail setter
+# --------------------------------------------------------------------------- #
+def test_add_includes_thumbnail_path_default_empty(lib: Library, fake_video: Path):
+    # A freshly added Video carries the additive thumbnailPath, defaulting to "".
+    v = lib.add(str(fake_video))
+    assert v["thumbnailPath"] == ""
+
+
+def test_normalize_backfills_missing_thumbnail_path(tmp_path: Path):
+    # A legacy Video record with NO thumbnailPath loads as "" (no KeyError).
+    idx = tmp_path / "idx.json"
+    idx.write_text(json.dumps({"version": 1, "videos": [{"path": "/x.mp4"}]}), encoding="utf-8")
+    lib = Library(idx)
+    assert lib.list()[0]["thumbnailPath"] == ""
+
+
+def test_normalize_preserves_existing_thumbnail_path(tmp_path: Path):
+    # A stored thumbnailPath survives the normalize round-trip.
+    idx = tmp_path / "idx.json"
+    idx.write_text(
+        json.dumps({"version": 1, "videos": [{"path": "/x.mp4", "thumbnailPath": "/p/t.jpg"}]}),
+        encoding="utf-8",
+    )
+    lib = Library(idx)
+    assert lib.list()[0]["thumbnailPath"] == "/p/t.jpg"
+
+
+def test_set_thumbnail_persists_and_returns_video(lib: Library, fake_video: Path):
+    v = lib.add(str(fake_video))
+    updated = lib.set_thumbnail(v["id"], "/posters/x.jpg")
+    assert updated is not None
+    assert updated["thumbnailPath"] == "/posters/x.jpg"
+    # Persisted: a fresh re-read of the index shows the poster path.
+    again = Library(lib.index_path, probe_duration=lambda _p: 0.0)
+    assert again.get(v["id"])["thumbnailPath"] == "/posters/x.jpg"
+
+
+def test_set_thumbnail_unknown_id_returns_none(lib: Library):
+    assert lib.set_thumbnail("nope", "/p/t.jpg") is None
+
+
+def test_set_thumbnail_skips_non_matching_rows(lib: Library, tmp_path: Path):
+    # Two videos: setting one must skip the other in the loop.
+    a = tmp_path / "a.mp4"
+    a.write_bytes(b"a")
+    b = tmp_path / "b.mp4"
+    b.write_bytes(b"b")
+    va = lib.add(str(a))
+    vb = lib.add(str(b))
+    updated = lib.set_thumbnail(vb["id"], "/p/b.jpg")
+    assert updated["id"] == vb["id"]
+    assert lib.get(va["id"])["thumbnailPath"] == ""
+    assert lib.get(vb["id"])["thumbnailPath"] == "/p/b.jpg"
 
 
 def test_default_probe_uses_ffmpeg_lazy(monkeypatch, tmp_path: Path, fake_video: Path):

--- a/sidecar/tests/test_main_entrypoint.py
+++ b/sidecar/tests/test_main_entrypoint.py
@@ -10,23 +10,36 @@ JSON-RPC server or touching numpy/cv2/etc.
 from __future__ import annotations
 
 import sys
+from pathlib import Path
+from types import SimpleNamespace
 
 import media_studio.__main__ as entry
+from media_studio.job_store import DiskJobStore
 
 
-def test_main_composes_and_delegates_to_rpc_main(monkeypatch):
-    """main(): runs both pre-serve guards, registers all handlers, then returns
-    rpc.main(argv)'s exit code."""
+def test_main_composes_and_delegates_to_rpc_main(monkeypatch, tmp_path):
+    """main(): runs both pre-serve guards, registers all handlers, builds a
+    DiskJobStore rooted at the returned Services.data_dir/jobs, and forwards it
+    into rpc.main(argv) — returning rpc.main's exit code (WU-6 composition seam).
+    """
     calls: list[str] = []
 
     monkeypatch.setattr(entry, "_suppress_windows_error_dialogs", lambda: calls.append("suppress"))
     monkeypatch.setattr(entry, "_preimport_native_modules", lambda: calls.append("preimport"))
-    monkeypatch.setattr(entry.handlers, "register_all", lambda: calls.append("register"))
+
+    fake_svc = SimpleNamespace(data_dir=tmp_path)
+
+    def fake_register_all():
+        calls.append("register")
+        return fake_svc
+
+    monkeypatch.setattr(entry.handlers, "register_all", fake_register_all)
 
     captured = {}
 
-    def fake_rpc_main(argv=None):
+    def fake_rpc_main(argv=None, *, store=None):
         captured["argv"] = argv
+        captured["store"] = store
         return 0
 
     monkeypatch.setattr(entry.rpc, "main", fake_rpc_main)
@@ -36,13 +49,17 @@ def test_main_composes_and_delegates_to_rpc_main(monkeypatch):
     # ordering: guards FIRST, then registration, then serve
     assert calls == ["suppress", "preimport", "register"]
     assert captured["argv"] == ["--flag"]
+    # the composition seam carries data_dir: a DiskJobStore at data_dir/jobs
+    store = captured["store"]
+    assert isinstance(store, DiskJobStore)
+    assert store.root == Path(tmp_path) / "jobs"
 
 
-def test_main_propagates_rpc_exit_code(monkeypatch):
+def test_main_propagates_rpc_exit_code(monkeypatch, tmp_path):
     monkeypatch.setattr(entry, "_suppress_windows_error_dialogs", lambda: None)
     monkeypatch.setattr(entry, "_preimport_native_modules", lambda: None)
-    monkeypatch.setattr(entry.handlers, "register_all", lambda: None)
-    monkeypatch.setattr(entry.rpc, "main", lambda argv=None: 130)
+    monkeypatch.setattr(entry.handlers, "register_all", lambda: SimpleNamespace(data_dir=tmp_path))
+    monkeypatch.setattr(entry.rpc, "main", lambda argv=None, *, store=None: 130)
     assert entry.main() == 130
 
 

--- a/sidecar/tests/test_rpc.py
+++ b/sidecar/tests/test_rpc.py
@@ -516,6 +516,50 @@ def test_build_server_returns_rpcserver():
     assert server._out is outstream
 
 
+def test_rpcserver_carries_injected_store(monkeypatch):
+    # WU-6: a store injected into RpcServer reaches the owned JobRegistry.
+    import io
+
+    from media_studio.job_store import InMemoryJobStore
+
+    store = InMemoryJobStore()
+    server = RpcServer(instream=io.StringIO(""), outstream=io.StringIO(), store=store)
+    assert server.jobs._store is store
+    # write-through actually goes to the injected store
+    server.jobs.create(lambda ctx: None)
+    assert len(store.load_all()) == 1
+
+
+def test_build_server_forwards_store():
+    import io
+
+    from media_studio.job_store import InMemoryJobStore
+    from media_studio.rpc import build_server
+
+    store = InMemoryJobStore()
+    server = build_server(instream=io.StringIO(""), outstream=io.StringIO(), store=store)
+    assert server.jobs._store is store
+
+
+def test_main_rehydrates_when_store_supplied(monkeypatch):
+    # WU-6: rpc.main with a store rehydrates the registry once before serving.
+    import io
+
+    from media_studio import rpc as rpc_mod
+    from media_studio.job_store import InMemoryJobStore
+
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "a.x", "params": {}})
+
+    built = RpcServer(instream=io.StringIO(""), outstream=io.StringIO(), store=store)
+    monkeypatch.setattr(rpc_mod, "build_server", lambda *, store=None: built)
+    assert rpc_mod.main(store=store) == 0
+    # the running job was rehydrated as INTERRUPTED (never auto-spawned)
+    from media_studio.jobs import JobStatus
+
+    assert built.jobs.get("job-1").status is JobStatus.INTERRUPTED
+
+
 def test_main_serves_until_stdin_closes(monkeypatch):
     # main() builds a server and serves until EOF, returning 0. build_server is
     # stubbed so no real stdio is touched.
@@ -526,7 +570,8 @@ def test_main_serves_until_stdin_closes(monkeypatch):
     streams_in = io.StringIO('{"jsonrpc":"2.0","id":1,"method":"ping"}\n')
     streams_out = io.StringIO()
     built = RpcServer(instream=streams_in, outstream=streams_out)
-    monkeypatch.setattr(rpc_mod, "build_server", lambda: built)
+    # WU-6: main() now forwards a (possibly None) store kwarg to build_server.
+    monkeypatch.setattr(rpc_mod, "build_server", lambda *, store=None: built)
     assert rpc_mod.main() == 0
     lines = [line for line in streams_out.getvalue().splitlines() if line.strip()]
     assert len(lines) == 1
@@ -542,7 +587,7 @@ def test_main_returns_130_on_keyboard_interrupt(monkeypatch):
         def serve(self) -> None:
             raise KeyboardInterrupt
 
-    def _build():
+    def _build(*, store=None):
         return _Interrupting(instream=io.StringIO(""), outstream=io.StringIO())
 
     monkeypatch.setattr(rpc_mod, "build_server", _build)

--- a/sidecar/tests/test_settings_store.py
+++ b/sidecar/tests/test_settings_store.py
@@ -215,3 +215,59 @@ def test_get_tolerates_non_list_providers(tmp_path: Path) -> None:
     path.write_text(json.dumps({"providers": "not-a-list"}), encoding="utf-8")
     store = SettingsStore(path)
     assert store.get()["providers"] == "not-a-list"
+
+
+# --------------------------------------------------------------------------- #
+# WU-0 (ux-qol): additive QoL defaults + merge behavior the downstream WUs rely on
+# --------------------------------------------------------------------------- #
+def test_qol_defaults_present_exact(store: SettingsStore) -> None:
+    """The four additive WU-0 keys land with their EXACT documented defaults."""
+    out = store.get()
+    assert out["lastOpenedVideoId"] == ""
+    assert out["autosave"] == {"enabled": True, "debounceMs": 1500}
+    assert out["exportDefaults"] == {"subtitleFormat": "srt", "nleFormat": "edl", "nleFps": 30}
+    assert out["savePresets"] == {"presets": {}, "active": ""}
+
+
+def test_export_defaults_exact_acceptance(store: SettingsStore) -> None:
+    """Acceptance pin: DEFAULT_SETTINGS['exportDefaults'] is exactly the §spec dict."""
+    assert DEFAULT_SETTINGS["exportDefaults"] == {
+        "subtitleFormat": "srt",
+        "nleFormat": "edl",
+        "nleFps": 30,
+    }
+
+
+def test_qol_keys_round_trip(store: SettingsStore) -> None:
+    """A scalar QoL key persists through the blind merge without disturbing siblings."""
+    store.set({"lastOpenedVideoId": "vid-42"})
+    out = store.get()
+    assert out["lastOpenedVideoId"] == "vid-42"
+    # Siblings remain at their defaults (untouched).
+    assert out["autosave"] == {"enabled": True, "debounceMs": 1500}
+    assert out["savePresets"] == {"presets": {}, "active": ""}
+
+
+def test_save_presets_set_is_shallow_replace_not_deep_merge(store: SettingsStore) -> None:
+    """settings.set is a SHALLOW dict.update merge (settings_store.py:167-182).
+
+    Setting savePresets to a partial block REPLACES the whole block — `presets`
+    is NOT preserved. This pins the REAL behavior (do not assume deep merge): a
+    caller that wants to keep `presets` must send the full block. This is the
+    contract WU-10/WU-11 must honor when they read/write savePresets.
+    """
+    store.set({"savePresets": {"presets": {"p1": {"x": 1}}, "active": "p1"}})
+    # A partial update with only `active` overwrites the entire savePresets block.
+    store.set({"savePresets": {"active": "p2"}})
+    out = store.get()
+    assert out["savePresets"] == {"active": "p2"}
+    assert "presets" not in out["savePresets"]
+
+
+def test_autosave_partial_set_round_trips(store: SettingsStore) -> None:
+    """Setting autosave round-trips; like savePresets, it is a shallow replace."""
+    store.set({"autosave": {"enabled": False}})
+    out = store.get()
+    assert out["autosave"] == {"enabled": False}
+    # Other top-level QoL keys are untouched by the shallow top-level merge.
+    assert out["exportDefaults"] == {"subtitleFormat": "srt", "nleFormat": "edl", "nleFps": 30}


### PR DESCRIPTION
## Summary

UX/QoL feature track delivering save/resume, save-options (presets), availability/readiness surfacing, and library/model thumbnails across the Python sidecar + Electron renderer. 15 work units (WU-0 … WU-14), 20 commits, branched off `main` at `9a114e9`.

## Work Units

- **WU-0** — additive QoL settings defaults + renderer type scaffold
- **WU-1** — `paths.describe` read-only data-layout RPC
- **WU-2** — `library.thumbnail` RPC + `Video.thumbnailPath`
- **WU-3** — `thumb:` mstream resolver branch for library posters
- **WU-4** — `useVideoThumbnail` hook + `thumb:` poster URL
- **WU-5** — `JobStore` + atomic disk job persistence
- **WU-6** — `JobRegistry` write-through + rehydrate + `INTERRUPTED` status
- **WU-7** — `JobInfo` interrupted status + `canResume` + Resume button
- **WU-8** — `readiness.summary` RPC + `readinessMeta.ts`
- **WU-9** — `ReadinessBadge` component + `readinessBadge.css`
- **WU-10** — `savePresets.*` RPC (list/apply/upsert/remove)
- **WU-11** — `SavePresetsControls` + `useAutosave` + savePresets client
- **WU-12** — `PathsPanel` renderer (data-layout view + change-root + open-folder)
- **WU-13** — App `lastOpenedVideoId` persist on `openVideo` + async restore on launch
- **WU-14** — wire thumbnails + readiness roll-up into library + model panels

## Hub envelope alignment

This track rides the Hub AI-Job envelope/pool/consent/budget contract — the readiness/availability and job save-resume surfaces sit on the same AI-job envelope, pool, consent, and budget model as the rest of the app (no divergent job lifecycle introduced).

## Validation (full real gate, run authoritatively at tip c901c43)

- **sidecar tests + coverage:** 3082 passed, 100.00% line+branch coverage (`pytest --cov=media_studio --cov-branch --cov-fail-under=100`)
- **renderer tests + coverage:** 1234 passed (67 files), 100% statements/branches/functions/lines (`vitest run --coverage`, thresholds 100)
- **lint/format:** ruff check + ruff format --check (sidecar) clean; biome 2.5.0 format + oxlint --deny-warnings (app) clean
- **types:** basedpyright 0 errors; tsc --noEmit (app) clean; tsc -p . --noEmit (render-cli) clean

## Merge-time note

These four QoL/feature branches each branched off `main` independently and each touches `handlers.register_all` in `sidecar/media_studio/handlers.py`. That is a merge-time integration concern (handler registration ordering/conflict), not a defect in this branch — this branch's own gate is fully green.