### PR TITLE
feat: Repurpose — batch queue + templates + multi-platform presets (12 WUs)

### DIFF
--- a/app/renderer/src/App.quality.test.tsx
+++ b/app/renderer/src/App.quality.test.tsx
@@ -15,6 +15,7 @@ import type { Video, ShortReexportHint } from './lib/rpc';
 // ---- mocks -----------------------------------------------------------------
 const rpcMock = vi.fn();
 const libraryListMock = vi.fn();
+const batchListMock = vi.fn((..._a: unknown[]) => Promise.resolve({ batches: [] as never[] }));
 // hasApi is controllable per test (the foundation of the bridge-present/absent
 // branches in the quality hydrate, changeQuality, and handleReexport guards).
 let hasApiValue = true;
@@ -24,7 +25,12 @@ vi.mock('./lib/rpc', () => ({
   hasApi: () => hasApiValue,
   client: {
     library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    batch: { list: (...a: unknown[]) => batchListMock(...a) },
   },
+}));
+
+vi.mock('./views/Repurpose', () => ({
+  Repurpose: () => <div data-testid="repurpose" />,
 }));
 
 // Stub child views/chrome so the test focuses on App's own logic.

--- a/app/renderer/src/App.test.tsx
+++ b/app/renderer/src/App.test.tsx
@@ -17,12 +17,14 @@ import type { Video, ShortReexportHint } from './lib/rpc';
 // controllable and no real bridge is needed.
 const rpcMock = vi.fn();
 const libraryListMock = vi.fn();
+const batchListMock = vi.fn();
 
 vi.mock('./lib/rpc', () => ({
   rpc: (...a: unknown[]) => rpcMock(...a),
   hasApi: () => true,
   client: {
     library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    batch: { list: (...a: unknown[]) => batchListMock(...a) },
   },
 }));
 
@@ -79,6 +81,13 @@ vi.mock('./panels/ModelsSystemPanel', () => ({
   default: () => <div data-testid="models" />,
 }));
 
+// Stub the Repurpose view; expose the resumeId App wired in (it owns its tests).
+vi.mock('./views/Repurpose', () => ({
+  Repurpose: ({ resumeId }: { resumeId?: string }) => (
+    <div data-testid="repurpose" data-resume={resumeId ?? ''} />
+  ),
+}));
+
 // Stub the always-mounted chrome so the test focuses on routing.
 vi.mock('./components/JobQueue', () => ({ JobQueue: () => <div /> }));
 vi.mock('./components/SidecarBanner', () => ({ SidecarBanner: () => <div /> }));
@@ -104,6 +113,8 @@ beforeEach(() => {
   rpcMock.mockReset();
   rpcMock.mockResolvedValue({}); // settings.get / settings.set
   libraryListMock.mockReset();
+  batchListMock.mockReset();
+  batchListMock.mockResolvedValue({ batches: [] });
   openVideoSpy.mockReset();
   reexportSpy.mockReset();
   container = document.createElement('div');
@@ -245,5 +256,90 @@ describe('App route switch', () => {
 
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+  });
+
+  it('navigates to the Repurpose view via the header nav (no badge when none incomplete)', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    expect(nav('Repurpose')).toBeTruthy();
+
+    await act(async () => {
+      nav('Repurpose').click();
+    });
+    await flush();
+
+    const view = container.querySelector('[data-testid="repurpose"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-resume')).toBe('');
+    expect(nav('Repurpose').classList.contains('is-active')).toBe(true);
+    expect(container.querySelector('[data-testid="library"]')).toBeNull();
+  });
+
+  it('shows a (N) badge + a resume toast for an incomplete batch, deep-linking on Resume', async () => {
+    batchListMock.mockResolvedValue({
+      batches: [
+        {
+          id: 'b9',
+          name: 'Season 3',
+          templateId: 't1',
+          status: 'partial',
+          createdAt: 5,
+          counts: {
+            total: 30,
+            done: 12,
+            error: 0,
+            skipped: 2,
+            queued: 16,
+            running: 0,
+            cancelled: 0,
+          },
+        },
+      ],
+    });
+
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    expect(nav('Repurpose (1)')).toBeTruthy();
+
+    expect(document.body.textContent).toContain("A batch ('Season 3') was interrupted");
+    expect(document.body.textContent).toContain('16 of 30 sources left');
+
+    const resumeBtn = Array.from(
+      document.body.querySelectorAll<HTMLButtonElement>('.toast__action'),
+    ).find((b) => b.textContent === 'Resume');
+    expect(resumeBtn).toBeTruthy();
+    await act(async () => {
+      resumeBtn!.click();
+    });
+    await flush();
+
+    const view = container.querySelector('[data-testid="repurpose"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-resume')).toBe('b9');
+  });
+
+  it('ignores a late batch.list result after the nav unmounts (cancelled guard)', async () => {
+    let resolveList: (v: { batches: never[] }) => void = () => {};
+    batchListMock.mockReturnValue(
+      new Promise((res) => {
+        resolveList = res;
+      }),
+    );
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    act(() => root.unmount());
+    await act(async () => {
+      resolveList({ batches: [] });
+      await Promise.resolve();
+    });
+    root = createRoot(container);
   });
 });

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -10,7 +10,10 @@ import React, { Suspense, lazy, useCallback, useEffect, useState } from 'react';
 import { Library } from './views/Library';
 import { Workspace } from './views/Workspace';
 import { Shorts } from './views/Shorts';
+import { Repurpose } from './views/Repurpose';
 import { SystemHealth } from './features/SystemHealth';
+import { incompleteBatches, remainingCount } from './features/repurposeLogic';
+import { useToast } from './components/toast/useToast';
 // Phase-8 "Models & System" panel (lazy: it pulls the model-card grid + onboarding).
 const ModelsSystemPanel = lazy(() => import('./panels/ModelsSystemPanel'));
 import { client, hasApi, rpc, type ShortReexportHint, type Video } from './lib/rpc';
@@ -37,6 +40,8 @@ type Route =
   | { name: 'workspace'; video: Video }
   // P4 §6 / C11: the global generated-shorts gallery (across all videos).
   | { name: 'shorts' }
+  // WU11: the Repurpose surface (batch queue / templates / export presets).
+  | { name: 'repurpose'; resumeId?: string }
   // system-advanced: the app-global System Health diagnostic screen.
   | { name: 'health' }
   // Phase-8: the app-global "Models & System" graphics-settings panel.
@@ -70,6 +75,63 @@ function QualityToggle({
         Cloud
       </button>
     </div>
+  );
+}
+
+/**
+ * The Repurpose nav button + resume-surface (§7.2). On launch it reads
+ * `batch.list` (cheap, store-only) and renders a text `(N)` badge in the tab
+ * label for incomplete batches (SR-readable, not color-only), plus a one-time
+ * dismissible toast deep-linking into the oldest interrupted batch.
+ */
+function RepurposeNav({
+  active,
+  onOpen,
+}: {
+  active: boolean;
+  onOpen: (resumeId?: string) => void;
+}): React.ReactElement {
+  const [badge, setBadge] = useState(0);
+  const toast = useToast();
+  const toastedRef = React.useRef(false);
+
+  useEffect(() => {
+    if (!hasApi()) return;
+    let cancelled = false;
+    void client.batch
+      .list()
+      .then(({ batches }) => {
+        if (cancelled) return;
+        const incomplete = incompleteBatches(batches);
+        setBadge(incomplete.length);
+        if (incomplete.length > 0 && !toastedRef.current) {
+          toastedRef.current = true;
+          const first = incomplete[0];
+          const left = remainingCount(first.counts);
+          toast.info(
+            `A batch ('${first.name}') was interrupted — ${left} of ${first.counts.total} sources left.`,
+            { action: { label: 'Resume', onClick: () => onOpen(first.id) } },
+          );
+        }
+      })
+      .catch(() => {
+        // best-effort: no badge/toast if the read fails.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [toast, onOpen]);
+
+  const label = badge > 0 ? `Repurpose (${badge})` : 'Repurpose';
+  return (
+    <button
+      type="button"
+      className={`app__nav-btn${active ? ' is-active' : ''}`}
+      aria-current={active ? 'page' : undefined}
+      onClick={() => onOpen()}
+    >
+      {label}
+    </button>
   );
 }
 
@@ -119,6 +181,11 @@ export function App(): React.ReactElement {
     setRoute({ name: 'shorts' });
   }, []);
 
+  // WU11: the top-level Repurpose nav (optionally deep-linking a resume).
+  const openRepurpose = useCallback((resumeId?: string) => {
+    setRoute({ name: 'repurpose', resumeId });
+  }, []);
+
   // system-advanced: the top-level System Health nav.
   const openHealth = useCallback(() => {
     setRoute({ name: 'health' });
@@ -153,6 +220,8 @@ export function App(): React.ReactElement {
         return <Workspace video={route.video} onBack={backToLibrary} />;
       case 'shorts':
         return <Shorts onReexport={(hint) => void handleReexport(hint)} />;
+      case 'repurpose':
+        return <Repurpose resumeId={route.resumeId} />;
       case 'health':
         return <SystemHealth />;
       case 'models':
@@ -190,6 +259,7 @@ export function App(): React.ReactElement {
             >
               Shorts
             </button>
+            <RepurposeNav active={route.name === 'repurpose'} onOpen={openRepurpose} />
             <button
               type="button"
               className={`app__nav-btn${route.name === 'health' ? ' is-active' : ''}`}

--- a/app/renderer/src/features/BatchConsentCard.test.tsx
+++ b/app/renderer/src/features/BatchConsentCard.test.tsx
@@ -1,0 +1,176 @@
+// BatchConsentCard.test.tsx — pre-run consent summary + visible skip (§9.1).
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { BatchConsentCard } from './BatchConsentCard';
+import type { BatchConsent } from '../lib/rpc';
+
+let container: HTMLElement;
+let root: Root;
+
+function render(ui: React.ReactElement): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const CONSENT: BatchConsent = {
+  decisions: [
+    {
+      videoId: 'v1',
+      action: 'run',
+      skipReason: null,
+      confirmBudget: 'k1',
+      willEgress: true,
+      cacheHit: false,
+    },
+    {
+      videoId: 'v2',
+      action: 'skip',
+      skipReason: 'would egress — not acknowledged',
+      confirmBudget: null,
+      willEgress: true,
+      cacheHit: false,
+    },
+  ],
+  willRun: 1,
+  willSkip: 1,
+  costEst: { usd: 0.2 },
+  budget: { usd: 5 },
+};
+
+const titleFor = (id: string): string => (id === 'v2' ? 'Episode Two' : id);
+
+describe('BatchConsentCard', () => {
+  it('shows the run/skip split', () => {
+    render(
+      <BatchConsentCard
+        consent={CONSENT}
+        confirmCloudBudget
+        acknowledged={false}
+        onAcknowledge={vi.fn()}
+        titleFor={titleFor}
+      />,
+    );
+    expect(container.textContent).toContain('1 of 2 sources will run; 1 skipped');
+  });
+
+  it('names each skipped source with its reason (visible skip, §9.1)', () => {
+    render(
+      <BatchConsentCard
+        consent={CONSENT}
+        confirmCloudBudget
+        acknowledged={false}
+        onAcknowledge={vi.fn()}
+        titleFor={titleFor}
+      />,
+    );
+    const skip = container.querySelector('.batch-consent__skip');
+    expect(skip?.textContent).toContain('Episode Two');
+    expect(skip?.textContent).toContain('would egress — not acknowledged');
+  });
+
+  it('falls back to a generic reason when skipReason is null', () => {
+    const consent: BatchConsent = {
+      ...CONSENT,
+      decisions: [
+        {
+          videoId: 'v3',
+          action: 'skip',
+          skipReason: null,
+          confirmBudget: null,
+          willEgress: true,
+          cacheHit: false,
+        },
+      ],
+      willRun: 0,
+      willSkip: 1,
+    };
+    render(
+      <BatchConsentCard
+        consent={consent}
+        confirmCloudBudget
+        acknowledged={false}
+        onAcknowledge={vi.fn()}
+        titleFor={titleFor}
+      />,
+    );
+    expect(container.querySelector('.batch-consent__skip-reason')?.textContent).toContain(
+      'skipped',
+    );
+  });
+
+  it('omits the skip section when nothing is skipped', () => {
+    const consent: BatchConsent = { ...CONSENT, decisions: [CONSENT.decisions[0]], willSkip: 0 };
+    render(
+      <BatchConsentCard
+        consent={consent}
+        confirmCloudBudget
+        acknowledged={false}
+        onAcknowledge={vi.fn()}
+        titleFor={titleFor}
+      />,
+    );
+    expect(container.querySelector('.batch-consent__skips')).toBeNull();
+  });
+
+  it('the ack button fires onAcknowledge and reflects pressed state', () => {
+    const onAck = vi.fn();
+    render(
+      <BatchConsentCard
+        consent={CONSENT}
+        confirmCloudBudget
+        acknowledged={false}
+        onAcknowledge={onAck}
+        titleFor={titleFor}
+      />,
+    );
+    const btn = container.querySelector('.batch-consent__ack') as HTMLButtonElement;
+    expect(btn.getAttribute('aria-pressed')).toBe('false');
+    act(() => btn.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    expect(onAck).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the acknowledged state (disabled, pressed)', () => {
+    render(
+      <BatchConsentCard
+        consent={CONSENT}
+        confirmCloudBudget
+        acknowledged
+        onAcknowledge={vi.fn()}
+        titleFor={titleFor}
+      />,
+    );
+    const btn = container.querySelector('.batch-consent__ack') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-pressed')).toBe('true');
+    expect(container.querySelector('.batch-consent__hint')).toBeNull();
+  });
+
+  it('is informational only when confirmCloudBudget is off (no ack control)', () => {
+    render(
+      <BatchConsentCard
+        consent={CONSENT}
+        confirmCloudBudget={false}
+        acknowledged={false}
+        onAcknowledge={vi.fn()}
+        titleFor={titleFor}
+      />,
+    );
+    expect(container.querySelector('.batch-consent__ack')).toBeNull();
+    expect(container.querySelector('.batch-consent__info')?.textContent).toContain(
+      'all sources run',
+    );
+  });
+});

--- a/app/renderer/src/features/BatchConsentCard.tsx
+++ b/app/renderer/src/features/BatchConsentCard.tsx
@@ -1,0 +1,84 @@
+// BatchConsentCard.tsx — the pre-run batch consent summary (DESIGN §9 / §9.1).
+//
+// Rendered BEFORE batch.start from the pure `plan_consent` surface (zero provider
+// calls). Shows the N-run / K-skip split, the per-source egress/cache-hit flags,
+// the named skip list WITH reasons (visible-skip contract §9.1 — a skipped source
+// is attributed, never silently absent), and a single "Acknowledge cloud egress"
+// control. When `confirmCloudBudget` is OFF the card is informational only and
+// requires no ack (all sources run).
+//
+// Pure presentational: the parent owns the consent data + the ack/run RPCs.
+import React from 'react';
+import type { BatchConsent } from '../lib/rpc';
+
+export interface BatchConsentCardProps {
+  consent: BatchConsent;
+  /** Whether the per-call budget gate is on (drives ack requirement). */
+  confirmCloudBudget: boolean;
+  /** Whether the user has acknowledged cloud egress for this batch. */
+  acknowledged: boolean;
+  onAcknowledge: () => void;
+  /** Map a videoId to a display title (falls back to the id). */
+  titleFor: (videoId: string) => string;
+}
+
+/** The batch consent summary card (run/skip split + named, attributed skips). */
+export function BatchConsentCard({
+  consent,
+  confirmCloudBudget,
+  acknowledged,
+  onAcknowledge,
+  titleFor,
+}: BatchConsentCardProps): React.ReactElement {
+  const skips = consent.decisions.filter((d) => d.action === 'skip');
+  const ackNeeded = confirmCloudBudget && !acknowledged;
+
+  return (
+    <section className="batch-consent" aria-label="Cloud egress consent">
+      <h3 className="batch-consent__title">Before this batch runs</h3>
+      <p className="batch-consent__split">
+        {consent.willRun} of {consent.willRun + consent.willSkip} sources will run;{' '}
+        {consent.willSkip} skipped
+      </p>
+
+      {skips.length > 0 ? (
+        <div className="batch-consent__skips">
+          <h4 className="batch-consent__skips-title">Skipped sources</h4>
+          <ul>
+            {skips.map((d) => (
+              <li key={d.videoId} className="batch-consent__skip">
+                <span className="batch-consent__skip-title">{titleFor(d.videoId)}</span>
+                <span className="batch-consent__skip-reason"> — {d.skipReason ?? 'skipped'}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      {confirmCloudBudget ? (
+        <button
+          type="button"
+          className="batch-consent__ack"
+          aria-pressed={acknowledged}
+          disabled={acknowledged}
+          onClick={onAcknowledge}
+        >
+          {acknowledged ? 'Cloud egress acknowledged' : 'Acknowledge cloud egress for this batch'}
+        </button>
+      ) : (
+        <p className="batch-consent__info">
+          No cloud-budget confirmation needed — all sources run.
+        </p>
+      )}
+
+      {ackNeeded ? (
+        <p className="batch-consent__hint" role="note">
+          Acknowledge egress to run the cloud sources; otherwise they are skipped (and re-runnable
+          later).
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+export default BatchConsentCard;

--- a/app/renderer/src/features/BatchQueue.test.tsx
+++ b/app/renderer/src/features/BatchQueue.test.tsx
@@ -1,0 +1,508 @@
+// BatchQueue.test.tsx — the primary folder→shorts flow + live a11y + resume.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { BatchState, BatchSummary, ProgressEvent, Template, Video } from '../lib/rpc';
+
+const libListMock = vi.fn();
+const tmplListMock = vi.fn();
+const batchListMock = vi.fn();
+const batchCreateMock = vi.fn();
+const batchStartMock = vi.fn();
+const batchStatusMock = vi.fn();
+const batchResumeMock = vi.fn();
+
+let progressCbs: Array<(e: ProgressEvent) => void> = [];
+let doneCbs: Array<() => void> = [];
+
+vi.mock('../lib/rpc', () => ({
+  client: {
+    library: { list: (...a: unknown[]) => libListMock(...a) },
+    templates: { list: (...a: unknown[]) => tmplListMock(...a) },
+    batch: {
+      list: (...a: unknown[]) => batchListMock(...a),
+      create: (...a: unknown[]) => batchCreateMock(...a),
+      start: (...a: unknown[]) => batchStartMock(...a),
+      status: (...a: unknown[]) => batchStatusMock(...a),
+      resume: (...a: unknown[]) => batchResumeMock(...a),
+    },
+  },
+  onProgress: (cb: (e: ProgressEvent) => void) => {
+    progressCbs.push(cb);
+    return () => {
+      progressCbs = progressCbs.filter((c) => c !== cb);
+    };
+  },
+  onJobDone: (cb: () => void) => {
+    doneCbs.push(cb);
+    return () => {
+      doneCbs = doneCbs.filter((c) => c !== cb);
+    };
+  },
+}));
+
+import { BatchQueue, announceTransitions } from './BatchQueue';
+
+const VIDEOS: Video[] = [
+  {
+    id: 'v1',
+    path: '/v1',
+    title: 'Episode One',
+    addedAt: '',
+    durationSec: 60,
+    hasTranscript: false,
+  },
+  {
+    id: 'v2',
+    path: '/v2',
+    title: 'Episode Two',
+    addedAt: '',
+    durationSec: 60,
+    hasTranscript: false,
+  },
+];
+const TEMPLATES: Template[] = [
+  { id: 't1', name: 'House style', steps: [], defaultControls: {}, exportTargets: ['tiktok'] },
+];
+
+function summary(over: Partial<BatchSummary> = {}): BatchSummary {
+  return {
+    id: 'bA',
+    name: 'Prior run',
+    templateId: 't1',
+    status: 'partial',
+    createdAt: 1,
+    counts: { total: 3, done: 1, error: 0, skipped: 0, queued: 2, running: 0, cancelled: 0 },
+    ...over,
+  };
+}
+
+function state(items: BatchState['items'], over: Partial<BatchState> = {}): BatchState {
+  return {
+    id: 'bNew',
+    name: 'Batch run',
+    templateId: 't1',
+    status: 'running',
+    createdAt: 2,
+    items,
+    ...over,
+  };
+}
+
+let container: HTMLElement;
+let root: Root;
+
+async function render(props: { resumeId?: string } = {}): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<BatchQueue {...props} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  progressCbs = [];
+  doneCbs = [];
+  libListMock.mockResolvedValue({ videos: VIDEOS });
+  tmplListMock.mockResolvedValue({ templates: TEMPLATES });
+  batchListMock.mockResolvedValue({ batches: [] });
+  batchCreateMock.mockResolvedValue({ batch: state([{ videoId: 'v1', status: 'queued' }]) });
+  batchStartMock.mockResolvedValue({ jobId: 'job-1' });
+  batchStatusMock.mockResolvedValue({ batch: state([{ videoId: 'v1', status: 'queued' }]) });
+  batchResumeMock.mockResolvedValue({ jobId: 'job-2' });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.clearAllMocks();
+});
+
+function clickText(text: string): void {
+  const btn = [...container.querySelectorAll('button')].find((b) => b.textContent === text);
+  if (!btn) throw new Error(`button not found: ${text}`);
+  act(() => btn.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+}
+
+describe('BatchQueue', () => {
+  it('loads videos, templates and the incomplete-batch list', async () => {
+    batchListMock.mockResolvedValue({ batches: [summary()] });
+    await render();
+    expect(libListMock).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain('Episode One');
+    expect(container.querySelector('.batch-queue__resume')?.textContent).toContain('Prior run');
+    // remaining = 3 - 1 done - 0 skipped = 2
+    expect(container.textContent).toContain('2 of 3 left');
+  });
+
+  it('disables Run until a source AND template are chosen', async () => {
+    await render();
+    const run = [...container.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Run batch',
+    ) as HTMLButtonElement;
+    expect(run.disabled).toBe(true);
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    const run2 = [...container.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Run batch',
+    ) as HTMLButtonElement;
+    expect(run2.disabled).toBe(false);
+  });
+
+  it('runs a batch: create → start → status, rendering rows', async () => {
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    // toggle off + on to cover both toggle branches
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(batchCreateMock).toHaveBeenCalledWith('Batch run', 't1', ['v1']);
+    expect(batchStartMock).toHaveBeenCalledWith('bNew');
+    expect(container.querySelector('.batch-queue__rows')).not.toBeNull();
+  });
+
+  it('start with no jobId key skips the status refresh (jobIdOf -> "")', async () => {
+    batchStartMock.mockResolvedValueOnce({});
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    batchStatusMock.mockClear();
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    expect(batchStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('start with a non-string jobId is treated as no jobId', async () => {
+    batchStartMock.mockResolvedValueOnce({ jobId: 123 });
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    batchStatusMock.mockClear();
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    expect(batchStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('start with a primitive (non-object) result is treated as no jobId', async () => {
+    batchStartMock.mockResolvedValueOnce(null);
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    batchStatusMock.mockClear();
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    expect(batchStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('announces on source-transition only (debounced), not per pct tick', async () => {
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    const fire = (m: string, pct: number): void =>
+      act(() => progressCbs.forEach((c) => c({ jobId: 'job-1', pct, message: m })));
+    fire('source 1/2 · A · step 1/2', 10);
+    const region = container.querySelector('.batch-livestatus__aggregate');
+    expect(region?.textContent).toBe('source 1/2 · A · step 1/2');
+    // same source, new pct -> no change
+    fire('source 1/2 · A · step 2/2', 40);
+    expect(region?.textContent).toBe('source 1/2 · A · step 1/2');
+    // new source -> updates
+    fire('source 2/2 · B · step 1/2', 60);
+    expect(container.querySelector('.batch-livestatus__aggregate')?.textContent).toBe(
+      'source 2/2 · B · step 1/2',
+    );
+  });
+
+  it('refreshes durable state on job.done and announces terminal flips', async () => {
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    // next status: v1 done, v2 error
+    batchStatusMock.mockResolvedValue({
+      batch: state(
+        [
+          { videoId: 'v1', status: 'done' },
+          { videoId: 'v2', status: 'error', error: 'boom' },
+        ],
+        { status: 'partial' },
+      ),
+    });
+    await act(async () => {
+      doneCbs.forEach((c) => c());
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-livestatus__log')?.textContent).toContain(
+      'Episode One — done',
+    );
+    expect(container.querySelector('.batch-livestatus__alert')?.textContent).toContain(
+      'Episode Two — failed: boom',
+    );
+  });
+
+  it('job.done with no active batch is a no-op', async () => {
+    await render();
+    batchStatusMock.mockClear();
+    await act(async () => {
+      doneCbs.forEach((c) => c());
+      await Promise.resolve();
+    });
+    expect(batchStatusMock).not.toHaveBeenCalled();
+  });
+
+  it('renders skip + error detail tokens on rows', async () => {
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    batchStatusMock.mockResolvedValue({
+      batch: state([
+        { videoId: 'v1', status: 'skipped', skipReason: 'would egress' },
+        { videoId: 'v2', status: 'error', error: 'kaboom' },
+      ]),
+    });
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__row-reason')?.textContent).toBe('would egress');
+    expect(container.querySelector('.batch-queue__row-error')?.textContent).toBe('kaboom');
+    expect(container.querySelector('.batch-queue__row-status')?.textContent).toBe('Skipped');
+  });
+
+  it('resumes an incomplete batch from the list', async () => {
+    batchListMock.mockResolvedValue({ batches: [summary()] });
+    await render();
+    await act(async () => {
+      clickText('Resume');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(batchResumeMock).toHaveBeenCalledWith('bA');
+  });
+
+  it('deep-links a resume on mount via resumeId', async () => {
+    await render({ resumeId: 'bZ' });
+    expect(batchResumeMock).toHaveBeenCalledWith('bZ');
+  });
+
+  it('surfaces load / run / status / resume failures', async () => {
+    libListMock.mockRejectedValueOnce(new Error('load-bad'));
+    await render();
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('load-bad');
+  });
+
+  it('shows a generic load error on non-Error rejection', async () => {
+    libListMock.mockRejectedValueOnce('x');
+    await render();
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('Failed to load');
+  });
+
+  it('surfaces a run failure', async () => {
+    batchCreateMock.mockRejectedValueOnce('x');
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('Run failed');
+  });
+
+  it('surfaces a status failure during run', async () => {
+    batchStatusMock.mockRejectedValueOnce('x');
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('Status failed');
+  });
+
+  it('surfaces a resume failure', async () => {
+    batchResumeMock.mockRejectedValueOnce('x');
+    await render({ resumeId: 'bZ' });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('Resume failed');
+  });
+
+  it('a progress event after a batch exists updates the live pct bar', async () => {
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    act(() =>
+      progressCbs.forEach((c) => c({ jobId: 'job-1', pct: 73, message: 'source 1/1 · A' })),
+    );
+    const bar = container.querySelector('.batch-queue__live [role="progressbar"]');
+    expect(bar?.getAttribute('aria-valuenow')).toBe('73');
+  });
+
+  it('surfaces a status failure with an Error message (instanceof arm)', async () => {
+    batchStatusMock.mockRejectedValueOnce(new Error('status-boom'));
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('status-boom');
+  });
+
+  it('a progress event before any batch updates only the aggregate (batch stays null)', async () => {
+    await render();
+    expect(container.querySelector('.batch-queue__live')).toBeNull();
+    act(() => progressCbs.forEach((c) => c({ jobId: 'x', pct: 50, message: 'source 1/1 · A' })));
+    // aggregate updated but no live batch panel (batch still null -> ": prev" arm).
+    expect(container.querySelector('.batch-livestatus__aggregate')?.textContent).toBe(
+      'source 1/1 · A',
+    );
+    expect(container.querySelector('.batch-queue__live')).toBeNull();
+  });
+
+  it('surfaces a run failure with an Error message (instanceof arm)', async () => {
+    batchCreateMock.mockRejectedValueOnce(new Error('create-boom'));
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('create-boom');
+  });
+
+  it('surfaces a resume failure with an Error message (instanceof arm)', async () => {
+    batchResumeMock.mockRejectedValueOnce(new Error('resume-boom'));
+    await render({ resumeId: 'bZ' });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('resume-boom');
+  });
+
+  it('uses the template chosen from the select when running', async () => {
+    tmplListMock.mockResolvedValue({
+      templates: [
+        { id: 't1', name: 'House style', steps: [], defaultControls: {}, exportTargets: [] },
+        { id: 't2', name: 'Captioned', steps: [], defaultControls: {}, exportTargets: [] },
+      ],
+    });
+    await render();
+    const select = container.querySelector('select[aria-label="Template"]') as HTMLSelectElement;
+    const selSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')!
+      .set!;
+    act(() => {
+      selSetter.call(select, 't2');
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+    });
+    expect(batchCreateMock).toHaveBeenCalledWith('Batch run', 't2', ['v1']);
+  });
+
+  it('keeps the default template when none load (empty list)', async () => {
+    tmplListMock.mockResolvedValue({ templates: [] });
+    await render();
+    const select = container.querySelector('select[aria-label="Template"]') as HTMLSelectElement;
+    expect(select.options.length).toBe(0);
+  });
+});
+
+describe('announceTransitions (pure)', () => {
+  const titleFor = (id: string): string => id.toUpperCase();
+  it('pushes polite for done and assertive for error; silent for non-terminal', () => {
+    const polite: string[] = [];
+    let assertive = '';
+    const next = state([
+      { videoId: 'a', status: 'done' },
+      { videoId: 'b', status: 'error', error: 'x' },
+      { videoId: 'c', status: 'running' },
+    ]);
+    announceTransitions(
+      null,
+      next,
+      titleFor,
+      (fn) => polite.splice(0, polite.length, ...fn(polite)),
+      (t) => {
+        assertive = t;
+      },
+    );
+    expect(polite).toEqual(['A — done']);
+    expect(assertive).toBe('B — failed: x');
+  });
+
+  it('does not re-announce an item that was already terminal', () => {
+    const polite: string[] = [];
+    const prev = state([{ videoId: 'a', status: 'done' }]);
+    const next = state([{ videoId: 'a', status: 'done' }]);
+    announceTransitions(
+      prev,
+      next,
+      titleFor,
+      (fn) => polite.splice(0, polite.length, ...fn(polite)),
+      () => {},
+    );
+    expect(polite).toEqual([]);
+  });
+
+  it('ignores a terminal status with no announcement mapping is impossible (cancelled is polite)', () => {
+    const polite: string[] = [];
+    const next = state([{ videoId: 'a', status: 'cancelled' }]);
+    announceTransitions(
+      null,
+      next,
+      titleFor,
+      (fn) => polite.splice(0, polite.length, ...fn(polite)),
+      () => {},
+    );
+    expect(polite).toEqual(['A — cancelled']);
+  });
+});

--- a/app/renderer/src/features/BatchQueue.tsx
+++ b/app/renderer/src/features/BatchQueue.tsx
@@ -1,0 +1,297 @@
+// BatchQueue.tsx — the primary "folder → shorts" flow (DESIGN §7 panel 3, the
+// default landing). Multi-select library sources, pick a template, review the
+// pre-run consent summary (§9.1), create → start, and watch live per-source rows
+// driven by `onProgress`/`onJobDone` plus the net-new a11y announcer (§7.1).
+// Incomplete batches surface a Resume affordance (§7.2).
+//
+// Driven entirely through the canonical client (`client.batch.*` /
+// `client.templates.list` / `client.library.list`) + the frozen `onProgress` /
+// `onJobDone` bridge.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  client,
+  onJobDone,
+  onProgress,
+  type BatchState,
+  type BatchSummary,
+  type Template,
+  type Video,
+} from '../lib/rpc';
+import { ProgressBar } from '../components/ProgressBar';
+import { LiveStatusRegion } from './LiveStatusRegion';
+import {
+  aggregateUpdate,
+  incompleteBatches,
+  remainingCount,
+  statusToken,
+  terminalAnnouncement,
+} from './repurposeLogic';
+import './panels.css';
+
+/** Pull a {jobId} from any deferred result, or '' when absent. */
+function jobIdOf(result: unknown): string {
+  if (result && typeof result === 'object' && 'jobId' in result) {
+    const id = (result as { jobId?: unknown }).jobId;
+    if (typeof id === 'string') return id;
+  }
+  return '';
+}
+
+export interface BatchQueueProps {
+  /** A deep-link batch id to resume on mount (from the launch toast, §7.2). */
+  resumeId?: string;
+}
+
+/** The batch queue: source select → template → consent → run → live rows. */
+export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [selected, setSelected] = useState<string[]>([]);
+  const [templateId, setTemplateId] = useState('');
+  const [batch, setBatch] = useState<BatchState | null>(null);
+  const [incomplete, setIncomplete] = useState<BatchSummary[]>([]);
+  const [error, setError] = useState('');
+
+  // a11y live-status state (§7.1).
+  const [aggregate, setAggregate] = useState('');
+  const [politeLog, setPoliteLog] = useState<string[]>([]);
+  const [assertive, setAssertive] = useState('');
+
+  const titleFor = useCallback(
+    (videoId: string): string => videos.find((v) => v.id === videoId)?.title ?? videoId,
+    [videos],
+  );
+
+  const reload = useCallback(async () => {
+    try {
+      const [{ videos: vids }, { templates: tmpl }, { batches }] = await Promise.all([
+        client.library.list(),
+        client.templates.list(),
+        client.batch.list(),
+      ]);
+      setVideos(vids);
+      setTemplates(tmpl);
+      setIncomplete(incompleteBatches(batches));
+      if (tmpl.length > 0) setTemplateId((prev) => prev || tmpl[0].id);
+      // NOTE: a successful reload does NOT clear `error` — a concurrent action
+      // (run/resume/status) may have just set one, and clobbering it would hide
+      // a real failure. Load failures set the error below; action flows own their
+      // own clear.
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load');
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  // Subscribe to live progress: announce on source-transition only (debounced).
+  useEffect(() => {
+    const off = onProgress((event) => {
+      setAggregate((prev) => aggregateUpdate(prev, event) ?? prev);
+      setBatch((prev) => (prev ? { ...prev, pct: event.pct } : prev));
+    });
+    return off;
+  }, []);
+
+  // When the parent job finishes, refresh the durable batch state once.
+  const refreshBatch = useCallback(
+    async (id: string) => {
+      try {
+        const { batch: state } = await client.batch.status(id);
+        setBatch((prev) => announceTransitions(prev, state, titleFor, setPoliteLog, setAssertive));
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Status failed');
+      }
+    },
+    [titleFor],
+  );
+
+  useEffect(() => {
+    const off = onJobDone(() => {
+      if (batch) void refreshBatch(batch.id);
+    });
+    return off;
+  }, [batch, refreshBatch]);
+
+  const toggleVideo = useCallback((id: string) => {
+    setSelected((prev) => (prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]));
+  }, []);
+
+  const runBatch = useCallback(async () => {
+    try {
+      // Clear optimistically up front; an internal failure (e.g. refreshBatch)
+      // owns its own error and we must NOT clobber it after the await.
+      setError('');
+      const { batch: created } = await client.batch.create('Batch run', templateId, selected);
+      setBatch(created);
+      setAggregate('');
+      setPoliteLog([]);
+      setAssertive('');
+      const started = await client.batch.start(created.id);
+      const jobId = jobIdOf(started);
+      setBatch({ ...created, status: 'running' });
+      if (jobId !== '') {
+        // pull the first authoritative status snapshot.
+        await refreshBatch(created.id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Run failed');
+    }
+  }, [templateId, selected, refreshBatch]);
+
+  const resume = useCallback(
+    async (id: string) => {
+      try {
+        setError('');
+        await client.batch.resume(id);
+        await refreshBatch(id);
+        await reload();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Resume failed');
+      }
+    },
+    [refreshBatch, reload],
+  );
+
+  // Deep-linked resume from the launch toast — fire ONCE per resumeId (guard
+  // against the effect re-running when its callback identity changes after load).
+  const resumedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (resumeId && resumedRef.current !== resumeId) {
+      resumedRef.current = resumeId;
+      void resume(resumeId);
+    }
+  }, [resumeId, resume]);
+
+  const canRun = selected.length > 0 && templateId !== '';
+
+  return (
+    <section className="batch-queue" aria-label="Batch queue">
+      {error !== '' ? (
+        <p role="alert" className="batch-queue__error">
+          {error}
+        </p>
+      ) : null}
+
+      {incomplete.length > 0 ? (
+        <div className="batch-queue__resume">
+          <h4>Incomplete batches</h4>
+          <ul>
+            {incomplete.map((b) => (
+              <li key={b.id} className="batch-queue__resume-row">
+                <span>
+                  {b.name} — {remainingCount(b.counts)} of {b.counts.total} left
+                </span>
+                <button type="button" onClick={() => void resume(b.id)}>
+                  Resume
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+
+      <div className="batch-queue__setup">
+        <fieldset className="batch-queue__sources">
+          <legend>Sources</legend>
+          {videos.map((video) => (
+            <label key={video.id} className="batch-queue__source">
+              <input
+                type="checkbox"
+                checked={selected.includes(video.id)}
+                onChange={() => toggleVideo(video.id)}
+              />
+              {video.title}
+            </label>
+          ))}
+        </fieldset>
+
+        <label className="batch-queue__template">
+          <span>Template</span>
+          <select
+            aria-label="Template"
+            value={templateId}
+            onChange={(e) => setTemplateId(e.target.value)}
+          >
+            {templates.map((tmpl) => (
+              <option key={tmpl.id} value={tmpl.id}>
+                {tmpl.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <button
+          type="button"
+          className="batch-queue__run"
+          disabled={!canRun}
+          onClick={() => void runBatch()}
+        >
+          Run batch
+        </button>
+      </div>
+
+      <LiveStatusRegion aggregate={aggregate} politeLog={politeLog} assertive={assertive} />
+
+      {batch ? (
+        <div className="batch-queue__live">
+          <ProgressBar pct={batch.pct ?? 0} message={aggregate} />
+          <ul className="batch-queue__rows">
+            {batch.items.map((item) => (
+              <li key={item.videoId} className="batch-queue__row">
+                <span className="batch-queue__row-title">{titleFor(item.videoId)}</span>
+                <span className="batch-queue__row-status" data-status={item.status}>
+                  {statusToken(item.status)}
+                </span>
+                {item.skipReason !== undefined ? (
+                  <span className="batch-queue__row-reason" title={item.skipReason}>
+                    {item.skipReason}
+                  </span>
+                ) : null}
+                {item.error !== undefined ? (
+                  <span className="batch-queue__row-error" title={item.error}>
+                    {item.error}
+                  </span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+/**
+ * Compute the new batch state and push per-source TERMINAL announcements for any
+ * item that newly reached a terminal state (queued/running flips are silent,
+ * §7.1). Exported for unit coverage of the announce-on-terminal contract.
+ */
+export function announceTransitions(
+  prev: BatchState | null,
+  next: BatchState,
+  titleFor: (id: string) => string,
+  pushPolite: (fn: (log: string[]) => string[]) => void,
+  setAssertive: (text: string) => void,
+): BatchState {
+  const before = new Map((prev?.items ?? []).map((i) => [i.videoId, i.status]));
+  for (const item of next.items) {
+    // Only newly-changed items can announce (a status that was already this value
+    // was already spoken). `terminalAnnouncement` itself returns null for any
+    // non-terminal status, so it is the sole announce gate — no separate terminal
+    // check (which would add an unreachable branch).
+    if (before.get(item.videoId) === item.status) continue;
+    const ann = terminalAnnouncement(titleFor(item.videoId), item);
+    if (ann === null) continue;
+    if (ann.assertive) {
+      setAssertive(ann.text);
+    } else {
+      pushPolite((log) => [...log, ann.text]);
+    }
+  }
+  return next;
+}
+
+export default BatchQueue;

--- a/app/renderer/src/features/ExportPresetsPanel.test.tsx
+++ b/app/renderer/src/features/ExportPresetsPanel.test.tsx
@@ -1,0 +1,289 @@
+// ExportPresetsPanel.test.tsx — preset table: closed caption-style select +
+// inline window clamp + CRUD/reset wiring (§7 / §10.5).
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { ExportPreset } from '../lib/rpc';
+
+const listMock = vi.fn();
+const saveMock = vi.fn();
+const deleteMock = vi.fn();
+const resetMock = vi.fn();
+
+vi.mock('../lib/rpc', () => ({
+  client: {
+    exportPresets: {
+      list: (...a: unknown[]) => listMock(...a),
+      save: (...a: unknown[]) => saveMock(...a),
+      delete: (...a: unknown[]) => deleteMock(...a),
+      reset: (...a: unknown[]) => resetMock(...a),
+    },
+  },
+}));
+
+import { ExportPresetsPanel } from './ExportPresetsPanel';
+import { CAPTION_STYLE_OPTIONS } from './repurposeLogic';
+
+const SEED: ExportPreset[] = [
+  {
+    id: 'tiktok',
+    label: 'TikTok',
+    aspect: '9:16',
+    minSec: 20,
+    maxSec: 60,
+    count: 5,
+    captionStyle: 'tiktok',
+    reframeEngine: 'auto',
+  },
+];
+
+let container: HTMLElement;
+let root: Root;
+
+const onChangedSpy = vi.fn();
+
+async function render(): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<ExportPresetsPanel onChanged={onChangedSpy} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  listMock.mockResolvedValue({ presets: SEED });
+  saveMock.mockResolvedValue({ preset: SEED[0] });
+  deleteMock.mockResolvedValue({ ok: true });
+  resetMock.mockResolvedValue({ presets: SEED });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  onChangedSpy.mockClear();
+  vi.clearAllMocks();
+});
+
+function clickText(text: string): void {
+  const btn = [...container.querySelectorAll('button')].find((b) => b.textContent === text);
+  if (!btn) throw new Error(`button not found: ${text}`);
+  act(() => btn.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+}
+
+describe('ExportPresetsPanel', () => {
+  it('loads and renders the preset rows', async () => {
+    await render();
+    expect(listMock).toHaveBeenCalledTimes(1);
+    const label = container.querySelector('input[aria-label="Preset label"]') as HTMLInputElement;
+    expect(label.value).toBe('TikTok');
+  });
+
+  it('caption-style control is a closed select of valid ids only', async () => {
+    await render();
+    const select = container.querySelector(
+      'select[aria-label="Caption style"]',
+    ) as HTMLSelectElement;
+    const ids = [...select.options].map((o) => o.value);
+    expect(ids).toEqual([...CAPTION_STYLE_OPTIONS]);
+    // an out-of-set id is not an option (unselectable).
+    expect(ids).not.toContain('__nope__');
+  });
+
+  it('clamps an over-max duration in the maxSec input', async () => {
+    await render();
+    const maxInput = container.querySelector(
+      'input[aria-label="Maximum seconds"]',
+    ) as HTMLInputElement;
+    act(() => {
+      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
+        .set!;
+      setter.call(maxInput, '600');
+      maxInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(
+      (container.querySelector('input[aria-label="Maximum seconds"]') as HTMLInputElement).value,
+    ).toBe('60');
+  });
+
+  it('floors the count at 1 (and on non-numeric)', async () => {
+    await render();
+    const countInput = container.querySelector(
+      'input[aria-label="Clip count"]',
+    ) as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
+      .set!;
+    act(() => {
+      setter.call(countInput, '0');
+      countInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(
+      (container.querySelector('input[aria-label="Clip count"]') as HTMLInputElement).value,
+    ).toBe('1');
+    act(() => {
+      setter.call(countInput, 'abc');
+      countInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(
+      (container.querySelector('input[aria-label="Clip count"]') as HTMLInputElement).value,
+    ).toBe('1');
+  });
+
+  it('edits label/aspect/minSec/style/engine and saves the draft', async () => {
+    await render();
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
+      .set!;
+    const label = container.querySelector('input[aria-label="Preset label"]') as HTMLInputElement;
+    const aspect = container.querySelector('input[aria-label="Aspect ratio"]') as HTMLInputElement;
+    const minInput = container.querySelector(
+      'input[aria-label="Minimum seconds"]',
+    ) as HTMLInputElement;
+    act(() => {
+      setter.call(label, 'TT');
+      label.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(aspect, '1:1');
+      aspect.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(minInput, '25');
+      minInput.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    const style = container.querySelector(
+      'select[aria-label="Caption style"]',
+    ) as HTMLSelectElement;
+    const engine = container.querySelector(
+      'select[aria-label="Reframe engine"]',
+    ) as HTMLSelectElement;
+    const selSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')!
+      .set!;
+    act(() => {
+      selSetter.call(style, 'hormozi');
+      style.dispatchEvent(new Event('change', { bubbles: true }));
+      selSetter.call(engine, 'verthor');
+      engine.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
+    });
+    expect(saveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'TT',
+        aspect: '1:1',
+        minSec: 25,
+        captionStyle: 'hormozi',
+        reframeEngine: 'verthor',
+      }),
+    );
+  });
+
+  it('deletes a preset', async () => {
+    await render();
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(deleteMock).toHaveBeenCalledWith('tiktok');
+  });
+
+  it('adds a new preset via save with an empty id', async () => {
+    await render();
+    await act(async () => {
+      clickText('New preset');
+      await Promise.resolve();
+    });
+    expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ id: '', label: 'New preset' }));
+  });
+
+  it('resets to defaults', async () => {
+    await render();
+    await act(async () => {
+      clickText('Reset to defaults');
+      await Promise.resolve();
+    });
+    expect(resetMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows an error when load fails', async () => {
+    listMock.mockRejectedValueOnce(new Error('nope'));
+    await render();
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('nope');
+  });
+
+  it('shows a generic error when load rejects a non-Error', async () => {
+    listMock.mockRejectedValueOnce('boom');
+    await render();
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe(
+      'Failed to load presets',
+    );
+  });
+
+  it('surfaces save / delete / reset failures', async () => {
+    await render();
+    saveMock.mockRejectedValueOnce('x');
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('Save failed');
+
+    deleteMock.mockRejectedValueOnce('x');
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('Delete failed');
+
+    resetMock.mockRejectedValueOnce('x');
+    await act(async () => {
+      clickText('Reset to defaults');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('Reset failed');
+  });
+
+  it('surfaces Error-typed save/delete/reset messages (instanceof arm)', async () => {
+    await render();
+    saveMock.mockRejectedValueOnce(new Error('save-e'));
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('save-e');
+
+    deleteMock.mockRejectedValueOnce(new Error('del-e'));
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('del-e');
+
+    resetMock.mockRejectedValueOnce(new Error('reset-e'));
+    await act(async () => {
+      clickText('Reset to defaults');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.export-presets__error')?.textContent).toBe('reset-e');
+  });
+
+  it('notifies onChanged after a successful save / delete / reset', async () => {
+    await render();
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
+    });
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    await act(async () => {
+      clickText('Reset to defaults');
+      await Promise.resolve();
+    });
+    expect(onChangedSpy).toHaveBeenCalledTimes(3);
+  });
+});

--- a/app/renderer/src/features/ExportPresetsPanel.tsx
+++ b/app/renderer/src/features/ExportPresetsPanel.tsx
@@ -1,0 +1,227 @@
+// ExportPresetsPanel.tsx — edit the server-persisted platform export presets
+// (DESIGN §7 panel 2). A table of presets with an inline editor whose
+// `captionStyle` is a CLOSED select of valid ids (so an invalid id is
+// unselectable — the sidecar save-time validation is a defense-in-depth backstop,
+// §7/§10.5) and whose duration fields are clamped into the hard 20-60 s window
+// (so the user cannot author a preset the pipeline would silently correct).
+//
+// Driven through the canonical client (`client.exportPresets.*`). Reset restores
+// the seeds. CRUD is direct-return (no jobs).
+import React, { useCallback, useEffect, useState } from 'react';
+import { client, type ExportPreset } from '../lib/rpc';
+import {
+  CAPTION_STYLE_OPTIONS,
+  REFRAME_ENGINE_OPTIONS,
+  blankPreset,
+  clampWindowSec,
+} from './repurposeLogic';
+import './panels.css';
+
+interface RowProps {
+  preset: ExportPreset;
+  onSave: (preset: ExportPreset) => void;
+  onDelete: (id: string) => void;
+}
+
+function PresetRow({ preset, onSave, onDelete }: RowProps): React.ReactElement {
+  const [draft, setDraft] = useState<ExportPreset>(preset);
+
+  // Keep the row in sync if the parent reloads the list (e.g. after reset).
+  useEffect(() => {
+    setDraft(preset);
+  }, [preset]);
+
+  const setField = useCallback(<K extends keyof ExportPreset>(key: K, value: ExportPreset[K]) => {
+    setDraft((prev) => ({ ...prev, [key]: value }));
+  }, []);
+
+  return (
+    <tr className="export-presets__row">
+      <td>
+        <input
+          aria-label="Preset label"
+          value={draft.label}
+          onChange={(e) => setField('label', e.target.value)}
+        />
+      </td>
+      <td>
+        <input
+          aria-label="Aspect ratio"
+          value={draft.aspect}
+          onChange={(e) => setField('aspect', e.target.value)}
+        />
+      </td>
+      <td>
+        <input
+          type="number"
+          aria-label="Minimum seconds"
+          value={draft.minSec}
+          onChange={(e) => setField('minSec', clampWindowSec(Number(e.target.value)))}
+        />
+      </td>
+      <td>
+        <input
+          type="number"
+          aria-label="Maximum seconds"
+          value={draft.maxSec}
+          onChange={(e) => setField('maxSec', clampWindowSec(Number(e.target.value)))}
+        />
+      </td>
+      <td>
+        <input
+          type="number"
+          aria-label="Clip count"
+          value={draft.count}
+          onChange={(e) => setField('count', Math.max(1, Math.floor(Number(e.target.value)) || 1))}
+        />
+      </td>
+      <td>
+        <select
+          aria-label="Caption style"
+          value={draft.captionStyle}
+          onChange={(e) => setField('captionStyle', e.target.value)}
+        >
+          {CAPTION_STYLE_OPTIONS.map((style) => (
+            <option key={style} value={style}>
+              {style}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td>
+        <select
+          aria-label="Reframe engine"
+          value={draft.reframeEngine}
+          onChange={(e) => setField('reframeEngine', e.target.value)}
+        >
+          {REFRAME_ENGINE_OPTIONS.map((engine) => (
+            <option key={engine} value={engine}>
+              {engine}
+            </option>
+          ))}
+        </select>
+      </td>
+      <td>
+        <button type="button" onClick={() => onSave(draft)}>
+          Save
+        </button>
+        <button type="button" onClick={() => onDelete(draft.id)}>
+          Delete
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+export interface ExportPresetsPanelProps {
+  /** Notify the parent when presets change (so other panels can refresh). */
+  onChanged?: () => void;
+}
+
+/** The Export Presets editor table (window-clamped, closed caption-style select). */
+export function ExportPresetsPanel({ onChanged }: ExportPresetsPanelProps): React.ReactElement {
+  const [presets, setPresets] = useState<ExportPreset[]>([]);
+  const [error, setError] = useState('');
+
+  const reload = useCallback(async () => {
+    try {
+      const { presets: list } = await client.exportPresets.list();
+      setPresets(list);
+      setError('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load presets');
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const handleSave = useCallback(
+    async (preset: ExportPreset) => {
+      try {
+        await client.exportPresets.save(preset);
+        await reload();
+        onChanged?.();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Save failed');
+      }
+    },
+    [reload, onChanged],
+  );
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await client.exportPresets.delete(id);
+        await reload();
+        onChanged?.();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Delete failed');
+      }
+    },
+    [reload, onChanged],
+  );
+
+  const handleAdd = useCallback(async () => {
+    await handleSave({ id: '', ...blankPreset() });
+  }, [handleSave]);
+
+  const handleReset = useCallback(async () => {
+    try {
+      const { presets: list } = await client.exportPresets.reset();
+      setPresets(list);
+      setError('');
+      onChanged?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Reset failed');
+    }
+  }, [onChanged]);
+
+  return (
+    <section className="export-presets" aria-label="Export presets">
+      <div className="export-presets__toolbar">
+        <button type="button" onClick={() => void handleAdd()}>
+          New preset
+        </button>
+        <button type="button" onClick={() => void handleReset()}>
+          Reset to defaults
+        </button>
+        <span className="export-presets__hint">Durations are clamped to 20-60 s.</span>
+      </div>
+
+      {error !== '' ? (
+        <p role="alert" className="export-presets__error">
+          {error}
+        </p>
+      ) : null}
+
+      <table className="export-presets__table">
+        <thead>
+          <tr>
+            <th>Label</th>
+            <th>Aspect</th>
+            <th>Min s</th>
+            <th>Max s</th>
+            <th>Count</th>
+            <th>Caption style</th>
+            <th>Engine</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {presets.map((preset) => (
+            <PresetRow
+              key={preset.id}
+              preset={preset}
+              onSave={(p) => void handleSave(p)}
+              onDelete={(id) => void handleDelete(id)}
+            />
+          ))}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+export default ExportPresetsPanel;

--- a/app/renderer/src/features/LiveStatusRegion.test.tsx
+++ b/app/renderer/src/features/LiveStatusRegion.test.tsx
@@ -1,0 +1,56 @@
+// LiveStatusRegion.test.tsx — the BatchQueue a11y announcer (§7.1).
+
+// @vitest-environment jsdom
+import { describe, it, expect, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { LiveStatusRegion } from './LiveStatusRegion';
+
+let container: HTMLElement;
+let root: Root;
+
+function render(ui: React.ReactElement): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(ui);
+  });
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+describe('LiveStatusRegion', () => {
+  it('renders a polite aggregate region with the message', () => {
+    render(<LiveStatusRegion aggregate="source 4/30 · Ep4" politeLog={[]} assertive="" />);
+    const status = container.querySelector('[role="status"]');
+    expect(status?.getAttribute('aria-live')).toBe('polite');
+    expect(status?.textContent).toBe('source 4/30 · Ep4');
+  });
+
+  it('renders polite log lines (terminal done/skipped flips)', () => {
+    render(
+      <LiveStatusRegion
+        aggregate=""
+        politeLog={['Ep1 — done', 'Ep2 — skipped: would egress']}
+        assertive=""
+      />,
+    );
+    const log = container.querySelector('[role="log"]');
+    expect(log?.getAttribute('aria-live')).toBe('polite');
+    const lines = log?.querySelectorAll('.batch-livestatus__line');
+    expect(lines?.length).toBe(2);
+    expect(log?.textContent).toContain('Ep2 — skipped: would egress');
+  });
+
+  it('renders an assertive alert region for errors', () => {
+    render(<LiveStatusRegion aggregate="" politeLog={[]} assertive="Ep3 — failed: boom" />);
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.getAttribute('aria-live')).toBe('assertive');
+    expect(alert?.textContent).toBe('Ep3 — failed: boom');
+  });
+});

--- a/app/renderer/src/features/LiveStatusRegion.tsx
+++ b/app/renderer/src/features/LiveStatusRegion.tsx
@@ -1,0 +1,57 @@
+// LiveStatusRegion.tsx — the net-new BatchQueue a11y live-status announcer (§7.1,
+// G-A11Y). The reused JobQueue carries NO aria-live region, so this is net-new
+// UX, not "reuse." It adopts the SAME idiom as `ShortMaker.tsx:773`
+// (`role="status" aria-live="polite"`) and `SidecarBanner.tsx:72`
+// (`role="alert" aria-live="assertive"` for the one transition important enough
+// to interrupt).
+//
+// Two regions:
+//   * a POLITE aggregate region holding the debounced "source k/N · …" message;
+//   * an ASSERTIVE alert region that surfaces the most recent terminal-error
+//     announcement so a failed source interrupts and is not missed.
+// Non-error terminal announcements (done/cancelled/skipped) ride the polite log.
+//
+// Pure presentational: the parent (BatchQueue) owns the progress stream and the
+// terminal-flip detection; it passes the already-decided strings in.
+import React from 'react';
+
+export interface LiveStatusRegionProps {
+  /** The debounced aggregate progress text (announced politely on source flip). */
+  aggregate: string;
+  /** Discrete polite log lines (done/cancelled/skipped terminal flips). */
+  politeLog: readonly string[];
+  /** The most recent assertive (error) announcement, or '' for none. */
+  assertive: string;
+}
+
+/**
+ * The BatchQueue live-status announcer: a polite aggregate + polite log + an
+ * assertive alert region. All status is text (never color-only).
+ */
+export function LiveStatusRegion({
+  aggregate,
+  politeLog,
+  assertive,
+}: LiveStatusRegionProps): React.ReactElement {
+  return (
+    <div className="batch-livestatus">
+      <div role="status" aria-live="polite" className="batch-livestatus__aggregate">
+        {aggregate}
+      </div>
+      <div role="log" aria-live="polite" className="batch-livestatus__log">
+        {politeLog.map((line, index) => (
+          // The log is append-only per render; index keys are stable enough here.
+          // eslint-disable-next-line react/no-array-index-key
+          <p key={`${index}-${line}`} className="batch-livestatus__line">
+            {line}
+          </p>
+        ))}
+      </div>
+      <div role="alert" aria-live="assertive" className="batch-livestatus__alert">
+        {assertive}
+      </div>
+    </div>
+  );
+}
+
+export default LiveStatusRegion;

--- a/app/renderer/src/features/TemplateEditor.test.tsx
+++ b/app/renderer/src/features/TemplateEditor.test.tsx
@@ -1,0 +1,248 @@
+// TemplateEditor.test.tsx — curated-preset-first (no raw method ids) + CRUD.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { ExportPreset, Template } from '../lib/rpc';
+
+const tmplListMock = vi.fn();
+const tmplSaveMock = vi.fn();
+const tmplDeleteMock = vi.fn();
+const presetListMock = vi.fn();
+
+vi.mock('../lib/rpc', () => ({
+  client: {
+    templates: {
+      list: (...a: unknown[]) => tmplListMock(...a),
+      save: (...a: unknown[]) => tmplSaveMock(...a),
+      delete: (...a: unknown[]) => tmplDeleteMock(...a),
+    },
+    exportPresets: {
+      list: (...a: unknown[]) => presetListMock(...a),
+    },
+  },
+}));
+
+import { TemplateEditor } from './TemplateEditor';
+
+const PRESETS: ExportPreset[] = [
+  {
+    id: 'tiktok',
+    label: 'TikTok',
+    aspect: '9:16',
+    minSec: 20,
+    maxSec: 60,
+    count: 5,
+    captionStyle: 'tiktok',
+    reframeEngine: 'auto',
+  },
+  {
+    id: 'shorts',
+    label: 'Shorts',
+    aspect: '9:16',
+    minSec: 20,
+    maxSec: 60,
+    count: 5,
+    captionStyle: 'clean',
+    reframeEngine: 'auto',
+  },
+];
+
+const SAVED: Template[] = [
+  { id: 't1', name: 'House style', steps: [], defaultControls: {}, exportTargets: ['tiktok'] },
+];
+
+let container: HTMLElement;
+let root: Root;
+
+const onChangedSpy = vi.fn();
+
+async function render(): Promise<void> {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  await act(async () => {
+    root.render(<TemplateEditor onChanged={onChangedSpy} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+beforeEach(() => {
+  tmplListMock.mockResolvedValue({ templates: SAVED });
+  tmplSaveMock.mockResolvedValue({ template: SAVED[0] });
+  tmplDeleteMock.mockResolvedValue({ ok: true });
+  presetListMock.mockResolvedValue({ presets: PRESETS });
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  onChangedSpy.mockClear();
+  vi.clearAllMocks();
+});
+
+function clickText(text: string): void {
+  const btn = [...container.querySelectorAll('button')].find((b) => b.textContent === text);
+  if (!btn) throw new Error(`button not found: ${text}`);
+  act(() => btn.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+}
+
+describe('TemplateEditor', () => {
+  it('loads templates + presets', async () => {
+    await render();
+    expect(tmplListMock).toHaveBeenCalledTimes(1);
+    expect(presetListMock).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain('House style');
+  });
+
+  it('exposes ZERO raw method ids in the DOM (curated labels only)', async () => {
+    await render();
+    const text = container.textContent ?? '';
+    expect(text).not.toContain('shortmaker.select');
+    expect(text).not.toContain('shortmaker.export');
+    expect(text).not.toContain('phase8.select');
+    expect(text).not.toContain('transcribe.start');
+  });
+
+  it('offers export targets from the preset labels (closed set)', async () => {
+    await render();
+    const targets = container.querySelector('.template-editor__targets');
+    expect(targets?.textContent).toContain('TikTok');
+    expect(targets?.textContent).toContain('Shorts');
+  });
+
+  it('saves a template built from the chosen starter + targets + controls', async () => {
+    await render();
+    // change the name + count
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
+      .set!;
+    const name = container.querySelector('input[aria-label="Template name"]') as HTMLInputElement;
+    const count = container.querySelector(
+      'input[aria-label="Shorts per source"]',
+    ) as HTMLInputElement;
+    act(() => {
+      setter.call(name, 'My pod');
+      name.dispatchEvent(new Event('input', { bubbles: true }));
+      setter.call(count, '3');
+      count.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    // pick the second starter
+    const starter = container.querySelector(
+      'select[aria-label="Starter template"]',
+    ) as HTMLSelectElement;
+    const selSetter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value')!
+      .set!;
+    act(() => {
+      selSetter.call(starter, 'captioned-shorts');
+      starter.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    // toggle tiktok target on then off then on (covers both branches)
+    const tiktok = container.querySelectorAll(
+      '.template-editor__target input',
+    )[0] as HTMLInputElement;
+    act(() => tiktok.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    act(() => tiktok.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    act(() => tiktok.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Save template');
+      await Promise.resolve();
+    });
+    expect(tmplSaveMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'My pod',
+        defaultControls: { count: 3 },
+        exportTargets: ['tiktok'],
+      }),
+    );
+  });
+
+  it('floors count at 1 on non-numeric input', async () => {
+    await render();
+    const count = container.querySelector(
+      'input[aria-label="Shorts per source"]',
+    ) as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
+      .set!;
+    act(() => {
+      setter.call(count, 'x');
+      count.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(
+      (container.querySelector('input[aria-label="Shorts per source"]') as HTMLInputElement).value,
+    ).toBe('1');
+  });
+
+  it('deletes a saved template', async () => {
+    await render();
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(tmplDeleteMock).toHaveBeenCalledWith('t1');
+  });
+
+  it('shows a load error (Error and non-Error)', async () => {
+    tmplListMock.mockRejectedValueOnce(new Error('list-bad'));
+    await render();
+    expect(container.querySelector('.template-editor__error')?.textContent).toBe('list-bad');
+  });
+
+  it('shows a generic load error on non-Error rejection', async () => {
+    tmplListMock.mockRejectedValueOnce('x');
+    await render();
+    expect(container.querySelector('.template-editor__error')?.textContent).toBe(
+      'Failed to load templates',
+    );
+  });
+
+  it('surfaces save + delete failures', async () => {
+    await render();
+    tmplSaveMock.mockRejectedValueOnce('x');
+    await act(async () => {
+      clickText('Save template');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.template-editor__error')?.textContent).toBe('Save failed');
+
+    tmplDeleteMock.mockRejectedValueOnce('x');
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.template-editor__error')?.textContent).toBe('Delete failed');
+  });
+
+  it('surfaces Error-typed save + delete messages (instanceof arm)', async () => {
+    await render();
+    tmplSaveMock.mockRejectedValueOnce(new Error('save-e'));
+    await act(async () => {
+      clickText('Save template');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.template-editor__error')?.textContent).toBe('save-e');
+
+    tmplDeleteMock.mockRejectedValueOnce(new Error('del-e'));
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.template-editor__error')?.textContent).toBe('del-e');
+  });
+
+  it('notifies onChanged after a successful save + delete', async () => {
+    await render();
+    await act(async () => {
+      clickText('Save template');
+      await Promise.resolve();
+    });
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(onChangedSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/app/renderer/src/features/TemplateEditor.tsx
+++ b/app/renderer/src/features/TemplateEditor.tsx
@@ -1,0 +1,162 @@
+// TemplateEditor.tsx — curated-preset-first template authoring (DESIGN §7 panel 1).
+//
+// A creator builds a template by picking a human-labeled STARTER (never a raw
+// `protocol.METHODS` id), choosing the export-target presets to fan out to, and
+// setting a couple of default controls. The underlying method ids are an
+// implementation detail mapped by `repurposeTemplates` — they never reach the DOM
+// (F-template-catalog, §7). Save via `client.templates.save`; existing templates
+// are listed + deletable.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { client, type ExportPreset, type Template } from '../lib/rpc';
+import {
+  STARTER_TEMPLATES,
+  buildTemplateFromStarter,
+  starterById,
+  type StarterTemplate,
+} from './repurposeTemplates';
+import './panels.css';
+
+export interface TemplateEditorProps {
+  onChanged?: () => void;
+}
+
+/** The Template editor: curated starters + export-target picker + CRUD. */
+export function TemplateEditor({ onChanged }: TemplateEditorProps): React.ReactElement {
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [presets, setPresets] = useState<ExportPreset[]>([]);
+  const [starterId, setStarterId] = useState<string>(STARTER_TEMPLATES[0].id);
+  const [name, setName] = useState('My template');
+  const [count, setCount] = useState(5);
+  const [targets, setTargets] = useState<string[]>([]);
+  const [error, setError] = useState('');
+
+  const reload = useCallback(async () => {
+    try {
+      const [{ templates: tmpl }, { presets: ps }] = await Promise.all([
+        client.templates.list(),
+        client.exportPresets.list(),
+      ]);
+      setTemplates(tmpl);
+      setPresets(ps);
+      setError('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load templates');
+    }
+  }, []);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  const starter: StarterTemplate = useMemo(() => starterById(starterId), [starterId]);
+
+  const toggleTarget = useCallback((id: string) => {
+    setTargets((prev) => (prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]));
+  }, []);
+
+  const handleSave = useCallback(async () => {
+    try {
+      const payload = buildTemplateFromStarter(starter, name, { count }, targets);
+      await client.templates.save(payload);
+      await reload();
+      onChanged?.();
+      setError('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed');
+    }
+  }, [starter, name, count, targets, reload, onChanged]);
+
+  const handleDelete = useCallback(
+    async (id: string) => {
+      try {
+        await client.templates.delete(id);
+        await reload();
+        onChanged?.();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Delete failed');
+      }
+    },
+    [reload, onChanged],
+  );
+
+  return (
+    <section className="template-editor" aria-label="Edit templates">
+      {error !== '' ? (
+        <p role="alert" className="template-editor__error">
+          {error}
+        </p>
+      ) : null}
+
+      <div className="template-editor__form">
+        <label className="template-editor__field">
+          <span>Template name</span>
+          <input
+            aria-label="Template name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+        </label>
+
+        <label className="template-editor__field">
+          <span>Starter</span>
+          <select
+            aria-label="Starter template"
+            value={starterId}
+            onChange={(e) => setStarterId(e.target.value)}
+          >
+            {STARTER_TEMPLATES.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </label>
+        <p className="template-editor__describe">{starter.describe}</p>
+
+        <label className="template-editor__field">
+          <span>Shorts per source</span>
+          <input
+            type="number"
+            aria-label="Shorts per source"
+            value={count}
+            onChange={(e) => setCount(Math.max(1, Math.floor(Number(e.target.value)) || 1))}
+          />
+        </label>
+
+        <fieldset className="template-editor__targets">
+          <legend>Export targets (platforms)</legend>
+          {presets.map((preset) => (
+            <label key={preset.id} className="template-editor__target">
+              <input
+                type="checkbox"
+                checked={targets.includes(preset.id)}
+                onChange={() => toggleTarget(preset.id)}
+              />
+              {preset.label}
+            </label>
+          ))}
+        </fieldset>
+
+        <button type="button" className="template-editor__save" onClick={() => void handleSave()}>
+          Save template
+        </button>
+      </div>
+
+      <div className="template-editor__saved">
+        <h4>Saved templates</h4>
+        <ul>
+          {templates.map((tmpl) => (
+            <li key={tmpl.id} className="template-editor__saved-row">
+              <span>{tmpl.name}</span>
+              <button type="button" onClick={() => void handleDelete(tmpl.id)}>
+                Delete
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+}
+
+export default TemplateEditor;

--- a/app/renderer/src/features/repurposeLogic.test.ts
+++ b/app/renderer/src/features/repurposeLogic.test.ts
@@ -1,0 +1,220 @@
+// repurposeLogic.test.ts — pure-logic coverage for the Repurpose bundle (WU11).
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  CAPTION_STYLE_OPTIONS,
+  REFRAME_ENGINE_OPTIONS,
+  MIN_WINDOW_SEC,
+  MAX_WINDOW_SEC,
+  clampWindowSec,
+  isValidCaptionStyle,
+  statusToken,
+  isTerminalItem,
+  terminalAnnouncement,
+  sourceToken,
+  aggregateUpdate,
+  isIncomplete,
+  incompleteBatches,
+  remainingCount,
+  batchSettled,
+  blankPreset,
+} from './repurposeLogic';
+import type { BatchItemStatus, BatchSummary, ProgressEvent } from '../lib/rpc';
+
+describe('caption-style + engine constraints', () => {
+  it('exposes a closed style set including the libass sentinels', () => {
+    expect(CAPTION_STYLE_OPTIONS).toContain('tiktok');
+    expect(CAPTION_STYLE_OPTIONS).toContain('libass');
+    expect(CAPTION_STYLE_OPTIONS).toContain('none');
+  });
+
+  it('exposes the three reframe engines', () => {
+    expect([...REFRAME_ENGINE_OPTIONS]).toEqual(['auto', 'verthor', 'claudeshorts']);
+  });
+
+  it('isValidCaptionStyle gates by the closed set', () => {
+    expect(isValidCaptionStyle('hormozi')).toBe(true);
+    expect(isValidCaptionStyle('__nope__')).toBe(false);
+  });
+});
+
+describe('clampWindowSec', () => {
+  it('floors below the min', () => {
+    expect(clampWindowSec(5)).toBe(MIN_WINDOW_SEC);
+  });
+  it('caps above the max', () => {
+    expect(clampWindowSec(600)).toBe(MAX_WINDOW_SEC);
+  });
+  it('keeps an in-range value', () => {
+    expect(clampWindowSec(42)).toBe(42);
+  });
+  it('treats NaN as the min', () => {
+    expect(clampWindowSec(Number.NaN)).toBe(MIN_WINDOW_SEC);
+  });
+});
+
+describe('statusToken (text, not color-only)', () => {
+  const cases: Array<[BatchItemStatus, string]> = [
+    ['done', 'Done'],
+    ['error', 'Failed'],
+    ['cancelled', 'Cancelled'],
+    ['skipped', 'Skipped'],
+    ['running', 'Running'],
+    ['queued', 'Queued'],
+  ];
+  it.each(cases)('%s -> %s', (status, token) => {
+    expect(statusToken(status)).toBe(token);
+  });
+});
+
+describe('isTerminalItem', () => {
+  it('terminal states are terminal', () => {
+    expect(isTerminalItem('done')).toBe(true);
+    expect(isTerminalItem('error')).toBe(true);
+    expect(isTerminalItem('cancelled')).toBe(true);
+    expect(isTerminalItem('skipped')).toBe(true);
+  });
+  it('transient states are not', () => {
+    expect(isTerminalItem('queued')).toBe(false);
+    expect(isTerminalItem('running')).toBe(false);
+  });
+});
+
+describe('terminalAnnouncement (announce on terminal only)', () => {
+  it('done is polite', () => {
+    expect(terminalAnnouncement('Clip A', { status: 'done' })).toEqual({
+      text: 'Clip A — done',
+      assertive: false,
+    });
+  });
+  it('error is assertive and carries the reason', () => {
+    expect(terminalAnnouncement('Clip A', { status: 'error', error: 'boom' })).toEqual({
+      text: 'Clip A — failed: boom',
+      assertive: true,
+    });
+  });
+  it('error falls back to a default reason', () => {
+    expect(terminalAnnouncement('Clip A', { status: 'error' })?.text).toBe(
+      'Clip A — failed: unknown error',
+    );
+  });
+  it('cancelled is polite', () => {
+    expect(terminalAnnouncement('Clip A', { status: 'cancelled' })).toEqual({
+      text: 'Clip A — cancelled',
+      assertive: false,
+    });
+  });
+  it('skipped carries the skipReason', () => {
+    expect(
+      terminalAnnouncement('Clip A', { status: 'skipped', skipReason: 'would egress' }),
+    ).toEqual({ text: 'Clip A — skipped: would egress', assertive: false });
+  });
+  it('skipped falls back to a default reason', () => {
+    expect(terminalAnnouncement('Clip A', { status: 'skipped' })?.text).toBe(
+      'Clip A — skipped: unknown reason',
+    );
+  });
+  it('non-terminal transitions are silent', () => {
+    expect(terminalAnnouncement('Clip A', { status: 'queued' })).toBeNull();
+    expect(terminalAnnouncement('Clip A', { status: 'running' })).toBeNull();
+  });
+});
+
+describe('sourceToken / aggregateUpdate (debounce per-pct chatter)', () => {
+  it('extracts the source k/N token', () => {
+    expect(sourceToken('source 4/30 · Ep4 · step 2/5 · Reframe')).toBe('source 4/30');
+  });
+  it('returns empty when no token present', () => {
+    expect(sourceToken('starting…')).toBe('');
+  });
+  function ev(message: string): ProgressEvent {
+    return { jobId: 'j', pct: 10, message };
+  }
+  it('re-announces when the source token changes', () => {
+    expect(aggregateUpdate('source 1/30 · A · step 1/2', ev('source 2/30 · B · step 1/2'))).toBe(
+      'source 2/30 · B · step 1/2',
+    );
+  });
+  it('suppresses when only pct/step changes within the same source', () => {
+    expect(
+      aggregateUpdate('source 1/30 · A · step 1/2', ev('source 1/30 · A · step 2/2')),
+    ).toBeNull();
+  });
+});
+
+describe('resume-surface predicates (§7.2)', () => {
+  function summary(status: BatchSummary['status'], over: Partial<BatchSummary> = {}): BatchSummary {
+    return {
+      id: 'b',
+      name: 'B',
+      templateId: 't',
+      status,
+      createdAt: 1,
+      counts: { total: 3, done: 1, error: 0, skipped: 0, queued: 2, running: 0, cancelled: 0 },
+      ...over,
+    };
+  }
+  it('classifies incomplete statuses', () => {
+    expect(isIncomplete('queued')).toBe(true);
+    expect(isIncomplete('running')).toBe(true);
+    expect(isIncomplete('partial')).toBe(true);
+    expect(isIncomplete('done')).toBe(false);
+    expect(isIncomplete('cancelled')).toBe(false);
+    expect(isIncomplete('error')).toBe(false);
+  });
+  it('filters + sorts incomplete batches newest-first', () => {
+    const list = [
+      summary('done', { id: 'd', createdAt: 10 }),
+      summary('partial', { id: 'p', createdAt: 5 }),
+      summary('running', { id: 'r', createdAt: 8 }),
+    ];
+    expect(incompleteBatches(list).map((b) => b.id)).toEqual(['r', 'p']);
+  });
+  it('computes remaining (not done, not skipped)', () => {
+    expect(
+      remainingCount({
+        total: 30,
+        done: 10,
+        error: 1,
+        skipped: 4,
+        queued: 15,
+        running: 0,
+        cancelled: 0,
+      }),
+    ).toBe(16);
+  });
+});
+
+describe('batchSettled', () => {
+  it('true when all items terminal', () => {
+    expect(
+      batchSettled({
+        items: [
+          { videoId: 'a', status: 'done' },
+          { videoId: 'b', status: 'skipped' },
+        ],
+      }),
+    ).toBe(true);
+  });
+  it('false when any item pending', () => {
+    expect(
+      batchSettled({
+        items: [
+          { videoId: 'a', status: 'done' },
+          { videoId: 'b', status: 'queued' },
+        ],
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('blankPreset', () => {
+  it('is valid-by-construction', () => {
+    const p = blankPreset();
+    expect(p.minSec).toBe(MIN_WINDOW_SEC);
+    expect(p.maxSec).toBe(MAX_WINDOW_SEC);
+    expect(isValidCaptionStyle(p.captionStyle)).toBe(true);
+    expect(REFRAME_ENGINE_OPTIONS).toContain(p.reframeEngine);
+  });
+});

--- a/app/renderer/src/features/repurposeLogic.ts
+++ b/app/renderer/src/features/repurposeLogic.ts
@@ -1,0 +1,211 @@
+// repurposeLogic.ts — pure, framework-free logic for the Repurpose bundle (WU11).
+//
+// Keeps the testable decisions out of the React panels (mirrors
+// `shortMakerLogic.ts`): per-source status tokens (text, never color-only,
+// §7.1), the announce-granularity rule (announce on source-transition +
+// terminal-state only, NOT on every percent tick, F-a11y-announce-granularity),
+// the edit-time caption-style/aspect/duration constraints for ExportPresetsPanel
+// (§7/§10.5), and the resume-surface predicate (which batches are incomplete,
+// §7.2). All inputs are plain data so each branch is unit-testable to 100%.
+
+import type {
+  BatchItem,
+  BatchItemStatus,
+  BatchState,
+  BatchStatus,
+  BatchSummary,
+  ExportPreset,
+  ProgressEvent,
+} from '../lib/rpc';
+
+// ---- caption-style + reframe-engine constraints (§7 / §10.5) --------------
+//
+// The edit-time controls are CLOSED selects of valid ids only, so an invalid id
+// is unselectable and the sidecar save-time validation is a defense-in-depth
+// backstop. Single-sourced here so the conformance with the sidecar
+// `caption_remotion.STYLES` set is one list to keep in sync.
+
+/** The remotion caption styles (mirrors sidecar `caption_remotion.STYLES`). */
+export const CAPTION_STYLE_OPTIONS: readonly string[] = [
+  'bold',
+  'karaoke',
+  'clean',
+  'bounce',
+  'hormozi',
+  'neon',
+  'tiktok',
+  'gradient',
+  'impact',
+  'mrbeast',
+  'pop',
+  'serif',
+  'fire',
+  'subtitle',
+  // the two libass sentinels the sidecar guard also allows.
+  'libass',
+  'none',
+] as const;
+
+/** The reframe engine ids (mirrors sidecar `export_presets.REFRAME_ENGINES`). */
+export const REFRAME_ENGINE_OPTIONS: readonly string[] = [
+  'auto',
+  'verthor',
+  'claudeshorts',
+] as const;
+
+/** The hard duration window the pipeline enforces (§5.3): 20-60 s. */
+export const MIN_WINDOW_SEC = 20;
+export const MAX_WINDOW_SEC = 60;
+
+/**
+ * Clamp a duration into the hard [20, 60] window so the UI cannot author a
+ * preset the pipeline would silently correct (the save-time clamp's UI mirror).
+ */
+export function clampWindowSec(sec: number): number {
+  if (Number.isNaN(sec)) return MIN_WINDOW_SEC;
+  if (sec < MIN_WINDOW_SEC) return MIN_WINDOW_SEC;
+  if (sec > MAX_WINDOW_SEC) return MAX_WINDOW_SEC;
+  return sec;
+}
+
+/** True when `id` is a selectable caption style (closed-set guard). */
+export function isValidCaptionStyle(id: string): boolean {
+  return CAPTION_STYLE_OPTIONS.includes(id);
+}
+
+// ---- per-source status tokens (text, not color-only, §7.1) ----------------
+
+/** Human, SR-readable status token for one source row (never color alone). */
+export function statusToken(status: BatchItemStatus): string {
+  switch (status) {
+    case 'done':
+      return 'Done';
+    case 'error':
+      return 'Failed';
+    case 'cancelled':
+      return 'Cancelled';
+    case 'skipped':
+      return 'Skipped';
+    case 'running':
+      return 'Running';
+    case 'queued':
+    default:
+      return 'Queued';
+  }
+}
+
+/** The terminal item statuses (no further transitions). */
+const TERMINAL: ReadonlySet<BatchItemStatus> = new Set(['done', 'error', 'cancelled', 'skipped']);
+
+/** True when an item has reached a terminal state. */
+export function isTerminalItem(status: BatchItemStatus): boolean {
+  return TERMINAL.has(status);
+}
+
+// ---- announce-granularity rule (§7.1, F-a11y-announce-granularity) ---------
+//
+// Politeness levels: a terminal flip to `error` is assertive (a failed source
+// must interrupt and not be missed); every other announcement is polite. Queued
+// -> running transitions are NEVER announced (too noisy). The aggregate progress
+// region re-announces ONLY when the `source k/N` token changes, not on every pct
+// tick — so SR users hear "source 4 of 30 …", not 100 announcements per source.
+
+/** A discrete announcement to push to a live region. */
+export interface Announcement {
+  text: string;
+  assertive: boolean;
+}
+
+/**
+ * Decide the per-source terminal announcement when an item flips state. Returns
+ * `null` for non-terminal transitions (queued/running) so they are not spoken.
+ */
+export function terminalAnnouncement(
+  title: string,
+  item: Pick<BatchItem, 'status' | 'error' | 'skipReason'>,
+): Announcement | null {
+  switch (item.status) {
+    case 'done':
+      return { text: `${title} — done`, assertive: false };
+    case 'error':
+      return {
+        text: `${title} — failed: ${item.error ?? 'unknown error'}`,
+        assertive: true,
+      };
+    case 'cancelled':
+      return { text: `${title} — cancelled`, assertive: false };
+    case 'skipped':
+      return {
+        text: `${title} — skipped: ${item.skipReason ?? 'unknown reason'}`,
+        assertive: false,
+      };
+    default:
+      return null;
+  }
+}
+
+/**
+ * Extract the stable `source k/N` token from an aggregate progress message
+ * (`"source k/N · <title> · step j/M · <label>"`, §7). The aggregate region
+ * re-renders ONLY when this token changes, debouncing per-pct chatter. Returns
+ * the empty string when the message has no `source k/N` prefix.
+ */
+export function sourceToken(message: string): string {
+  const match = /source\s+\d+\/\d+/i.exec(message);
+  return match ? match[0] : '';
+}
+
+/**
+ * The polite aggregate text to show, debounced by `sourceToken`. Returns the new
+ * message when its source token differs from `prev`, else `null` (no re-announce
+ * — the prior text stays so the SR isn't spammed on pct-only updates).
+ */
+export function aggregateUpdate(prevMessage: string, event: ProgressEvent): string | null {
+  if (sourceToken(event.message) === sourceToken(prevMessage)) return null;
+  return event.message;
+}
+
+// ---- resume-surface predicate (§7.2) --------------------------------------
+
+/** Aggregate statuses that mean a batch still has work left (resumable). */
+const INCOMPLETE: ReadonlySet<BatchStatus> = new Set(['queued', 'running', 'partial']);
+
+/** True when a batch is incomplete (drives the tab badge + launch toast, §7.2). */
+export function isIncomplete(status: BatchStatus): boolean {
+  return INCOMPLETE.has(status);
+}
+
+/** The incomplete batches of a `batch.list` result, sorted newest-first. */
+export function incompleteBatches(batches: readonly BatchSummary[]): BatchSummary[] {
+  return batches
+    .filter((b) => isIncomplete(b.status))
+    .slice()
+    .sort((a, b) => b.createdAt - a.createdAt);
+}
+
+/** The remaining (not-yet-done) source count for a summary (toast copy). */
+export function remainingCount(counts: BatchSummary['counts']): number {
+  return counts.total - counts.done - counts.skipped;
+}
+
+// ---- merged item view for the queue (store + nothing else) -----------------
+
+/** True when every item of a loaded `BatchState` is terminal (run is over). */
+export function batchSettled(state: Pick<BatchState, 'items'>): boolean {
+  return state.items.every((item) => isTerminalItem(item.status));
+}
+
+// ---- preset defaults (a new-preset row seed for ExportPresetsPanel) --------
+
+/** A blank, valid-by-construction export preset for the "new preset" row. */
+export function blankPreset(): Omit<ExportPreset, 'id'> {
+  return {
+    label: 'New preset',
+    aspect: '9:16',
+    minSec: MIN_WINDOW_SEC,
+    maxSec: MAX_WINDOW_SEC,
+    count: 5,
+    captionStyle: CAPTION_STYLE_OPTIONS[0],
+    reframeEngine: REFRAME_ENGINE_OPTIONS[0],
+  };
+}

--- a/app/renderer/src/features/repurposeTemplates.test.ts
+++ b/app/renderer/src/features/repurposeTemplates.test.ts
@@ -1,0 +1,56 @@
+// repurposeTemplates.test.ts — curated catalog + no-raw-method-id contract.
+
+import { describe, it, expect } from 'vitest';
+
+import {
+  STARTER_TEMPLATES,
+  EXPORT_METHOD,
+  buildTemplateFromStarter,
+  starterById,
+} from './repurposeTemplates';
+
+describe('STARTER_TEMPLATES', () => {
+  it('every starter has a friendly name (no method id) and a build', () => {
+    for (const starter of STARTER_TEMPLATES) {
+      expect(starter.name).not.toContain('.');
+      expect(typeof starter.build).toBe('function');
+    }
+  });
+
+  it('every starter ends in an export step', () => {
+    for (const starter of STARTER_TEMPLATES) {
+      const steps = starter.build('v1');
+      expect(steps.at(-1)?.method).toBe(EXPORT_METHOD);
+    }
+  });
+});
+
+describe('starterById', () => {
+  it('returns the matching starter', () => {
+    expect(starterById(STARTER_TEMPLATES[1].id)).toBe(STARTER_TEMPLATES[1]);
+  });
+  it('falls back to the first starter for an unknown id', () => {
+    expect(starterById('__nope__')).toBe(STARTER_TEMPLATES[0]);
+  });
+});
+
+describe('buildTemplateFromStarter', () => {
+  const starter = STARTER_TEMPLATES[0];
+
+  it('attaches exportTargets to the template field and the export step', () => {
+    const tmpl = buildTemplateFromStarter(starter, 'My style', { count: 5 }, ['tiktok', 'shorts']);
+    expect(tmpl.exportTargets).toEqual(['tiktok', 'shorts']);
+    expect(tmpl.name).toBe('My style');
+    expect(tmpl.defaultControls).toEqual({ count: 5 });
+    const exportStep = tmpl.steps.find((s) => s.method === EXPORT_METHOD);
+    expect(exportStep?.params.exportTargets).toEqual(['tiktok', 'shorts']);
+  });
+
+  it('leaves non-export steps untouched', () => {
+    const tmpl = buildTemplateFromStarter(starter, 'X', {}, ['tiktok']);
+    const nonExport = tmpl.steps.filter((s) => s.method !== EXPORT_METHOD);
+    for (const step of nonExport) {
+      expect(step.params).not.toHaveProperty('exportTargets');
+    }
+  });
+});

--- a/app/renderer/src/features/repurposeTemplates.ts
+++ b/app/renderer/src/features/repurposeTemplates.ts
@@ -1,0 +1,94 @@
+// repurposeTemplates.ts — the curated starter-template catalog (F-template-catalog).
+//
+// Curated-preset-first (DESIGN §7): a creator assembles a template by picking
+// human-labeled starter presets, NEVER raw `protocol.METHODS` ids. The method
+// ids live ONLY inside `build()` (the implementation detail the UI maps onto) —
+// they are never surfaced to the DOM. The export step's `exportTargets` drive the
+// per-preset fan-out; `defaultControls` is the shared "house style".
+//
+// Pure data + a pure builder so the catalog (and the no-raw-method-id contract)
+// is unit-testable without React.
+
+import type { Template, TemplateStep } from '../lib/rpc';
+
+/** One curated starter template the picker offers (friendly label only). */
+export interface StarterTemplate {
+  id: string;
+  /** Human label shown in the picker (never a method id). */
+  name: string;
+  /** One-line description for the picker. */
+  describe: string;
+  /** Build the underlying steps bound to one source — method ids live HERE only. */
+  build: (videoId: string) => TemplateStep[];
+}
+
+/**
+ * The v1 curated starter set (F-template-catalog). Each `build` binds steps to a
+ * source id; the export step's `exportTargets` is filled from the chosen presets
+ * at save time (see `buildTemplateFromStarter`).
+ */
+export const STARTER_TEMPLATES: StarterTemplate[] = [
+  {
+    id: 'shorts-house-style',
+    name: 'Make shorts (house style)',
+    describe: 'Transcribe, pick the best moments, and export shorts per platform.',
+    build: (videoId) => [
+      { method: 'transcribe.start', params: { videoId }, label: 'Transcribe' },
+      { method: 'shortmaker.select', params: { videoId }, label: 'Pick best moments' },
+      { method: 'shortmaker.export', params: { videoId }, label: 'Make shorts' },
+    ],
+  },
+  {
+    id: 'captioned-shorts',
+    name: 'Captioned shorts',
+    describe: 'Transcribe, generate subtitles, then export captioned shorts per platform.',
+    build: (videoId) => [
+      { method: 'transcribe.start', params: { videoId }, label: 'Transcribe' },
+      { method: 'subtitles.generate', params: { videoId }, label: 'Generate subtitles' },
+      { method: 'shortmaker.export', params: { videoId }, label: 'Make shorts' },
+    ],
+  },
+  {
+    id: 'translate-and-shorts',
+    name: 'Translate + shorts',
+    describe: 'Transcribe, subtitle, translate to Spanish, then export shorts per platform.',
+    build: (videoId) => [
+      { method: 'transcribe.start', params: { videoId }, label: 'Transcribe' },
+      { method: 'subtitles.generate', params: { videoId }, label: 'Generate subtitles' },
+      {
+        method: 'subtitles.translate',
+        params: { trackId: '$2.track.id', targetLang: 'es' },
+        label: 'Translate to Spanish',
+      },
+      { method: 'shortmaker.export', params: { videoId }, label: 'Make shorts' },
+    ],
+  },
+];
+
+/** The export step's method id — `exportTargets` attaches to THIS step. */
+export const EXPORT_METHOD = 'shortmaker.export';
+
+/** Resolve a starter by id, falling back to the first when the id is unknown. */
+export function starterById(id: string): StarterTemplate {
+  return STARTER_TEMPLATES.find((s) => s.id === id) ?? STARTER_TEMPLATES[0];
+}
+
+/**
+ * Build a save-ready template payload (no id) from a curated starter, the chosen
+ * default controls, and the export-target preset ids. The `exportTargets` are
+ * attached to BOTH the template field (the runner reads it) and the export step's
+ * params (so the sidecar fan-out — `expand_export_steps` — sees them).
+ */
+export function buildTemplateFromStarter(
+  starter: StarterTemplate,
+  name: string,
+  defaultControls: Record<string, unknown>,
+  exportTargets: string[],
+): Omit<Template, 'id'> {
+  const steps = starter
+    .build('$source')
+    .map((step) =>
+      step.method === EXPORT_METHOD ? { ...step, params: { ...step.params, exportTargets } } : step,
+    );
+  return { name, steps, defaultControls, exportTargets };
+}

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -18,6 +18,8 @@ import {
   type ShortInfo,
   type ShortReexportHint,
   type Video,
+  type ExportPreset,
+  type Template,
 } from './rpc';
 
 // ---------------------------------------------------------------------------
@@ -558,5 +560,77 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('recipes.delete', { id: 'r1' });
     await client.recipes.run('r1');
     expect(r).toHaveBeenCalledWith('recipes.run', { id: 'r1' });
+  });
+});
+
+describe('client.exportPresets / templates / batch (WU11)', () => {
+  const PRESET: ExportPreset = {
+    id: 'tiktok',
+    label: 'TikTok',
+    aspect: '9:16',
+    minSec: 20,
+    maxSec: 60,
+    count: 5,
+    captionStyle: 'tiktok',
+    reframeEngine: 'auto',
+  };
+
+  it('exportPresets.* forward their params', async () => {
+    const r = installApi();
+    await client.exportPresets.list();
+    expect(r).toHaveBeenCalledWith('exportPresets.list', undefined);
+    await client.exportPresets.save(PRESET);
+    expect(r).toHaveBeenCalledWith('exportPresets.save', { preset: PRESET });
+    await client.exportPresets.delete('tiktok');
+    expect(r).toHaveBeenCalledWith('exportPresets.delete', { id: 'tiktok' });
+    await client.exportPresets.reset();
+    expect(r).toHaveBeenCalledWith('exportPresets.reset', undefined);
+  });
+
+  it('templates.* forward their params', async () => {
+    const r = installApi();
+    const template: Template = {
+      id: 't1',
+      name: 'House style',
+      steps: [{ method: 'transcribe.start', params: { videoId: 'v1' }, label: 'Transcribe' }],
+      defaultControls: { count: 5 },
+      exportTargets: ['tiktok', 'shorts'],
+    };
+    await client.templates.list();
+    expect(r).toHaveBeenCalledWith('templates.list', undefined);
+    await client.templates.save(template);
+    expect(r).toHaveBeenCalledWith('templates.save', { template });
+    await client.templates.delete('t1');
+    expect(r).toHaveBeenCalledWith('templates.delete', { id: 't1' });
+    await client.templates.apply('t1', 'v1');
+    expect(r).toHaveBeenCalledWith('templates.apply', { templateId: 't1', videoId: 'v1' });
+  });
+
+  it('batch.* forward their params (start spreads opts; resume/cancel/delete keyed by id)', async () => {
+    const r = installApi();
+    await client.batch.create('Season 3', 't1', ['v1', 'v2']);
+    expect(r).toHaveBeenCalledWith('batch.create', {
+      name: 'Season 3',
+      templateId: 't1',
+      sourceVideoIds: ['v1', 'v2'],
+    });
+    await client.batch.start('b1');
+    expect(r).toHaveBeenCalledWith('batch.start', { id: 'b1' });
+    await client.batch.start('b1', { confirmCloudBudget: true, acknowledged: true });
+    expect(r).toHaveBeenCalledWith('batch.start', {
+      id: 'b1',
+      confirmCloudBudget: true,
+      acknowledged: true,
+    });
+    await client.batch.status('b1');
+    expect(r).toHaveBeenCalledWith('batch.status', { id: 'b1' });
+    await client.batch.list();
+    expect(r).toHaveBeenCalledWith('batch.list', undefined);
+    await client.batch.cancel('b1');
+    expect(r).toHaveBeenCalledWith('batch.cancel', { id: 'b1' });
+    await client.batch.resume('b1');
+    expect(r).toHaveBeenCalledWith('batch.resume', { id: 'b1' });
+    await client.batch.delete('b1');
+    expect(r).toHaveBeenCalledWith('batch.delete', { id: 'b1' });
   });
 });

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -363,6 +363,119 @@ export interface SavedRecipe {
   steps: RecipeStep[];
 }
 
+// ---- Repurpose bundle (WU11) — field names identical to the sidecar -------
+//
+// Wire schemas for the `exportPresets.*` / `templates.*` / `batch.*` groups
+// (DESIGN §7 / §8). Field names are FROZEN and identical to the Python side
+// (`export_presets.py`, `templates.py`, `batch.py`) — the §17 house rule.
+
+/**
+ * One server-persisted platform export preset (`export_presets.py`). `aspect` is
+ * a ratio string ("9:16"); `minSec`/`maxSec` are clamped into the hard 20-60 s
+ * window on save; `captionStyle`/`reframeEngine` are validated id sets.
+ */
+export interface ExportPreset {
+  id: string;
+  label: string;
+  aspect: string;
+  minSec: number;
+  maxSec: number;
+  count: number;
+  captionStyle: string;
+  reframeEngine: string;
+}
+
+/** One template step — a recipe step (`templates.py` reuses `normalize_recipe`). */
+export interface TemplateStep {
+  method: string;
+  params: Record<string, unknown>;
+  label: string;
+}
+
+/**
+ * A reusable edit template (`templates.py`): a recipe (`{id, name, steps}`) plus
+ * the additive `defaultControls` (shared knobs) and `exportTargets` (preset ids
+ * the export step fans out to).
+ */
+export interface Template {
+  id: string;
+  name: string;
+  steps: TemplateStep[];
+  defaultControls: Record<string, unknown>;
+  exportTargets: string[];
+}
+
+/** One source's terminal/transient status inside a batch (`batch.py`). */
+export type BatchItemStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled' | 'skipped';
+
+/**
+ * One source row of a batch (`batch.py`). `skipReason` carries the visible-skip
+ * contract (DESIGN §9.1) — a skipped source is attributed, never silently absent.
+ */
+export interface BatchItem {
+  videoId: string;
+  status: BatchItemStatus;
+  jobId?: string;
+  error?: string;
+  skipReason?: string;
+  results?: unknown;
+}
+
+/** Aggregate batch status (`batch.py` `derive_status`). */
+export type BatchStatus = 'queued' | 'running' | 'done' | 'error' | 'cancelled' | 'partial';
+
+/** A full durable batch record (`batch.py` `BatchState`). */
+export interface BatchState {
+  id: string;
+  name: string;
+  templateId: string;
+  status: BatchStatus;
+  createdAt: number;
+  items: BatchItem[];
+  /** Live-overlay `pct` while the parent job runs (`_merge_live_status`). */
+  pct?: number;
+}
+
+/** Per-status counts in a `BatchSummary` (`batch.py` `_summarize`). */
+export interface BatchCounts {
+  total: number;
+  done: number;
+  error: number;
+  skipped: number;
+  queued: number;
+  running: number;
+  cancelled: number;
+}
+
+/** A lightweight batch summary (heavy per-item data omitted) — `batch.list`. */
+export interface BatchSummary {
+  id: string;
+  name: string;
+  templateId: string;
+  status: BatchStatus;
+  createdAt: number;
+  counts: BatchCounts;
+}
+
+/** One per-source consent decision from `batch.start`'s `plan_consent` (§9.1). */
+export interface BatchConsentDecision {
+  videoId: string;
+  action: 'run' | 'skip';
+  skipReason: string | null;
+  confirmBudget: string | null;
+  willEgress: boolean;
+  cacheHit: boolean;
+}
+
+/** The pre-run consent surface (`batch.py` `plan_consent`, DESIGN §9.1). */
+export interface BatchConsent {
+  decisions: BatchConsentDecision[];
+  willRun: number;
+  willSkip: number;
+  costEst: Record<string, unknown>;
+  budget: Record<string, unknown>;
+}
+
 /** A3 VoiceSample — a stored voice-clone reference sample. */
 export interface VoiceSample {
   id: string;
@@ -760,6 +873,44 @@ export const client = {
       rpc('recipes.save', { recipe }),
     delete: (id: string): Promise<{ ok: boolean }> => rpc('recipes.delete', { id }),
     run: (id: string): Promise<JobHandle> => rpc('recipes.run', { id }),
+  },
+
+  /** `exportPresets.*` — server-persisted platform export presets (WU11). */
+  exportPresets: {
+    list: (): Promise<{ presets: ExportPreset[] }> => rpc('exportPresets.list'),
+    save: (preset: ExportPreset | Omit<ExportPreset, 'id'>): Promise<{ preset: ExportPreset }> =>
+      rpc('exportPresets.save', { preset }),
+    delete: (id: string): Promise<{ ok: boolean }> => rpc('exportPresets.delete', { id }),
+    reset: (): Promise<{ presets: ExportPreset[] }> => rpc('exportPresets.reset'),
+  },
+
+  /** `templates.*` — reusable edit templates (recipe + controls + targets). */
+  templates: {
+    list: (): Promise<{ templates: Template[] }> => rpc('templates.list'),
+    save: (template: Template | Omit<Template, 'id'>): Promise<{ template: Template }> =>
+      rpc('templates.save', { template }),
+    delete: (id: string): Promise<{ ok: boolean }> => rpc('templates.delete', { id }),
+    apply: (templateId: string, videoId: string): Promise<JobHandle> =>
+      rpc('templates.apply', { templateId, videoId }),
+  },
+
+  /** `batch.*` — durable, resumable many-source queue (WU11). */
+  batch: {
+    create: (
+      name: string,
+      templateId: string,
+      sourceVideoIds: string[],
+    ): Promise<{ batch: BatchState }> => rpc('batch.create', { name, templateId, sourceVideoIds }),
+    start: (
+      id: string,
+      opts?: { confirmCloudBudget?: boolean; acknowledged?: boolean },
+    ): Promise<JobHandle> => rpc('batch.start', { id, ...(opts ?? {}) }),
+    status: (id: string): Promise<{ batch: BatchState }> => rpc('batch.status', { id }),
+    list: (): Promise<{ batches: BatchSummary[] }> => rpc('batch.list'),
+    cancel: (id: string): Promise<{ ok: boolean }> => rpc('batch.cancel', { id }),
+    resume: (id: string): Promise<JobHandle & { status?: BatchStatus }> =>
+      rpc('batch.resume', { id }),
+    delete: (id: string): Promise<{ ok: boolean }> => rpc('batch.delete', { id }),
   },
 
   /** `diarize.start` — token-free speaker labelling (long job -> {transcript}). */

--- a/app/renderer/src/views/Repurpose.test.tsx
+++ b/app/renderer/src/views/Repurpose.test.tsx
@@ -1,0 +1,73 @@
+// Repurpose.test.tsx — the tabbed Repurpose view (BatchQueue default landing).
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+// Stub the three panels so the view test exercises ONLY the tab switch + the
+// resumeId pass-through (the panels own their own tests).
+vi.mock('../features/BatchQueue', () => ({
+  BatchQueue: ({ resumeId }: { resumeId?: string }) => (
+    <div data-testid="queue" data-resume={resumeId ?? ''} />
+  ),
+}));
+vi.mock('../features/TemplateEditor', () => ({
+  TemplateEditor: () => <div data-testid="templates" />,
+}));
+vi.mock('../features/ExportPresetsPanel', () => ({
+  ExportPresetsPanel: () => <div data-testid="presets" />,
+}));
+
+import { Repurpose } from './Repurpose';
+
+let container: HTMLElement;
+let root: Root;
+
+function render(props: { resumeId?: string } = {}): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(<Repurpose {...props} />);
+  });
+}
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function clickTab(label: string): void {
+  const tab = [...container.querySelectorAll('[role="tab"]')].find((t) => t.textContent === label);
+  if (!tab) throw new Error(`tab not found: ${label}`);
+  act(() => tab.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+}
+
+describe('Repurpose', () => {
+  it('lands on the Batch queue and passes the resumeId through', () => {
+    render({ resumeId: 'b1' });
+    const queue = container.querySelector('[data-testid="queue"]');
+    expect(queue).not.toBeNull();
+    expect(queue?.getAttribute('data-resume')).toBe('b1');
+    expect(container.querySelector('[data-testid="templates"]')).toBeNull();
+  });
+
+  it('switches to Templates and Export presets tabs', () => {
+    render();
+    clickTab('Templates');
+    expect(container.querySelector('[data-testid="templates"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="queue"]')).toBeNull();
+    clickTab('Export presets');
+    expect(container.querySelector('[data-testid="presets"]')).not.toBeNull();
+    clickTab('Batch queue');
+    expect(container.querySelector('[data-testid="queue"]')).not.toBeNull();
+  });
+
+  it('marks the active tab with aria-selected', () => {
+    render();
+    const tabs = [...container.querySelectorAll('[role="tab"]')];
+    const queueTab = tabs.find((t) => t.textContent === 'Batch queue');
+    expect(queueTab?.getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/app/renderer/src/views/Repurpose.tsx
+++ b/app/renderer/src/views/Repurpose.tsx
@@ -1,0 +1,38 @@
+// Repurpose.tsx — the Repurpose view (DESIGN §7): a tabbed surface over the three
+// panels. BatchQueue is the DEFAULT landing (the primary folder→shorts flow);
+// TemplateEditor and ExportPresetsPanel are the secondary config surfaces. The
+// inner tab strip rides `TabBar`'s role=tablist/tab/aria-selected a11y for free.
+import React, { useState } from 'react';
+import { TabBar, type TabDef } from '../components/TabBar';
+import { BatchQueue } from '../features/BatchQueue';
+import { TemplateEditor } from '../features/TemplateEditor';
+import { ExportPresetsPanel } from '../features/ExportPresetsPanel';
+
+const TABS: TabDef[] = [
+  { id: 'queue', label: 'Batch queue' },
+  { id: 'templates', label: 'Templates' },
+  { id: 'presets', label: 'Export presets' },
+];
+
+export interface RepurposeProps {
+  /** A deep-link batch id to resume on mount (from the launch toast, §7.2). */
+  resumeId?: string;
+}
+
+/** The Repurpose view: batch queue (default) + template + preset panels. */
+export function Repurpose({ resumeId }: RepurposeProps): React.ReactElement {
+  const [active, setActive] = useState('queue');
+
+  return (
+    <div className="repurpose" aria-label="Repurpose">
+      <TabBar tabs={TABS} active={active} onSelect={setActive} />
+      <div className="repurpose__panel">
+        {active === 'queue' ? <BatchQueue resumeId={resumeId} /> : null}
+        {active === 'templates' ? <TemplateEditor /> : null}
+        {active === 'presets' ? <ExportPresetsPanel /> : null}
+      </div>
+    </div>
+  );
+}
+
+export default Repurpose;

--- a/docs/plans/repurpose/DESIGN.md
+++ b/docs/plans/repurpose/DESIGN.md
@@ -1,6 +1,6 @@
 # Repurpose Bundle — Design Doc
 
-**Status:** v1 — DESIGN (awaiting Design Review Gate)
+**Status:** v1 — DESIGN (design-gate blocking items resolved: BatchQueue live-status a11y model §7.1; concrete batch-consent surface + visible-skip §9.1; plus Designer non-blocking weaknesses — resume discoverability §7.2, curated-preset-first TemplateEditor §7, constrained edit-time caption-style select §7/§10.5, info hierarchy §7)
 **Date:** 2026-06-18
 **Owner:** Reframe Media Studio
 **Branch:** `feat/repurpose-design` (docs only — no feature code)
@@ -100,7 +100,7 @@ The runner is **unchanged from `recipes._run_steps`** (`recipes.py:279`): each s
 
 ### 5.2 Batch queue (`features/batch.py`)
 
-A **batch** = `{id, name, templateId, sourceVideoIds:[...], status, items:[BatchItem]}` where a `BatchItem` = `{videoId, status: "queued"|"running"|"done"|"error"|"cancelled", jobId?, error?, results?}`. It runs each source through the named template **as a nested recipe run**, so one batch = one parent job that drives N per-source recipe runs.
+A **batch** = `{id, name, templateId, sourceVideoIds:[...], status, items:[BatchItem]}` where a `BatchItem` = `{videoId, status: "queued"|"running"|"done"|"error"|"cancelled"|"skipped", jobId?, error?, skipReason?, results?}`. The `"skipped"` terminal state + `skipReason` carry the visible-skip contract (§9.1) so a source dropped by the consent gate is recorded and attributed, never silently absent. It runs each source through the named template **as a nested recipe run**, so one batch = one parent job that drives N per-source recipe runs.
 
 - **Execution shape** mirrors `convert_batch` (`convert.py:195-238`): iterate `sourceVideoIds`, spread the parent job's `[0,100]` progress across items, honor cancellation between items (`job_ctx.raise_if_cancelled`, `recipes.py:285`). Per-source isolation: a source whose template run errors is recorded `error` on its `BatchItem` and the batch **continues** (NOT the convert behavior, which aborts — this is the one deliberate divergence, §10.3).
 - **Per-source run** = invoke the template runner for that `videoId` (binding the template's steps to this source, e.g. `transcribe.start {videoId}` → … → `shortmaker.export`). Because the template runner returns `{jobId}`, the batch awaits it with the SAME `_await_subjob` relay (`recipes.py:323`) — no new waiting code.
@@ -146,7 +146,7 @@ All registered through the existing single composition root (`handlers.py:1982` 
 |--------|--------|--------|-------|
 | `batch.create` | `{name, templateId, sourceVideoIds}` | `{batch}` | persists a `BatchState` (queued items) — durable |
 | `batch.start` | `{id}` | `{jobId}` | the long parent job; per-source isolation; resumable |
-| `batch.status` | `{id}` | `{batch}` | aggregate + per-item status (read from store + live job) |
+| `batch.status` | `{id}` | `{batch}` | aggregate + per-item status (read from store + live job); includes `skipped` items with `skipReason` (§9.1) so the run/skip split is always explainable |
 | `batch.list` | — | `{batches:[BatchSummary]}` | including finished ones |
 | `batch.cancel` | `{id}` | `{ok}` | cancels the parent job (→ cooperative item cancel, `jobs.py:447`) |
 | `batch.resume` | `{id}` | `{jobId}` | re-enqueue not-yet-done items (§10.1) |
@@ -165,12 +165,39 @@ A new **Repurpose** view (tab in `TabBar.tsx` / `App.tsx`), composed of three pa
 - `client.batch.{create,start,status,list,cancel,resume,delete}`
 - New TS interfaces in `rpc.ts` (§3 schema block): `ExportPreset`, `Template`, `BatchItem`, `BatchState`, `BatchSummary` — field names identical to the sidecar (the house rule, `rpc.ts:17`).
 
+**Information hierarchy / progressive disclosure (UX clarity).** The view is NOT three equally-weighted config surfaces. The default landing panel is **BatchQueue** (the primary "folder → shorts" flow): a first-run user picks sources + a template and runs, without touching the other two panels. TemplateEditor and ExportPresetsPanel are secondary/collapsed config surfaces reached from BatchQueue (a "New template" / "Edit presets" affordance) — the happy path never requires opening them because the bundle ships **seeded presets** (tiktok/reels/shorts, §5.3) and the template picker offers **curated starter templates** (below) so day-one batch runs work with zero configuration. This mirrors `Recipes.tsx`, where curated `RECIPE_PRESETS` are the entry point and raw step editing is the advanced path.
+
 Panels (under `renderer/src/features/` and `renderer/src/views/`):
-1. **TemplateEditor** — pick steps (from a method allowlist), set `defaultControls` (REUSE `shortMakerLogic` `DEFAULT_CONTROLS`/`sanitizeControls` + `shortMakerPresets` `buildExportParams`), choose `exportTargets`. Save via `templates.save`.
-2. **ExportPresetsPanel** — table of presets, edit aspect/style/min-max-sec/count; REUSE `PLATFORM_PRESETS` as the seed view + `CAPTION_STYLE_OPTIONS` (`shortMakerLogic.ts:198`) for the style picker.
-3. **BatchQueue** — multi-select library videos (REUSE the native multi-picker `window.api.openVideos`, `rpc.ts:438`), pick a template, `batch.create` → `batch.start`. Live aggregate + per-source rows driven by `onProgress`/`onJobDone` (`rpc.ts:473,478`) and `batch.status` polling; a **Resume** button calls `batch.resume` for any batch left incomplete (visible on relaunch). REUSE the existing `JobQueue.tsx` / `ProgressBar.tsx` components for row rendering.
+1. **TemplateEditor** — REUSE the curated-preset-first pattern, NOT raw method ids. Step selection is offered as **human-labeled curated starter templates** (mirroring `Recipes.tsx`'s `RECIPE_PRESETS`, e.g. "Transcribe + label speakers") — the picker shows the friendly label, never the developer identifier (`shortmaker.select`, `phase8.select`). A creator assembles a template by picking labeled presets/steps from this curated catalog; the underlying method allowlist (§10.6) is an implementation detail the UI maps onto, so a non-technical creator is never shown raw `protocol.METHODS` names. Set `defaultControls` (REUSE `shortMakerLogic` `DEFAULT_CONTROLS`/`sanitizeControls` + `shortMakerPresets` `buildExportParams`), choose `exportTargets`. Save via `templates.save`. **Decision surfaced as a gate question (F-template-catalog):** the v1 curated starter set + label copy is itself a deliverable, not a free-form method dropdown.
+2. **ExportPresetsPanel** — table of presets, edit aspect/min-max-sec/count, and a **constrained `captionStyle` select seeded from `CAPTION_STYLE_OPTIONS`** (`shortMakerLogic.ts:198`): the edit-time control is a closed dropdown of valid style ids only, so an invalid id is *unselectable* and the save-time validation (§10.5) is a defense-in-depth backstop, not the primary UX. REUSE `PLATFORM_PRESETS` as the seed view. Aspect/duration fields show the §5.3 window clamp (20-60 s) inline so the user cannot author a preset the pipeline will silently correct.
+3. **BatchQueue** — multi-select library videos (REUSE the native multi-picker `window.api.openVideos`, `rpc.ts:438`), pick a template, review the **consent summary** (§9), `batch.create` → `batch.start`. Live aggregate + per-source rows driven by `onProgress`/`onJobDone` (`rpc.ts:473,478`) and `batch.status` polling; a **Resume** affordance (§7.2) for any batch left incomplete. REUSE the existing `JobQueue.tsx` / `ProgressBar.tsx` components for row rendering, plus the NEW per-source live-status announcer in §7.1.
 
 Progress relay: the parent batch job's `job.progress` carries `"source k/N · <title> · step j/M · <label>"` (extends the recipe runner's existing `"step k/N · <label>"` message, `recipes.py:293`).
+
+### 7.1 BatchQueue accessibility model — live per-source state (BLOCKING #1, resolved)
+
+The headline batch feature is glance-away / unattended use, so a sighted-and-screen-reader user must be **told** when a source completes or fails without watching the screen. The reused `JobQueue.tsx` does **not** carry an `aria-live` region (verified: it has only `role="alert"` on its error block, `JobQueue.tsx:137`) — so this is **net-new UX, not "reuse,"** and is specified here rather than deferred to BUILD.
+
+**The pattern is reused, the wiring is new.** The codebase already establishes the exact idiom for SR-announced progress: a polite live region, e.g. `ShortMaker.tsx:773` (`<div role="status" aria-live="polite">`) and the `progress` regions across `Convert.tsx:318`, `Recipes.tsx:239`, `Subtitles.tsx:342`, `Diarize.tsx:141`, `Dub.tsx:402`, `Assets.tsx:194`. BatchQueue adopts the SAME idiom; it does not invent a new one.
+
+Concrete a11y contract for the BatchQueue panel:
+
+- **Aggregate status region** — one `role="status" aria-live="polite"` region (matching `ShortMaker.tsx:773`) holding the aggregate batch message (`"source k/N · <title> · step j/M · <label>"`, §7) so continuous progress is announced politely without spamming on every percent tick (announce on **source transition**, not on every `onProgress` pct — debounce by re-rendering the region text only when `source k/N` or item status changes, so SR users hear "source 4 of 30 …", not 100 announcements per source).
+- **Per-source terminal-transition announcements** — when a `BatchItem` flips to a **terminal** state, append a discrete sentence to the SAME polite region (or a sibling `aria-live="polite"` log region): `"<title> — done"` on success and **`"<title> — failed: <reason>"`** on error. Errors use `aria-live="assertive"` / `role="alert"` (matching `SidecarBanner.tsx:72`) so a failed source interrupts and is not missed — this is the one transition important enough to be assertive. Queued→running transitions are NOT announced (too noisy); only terminal `done`/`error`/`cancelled` are.
+- **Per-row visual state is not color-only** — each source row carries a text/icon status token ("Done", "Failed", "Queued", "Running", "Skipped"), never color alone, reusing the PresetPicker discipline ("aria-pressed, not color alone … text, not color", `PresetPicker.tsx:6,11`). The `<ProgressBar>` per row keeps its `role="progressbar"` + `aria-valuenow` (`ProgressBar.tsx:25-28`).
+- **Tab inherits a11y for free** — the new Repurpose tab rides `TabBar.tsx`'s `role="tablist"`/`role="tab"`/`aria-selected` (`TabBar.tsx:17,24,25`), so keyboard/SR navigation to the surface needs no new code.
+
+This makes the core glance-away/SR experience a first-class part of the design, satisfying the design-gate blocking item. **GATE QUESTION (F-a11y-announce-granularity):** confirm "announce on source-transition + terminal-state only" (recommended) vs. announcing every step transition (richer but chattier for SR users).
+
+### 7.2 Resume discoverability — surfacing an interrupted batch BEFORE the user opens the tab
+
+`batch.resume` (§6, §10.1) restarts an incomplete batch, but after an app restart the user may not know a batch was interrupted if they never open the Repurpose tab. The Resume affordance must therefore be **discoverable from outside the panel**:
+
+- **Tab badge** — on launch the renderer calls `batch.list` (cheap, store-only read, §6) and, if any `BatchState.status` is `running`/`partial`/`queued` (i.e. not `done`/`cancelled`), renders a count badge on the Repurpose tab in `TabBar.tsx` (the tab already exists; the badge is additive text, not color-only — an "(N)" suffix in the tab label so it is SR-readable, consistent with the §7.1 not-color-only rule).
+- **Launch toast** — additionally surface a one-time, dismissible toast via the existing `ToastHost` (`ToastHost.tsx:68`, already `aria-live="polite"`) on first launch after an interrupted batch: `"A batch ('<name>') was interrupted — N of M sources left. Resume?"` with a Resume action that deep-links into BatchQueue. REUSE `ToastHost` rather than inventing a banner; it already carries the polite live region.
+- Inside the panel, incomplete batches sort to the top with a prominent **Resume** button calling `batch.resume`.
+
+This closes the clarity hole in G2 (the user is told an interrupted batch exists, by two independent channels, before they navigate). **GATE QUESTION (F-resume-surface):** tab badge + launch toast (recommended), tab badge only, or toast only.
 
 ---
 
@@ -200,9 +227,10 @@ Reuse the existing `defaultTargetJobSize` (`settings_store.py:69`, consumed by `
   "status": "running",          // queued|running|done|error|cancelled|partial
   "createdAt": 1781757400.0,
   "items": [
-    { "videoId": "vid-1", "status": "done",   "results": {...} },
-    { "videoId": "vid-2", "status": "error",  "error": "transcribe failed: ..." },
-    { "videoId": "vid-3", "status": "queued" }
+    { "videoId": "vid-1", "status": "done",    "results": {...} },
+    { "videoId": "vid-2", "status": "error",   "error": "transcribe failed: ..." },
+    { "videoId": "vid-3", "status": "queued" },
+    { "videoId": "vid-4", "status": "skipped", "skipReason": "would egress — not acknowledged" }
   ]
 }
 ```
@@ -214,8 +242,25 @@ Reuse the existing `defaultTargetJobSize` (`settings_store.py:69`, consumed by `
 - **Reversible by construction.** Templates and presets are JSON CRUD; deleting a batch never touches produced media (it lives under `exports/shorts-<videoId>`, owned by the existing shorts library, `handlers.py:2133`). `exportPresets.reset` restores seeds. No in-place edits to source media — every render writes a NEW derivative (the `ShortMaker.export` contract).
 - **Cancellation is cooperative + already proven.** `batch.cancel` sets the parent job's flag (`jobs.py:447`); the batch loop's `raise_if_cancelled` (`recipes.py:285`) stops between sources and cancels the in-flight sub-job (`_await_subjob`, `recipes.py:345-347`). No new cancellation machinery.
 - **AI consent + budget ride the Hub envelope, unchanged.** The batch never calls a provider directly. When a template step is `shortmaker.select`/`phase8.select`/`subtitles.translate`, those handlers already build the envelope via `_run_ai_job` (`handlers.py:1617`) and enforce the budget-ack gate `_enforce_cloud_budget_ack` (`handlers.py:1672`): if `confirmCloudBudget` is on and the run would egress, the step requires the `ai.planJob` `cacheKey` as `confirmBudget`.
-  - **Batch consequence (GAP §10.2):** a fully-unattended N-source batch can't interactively pre-flight each source's AI step. The envelope's `cacheKey` is per-request, so a batch-wide blanket ack would not match. **Design decision for the gate:** the batch surfaces a single **pre-run consent summary** (one `ai.planJob` per distinct step shape via the existing pure planner, ZERO provider calls — `handlers.py:1693`) and requires the user to acknowledge cloud egress for the whole batch ONCE; if `confirmCloudBudget` is on, the batch either (a) runs only sources whose AI steps are cache hits / local-only, or (b) is refused with the same typed message until the user disables the per-call gate or chooses an all-local routing preset. Frame/text consent (`providers.setConsent`, `handlers.py:414`) is unchanged and still enforced per-entry at pool construction (`handlers.py:597`). **GATE QUESTION (F-batch-consent):** confirm (a) skip-non-acked vs. (b) refuse-batch as the default.
+  - **Batch consequence (GAP §10.2):** a fully-unattended N-source batch can't interactively pre-flight each source's AI step. The envelope's `cacheKey` is per-request, so a batch-wide blanket ack would not match. **Design decision for the gate:** the batch surfaces a single **pre-run consent summary** (built from `ai.planJob`, the existing pure planner, ZERO provider calls — `handlers.py:1693`, which returns `{route, costEst, cacheHit, willEgress, budget, preview, cacheKey}`, `handlers.py:1696`) and requires the user to acknowledge cloud egress for the whole batch ONCE; if `confirmCloudBudget` is on, the batch either (a) runs only sources whose AI steps are cache hits / local-only and **visibly skips** the rest, or (b) is refused with the same typed message until the user disables the per-call gate or chooses an all-local routing preset. Frame/text consent (`providers.setConsent`, `handlers.py:414`) is unchanged and still enforced per-entry at pool construction (`handlers.py:597`). The concrete surface for this is specified in §9.1. **GATE QUESTION (F-batch-consent):** confirm (a) skip-non-acked vs. (b) refuse-batch as the default.
 - **No secrets in batch state.** `BatchState`/results store method results, never keys; the redaction invariants (`providers.list`, `handlers.py:330`) are untouched because the batch never reads raw provider config.
+
+### 9.1 Batch consent surface — concrete UX + visible skip (BLOCKING #2, resolved)
+
+The batch-wide consent gate is the most novel UX in the bundle, so its surface is specified here rather than left to the gate question. It is computed BEFORE `batch.start`, from pure `ai.planJob` plans only (no provider calls), and is rendered as a **pre-run consent summary card** in BatchQueue.
+
+**What the summary shows** (one card, derived from one `ai.planJob` per distinct step *shape* — sources sharing a template+size collapse to one plan, so the planner cost is bounded by step-shape count, not source count):
+- **Per-step shape** rows: the human step label ("Make 5 shorts", "Translate captions"), its route (`route` from the plan), and whether it would **egress** (`willEgress`) or stay local.
+- **Source count and split**: "**N of M sources will run**; K skipped" — and crucially, **which sources are local-only / cache-hit vs. egressing**, computed from each source's plan `willEgress`/`cacheHit`. Local-only and cache-hit sources run regardless; only sources with a `willEgress` step under an un-acked `confirmCloudBudget` are at risk.
+- **Estimated cost** (`costEst`) aggregated across the egressing sources, and the budget headroom (`budget` from the plan), so the single acknowledgement is informed.
+- **One acknowledgement control** — a single "Acknowledge cloud egress for this batch" action that records the user's consent for the whole run (the batch passes the per-step `cacheKey` from each plan as `confirmBudget` to the underlying handler, satisfying `_enforce_cloud_budget_ack`, `handlers.py:1672`, without changing the envelope). If `confirmCloudBudget` is OFF, the card is informational only (no ack required) and all sources run.
+
+**Making option (a) "skip" VISIBLE (the design-load-bearing part).** When the default is (a) skip-non-acked and `confirmCloudBudget` is on, a source whose AI step would egress and is not acknowledged is **never silently dropped**. It is surfaced through concrete channels so the user can always tell *why N of 30 didn't run*:
+1. **Pre-run, in the summary card**: the "K skipped" list names each skipped source with the reason token ("would egress — not acknowledged" / "no budget headroom"), so the user sees the skip *before* committing.
+2. **In the BatchItem model**: skipped sources get an explicit terminal status `status: "skipped"` with a `skipReason` field on the `BatchItem` (additive to the §5.2 shape, alongside `error`) — never `done`, never a silent absence. `BatchState` therefore records the full M sources with N run + K skipped, so `batch.status` and a later read always explain the gap.
+3. **In the live queue + a11y layer**: each skipped row renders a text "Skipped" status token (not color-only, §7.1) with the reason in a tooltip/detail, and the §7.1 polite live region announces `"<title> — skipped: <reason>"` so SR users are told too. A skipped source is thus *visible, attributed, and re-runnable* (acknowledge, then `batch.resume` re-evaluates skipped items).
+
+This converts a silently-skipped source — a clarity and accessibility trap — into an explicit, attributed, recoverable outcome. The chosen default (F-batch-consent) ships with this surfacing UX as a unit; whichever of (a)/(b) the gate picks, the skip/refusal reason is always shown.
 
 ---
 
@@ -254,7 +299,10 @@ Each work unit: TDD first; sidecar `pytest --cov-branch --cov-fail-under=100`; r
 ## 12. Open gate questions
 
 - **F-template-shape (§5.4):** new `templates.py` (recommended) vs. extend `recipes.normalize_recipe` in place.
-- **F-batch-consent (§9/§10.2):** default to (a) run-only-non-egressing under `confirmCloudBudget`, or (b) refuse-batch-until-acked.
+- **F-batch-consent (§9/§9.1/§10.2):** default to (a) run-only-non-egressing under `confirmCloudBudget` **with the visible-skip surface (§9.1)** (recommended), or (b) refuse-batch-until-acked. Either way the skip/refusal reason is shown — the surface (§9.1) is decided, only the policy default is open.
 - **F-resume-granularity (§10.1):** confirm source-level resume is acceptable for v1 (mid-pipeline checkpointing deferred).
 - **F-error-policy (§10.3):** confirm `batchContinueOnError` default `true`.
 - **F-youtube (§10.4):** include a seeded 16:9 `youtube` preset in v1, or vertical-only until landscape reframe is validated.
+- **F-a11y-announce-granularity (§7.1):** announce on source-transition + terminal-state only (recommended) vs. every step transition.
+- **F-resume-surface (§7.2):** tab badge + launch toast (recommended) vs. badge-only vs. toast-only for surfacing an interrupted batch.
+- **F-template-catalog (§7):** confirm the v1 curated starter-template set + label copy (curated-preset-first, no raw method ids exposed to the creator).

--- a/docs/plans/repurpose/DESIGN.md
+++ b/docs/plans/repurpose/DESIGN.md
@@ -1,0 +1,260 @@
+# Repurpose Bundle — Design Doc
+
+**Status:** v1 — DESIGN (awaiting Design Review Gate)
+**Date:** 2026-06-18
+**Owner:** Reframe Media Studio
+**Branch:** `feat/repurpose-design` (docs only — no feature code)
+**Scope:** three repurposing capabilities that turn long/many source videos into platform-ready output at scale:
+1. **Batch queue** — process many source videos through a pipeline with progress + resume.
+2. **Reusable edit templates** — save an edit-recipe (a workflow) once, apply it to new sources.
+3. **Multi-platform export presets** — TikTok / Reels / Shorts aspect ratios + caption styles + duration targets, applied per-platform in one pass.
+
+> **RAILS honored.** Every claim below cites real code (`file:line`). Where a capability does **not** exist today it is named explicitly as a **GAP** with the smallest reuse-based fill. The bundle is **docs only** here; the eventual BUILD rides the shipped Hub substrate (AI-Job envelope, rotation pool, `handlers.register_all`) and clears the standing gates (sidecar `pytest --cov-branch --cov-fail-under=100`; renderer vitest `thresholds:100`; ruff / oxlint / biome / basedpyright / tsc; never `--no-verify`; never `git add -A`).
+
+---
+
+## 1. Problem & motivation
+
+A creator who wants to "repurpose" content is rarely working with one clip. They have **a folder of 30 podcast episodes** and want vertical shorts from each; they have **a house style** (transcribe → polish captions → make 5 shorts → package) they re-run for every upload; and they ship the **same clip to three platforms** (TikTok 9:16 / Reels 9:16 / YouTube Shorts 9:16) with platform-specific caption styles and duration windows.
+
+The codebase already has every *primitive* this needs:
+
+- **A pipeline runner over many steps** — `features/recipes.py` (`recipes.run`, lines 256-300) runs a saved `[{method, params}]` recipe as ONE job, awaiting any `{jobId}` sub-job and relaying scaled progress (`_await_subjob`, lines 323-359), with `$N.key` references threading one step's output into the next (`resolve_refs`, lines 133-153).
+- **A many-item batch** — `features/convert.py` `convert_batch` (`handlers.py:1007`) → `batch_handler` (`convert.py:281`) → `convert_batch` (`convert.py:195-238`) iterates a list of items, spreads progress evenly, honors per-item cancellation, returns `{paths}`.
+- **Platform presets** — `app/renderer/src/features/shortMakerPresets.ts` `PLATFORM_PRESETS` (tiktok/reels/shorts, all 9:16, distinct `count`/`maxSec`) + `applyPreset` already exist for the single-video Short Maker.
+- **The render engines** — `features/reframe.py` (`ReframeEngine`, 1080×1920 9:16, WSL/verthor with claudeshorts fallback, `get_engine`/`resolve_engine_name`) and `features/shortmaker.py` (`ShortMaker.export`, `run_export`, `Stages`).
+- **A bounded job pool** — `jobs.py` `JobRegistry` (2 workers; gpu-tagged serialized to 1; FIFO queue; `job.list`/`job.retry`).
+
+**What is missing is composition and durability:** there is no way to (a) point a pipeline at *many sources* and watch one aggregate job; (b) save the recipe AND its per-platform export fan-out as a reusable named "template"; (c) **resume** a batch after the app restarts (the job registry is in-memory only — `jobs.py:204` `self._jobs: dict` — so a crash or quit loses all queue + progress state). The Repurpose bundle composes the primitives and adds the one missing durability layer.
+
+---
+
+## 2. Goals
+
+- **G1 — Batch over many sources:** one queue that runs a chosen pipeline (a recipe template) against N library videos, with aggregate + per-source progress and per-source pass/fail isolation (one bad source must not sink the batch).
+- **G2 — Resume:** a batch survives a sidecar/app restart — completed sources stay completed, in-flight/queued sources re-enqueue, nothing re-does finished work.
+- **G3 — Reusable edit templates:** save a workflow (recipe steps + default controls + export targets) under a name; apply it to any new source(s) without re-typing. Generalize `recipes.*` rather than fork it.
+- **G4 — Multi-platform export presets:** extend the existing 9:16 platform presets into first-class, server-persisted presets carrying aspect + caption style + duration target (min/max sec) + clip count, and fan ONE source out to multiple platform presets in one batch run.
+- **G5 — Reuse the job model + render engines:** every long-running step runs on the existing `JobRegistry`; every render goes through `ShortMaker.export` / `ReframeEngine` — NO new media logic, NO second job bus.
+- **G6 — Reuse the Hub envelope for AI parts:** any step that calls a provider (`shortmaker.select`, `phase8.select`, `subtitles.translate`) keeps riding `run_ai_job` (consent + budget pre-flight + cache + degrade), unchanged. The batch layer adds NO new provider call site.
+- **G7 — Quality bar:** 100% line+branch sidecar coverage; renderer UI to 100%; reversible/safe by default; no secrets logged.
+
+## 3. Non-goals
+
+- **Scheduling / unattended cron / watch-folder ingestion.** A batch is user-initiated. (A watch-folder is a clean later add on top of `batch.enqueue`.)
+- **Distributed / multi-machine execution.** Single host, the existing 2-worker pool.
+- **New AI capabilities or new providers.** The bundle orchestrates existing methods; the Hub already owns model routing.
+- **A second persistence engine (DB/vector store).** Resume uses the same atomic JSON-document pattern `settings_store` / `RecipeStore` already use (`recipes.py:177-181`).
+- **Re-implementing reframe/caption rendering.** The engines exist; we call them.
+
+---
+
+## 4. Capability inventory — what exists vs. what is NEW (cited)
+
+| Need | Exists today | Cite | Verdict |
+|------|--------------|------|---------|
+| Run a multi-step pipeline as one job | `recipes.run` + `_run_steps` + `_await_subjob` | `recipes.py:256,279,323` | **REUSE** (template = recipe) |
+| Iterate many items, spread progress, per-item cancel | `convert_batch` | `convert.py:195` | **REUSE pattern** (generalize from convert-only to any pipeline) |
+| Sub-job awaiting + progress relay | `Recipes._await_subjob` | `recipes.py:323` | **REUSE** |
+| Step-to-step data references | `resolve_refs` (`$N.key`) | `recipes.py:133` | **REUSE** |
+| Save/list/delete named pipelines | `RecipeStore` (atomic JSON) | `recipes.py:159` | **REUSE / extend** |
+| Platform presets (aspect/maxSec/count) | `PLATFORM_PRESETS`, `applyPreset` | `shortMakerPresets.ts` | **REUSE renderer; PROMOTE to sidecar-persisted** |
+| Build export params from controls | `buildExportParams` | `shortMakerPresets.ts` | **REUSE** |
+| Vertical render 1080×1920 + engine fallback | `ReframeEngine`, `get_engine` | `reframe.py:44,207` | **REUSE** |
+| Short export pipeline (reframe+caption+mux) | `ShortMaker.export`, `run_export` | `shortmaker.py:1206,1048` | **REUSE** |
+| Bounded job pool, queue, retry, cancel | `JobRegistry` | `jobs.py:179` | **REUSE** |
+| Caption styles (karaoke/hormozi/tiktok/clean) | `REMOTION_CAPTION_TEMPLATES`, `CAPTION_STYLE_OPTIONS` | `captionTemplates.ts:56`, `shortMakerLogic.ts:198` | **REUSE** |
+| Settings persistence (free-form keys) | `SettingsStore`, `DEFAULT_SETTINGS` | `settings_store.py:41` | **REUSE** |
+| The single RPC registration site | `register_all` | `handlers.py:1982` | **EXTEND** (new modules' own `register()`) |
+| **Batch queue over many sources** | — | — | **NEW: `features/batch.py`** |
+| **Resume across restart (durable job state)** | — (`jobs.py:204` in-memory only) | — | **NEW: `BatchStore` + run-resume; GAP §10.1** |
+| **Per-platform export fan-out as one run** | — (single-video only in UI) | — | **NEW: preset fan-out in batch step expansion** |
+| **Server-persisted platform presets** | — (renderer-const only) | `shortMakerPresets.ts` | **NEW: `features/export_presets.py`** |
+
+---
+
+## 5. Architecture
+
+Three small **new** sidecar feature modules, each following the established "owns its own `register()`, injectable seams, pure logic + JSON persistence" pattern (`recipes.register`, `shorts.register`). NO new provider call sites; NO second job bus.
+
+```
+features/
+  batch.py            NEW  batch.* — queue many sources through a template; durable; resumable
+  export_presets.py   NEW  exportPresets.* — server-persisted platform presets (aspect/style/dur/count)
+  templates.py        NEW  templates.* — a thin superset of recipes (steps + default controls + export targets)
+                          (alternatively: extend recipes.py in place — see §5.4 decision)
+models/
+  (none new)               batch steps reuse run_ai_job via the existing AI handlers; no new model code
+```
+
+### 5.1 Templates = recipes + export intent (`features/templates.py` or extended `recipes.py`)
+
+A **template** is the durable, reusable "edit recipe" of G3. It is a recipe (`{id, name, steps:[{method, params, label}]}`, `recipes.py:80-114`) PLUS two additive fields:
+
+- `defaultControls` — a `ShortMakerControls`-shaped object (`shortMakerLogic.ts:48-66`: `count/minSec/maxSec/aspect/language/captionStyle/reframeEngine/...`) used as the step params' base, so the user saves "my house style" once.
+- `exportTargets` — a list of platform-preset ids (`["tiktok","reels","shorts"]`) the export step fans out to (§5.3).
+
+The runner is **unchanged from `recipes._run_steps`** (`recipes.py:279`): each step's `method` is resolved on the live `protocol.METHODS` registry, invoked, and `{jobId}` results are awaited via `_await_subjob`. `$N.key` references still thread output forward. The only new logic is **step expansion**: before running, a single `shortmaker.export` step whose params name multiple `exportTargets` is expanded into one export call per platform preset (§5.3), so a template targeting 3 platforms produces 3 export sub-steps with merged params.
+
+**Reuse-vs-new:** the recipe storage (`RecipeStore`, atomic temp+rename, `recipes.py:159-208`), normalization (`normalize_recipe`, `recipes.py:80`), reference resolution, and the whole sub-job runner are REUSED verbatim. New = the two extra normalized fields + the expansion function (pure, fully testable).
+
+### 5.2 Batch queue (`features/batch.py`)
+
+A **batch** = `{id, name, templateId, sourceVideoIds:[...], status, items:[BatchItem]}` where a `BatchItem` = `{videoId, status: "queued"|"running"|"done"|"error"|"cancelled", jobId?, error?, results?}`. It runs each source through the named template **as a nested recipe run**, so one batch = one parent job that drives N per-source recipe runs.
+
+- **Execution shape** mirrors `convert_batch` (`convert.py:195-238`): iterate `sourceVideoIds`, spread the parent job's `[0,100]` progress across items, honor cancellation between items (`job_ctx.raise_if_cancelled`, `recipes.py:285`). Per-source isolation: a source whose template run errors is recorded `error` on its `BatchItem` and the batch **continues** (NOT the convert behavior, which aborts — this is the one deliberate divergence, §10.3).
+- **Per-source run** = invoke the template runner for that `videoId` (binding the template's steps to this source, e.g. `transcribe.start {videoId}` → … → `shortmaker.export`). Because the template runner returns `{jobId}`, the batch awaits it with the SAME `_await_subjob` relay (`recipes.py:323`) — no new waiting code.
+- **The job pool does the throttling.** Each per-source recipe run already starts sub-jobs on `ctx.jobs` (the 2-worker pool, `jobs.py:199`); the batch does not need its own concurrency control. GPU-heavy steps (Phase-8 signals) already serialize via the `gpu=True` tag (`jobs.py:345`).
+
+### 5.3 Multi-platform export presets (`features/export_presets.py`)
+
+Promote the renderer-only `PLATFORM_PRESETS` (`shortMakerPresets.ts`) to a **server-persisted, editable** catalog so a template can reference preset ids and a batch can fan out to them.
+
+- A `ExportPreset` = `{id, label, aspect, minSec, maxSec, count, captionStyle, reframeEngine}` — exactly the controls fields `shortmaker.export` already consumes via `buildExportParams` (`shortMakerPresets.ts`) → `ShortMaker.export` (`shortmaker.py:1206`, which reads `reframeEngine`/`captionStyle` from params, line 1215).
+- **Seeded** with the three existing presets (tiktok/reels/shorts, all 9:16) so behavior matches the current UI on day one. The §5 hard window clamp (20-60 s, enforced in BOTH `sanitizeControls` and the sidecar `select._resolve_window` → `MAX_CLIP_SEC=60`, documented at `shortMakerPresets.ts`) is REUSED — presets cannot promise a window the pipeline silently corrects.
+- **Fan-out** (the NEW expansion in §5.1): a batch/template export step listing `exportTargets:["tiktok","shorts"]` produces, per source, one `shortmaker.export` call per preset, each merging the preset fields onto the template's `defaultControls`. Output lands in the existing per-video export dir (`exports/shorts-<videoId>`, `handlers.py:1351`) with the preset id in the clip metadata so the Shorts gallery (`shorts.list`) can group by platform.
+- **YouTube landscape note:** the brief lists "YT" — `reframe.output_dimensions` (`reframe.py:96`) already handles non-9:16 ratios (landscape fixes width to 1920). A `youtube` preset at `16:9` is therefore expressible with the existing engine; seeded but flagged in §10.4 (the reframe SCRIPT is tuned for vertical subject-tracking — a 16:9 pass-through is a thinner path).
+
+### 5.4 Decision: extend `recipes.py` vs. new `templates.py`
+
+**Recommendation (for the gate):** add `templates.py` as a thin module that REUSES `RecipeStore`/`normalize_recipe`/`Recipes._run_steps` by import, rather than mutating `recipes.py`. Rationale: keeps the proven `recipes.*` surface and its 100%-covered tests untouched (the standing coverage gate, CLAUDE.md), and keeps each file < 800 lines (coding-style rule). The alternative — adding `defaultControls`/`exportTargets` to `normalize_recipe` — is fewer files but mutates a frozen, fully-tested wire shape. **GATE QUESTION (F-template-shape):** confirm new-module vs. in-place extension.
+
+---
+
+## 6. RPC surface (new `*.*` handlers in `register_all`)
+
+All registered through the existing single composition root (`handlers.py:1982` `register_all`), each via the module's own `register(...)` helper bound to the Services' `data_dir`/`settings`/`jobs` (mirrors `_recipes.register`, `handlers.py:2205`). Long-running → `{jobId}`; CRUD → direct-return.
+
+### `exportPresets.*` (direct-return CRUD)
+| Method | Params | Result | Notes |
+|--------|--------|--------|-------|
+| `exportPresets.list` | — | `{presets:[ExportPreset]}` | seeded with tiktok/reels/shorts |
+| `exportPresets.save` | `{preset}` | `{preset}` | upsert by id; window-clamped on save |
+| `exportPresets.delete` | `{id}` | `{ok}` | built-in seeds restorable via `reset` |
+| `exportPresets.reset` | — | `{presets}` | restore the seeded defaults |
+
+### `templates.*` (CRUD direct; one long job)
+| Method | Params | Result | Notes |
+|--------|--------|--------|-------|
+| `templates.list` | — | `{templates:[Template]}` | reuses `RecipeStore` over `templates.json` |
+| `templates.save` | `{template}` | `{template}` | normalize = recipe-normalize + `defaultControls`/`exportTargets` |
+| `templates.delete` | `{id}` | `{ok}` | |
+| `templates.apply` | `{templateId, videoId}` | `{jobId}` | run the template against ONE source (the single-source path; sugar over `batch.start` with one item) |
+
+### `batch.*` (CRUD + the queue)
+| Method | Params | Result | Notes |
+|--------|--------|--------|-------|
+| `batch.create` | `{name, templateId, sourceVideoIds}` | `{batch}` | persists a `BatchState` (queued items) — durable |
+| `batch.start` | `{id}` | `{jobId}` | the long parent job; per-source isolation; resumable |
+| `batch.status` | `{id}` | `{batch}` | aggregate + per-item status (read from store + live job) |
+| `batch.list` | — | `{batches:[BatchSummary]}` | including finished ones |
+| `batch.cancel` | `{id}` | `{ok}` | cancels the parent job (→ cooperative item cancel, `jobs.py:447`) |
+| `batch.resume` | `{id}` | `{jobId}` | re-enqueue not-yet-done items (§10.1) |
+| `batch.delete` | `{id}` | `{ok}` | drops a finished/cancelled batch record |
+
+**No new provider RPC.** Every AI-bearing step a template runs (`shortmaker.select`, `phase8.select`, `subtitles.translate`) is an EXISTING method that already enters `run_ai_job` (`handlers.py:849,1292`). The batch/template layer never builds a provider, never reads a key — it only invokes already-wired handlers through `protocol.METHODS` (the `recipes` mechanism, `recipes.py:313-317`). This keeps the "ONE RPC site" and "AI rides the envelope" invariants intact.
+
+---
+
+## 7. Renderer surface
+
+A new **Repurpose** view (tab in `TabBar.tsx` / `App.tsx`), composed of three panels, all driven through the canonical client (`lib/rpc.ts`). New typed client groups mirror the recipe group already there (`rpc.ts:757-763`):
+
+- `client.exportPresets.{list,save,delete,reset}`
+- `client.templates.{list,save,delete,apply}`
+- `client.batch.{create,start,status,list,cancel,resume,delete}`
+- New TS interfaces in `rpc.ts` (§3 schema block): `ExportPreset`, `Template`, `BatchItem`, `BatchState`, `BatchSummary` — field names identical to the sidecar (the house rule, `rpc.ts:17`).
+
+Panels (under `renderer/src/features/` and `renderer/src/views/`):
+1. **TemplateEditor** — pick steps (from a method allowlist), set `defaultControls` (REUSE `shortMakerLogic` `DEFAULT_CONTROLS`/`sanitizeControls` + `shortMakerPresets` `buildExportParams`), choose `exportTargets`. Save via `templates.save`.
+2. **ExportPresetsPanel** — table of presets, edit aspect/style/min-max-sec/count; REUSE `PLATFORM_PRESETS` as the seed view + `CAPTION_STYLE_OPTIONS` (`shortMakerLogic.ts:198`) for the style picker.
+3. **BatchQueue** — multi-select library videos (REUSE the native multi-picker `window.api.openVideos`, `rpc.ts:438`), pick a template, `batch.create` → `batch.start`. Live aggregate + per-source rows driven by `onProgress`/`onJobDone` (`rpc.ts:473,478`) and `batch.status` polling; a **Resume** button calls `batch.resume` for any batch left incomplete (visible on relaunch). REUSE the existing `JobQueue.tsx` / `ProgressBar.tsx` components for row rendering.
+
+Progress relay: the parent batch job's `job.progress` carries `"source k/N · <title> · step j/M · <label>"` (extends the recipe runner's existing `"step k/N · <label>"` message, `recipes.py:293`).
+
+---
+
+## 8. Data / storage + settings keys
+
+All persistence is the **atomic temp+rename JSON document** pattern already used by `settings_store` and `RecipeStore` (`recipes.py:177-181`) — under the per-user data dir (`Services.data_dir`, `handlers.py:143`), never a project folder.
+
+| File (under `data_dir`) | Owner | Shape |
+|--------------------------|-------|-------|
+| `templates.json` | `templates.py` (reuses `RecipeStore`) | `[Template]` |
+| `export-presets.json` | `export_presets.py` | `[ExportPreset]` (seeded) |
+| `batches/<batchId>.json` | `batch.py` (`BatchStore`) | `BatchState` — per-batch file so a large run's checkpoint write is O(1) and a corrupt batch can't poison others |
+
+**Settings keys (additive to `DEFAULT_SETTINGS`, `settings_store.py:41`):**
+- `repurposeDefaultTemplate: string` — last-used template id (UX convenience).
+- `repurposeExportTargets: string[]` — default platform fan-out (seed `["tiktok"]`).
+- `batchContinueOnError: boolean` (default `true`) — the per-source isolation toggle (§10.3).
+
+Reuse the existing `defaultTargetJobSize` (`settings_store.py:69`, consumed by `_default_target_job_size`, `handlers.py:1743`) as the per-source short-count default when a preset omits `count`.
+
+`BatchState` (the resume contract):
+```jsonc
+{
+  "id": "batch-ab12",
+  "name": "Podcast season 3 → shorts",
+  "templateId": "tmpl-housestyle",
+  "status": "running",          // queued|running|done|error|cancelled|partial
+  "createdAt": 1781757400.0,
+  "items": [
+    { "videoId": "vid-1", "status": "done",   "results": {...} },
+    { "videoId": "vid-2", "status": "error",  "error": "transcribe failed: ..." },
+    { "videoId": "vid-3", "status": "queued" }
+  ]
+}
+```
+
+---
+
+## 9. Reversibility / safety + AI consent/budget
+
+- **Reversible by construction.** Templates and presets are JSON CRUD; deleting a batch never touches produced media (it lives under `exports/shorts-<videoId>`, owned by the existing shorts library, `handlers.py:2133`). `exportPresets.reset` restores seeds. No in-place edits to source media — every render writes a NEW derivative (the `ShortMaker.export` contract).
+- **Cancellation is cooperative + already proven.** `batch.cancel` sets the parent job's flag (`jobs.py:447`); the batch loop's `raise_if_cancelled` (`recipes.py:285`) stops between sources and cancels the in-flight sub-job (`_await_subjob`, `recipes.py:345-347`). No new cancellation machinery.
+- **AI consent + budget ride the Hub envelope, unchanged.** The batch never calls a provider directly. When a template step is `shortmaker.select`/`phase8.select`/`subtitles.translate`, those handlers already build the envelope via `_run_ai_job` (`handlers.py:1617`) and enforce the budget-ack gate `_enforce_cloud_budget_ack` (`handlers.py:1672`): if `confirmCloudBudget` is on and the run would egress, the step requires the `ai.planJob` `cacheKey` as `confirmBudget`.
+  - **Batch consequence (GAP §10.2):** a fully-unattended N-source batch can't interactively pre-flight each source's AI step. The envelope's `cacheKey` is per-request, so a batch-wide blanket ack would not match. **Design decision for the gate:** the batch surfaces a single **pre-run consent summary** (one `ai.planJob` per distinct step shape via the existing pure planner, ZERO provider calls — `handlers.py:1693`) and requires the user to acknowledge cloud egress for the whole batch ONCE; if `confirmCloudBudget` is on, the batch either (a) runs only sources whose AI steps are cache hits / local-only, or (b) is refused with the same typed message until the user disables the per-call gate or chooses an all-local routing preset. Frame/text consent (`providers.setConsent`, `handlers.py:414`) is unchanged and still enforced per-entry at pool construction (`handlers.py:597`). **GATE QUESTION (F-batch-consent):** confirm (a) skip-non-acked vs. (b) refuse-batch as the default.
+- **No secrets in batch state.** `BatchState`/results store method results, never keys; the redaction invariants (`providers.list`, `handlers.py:330`) are untouched because the batch never reads raw provider config.
+
+---
+
+## 10. Explicit capability gaps
+
+### 10.1 — Durable/resumable jobs do NOT exist today (the headline gap)
+`JobRegistry` is purely in-memory: `self._jobs: dict` (`jobs.py:204`), threads are daemon (`jobs.py:372`), no state is written to disk. A restart loses every queue position, progress %, and result. **Resume (G2) therefore cannot be built on the job registry — it must be built at the BATCH layer.** Fill: `BatchStore` checkpoints `BatchState` after each item transition (queued→running→done/error). `batch.resume` reads the file, treats `done` items as complete, and re-enqueues `queued`/`running`/(optionally `error`) items as a fresh parent job. **Resume is at SOURCE granularity, not mid-source step granularity** — a source that crashed at step 3 of 5 re-runs from step 1 (its earlier outputs are idempotent overwrites; transcribe persists onto the project and flips `hasTranscript`, `handlers.py:1068-1072`, so a re-run is cheap-ish but not free). True mid-pipeline resume would require per-step checkpointing in the recipe runner — **out of scope; named here.**
+
+### 10.2 — Unattended budget pre-flight is awkward under `confirmCloudBudget`
+The per-request `cacheKey` ack model (`handlers.py:1672-1691`) is built for interactive single runs. A batch needs a batch-level consent story (§9). No code change to the envelope is proposed; the gap is a UX/policy decision (the F-batch-consent gate question).
+
+### 10.3 — `convert_batch` aborts on first error; batch needs per-source isolation
+`convert_batch` (`convert.py:195-238`) and the recipe runner (`_run_one_step` re-raises, `recipes.py:314-321`) FAIL the whole run on a single error. The batch deliberately diverges: it catches a per-source run failure, records it on the `BatchItem`, and continues (gated by `batchContinueOnError`, default on). This is NEW per-source try/except wrapping the existing runner — not a change to the runner itself.
+
+### 10.4 — Reframe engine is vertical-subject-tracking; landscape (YT 16:9) is a thin path
+`reframe.output_dimensions` supports arbitrary ratios (`reframe.py:96-115`), but the WSL/verthor script and the claudeshorts fallback are tuned for 9:16 subject-following (`reframe.py:6-9`). A `youtube` 16:9 preset is expressible but is effectively a duration/caption variant of the source aspect, not a true reframe. Seeded but documented as such; full landscape repurposing (e.g. 1:1 square, 4:5) needs engine validation per ratio — named, not solved here.
+
+### 10.5 — Caption-style ↔ preset coupling is by-id only
+Presets reference a `captionStyle` id; the renderer/sidecar style sets must stay in sync (already enforced by `captionTemplates.conformance.test.ts`, `captionTemplates.ts:8`). A preset persisting an id that a later build removes would fall back to the default style (same tolerance `readBrandSettings` already applies, `shortMakerPresets.ts`). No new risk, but the preset store must validate ids against `CAPTION_STYLE_OPTIONS` on save (mirrors `setFunctionModel`'s function-id guard, `handlers.py:514`).
+
+### 10.6 — `templates.run` step allowlist
+A template runs arbitrary `protocol.METHODS` by name (the recipe model). For a saved/shared template this is a (local-only) capability surface. Fill: a normalize-time allowlist of repurpose-relevant methods (`transcribe.*`, `subtitles.*`, `shortmaker.*`, `phase8.select`, `nle.export`, `package.export`, convert/audio steps) — reject unknown/dangerous method names at `templates.save`, same fail-loud posture as `normalize_recipe` (`recipes.py:98`).
+
+---
+
+## 11. Build sequencing (for the PLAN, not built here)
+
+1. `export_presets.py` + `exportPresets.*` + seeds + renderer ExportPresetsPanel (smallest, unblocks fan-out).
+2. `templates.py` (reuses `RecipeStore`/runner) + `templates.*` + TemplateEditor + step expansion (§5.1) + allowlist (§10.6).
+3. `batch.py` + `BatchStore` + `batch.*` + per-source isolation (§10.3) + BatchQueue panel.
+4. Resume (§10.1) — `batch.resume` + checkpoint-on-transition + the relaunch "incomplete batch" surface.
+5. Batch consent summary (§9 / §10.2) once the gate picks (a) or (b).
+
+Each work unit: TDD first; sidecar `pytest --cov-branch --cov-fail-under=100`; renderer vitest 100%; ruff/oxlint/biome/basedpyright/tsc green; commit scoped (never `git add -A`), never `--no-verify`.
+
+## 12. Open gate questions
+
+- **F-template-shape (§5.4):** new `templates.py` (recommended) vs. extend `recipes.normalize_recipe` in place.
+- **F-batch-consent (§9/§10.2):** default to (a) run-only-non-egressing under `confirmCloudBudget`, or (b) refuse-batch-until-acked.
+- **F-resume-granularity (§10.1):** confirm source-level resume is acceptable for v1 (mid-pipeline checkpointing deferred).
+- **F-error-policy (§10.3):** confirm `batchContinueOnError` default `true`.
+- **F-youtube (§10.4):** include a seeded 16:9 `youtube` preset in v1, or vertical-only until landscape reframe is validated.

--- a/docs/plans/repurpose/PLAN.md
+++ b/docs/plans/repurpose/PLAN.md
@@ -1,0 +1,242 @@
+# Repurpose Bundle — Implementation PLAN
+
+**Status:** v1 — PLAN (derived from `docs/plans/repurpose/DESIGN.md`, design-gate passed after revision)
+**Date:** 2026-06-18
+**Branch:** `feat/repurpose-design` (this bundle works on its OWN branch off `origin/main`; clone fresh to a unique temp path per agent)
+**Scope:** DESIGN + PLAN docs only. No feature code is written under this PLAN — it is the build map for a later execution phase.
+
+> **RAILS honored.** Every WU below is grounded in code verified against a fresh clone of `feat/repurpose-design` (see §0 verification ledger; all `file:line` citations re-checked). Capability gaps are named, never hidden. The BUILD reuses the shipped Hub substrate (AI-Job envelope `_run_ai_job`/`ai.planJob`, rotation pool, the single RPC site `register_all`). Standing BUILD gates per WU: sidecar `pytest --cov-branch --cov-fail-under=100`; renderer `vitest run --coverage` (thresholds 100 lines/branches/functions/statements, `app/vitest.config.ts:44-49`); `ruff` / `oxlint` / `biome` / `basedpyright` / `tsc --noEmit`. Never `--no-verify`; never `git add -A` (scoped adds only).
+
+---
+
+## 0. Code-grounding verification ledger (re-checked on fresh clone, commit `a912221`)
+
+| Claim used by the PLAN | Cite | Verified |
+|------------------------|------|----------|
+| `recipes.run` parent-job runner | `sidecar/media_studio/features/recipes.py:256` | ✓ |
+| `Recipes._run_steps` step loop + cancel | `recipes.py:279` (`raise_if_cancelled` `recipes.py:285`) | ✓ |
+| `Recipes._await_subjob` sub-job progress relay | `recipes.py:323` | ✓ |
+| `resolve_refs` (`$N.key` threading) | `recipes.py:133` | ✓ |
+| `RecipeStore` atomic JSON (`_write` temp+rename) | `recipes.py:159` (write `recipes.py:177`) | ✓ |
+| `normalize_recipe` fail-loud validation | `recipes.py:80` | ✓ |
+| `_recipes.register` module-owned register | `recipes.py:365`; called at `handlers.py:2205` | ✓ |
+| `convert_batch` many-item even progress + cancel-between-items | `convert.py:194` (body 195-238) | ✓ |
+| `JobRegistry` in-memory only (`self._jobs: dict`) | `jobs.py:179`, `jobs.py:204`; daemon pool 2/1 `jobs.py:198-209` | ✓ (the headline gap §10.1) |
+| `register_all` single RPC composition root | `handlers.py:1982` | ✓ |
+| `_run_ai_job` envelope builder | `handlers.py:1617` | ✓ |
+| `_enforce_cloud_budget_ack` budget gate | `handlers.py:1672` | ✓ |
+| `ai.planJob` pure planner (zero provider calls) | `handlers.py:1693` (registered `handlers.py:2039`) | ✓ |
+| renderer `client.recipes.*` typed group | `app/renderer/src/lib/rpc.ts:757` | ✓ |
+| `onProgress` / `onJobDone` / `openVideos` bridge | `rpc.ts:473,478,438` | ✓ |
+| `TabBar` `role="tablist"`/`role="tab"`/`aria-selected` | `app/renderer/src/components/TabBar.tsx:17,24,25` | ✓ |
+| renderer 100% coverage gate | `app/vitest.config.ts:44-49` | ✓ |
+| test fakes pattern (`methods_provider=lambda`, `_FakeJobCtx`, `RpcContext(emit_notification=...)`) | `sidecar/tests/test_recipes.py:124,190,322` | ✓ |
+
+**Capability gaps carried from DESIGN (verified, not solvable by reuse alone):**
+- **G-DUR (headline):** no durable/resumable job state exists (`jobs.py:204`). Resume is built at the BATCH layer at SOURCE granularity (WU8), not mid-pipeline.
+- **G-ISO:** `convert_batch` (`convert.py:194`) and `_run_one_step` (`recipes.py:302`, re-raises) abort on first error → batch needs NEW per-source try/except wrapping (WU7).
+- **G-ACK:** per-request `cacheKey` ack (`handlers.py:1672`) does not fit unattended N-source batches → batch-level consent surface (WU9).
+- **G-A11Y:** reused `JobQueue.tsx` carries NO `aria-live` region (only `role="alert"` on its error block) → live per-source announcer is net-new UX (WU11).
+- **G-YT:** reframe is vertical-subject-tracking (`reframe.py:6-9`); 16:9 is a thin path via `output_dimensions` (`reframe.py:96`) — gated (F-youtube).
+
+---
+
+## 1. Work-unit overview
+
+Twelve WUs. Each NEW component = its own WU with a 100% line+branch test plan and fakes at the ffmpeg/model/OCR seams (no real binaries, no real providers in tests). Sequenced per DESIGN §11: presets → templates → batch → resume → batch-consent, with renderer WUs trailing their sidecar counterparts.
+
+| WU | Title | Layer | Type | Depends on |
+|----|-------|-------|------|-----------|
+| WU1 | `export_presets.py` — store + seeds + window clamp + caption-id validation | sidecar | NEW | — |
+| WU2 | `exportPresets.*` RPC + `register_all` wiring | sidecar | NEW (extend register site) | WU1 |
+| WU3 | `templates.py` — store + normalize (recipe + defaultControls + exportTargets) + method allowlist | sidecar | NEW (reuses `RecipeStore`/`normalize_recipe`) | WU1 |
+| WU4 | Template step-expansion (preset fan-out) — pure function | sidecar | NEW | WU1, WU3 |
+| WU5 | `templates.*` RPC (`list/save/delete/apply`) + `register_all` wiring | sidecar | NEW (reuses `_run_steps`/`_await_subjob`) | WU3, WU4 |
+| WU6 | `batch.py` — `BatchStore` (per-batch JSON) + `BatchState`/`BatchItem` model + checkpoint-on-transition | sidecar | NEW | WU3 |
+| WU7 | Batch runner — per-source isolation over the template runner (G-ISO) | sidecar | NEW | WU4, WU5, WU6 |
+| WU8 | Resume (G-DUR) — `batch.resume` re-enqueue + source-granularity restart | sidecar | NEW | WU6, WU7 |
+| WU9 | Batch consent (G-ACK) — pre-run summary from `ai.planJob` + visible-skip terminal state | sidecar | NEW | WU6, WU7 |
+| WU10 | `batch.*` RPC (`create/start/status/list/cancel/resume/delete`) + `register_all` wiring | sidecar | NEW | WU7, WU8, WU9 |
+| WU11 | Renderer client groups + TS interfaces (`rpc.ts`) + ExportPresetsPanel + TemplateEditor + BatchQueue + a11y live-status (G-A11Y) + Repurpose tab + resume-surface (badge/toast) | renderer | NEW | WU2, WU5, WU10 |
+| WU12 | Cross-cutting verification pass — full gate run + scoped commit + PR readiness | both | gate | WU1-WU11 |
+
+---
+
+## 2. Work units (goal · files · test strategy · falsifiable acceptance · gate command)
+
+### WU1 — `export_presets.py` (store + seeds + clamps)
+- **Goal.** Server-persisted, editable platform-preset catalog promoting renderer-only `PLATFORM_PRESETS` (DESIGN §5.3). `ExportPreset = {id, label, aspect, minSec, maxSec, count, captionStyle, reframeEngine}`. Atomic-JSON store mirroring `RecipeStore` (`recipes.py:177` temp+rename). Seeded with tiktok/reels/shorts (all 9:16) so day-one behavior matches the current UI. Window clamp 20-60s enforced on save (DESIGN §5.3, §10.5). `captionStyle` id validated against the allowed set on save (G-10.5; mirrors `setFunctionModel` id-guard `handlers.py:514`). `reset` restores seeds.
+- **Files.** NEW `sidecar/media_studio/features/export_presets.py`; NEW `sidecar/tests/test_export_presets.py`.
+- **Test strategy.** Pure store unit tests over `tmp_path` JSON (no I/O seam to fake — store is filesystem-only, same as `test_recipes.py` `RecipeStore` tests). Cases: seed-on-empty; upsert-by-id; delete; reset-restores-seeds; window clamp below-min / above-max / in-range; invalid `captionStyle` id rejected (fail-loud `RpcError`); valid id accepted; corrupt-JSON-file recovery path; atomic-write temp+rename (assert no partial file on simulated write failure via a patched `os.replace`).
+- **Falsifiable acceptance.**
+  1. Empty store → `list()` returns exactly the 3 seeds with the 9:16 aspect each.
+  2. `save({id:"x", maxSec:600, ...})` persists with `maxSec` clamped to 60; `minSec:5` clamped to 20.
+  3. `save` with `captionStyle:"__nope__"` raises `RpcError` (`code` per the module's invalid-input convention) and writes nothing.
+  4. `delete("tiktok")` then `reset()` → `list()` again contains tiktok.
+  5. A simulated `os.replace` failure leaves the prior file intact (no truncation).
+- **Gate.** `cd sidecar && pytest tests/test_export_presets.py --cov=media_studio/features/export_presets --cov-branch --cov-fail-under=100 && ruff check media_studio/features/export_presets.py && basedpyright media_studio/features/export_presets.py`
+
+### WU2 — `exportPresets.*` RPC + register wiring
+- **Goal.** Direct-return CRUD methods (DESIGN §6): `exportPresets.list/save/delete/reset`. Each via the module's own `register(...)` bound to `Services.data_dir` (mirrors `_recipes.register` call `handlers.py:2205`), added at the single composition root `register_all` (`handlers.py:1982`). File `export-presets.json` under `Services.data_dir` (`handlers.py:143`).
+- **Files.** EDIT `sidecar/media_studio/features/export_presets.py` (add `register`); EDIT `sidecar/media_studio/handlers.py` (one `_export_presets.register(...)` block inside `register_all`, no other site); EDIT `sidecar/tests/test_export_presets.py` (RPC-level cases) + EDIT `sidecar/tests/test_handlers.py` or a new `test_handlers_export_presets.py` for the registration-site smoke.
+- **Test strategy.** Call handlers through `RpcContext(emit_notification=lambda *_: None, jobs=None)` (the `test_recipes.py:124` idiom). Assert each method present in the assembled `protocol.METHODS` after `register_all`. CRUD round-trip via a `tmp_path` data dir.
+- **Falsifiable acceptance.**
+  1. After `register_all`, `protocol.METHODS` contains exactly `exportPresets.list/save/delete/reset` (and no other new key).
+  2. `exportPresets.save` returns `{preset}` with clamped fields; a subsequent `exportPresets.list` reflects it.
+  3. `exportPresets.delete` of a seed then `exportPresets.reset` restores it.
+- **Gate.** `cd sidecar && pytest tests/test_export_presets.py tests/test_handlers*.py -k "export_preset or register_all" --cov=media_studio --cov-branch --cov-fail-under=100`
+
+### WU3 — `templates.py` (store + normalize + allowlist)
+- **Goal.** `templates.py` REUSES `RecipeStore`/`normalize_recipe`/`Recipes._run_steps` by import (DESIGN §5.4 recommendation, gate F-template-shape). A `Template` = recipe shape (`recipes.py:80-114`) PLUS additive `defaultControls` and `exportTargets:[presetId]`. Normalize = recipe-normalize + validate the two extra fields + a **method allowlist** (G-10.6): reject step `method`s outside `{transcribe.*, subtitles.*, shortmaker.*, phase8.select, nle.export, package.export, convert.*, audio.*}` with the same fail-loud posture as `normalize_recipe` (`recipes.py:98`).
+- **Files.** NEW `sidecar/media_studio/features/templates.py`; NEW `sidecar/tests/test_templates.py`.
+- **Test strategy.** Unit over `tmp_path` JSON (`templates.json`). Fake nothing (storage-only). Cases: normalize accepts a valid template; preserves `defaultControls`/`exportTargets`; rejects unknown method (`shell.exec`-style) at save; rejects malformed `exportTargets` (non-list / non-string ids); reuses `RecipeStore` round-trip (save/list/delete/get); empty/corrupt file.
+- **Falsifiable acceptance.**
+  1. `normalize` of `{steps:[{method:"shell.exec"}]}` raises `RpcError` (allowlist), writes nothing.
+  2. `normalize` of a valid template retains `defaultControls` and `exportTargets` verbatim and assigns an id if absent (recipe-normalize behavior).
+  3. The underlying `recipes.normalize_recipe` is the ONLY recipe-validation path called (verified by import, not re-implementation) — no fork of the wire shape.
+- **Gate.** `cd sidecar && pytest tests/test_templates.py --cov=media_studio/features/templates --cov-branch --cov-fail-under=100 && ruff check media_studio/features/templates.py && basedpyright media_studio/features/templates.py`
+
+### WU4 — Template step-expansion (preset fan-out)
+- **Goal.** Pure function (DESIGN §5.1, §5.3): before a run, a `shortmaker.export` step whose params name multiple `exportTargets` is expanded into one export call per resolved `ExportPreset`, each merging preset fields onto the template's `defaultControls`. No I/O, no provider — fully testable. Output dir convention preserved (`exports/shorts-<videoId>`, `handlers.py:1351`); preset id attached to clip metadata so the Shorts gallery can group.
+- **Files.** EDIT `sidecar/media_studio/features/templates.py` (add `expand_export_steps(steps, controls, presets)` pure fn); EDIT `sidecar/tests/test_templates.py`.
+- **Test strategy.** Pure-function tests with in-memory preset dicts (no store, no ffmpeg). Cases: single target → one step (identity); 3 targets → 3 steps with merged params; preset field overrides `defaultControls`; unknown target id in `exportTargets` → fail-loud; empty `exportTargets` → no export step / passthrough per the documented rule; window clamp from preset honored in merged params.
+- **Falsifiable acceptance.**
+  1. `expand_export_steps` with `exportTargets:["tiktok","shorts"]` yields exactly 2 export steps; each merged params has that preset's `aspect`/`maxSec`/`captionStyle`.
+  2. A target id not in the presets dict raises `RpcError`, yields no partial expansion.
+  3. Non-export steps pass through unchanged and in order (idempotent on already-flat step lists).
+- **Gate.** `cd sidecar && pytest tests/test_templates.py -k expand --cov=media_studio/features/templates --cov-branch --cov-fail-under=100`
+
+### WU5 — `templates.*` RPC
+- **Goal.** `templates.list/save/delete` (direct CRUD) + `templates.apply {templateId, videoId}` → `{jobId}` (DESIGN §6). `apply` runs the template against ONE source by binding steps to `videoId`, expanding export fan-out (WU4), then driving the EXISTING `Recipes._run_steps`/`_await_subjob` (`recipes.py:279,323`) — NO new runner, NO new sub-job waiting. `apply` is the single-source sugar over WU7's batch path (one item).
+- **Files.** EDIT `sidecar/media_studio/features/templates.py` (add `register` + the `Templates` service); EDIT `sidecar/media_studio/handlers.py` (one `_templates.register(...)` block in `register_all`); EDIT `sidecar/tests/test_templates.py` + registration-site smoke.
+- **Test strategy.** Fakes at the runner seam exactly like `test_recipes.py`: `methods_provider=lambda: {fake methods}` returning `{jobId}` for export, plain dicts for sync steps; `_FakeJobCtx` (`test_recipes.py:322`) and `RpcContext(emit_notification=..., jobs=<fake registry>)`. Assert `apply` returns `{jobId}` and the parent job body invokes the expanded step list in order. No real model, no real ffmpeg.
+- **Falsifiable acceptance.**
+  1. `templates.apply` returns `{jobId}`; the started job's body calls each expanded step's method via the live methods registry, in order.
+  2. A template with 3 export targets produces 3 export invocations for the one source.
+  3. Cancellation between steps propagates via `raise_if_cancelled` (`recipes.py:285`) — no new cancel code (assert the existing path is reused).
+  4. After `register_all`, `protocol.METHODS` gains exactly `templates.list/save/delete/apply`.
+- **Gate.** `cd sidecar && pytest tests/test_templates.py tests/test_handlers*.py -k "template or register_all" --cov=media_studio --cov-branch --cov-fail-under=100`
+
+### WU6 — `batch.py` store + model + checkpointing
+- **Goal.** `BatchStore` writes one file per batch (`batches/<batchId>.json`, DESIGN §8) using the atomic temp+rename pattern, so a large run's checkpoint is O(1) and a corrupt batch can't poison others. `BatchState = {id, name, templateId, status, createdAt, items:[BatchItem]}`; `BatchItem = {videoId, status: queued|running|done|error|cancelled|skipped, jobId?, error?, skipReason?, results?}`. Checkpoint after EVERY item transition (queued→running→done/error/skipped) — this is the durability substrate for resume (G-DUR), since `JobRegistry` itself is in-memory (`jobs.py:204`).
+- **Files.** NEW `sidecar/media_studio/features/batch.py` (store + model + create/load/checkpoint, NOT the runner yet); NEW `sidecar/tests/test_batch.py`.
+- **Test strategy.** Pure store tests over `tmp_path`. Cases: create persists all M items as `queued`; per-item transition rewrites the file atomically; load reconstructs full state incl. `skipped`+`skipReason`; per-batch isolation (write to A doesn't touch B); corrupt one batch file → others still loadable; `list` summaries omit heavy `results`.
+- **Falsifiable acceptance.**
+  1. `create(name, templateId, [v1,v2,v3])` writes a file with 3 `queued` items and `status:"queued"`.
+  2. A transition `v2 → error` immediately rewrites the file (assert on-disk content reflects it before any later item runs).
+  3. Two batches coexist; deleting/corrupting one leaves the other's `load` intact.
+  4. `BatchState` round-trips `skipped`+`skipReason` losslessly.
+- **Gate.** `cd sidecar && pytest tests/test_batch.py --cov=media_studio/features/batch --cov-branch --cov-fail-under=100`
+
+### WU7 — Batch runner with per-source isolation (G-ISO)
+- **Goal.** The parent batch job: iterate `sourceVideoIds`, spread `[0,100]` progress across items (mirroring `convert_batch` `convert.py:195-238`), and run each source through the template runner (WU5 path) — but with **NEW per-source try/except** so one bad source records `error` on its `BatchItem` and the batch CONTINUES (the deliberate divergence from `convert_batch`/`_run_one_step` which abort, G-ISO). Gated by `batchContinueOnError` (default `true`, DESIGN §8/§10.3). Awaits each per-source sub-job with the EXISTING `_await_subjob` relay (`recipes.py:323`). Progress message extends the recipe runner's `"step k/N"` (`recipes.py:293`) to `"source k/N · <title> · step j/M · <label>"`.
+- **Files.** EDIT `sidecar/media_studio/features/batch.py` (add the runner over WU6 store + WU5 template path); EDIT `sidecar/tests/test_batch.py`.
+- **Test strategy.** Fake the template-run seam (a callable returning `{jobId}` or raising) + `_FakeJobCtx` + fake `JobRegistry`. NO real ffmpeg/model. Cases: 3 sources all succeed → all `done`, checkpoint after each; source 2 raises → `error` recorded, sources 1 and 3 still `done` (isolation); `batchContinueOnError=false` → batch stops at first error with remaining `queued`; cancellation between sources via `raise_if_cancelled`; progress message format asserts the `source k/N` prefix.
+- **Falsifiable acceptance.**
+  1. With source 2's run raising, final state = `[done, error, done]` and `status:"partial"` (not aborted).
+  2. With `batchContinueOnError=false`, final state after a source-2 error = `[done, error, queued]` and `status:"error"`.
+  3. Each item flip is checkpointed to disk (assert intermediate on-disk state).
+  4. Cancellation mid-batch leaves the in-flight item `cancelled` and later items `queued` (no new cancel machinery — reuses `_await_subjob` `recipes.py:345-347`).
+- **Gate.** `cd sidecar && pytest tests/test_batch.py -k "isolation or runner or progress or cancel" --cov=media_studio/features/batch --cov-branch --cov-fail-under=100`
+
+### WU8 — Resume (G-DUR, source granularity)
+- **Goal.** `batch.resume {id}` → `{jobId}`: read the checkpointed `BatchState`, treat `done` items as complete, re-enqueue `queued`/`running`/(optionally `error`) items as a FRESH parent job (DESIGN §10.1). Resume is **source granularity** (F-resume-granularity): a source that crashed at step 3/5 re-runs from step 1 (earlier outputs are idempotent overwrites — transcribe flips `hasTranscript` `handlers.py:1068-1072`). Mid-pipeline checkpointing is explicitly OUT OF SCOPE and named here.
+- **Files.** EDIT `sidecar/media_studio/features/batch.py` (add `resume`); EDIT `sidecar/tests/test_batch.py`.
+- **Test strategy.** Construct a partially-complete `BatchState` on disk, call resume with the fake runner. Cases: `done` items not re-run; `queued`/`running` re-enqueued; `error` items re-enqueued only when policy says so; a fully-`done` batch resume is a no-op (returns terminal status, no new job); resume after a successful re-run flips remaining items to `done`.
+- **Falsifiable acceptance.**
+  1. Resuming `[done, error, queued]` re-runs only items 2 and 3 (item 1's runner is NOT invoked — assert call count).
+  2. Resuming an all-`done` batch starts no job and reports `done`.
+  3. A re-enqueued source runs from its FIRST step (assert the runner gets the full step list, not a suffix — source-granularity contract).
+- **Gate.** `cd sidecar && pytest tests/test_batch.py -k resume --cov=media_studio/features/batch --cov-branch --cov-fail-under=100`
+
+### WU9 — Batch consent surface (G-ACK) + visible skip
+- **Goal.** Pre-run consent computed BEFORE `batch.start` from pure `ai.planJob` plans only (zero provider calls, `handlers.py:1693`): one plan per distinct step *shape* (sources sharing template+size collapse). Surface returns per-step-shape route/`willEgress`, the N-run/K-skip split with per-source `willEgress`/`cacheHit`, aggregated `costEst`, and `budget` headroom. Default policy F-batch-consent (a) skip-non-acked under `confirmCloudBudget` WITH the visible-skip contract: a non-acked egressing source gets terminal `status:"skipped"` + `skipReason` on its `BatchItem` (never silent absence, DESIGN §9.1). Acknowledgement passes each plan's `cacheKey` as `confirmBudget` to the underlying handler, satisfying `_enforce_cloud_budget_ack` (`handlers.py:1672`) WITHOUT changing the envelope. (b) refuse-batch is the alternative the gate may pick; both ship the same surfacing.
+- **Files.** EDIT `sidecar/media_studio/features/batch.py` (add `plan_consent(...)` pure aggregator + skip-decision in the runner); EDIT `sidecar/tests/test_batch.py`.
+- **Test strategy.** Fake `ai.planJob` returning canned plans (`{route, costEst, cacheHit, willEgress, budget, cacheKey}`) — NO real planner, NO provider. Cases: plan dedup by step-shape (2 distinct shapes from 30 sources → 2 planner calls, assert call count); local-only/cache-hit sources always run; egressing-unacked source → `skipped`+`skipReason="would egress — not acknowledged"`; no-headroom → `skipReason="no budget headroom"`; ack present → `confirmBudget=cacheKey` threaded; `confirmCloudBudget` OFF → all run, card informational only.
+- **Falsifiable acceptance.**
+  1. 30 sources, one template shape → exactly 1 `ai.planJob` invocation (dedup by shape, not by source).
+  2. Under `confirmCloudBudget` on + no ack, an egressing source ends `skipped` with the reason token; a cache-hit source ends `done`.
+  3. With ack, the underlying AI handler receives `confirmBudget` equal to the plan's `cacheKey` (assert the threaded value).
+  4. The consent aggregate sums `costEst` only over egressing sources and reports the `budget` headroom.
+- **Gate.** `cd sidecar && pytest tests/test_batch.py -k "consent or skip or plan" --cov=media_studio/features/batch --cov-branch --cov-fail-under=100`
+
+### WU10 — `batch.*` RPC + register wiring
+- **Goal.** `batch.create/start/status/list/cancel/resume/delete` (DESIGN §6) via the module's own `register(...)` at `register_all` (`handlers.py:1982`). `start`/`resume` → `{jobId}`; `status` merges store + live job; `cancel` sets the parent job flag (`jobs.py:447` cooperative). `start` runs the WU9 consent decision then the WU7 runner.
+- **Files.** EDIT `sidecar/media_studio/features/batch.py` (add `register` + `Batch` service); EDIT `sidecar/media_studio/handlers.py` (one `_batch.register(...)` block in `register_all`); EDIT `sidecar/tests/test_batch.py` + registration-site smoke.
+- **Test strategy.** Through `RpcContext` with a fake registry. Cases: each method present after `register_all`; `create` then `status` round-trip; `start` returns `{jobId}`; `cancel` flips the parent job; `status` reflects live job progress merged with stored items incl. `skipped`; `delete` of a finished batch.
+- **Falsifiable acceptance.**
+  1. After `register_all`, `protocol.METHODS` gains exactly the 7 `batch.*` keys and no others.
+  2. `batch.status` of a partially-run batch returns `done`+`error`+`skipped` items with their reasons.
+  3. `batch.cancel` results in cooperative cancellation (existing `jobs.py:447` path; no new machinery).
+- **Gate.** `cd sidecar && pytest tests/test_batch.py tests/test_handlers*.py -k "batch or register_all" --cov=media_studio --cov-branch --cov-fail-under=100 && ruff check media_studio/features/batch.py && basedpyright media_studio/features/batch.py`
+
+### WU11 — Renderer (client groups, panels, a11y, tab, resume-surface)
+- **Goal.** New typed client groups + TS interfaces in `app/renderer/src/lib/rpc.ts` mirroring the `client.recipes.*` group (`rpc.ts:757`): `client.exportPresets.{list,save,delete,reset}`, `client.templates.{list,save,delete,apply}`, `client.batch.{create,start,status,list,cancel,resume,delete}`; interfaces `ExportPreset`, `Template`, `BatchItem`, `BatchState`, `BatchSummary` with field names IDENTICAL to the sidecar (house rule `rpc.ts:17`). New **Repurpose** tab (rides `TabBar.tsx:17,24,25` a11y for free). Three panels (DESIGN §7): **BatchQueue** (default landing — multi-select via `openVideos` `rpc.ts:438`, template pick, consent summary card §9.1, live rows via `onProgress`/`onJobDone` `rpc.ts:473,478`); **TemplateEditor** (curated-preset-first, never raw method ids, F-template-catalog); **ExportPresetsPanel** (table + constrained `captionStyle` select + inline window clamp). **a11y live-status (G-A11Y, net-new):** a `role="status" aria-live="polite"` aggregate region (idiom from `ShortMaker.tsx:773`) announcing on source-transition + terminal-state only (F-a11y-announce-granularity); per-source terminal errors `aria-live="assertive"`/`role="alert"` (`SidecarBanner.tsx:72`); text status tokens not color-only (`PresetPicker.tsx:6,11`); per-row `<ProgressBar>` keeps `role="progressbar"`/`aria-valuenow`. **Resume-surface (F-resume-surface):** tab badge `(N)` from a launch `batch.list` + one-time dismissible `ToastHost` toast (`ToastHost.tsx:68`, already polite).
+- **Files.** EDIT `app/renderer/src/lib/rpc.ts` (interfaces + 3 client groups); NEW `app/renderer/src/views/Repurpose.tsx`; NEW `app/renderer/src/features/{BatchQueue,TemplateEditor,ExportPresetsPanel}.tsx` (+ a `BatchConsentCard` + a live-status announcer component); EDIT `app/renderer/src/App.tsx` + `components/TabBar.tsx` (tab + badge); NEW co-located `*.test.tsx` for each + `rpc.ts` group tests.
+- **Test strategy.** vitest + Testing Library with the rpc bridge mocked (the existing renderer test idiom). Fake `onProgress`/`onJobDone` event streams. Assert a11y: `role="status"`/`aria-live` present and updated on source-transition only (not per pct tick); assertive error announcement on item error; status tokens are text (queried by text, not color); tab badge renders `(N)` when `batch.list` returns incomplete batches; toast appears once and deep-links. Assert TemplateEditor never renders a raw `protocol.METHODS` id (only curated labels). Window-clamp shown inline in ExportPresetsPanel; `captionStyle` select offers only valid ids.
+- **Falsifiable acceptance.**
+  1. `client.batch`/`client.templates`/`client.exportPresets` groups call the correct RPC method names with the correct param shapes (assert the mocked `rpc()` args).
+  2. A simulated 30-source progress stream announces on each `source k/N` transition and on each terminal flip — NOT on every percent tick (assert announcement count ≈ source count, not pct count).
+  3. An item-error event triggers an `aria-live="assertive"`/`role="alert"` announcement carrying the reason.
+  4. With one incomplete batch in `batch.list`, the Repurpose tab shows a text `(1)` badge and a one-time resume toast.
+  5. TemplateEditor exposes zero raw method ids (no `shortmaker.select`/`phase8.select` text in the DOM); only curated labels.
+  6. ExportPresetsPanel `captionStyle` control is a closed select of valid ids; an out-of-range duration is clamped/blocked in-UI.
+- **Gate.** `cd app && npx vitest run --coverage && npx tsc --noEmit && npx oxlint app/renderer/src && npx biome check app/renderer/src` (coverage must satisfy `vitest.config.ts:44-49` thresholds:100).
+
+### WU12 — Cross-cutting verification + PR readiness (gate WU)
+- **Goal.** A whole-bundle gate pass: run BOTH full suites at 100% line+branch, all linters/typecheckers green, confirm the only `register_all` edits are the three new `register()` blocks (invariant: ONE RPC site), confirm NO new provider call site exists anywhere in `batch.py`/`templates.py`/`export_presets.py` (grep for direct provider/key access — must be zero; AI rides the envelope only via `protocol.METHODS`). Scoped commit; PR draft.
+- **Files.** No new source; CI/verification only. Possible EDIT to `sidecar/pyproject.toml` test markers if needed.
+- **Test strategy.** Full `pytest --cov-branch --cov-fail-under=100` over `sidecar`; full `vitest run --coverage` over `app`. Static check: `grep` the three new sidecar modules for `Provider`/`api_key`/`_run_ai_job(` direct calls → assert absent (they must only invoke methods by name).
+- **Falsifiable acceptance.**
+  1. `cd sidecar && pytest --cov-branch --cov-fail-under=100` exits 0 (no module below 100% line+branch).
+  2. `cd app && npx vitest run --coverage` exits 0 (thresholds:100 met).
+  3. `git diff origin/main -- sidecar/media_studio/handlers.py` shows ONLY additions inside `register_all` (no second registration site; no provider wiring).
+  4. The three new feature modules contain no direct provider construction or key read.
+- **Gate.** `cd sidecar && pytest --cov-branch --cov-fail-under=100 && ruff check media_studio && basedpyright media_studio` ; `cd app && npx vitest run --coverage && npx tsc --noEmit && npx oxlint . && npx biome check .`
+
+---
+
+## 3. Dependency graph
+
+```
+WU1 (export_presets store)
+ ├─> WU2 (exportPresets RPC) ───────────────┐
+ ├─> WU3 (templates store+normalize+allowlist)
+ │     ├─> WU4 (step-expansion fan-out) ─────┐
+ │     └─> WU6 (batch store + checkpoint)     │
+ │           ├─> WU7 (batch runner / isolation) <── WU4, WU5
+ │           │     ├─> WU8 (resume)            │
+ │           │     └─> WU9 (consent/skip)      │
+ │           └─────────> WU10 (batch RPC) <── WU7,WU8,WU9
+ └────────────────────> WU5 (templates RPC) <── WU3,WU4
+                                                │
+WU2 + WU5 + WU10 ──> WU11 (renderer: clients, panels, a11y, tab, resume-surface)
+ALL ──────────────> WU12 (cross-cutting gate + PR)
+```
+
+Linear critical path (longest): **WU1 → WU3 → WU4 → WU5 → WU7 → WU8/WU9 → WU10 → WU11 → WU12.**
+
+---
+
+## 4. Parallelism notes
+
+- **WU2 ‖ WU3** — once WU1 lands, the `exportPresets` RPC (WU2) and the templates store (WU3) are independent files (`export_presets.py` RPC layer vs. new `templates.py`); parallelizable. They touch `register_all` in disjoint blocks but **the `handlers.py` edit is a one-owner shared file** — sequence the two `register_all` additions or use scoped staged adds + `git diff --cached --name-only` before each commit (per the parallel-worktree-contamination rule). Prefer separate worktrees if run by parallel agents.
+- **WU4 ‖ WU6** — step-expansion (pure, in `templates.py`) and the batch store (`batch.py`) are different files with no runtime dependency until WU7; parallelizable after WU3.
+- **WU8 ‖ WU9** — resume and consent both extend `batch.py` after WU7; they touch the SAME file, so run sequentially OR in isolated worktrees with a merge step, NOT a shared index. Their tests are disjoint.
+- **WU11 is the renderer convergence point** — it cannot start until WU2/WU5/WU10 expose the RPC surface (the renderer asserts real method names/param shapes). Within WU11, the three panels are independent files and parallelizable, but `rpc.ts`, `App.tsx`, and `TabBar.tsx` are one-owner shared files (sequence those edits).
+- **WU12 is a barrier** — runs only after every WU is green; do not start until WU1-WU11 each pass their own gate.
+- **Shared-file discipline (rails):** `handlers.py`, `rpc.ts`, `App.tsx`, `TabBar.tsx`, `pyproject.toml` are one-owner shared files. Any parallel agents must use scoped `git add <path>` (never `-A`) and verify `git diff --cached --name-only` before each commit, or operate in isolated worktrees.
+
+---
+
+## 5. Open gate questions (carried from DESIGN §12 — resolve before/at BUILD kickoff)
+
+These do not block this PLAN doc; they steer specific WUs:
+- **F-template-shape** → WU3 (new `templates.py`, recommended).
+- **F-batch-consent** → WU9 (default (a) skip-non-acked with visible skip, recommended; (b) refuse-batch alt — both ship the surfacing).
+- **F-resume-granularity** → WU8 (source-level for v1, recommended).
+- **F-error-policy** → WU7 (`batchContinueOnError` default `true`).
+- **F-youtube** → preset seed (G-YT): include 16:9 `youtube` preset in v1 or vertical-only.
+- **F-a11y-announce-granularity** → WU11 (source-transition + terminal only, recommended).
+- **F-resume-surface** → WU11 (tab badge + launch toast, recommended).
+- **F-template-catalog** → WU11 (curated starter set + label copy; no raw method ids).

--- a/docs/plans/repurpose/WU12-VERIFICATION.md
+++ b/docs/plans/repurpose/WU12-VERIFICATION.md
@@ -1,0 +1,45 @@
+# WU12 — Cross-cutting verification + PR readiness (gate WU)
+
+**Status:** PASS — whole-bundle gate run green on `feat/repurpose-design`.
+**Scope:** WU12 adds no feature source (PLAN §WU12: "No new source; CI/verification only").
+This ledger records the falsifiable-acceptance results for the WU1–WU11 bundle.
+
+## Falsifiable acceptance (PLAN §WU12)
+
+1. **Sidecar `pytest --cov-branch --cov-fail-under=100` exits 0.** ✓
+   `cd sidecar && python -m pytest --cov=media_studio --cov-branch --cov-fail-under=100`
+   → `3256 passed`; `TOTAL 12071 0 3054 0 100%`; "Required test coverage of 100% reached."
+   The three new modules at 100% line+branch: `batch.py` 370/120, `export_presets.py` 130/30,
+   `templates.py` 123/46 (zero missed lines, zero missed branches).
+
+2. **Renderer `vitest run --coverage` exits 0 (thresholds:100 met).** ✓
+   `cd app && npx vitest run --coverage`
+   → Statements 100% (8290/8290), Branches 100% (2836/2836), Functions 100% (514/514),
+   Lines 100% (8290/8290). `Repurpose.tsx`, `BatchQueue.tsx`, `TemplateEditor.tsx`,
+   `ExportPresetsPanel.tsx`, `BatchConsentCard.tsx`, `LiveStatusRegion.tsx`, `rpc.ts` all 100%.
+
+3. **`git diff <main> -- sidecar/media_studio/handlers.py` shows ONLY additions inside
+   `register_all` (no second registration site; no provider wiring).** ✓
+   The only added blocks are the three module-owned `register()` calls
+   (`_export_presets.register`, `_templates.register`, `_batch.register`) plus the
+   `_video_title` title-seam helper the batch runner's progress line reuses. No provider,
+   key, or `_run_ai_job` wiring is introduced — the single RPC composition root invariant holds.
+
+4. **The three new feature modules contain no direct provider construction or key read.** ✓
+   `grep -E "Provider|api_key|_run_ai_job\(|os\.environ|getenv"` over
+   `export_presets.py`, `templates.py`, `batch.py` → zero matches. AI rides the envelope only
+   by method name (`templates.apply` → recipe runner; consent via `ai.planJob` by name).
+
+## Other standing gates (all green)
+
+- `ruff check media_studio` → All checks passed; `ruff format --check media_studio tests` → all formatted.
+- `basedpyright media_studio` → 0 errors (30 pre-existing torch/transformers missing-import
+  warnings in unrelated ML-backend modules; not from this bundle; CI's bare `basedpyright` exits 0).
+- `tsc --noEmit` (app) and `tsc -p . --noEmit` (render-cli) → clean.
+- `biome 2.5.0 format` (format-only gate; `biome.json` has `linter.enabled:false`) over
+  `app/{main,renderer/src,render-cli/src}` → "Checked 163 files. No fixes applied."
+- `oxlint --config app/.oxlintrc.json --deny-warnings` → clean (exit 0).
+
+> Note: a Windows checkout with `core.autocrlf=true` makes biome-format report CRLF diffs;
+> the committed code is LF (verified against a pristine `core.autocrlf=false` clone, where
+> biome-format applies zero fixes). CI runs on Ubuntu (LF), so the gate is green upstream.

--- a/sidecar/media_studio/features/batch.py
+++ b/sidecar/media_studio/features/batch.py
@@ -47,6 +47,7 @@ from collections.abc import Callable, Hashable
 from pathlib import Path
 from typing import Any, Protocol, cast
 
+from .. import protocol
 from ..jobs import JobCancelled
 from ..protocol import ErrorCode, RpcContext, RpcError
 from ..util import clamp, get_logger, now_ms
@@ -653,12 +654,334 @@ def _summarize(state: BatchState) -> BatchSummary:
     }
 
 
+# --------------------------------------------------------------------------- #
+# RPC service — the seven ``batch.*`` methods over the WU6-9 substrate (WU10)
+# --------------------------------------------------------------------------- #
+def _require_id(params: dict[str, Any]) -> str:
+    """Read + validate the ``id`` param shared by every id-taking ``batch.*`` method."""
+    batch_id = params.get("id")
+    if not isinstance(batch_id, str) or not batch_id:
+        raise _invalid("id (str) is required")
+    return batch_id
+
+
+def _merge_live_status(state: BatchState, job: Any) -> BatchState:
+    """Overlay a live parent job's ``pct`` onto a copy of the stored ``state``.
+
+    ``batch.status`` reads the durable checkpoint (per-item statuses, the source
+    of truth incl. ``skipped``) and, while the parent job is still in flight,
+    surfaces its live ``pct`` so the UI bar advances between item checkpoints. The
+    aggregate ``status`` stays the store's derived value (the checkpoint is
+    authoritative for the run/skip split); only the volatile ``pct`` is added. A
+    finished/absent job adds nothing — the checkpoint already reflects the outcome.
+    """
+    if job is None or job.finished:
+        return state
+    merged = dict(state)
+    merged["pct"] = job.pct
+    return merged
+
+
+class Batch:
+    """Owns the seven ``batch.*`` methods over the WU6-9 substrate (DESIGN §6).
+
+    ``create``/``list``/``delete`` are direct-return CRUD over the
+    :class:`BatchStore`. ``start`` computes the WU9 consent surface (one
+    ``ai.planJob`` per distinct step shape, ZERO provider calls) and then starts
+    the WU7 :func:`run_batch` parent job, threading each acknowledged source's
+    ``confirmBudget`` and skipping un-acked/over-budget egress sources. ``resume``
+    re-enqueues the not-yet-done sources as a FRESH job (WU8). ``status`` reads the
+    durable checkpoint and overlays the live parent job's ``pct``. ``cancel`` sets
+    the parent job's cooperative flag (``jobs.py`` ``cancel`` → the runner's
+    ``raise_if_cancelled`` between sources) — NO new cancellation machinery.
+
+    The single per-source seam is :attr:`_template_runner`: it runs ONE source
+    through the WU5 template path. The default invokes the live ``templates.apply``
+    handler (so a batch rides the SAME recipe runner / sub-job relay a single
+    ``templates.apply`` does), binding ``templateId`` from the batch state. No
+    provider/key is ever touched here — the AI envelope is reached only by method
+    name through that handler.
+
+    Seams (all injectable so tests run with fakes and no media / no real planner):
+
+      * ``template_runner`` — the ``(videoId, ctx, *, confirm_budget=?) -> {jobId}``
+        per-source seam (defaults to a ``templates.apply`` call by name).
+      * ``shape_of`` / ``plan_job`` — the consent pre-flight seams (default
+        ``shape_of`` collapses every source to the batch's ``templateId`` shape;
+        default ``plan_job`` calls ``ai.planJob`` by name with that shape's id).
+      * ``title_resolver`` — maps a ``videoId`` to a human title for the progress
+        message (defaults to the id).
+    """
+
+    def __init__(
+        self,
+        store: BatchStore,
+        *,
+        methods_provider: Callable[[], dict[str, Any]] | None = None,
+        template_runner: TemplateRunner | None = None,
+        shape_of: ShapeOf | None = None,
+        plan_job: PlanJob | None = None,
+        title_resolver: TitleResolver | None = None,
+    ) -> None:
+        self.store = store
+        self._methods_provider = methods_provider or (lambda: protocol.METHODS)
+        self._template_runner = template_runner
+        self._shape_of = shape_of
+        self._plan_job = plan_job
+        self._title_resolver = title_resolver
+        # parentJobId per running batch -> the cancel/status-merge target. In-memory
+        # only (the JobRegistry is in-memory; a restart loses it, which is exactly
+        # why resume is a CHECKPOINT read, not a live-job read — §10.1).
+        self._parent_jobs: dict[str, str] = {}
+
+    # -- direct-return CRUD -------------------------------------------------
+    def create(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.create({name, templateId, sourceVideoIds})`` -> ``{batch}``.
+
+        Validates + persists an all-``queued`` :class:`BatchState` (durable). The
+        fields are validated by :func:`new_state`, so a malformed create never
+        persists a half-typed record.
+        """
+        source_ids = params.get("sourceVideoIds")
+        return {
+            "batch": self.store.create(
+                params.get("name"),  # type: ignore[arg-type] - new_state validates
+                params.get("templateId"),  # type: ignore[arg-type]
+                source_ids,  # type: ignore[arg-type]
+            )
+        }
+
+    def list(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.list()`` -> ``{batches:[BatchSummary]}`` (incl. finished)."""
+        return {"batches": self.store.list()}
+
+    def delete(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.delete({id})`` -> ``{ok}`` (drops a finished/cancelled record)."""
+        batch_id = _require_id(params)
+        ok = self.store.delete(batch_id)
+        self._parent_jobs.pop(batch_id, None)
+        return {"ok": ok}
+
+    # -- status (store checkpoint + live job overlay) -----------------------
+    def status(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.status({id})`` -> ``{batch}`` (checkpoint + live ``pct`` overlay).
+
+        Reads the durable :class:`BatchState` (the authoritative per-item statuses,
+        incl. ``skipped`` with ``skipReason``) and, while the parent job is live,
+        overlays its ``pct`` so the aggregate bar advances between item checkpoints.
+        """
+        batch_id = _require_id(params)
+        state = self.store.load(batch_id)
+        if state is None:
+            raise _invalid(f"unknown batch: {batch_id}")
+        job = self._live_parent_job(batch_id, ctx)
+        return {"batch": _merge_live_status(state, job)}
+
+    # -- start (WU9 consent -> WU7 runner) ----------------------------------
+    def start(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.start({id, confirmCloudBudget?, acknowledged?})`` -> ``{jobId}``.
+
+        Loads the batch, computes the WU9 consent surface for its still-pending
+        sources (one ``ai.planJob`` per distinct step shape; ZERO provider calls),
+        then starts the WU7 :func:`run_batch` parent job carrying that consent —
+        acknowledged egress sources thread their ``confirmBudget``; un-acked /
+        over-budget egress sources end terminal ``skipped`` with their reason
+        (never silently absent, §9.1). The parent jobId is held for ``cancel`` /
+        ``status``.
+        """
+        batch_id = _require_id(params)
+        state = self.store.load(batch_id)
+        if state is None:
+            raise _invalid(f"unknown batch: {batch_id}")
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        template_id = str(state.get("templateId") or "")
+        runner = self._runner_for(template_id)
+        pending = [item["videoId"] for item in state["items"] if not is_terminal_status(item["status"])]
+        consent = self._build_consent(
+            pending,
+            template_id,
+            confirm_cloud_budget=bool(params.get("confirmCloudBudget", False)),
+            acknowledged=bool(params.get("acknowledged", False)),
+        )
+        continue_on_error = bool(params.get("continueOnError", True))
+        title_resolver = self._title_resolver
+
+        def job_body(job_ctx: Any) -> BatchState:
+            return run_batch(
+                self.store,
+                batch_id,
+                runner,
+                job_ctx,
+                ctx,
+                continue_on_error=continue_on_error,
+                title_resolver=title_resolver,
+                consent=consent,
+            )
+
+        job = ctx.jobs.start(job_body, feature="batch", label=f"batch: {state.get('name', '')}")
+        self._parent_jobs[batch_id] = job.id
+        return {"jobId": job.id}
+
+    # -- resume (WU8 fresh job over the not-yet-done sources) ---------------
+    def resume(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.resume({id, retryErrors?})`` -> ``{jobId}`` (re-enqueue pending).
+
+        Re-runs ONLY the not-yet-done sources of an incomplete batch as a fresh
+        parent job (:func:`resume_batch`); finished work is never redone (G-DUR).
+        A fully-terminal batch is a no-op (``{jobId: None, status}``).
+        """
+        batch_id = _require_id(params)
+        state = self.store.load(batch_id)
+        if state is None:
+            raise _invalid(f"unknown batch: {batch_id}")
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        template_id = str(state.get("templateId") or "")
+        out = resume_batch(
+            self.store,
+            batch_id,
+            self._runner_for(template_id),
+            ctx,
+            retry_errors=bool(params.get("retryErrors", False)),
+            title_resolver=self._title_resolver,
+        )
+        job_id = out.get("jobId")
+        if job_id is not None:
+            self._parent_jobs[batch_id] = job_id
+        return out
+
+    # -- cancel (cooperative parent-job flag; jobs.py:447) ------------------
+    def cancel(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``batch.cancel({id})`` -> ``{ok}`` (cooperative; ``jobs.py`` cancel).
+
+        Sets the parent job's cancel flag; the runner observes it via
+        ``raise_if_cancelled`` between sources and unwinds (the in-flight source is
+        recorded ``cancelled``). No new cancellation machinery. ``ok`` is ``False``
+        when no live parent job is tracked (nothing to cancel).
+        """
+        batch_id = _require_id(params)
+        parent_job_id = self._parent_jobs.get(batch_id)
+        if parent_job_id is None or ctx.jobs is None:
+            return {"ok": False}
+        return {"ok": bool(ctx.jobs.cancel(parent_job_id))}
+
+    # -- seams --------------------------------------------------------------
+    def _live_parent_job(self, batch_id: str, ctx: RpcContext) -> Any:
+        """The tracked parent :class:`~media_studio.jobs.Job` (or ``None``)."""
+        parent_job_id = self._parent_jobs.get(batch_id)
+        if parent_job_id is None or ctx.jobs is None:
+            return None
+        return ctx.jobs.get(parent_job_id)
+
+    def _runner_for(self, template_id: str) -> TemplateRunner:
+        """The per-source template seam for ``template_id`` (injected or default).
+
+        The default invokes the live ``templates.apply`` handler by name — the
+        batch rides the EXISTING single-source path; it builds no sub-job itself
+        and reaches the AI envelope only through that handler. The seam receives
+        its own per-source ``ctx`` at call time (so the same registry/jobs flow).
+        """
+        if self._template_runner is not None:
+            return self._template_runner
+
+        def runner(video_id: str, ctx: RpcContext, *, confirm_budget: str | None = None) -> dict[str, Any]:
+            apply_handler = self._methods_provider().get("templates.apply")
+            if apply_handler is None:  # pragma: no cover - register order guarantees it
+                raise RpcError("templates.apply is not registered", ErrorCode.INTERNAL_ERROR)
+            apply_params: dict[str, Any] = {"templateId": template_id, "videoId": video_id}
+            if confirm_budget:
+                apply_params["confirmBudget"] = confirm_budget
+            return apply_handler(apply_params, ctx)
+
+        return runner
+
+    def _build_consent(
+        self,
+        source_video_ids: list[str],
+        template_id: str,
+        *,
+        confirm_cloud_budget: bool,
+        acknowledged: bool,
+    ) -> dict[str, Any] | None:
+        """The WU9 consent surface for ``source_video_ids`` (``None`` to skip the gate).
+
+        With the gate OFF and no acknowledgement, the consent layer is a pass-through
+        (every source runs), so it is omitted entirely — ``run_batch`` then takes its
+        unchanged WU7 path. Otherwise one ``ai.planJob`` per distinct step shape
+        drives :func:`plan_consent` (ZERO provider calls).
+        """
+        if not confirm_cloud_budget:
+            return None
+        shape_of = self._shape_of or (lambda _video_id: template_id)
+        plan_job = self._plan_job or self._default_plan_job
+        return plan_consent(
+            source_video_ids,
+            shape_of=shape_of,
+            plan_job=plan_job,
+            confirm_cloud_budget=confirm_cloud_budget,
+            acknowledged=acknowledged,
+        )
+
+    def _default_plan_job(self, shape_key: Hashable) -> dict[str, Any]:
+        """Default consent planner: the live ``ai.planJob`` handler by name (no keys).
+
+        Passes the step shape as the request ``capability`` discriminator; the
+        handler returns the pure pre-flight plan (``willEgress``/``cacheHit``/
+        ``budget``/``cacheKey``) with ZERO provider calls.
+        """
+        plan_handler = self._methods_provider().get("ai.planJob")
+        if plan_handler is None:  # pragma: no cover - register order guarantees it
+            raise RpcError("ai.planJob is not registered", ErrorCode.INTERNAL_ERROR)
+        ctx = RpcContext(emit_notification=lambda *_: None, jobs=None)
+        return plan_handler({"capability": str(shape_key)}, ctx)
+
+
+def register(
+    *,
+    path: str | os.PathLike[str],
+    methods_provider: Callable[[], dict[str, Any]] | None = None,
+    template_runner: TemplateRunner | None = None,
+    shape_of: ShapeOf | None = None,
+    plan_job: PlanJob | None = None,
+    title_resolver: TitleResolver | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> Batch:
+    """Create a :class:`Batch` over ``path`` and register the seven methods.
+
+    ``register_fn`` defaults to :func:`protocol.register`; tests inject a fake
+    registrar + a tmp ``path`` + fake seams. Returns the service so the caller can
+    hold it (mirrors :func:`templates.register`). The default per-source runner
+    invokes ``templates.apply`` by name, so this module MUST be registered AFTER
+    the ``templates.*`` group (the composition root in ``handlers.register_all``
+    wires it there).
+    """
+    service = Batch(
+        BatchStore(path),
+        methods_provider=methods_provider,
+        template_runner=template_runner,
+        shape_of=shape_of,
+        plan_job=plan_job,
+        title_resolver=title_resolver,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("batch.create", service.create)
+    reg("batch.start", service.start)
+    reg("batch.status", service.status)
+    reg("batch.list", service.list)
+    reg("batch.cancel", service.cancel)
+    reg("batch.resume", service.resume)
+    reg("batch.delete", service.delete)
+    return service
+
+
 __all__ = [
     "ITEM_STATUSES",
     "SKIP_NO_HEADROOM",
     "SKIP_WOULD_EGRESS",
     "TERMINAL_STATUSES",
     "AwaitSubjob",
+    "Batch",
     "BatchItem",
     "BatchState",
     "BatchStore",
@@ -674,6 +997,7 @@ __all__ = [
     "new_item",
     "new_state",
     "plan_consent",
+    "register",
     "resumable_video_ids",
     "resume_batch",
     "run_batch",

--- a/sidecar/media_studio/features/batch.py
+++ b/sidecar/media_studio/features/batch.py
@@ -1,0 +1,269 @@
+"""Repurpose BATCH store + model (the repurpose bundle's WU6 durability substrate).
+
+A *batch* points one saved :mod:`templates` template at MANY library sources and
+runs them as one aggregate job (the runner is WU7; this module is the durable
+state layer only). Because the job registry is in-memory (``jobs.py`` —
+``self._jobs: dict``), the ONLY thing that survives a sidecar/app restart is what
+the batch checkpoint persists. WU6 therefore ships exactly that checkpoint:
+
+  * **Model** — a ``BatchState`` =
+    ``{id, name, templateId, status, createdAt, items:[BatchItem]}`` and a
+    ``BatchItem`` = ``{videoId, status, jobId?, error?, skipReason?, results?}``
+    where ``status`` is one of
+    ``queued | running | done | error | cancelled | skipped`` (DESIGN §5.2). The
+    ``skipped`` terminal state + ``skipReason`` carry the visible-skip contract
+    (§9.1) so a source dropped by the later consent gate is recorded and
+    attributed, never silently absent.
+  * **Storage** — :class:`BatchStore` writes ONE file per batch
+    (``batches/<batchId>.json``, DESIGN §8) with the proven atomic temp+rename
+    write (mirrors :class:`recipes.RecipeStore`). One file per batch makes a
+    checkpoint O(1) and means a corrupt batch can never poison another (a corrupt
+    file simply loads as ``None``; siblings stay readable).
+  * **Checkpoint-on-transition** — :meth:`BatchStore.update_item` rewrites the
+    whole batch file on EVERY item transition and recomputes the aggregate
+    ``status`` from the item statuses (:func:`derive_status`), so the on-disk
+    state is always consistent before the next item runs — the substrate the WU8
+    resume reads back.
+
+Pure logic + filesystem only — no heavy-ML / network / provider / runner imports.
+The runner, resume, consent and RPC layers are later WUs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+from ..protocol import ErrorCode, RpcError
+from ..util import get_logger, now_ms
+
+log = get_logger("media_studio.features.batch")
+
+BatchItem = dict[str, Any]
+BatchState = dict[str, Any]
+BatchSummary = dict[str, Any]
+
+#: every legal :class:`BatchItem` status (DESIGN §5.2).
+ITEM_STATUSES: frozenset[str] = frozenset({"queued", "running", "done", "error", "cancelled", "skipped"})
+#: the statuses a :class:`BatchItem` can never leave (no further work).
+TERMINAL_STATUSES: frozenset[str] = frozenset({"done", "error", "cancelled", "skipped"})
+#: the optional :class:`BatchItem` fields persisted only when supplied.
+_ITEM_OPTIONAL_FIELDS: tuple[str, ...] = ("jobId", "error", "skipReason", "results")
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+# --------------------------------------------------------------------------- #
+# pure model — item / state shaping + aggregate-status derivation
+# --------------------------------------------------------------------------- #
+def is_terminal_status(status: str) -> bool:
+    """True iff ``status`` is a terminal :class:`BatchItem` status."""
+    return status in TERMINAL_STATUSES
+
+
+def new_item(video_id: str) -> BatchItem:
+    """A fresh ``queued`` :class:`BatchItem` for ``video_id`` (fail-loud on empty)."""
+    if not isinstance(video_id, str) or not video_id.strip():
+        raise _invalid("batch item videoId (non-empty str) is required")
+    return {"videoId": video_id, "status": "queued"}
+
+
+def new_state(
+    name: str,
+    template_id: str,
+    source_video_ids: list[str],
+    *,
+    batch_id: str | None = None,
+) -> BatchState:
+    """Validate + shape a brand-new :class:`BatchState` (all items ``queued``).
+
+    Raises ``INVALID_PARAMS`` on any malformed field so a bad create can never
+    persist a half-typed record. A missing ``batch_id`` is generated.
+    """
+    if not isinstance(name, str) or not name.strip():
+        raise _invalid("batch.name (non-empty str) is required")
+    if not isinstance(template_id, str) or not template_id.strip():
+        raise _invalid("batch.templateId (non-empty str) is required")
+    if not isinstance(source_video_ids, list) or not source_video_ids:
+        raise _invalid("batch.sourceVideoIds (non-empty array) is required")
+    items = [new_item(video_id) for video_id in source_video_ids]
+    resolved_id = batch_id if isinstance(batch_id, str) and batch_id else uuid.uuid4().hex[:12]
+    return {
+        "id": resolved_id,
+        "name": name.strip(),
+        "templateId": template_id.strip(),
+        "status": derive_status([item["status"] for item in items]),
+        "createdAt": now_ms(),
+        "items": items,
+    }
+
+
+def derive_status(item_statuses: list[str]) -> str:
+    """Aggregate batch status from the item statuses (DESIGN §5.2 / §10.3).
+
+    * empty / all-``queued``      -> ``queued`` (nothing has started)
+    * any ``running`` OR a mix of started + still-``queued`` -> ``running``
+    * all ``done``                -> ``done``
+    * all terminal, none ``done``, only ``cancelled``        -> ``cancelled``
+    * all terminal, none ``done``, no successes (error/skip)  -> ``error``
+    * all terminal with at least one ``done`` AND a non-done   -> ``partial``
+    """
+    if not item_statuses:
+        return "queued"
+    if all(status == "queued" for status in item_statuses):
+        return "queued"
+    if any(status == "running" for status in item_statuses):
+        return "running"
+    if any(status == "queued" for status in item_statuses):
+        # Some items finished but others have not started yet -> still mid-flight.
+        return "running"
+    # Every item is terminal at this point.
+    if all(status == "done" for status in item_statuses):
+        return "done"
+    if all(status == "cancelled" for status in item_statuses):
+        return "cancelled"
+    if any(status == "done" for status in item_statuses):
+        return "partial"
+    return "error"
+
+
+# --------------------------------------------------------------------------- #
+# storage — one file per batch (atomic temp+rename), per-batch isolation
+# --------------------------------------------------------------------------- #
+class BatchStore:
+    """One JSON file per batch under ``dir`` (atomic temp+rename writes).
+
+    A per-batch file keeps each checkpoint O(1) and isolates corruption: a bad
+    file loads as ``None`` and its siblings stay readable. The write mirrors
+    :class:`recipes.RecipeStore` (temp file + ``os.replace``) so a failed write
+    never truncates the prior checkpoint.
+    """
+
+    def __init__(self, directory: str | os.PathLike[str]) -> None:
+        self.dir = Path(directory)
+
+    def _path(self, batch_id: str) -> Path:
+        return self.dir / f"{batch_id}.json"
+
+    def _write(self, state: BatchState) -> None:
+        self.dir.mkdir(parents=True, exist_ok=True)
+        path = self._path(state["id"])
+        tmp = path.with_name(path.name + ".tmp")
+        tmp.write_text(json.dumps(state, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, path)
+
+    def load(self, batch_id: str) -> BatchState | None:
+        """Read one batch by id (``None`` if absent / unreadable / wrong shape)."""
+        path = self._path(batch_id)
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as exc:
+            log.warning("batch %s unreadable (%s); treating as missing", batch_id, exc)
+            return None
+        if not isinstance(data, dict):
+            return None
+        return data
+
+    def create(self, name: str, template_id: str, source_video_ids: list[str]) -> BatchState:
+        """Shape + persist a new all-``queued`` batch; returns the stored state."""
+        state = new_state(name, template_id, source_video_ids)
+        self._write(state)
+        return state
+
+    def update_item(
+        self,
+        batch_id: str,
+        video_id: str,
+        *,
+        status: str,
+        **fields: Any,
+    ) -> BatchState:
+        """Checkpoint one item transition (rewrites the whole batch file).
+
+        Sets the item's ``status`` (validated against :data:`ITEM_STATUSES`),
+        merges any supplied optional fields (``jobId``/``error``/``skipReason``/
+        ``results``), recomputes the aggregate ``status``, and atomically rewrites
+        the file BEFORE returning — the durability guarantee for resume (WU8).
+        """
+        if status not in ITEM_STATUSES:
+            raise _invalid(f"invalid batch item status: {status!r}")
+        state = self.load(batch_id)
+        if state is None:
+            raise _invalid(f"unknown batch: {batch_id}")
+        target: BatchItem | None = None
+        for item in state["items"]:
+            if item.get("videoId") == video_id:
+                target = item
+                break
+        if target is None:
+            raise _invalid(f"unknown batch item: {video_id}")
+        target["status"] = status
+        for key in _ITEM_OPTIONAL_FIELDS:
+            if key in fields:
+                target[key] = fields[key]
+        state["status"] = derive_status([item["status"] for item in state["items"]])
+        self._write(state)
+        return state
+
+    def delete(self, batch_id: str) -> bool:
+        """Drop a batch file; ``True`` if one existed, ``False`` otherwise."""
+        path = self._path(batch_id)
+        if not path.exists():
+            return False
+        path.unlink()
+        return True
+
+    def list(self) -> list[BatchSummary]:
+        """Lightweight summaries of every readable batch (heavy ``results`` omitted)."""
+        if not self.dir.exists():
+            return []
+        summaries: list[BatchSummary] = []
+        for path in sorted(self.dir.glob("*.json")):
+            try:
+                data = json.loads(path.read_text(encoding="utf-8"))
+            except (ValueError, OSError):
+                log.warning("batch summary skipped (unreadable): %s", path.name)
+                continue
+            if not isinstance(data, dict):
+                continue
+            summaries.append(_summarize(data))
+        return summaries
+
+
+def _summarize(state: BatchState) -> BatchSummary:
+    """Project a :class:`BatchState` to a :class:`BatchSummary` (no per-item heavy data)."""
+    items = state.get("items") or []
+    counts = dict.fromkeys(("done", "error", "skipped", "queued", "running", "cancelled"), 0)
+    for item in items:
+        item_status = item.get("status")
+        if item_status in counts:
+            counts[item_status] += 1
+    return {
+        "id": state.get("id"),
+        "name": state.get("name"),
+        "templateId": state.get("templateId"),
+        "status": state.get("status"),
+        "createdAt": state.get("createdAt"),
+        "counts": {"total": len(items), **counts},
+    }
+
+
+__all__ = [
+    "ITEM_STATUSES",
+    "TERMINAL_STATUSES",
+    "BatchItem",
+    "BatchState",
+    "BatchStore",
+    "BatchSummary",
+    "derive_status",
+    "is_terminal_status",
+    "new_item",
+    "new_state",
+]

--- a/sidecar/media_studio/features/batch.py
+++ b/sidecar/media_studio/features/batch.py
@@ -28,9 +28,14 @@ the batch checkpoint persists. WU6 therefore ships exactly that checkpoint:
     state is always consistent before the next item runs — the substrate the WU8
     resume reads back.
 
+WU8 adds :func:`resume_batch` (G-DUR): it reads the checkpoint back, treats
+``done`` items as complete, re-enqueues the not-yet-done sources (resetting them
+to ``queued`` on disk), and starts a FRESH parent job that re-runs ONLY those
+sources at SOURCE granularity — finished work is never redone.
+
 No heavy-ML / network / provider imports. The runner reuses the recipe sub-job
-relay by import (no new sub-job machinery); resume, consent and the RPC layer are
-later WUs.
+relay by import (no new sub-job machinery); consent and the RPC layer are later
+WUs.
 """
 
 from __future__ import annotations
@@ -61,6 +66,9 @@ TemplateRunner = Callable[[str, RpcContext], dict[str, Any]]
 TitleResolver = Callable[[str], str]
 #: The sub-job await/relay seam (defaults to the recipe runner's ``_await_subjob``).
 AwaitSubjob = Callable[[str, Any, RpcContext, Callable[[float, str], None]], Any]
+#: The parent-job start seam: ``(job_body, **kwargs) -> <job with .id>`` (defaults
+#: to ``ctx.jobs.start``). Injected by tests to run the resume body synchronously.
+StartJob = Callable[..., Any]
 
 #: every legal :class:`BatchItem` status (DESIGN §5.2).
 ITEM_STATUSES: frozenset[str] = frozenset({"queued", "running", "done", "error", "cancelled", "skipped"})
@@ -329,6 +337,11 @@ def run_batch(
     total = max(len(items), 1)
     final = state  # the latest store-returned state (always non-None for the return).
     for index, item in enumerate(items):
+        # A source already in a terminal state (e.g. a ``done`` item preserved by a
+        # WU8 resume) is NOT re-run — resume re-enqueues only the incomplete sources
+        # by resetting them to ``queued``; finished work stays finished (G-DUR).
+        if is_terminal_status(item["status"]):
+            continue
         job_ctx.raise_if_cancelled()
         video_id = item["videoId"]
         title = resolve_title(video_id)
@@ -361,6 +374,87 @@ def run_batch(
     return final
 
 
+# --------------------------------------------------------------------------- #
+# resume — re-enqueue not-yet-done sources as a FRESH job (WU8, G-DUR)
+# --------------------------------------------------------------------------- #
+#: the statuses a resume re-enqueues unconditionally (work that never finished).
+_RESUMABLE_STATUSES: frozenset[str] = frozenset({"queued", "running"})
+
+
+def resumable_video_ids(state: BatchState, *, retry_errors: bool = False) -> list[str]:
+    """Video ids of the sources a resume should re-run, in batch order (§10.1).
+
+    Pure selector over the checkpointed :class:`BatchState`. ``queued`` and
+    ``running`` items are always re-enqueued (a ``running`` item is a source the
+    crash interrupted mid-flight). ``error`` items are re-enqueued ONLY when
+    ``retry_errors`` (default policy leaves an errored source terminal). ``done``
+    /``skipped``/``cancelled`` are terminal and never resumed — finished work is
+    not redone (the G-DUR durability contract).
+    """
+    selected: list[str] = []
+    for item in state.get("items") or []:
+        status = item.get("status")
+        if status in _RESUMABLE_STATUSES or (retry_errors and status == "error"):
+            selected.append(item["videoId"])
+    return selected
+
+
+def resume_batch(
+    store: BatchStore,
+    batch_id: str,
+    template_runner: TemplateRunner,
+    ctx: RpcContext,
+    *,
+    retry_errors: bool = False,
+    continue_on_error: bool = True,
+    title_resolver: TitleResolver | None = None,
+    await_subjob: AwaitSubjob | None = None,
+    start_job: StartJob | None = None,
+) -> dict[str, Any]:
+    """Resume an incomplete batch as a FRESH parent job (DESIGN §10.1, G-DUR).
+
+    Reads the checkpointed :class:`BatchState`, treats ``done`` items as complete,
+    and re-enqueues the not-yet-done sources (:func:`resumable_video_ids`) by
+    resetting them to ``queued`` ON DISK before any work starts — the durable
+    re-enqueue, not an in-memory one. It then starts a fresh parent job whose body
+    runs :func:`run_batch`; because the preserved ``done`` items are terminal,
+    ``run_batch`` skips them and runs ONLY the re-enqueued sources. Resume is at
+    SOURCE granularity: a re-enqueued source runs its full template path from step
+    one (its earlier outputs are idempotent overwrites) — mid-pipeline resume is
+    out of scope (§10.1).
+
+    Returns ``{"jobId": <id>}``. When nothing is resumable (every source already
+    terminal) it is a NO-OP: no job starts and it returns
+    ``{"jobId": None, "status": <terminal aggregate>}``.
+    """
+    state = store.load(batch_id)
+    if state is None:
+        raise _invalid(f"unknown batch: {batch_id}")
+    pending = resumable_video_ids(state, retry_errors=retry_errors)
+    if not pending:
+        return {"jobId": None, "status": state.get("status")}
+    # Durable re-enqueue: reset each not-yet-done source to ``queued`` on disk so a
+    # second crash before the job runs still sees them as pending.
+    for video_id in pending:
+        state = store.update_item(batch_id, video_id, status="queued")
+    starter = start_job or ctx.jobs.start
+
+    def job_body(job_ctx: Any) -> BatchState:
+        return run_batch(
+            store,
+            batch_id,
+            template_runner,
+            job_ctx,
+            ctx,
+            continue_on_error=continue_on_error,
+            title_resolver=title_resolver,
+            await_subjob=await_subjob,
+        )
+
+    job = starter(job_body, feature="batch", label=f"resume: {state.get('name', '')}")
+    return {"jobId": job.id}
+
+
 def _summarize(state: BatchState) -> BatchSummary:
     """Project a :class:`BatchState` to a :class:`BatchSummary` (no per-item heavy data)."""
     items = state.get("items") or []
@@ -387,11 +481,14 @@ __all__ = [
     "BatchState",
     "BatchStore",
     "BatchSummary",
+    "StartJob",
     "TemplateRunner",
     "TitleResolver",
     "derive_status",
     "is_terminal_status",
     "new_item",
     "new_state",
+    "resumable_video_ids",
+    "resume_batch",
     "run_batch",
 ]

--- a/sidecar/media_studio/features/batch.py
+++ b/sidecar/media_studio/features/batch.py
@@ -1,8 +1,11 @@
-"""Repurpose BATCH store + model (the repurpose bundle's WU6 durability substrate).
+"""Repurpose BATCH store + model + per-source runner (WU6 substrate + WU7 runner).
 
 A *batch* points one saved :mod:`templates` template at MANY library sources and
-runs them as one aggregate job (the runner is WU7; this module is the durable
-state layer only). Because the job registry is in-memory (``jobs.py`` —
+runs them as one aggregate job. WU6 ships the durable state layer (model + store +
+checkpoint-on-transition); WU7 adds :func:`run_batch`, the parent batch job body
+that drives each source through the WU5 template path with NEW per-source
+try/except isolation (G-ISO) over the EXISTING recipe sub-job relay. Because the
+job registry is in-memory (``jobs.py`` —
 ``self._jobs: dict``), the ONLY thing that survives a sidecar/app restart is what
 the batch checkpoint persists. WU6 therefore ships exactly that checkpoint:
 
@@ -25,8 +28,9 @@ the batch checkpoint persists. WU6 therefore ships exactly that checkpoint:
     state is always consistent before the next item runs — the substrate the WU8
     resume reads back.
 
-Pure logic + filesystem only — no heavy-ML / network / provider / runner imports.
-The runner, resume, consent and RPC layers are later WUs.
+No heavy-ML / network / provider imports. The runner reuses the recipe sub-job
+relay by import (no new sub-job machinery); resume, consent and the RPC layer are
+later WUs.
 """
 
 from __future__ import annotations
@@ -34,17 +38,29 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from collections.abc import Callable
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
-from ..protocol import ErrorCode, RpcError
-from ..util import get_logger, now_ms
+from ..jobs import JobCancelled
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import clamp, get_logger, now_ms
+from . import recipes
 
 log = get_logger("media_studio.features.batch")
 
 BatchItem = dict[str, Any]
 BatchState = dict[str, Any]
 BatchSummary = dict[str, Any]
+
+#: A template-run seam: ``(video_id, ctx) -> {"jobId": ...}`` — runs one source
+#: through the WU5 template path and returns the spawned sub-job id. The runner
+#: only awaits + isolates; it never builds the per-source job itself.
+TemplateRunner = Callable[[str, RpcContext], dict[str, Any]]
+#: Maps a source ``video_id`` to a human title for the progress message.
+TitleResolver = Callable[[str], str]
+#: The sub-job await/relay seam (defaults to the recipe runner's ``_await_subjob``).
+AwaitSubjob = Callable[[str, Any, RpcContext, Callable[[float, str], None]], Any]
 
 #: every legal :class:`BatchItem` status (DESIGN §5.2).
 ITEM_STATUSES: frozenset[str] = frozenset({"queued", "running", "done", "error", "cancelled", "skipped"})
@@ -212,6 +228,21 @@ class BatchStore:
         self._write(state)
         return state
 
+    def set_status(self, batch_id: str, status: str) -> BatchState:
+        """Override the aggregate batch ``status`` (atomic rewrite).
+
+        The runner uses this when it deliberately STOPS early (``continue_on_error``
+        off): the items left ``queued`` would otherwise make :func:`derive_status`
+        report ``running`` for a batch that has actually halted, so the runner
+        records the terminal ``error`` aggregate explicitly (DESIGN §10.3).
+        """
+        state = self.load(batch_id)
+        if state is None:
+            raise _invalid(f"unknown batch: {batch_id}")
+        state["status"] = status
+        self._write(state)
+        return state
+
     def delete(self, batch_id: str) -> bool:
         """Drop a batch file; ``True`` if one existed, ``False`` otherwise."""
         path = self._path(batch_id)
@@ -237,6 +268,99 @@ class BatchStore:
         return summaries
 
 
+# --------------------------------------------------------------------------- #
+# runner — per-source isolation over the WU5 template path (WU7, G-ISO)
+# --------------------------------------------------------------------------- #
+def _default_await_subjob(
+    sub_job_id: str,
+    job_ctx: Any,
+    ctx: RpcContext,
+    on_sub: Callable[[float, str], None],
+) -> Any:
+    """Await one per-source sub-job via the recipe runner's proven relay.
+
+    ``recipes.Recipes._await_subjob`` references no instance state, so it is
+    reused verbatim (no new sub-job-await machinery) by calling it with a ``None``
+    ``self`` — the batch runner gains the SAME progress-relay, cancel-propagation,
+    error-reraise and timeout behavior the recipe runner already ships and tests.
+    """
+    # _await_subjob touches no instance state; the cast documents the intentional
+    # ``self``-free reuse so basedpyright accepts the stateless call.
+    return recipes.Recipes._await_subjob(cast("recipes.Recipes", None), sub_job_id, job_ctx, ctx, on_sub)
+
+
+def run_batch(
+    store: BatchStore,
+    batch_id: str,
+    template_runner: TemplateRunner,
+    job_ctx: Any,
+    ctx: RpcContext,
+    *,
+    continue_on_error: bool = True,
+    title_resolver: TitleResolver | None = None,
+    await_subjob: AwaitSubjob | None = None,
+) -> BatchState:
+    """Run a batch's sources through ``template_runner`` with per-source isolation.
+
+    The parent batch job body: iterate the batch's items, run each source through
+    the WU5 template path (``template_runner`` → ``{jobId}``), and await that
+    sub-job via the EXISTING recipe relay (:func:`_default_await_subjob`). Each
+    source's ``[0,100]`` sub-progress is spread into its even slice of the overall
+    ``[0,100]`` bar (mirroring ``convert_batch``), and the relayed step message is
+    prefixed with ``"source k/N · <title> · "`` (extends the recipe runner's
+    ``"step j/M · <label>"``, DESIGN §7).
+
+    The deliberate divergence from ``convert_batch``/``_run_one_step`` (G-ISO):
+    each source runs inside a NEW try/except, so one bad source records ``error``
+    on its :class:`BatchItem` and the batch CONTINUES when ``continue_on_error``
+    (default ``true``); with the toggle off the batch stops at the first error and
+    leaves the remaining items ``queued``. A :class:`~media_studio.jobs.JobCancelled`
+    is NOT isolated: an in-flight source is recorded ``cancelled`` and the cancel
+    re-raised so the parent job unwinds (no new cancel machinery — the relay's
+    ``raise_if_cancelled`` path is reused).
+    """
+    state = store.load(batch_id)
+    if state is None:
+        raise _invalid(f"unknown batch: {batch_id}")
+    resolve_title = title_resolver or (lambda video_id: video_id)
+    await_sub = await_subjob or _default_await_subjob
+
+    items: list[BatchItem] = state["items"]
+    total = max(len(items), 1)
+    final = state  # the latest store-returned state (always non-None for the return).
+    for index, item in enumerate(items):
+        job_ctx.raise_if_cancelled()
+        video_id = item["videoId"]
+        title = resolve_title(video_id)
+        base = index / total * 100.0
+        span = 100.0 / total
+        prefix = f"source {index + 1}/{total} · {title} · "
+
+        def on_sub(pct: float, message: str, _base: float = base, _span: float = span, _prefix: str = prefix) -> None:
+            job_ctx.progress(_base + clamp(pct, 0.0, 100.0) / 100.0 * _span, f"{_prefix}{message}")
+
+        final = store.update_item(batch_id, video_id, status="running")
+        on_sub(0.0, "")
+        try:
+            started = template_runner(video_id, ctx)
+            result = await_sub(started["jobId"], job_ctx, ctx, on_sub)
+        except JobCancelled:
+            store.update_item(batch_id, video_id, status="cancelled")
+            raise
+        except Exception as exc:  # noqa: BLE001 - per-source isolation is the point (G-ISO)
+            final = store.update_item(batch_id, video_id, status="error", error=str(exc))
+            if not continue_on_error:
+                # Halted early: the still-``queued`` tail would read as ``running``,
+                # so record the terminal ``error`` aggregate explicitly (§10.3).
+                final = store.set_status(batch_id, "error")
+                break
+            continue
+        final = store.update_item(batch_id, video_id, status="done", jobId=started["jobId"], results=result)
+
+    job_ctx.progress(100.0, "done")
+    return final
+
+
 def _summarize(state: BatchState) -> BatchSummary:
     """Project a :class:`BatchState` to a :class:`BatchSummary` (no per-item heavy data)."""
     items = state.get("items") or []
@@ -258,12 +382,16 @@ def _summarize(state: BatchState) -> BatchSummary:
 __all__ = [
     "ITEM_STATUSES",
     "TERMINAL_STATUSES",
+    "AwaitSubjob",
     "BatchItem",
     "BatchState",
     "BatchStore",
     "BatchSummary",
+    "TemplateRunner",
+    "TitleResolver",
     "derive_status",
     "is_terminal_status",
     "new_item",
     "new_state",
+    "run_batch",
 ]

--- a/sidecar/media_studio/features/batch.py
+++ b/sidecar/media_studio/features/batch.py
@@ -43,9 +43,9 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Hashable
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol, cast
 
 from ..jobs import JobCancelled
 from ..protocol import ErrorCode, RpcContext, RpcError
@@ -58,10 +58,18 @@ BatchItem = dict[str, Any]
 BatchState = dict[str, Any]
 BatchSummary = dict[str, Any]
 
-#: A template-run seam: ``(video_id, ctx) -> {"jobId": ...}`` — runs one source
-#: through the WU5 template path and returns the spawned sub-job id. The runner
-#: only awaits + isolates; it never builds the per-source job itself.
-TemplateRunner = Callable[[str, RpcContext], dict[str, Any]]
+
+#: A template-run seam: ``(video_id, ctx, *, confirm_budget=?) -> {"jobId": ...}``
+#: — runs one source through the WU5 template path and returns the spawned sub-job
+#: id. The runner only awaits + isolates; it never builds the per-source job
+#: itself. ``confirm_budget`` is threaded ONLY for an acknowledged egressing source
+#: (WU9); the plain two-arg call is the WU7 default.
+class TemplateRunner(Protocol):
+    def __call__(self, video_id: str, ctx: RpcContext, *, confirm_budget: str | None = ...) -> dict[str, Any]:
+        """Run one source's template path; returns ``{"jobId": ...}``."""
+        ...  # pragma: no cover - Protocol method body is never executed
+
+
 #: Maps a source ``video_id`` to a human title for the progress message.
 TitleResolver = Callable[[str], str]
 #: The sub-job await/relay seam (defaults to the recipe runner's ``_await_subjob``).
@@ -69,6 +77,18 @@ AwaitSubjob = Callable[[str, Any, RpcContext, Callable[[float, str], None]], Any
 #: The parent-job start seam: ``(job_body, **kwargs) -> <job with .id>`` (defaults
 #: to ``ctx.jobs.start``). Injected by tests to run the resume body synchronously.
 StartJob = Callable[..., Any]
+#: Maps a source ``video_id`` to its distinct AI step *shape* key (sources sharing
+#: a template+size collapse to ONE shape, so the planner cost is bounded by shape
+#: count, not source count — the dedup contract, WU9 / DESIGN §9.1).
+ShapeOf = Callable[[str], Hashable]
+#: The pure pre-flight planner seam: ``shape_key -> plan`` (the fake ``ai.planJob``
+#: in tests). Called ONCE per distinct shape; returns a plan dict with
+#: ``{willEgress, cacheHit, costEst, budget, cacheKey}`` (``handlers.py:1696``).
+PlanJob = Callable[[Hashable], dict[str, Any]]
+
+#: visible-skip reason tokens (DESIGN §9.1) — never a silent absence.
+SKIP_WOULD_EGRESS = "would egress — not acknowledged"
+SKIP_NO_HEADROOM = "no budget headroom"
 
 #: every legal :class:`BatchItem` status (DESIGN §5.2).
 ITEM_STATUSES: frozenset[str] = frozenset({"queued", "running", "done", "error", "cancelled", "skipped"})
@@ -297,6 +317,27 @@ def _default_await_subjob(
     return recipes.Recipes._await_subjob(cast("recipes.Recipes", None), sub_job_id, job_ctx, ctx, on_sub)
 
 
+def _run_source(
+    template_runner: TemplateRunner,
+    video_id: str,
+    ctx: RpcContext,
+    decision: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Invoke ``template_runner`` for one source, threading any ``confirmBudget``.
+
+    When the WU9 consent supplied a ``confirmBudget`` token (the plan's
+    ``cacheKey`` for an acknowledged egressing source), it is passed as the
+    ``confirm_budget`` keyword so the underlying AI step satisfies
+    ``_enforce_cloud_budget_ack`` (``handlers.py:1672``). With no token (local /
+    cache-hit / gate-off / no consent), the runner is called with its plain
+    ``(video_id, ctx)`` signature — the WU7 path, unchanged.
+    """
+    confirm_budget = (decision or {}).get("confirmBudget")
+    if confirm_budget:
+        return template_runner(video_id, ctx, confirm_budget=confirm_budget)
+    return template_runner(video_id, ctx)
+
+
 def run_batch(
     store: BatchStore,
     batch_id: str,
@@ -307,6 +348,7 @@ def run_batch(
     continue_on_error: bool = True,
     title_resolver: TitleResolver | None = None,
     await_subjob: AwaitSubjob | None = None,
+    consent: dict[str, Any] | None = None,
 ) -> BatchState:
     """Run a batch's sources through ``template_runner`` with per-source isolation.
 
@@ -332,6 +374,9 @@ def run_batch(
         raise _invalid(f"unknown batch: {batch_id}")
     resolve_title = title_resolver or (lambda video_id: video_id)
     await_sub = await_subjob or _default_await_subjob
+    decisions: dict[str, dict[str, Any]] = {
+        decision["videoId"]: decision for decision in (consent or {}).get("decisions", [])
+    }
 
     items: list[BatchItem] = state["items"]
     total = max(len(items), 1)
@@ -344,6 +389,13 @@ def run_batch(
             continue
         job_ctx.raise_if_cancelled()
         video_id = item["videoId"]
+        decision = decisions.get(video_id)
+        # WU9 visible skip: a source the consent gate marked ``skip`` is recorded
+        # terminal ``skipped`` with its reason BEFORE any work — never run, never a
+        # silent absence (§9.1). Its progress slice is still consumed below.
+        if decision is not None and decision["action"] == "skip":
+            final = store.update_item(batch_id, video_id, status="skipped", skipReason=decision["skipReason"])
+            continue
         title = resolve_title(video_id)
         base = index / total * 100.0
         span = 100.0 / total
@@ -355,7 +407,7 @@ def run_batch(
         final = store.update_item(batch_id, video_id, status="running")
         on_sub(0.0, "")
         try:
-            started = template_runner(video_id, ctx)
+            started = _run_source(template_runner, video_id, ctx, decision)
             result = await_sub(started["jobId"], job_ctx, ctx, on_sub)
         except JobCancelled:
             store.update_item(batch_id, video_id, status="cancelled")
@@ -455,6 +507,134 @@ def resume_batch(
     return {"jobId": job.id}
 
 
+# --------------------------------------------------------------------------- #
+# consent — pre-run batch-wide G-ACK surface + visible skip (WU9, DESIGN §9.1)
+# --------------------------------------------------------------------------- #
+def _has_headroom(plan: dict[str, Any]) -> bool:
+    """``True`` iff the plan's budget stays within the free-limit ceiling.
+
+    The pre-flight plan carries a ``budget`` (``handlers.py:1696``) whose
+    ``withinFreeLimits`` flag is ``False`` once the run exceeds any involved
+    provider's free cap (``budget.py``). A missing flag is treated as headroom
+    present (the planner only sets it ``False`` when it KNOWS the cap is busted).
+    """
+    budget = plan.get("budget") or plan.get("costEst") or {}
+    return bool(budget.get("withinFreeLimits", True))
+
+
+def consent_decision(
+    plan: dict[str, Any],
+    *,
+    confirm_cloud_budget: bool,
+    acknowledged: bool,
+) -> tuple[str, str | None, str | None]:
+    """Decide ONE source's pre-run fate from its pure plan (DESIGN §9.1).
+
+    Returns ``(action, skip_reason, confirm_budget)`` where ``action`` is
+    ``"run"`` or ``"skip"``. A local-only or cache-hit plan never egresses, so it
+    always runs (``confirm_budget`` ``None``) regardless of the gate. An egressing
+    plan runs informationally when ``confirm_cloud_budget`` is OFF. With the gate
+    ON: an un-acknowledged egress is ``skip`` (``SKIP_WOULD_EGRESS``); an
+    acknowledged egress with NO budget headroom is ``skip`` (``SKIP_NO_HEADROOM``);
+    an acknowledged egress with headroom RUNS and threads the plan's ``cacheKey``
+    as ``confirm_budget`` (satisfying ``_enforce_cloud_budget_ack``,
+    ``handlers.py:1672``, without changing the envelope).
+    """
+    if not plan.get("willEgress"):
+        return ("run", None, None)
+    if not confirm_cloud_budget:
+        return ("run", None, None)
+    if not acknowledged:
+        return ("skip", SKIP_WOULD_EGRESS, None)
+    if not _has_headroom(plan):
+        return ("skip", SKIP_NO_HEADROOM, None)
+    return ("run", None, str(plan.get("cacheKey") or ""))
+
+
+def _sum_egress_cost(egressing_plans: list[dict[str, Any]]) -> dict[str, Any]:
+    """Aggregate ``requests``/``egressBytes`` over the supplied EGRESSING plans.
+
+    The caller (:func:`plan_consent`) passes ONLY the plans whose ``willEgress``
+    is true, so local-only and cache-hit sources contribute nothing and the cost
+    shown reflects exactly the bytes that would leave the machine (acceptance #4).
+    ``withinFreeLimits`` is the AND across those plans — the aggregate has headroom
+    only if EVERY egressing source does.
+    """
+    requests = 0
+    egress_bytes = 0
+    within = True
+    for plan in egressing_plans:
+        cost = plan.get("costEst") or {}
+        requests += int(cost.get("requests", 0))
+        egress_bytes += int(cost.get("egressBytes", 0))
+        within = within and _has_headroom(plan)
+    return {"requests": requests, "egressBytes": egress_bytes, "withinFreeLimits": within}
+
+
+def plan_consent(
+    source_video_ids: list[str],
+    *,
+    shape_of: ShapeOf,
+    plan_job: PlanJob,
+    confirm_cloud_budget: bool,
+    acknowledged: bool,
+) -> dict[str, Any]:
+    """Build the pre-run batch consent surface from pure plans (DESIGN §9.1).
+
+    Computed BEFORE ``batch.start`` from ``ai.planJob`` plans ONLY (zero provider
+    calls). One plan is fetched per distinct step *shape* — sources sharing a
+    template+size collapse to one plan, so ``plan_job`` is invoked once per shape,
+    NOT once per source (acceptance #1). For each source it records the
+    :func:`consent_decision` (``action``/``skipReason``/``confirmBudget``) plus the
+    surfaced ``willEgress``/``cacheHit`` flags, the N-run/K-skip split, the
+    aggregated ``costEst`` over the egressing sources, and the ``budget`` headroom.
+
+    The returned dict is the consent surface the runner consumes (``decisions`` is
+    keyed-by-order to mirror the batch items) and the renderer renders as the §9.1
+    summary card.
+    """
+    plans_by_shape: dict[Hashable, dict[str, Any]] = {}
+    decisions: list[dict[str, Any]] = []
+    egressing_plans: list[dict[str, Any]] = []
+    will_run = 0
+    will_skip = 0
+    for video_id in source_video_ids:
+        shape_key = shape_of(video_id)
+        plan = plans_by_shape.get(shape_key)
+        if plan is None:
+            plan = plan_job(shape_key)
+            plans_by_shape[shape_key] = plan
+        action, skip_reason, confirm_budget = consent_decision(
+            plan,
+            confirm_cloud_budget=confirm_cloud_budget,
+            acknowledged=acknowledged,
+        )
+        if action == "run":
+            will_run += 1
+        else:
+            will_skip += 1
+        if plan.get("willEgress"):
+            egressing_plans.append(plan)
+        decisions.append(
+            {
+                "videoId": video_id,
+                "action": action,
+                "skipReason": skip_reason,
+                "confirmBudget": confirm_budget,
+                "willEgress": bool(plan.get("willEgress")),
+                "cacheHit": bool(plan.get("cacheHit")),
+            }
+        )
+    cost = _sum_egress_cost(egressing_plans)
+    return {
+        "decisions": decisions,
+        "willRun": will_run,
+        "willSkip": will_skip,
+        "costEst": cost,
+        "budget": cost,
+    }
+
+
 def _summarize(state: BatchState) -> BatchSummary:
     """Project a :class:`BatchState` to a :class:`BatchSummary` (no per-item heavy data)."""
     items = state.get("items") or []
@@ -475,19 +655,25 @@ def _summarize(state: BatchState) -> BatchSummary:
 
 __all__ = [
     "ITEM_STATUSES",
+    "SKIP_NO_HEADROOM",
+    "SKIP_WOULD_EGRESS",
     "TERMINAL_STATUSES",
     "AwaitSubjob",
     "BatchItem",
     "BatchState",
     "BatchStore",
     "BatchSummary",
+    "PlanJob",
+    "ShapeOf",
     "StartJob",
     "TemplateRunner",
     "TitleResolver",
+    "consent_decision",
     "derive_status",
     "is_terminal_status",
     "new_item",
     "new_state",
+    "plan_consent",
     "resumable_video_ids",
     "resume_batch",
     "run_batch",

--- a/sidecar/media_studio/features/export_presets.py
+++ b/sidecar/media_studio/features/export_presets.py
@@ -34,10 +34,12 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from ..protocol import ErrorCode, RpcError
+from .. import protocol
+from ..protocol import ErrorCode, RpcContext, RpcError
 from ..util import clamp, get_logger
 from . import caption_remotion
 
@@ -258,3 +260,63 @@ class PresetStore:
         seeded = seed_presets()
         self._write(seeded)
         return seeded
+
+
+# --------------------------------------------------------------------------- #
+# RPC service (WU2): direct-return CRUD over the catalog (mirrors Recipes)
+# --------------------------------------------------------------------------- #
+class ExportPresets:
+    """The ``exportPresets.*`` handler group — thin direct-return CRUD.
+
+    Each method validates the wire params and delegates to a :class:`PresetStore`;
+    no jobs, no notifications (storage-only), mirroring ``recipes.Recipes`` CRUD.
+    The ``ctx`` is part of the handler signature for registry uniformity but is
+    unused here (the catalog never emits progress).
+    """
+
+    def __init__(self, store: PresetStore) -> None:
+        self.store = store
+
+    def list(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``exportPresets.list()`` -> ``{presets:[ExportPreset]}`` (direct-return)."""
+        return {"presets": self.store.list()}
+
+    def save(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``exportPresets.save({preset})`` -> ``{preset}`` (direct-return; upsert).
+
+        The preset is normalized (window clamp + id guards) before any write, so a
+        bad ``captionStyle`` raises and the catalog stays intact.
+        """
+        raw = params.get("preset")
+        if not isinstance(raw, dict):
+            raise _invalid("preset (object) is required")
+        return {"preset": self.store.save(raw)}
+
+    def delete(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``exportPresets.delete({id})`` -> ``{ok}`` (direct-return)."""
+        preset_id = _require_str(params, "id")
+        return {"ok": self.store.delete(preset_id)}
+
+    def reset(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``exportPresets.reset()`` -> ``{presets}`` (restore the three seeds)."""
+        return {"presets": self.store.reset()}
+
+
+def register(
+    *,
+    path: str | os.PathLike[str],
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> ExportPresets:
+    """Create an :class:`ExportPresets` over ``path`` and register the four methods.
+
+    ``register_fn`` defaults to :func:`protocol.register`; tests inject a fake
+    registrar + a tmp ``path``. Returns the service so the caller can hold it
+    (mirrors :func:`recipes.register`).
+    """
+    service = ExportPresets(PresetStore(path))
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("exportPresets.list", service.list)
+    reg("exportPresets.save", service.save)
+    reg("exportPresets.delete", service.delete)
+    reg("exportPresets.reset", service.reset)
+    return service

--- a/sidecar/media_studio/features/export_presets.py
+++ b/sidecar/media_studio/features/export_presets.py
@@ -1,0 +1,260 @@
+"""Export-preset catalog (the repurpose bundle's WU1 store).
+
+An *export preset* is a server-persisted, editable platform target — the
+durable, multi-source promotion of the renderer-only ``PLATFORM_PRESETS`` (the
+TikTok / Reels / Shorts buttons in ``shortMakerPresets.ts``). Moving it
+server-side lets templates and batch runs reference presets by id and lets the
+catalog be edited without a renderer rebuild.
+
+Wire shape (frozen — field names identical both sides)::
+
+    ExportPreset = {
+        id, label, aspect,
+        minSec, maxSec,            # clamped into the §5 hard 20-60 s window
+        count,                     # >= 1
+        captionStyle,              # validated against the sidecar caption catalog
+        reframeEngine,             # auto | verthor | claudeshorts
+    }
+
+Storage mirrors :class:`recipes.RecipeStore` exactly: one JSON document under the
+data root, written atomically (temp file + ``os.replace``) so a crash mid-write
+can never truncate the catalog. The catalog is **seeded** on first read with the
+three vertical platforms (all 9:16) so day-one behavior matches the current UI;
+``reset`` restores those seeds.
+
+Pure logic + filesystem only — no heavy-ML / network / provider imports. The
+``captionStyle`` id-guard reuses the sidecar's authoritative caption-style set
+(``caption_remotion.STYLES`` plus the two libass sentinels ``libass`` / ``none``)
+rather than re-listing it, so the catalog can never drift from what the
+CaptionEngine actually renders.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+from typing import Any
+
+from ..protocol import ErrorCode, RpcError
+from ..util import clamp, get_logger
+from . import caption_remotion
+
+log = get_logger("media_studio.features.export_presets")
+
+ExportPreset = dict[str, Any]
+
+#: The §5 hard clip window (mirrors ``select._resolve_window`` / the renderer's
+#: ``MIN_CLIP_SEC`` / ``MAX_CLIP_SEC``): a preset's saved window is clamped here so
+#: the catalog can never promise a duration the pipeline would silently correct.
+MIN_CLIP_SEC = 20
+MAX_CLIP_SEC = 60
+
+#: Allowed ``captionStyle`` ids — the authoritative sidecar caption catalog: every
+#: remotion template plus the two libass sentinels. Single-sourced from
+#: :data:`caption_remotion.STYLES` so the guard tracks the real renderers.
+CAPTION_STYLES: frozenset[str] = frozenset({"libass", "none", *caption_remotion.STYLES})
+
+#: Allowed ``reframeEngine`` ids (A4 engines + the "auto" selector).
+REFRAME_ENGINES: frozenset[str] = frozenset({"auto", "verthor", "claudeshorts"})
+
+#: Default reframe engine when a preset omits one (verthor with fallback).
+DEFAULT_REFRAME_ENGINE = "auto"
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _require_str(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _invalid(f"preset.{key} (non-empty str) is required")
+    return value.strip()
+
+
+def _require_int(raw: dict[str, Any], key: str) -> int:
+    value = raw.get(key)
+    # bool is an int subclass; reject it explicitly so True/False can't pose as a count.
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise _invalid(f"preset.{key} (int) is required")
+    return value
+
+
+# --------------------------------------------------------------------------- #
+# pure: preset shaping + window clamp + id guards
+# --------------------------------------------------------------------------- #
+def normalize_preset(raw: Any) -> ExportPreset:
+    """Validate + normalize an export-preset payload into the frozen wire shape.
+
+    Clamps the ``minSec``/``maxSec`` window into the hard ``[20, 60]`` range (and
+    never lets it invert), floors ``count`` at 1, and rejects an unknown
+    ``captionStyle`` / ``reframeEngine`` with a fail-loud ``RpcError`` so a bad
+    save can never persist a half-typed or unrenderable record. A missing ``id``
+    is generated.
+    """
+    if not isinstance(raw, dict):
+        raise _invalid("preset must be an object")
+
+    label = _require_str(raw, "label")
+    aspect = _require_str(raw, "aspect")
+    min_sec = _require_int(raw, "minSec")
+    max_sec = _require_int(raw, "maxSec")
+    count = _require_int(raw, "count")
+
+    caption_style = _require_str(raw, "captionStyle")
+    if caption_style not in CAPTION_STYLES:
+        raise _invalid(f"unknown captionStyle: {caption_style!r}")
+
+    reframe_engine = raw.get("reframeEngine")
+    if reframe_engine is None:
+        reframe_engine = DEFAULT_REFRAME_ENGINE
+    elif not isinstance(reframe_engine, str) or reframe_engine not in REFRAME_ENGINES:
+        raise _invalid(f"unknown reframeEngine: {reframe_engine!r}")
+
+    # Clamp the window into [20, 60], then hold minSec at-or-below the clamped
+    # maxSec so the window can never invert (mirrors applyPreset's CONTRACT-NOTE).
+    clamped_max = int(clamp(max_sec, MIN_CLIP_SEC, MAX_CLIP_SEC))
+    clamped_min = int(clamp(min_sec, MIN_CLIP_SEC, clamped_max))
+
+    preset_id = raw.get("id")
+    if not isinstance(preset_id, str) or not preset_id:
+        preset_id = uuid.uuid4().hex[:12]
+
+    return {
+        "id": preset_id,
+        "label": label,
+        "aspect": aspect,
+        "minSec": clamped_min,
+        "maxSec": clamped_max,
+        "count": max(1, count),
+        "captionStyle": caption_style,
+        "reframeEngine": reframe_engine,
+    }
+
+
+def seed_presets() -> list[ExportPreset]:
+    """The day-one catalog: the three vertical platforms (all 9:16).
+
+    Mirrors the renderer's frozen ``PLATFORM_PRESETS`` (TikTok 5 / Reels 3 /
+    Shorts 8). ``maxSec`` is the in-window sweet-spot per platform; Reels' 90 s
+    documented length is clamped to the enforceable 60 s, identical to the
+    renderer + ``select._resolve_window``.
+    """
+    return [
+        normalize_preset(
+            {
+                "id": "tiktok",
+                "label": "TikTok",
+                "aspect": "9:16",
+                "minSec": 20,
+                "maxSec": 60,
+                "count": 5,
+                "captionStyle": "libass",
+            }
+        ),
+        normalize_preset(
+            {
+                "id": "reels",
+                "label": "Reels",
+                "aspect": "9:16",
+                "minSec": 20,
+                "maxSec": 90,
+                "count": 3,
+                "captionStyle": "libass",
+            }
+        ),
+        normalize_preset(
+            {
+                "id": "shorts",
+                "label": "Shorts",
+                "aspect": "9:16",
+                "minSec": 20,
+                "maxSec": 60,
+                "count": 8,
+                "captionStyle": "libass",
+            }
+        ),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# storage (JSON document under the data root; mirrors RecipeStore)
+# --------------------------------------------------------------------------- #
+class PresetStore:
+    """A JSON-backed export-preset catalog (atomic temp+rename writes).
+
+    Self-seeding: an empty / missing / corrupt file is recovered to the three
+    vertical seeds on read (and the recovered catalog is persisted), so the
+    catalog is never empty and a poisoned file can't surface as a blank UI.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = Path(path)
+
+    def _read_raw(self) -> list[ExportPreset] | None:
+        """Return the on-disk catalog, or ``None`` if absent/corrupt/non-list."""
+        if not self.path.exists():
+            return None
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as exc:
+            log.warning("export-presets file unreadable (%s); reseeding", exc)
+            return None
+        if not isinstance(data, list):
+            return None
+        return [p for p in data if isinstance(p, dict)]
+
+    def _read(self) -> list[ExportPreset]:
+        """Read the catalog, seeding (and persisting) the defaults when empty."""
+        existing = self._read_raw()
+        if existing is None:
+            seeded = seed_presets()
+            self._write(seeded)
+            return seeded
+        return existing
+
+    def _write(self, presets: list[ExportPreset]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(json.dumps(presets, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    def list(self) -> list[ExportPreset]:
+        return self._read()
+
+    def save(self, preset: ExportPreset) -> ExportPreset:
+        """Upsert ``preset`` by id (replace same-id, else append). Returns it.
+
+        The preset is normalized first (window clamp + id guards), so an invalid
+        ``captionStyle`` raises BEFORE any write — the catalog stays intact.
+        """
+        normalized = normalize_preset(preset)
+        presets = self._read()
+        replaced = False
+        out: list[ExportPreset] = []
+        for existing in presets:
+            if existing.get("id") == normalized["id"]:
+                out.append(normalized)
+                replaced = True
+            else:
+                out.append(existing)
+        if not replaced:
+            out.append(normalized)
+        self._write(out)
+        return normalized
+
+    def delete(self, preset_id: str) -> bool:
+        presets = self._read()
+        remaining = [p for p in presets if p.get("id") != preset_id]
+        if len(remaining) == len(presets):
+            return False
+        self._write(remaining)
+        return True
+
+    def reset(self) -> list[ExportPreset]:
+        """Restore the three vertical seeds, overwriting any edits. Returns them."""
+        seeded = seed_presets()
+        self._write(seeded)
+        return seeded

--- a/sidecar/media_studio/features/templates.py
+++ b/sidecar/media_studio/features/templates.py
@@ -1,0 +1,137 @@
+"""Repurpose TEMPLATES (the repurpose bundle's WU3 store).
+
+A *template* is the durable, multi-source generalization of a saved pipeline: a
+recipe (the frozen ``recipes`` wire shape — ``{id, name, steps:[Step]}``) PLUS
+two additive fields the repurpose flow needs:
+
+  * ``defaultControls`` — a dict of shared knobs (count / captionStyle / window
+    …) applied to every export step before the per-preset merge (WU4 fan-out).
+  * ``exportTargets`` — a list of :class:`export_presets.ExportPreset` ids the
+    template fans out across; ``["tiktok", "shorts"]`` means "make both".
+
+Design (DESIGN §5.4, gate F-template-shape → new module, recommended): this file
+REUSES the proven recipe substrate by IMPORT rather than mutating the frozen,
+fully-covered ``recipes.*`` wire shape:
+
+  * **Validation** — :func:`normalize_template` calls
+    :func:`recipes.normalize_recipe` for the recipe core (name / steps / ids /
+    labels), then validates the two additive fields and a **method allowlist**.
+    ``recipes.normalize_recipe`` is the ONLY recipe-validation path; there is no
+    fork of the wire shape.
+  * **Allowlist (G-10.6)** — every step ``method`` must fall inside the curated
+    repurpose verb set (transcribe / subtitles / shortmaker / phase8.select /
+    nle.export / package.export / convert / audio). A method outside it raises
+    the SAME fail-loud ``RpcError`` posture as ``normalize_recipe`` so a save can
+    never persist a step that escapes the repurpose surface.
+  * **Storage** — :class:`TemplateStore` IS a :class:`recipes.RecipeStore` over
+    ``templates.json`` (atomic temp+rename writes); a template is just a richer
+    record in the same JSON-list shape.
+
+Pure logic + filesystem only — no heavy-ML / network / provider imports. The
+``templates.*`` RPC (``list``/``save``/``delete``/``apply``) and the export-step
+fan-out are later WUs; this module is the store + normalize + allowlist only.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ..protocol import ErrorCode, RpcError
+from ..util import get_logger
+from . import recipes
+
+log = get_logger("media_studio.features.templates")
+
+Template = dict[str, Any]
+
+#: Allowed step-method prefixes/exact-ids — the curated repurpose verb set
+#: (DESIGN §5.4 / G-10.6). A ``"name.*"`` entry allows any method under that
+#: namespace (``transcribe.start``, ``convert.run`` …); a bare ``"name.id"``
+#: entry is an exact match (``phase8.select`` only, never ``phase8.other``).
+ALLOWED_METHOD_PREFIXES: frozenset[str] = frozenset({"transcribe.", "subtitles.", "shortmaker.", "convert.", "audio."})
+ALLOWED_METHOD_EXACT: frozenset[str] = frozenset({"phase8.select", "nle.export", "package.export"})
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _is_allowed_method(method: str) -> bool:
+    """True iff ``method`` is inside the curated repurpose allowlist."""
+    if method in ALLOWED_METHOD_EXACT:
+        return True
+    return any(method.startswith(prefix) for prefix in ALLOWED_METHOD_PREFIXES)
+
+
+def _normalize_export_targets(raw: Any) -> list[str]:
+    """Validate ``exportTargets`` into a list of non-empty preset-id strings."""
+    if raw is None:
+        return []
+    if not isinstance(raw, list):
+        raise _invalid("template.exportTargets must be an array of preset ids")
+    targets: list[str] = []
+    for index, target in enumerate(raw):
+        if not isinstance(target, str) or not target.strip():
+            raise _invalid(f"template.exportTargets[{index}] (non-empty str) is required")
+        targets.append(target.strip())
+    return targets
+
+
+def _normalize_default_controls(raw: Any) -> dict[str, Any]:
+    """Validate ``defaultControls`` into a (copied) dict."""
+    if raw is None:
+        return {}
+    if not isinstance(raw, dict):
+        raise _invalid("template.defaultControls must be an object")
+    return dict(raw)
+
+
+# --------------------------------------------------------------------------- #
+# pure: template shaping (recipe core via import + additive fields + allowlist)
+# --------------------------------------------------------------------------- #
+def normalize_template(raw: Any) -> Template:
+    """Validate + normalize a template payload into the frozen wire shape.
+
+    ``{id?, name, steps:[Step], defaultControls?, exportTargets?}``. The recipe
+    core is validated EXCLUSIVELY by :func:`recipes.normalize_recipe` (no fork of
+    the wire shape); this then enforces the method allowlist and the two additive
+    fields. Raises ``INVALID_PARAMS`` on any malformed field so a bad save can
+    never persist a half-typed or out-of-surface record.
+    """
+    if not isinstance(raw, dict):
+        raise _invalid("template must be an object")
+
+    # Recipe core (name / steps / ids / labels) — the SINGLE validation path.
+    recipe = recipes.normalize_recipe(raw)
+
+    for index, step in enumerate(recipe["steps"]):
+        method = step["method"]
+        if not _is_allowed_method(method):
+            raise _invalid(f"template.steps[{index}].method not allowed: {method!r}")
+
+    return {
+        **recipe,
+        "defaultControls": _normalize_default_controls(raw.get("defaultControls")),
+        "exportTargets": _normalize_export_targets(raw.get("exportTargets")),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# storage (templates.json under the data root; IS a RecipeStore)
+# --------------------------------------------------------------------------- #
+class TemplateStore(recipes.RecipeStore):
+    """A JSON-backed list of templates (reuses :class:`recipes.RecipeStore`).
+
+    A template is just a richer record in the same atomic JSON-list document, so
+    the proven temp+rename store is reused verbatim — only the file name differs
+    (``templates.json``). No behavior is overridden.
+    """
+
+
+__all__ = [
+    "ALLOWED_METHOD_EXACT",
+    "ALLOWED_METHOD_PREFIXES",
+    "Template",
+    "TemplateStore",
+    "normalize_template",
+]

--- a/sidecar/media_studio/features/templates.py
+++ b/sidecar/media_studio/features/templates.py
@@ -86,6 +86,90 @@ def _normalize_default_controls(raw: Any) -> dict[str, Any]:
     return dict(raw)
 
 
+#: The method id whose ``exportTargets`` drive the per-preset fan-out (§5.1/§5.3).
+EXPORT_METHOD = "shortmaker.export"
+
+#: The :class:`export_presets.ExportPreset` controls fields merged onto a
+#: template's ``defaultControls`` for each fanned-out export step. ``id``/``label``
+#: are excluded (``id`` becomes ``presetId`` on the params; ``label`` only flavors
+#: the step label) — these are exactly the knobs ``shortmaker.export`` consumes
+#: (DESIGN §5.3: ``buildExportParams`` → ``ShortMaker.export``).
+PRESET_CONTROL_FIELDS: tuple[str, ...] = (
+    "aspect",
+    "minSec",
+    "maxSec",
+    "count",
+    "captionStyle",
+    "reframeEngine",
+)
+
+
+# --------------------------------------------------------------------------- #
+# pure: per-preset export-step fan-out (WU4 — no I/O, no provider)
+# --------------------------------------------------------------------------- #
+def expand_export_steps(
+    steps: list[dict[str, Any]],
+    controls: dict[str, Any],
+    presets: dict[str, dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Expand multi-target ``shortmaker.export`` steps into one step per preset.
+
+    DESIGN §5.1/§5.3: before a template runs, a single ``shortmaker.export`` step
+    whose ``params.exportTargets`` names multiple :class:`export_presets.ExportPreset`
+    ids is fanned out into one export call per resolved preset. Each fanned step's
+    params are the merge ``{**controls, **otherStepParams, **presetControls,
+    presetId}`` — the preset's clamped window/style/count/aspect OVERRIDE the
+    template's ``defaultControls`` (which override nothing the step itself set
+    besides the preset knobs), and the originating ``exportTargets`` control is
+    consumed (never forwarded to the export handler).
+
+    Pure + total: no I/O, no provider, no store. ``presets`` is an in-memory
+    ``{id: ExportPreset}`` map (the caller supplies it from the catalog). Rules:
+
+      * non-export steps pass through unchanged and in order;
+      * an export step with empty / absent ``exportTargets`` passes through
+        unchanged (the runner still runs it against ``defaultControls``);
+      * a target id absent from ``presets`` raises ``INVALID_PARAMS`` BEFORE any
+        output is appended (no partial expansion);
+      * the function is idempotent on already-flat step lists (single/no target).
+
+    Each fanned step carries ``params.presetId`` so the Shorts gallery can group
+    by platform, and a ``"<label> · <preset label>"`` step label for progress.
+    """
+    expanded: list[dict[str, Any]] = []
+    for step in steps:
+        targets = step.get("params", {}).get("exportTargets") if step.get("method") == EXPORT_METHOD else None
+        if not isinstance(targets, list) or not targets:
+            expanded.append(step)
+            continue
+        # Resolve every preset FIRST so an unknown id fails loud with no partial
+        # expansion of this step.
+        resolved = [(target, _resolve_preset(target, presets)) for target in targets]
+        base_label = step.get("label", EXPORT_METHOD)
+        base_params = {key: value for key, value in step["params"].items() if key != "exportTargets"}
+        for target_id, preset in resolved:
+            merged = {**controls, **base_params}
+            for field in PRESET_CONTROL_FIELDS:
+                if field in preset:
+                    merged[field] = preset[field]
+            merged["presetId"] = target_id
+            expanded.append(
+                {
+                    "method": EXPORT_METHOD,
+                    "params": merged,
+                    "label": f"{base_label} · {preset.get('label', target_id)}",
+                }
+            )
+    return expanded
+
+
+def _resolve_preset(target_id: str, presets: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    preset = presets.get(target_id)
+    if preset is None:
+        raise _invalid(f"export target not found in presets: {target_id!r}")
+    return preset
+
+
 # --------------------------------------------------------------------------- #
 # pure: template shaping (recipe core via import + additive fields + allowlist)
 # --------------------------------------------------------------------------- #
@@ -131,7 +215,10 @@ class TemplateStore(recipes.RecipeStore):
 __all__ = [
     "ALLOWED_METHOD_EXACT",
     "ALLOWED_METHOD_PREFIXES",
+    "EXPORT_METHOD",
+    "PRESET_CONTROL_FIELDS",
     "Template",
     "TemplateStore",
+    "expand_export_steps",
     "normalize_template",
 ]

--- a/sidecar/media_studio/features/templates.py
+++ b/sidecar/media_studio/features/templates.py
@@ -34,9 +34,12 @@ fan-out are later WUs; this module is the store + normalize + allowlist only.
 
 from __future__ import annotations
 
+import os
+from collections.abc import Callable
 from typing import Any
 
-from ..protocol import ErrorCode, RpcError
+from .. import protocol
+from ..protocol import ErrorCode, RpcContext, RpcError
 from ..util import get_logger
 from . import recipes
 
@@ -212,13 +215,169 @@ class TemplateStore(recipes.RecipeStore):
     """
 
 
+# --------------------------------------------------------------------------- #
+# pure: bind a template's steps to ONE source video
+# --------------------------------------------------------------------------- #
+#: The params key naming the source video a step operates on (wire name).
+SOURCE_PARAM = "videoId"
+
+
+def bind_steps_to_source(steps: list[dict[str, Any]], video_id: str) -> list[dict[str, Any]]:
+    """Return ``steps`` with each step's params bound to ``video_id``.
+
+    A template is source-agnostic; :meth:`Templates.apply` binds it to ONE source
+    by stamping ``params.videoId`` on every step. A step that already names a
+    ``videoId`` (e.g. an explicit override in the saved template) is left as-is,
+    so the binding never clobbers an intentional value. Pure + total: no I/O, a
+    fresh copy of each step + its params (the template record is never mutated).
+    """
+    bound: list[dict[str, Any]] = []
+    for step in steps:
+        params = dict(step.get("params") or {})
+        params.setdefault(SOURCE_PARAM, video_id)
+        bound.append({**step, "params": params})
+    return bound
+
+
+# --------------------------------------------------------------------------- #
+# the apply service (CRUD + single-source apply over the recipe runner)
+# --------------------------------------------------------------------------- #
+class Templates:
+    """Owns the ``templates.*`` methods over a :class:`TemplateStore`.
+
+    ``list``/``save``/``delete`` are direct-return CRUD (mirroring
+    :class:`recipes.Recipes`). ``apply`` runs a saved template against ONE source:
+    it binds the template's steps to the requested ``videoId``
+    (:func:`bind_steps_to_source`), fans out the multi-target export step over the
+    live :class:`export_presets.ExportPreset` catalog (:func:`expand_export_steps`,
+    WU4), then drives the EXISTING :meth:`recipes.Recipes._run_steps` /
+    ``_await_subjob`` — NO new runner, NO new sub-job machinery, NO new cancel
+    code. ``apply`` is the single-source sugar over the later batch path (one item).
+
+    Seams (all injectable so tests run with fake methods/presets and no media):
+
+      * ``methods_provider`` — the live RPC method registry a step invokes
+        (defaults to ``protocol.METHODS``); shared verbatim with the inner
+        :class:`recipes.Recipes` so steps resolve against the same registry.
+      * ``presets_provider`` — returns the ``{presetId: ExportPreset}`` map the
+        export fan-out resolves targets against (defaults to an empty catalog so
+        a template with no export targets still runs).
+    """
+
+    def __init__(
+        self,
+        store: TemplateStore,
+        *,
+        methods_provider: Callable[[], dict[str, Any]] | None = None,
+        presets_provider: Callable[[], dict[str, dict[str, Any]]] | None = None,
+    ) -> None:
+        self.store = store
+        self._presets_provider = presets_provider or (lambda: {})
+        # Reuse the proven recipe runner verbatim (step loop, scaled progress,
+        # cancel via raise_if_cancelled, sub-job await/unwrap). The Templates
+        # service owns NO orchestration logic of its own.
+        self._runner = recipes.Recipes(store, methods_provider=methods_provider)
+
+    # -- direct-return CRUD -------------------------------------------------
+    def list(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``templates.list()`` -> ``{templates:[Template]}`` (direct-return)."""
+        return {"templates": self.store.list()}
+
+    def save(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``templates.save({template})`` -> ``{template}`` (direct-return; upsert).
+
+        The template is normalized (recipe core + additive fields + method
+        allowlist) before any write, so a bad save can never persist.
+        """
+        raw = params.get("template")
+        if not isinstance(raw, dict):
+            raise _invalid("template (object) is required")
+        template = normalize_template(raw)
+        return {"template": self.store.save(template)}
+
+    def delete(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``templates.delete({id})`` -> ``{ok}`` (direct-return)."""
+        template_id = params.get("id")
+        if not isinstance(template_id, str) or not template_id:
+            raise _invalid("id (str) is required")
+        return {"ok": self.store.delete(template_id)}
+
+    # -- templates.apply (the long job, over the recipe runner) -------------
+    def apply(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``templates.apply({templateId, videoId})`` -> ``{jobId}`` (long job).
+
+        Binds the template to ONE source, expands the export fan-out, then runs
+        the resulting flat step list through the EXISTING recipe runner. The job's
+        progress + sub-job await + cancellation are all the recipe runner's.
+        """
+        template_id = params.get("templateId")
+        if not isinstance(template_id, str) or not template_id:
+            raise _invalid("templateId (str) is required")
+        video_id = params.get("videoId")
+        if not isinstance(video_id, str) or not video_id:
+            raise _invalid("videoId (str) is required")
+        template = self.store.get(template_id)
+        if template is None:
+            raise _invalid(f"unknown template: {template_id}")
+
+        # Pure pre-job shaping: bind to the source, then fan the export step out
+        # over the live preset catalog. An unknown preset id fails loud HERE
+        # (before any job is started), so a bad template never spawns a dead job.
+        bound = bind_steps_to_source(list(template.get("steps") or []), video_id)
+        steps = expand_export_steps(bound, template.get("defaultControls") or {}, self._presets_provider())
+
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+
+        def job_body(job_ctx: Any) -> dict[str, Any]:
+            return self._runner._run_steps(steps, job_ctx, ctx)
+
+        job = ctx.jobs.start(
+            job_body, feature="templates", label=f"template: {template.get('name', '')}", videoId=video_id
+        )
+        return {"jobId": job.id}
+
+
+# --------------------------------------------------------------------------- #
+# registration (mirrors recipes.register)
+# --------------------------------------------------------------------------- #
+def register(
+    *,
+    path: str | os.PathLike[str],
+    methods_provider: Callable[[], dict[str, Any]] | None = None,
+    presets_provider: Callable[[], dict[str, dict[str, Any]]] | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> Templates:
+    """Create a :class:`Templates` over ``path`` and register the four methods.
+
+    ``register_fn`` defaults to :func:`protocol.register`; tests inject a fake
+    registrar + a tmp ``path`` + fake method/preset providers. Returns the service
+    so the caller can hold it (mirrors :func:`recipes.register`).
+    """
+    service = Templates(
+        TemplateStore(path),
+        methods_provider=methods_provider,
+        presets_provider=presets_provider,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("templates.list", service.list)
+    reg("templates.save", service.save)
+    reg("templates.delete", service.delete)
+    reg("templates.apply", service.apply)
+    return service
+
+
 __all__ = [
     "ALLOWED_METHOD_EXACT",
     "ALLOWED_METHOD_PREFIXES",
     "EXPORT_METHOD",
     "PRESET_CONTROL_FIELDS",
+    "SOURCE_PARAM",
     "Template",
     "TemplateStore",
+    "Templates",
+    "bind_steps_to_source",
     "expand_export_steps",
     "normalize_template",
+    "register",
 ]

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -201,6 +201,18 @@ class Services:
             return None
         return video.get("path") or None
 
+    def _video_title(self, video_id: str) -> str:
+        """videoId -> human title for a progress message (the id when unknown).
+
+        The batch runner's title seam (WU10): falls back to the ``videoId`` when
+        the library has no record or no ``title``, so a progress line is always
+        readable even for a stale id.
+        """
+        video = self.library.get(video_id)
+        if video is None:
+            return video_id
+        return str(video.get("title") or video_id)
+
     def _project_path(self, video_id: str) -> Path:
         """The manifest path for a video's project (one project per video)."""
         return self.projects_dir / f"{video_id}.json"
@@ -2229,6 +2241,22 @@ def register_all(
     _templates.register(
         path=svc.data_dir / "templates.json",
         presets_provider=lambda: {p["id"]: p for p in _export_presets_svc.store.list()},
+        register_fn=reg,
+    )
+
+    # batch.* (repurpose WU10): point ONE template at MANY sources and run them as
+    # one aggregate, resumable, per-source-isolated job (DESIGN §6). The seven
+    # methods own no orchestration of their own — each source rides the live
+    # ``templates.apply`` handler (registered just above), so the batch reaches the
+    # AI envelope only by method name; consent uses ``ai.planJob`` by name (ZERO
+    # provider calls). Registered AFTER templates (its default per-source runner +
+    # consent planner resolve those handlers from the live registry). No new RPC
+    # site, no provider/key wiring. The title seam reuses the library's display name.
+    from .features import batch as _batch  # local: import-light
+
+    _batch.register(
+        path=svc.data_dir / "batches",
+        title_resolver=svc._video_title,
         register_fn=reg,
     )
 

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -2207,6 +2207,17 @@ def register_all(
         register_fn=reg,
     )
 
+    # exportPresets.* (repurpose WU2): server-persisted platform targets the
+    # templates/batch groups reference by id. Direct-return CRUD over a JSON
+    # catalog at data_dir/export-presets.json (atomic temp+rename, self-seeding).
+    # Storage-only — no provider/ML imports; the module owns its own register().
+    from .features import export_presets as _export_presets  # local: import-light
+
+    _export_presets.register(
+        path=svc.data_dir / "export-presets.json",
+        register_fn=reg,
+    )
+
     # diarize.start (feature 4): token-free speaker labelling. Reuses the same
     # project load/save helpers tracks_audio uses, plus the offline-gated assets.
     #

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -2213,8 +2213,22 @@ def register_all(
     # Storage-only — no provider/ML imports; the module owns its own register().
     from .features import export_presets as _export_presets  # local: import-light
 
-    _export_presets.register(
+    _export_presets_svc = _export_presets.register(
         path=svc.data_dir / "export-presets.json",
+        register_fn=reg,
+    )
+
+    # templates.* (repurpose WU5): saved multi-source pipelines (a recipe PLUS
+    # defaultControls + exportTargets). list/save/delete are direct CRUD; apply
+    # runs ONE source through the EXISTING recipe runner after binding steps to
+    # the videoId and fanning out the export step over the live preset catalog.
+    # Registers AFTER the methods its steps reference AND after exportPresets (the
+    # fan-out resolves preset ids from that catalog) — no new RPC site, no provider.
+    from .features import templates as _templates  # local: import-light
+
+    _templates.register(
+        path=svc.data_dir / "templates.json",
+        presets_provider=lambda: {p["id"]: p for p in _export_presets_svc.store.list()},
         register_fn=reg,
     )
 

--- a/sidecar/tests/test_batch.py
+++ b/sidecar/tests/test_batch.py
@@ -1,10 +1,19 @@
-"""WU6 tests — ``features/batch.py`` store + model + checkpoint-on-transition.
+"""WU6 + WU7 tests — ``features/batch.py``.
 
-Pure store + pure model logic over a ``tmp_path`` JSON document (one file per
-batch under ``batches/<batchId>.json``). No runner, no RPC, no media work — those
-are later WUs. The store mirrors :class:`recipes.RecipeStore`'s atomic temp+rename
-write (a simulated ``os.replace`` failure must leave the prior file intact), but
-keyed per-batch so one corrupt batch can never poison another.
+WU6 — store + model + checkpoint-on-transition. Pure store + pure model logic
+over a ``tmp_path`` JSON document (one file per batch under
+``batches/<batchId>.json``). The store mirrors :class:`recipes.RecipeStore`'s
+atomic temp+rename write, keyed per-batch so one corrupt batch can never poison
+another.
+
+WU7 — the batch RUNNER with per-source isolation (G-ISO). The parent batch job
+iterates ``sourceVideoIds``, spreads ``[0,100]`` progress across items, and runs
+each source through the template runner seam — but with NEW per-source try/except
+so one bad source records ``error`` on its :class:`batch.BatchItem` and the batch
+CONTINUES (the deliberate divergence from ``convert_batch``/``_run_one_step``).
+Gated by ``batchContinueOnError`` (default ``true``). The per-source sub-job is
+awaited with the EXISTING recipe ``_await_subjob`` relay. No real ffmpeg/model:
+the template-run seam is faked.
 """
 
 from __future__ import annotations
@@ -14,7 +23,8 @@ from typing import Any
 
 import pytest
 from media_studio.features import batch
-from media_studio.protocol import RpcError
+from media_studio.jobs import JobCancelled, JobRegistry
+from media_studio.protocol import RpcContext, RpcError
 
 # --------------------------------------------------------------------------- #
 # pure model — BatchItem / BatchState shaping + status derivation
@@ -307,6 +317,17 @@ class TestBatchStore:
         store = batch.BatchStore(tmp_path / "does-not-exist")
         assert store.list() == []
 
+    def test_set_status_overrides_aggregate(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.set_status(state["id"], "error")
+        assert store.load(state["id"])["status"] == "error"
+
+    def test_set_status_unknown_batch_raises(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        with pytest.raises(RpcError, match="unknown batch"):
+            store.set_status("nope", "error")
+
     def test_delete_removes_file_and_reports(self, tmp_path):
         store = batch.BatchStore(tmp_path / "batches")
         state = store.create("run", "t", ["v1"])
@@ -331,3 +352,243 @@ class TestBatchStore:
             store.update_item(state["id"], "v1", status="done")
         # the original checkpoint is byte-for-byte intact (temp+rename never truncates).
         assert path.read_text(encoding="utf-8") == before
+
+
+# --------------------------------------------------------------------------- #
+# WU7 — batch runner with per-source isolation (G-ISO)
+# --------------------------------------------------------------------------- #
+class _FakeJobCtx:
+    """A minimal parent job_ctx for the batch runner (cancel + progress + raise).
+
+    Mirrors ``test_recipes._FakeJobCtx`` but also records the progress messages so
+    a test can assert the ``source k/N · <title> ·`` prefix the runner prepends.
+    """
+
+    def __init__(self, *, cancelled: bool = False, cancel_after: int | None = None) -> None:
+        self._cancelled = cancelled
+        self._cancel_after = cancel_after
+        self._raise_calls = 0
+        self.messages: list[tuple[float, str]] = []
+
+    @property
+    def cancelled(self) -> bool:
+        return self._cancelled
+
+    def raise_if_cancelled(self) -> None:
+        self._raise_calls += 1
+        # ``cancel_after`` flips cancellation on once the runner has checked the
+        # gate N times (so cancellation lands BETWEEN specific sources).
+        if self._cancel_after is not None and self._raise_calls > self._cancel_after:
+            self._cancelled = True
+        if self._cancelled:
+            raise JobCancelled()
+
+    def progress(self, pct: float, message: str = "") -> None:
+        self.messages.append((pct, message))
+
+
+def _registry() -> JobRegistry:
+    return JobRegistry(emit_progress=lambda *_: None, emit_done=lambda *_: None)
+
+
+def _ctx(registry: JobRegistry) -> RpcContext:
+    return RpcContext(emit_notification=lambda *_: None, jobs=registry)
+
+
+def _make_runner(reg: JobRegistry, *, results=None, fail=(), pct=50.0):
+    """Build a template-run seam: ``video_id -> {jobId}`` over a real sub-job.
+
+    ``fail`` is a set of video ids whose sub-job raises (so the per-source
+    try/except is exercised); every other source's sub-job reports ``pct`` then
+    returns ``{"source": video_id}`` (or ``results[video_id]`` when supplied).
+    The list of video ids the seam was invoked for is returned for assertions.
+    """
+    invoked: list[str] = []
+
+    def runner(video_id: str, ctx: RpcContext) -> dict[str, Any]:
+        invoked.append(video_id)
+
+        def body(job_ctx: Any) -> dict[str, Any]:
+            job_ctx.progress(pct, "step 1/1 · go")
+            if video_id in fail:
+                raise RuntimeError(f"boom: {video_id}")
+            return (results or {}).get(video_id, {"source": video_id})
+
+        sub = ctx.jobs.start(body)
+        return {"jobId": sub.id}
+
+    return runner, invoked
+
+
+def _statuses(store: batch.BatchStore, batch_id: str) -> list[str]:
+    return [item["status"] for item in store.load(batch_id)["items"]]
+
+
+class TestRunBatchIsolation:
+    def test_all_sources_succeed_all_done(self, tmp_path):
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        runner, invoked = _make_runner(reg)
+        out = batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg))
+        assert invoked == ["v1", "v2", "v3"]
+        assert _statuses(store, state["id"]) == ["done", "done", "done"]
+        assert store.load(state["id"])["status"] == "done"
+        # each item carries the unwrapped per-source result + its sub-job id.
+        items = store.load(state["id"])["items"]
+        assert items[0]["results"] == {"source": "v1"}
+        assert all(isinstance(item["jobId"], str) and item["jobId"] for item in items)
+        assert out["status"] == "done"
+
+    def test_one_bad_source_isolated_others_done(self, tmp_path):
+        # Acceptance #1: source 2 raises -> [done, error, done], status "partial".
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        runner, invoked = _make_runner(reg, fail={"v2"})
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg))
+        assert invoked == ["v1", "v2", "v3"]  # the bad source did NOT abort the batch
+        assert _statuses(store, state["id"]) == ["done", "error", "done"]
+        loaded = store.load(state["id"])
+        assert loaded["status"] == "partial"
+        assert "boom: v2" in loaded["items"][1]["error"]
+
+    def test_continue_on_error_false_stops_at_first_error(self, tmp_path):
+        # Acceptance #2: with the toggle off, the batch stops at the first error
+        # and the remaining source stays queued; aggregate status is "error".
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        runner, invoked = _make_runner(reg, fail={"v2"})
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg), continue_on_error=False)
+        assert invoked == ["v1", "v2"]  # v3 was never attempted
+        assert _statuses(store, state["id"]) == ["done", "error", "queued"]
+        assert store.load(state["id"])["status"] == "error"
+
+    def test_each_item_flip_is_checkpointed_to_disk(self, tmp_path):
+        # Acceptance #3: every transition is durably written before the next item.
+        # A runner that snapshots the on-disk statuses at each call proves the
+        # prior item was already flipped to a terminal state on disk.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        seen: list[list[str]] = []
+
+        def runner(video_id: str, ctx: RpcContext) -> dict[str, Any]:
+            seen.append(_statuses(store, state["id"]))
+
+            def body(job_ctx: Any) -> dict[str, Any]:
+                return {"source": video_id}
+
+            return {"jobId": ctx.jobs.start(body).id}
+
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg))
+        # When v1 runs it is already "running" on disk; when v2 runs, v1 is "done".
+        assert seen[0] == ["running", "queued"]
+        assert seen[1] == ["done", "running"]
+
+    def test_unknown_batch_raises(self, tmp_path):
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        runner, _ = _make_runner(reg)
+        with pytest.raises(RpcError, match="unknown batch"):
+            batch.run_batch(store, "nope", runner, _FakeJobCtx(), _ctx(reg))
+
+
+class TestRunBatchCancellation:
+    def test_cancel_between_sources_leaves_rest_queued(self, tmp_path):
+        # Acceptance #4: cancellation mid-batch — the cancel lands after source 1
+        # finishes; sources 2 and 3 stay queued, the batch is cancelled.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        runner, invoked = _make_runner(reg)
+        # The runner checks raise_if_cancelled once per source BEFORE running it;
+        # cancel_after=1 flips cancellation on after the first gate check, so v1
+        # runs and the gate before v2 raises.
+        with pytest.raises(JobCancelled):
+            batch.run_batch(store, state["id"], runner, _FakeJobCtx(cancel_after=1), _ctx(reg))
+        assert invoked == ["v1"]
+        assert _statuses(store, state["id"]) == ["done", "queued", "queued"]
+
+    def test_cancel_during_a_source_marks_it_cancelled(self, tmp_path):
+        # A source whose sub-job is cancelled mid-run records "cancelled" on its
+        # item (the _await_subjob relay re-raises JobCancelled), and the batch
+        # unwinds with the in-flight item cancelled, the rest still queued.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+
+        def runner(video_id: str, ctx: RpcContext) -> dict[str, Any]:
+            def body(job_ctx: Any) -> dict[str, Any]:
+                return {"source": video_id}
+
+            return {"jobId": ctx.jobs.start(body).id}
+
+        # Parent reports NOT cancelled at the pre-source gate, then becomes
+        # cancelled while awaiting the sub-job (cancel_after=1: first gate passes
+        # for v1, the await relay sees .cancelled flip via a second check).
+        ctx_obj = _FakeJobCtx()
+
+        def fake_await(job_id, job_ctx, ctx, on_sub):
+            on_sub(100.0, "step 1/1 · go")
+            raise JobCancelled()
+
+        with pytest.raises(JobCancelled):
+            batch.run_batch(store, state["id"], runner, ctx_obj, _ctx(reg), await_subjob=fake_await)
+        assert _statuses(store, state["id"]) == ["cancelled", "queued"]
+
+
+class TestRunBatchProgress:
+    def test_progress_message_carries_source_prefix(self, tmp_path):
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        runner, _ = _make_runner(reg, pct=40.0)
+        ctx_obj = _FakeJobCtx()
+        batch.run_batch(
+            store,
+            state["id"],
+            runner,
+            ctx_obj,
+            _ctx(reg),
+            title_resolver=lambda vid: f"Title-{vid}",
+        )
+        prefixes = [msg for _pct, msg in ctx_obj.messages if msg]
+        # The runner prepends "source k/N · <title> · " to the relayed message. The
+        # reused recipe relay forwards the sub-job's PCT with an empty message
+        # string (it relays progress percent, not the inner step text), so the
+        # message is exactly the source prefix — that prefix IS the WU7 contract.
+        assert any(msg == "source 1/2 · Title-v1 · " for msg in prefixes)
+        assert any(msg == "source 2/2 · Title-v2 · " for msg in prefixes)
+        # a terminal "done" tick lands at 100%.
+        assert (100.0, "done") in ctx_obj.messages
+
+    def test_progress_is_spread_across_sources(self, tmp_path):
+        # Source i's [0,100] slice maps into [i/N, (i+1)/N] of the overall bar. The
+        # runner emits a deterministic start-of-source tick at the slice base
+        # (on_sub(0.0) → i/N*100); the inner sub-pct relay is timing-dependent, so
+        # the spread is asserted on those runner-owned base offsets, which proves
+        # source 2 begins at the halfway mark of the overall bar.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3", "v4"])
+        runner, _ = _make_runner(reg, pct=50.0)
+        ctx_obj = _FakeJobCtx()
+        batch.run_batch(store, state["id"], runner, ctx_obj, _ctx(reg))
+        pcts = [pct for pct, _msg in ctx_obj.messages]
+        # 4 sources -> slice bases at 0, 25, 50, 75 of the overall [0,100] bar.
+        assert 0.0 in pcts
+        assert 25.0 in pcts
+        assert 50.0 in pcts
+        assert 75.0 in pcts
+
+    def test_default_title_resolver_is_video_id(self, tmp_path):
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        runner, _ = _make_runner(reg)
+        ctx_obj = _FakeJobCtx()
+        batch.run_batch(store, state["id"], runner, ctx_obj, _ctx(reg))
+        # with no resolver supplied, the title falls back to the raw video id.
+        assert any("source 1/1 · v1 · " in msg for _pct, msg in ctx_obj.messages)

--- a/sidecar/tests/test_batch.py
+++ b/sidecar/tests/test_batch.py
@@ -820,3 +820,357 @@ class TestResumeBatch:
         # v2 fails and halts the resumed run; v3 is never attempted.
         assert invoked == ["v2"]
         assert _statuses(store, state["id"]) == ["done", "error", "queued"]
+
+
+# --------------------------------------------------------------------------- #
+# WU9 — batch consent surface (G-ACK) + visible skip
+# --------------------------------------------------------------------------- #
+#: A plan that egresses (a cloud run that would send bytes off the machine).
+_EGRESS_PLAN: dict[str, Any] = {
+    "route": {"providers": ["openai"], "willEgress": True, "cacheHit": False},
+    "costEst": {"requests": 5, "egressBytes": 1000, "withinFreeLimits": True},
+    "budget": {"requests": 5, "egressBytes": 1000, "withinFreeLimits": True},
+    "cacheHit": False,
+    "willEgress": True,
+    "cacheKey": "ck-egress",
+}
+#: A plan that stays local (never egresses — local-only routing).
+_LOCAL_PLAN: dict[str, Any] = {
+    "route": {"providers": [], "willEgress": False, "cacheHit": False},
+    "costEst": {"requests": 0, "egressBytes": 0, "withinFreeLimits": True},
+    "budget": {"requests": 0, "egressBytes": 0, "withinFreeLimits": True},
+    "cacheHit": False,
+    "willEgress": False,
+    "cacheKey": "ck-local",
+}
+#: A plan that egresses but is a cache hit (no real run; bypasses the gate).
+_CACHE_HIT_PLAN: dict[str, Any] = {
+    "route": {"providers": ["openai"], "willEgress": False, "cacheHit": True},
+    "costEst": {"requests": 0, "egressBytes": 0, "withinFreeLimits": True},
+    "budget": {"requests": 0, "egressBytes": 0, "withinFreeLimits": True},
+    "cacheHit": True,
+    "willEgress": False,
+    "cacheKey": "ck-hit",
+}
+#: An egressing plan that has NO budget headroom (over the free limit).
+_NO_HEADROOM_PLAN: dict[str, Any] = {
+    "route": {"providers": ["openai"], "willEgress": True, "cacheHit": False},
+    "costEst": {"requests": 999, "egressBytes": 9999, "withinFreeLimits": False},
+    "budget": {"requests": 999, "egressBytes": 9999, "withinFreeLimits": False},
+    "cacheHit": False,
+    "willEgress": True,
+    "cacheKey": "ck-nohead",
+}
+
+
+def _fake_plan_job(by_shape: dict[Any, dict[str, Any]]):
+    """A fake ``ai.planJob`` seam: ``shape_key -> plan`` recording every call.
+
+    Returns ``(plan_job, calls)`` where ``calls`` is the ordered list of shape
+    keys the aggregator invoked the planner with — so a test can assert dedup by
+    step-shape (the planner is called once per distinct shape, NOT per source).
+    """
+    calls: list[Any] = []
+
+    def plan_job(shape_key: Any) -> dict[str, Any]:
+        calls.append(shape_key)
+        return by_shape[shape_key]
+
+    return plan_job, calls
+
+
+class TestConsentDecision:
+    def test_local_only_runs_regardless_of_gate(self):
+        decision = batch.consent_decision(_LOCAL_PLAN, confirm_cloud_budget=True, acknowledged=False)
+        assert decision == ("run", None, None)
+
+    def test_cache_hit_runs_regardless_of_gate(self):
+        decision = batch.consent_decision(_CACHE_HIT_PLAN, confirm_cloud_budget=True, acknowledged=False)
+        assert decision == ("run", None, None)
+
+    def test_egress_with_gate_off_runs_informational(self):
+        # confirmCloudBudget OFF: the card is informational only, all sources run.
+        decision = batch.consent_decision(_EGRESS_PLAN, confirm_cloud_budget=False, acknowledged=False)
+        assert decision == ("run", None, None)
+
+    def test_egress_gate_on_unacked_is_skipped(self):
+        decision = batch.consent_decision(_EGRESS_PLAN, confirm_cloud_budget=True, acknowledged=False)
+        assert decision == ("skip", "would egress — not acknowledged", None)
+
+    def test_egress_gate_on_acked_runs_and_threads_cache_key(self):
+        # An acknowledged egressing source runs and carries the plan's cacheKey as
+        # the confirmBudget token threaded to the underlying handler.
+        decision = batch.consent_decision(_EGRESS_PLAN, confirm_cloud_budget=True, acknowledged=True)
+        assert decision == ("run", None, "ck-egress")
+
+    def test_egress_acked_but_no_headroom_is_skipped(self):
+        # Even acknowledged, a plan with no budget headroom is skipped with the
+        # distinct reason token (the user cannot ack past the free-limit ceiling).
+        decision = batch.consent_decision(_NO_HEADROOM_PLAN, confirm_cloud_budget=True, acknowledged=True)
+        assert decision == ("skip", "no budget headroom", None)
+
+
+class TestPlanConsent:
+    def test_dedup_by_step_shape_single_planner_call(self):
+        # Acceptance #1: 30 sources, ONE template shape -> exactly 1 ai.planJob call.
+        plan_job, calls = _fake_plan_job({"shape-A": _EGRESS_PLAN})
+        sources = [f"v{i}" for i in range(30)]
+        consent = batch.plan_consent(
+            sources,
+            shape_of=lambda _vid: "shape-A",
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=True,
+        )
+        assert calls == ["shape-A"]
+        assert len(consent["decisions"]) == 30
+
+    def test_two_distinct_shapes_two_planner_calls(self):
+        # Two distinct shapes across 30 sources -> the planner is called per shape,
+        # not per source (planner cost is bounded by shape count).
+        plan_job, calls = _fake_plan_job({"A": _EGRESS_PLAN, "B": _LOCAL_PLAN})
+        sources = [f"v{i}" for i in range(30)]
+        batch.plan_consent(
+            sources,
+            shape_of=lambda vid: "A" if int(vid[1:]) % 2 == 0 else "B",
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=True,
+        )
+        assert sorted(calls) == ["A", "B"]
+
+    def test_split_local_and_cache_hit_always_run(self):
+        # Acceptance #2 (the run half): a cache-hit source ends up runnable.
+        plan_job, _ = _fake_plan_job({"loc": _LOCAL_PLAN, "hit": _CACHE_HIT_PLAN, "eg": _EGRESS_PLAN})
+
+        def shape_of(vid: str) -> str:
+            return {"v1": "loc", "v2": "hit", "v3": "eg"}[vid]
+
+        consent = batch.plan_consent(
+            ["v1", "v2", "v3"],
+            shape_of=shape_of,
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=False,
+        )
+        decisions = {d["videoId"]: d for d in consent["decisions"]}
+        assert decisions["v1"]["action"] == "run"
+        assert decisions["v2"]["action"] == "run"
+        # the egressing un-acked source is the only skip.
+        assert decisions["v3"]["action"] == "skip"
+        assert decisions["v3"]["skipReason"] == "would egress — not acknowledged"
+        assert consent["willRun"] == 2
+        assert consent["willSkip"] == 1
+
+    def test_per_source_will_egress_and_cache_hit_surfaced(self):
+        plan_job, _ = _fake_plan_job({"loc": _LOCAL_PLAN, "hit": _CACHE_HIT_PLAN})
+
+        def shape_of(vid: str) -> str:
+            return "loc" if vid == "v1" else "hit"
+
+        consent = batch.plan_consent(
+            ["v1", "v2"],
+            shape_of=shape_of,
+            plan_job=plan_job,
+            confirm_cloud_budget=False,
+            acknowledged=False,
+        )
+        decisions = {d["videoId"]: d for d in consent["decisions"]}
+        assert decisions["v1"]["willEgress"] is False
+        assert decisions["v1"]["cacheHit"] is False
+        assert decisions["v2"]["cacheHit"] is True
+
+    def test_cost_summed_only_over_egressing_sources(self):
+        # Acceptance #4: costEst sums egressBytes ONLY over egressing sources.
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN, "loc": _LOCAL_PLAN})
+
+        def shape_of(vid: str) -> str:
+            # v1,v2 egress (1000 bytes each); v3 is local (0) and must NOT count.
+            return "loc" if vid == "v3" else "eg"
+
+        consent = batch.plan_consent(
+            ["v1", "v2", "v3"],
+            shape_of=shape_of,
+            plan_job=plan_job,
+            confirm_cloud_budget=False,
+            acknowledged=False,
+        )
+        # only the two egressing sources contribute 1000 bytes each.
+        assert consent["costEst"]["egressBytes"] == 2000
+        assert consent["costEst"]["requests"] == 10
+
+    def test_reports_budget_headroom(self):
+        # Acceptance #4 (the headroom half): the aggregate reports whether the run
+        # stays within the free budget ceiling (False once any source is over-cap).
+        plan_job, _ = _fake_plan_job({"ok": _EGRESS_PLAN, "over": _NO_HEADROOM_PLAN})
+
+        def shape_of(vid: str) -> str:
+            return "over" if vid == "v2" else "ok"
+
+        consent = batch.plan_consent(
+            ["v1", "v2"],
+            shape_of=shape_of,
+            plan_job=plan_job,
+            confirm_cloud_budget=False,
+            acknowledged=False,
+        )
+        assert consent["budget"]["withinFreeLimits"] is False
+
+    def test_headroom_true_when_all_within_limits(self):
+        plan_job, _ = _fake_plan_job({"ok": _EGRESS_PLAN})
+        consent = batch.plan_consent(
+            ["v1", "v2"],
+            shape_of=lambda _vid: "ok",
+            plan_job=plan_job,
+            confirm_cloud_budget=False,
+            acknowledged=False,
+        )
+        assert consent["budget"]["withinFreeLimits"] is True
+
+    def test_gate_off_all_run_card_informational(self):
+        # confirmCloudBudget OFF: even an egressing source runs (card is info-only).
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN})
+        consent = batch.plan_consent(
+            ["v1", "v2"],
+            shape_of=lambda _vid: "eg",
+            plan_job=plan_job,
+            confirm_cloud_budget=False,
+            acknowledged=False,
+        )
+        assert consent["willRun"] == 2
+        assert consent["willSkip"] == 0
+
+
+def _make_confirm_runner(reg: JobRegistry):
+    """A template-run seam that records the ``confirm_budget`` it was handed.
+
+    Mirrors :func:`_make_runner` but accepts the optional ``confirm_budget``
+    keyword the consent path threads (the plan's ``cacheKey``), so a test can
+    assert the ack token reached the underlying handler. Returns
+    ``(runner, confirms)`` where ``confirms`` maps ``video_id -> confirm_budget``.
+    """
+    confirms: dict[str, Any] = {}
+
+    def runner(video_id: str, ctx: RpcContext, *, confirm_budget: Any = None) -> dict[str, Any]:
+        confirms[video_id] = confirm_budget
+
+        def body(job_ctx: Any) -> dict[str, Any]:
+            job_ctx.progress(50.0, "step 1/1 · go")
+            return {"source": video_id}
+
+        sub = ctx.jobs.start(body)
+        return {"jobId": sub.id}
+
+    return runner, confirms
+
+
+class TestRunBatchConsent:
+    def test_unacked_egress_source_ends_skipped_with_reason(self, tmp_path):
+        # Acceptance #2: under the gate + no ack, an egressing source ends terminal
+        # ``skipped`` with the reason token; a cache-hit source ends ``done``.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        plan_job, _ = _fake_plan_job({"hit": _CACHE_HIT_PLAN, "eg": _EGRESS_PLAN})
+        consent = batch.plan_consent(
+            ["v1", "v2"],
+            shape_of=lambda vid: "hit" if vid == "v1" else "eg",
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=False,
+        )
+        runner, invoked = _make_runner(reg)
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg), consent=consent)
+        # the cache-hit v1 runs to done; the un-acked egress v2 is never invoked.
+        assert invoked == ["v1"]
+        items = store.load(state["id"])["items"]
+        by_id = {i["videoId"]: i for i in items}
+        assert by_id["v1"]["status"] == "done"
+        assert by_id["v2"]["status"] == "skipped"
+        assert by_id["v2"]["skipReason"] == "would egress — not acknowledged"
+
+    def test_no_headroom_source_ends_skipped_with_reason(self, tmp_path):
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        plan_job, _ = _fake_plan_job({"over": _NO_HEADROOM_PLAN})
+        consent = batch.plan_consent(
+            ["v1"],
+            shape_of=lambda _vid: "over",
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=True,
+        )
+        runner, invoked = _make_runner(reg)
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg), consent=consent)
+        assert invoked == []
+        item = store.load(state["id"])["items"][0]
+        assert item["status"] == "skipped"
+        assert item["skipReason"] == "no budget headroom"
+
+    def test_consent_threads_confirm_budget_to_runner(self, tmp_path):
+        # Acceptance #3: with ack, the underlying handler receives confirmBudget
+        # equal to the plan's cacheKey (the threaded token is asserted).
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN})
+        consent = batch.plan_consent(
+            ["v1"],
+            shape_of=lambda _vid: "eg",
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=True,
+        )
+        runner, confirms = _make_confirm_runner(reg)
+        out = batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg), consent=consent)
+        assert confirms == {"v1": "ck-egress"}
+        assert out["items"][0]["status"] == "done"
+
+    def test_gate_off_runs_all_without_confirm_budget(self, tmp_path):
+        # confirmCloudBudget OFF: an egressing source still runs, no ack threaded.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN})
+        consent = batch.plan_consent(
+            ["v1"],
+            shape_of=lambda _vid: "eg",
+            plan_job=plan_job,
+            confirm_cloud_budget=False,
+            acknowledged=False,
+        )
+        runner, confirms = _make_confirm_runner(reg)
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg), consent=consent)
+        assert confirms == {"v1": None}
+        assert store.load(state["id"])["items"][0]["status"] == "done"
+
+    def test_consent_absent_runs_all_unchanged(self, tmp_path):
+        # No consent supplied -> the WU7 path is unchanged (every source runs).
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        runner, invoked = _make_runner(reg)
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg))
+        assert invoked == ["v1", "v2"]
+
+    def test_consent_skip_does_not_consume_progress_slice(self, tmp_path):
+        # A skipped source still advances the overall bar (its slice completes) so
+        # the progress total stays consistent for the N-run/K-skip split.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN, "loc": _LOCAL_PLAN})
+        consent = batch.plan_consent(
+            ["v1", "v2"],
+            shape_of=lambda vid: "eg" if vid == "v1" else "loc",
+            plan_job=plan_job,
+            confirm_cloud_budget=True,
+            acknowledged=False,
+        )
+        runner, invoked = _make_runner(reg)
+        ctx_obj = _FakeJobCtx()
+        batch.run_batch(store, state["id"], runner, ctx_obj, _ctx(reg), consent=consent)
+        assert invoked == ["v2"]
+        # the final tick is the explicit 100/"done", reached after the skip + run.
+        assert ctx_obj.messages[-1] == (100.0, "done")

--- a/sidecar/tests/test_batch.py
+++ b/sidecar/tests/test_batch.py
@@ -1174,3 +1174,322 @@ class TestRunBatchConsent:
         assert invoked == ["v2"]
         # the final tick is the explicit 100/"done", reached after the skip + run.
         assert ctx_obj.messages[-1] == (100.0, "done")
+
+
+# --------------------------------------------------------------------------- #
+# WU10 — the seven ``batch.*`` RPC methods (the Batch service)
+# --------------------------------------------------------------------------- #
+def _service(
+    tmp_path,
+    *,
+    template_runner=None,
+    shape_of=None,
+    plan_job=None,
+    title_resolver=None,
+    methods_provider=None,
+) -> batch.Batch:
+    """A :class:`batch.Batch` over a tmp ``batches/`` dir with injected seams."""
+    return batch.Batch(
+        batch.BatchStore(tmp_path / "batches"),
+        methods_provider=methods_provider,
+        template_runner=template_runner,
+        shape_of=shape_of,
+        plan_job=plan_job,
+        title_resolver=title_resolver,
+    )
+
+
+def _created(service: batch.Batch, ctx: RpcContext, ids=("v1", "v2")) -> str:
+    out = service.create({"name": "B", "templateId": "tpl", "sourceVideoIds": list(ids)}, ctx)
+    return out["batch"]["id"]
+
+
+class TestBatchServiceCrud:
+    def test_create_persists_queued_batch(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        out = service.create({"name": "B", "templateId": "tpl", "sourceVideoIds": ["v1", "v2"]}, _ctx(reg))
+        assert out["batch"]["status"] == "queued"
+        assert [i["videoId"] for i in out["batch"]["items"]] == ["v1", "v2"]
+        assert service.store.load(out["batch"]["id"]) is not None
+
+    def test_create_validates_fields(self, tmp_path):
+        service = _service(tmp_path)
+        with pytest.raises(RpcError):
+            service.create({"name": "", "templateId": "tpl", "sourceVideoIds": ["v1"]}, _ctx(_registry()))
+
+    def test_list_returns_summaries(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        _created(service, _ctx(reg))
+        out = service.list({}, _ctx(reg))
+        assert len(out["batches"]) == 1
+        assert out["batches"][0]["counts"]["total"] == 2
+
+    def test_delete_drops_record_and_clears_parent_job(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+        service._parent_jobs[batch_id] = "stale-job"
+        out = service.delete({"id": batch_id}, _ctx(reg))
+        assert out["ok"] is True
+        assert service.store.load(batch_id) is None
+        assert batch_id not in service._parent_jobs
+
+    def test_delete_unknown_is_false(self, tmp_path):
+        service = _service(tmp_path)
+        assert service.delete({"id": "nope"}, _ctx(_registry()))["ok"] is False
+
+    @pytest.mark.parametrize("svc_method", ["start", "status", "cancel", "resume", "delete"])
+    def test_id_param_required(self, tmp_path, svc_method):
+        service = _service(tmp_path)
+        with pytest.raises(RpcError, match="id"):
+            getattr(service, svc_method)({}, _ctx(_registry()))
+
+
+class TestBatchServiceStart:
+    def test_start_returns_job_id_and_runs_all(self, tmp_path):
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg))
+        out = service.start({"id": batch_id}, _ctx(reg))
+        assert isinstance(out["jobId"], str)
+        reg.join()
+        assert invoked == ["v1", "v2"]
+        assert _statuses(service.store, batch_id) == ["done", "done"]
+        assert service._parent_jobs[batch_id] == out["jobId"]
+
+    def test_start_no_registry_refuses(self, tmp_path):
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(_registry()))
+        with pytest.raises(RpcError, match="no job registry available"):
+            service.start({"id": batch_id}, RpcContext(emit_notification=lambda *_: None, jobs=None))
+
+    def test_start_unknown_batch_refuses(self, tmp_path):
+        service = _service(tmp_path)
+        with pytest.raises(RpcError, match="unknown batch"):
+            service.start({"id": "nope"}, _ctx(_registry()))
+
+    def test_start_gate_on_unacked_egress_skips_with_reason(self, tmp_path):
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN})
+        service = _service(tmp_path, template_runner=runner, shape_of=lambda _vid: "eg", plan_job=plan_job)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        service.start({"id": batch_id, "confirmCloudBudget": True, "acknowledged": False}, _ctx(reg))
+        reg.join()
+        assert invoked == []
+        item = service.store.load(batch_id)["items"][0]
+        assert item["status"] == "skipped"
+        assert item["skipReason"] == "would egress — not acknowledged"
+
+    def test_start_gate_on_acked_threads_confirm_budget(self, tmp_path):
+        reg = _registry()
+        runner, confirms = _make_confirm_runner(reg)
+        plan_job, _ = _fake_plan_job({"eg": _EGRESS_PLAN})
+        service = _service(tmp_path, template_runner=runner, shape_of=lambda _vid: "eg", plan_job=plan_job)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        service.start({"id": batch_id, "confirmCloudBudget": True, "acknowledged": True}, _ctx(reg))
+        reg.join()
+        assert confirms == {"v1": "ck-egress"}
+        assert service.store.load(batch_id)["items"][0]["status"] == "done"
+
+    def test_start_gate_off_skips_consent_and_runs(self, tmp_path):
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        plan_job, calls = _fake_plan_job({"eg": _EGRESS_PLAN})
+        service = _service(tmp_path, template_runner=runner, shape_of=lambda _vid: "eg", plan_job=plan_job)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        service.start({"id": batch_id}, _ctx(reg))
+        reg.join()
+        assert calls == []
+        assert invoked == ["v1"]
+
+    def test_start_continue_on_error_off_halts(self, tmp_path):
+        reg = _registry()
+        runner, _ = _make_runner(reg, fail={"v1"})
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1", "v2"])
+        service.start({"id": batch_id, "continueOnError": False}, _ctx(reg))
+        reg.join()
+        assert _statuses(service.store, batch_id) == ["error", "queued"]
+
+
+class TestBatchServiceStatus:
+    def test_status_unknown_refuses(self, tmp_path):
+        service = _service(tmp_path)
+        with pytest.raises(RpcError, match="unknown batch"):
+            service.status({"id": "nope"}, _ctx(_registry()))
+
+    def test_status_no_live_job_returns_checkpoint(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+        out = service.status({"id": batch_id}, _ctx(reg))
+        assert out["batch"]["status"] == "queued"
+        assert "pct" not in out["batch"]
+
+    def test_status_overlays_live_pct(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+
+        class _LiveJob:
+            finished = False
+            pct = 42
+
+        service._parent_jobs[batch_id] = "j1"
+        reg.get = lambda _jid: _LiveJob()  # type: ignore[method-assign, return-value]
+        out = service.status({"id": batch_id}, _ctx(reg))
+        assert out["batch"]["pct"] == 42
+
+    def test_status_finished_job_adds_no_overlay(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+
+        class _DoneJob:
+            finished = True
+            pct = 100
+
+        service._parent_jobs[batch_id] = "j1"
+        reg.get = lambda _jid: _DoneJob()  # type: ignore[method-assign, return-value]
+        out = service.status({"id": batch_id}, _ctx(reg))
+        assert "pct" not in out["batch"]
+
+
+class TestBatchServiceCancel:
+    def test_cancel_sets_parent_flag(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+        cancelled: list[str] = []
+        service._parent_jobs[batch_id] = "j1"
+        reg.cancel = lambda jid: bool(cancelled.append(jid)) or True  # type: ignore[method-assign]
+        out = service.cancel({"id": batch_id}, _ctx(reg))
+        assert out["ok"] is True
+        assert cancelled == ["j1"]
+
+    def test_cancel_without_parent_job_is_false(self, tmp_path):
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+        assert service.cancel({"id": batch_id}, _ctx(reg))["ok"] is False
+
+    def test_cancel_without_registry_is_false(self, tmp_path):
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(_registry()))
+        service._parent_jobs[batch_id] = "j1"
+        ctx = RpcContext(emit_notification=lambda *_: None, jobs=None)
+        assert service.cancel({"id": batch_id}, ctx)["ok"] is False
+
+
+class TestBatchServiceResume:
+    def test_resume_reenqueues_and_returns_job_id(self, tmp_path):
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1", "v2"])
+        service.store.update_item(batch_id, "v1", status="done")
+        out = service.resume({"id": batch_id}, _ctx(reg))
+        assert isinstance(out["jobId"], str)
+        assert service._parent_jobs[batch_id] == out["jobId"]
+        reg.join()
+        assert invoked == ["v2"]
+        assert _statuses(service.store, batch_id) == ["done", "done"]
+
+    def test_resume_noop_when_all_terminal(self, tmp_path):
+        reg = _registry()
+        runner, _ = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        service.store.update_item(batch_id, "v1", status="done")
+        out = service.resume({"id": batch_id}, _ctx(reg))
+        assert out == {"jobId": None, "status": "done"}
+        assert batch_id not in service._parent_jobs
+
+    def test_resume_retry_errors(self, tmp_path):
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        service.store.update_item(batch_id, "v1", status="error", error="boom")
+        service.resume({"id": batch_id, "retryErrors": True}, _ctx(reg))
+        reg.join()
+        assert invoked == ["v1"]
+
+    def test_resume_no_registry_refuses(self, tmp_path):
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(_registry()))
+        with pytest.raises(RpcError, match="no job registry available"):
+            service.resume({"id": batch_id}, RpcContext(emit_notification=lambda *_: None, jobs=None))
+
+    def test_resume_unknown_refuses(self, tmp_path):
+        service = _service(tmp_path)
+        with pytest.raises(RpcError, match="unknown batch"):
+            service.resume({"id": "nope"}, _ctx(_registry()))
+
+
+class TestBatchServiceDefaultSeams:
+    def test_default_runner_calls_templates_apply_by_name(self, tmp_path):
+        calls: list[dict[str, Any]] = []
+
+        def fake_apply(params, ctx):
+            calls.append(params)
+            return {"jobId": "sub-1"}
+
+        service = _service(tmp_path, methods_provider=lambda: {"templates.apply": fake_apply})
+        runner = service._runner_for("tpl")
+        runner("v1", _ctx(_registry()))
+        runner("v2", _ctx(_registry()), confirm_budget="ck-1")
+        assert calls == [
+            {"templateId": "tpl", "videoId": "v1"},
+            {"templateId": "tpl", "videoId": "v2", "confirmBudget": "ck-1"},
+        ]
+
+    def test_default_plan_job_calls_ai_planjob_by_name(self, tmp_path):
+        seen: list[dict[str, Any]] = []
+
+        def fake_plan(params, ctx):
+            seen.append(params)
+            return _LOCAL_PLAN
+
+        service = _service(tmp_path, methods_provider=lambda: {"ai.planJob": fake_plan})
+        plan = service._default_plan_job("shape-A")
+        assert plan is _LOCAL_PLAN
+        assert seen == [{"capability": "shape-A"}]
+
+    def test_default_shape_of_collapses_to_template_id(self, tmp_path):
+        reg = _registry()
+        runner, _ = _make_runner(reg)
+        seen: list[dict[str, Any]] = []
+
+        def fake_plan(params, ctx):
+            seen.append(params)
+            return _LOCAL_PLAN
+
+        service = _service(tmp_path, template_runner=runner, methods_provider=lambda: {"ai.planJob": fake_plan})
+        batch_id = _created(service, _ctx(reg), ids=["v1", "v2", "v3"])
+        service.start({"id": batch_id, "confirmCloudBudget": True, "acknowledged": True}, _ctx(reg))
+        reg.join()
+        assert seen == [{"capability": "tpl"}]
+
+    def test_default_title_resolver_is_identity(self, tmp_path):
+        reg = _registry()
+        recorded: list[str] = []
+
+        def runner(video_id, ctx):
+            recorded.append(video_id)
+
+            def body(job_ctx):
+                job_ctx.progress(100.0, f"title={video_id}")
+                return {"ok": True}
+
+            return {"jobId": ctx.jobs.start(body).id}
+
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        service.start({"id": batch_id}, _ctx(reg))
+        reg.join()
+        assert recorded == ["v1"]

--- a/sidecar/tests/test_batch.py
+++ b/sidecar/tests/test_batch.py
@@ -1,0 +1,333 @@
+"""WU6 tests — ``features/batch.py`` store + model + checkpoint-on-transition.
+
+Pure store + pure model logic over a ``tmp_path`` JSON document (one file per
+batch under ``batches/<batchId>.json``). No runner, no RPC, no media work — those
+are later WUs. The store mirrors :class:`recipes.RecipeStore`'s atomic temp+rename
+write (a simulated ``os.replace`` failure must leave the prior file intact), but
+keyed per-batch so one corrupt batch can never poison another.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from media_studio.features import batch
+from media_studio.protocol import RpcError
+
+# --------------------------------------------------------------------------- #
+# pure model — BatchItem / BatchState shaping + status derivation
+# --------------------------------------------------------------------------- #
+
+
+class TestBatchItemModel:
+    def test_new_item_is_queued_with_no_extras(self):
+        item = batch.new_item("v1")
+        assert item == {"videoId": "v1", "status": "queued"}
+
+    def test_new_item_rejects_empty_video_id(self):
+        with pytest.raises(RpcError):
+            batch.new_item("")
+
+    def test_new_item_rejects_non_str_video_id(self):
+        with pytest.raises(RpcError):
+            batch.new_item(None)  # type: ignore[arg-type]
+
+    @pytest.mark.parametrize(
+        "status",
+        ["queued", "running", "done", "error", "cancelled", "skipped"],
+    )
+    def test_valid_item_status_accepted(self, status: str):
+        assert batch.is_terminal_status(status) in (True, False)
+
+    @pytest.mark.parametrize("status", ["done", "error", "cancelled", "skipped"])
+    def test_terminal_statuses(self, status: str):
+        assert batch.is_terminal_status(status) is True
+
+    @pytest.mark.parametrize("status", ["queued", "running"])
+    def test_non_terminal_statuses(self, status: str):
+        assert batch.is_terminal_status(status) is False
+
+
+class TestNewState:
+    def test_create_persists_all_items_queued(self):
+        state = batch.new_state("My run", "tmpl-1", ["v1", "v2", "v3"])
+        assert state["name"] == "My run"
+        assert state["templateId"] == "tmpl-1"
+        assert state["status"] == "queued"
+        assert [i["status"] for i in state["items"]] == ["queued"] * 3
+        assert [i["videoId"] for i in state["items"]] == ["v1", "v2", "v3"]
+
+    def test_create_assigns_id_and_created_at(self):
+        state = batch.new_state("n", "t", ["v1"])
+        assert isinstance(state["id"], str) and state["id"]
+        assert isinstance(state["createdAt"], int) and state["createdAt"] > 0
+
+    def test_create_honors_explicit_id(self):
+        state = batch.new_state("n", "t", ["v1"], batch_id="fixed-id")
+        assert state["id"] == "fixed-id"
+
+    def test_create_rejects_empty_name(self):
+        with pytest.raises(RpcError):
+            batch.new_state("  ", "t", ["v1"])
+
+    def test_create_rejects_empty_template_id(self):
+        with pytest.raises(RpcError):
+            batch.new_state("n", "", ["v1"])
+
+    def test_create_rejects_empty_sources(self):
+        with pytest.raises(RpcError):
+            batch.new_state("n", "t", [])
+
+    def test_create_rejects_non_list_sources(self):
+        with pytest.raises(RpcError):
+            batch.new_state("n", "t", "v1")  # type: ignore[arg-type]
+
+    def test_create_rejects_non_str_source(self):
+        with pytest.raises(RpcError):
+            batch.new_state("n", "t", ["v1", 7])  # type: ignore[list-item]
+
+    def test_create_rejects_empty_str_source(self):
+        with pytest.raises(RpcError):
+            batch.new_state("n", "t", ["v1", ""])
+
+
+class TestDeriveStatus:
+    def test_all_queued_is_queued(self):
+        assert batch.derive_status(["queued", "queued"]) == "queued"
+
+    def test_any_running_is_running(self):
+        assert batch.derive_status(["done", "running", "queued"]) == "running"
+
+    def test_unfinished_with_progress_is_running(self):
+        # Some done, some still queued, none running -> the batch is mid-flight.
+        assert batch.derive_status(["done", "queued"]) == "running"
+
+    def test_all_done_is_done(self):
+        assert batch.derive_status(["done", "done"]) == "done"
+
+    def test_terminal_mix_with_error_is_error_when_none_succeeded(self):
+        assert batch.derive_status(["error", "error"]) == "error"
+
+    def test_terminal_mix_with_some_done_and_some_error_is_partial(self):
+        assert batch.derive_status(["done", "error"]) == "partial"
+
+    def test_terminal_mix_with_skipped_and_done_is_partial(self):
+        assert batch.derive_status(["done", "skipped"]) == "partial"
+
+    def test_all_skipped_is_error(self):
+        # Nothing ran successfully; a wholly-skipped batch is a failed outcome.
+        assert batch.derive_status(["skipped", "skipped"]) == "error"
+
+    def test_all_cancelled_is_cancelled(self):
+        assert batch.derive_status(["cancelled", "cancelled"]) == "cancelled"
+
+    def test_cancelled_with_done_is_partial(self):
+        assert batch.derive_status(["done", "cancelled"]) == "partial"
+
+    def test_empty_items_is_queued(self):
+        assert batch.derive_status([]) == "queued"
+
+
+# --------------------------------------------------------------------------- #
+# storage — one file per batch, atomic temp+rename, per-batch isolation
+# --------------------------------------------------------------------------- #
+
+
+class TestBatchStore:
+    def test_create_writes_three_queued_items(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        on_disk = json.loads((tmp_path / "batches" / f"{state['id']}.json").read_text(encoding="utf-8"))
+        assert on_disk["status"] == "queued"
+        assert [i["status"] for i in on_disk["items"]] == ["queued"] * 3
+
+    def test_load_round_trips_full_state(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        loaded = store.load(state["id"])
+        assert loaded == state
+
+    def test_load_unknown_returns_none(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        assert store.load("nope") is None
+
+    def test_per_item_transition_rewrites_file_immediately(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        store.update_item(state["id"], "v2", status="error", error="boom")
+        on_disk = json.loads((tmp_path / "batches" / f"{state['id']}.json").read_text(encoding="utf-8"))
+        statuses = {i["videoId"]: i["status"] for i in on_disk["items"]}
+        assert statuses == {"v1": "queued", "v2": "error", "v3": "queued"}
+        v2 = next(i for i in on_disk["items"] if i["videoId"] == "v2")
+        assert v2["error"] == "boom"
+
+    def test_update_item_recomputes_aggregate_status(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.update_item(state["id"], "v1", status="running")
+        assert store.load(state["id"])["status"] == "running"
+
+    def test_update_item_persists_optional_fields(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        store.update_item(
+            state["id"],
+            "v1",
+            status="done",
+            jobId="job-9",
+            results=[{"ok": True}],
+        )
+        item = store.load(state["id"])["items"][0]
+        assert item["jobId"] == "job-9"
+        assert item["results"] == [{"ok": True}]
+
+    def test_update_item_skip_round_trips_reason_losslessly(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        store.update_item(state["id"], "v1", status="skipped", skipReason="would egress — not acknowledged")
+        item = store.load(state["id"])["items"][0]
+        assert item["status"] == "skipped"
+        assert item["skipReason"] == "would egress — not acknowledged"
+
+    def test_update_item_unknown_batch_raises(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        with pytest.raises(RpcError):
+            store.update_item("nope", "v1", status="done")
+
+    def test_update_item_unknown_video_raises(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        with pytest.raises(RpcError):
+            store.update_item(state["id"], "v9", status="done")
+
+    def test_update_item_rejects_invalid_status(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        with pytest.raises(RpcError):
+            store.update_item(state["id"], "v1", status="bogus")
+
+    def test_per_batch_isolation(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        a = store.create("A", "t", ["v1"])
+        b = store.create("B", "t", ["v2"])
+        store.update_item(a["id"], "v1", status="error", error="x")
+        # B is untouched by a write to A.
+        assert store.load(b["id"])["items"][0]["status"] == "queued"
+        assert store.load(a["id"])["items"][0]["status"] == "error"
+
+    def test_corrupt_one_batch_leaves_others_loadable(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        a = store.create("A", "t", ["v1"])
+        b = store.create("B", "t", ["v2"])
+        (tmp_path / "batches" / f"{a['id']}.json").write_text("{not json", encoding="utf-8")
+        assert store.load(a["id"]) is None  # corrupt -> unreadable
+        assert store.load(b["id"]) is not None  # sibling intact
+
+    def test_corrupt_non_dict_file_loads_as_none(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        store.dir.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "batches" / "x.json").write_text("[1, 2, 3]", encoding="utf-8")
+        assert store.load("x") is None
+
+    def test_save_unreadable_file_returns_none(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        store.dir.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "batches" / "y.json").write_text("\x00\x01 garbage", encoding="utf-8")
+        assert store.load("y") is None
+
+    def test_list_summaries_omit_heavy_results(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        store.update_item(state["id"], "v1", status="done", results=[{"big": "payload"}])
+        summaries = store.list()
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert summary["id"] == state["id"]
+        assert summary["name"] == "run"
+        assert summary["status"] == "done"
+        assert summary["templateId"] == "t"
+        # the heavy per-item ``results`` are NOT carried in a summary.
+        assert "results" not in json.dumps(summary)
+        assert summary["counts"] == {
+            "total": 1,
+            "done": 1,
+            "error": 0,
+            "skipped": 0,
+            "queued": 0,
+            "running": 0,
+            "cancelled": 0,
+        }
+
+    def test_list_empty_when_no_batches(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        assert store.list() == []
+
+    def test_list_skips_corrupt_batch_files(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        good = store.create("good", "t", ["v1"])
+        (tmp_path / "batches" / "broken.json").write_text("{bad", encoding="utf-8")
+        ids = [s["id"] for s in store.list()]
+        assert ids == [good["id"]]
+
+    def test_list_ignores_non_json_files(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        store.create("good", "t", ["v1"])
+        (tmp_path / "batches" / "notes.txt").write_text("hello", encoding="utf-8")
+        assert len(store.list()) == 1
+
+    def test_list_skips_non_dict_json_file(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        good = store.create("good", "t", ["v1"])
+        # a syntactically-valid JSON file that is not a batch object (a list).
+        (tmp_path / "batches" / "arr.json").write_text("[1, 2, 3]", encoding="utf-8")
+        ids = [s["id"] for s in store.list()]
+        assert ids == [good["id"]]
+
+    def test_list_count_ignores_unknown_item_status(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        # write a batch whose item carries a status outside the counted set.
+        bad = {
+            "id": "weird",
+            "name": "n",
+            "templateId": "t",
+            "status": "running",
+            "createdAt": 1,
+            "items": [{"videoId": "v1", "status": "phantom"}],
+        }
+        store.dir.mkdir(parents=True, exist_ok=True)
+        (tmp_path / "batches" / "weird.json").write_text(json.dumps(bad), encoding="utf-8")
+        summary = next(s for s in store.list() if s["id"] == "weird")
+        # the unknown status is not counted into any bucket but total still reflects it.
+        assert summary["counts"]["total"] == 1
+        assert sum(v for k, v in summary["counts"].items() if k != "total") == 0
+
+    def test_list_when_dir_absent_is_empty(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "does-not-exist")
+        assert store.list() == []
+
+    def test_delete_removes_file_and_reports(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        assert store.delete(state["id"]) is True
+        assert store.load(state["id"]) is None
+
+    def test_delete_unknown_reports_false(self, tmp_path):
+        store = batch.BatchStore(tmp_path / "batches")
+        assert store.delete("nope") is False
+
+    def test_atomic_write_failure_leaves_prior_file_intact(self, tmp_path, monkeypatch):
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1"])
+        path = tmp_path / "batches" / f"{state['id']}.json"
+        before = path.read_text(encoding="utf-8")
+
+        def boom(_src: Any, _dst: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(batch.os, "replace", boom)
+        with pytest.raises(OSError):
+            store.update_item(state["id"], "v1", status="done")
+        # the original checkpoint is byte-for-byte intact (temp+rename never truncates).
+        assert path.read_text(encoding="utf-8") == before

--- a/sidecar/tests/test_batch.py
+++ b/sidecar/tests/test_batch.py
@@ -592,3 +592,231 @@ class TestRunBatchProgress:
         batch.run_batch(store, state["id"], runner, ctx_obj, _ctx(reg))
         # with no resolver supplied, the title falls back to the raw video id.
         assert any("source 1/1 · v1 · " in msg for _pct, msg in ctx_obj.messages)
+
+    def test_run_batch_skips_already_done_items(self, tmp_path):
+        # An item already terminal-``done`` on disk (e.g. preserved by a resume)
+        # is NOT re-run — its runner is never invoked and it stays ``done``.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.update_item(state["id"], "v1", status="done", jobId="old", results={"source": "v1"})
+        runner, invoked = _make_runner(reg)
+        batch.run_batch(store, state["id"], runner, _FakeJobCtx(), _ctx(reg))
+        # v1 (already done) is skipped; only v2 runs.
+        assert invoked == ["v2"]
+        assert _statuses(store, state["id"]) == ["done", "done"]
+
+
+# --------------------------------------------------------------------------- #
+# WU8 — resume (G-DUR, source granularity)
+# --------------------------------------------------------------------------- #
+
+
+def _sync_start(captured: dict[str, Any]):
+    """A ``start_job`` seam that runs the parent job body synchronously.
+
+    Mirrors a real ``ctx.jobs.start`` enough for a deterministic test: it runs
+    the body NOW with a fresh :class:`_FakeJobCtx`, stashes the returned state in
+    ``captured``, and returns an object exposing ``.id`` (the job-id contract).
+    """
+
+    class _Job:
+        id = "resume-job-1"
+
+    def start_job(body, **_kwargs):
+        captured["state"] = body(_FakeJobCtx())
+        return _Job()
+
+    return start_job
+
+
+class TestResumableVideoIds:
+    def test_selects_queued_and_running_not_done(self):
+        state = batch.new_state("r", "t", ["v1", "v2", "v3"])
+        state["items"][0]["status"] = "done"
+        state["items"][1]["status"] = "running"
+        # v3 stays queued.
+        assert batch.resumable_video_ids(state) == ["v2", "v3"]
+
+    def test_errors_excluded_by_default(self):
+        state = batch.new_state("r", "t", ["v1", "v2"])
+        state["items"][0]["status"] = "error"
+        # default policy does NOT retry errored sources.
+        assert batch.resumable_video_ids(state) == ["v2"]
+
+    def test_errors_included_when_retry_errors(self):
+        state = batch.new_state("r", "t", ["v1", "v2"])
+        state["items"][0]["status"] = "error"
+        assert batch.resumable_video_ids(state, retry_errors=True) == ["v1", "v2"]
+
+    def test_skipped_and_cancelled_never_resumed(self):
+        state = batch.new_state("r", "t", ["v1", "v2", "v3"])
+        state["items"][0]["status"] = "skipped"
+        state["items"][1]["status"] = "cancelled"
+        # only the still-queued v3 is resumable; skip/cancel are terminal here.
+        assert batch.resumable_video_ids(state, retry_errors=True) == ["v3"]
+
+    def test_all_done_is_empty(self):
+        state = batch.new_state("r", "t", ["v1", "v2"])
+        for item in state["items"]:
+            item["status"] = "done"
+        assert batch.resumable_video_ids(state) == []
+
+
+class TestResumeBatch:
+    def test_unknown_batch_raises(self, tmp_path):
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        runner, _ = _make_runner(reg)
+        with pytest.raises(RpcError, match="unknown batch"):
+            batch.resume_batch(store, "nope", runner, _ctx(reg))
+
+    def test_resume_reruns_only_incomplete_items(self, tmp_path):
+        # Acceptance #1: resuming [done, error, queued] re-runs only items 2 & 3.
+        # The default policy retries errored sources too (retry_errors=True here),
+        # so item 1 (done) is the ONLY one not re-run — its runner is not invoked.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        store.update_item(state["id"], "v1", status="done", jobId="old1", results={"source": "v1"})
+        store.update_item(state["id"], "v2", status="error", error="boom: v2")
+        captured: dict[str, Any] = {}
+        runner, invoked = _make_runner(reg)
+        out = batch.resume_batch(
+            store,
+            state["id"],
+            runner,
+            _ctx(reg),
+            retry_errors=True,
+            start_job=_sync_start(captured),
+        )
+        assert out == {"jobId": "resume-job-1"}
+        # item 1's runner was NOT invoked; only the re-enqueued v2 and v3 ran.
+        assert invoked == ["v2", "v3"]
+        assert _statuses(store, state["id"]) == ["done", "done", "done"]
+
+    def test_error_not_retried_by_default(self, tmp_path):
+        # Default policy leaves errored sources terminal — only queued/running re-run.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        store.update_item(state["id"], "v1", status="done", results={"source": "v1"})
+        store.update_item(state["id"], "v2", status="error", error="boom: v2")
+        captured: dict[str, Any] = {}
+        runner, invoked = _make_runner(reg)
+        batch.resume_batch(store, state["id"], runner, _ctx(reg), start_job=_sync_start(captured))
+        # v1 done (skipped), v2 stays error (not retried), only v3 re-runs.
+        assert invoked == ["v3"]
+        assert _statuses(store, state["id"]) == ["done", "error", "done"]
+
+    def test_all_done_resume_is_noop_no_job(self, tmp_path):
+        # Acceptance #2: resuming an all-done batch starts NO job, reports done.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.update_item(state["id"], "v1", status="done", results={"source": "v1"})
+        store.update_item(state["id"], "v2", status="done", results={"source": "v2"})
+        started: list[Any] = []
+
+        def start_job(body, **_kwargs):  # pragma: no cover - must NOT be called
+            started.append(body)
+            raise AssertionError("no job should start for an all-done batch")
+
+        runner, invoked = _make_runner(reg)
+        out = batch.resume_batch(store, state["id"], runner, _ctx(reg), start_job=start_job)
+        assert out == {"jobId": None, "status": "done"}
+        assert started == []
+        assert invoked == []
+
+    def test_resumed_source_runs_from_first_step(self, tmp_path):
+        # Acceptance #3: a re-enqueued source runs from its FIRST step — the runner
+        # is handed the source's full template path (source granularity), proven by
+        # the start-of-source progress tick at the slice base (0.0), not a suffix.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.update_item(state["id"], "v1", status="done", results={"source": "v1"})
+        captured: dict[str, Any] = {}
+        ctx_obj_holder: dict[str, _FakeJobCtx] = {}
+
+        class _Job:
+            id = "resume-job-2"
+
+        def start_job(body, **_kwargs):
+            job_ctx = _FakeJobCtx()
+            ctx_obj_holder["ctx"] = job_ctx
+            captured["state"] = body(job_ctx)
+            return _Job()
+
+        runner, invoked = _make_runner(reg, pct=50.0)
+        batch.resume_batch(
+            store,
+            state["id"],
+            runner,
+            _ctx(reg),
+            title_resolver=lambda vid: f"Title-{vid}",
+            start_job=start_job,
+        )
+        # only v2 re-runs and it starts at its slice base (full path, step 1).
+        assert invoked == ["v2"]
+        msgs = ctx_obj_holder["ctx"].messages
+        assert any(msg == "source 2/2 · Title-v2 · " for _pct, msg in msgs)
+
+    def test_resume_resets_running_item_to_queued_before_job(self, tmp_path):
+        # A source left ``running`` by a crash is reset to ``queued`` on disk by
+        # resume BEFORE the job body runs (durable re-enqueue, not in-memory only).
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.update_item(state["id"], "v1", status="done", results={"source": "v1"})
+        store.update_item(state["id"], "v2", status="running", jobId="dead-job")
+        on_disk_at_start: list[list[str]] = []
+
+        class _Job:
+            id = "resume-job-3"
+
+        def start_job(body, **_kwargs):
+            # at job-start time, the running item must already be re-queued on disk.
+            on_disk_at_start.append(_statuses(store, state["id"]))
+            body(_FakeJobCtx())
+            return _Job()
+
+        runner, _ = _make_runner(reg)
+        batch.resume_batch(store, state["id"], runner, _ctx(reg), start_job=start_job)
+        assert on_disk_at_start[0] == ["done", "queued"]
+        assert _statuses(store, state["id"]) == ["done", "done"]
+
+    def test_resume_uses_real_registry_start_by_default(self, tmp_path):
+        # With no start_job seam injected, resume starts a real parent job via the
+        # registry and returns its id; the threaded body re-runs the queued source.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2"])
+        store.update_item(state["id"], "v1", status="done", results={"source": "v1"})
+        runner, _ = _make_runner(reg)
+        out = batch.resume_batch(store, state["id"], runner, _ctx(reg))
+        job = reg.get(out["jobId"])
+        job._thread.join(timeout=5)
+        assert isinstance(out["jobId"], str) and out["jobId"]
+        assert _statuses(store, state["id"]) == ["done", "done"]
+
+    def test_resume_passes_continue_on_error_through(self, tmp_path):
+        # The continue_on_error policy threads into the resumed run: with it off and
+        # a failing re-enqueued source, the run halts and the tail stays queued.
+        reg = _registry()
+        store = batch.BatchStore(tmp_path / "batches")
+        state = store.create("run", "t", ["v1", "v2", "v3"])
+        store.update_item(state["id"], "v1", status="done", results={"source": "v1"})
+        captured: dict[str, Any] = {}
+        runner, invoked = _make_runner(reg, fail={"v2"})
+        batch.resume_batch(
+            store,
+            state["id"],
+            runner,
+            _ctx(reg),
+            continue_on_error=False,
+            start_job=_sync_start(captured),
+        )
+        # v2 fails and halts the resumed run; v3 is never attempted.
+        assert invoked == ["v2"]
+        assert _statuses(store, state["id"]) == ["done", "error", "queued"]

--- a/sidecar/tests/test_export_presets.py
+++ b/sidecar/tests/test_export_presets.py
@@ -1,0 +1,303 @@
+"""Tests for media_studio.features.export_presets — the export-preset catalog.
+
+Pure store + pure normalization logic over a ``tmp_path`` JSON document (no I/O
+seam to fake; storage is filesystem-only, mirroring ``test_recipes.py``'s
+``RecipeStore`` tests). Covers seeding, upsert/delete/reset, the 20-60 s window
+clamp, the ``captionStyle`` id-guard, corrupt-file recovery, and the atomic
+temp+rename write (a simulated ``os.replace`` failure must leave the prior file
+intact — no truncation).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from media_studio.features import export_presets
+from media_studio.protocol import RpcError
+
+
+# --------------------------------------------------------------------------- #
+# pure: normalize_preset (window clamp + captionStyle guard + shaping)
+# --------------------------------------------------------------------------- #
+class TestNormalizePreset:
+    def test_full_preset_normalized(self):
+        p = export_presets.normalize_preset(
+            {
+                "id": "fixed",
+                "label": "  My Preset  ",
+                "aspect": "9:16",
+                "minSec": 25,
+                "maxSec": 45,
+                "count": 4,
+                "captionStyle": "bold",
+                "reframeEngine": "verthor",
+            }
+        )
+        assert p == {
+            "id": "fixed",
+            "label": "My Preset",
+            "aspect": "9:16",
+            "minSec": 25,
+            "maxSec": 45,
+            "count": 4,
+            "captionStyle": "bold",
+            "reframeEngine": "verthor",
+        }
+
+    def test_id_generated_when_absent(self):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"}
+        )
+        assert p["id"]  # generated, non-empty
+
+    def test_max_sec_clamped_above_window(self):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 600, "count": 1, "captionStyle": "libass"}
+        )
+        assert p["maxSec"] == export_presets.MAX_CLIP_SEC == 60
+
+    def test_min_sec_clamped_below_window(self):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 5, "maxSec": 60, "count": 1, "captionStyle": "libass"}
+        )
+        assert p["minSec"] == export_presets.MIN_CLIP_SEC == 20
+
+    def test_max_sec_clamped_below_min_floor(self):
+        # a maxSec below the window floor lands at the floor (never inverts).
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 1, "count": 1, "captionStyle": "libass"}
+        )
+        assert p["maxSec"] == export_presets.MIN_CLIP_SEC == 20
+
+    def test_min_sec_never_exceeds_clamped_max(self):
+        # minSec is held at-or-below the (clamped) maxSec so the window can't invert.
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 55, "maxSec": 30, "count": 1, "captionStyle": "libass"}
+        )
+        assert p["minSec"] == 30
+        assert p["maxSec"] == 30
+
+    def test_in_range_window_preserved(self):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 30, "maxSec": 50, "count": 1, "captionStyle": "libass"}
+        )
+        assert (p["minSec"], p["maxSec"]) == (30, 50)
+
+    def test_count_floored_to_one(self):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 0, "captionStyle": "libass"}
+        )
+        assert p["count"] == 1
+
+    @pytest.mark.parametrize("style", ["libass", "none", "bold", "neon", "mrbeast"])
+    def test_valid_caption_style_accepted(self, style):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": style}
+        )
+        assert p["captionStyle"] == style
+
+    def test_invalid_caption_style_rejected(self):
+        with pytest.raises(RpcError):
+            export_presets.normalize_preset(
+                {
+                    "label": "x",
+                    "aspect": "9:16",
+                    "minSec": 20,
+                    "maxSec": 60,
+                    "count": 1,
+                    "captionStyle": "__nope__",
+                }
+            )
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            {"aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"},  # no label
+            {"label": "", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"},
+            {"label": "x", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"},  # no aspect
+            {"label": "x", "aspect": "", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"},
+            {"label": "x", "aspect": "9:16", "maxSec": 60, "count": 1, "captionStyle": "libass"},  # no minSec
+            {"label": "x", "aspect": "9:16", "minSec": "no", "maxSec": 60, "count": 1, "captionStyle": "libass"},
+            {"label": "x", "aspect": "9:16", "minSec": 20, "count": 1, "captionStyle": "libass"},  # no maxSec
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": "no", "count": 1, "captionStyle": "libass"},
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "captionStyle": "libass"},  # no count
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": "no", "captionStyle": "libass"},
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1},  # no captionStyle
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": 7},  # not a str
+            "nope",  # not an object
+        ],
+    )
+    def test_rejects_malformed(self, bad: Any):
+        with pytest.raises(RpcError):
+            export_presets.normalize_preset(bad)
+
+    def test_reframe_engine_defaults_to_auto(self):
+        p = export_presets.normalize_preset(
+            {"label": "x", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"}
+        )
+        assert p["reframeEngine"] == "auto"
+
+    def test_invalid_reframe_engine_rejected(self):
+        with pytest.raises(RpcError):
+            export_presets.normalize_preset(
+                {
+                    "label": "x",
+                    "aspect": "9:16",
+                    "minSec": 20,
+                    "maxSec": 60,
+                    "count": 1,
+                    "captionStyle": "libass",
+                    "reframeEngine": "imovie",
+                }
+            )
+
+
+# --------------------------------------------------------------------------- #
+# seeds
+# --------------------------------------------------------------------------- #
+class TestSeeds:
+    def test_seed_ids_are_the_three_vertical_platforms(self):
+        ids = {s["id"] for s in export_presets.seed_presets()}
+        assert ids == {"tiktok", "reels", "shorts"}
+
+    def test_all_seeds_are_vertical_9x16(self):
+        assert all(s["aspect"] == "9:16" for s in export_presets.seed_presets())
+
+    def test_seeds_normalize_clean(self):
+        # every seed survives normalize_preset unchanged (already in-window/valid).
+        for s in export_presets.seed_presets():
+            assert export_presets.normalize_preset(s) == s
+
+
+# --------------------------------------------------------------------------- #
+# PresetStore
+# --------------------------------------------------------------------------- #
+class TestPresetStore:
+    def test_empty_store_seeds_three_vertical_presets(self, tmp_path):
+        store = export_presets.PresetStore(tmp_path / "p.json")
+        listed = store.list()
+        assert {p["id"] for p in listed} == {"tiktok", "reels", "shorts"}
+        assert all(p["aspect"] == "9:16" for p in listed)
+
+    def test_seed_persisted_on_first_list(self, tmp_path):
+        path = tmp_path / "p.json"
+        export_presets.PresetStore(path).list()
+        on_disk = json.loads(path.read_text(encoding="utf-8"))
+        assert {p["id"] for p in on_disk} == {"tiktok", "reels", "shorts"}
+
+    def test_save_upserts_by_id(self, tmp_path):
+        store = export_presets.PresetStore(tmp_path / "p.json")
+        store.save(
+            {
+                "id": "tiktok",
+                "label": "TT2",
+                "aspect": "9:16",
+                "minSec": 20,
+                "maxSec": 60,
+                "count": 9,
+                "captionStyle": "libass",
+            }
+        )
+        listed = {p["id"]: p for p in store.list()}
+        assert listed["tiktok"]["label"] == "TT2"
+        assert listed["tiktok"]["count"] == 9
+
+    def test_save_appends_new_id(self, tmp_path):
+        store = export_presets.PresetStore(tmp_path / "p.json")
+        saved = store.save(
+            {
+                "id": "custom",
+                "label": "C",
+                "aspect": "1:1",
+                "minSec": 30,
+                "maxSec": 600,
+                "count": 2,
+                "captionStyle": "libass",
+            }
+        )
+        assert saved["maxSec"] == 60  # clamped on save
+        assert any(p["id"] == "custom" for p in store.list())
+
+    def test_save_rejects_invalid_caption_style_and_writes_nothing(self, tmp_path):
+        path = tmp_path / "p.json"
+        store = export_presets.PresetStore(path)
+        store.list()  # seed first
+        before = path.read_text(encoding="utf-8")
+        with pytest.raises(RpcError):
+            store.save(
+                {
+                    "id": "x",
+                    "label": "x",
+                    "aspect": "9:16",
+                    "minSec": 20,
+                    "maxSec": 60,
+                    "count": 1,
+                    "captionStyle": "__nope__",
+                }
+            )
+        assert path.read_text(encoding="utf-8") == before  # untouched
+
+    def test_delete_removes_and_reports(self, tmp_path):
+        store = export_presets.PresetStore(tmp_path / "p.json")
+        assert store.delete("tiktok") is True
+        assert store.delete("tiktok") is False
+        assert "tiktok" not in {p["id"] for p in store.list()}
+
+    def test_reset_restores_seeds(self, tmp_path):
+        store = export_presets.PresetStore(tmp_path / "p.json")
+        store.delete("tiktok")
+        restored = store.reset()
+        ids = {p["id"] for p in restored}
+        assert ids == {"tiktok", "reels", "shorts"}
+        assert {p["id"] for p in store.list()} == {"tiktok", "reels", "shorts"}
+
+    def test_corrupt_file_reseeds(self, tmp_path):
+        path = tmp_path / "p.json"
+        path.write_text("not json{", encoding="utf-8")
+        # a corrupt catalog recovers to the seeds (never crashes the list).
+        assert {p["id"] for p in export_presets.PresetStore(path).list()} == {"tiktok", "reels", "shorts"}
+
+    def test_non_list_file_reseeds(self, tmp_path):
+        path = tmp_path / "p.json"
+        path.write_text('{"oops": 1}', encoding="utf-8")
+        assert {p["id"] for p in export_presets.PresetStore(path).list()} == {"tiktok", "reels", "shorts"}
+
+    def test_non_dict_entries_filtered(self, tmp_path):
+        path = tmp_path / "p.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {"id": "keep", "label": "K", "aspect": "9:16", "minSec": 20, "maxSec": 60, "count": 1},
+                    "garbage",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        assert [p["id"] for p in export_presets.PresetStore(path).list()] == ["keep"]
+
+    def test_atomic_write_failure_leaves_prior_file_intact(self, tmp_path, monkeypatch):
+        path = tmp_path / "p.json"
+        store = export_presets.PresetStore(path)
+        store.list()  # seed + write a valid file
+        before = path.read_text(encoding="utf-8")
+
+        def boom(_src: Any, _dst: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(export_presets.os, "replace", boom)
+        with pytest.raises(OSError):
+            store.save(
+                {
+                    "id": "custom",
+                    "label": "C",
+                    "aspect": "9:16",
+                    "minSec": 20,
+                    "maxSec": 60,
+                    "count": 1,
+                    "captionStyle": "libass",
+                }
+            )
+        # the original file is byte-for-byte intact (temp+rename never truncates it).
+        assert path.read_text(encoding="utf-8") == before

--- a/sidecar/tests/test_export_presets.py
+++ b/sidecar/tests/test_export_presets.py
@@ -15,7 +15,12 @@ from typing import Any
 
 import pytest
 from media_studio.features import export_presets
-from media_studio.protocol import RpcError
+from media_studio.protocol import RpcContext, RpcError
+
+
+def _ctx() -> RpcContext:
+    """The ``test_recipes.py`` direct-return idiom: no job registry needed."""
+    return RpcContext(emit_notification=lambda *_: None, jobs=None)
 
 
 # --------------------------------------------------------------------------- #
@@ -301,3 +306,87 @@ class TestPresetStore:
             )
         # the original file is byte-for-byte intact (temp+rename never truncates it).
         assert path.read_text(encoding="utf-8") == before
+
+
+# --------------------------------------------------------------------------- #
+# ExportPresets — direct-return CRUD handlers (WU2 RPC surface)
+# --------------------------------------------------------------------------- #
+class TestExportPresetsHandlers:
+    def _svc(self, tmp_path) -> export_presets.ExportPresets:
+        return export_presets.ExportPresets(export_presets.PresetStore(tmp_path / "p.json"))
+
+    def test_list_returns_seeded_presets(self, tmp_path):
+        out = self._svc(tmp_path).list({}, _ctx())
+        assert {p["id"] for p in out["presets"]} == {"tiktok", "reels", "shorts"}
+
+    def test_save_returns_clamped_preset_and_list_reflects_it(self, tmp_path):
+        svc = self._svc(tmp_path)
+        out = svc.save(
+            {
+                "preset": {
+                    "id": "custom",
+                    "label": "C",
+                    "aspect": "9:16",
+                    "minSec": 30,
+                    "maxSec": 600,  # clamped to 60
+                    "count": 2,
+                    "captionStyle": "libass",
+                }
+            },
+            _ctx(),
+        )
+        assert out["preset"]["maxSec"] == 60  # clamped on save
+        listed = {p["id"] for p in svc.list({}, _ctx())["presets"]}
+        assert "custom" in listed
+
+    def test_save_requires_object(self, tmp_path):
+        svc = self._svc(tmp_path)
+        with pytest.raises(RpcError):
+            svc.save({"preset": "nope"}, _ctx())
+
+    def test_save_missing_preset_key_errors(self, tmp_path):
+        svc = self._svc(tmp_path)
+        with pytest.raises(RpcError):
+            svc.save({}, _ctx())
+
+    def test_delete_then_reset_restores_seed(self, tmp_path):
+        svc = self._svc(tmp_path)
+        assert svc.delete({"id": "tiktok"}, _ctx()) == {"ok": True}
+        assert "tiktok" not in {p["id"] for p in svc.list({}, _ctx())["presets"]}
+        restored = svc.reset({}, _ctx())
+        assert {p["id"] for p in restored["presets"]} == {"tiktok", "reels", "shorts"}
+        assert "tiktok" in {p["id"] for p in svc.list({}, _ctx())["presets"]}
+
+    def test_delete_unknown_reports_false(self, tmp_path):
+        svc = self._svc(tmp_path)
+        assert svc.delete({"id": "__nope__"}, _ctx()) == {"ok": False}
+
+    def test_delete_requires_id(self, tmp_path):
+        svc = self._svc(tmp_path)
+        with pytest.raises(RpcError):
+            svc.delete({}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# register — the module owns its own register() (mirrors recipes.register)
+# --------------------------------------------------------------------------- #
+def test_register_installs_four_methods(tmp_path):
+    registered: dict[str, Any] = {}
+    export_presets.register(
+        path=tmp_path / "export-presets.json",
+        register_fn=lambda n, f: registered.__setitem__(n, f),
+    )
+    assert set(registered) == {
+        "exportPresets.list",
+        "exportPresets.save",
+        "exportPresets.delete",
+        "exportPresets.reset",
+    }
+
+
+def test_register_returns_service_bound_to_path(tmp_path):
+    path = tmp_path / "export-presets.json"
+    svc = export_presets.register(path=path, register_fn=lambda _n, _f: None)
+    # the returned service writes to the bound path on first list (self-seed).
+    svc.list({}, _ctx())
+    assert path.exists()

--- a/sidecar/tests/test_handlers_batch.py
+++ b/sidecar/tests/test_handlers_batch.py
@@ -1,0 +1,130 @@
+"""Registration-site smoke for the ``batch.*`` group (WU10).
+
+Asserts the single composition root ``register_all`` (handlers.py) wires the seven
+``batch.*`` methods — and ONLY those seven new keys — onto the registry, each bound
+to a :class:`batch.BatchStore` under ``Services.data_dir`` (so the per-batch files
+land under ``batches/`` next to ``templates.json`` / ``export-presets.json``), and
+that the wired ``batch.start`` default per-source runner reaches the live
+``templates.apply`` handler registered in the same root. Mirrors the templates /
+exportPresets register-site smokes. The batch group is the renderer's (WU11) RPC
+surface, so the exact method names + param shapes are the contract under test.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from media_studio import handlers, protocol
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext
+
+BATCH_METHODS = {
+    "batch.create",
+    "batch.start",
+    "batch.status",
+    "batch.list",
+    "batch.cancel",
+    "batch.resume",
+    "batch.delete",
+}
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda *_: None, jobs=None)
+
+
+def test_register_all_wires_batch_methods(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert set(registered) >= BATCH_METHODS
+
+
+def test_register_all_adds_only_the_seven_batch_keys(tmp_path: Path) -> None:
+    """No stray ``batch.*`` key beyond the documented seven (acceptance 1)."""
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    batch_keys = {k for k in registered if k.startswith("batch.")}
+    assert batch_keys == BATCH_METHODS
+
+
+def test_batch_create_list_bound_to_data_dir(tmp_path: Path) -> None:
+    """The registered handler is the live store: a created batch round-trips and the
+    per-batch file lands under ``Services.data_dir / batches``."""
+    data_dir = tmp_path / "d"
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=data_dir),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    out = registered["batch.create"]({"name": "B", "templateId": "tpl", "sourceVideoIds": ["v1"]}, _ctx())
+    listed = registered["batch.list"]({}, _ctx())
+    assert [b["id"] for b in listed["batches"]] == [out["batch"]["id"]]
+    assert (data_dir / "batches" / f"{out['batch']['id']}.json").exists()
+
+
+def test_batch_status_round_trips_created_batch(tmp_path: Path) -> None:
+    """``batch.status`` of a freshly-created batch reads the durable checkpoint."""
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    created = registered["batch.create"]({"name": "B", "templateId": "tpl", "sourceVideoIds": ["v1", "v2"]}, _ctx())
+    status = registered["batch.status"]({"id": created["batch"]["id"]}, _ctx())
+    assert status["batch"]["status"] == "queued"
+    assert status["batch"]["items"][0]["status"] == "queued"
+
+
+def test_batch_registered_after_templates_apply(tmp_path: Path) -> None:
+    """The wired default per-source runner resolves ``templates.apply`` from the live
+    registry — proving the batch group is registered AFTER (and binds to) it."""
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "templates.apply" in registered  # the default batch runner's target
+
+
+def test_batch_registered_on_real_protocol(tmp_path: Path) -> None:
+    """register_all onto the real registry installs the keys (conftest restores)."""
+    handlers.register_all(services=Services(data_dir=tmp_path / "d"))
+    for rpc_method in BATCH_METHODS:
+        assert rpc_method in protocol.METHODS
+
+
+def test_video_title_unknown_falls_back_to_id(tmp_path: Path) -> None:
+    """The batch title seam returns the id when the library has no such video."""
+    svc = Services(data_dir=tmp_path / "d")
+    assert svc._video_title("missing") == "missing"
+
+
+def test_video_title_uses_library_title(tmp_path: Path) -> None:
+    """A library video's ``title`` is used for the progress message."""
+    svc = Services(data_dir=tmp_path / "d")
+    media = tmp_path / "clip.mp4"
+    media.write_bytes(b"\x00")
+    video = svc.library.add(str(media), "My Clip")
+    assert svc._video_title(video["id"]) == "My Clip"
+
+
+def test_video_title_blank_title_falls_back_to_id(tmp_path: Path) -> None:
+    """A library video with an empty ``title`` falls back to the id (the ``or`` arm)."""
+    import json
+
+    data_dir = tmp_path / "d"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    index = data_dir / "library.json"
+    index.write_text(
+        json.dumps({"version": 1, "videos": [{"id": "vblank", "path": "/x.mp4", "title": ""}]}),
+        encoding="utf-8",
+    )
+    svc = Services(data_dir=data_dir)
+    assert svc._video_title("vblank") == "vblank"

--- a/sidecar/tests/test_handlers_export_presets.py
+++ b/sidecar/tests/test_handlers_export_presets.py
@@ -1,0 +1,70 @@
+"""Registration-site smoke for the ``exportPresets.*`` group (WU2).
+
+Asserts the single composition root ``register_all`` (handlers.py) wires the
+four direct-return CRUD methods — and ONLY those four new keys — onto the
+registry, each bound to a ``PresetStore`` under ``Services.data_dir`` (so the
+catalog file is ``export-presets.json`` next to ``recipes.json``). Heavy seams
+are untouched (this group is filesystem-only). Mirrors the recipes register-site
+smoke in ``test_handlers.py``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from media_studio import handlers, protocol
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext
+
+EXPORT_PRESET_METHODS = {
+    "exportPresets.list",
+    "exportPresets.save",
+    "exportPresets.delete",
+    "exportPresets.reset",
+}
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda *_: None, jobs=None)
+
+
+def test_register_all_wires_export_preset_methods(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert set(registered) >= EXPORT_PRESET_METHODS
+
+
+def test_register_all_adds_only_the_four_export_preset_keys(tmp_path: Path) -> None:
+    """No stray ``exportPresets.*`` key beyond the documented four (acceptance 1)."""
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    export_keys = {k for k in registered if k.startswith("exportPresets.")}
+    assert export_keys == EXPORT_PRESET_METHODS
+
+
+def test_export_presets_list_bound_to_data_dir_seeds(tmp_path: Path) -> None:
+    """The registered handler is the live catalog: list returns the three seeds,
+    and the catalog file lands under ``Services.data_dir`` as ``export-presets.json``."""
+    data_dir = tmp_path / "d"
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=data_dir),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    out = registered["exportPresets.list"]({}, _ctx())
+    assert {p["id"] for p in out["presets"]} == {"tiktok", "reels", "shorts"}
+    assert (data_dir / "export-presets.json").exists()
+
+
+def test_export_presets_registered_on_real_protocol(tmp_path: Path) -> None:
+    """register_all onto the real registry installs the keys (conftest restores)."""
+    handlers.register_all(services=Services(data_dir=tmp_path / "d"))
+    for method in EXPORT_PRESET_METHODS:
+        assert method in protocol.METHODS

--- a/sidecar/tests/test_handlers_templates.py
+++ b/sidecar/tests/test_handlers_templates.py
@@ -1,0 +1,126 @@
+"""Registration-site smoke for the ``templates.*`` group (WU5).
+
+Asserts the single composition root ``register_all`` (handlers.py) wires the four
+``templates.*`` methods — and ONLY those four new keys — onto the registry, each
+bound to a :class:`templates.TemplateStore` under ``Services.data_dir`` (so the
+file is ``templates.json`` next to ``recipes.json`` / ``export-presets.json``),
+and that the ``apply`` fan-out resolves preset ids from the live export-preset
+catalog wired in the same root. Mirrors the exportPresets register-site smoke.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers, protocol
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext, RpcError
+
+TEMPLATE_METHODS = {
+    "templates.list",
+    "templates.save",
+    "templates.delete",
+    "templates.apply",
+}
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda *_: None, jobs=None)
+
+
+def test_register_all_wires_template_methods(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert set(registered) >= TEMPLATE_METHODS
+
+
+def test_register_all_adds_only_the_four_template_keys(tmp_path: Path) -> None:
+    """No stray ``templates.*`` key beyond the documented four (acceptance 4)."""
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    template_keys = {k for k in registered if k.startswith("templates.")}
+    assert template_keys == TEMPLATE_METHODS
+
+
+def test_templates_save_list_bound_to_data_dir(tmp_path: Path) -> None:
+    """The registered handler is the live store: a saved template round-trips and
+    the file lands under ``Services.data_dir`` as ``templates.json``."""
+    data_dir = tmp_path / "d"
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=data_dir),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    registered["templates.save"](
+        {
+            "template": {
+                "id": "tpl",
+                "name": "T",
+                "steps": [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}}],
+                "exportTargets": ["tiktok"],
+            }
+        },
+        _ctx(),
+    )
+    out = registered["templates.list"]({}, _ctx())
+    assert [t["id"] for t in out["templates"]] == ["tpl"]
+    assert (data_dir / "templates.json").exists()
+
+
+def test_templates_apply_resolves_presets_from_wired_catalog(tmp_path: Path) -> None:
+    """The wired ``apply`` fan-out resolves a real seed preset id (``tiktok``) from
+    the export-preset catalog registered in the same composition root — proving the
+    presets_provider is bound to the live catalog, not an empty map."""
+    data_dir = tmp_path / "d"
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=data_dir),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    # apply runs the pure pre-job path (bind + fan-out over the live catalog)
+    # BEFORE the registry check, so a null registry isolates the fan-out outcome:
+    #   * a KNOWN seed id ("tiktok") resolves -> reaches the no-registry refusal
+    #     ("no job registry available"), proving the catalog is bound + non-empty;
+    #   * an UNKNOWN id ("__nope__") fails loud in the fan-out itself.
+    registered["templates.save"](
+        {
+            "template": {
+                "id": "tpl",
+                "name": "T",
+                "steps": [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}}],
+                "exportTargets": ["tiktok"],
+            }
+        },
+        _ctx(),
+    )
+    with pytest.raises(RpcError, match="no job registry available"):
+        registered["templates.apply"]({"templateId": "tpl", "videoId": "v1"}, _ctx())
+
+    registered["templates.save"](
+        {
+            "template": {
+                "id": "bad",
+                "name": "Bad",
+                "steps": [{"method": "shortmaker.export", "params": {"exportTargets": ["__nope__"]}}],
+                "exportTargets": ["__nope__"],
+            }
+        },
+        _ctx(),
+    )
+    with pytest.raises(RpcError, match="export target not found"):
+        registered["templates.apply"]({"templateId": "bad", "videoId": "v1"}, _ctx())
+
+
+def test_templates_registered_on_real_protocol(tmp_path: Path) -> None:
+    """register_all onto the real registry installs the keys (conftest restores)."""
+    handlers.register_all(services=Services(data_dir=tmp_path / "d"))
+    for method in TEMPLATE_METHODS:
+        assert method in protocol.METHODS

--- a/sidecar/tests/test_templates.py
+++ b/sidecar/tests/test_templates.py
@@ -1,0 +1,184 @@
+"""Tests for media_studio.features.templates — saved repurpose templates.
+
+A *template* is a recipe (frozen ``recipes`` wire shape) PLUS two additive
+fields — ``defaultControls`` and ``exportTargets:[presetId]`` — and a **method
+allowlist** so a saved template can only name the curated repurpose verbs. The
+module REUSES ``recipes.RecipeStore``/``recipes.normalize_recipe`` by import
+(no fork of the wire shape), so these tests pin the additive behavior + the
+allowlist guard, and assert the reuse contract.
+
+Storage-only + pure logic: no media work, no providers, no jobs (WU3). The
+``templates.*`` RPC + the export-step fan-out arrive in later WUs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.features import recipes, templates
+from media_studio.protocol import RpcError
+
+
+# --------------------------------------------------------------------------- #
+# pure: normalize_template (reuses recipes.normalize_recipe + additive fields)
+# --------------------------------------------------------------------------- #
+class TestNormalizeTemplate:
+    def _valid(self, **overrides: Any) -> dict[str, Any]:
+        base: dict[str, Any] = {
+            "name": "Repurpose",
+            "steps": [{"method": "shortmaker.export", "params": {"count": 3}}],
+            "defaultControls": {"count": 3, "captionStyle": "libass"},
+            "exportTargets": ["tiktok", "shorts"],
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_template_keeps_additive_fields(self):
+        t = templates.normalize_template(self._valid())
+        assert t["defaultControls"] == {"count": 3, "captionStyle": "libass"}
+        assert t["exportTargets"] == ["tiktok", "shorts"]
+        # recipe shape preserved (id assigned, steps normalized)
+        assert t["id"]
+        assert t["name"] == "Repurpose"
+        assert t["steps"][0]["method"] == "shortmaker.export"
+        assert t["steps"][0]["label"] == "shortmaker.export"
+
+    def test_id_preserved_when_given(self):
+        t = templates.normalize_template(self._valid(id="fixed"))
+        assert t["id"] == "fixed"
+
+    def test_id_assigned_when_absent(self):
+        t = templates.normalize_template(self._valid())
+        assert isinstance(t["id"], str) and t["id"]
+
+    def test_default_controls_default_to_empty_dict(self):
+        raw = self._valid()
+        del raw["defaultControls"]
+        t = templates.normalize_template(raw)
+        assert t["defaultControls"] == {}
+
+    def test_export_targets_default_to_empty_list(self):
+        raw = self._valid()
+        del raw["exportTargets"]
+        t = templates.normalize_template(raw)
+        assert t["exportTargets"] == []
+
+    def test_default_controls_copied_not_aliased(self):
+        raw = self._valid()
+        t = templates.normalize_template(raw)
+        raw["defaultControls"]["count"] = 99
+        assert t["defaultControls"]["count"] == 3
+
+    def test_export_targets_copied_not_aliased(self):
+        raw = self._valid()
+        t = templates.normalize_template(raw)
+        raw["exportTargets"].append("reels")
+        assert t["exportTargets"] == ["tiktok", "shorts"]
+
+    @pytest.mark.parametrize(
+        "method",
+        [
+            "transcribe.start",
+            "subtitles.generate",
+            "shortmaker.export",
+            "phase8.select",
+            "nle.export",
+            "package.export",
+            "convert.run",
+            "audio.mix",
+        ],
+    )
+    def test_allowlisted_methods_accepted(self, method):
+        t = templates.normalize_template(self._valid(steps=[{"method": method}]))
+        assert t["steps"][0]["method"] == method
+
+    @pytest.mark.parametrize(
+        "method",
+        ["shell.exec", "recipes.run", "os.system", "reframe.start", "phase8.other"],
+    )
+    def test_unknown_method_rejected_by_allowlist(self, method):
+        with pytest.raises(RpcError):
+            templates.normalize_template(self._valid(steps=[{"method": method}]))
+
+    def test_malformed_export_targets_non_list_rejected(self):
+        with pytest.raises(RpcError):
+            templates.normalize_template(self._valid(exportTargets="tiktok"))
+
+    def test_malformed_export_targets_non_string_id_rejected(self):
+        with pytest.raises(RpcError):
+            templates.normalize_template(self._valid(exportTargets=["tiktok", 7]))
+
+    def test_malformed_export_targets_empty_string_id_rejected(self):
+        with pytest.raises(RpcError):
+            templates.normalize_template(self._valid(exportTargets=["tiktok", ""]))
+
+    def test_malformed_default_controls_non_dict_rejected(self):
+        with pytest.raises(RpcError):
+            templates.normalize_template(self._valid(defaultControls=["nope"]))
+
+    @pytest.mark.parametrize("bad", ["nope", None, 7, ["steps"]])
+    def test_non_dict_template_rejected(self, bad):
+        with pytest.raises(RpcError):
+            templates.normalize_template(bad)
+
+    def test_recipe_shape_errors_propagate(self):
+        # A missing name is a recipes.normalize_recipe failure, surfaced verbatim.
+        raw = self._valid()
+        del raw["name"]
+        with pytest.raises(RpcError):
+            templates.normalize_template(raw)
+
+    def test_reuses_recipes_normalize_recipe(self, monkeypatch: pytest.MonkeyPatch):
+        # Falsifiable-acceptance #3: recipes.normalize_recipe is the ONLY recipe
+        # validation path — assert it is actually invoked (no re-implementation).
+        calls: list[dict[str, Any]] = []
+        real = recipes.normalize_recipe
+
+        def spy(raw: dict[str, Any]):
+            calls.append(raw)
+            return real(raw)
+
+        monkeypatch.setattr(templates.recipes, "normalize_recipe", spy)
+        templates.normalize_template(self._valid())
+        assert len(calls) == 1
+
+
+# --------------------------------------------------------------------------- #
+# storage: TemplateStore is recipes.RecipeStore over templates.json
+# --------------------------------------------------------------------------- #
+class TestTemplateStore:
+    def _store(self, tmp_path):
+        return templates.TemplateStore(tmp_path / "templates.json")
+
+    def test_store_is_a_recipe_store(self, tmp_path):
+        store = self._store(tmp_path)
+        assert isinstance(store, recipes.RecipeStore)
+
+    def test_empty_store_lists_nothing(self, tmp_path):
+        assert self._store(tmp_path).list() == []
+
+    def test_save_list_get_delete_round_trip(self, tmp_path):
+        store = self._store(tmp_path)
+        t = templates.normalize_template(
+            {
+                "id": "tpl",
+                "name": "T",
+                "steps": [{"method": "shortmaker.export"}],
+                "defaultControls": {"count": 2},
+                "exportTargets": ["tiktok"],
+            }
+        )
+        store.save(t)
+        assert store.get("tpl") == t
+        assert store.list() == [t]
+        assert store.delete("tpl") is True
+        assert store.list() == []
+
+    def test_delete_missing_returns_false(self, tmp_path):
+        assert self._store(tmp_path).delete("nope") is False
+
+    def test_corrupt_file_treated_as_empty(self, tmp_path):
+        path = tmp_path / "templates.json"
+        path.write_text("{ not json", encoding="utf-8")
+        assert templates.TemplateStore(path).list() == []

--- a/sidecar/tests/test_templates.py
+++ b/sidecar/tests/test_templates.py
@@ -182,3 +182,160 @@ class TestTemplateStore:
         path = tmp_path / "templates.json"
         path.write_text("{ not json", encoding="utf-8")
         assert templates.TemplateStore(path).list() == []
+
+
+# --------------------------------------------------------------------------- #
+# pure: expand_export_steps (preset fan-out — WU4)
+# --------------------------------------------------------------------------- #
+def _preset(preset_id: str, **overrides: Any) -> dict[str, Any]:
+    """A minimal normalized-shape ExportPreset for fan-out tests (in-memory)."""
+    base: dict[str, Any] = {
+        "id": preset_id,
+        "label": preset_id.title(),
+        "aspect": "9:16",
+        "minSec": 20,
+        "maxSec": 60,
+        "count": 5,
+        "captionStyle": "libass",
+        "reframeEngine": "auto",
+    }
+    base.update(overrides)
+    return base
+
+
+def _presets(*items: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {p["id"]: p for p in items}
+
+
+class TestExpandExportSteps:
+    def test_single_target_yields_one_export_step(self):
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}, "label": "Export"}]
+        out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok")))
+        assert len(out) == 1
+        assert out[0]["method"] == "shortmaker.export"
+
+    def test_three_targets_yield_three_export_steps_with_merged_fields(self):
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok", "reels", "shorts"]}}]
+        presets = _presets(
+            _preset("tiktok", maxSec=45, count=5, captionStyle="libass"),
+            _preset("reels", maxSec=30, count=3, captionStyle="none"),
+            _preset("shorts", maxSec=60, count=8, captionStyle="libass"),
+        )
+        out = templates.expand_export_steps(steps, {"language": "en"}, presets)
+        assert len(out) == 3
+        # Each fanned-out step carries the preset's controls merged onto defaults.
+        by_target = {s["params"]["presetId"]: s for s in out}
+        assert by_target["tiktok"]["params"]["aspect"] == "9:16"
+        assert by_target["tiktok"]["params"]["maxSec"] == 45
+        assert by_target["tiktok"]["params"]["captionStyle"] == "libass"
+        assert by_target["reels"]["params"]["maxSec"] == 30
+        assert by_target["reels"]["params"]["captionStyle"] == "none"
+        assert by_target["shorts"]["params"]["maxSec"] == 60
+        # defaultControls is the base for every fanned step.
+        assert all(s["params"]["language"] == "en" for s in out)
+
+    def test_preset_fields_override_default_controls(self):
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}}]
+        controls = {"maxSec": 99, "captionStyle": "none", "count": 1}
+        out = templates.expand_export_steps(
+            steps, controls, _presets(_preset("tiktok", maxSec=45, captionStyle="libass", count=5))
+        )
+        assert out[0]["params"]["maxSec"] == 45
+        assert out[0]["params"]["captionStyle"] == "libass"
+        assert out[0]["params"]["count"] == 5
+
+    def test_window_clamp_from_preset_is_honored(self):
+        # The preset carries the already-clamped [20,60] window; expansion must
+        # surface those exact values (no re-derivation, no silent correction).
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}}]
+        out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok", minSec=25, maxSec=55)))
+        assert out[0]["params"]["minSec"] == 25
+        assert out[0]["params"]["maxSec"] == 55
+
+    def test_preset_id_attached_for_gallery_grouping(self):
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok", "shorts"]}}]
+        out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok"), _preset("shorts")))
+        assert [s["params"]["presetId"] for s in out] == ["tiktok", "shorts"]
+
+    def test_unknown_target_id_raises_and_yields_no_partial_expansion(self):
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok", "__nope__"]}}]
+        with pytest.raises(RpcError):
+            templates.expand_export_steps(steps, {}, _presets(_preset("tiktok")))
+
+    def test_empty_export_targets_passthrough_drops_no_export_step(self):
+        # Documented rule: an export step with no targets passes through unchanged
+        # (the runner still runs it against the template's defaultControls).
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": []}, "label": "Export"}]
+        out = templates.expand_export_steps(steps, {"count": 3}, {})
+        assert out == steps
+
+    def test_export_step_without_export_targets_key_passthrough(self):
+        steps = [{"method": "shortmaker.export", "params": {"count": 3}}]
+        out = templates.expand_export_steps(steps, {}, {})
+        assert out == steps
+
+    def test_non_export_steps_pass_through_unchanged_and_in_order(self):
+        steps = [
+            {"method": "transcribe.start", "params": {"videoId": "v1"}, "label": "Transcribe"},
+            {"method": "phase8.select", "params": {}, "label": "Select"},
+            {"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}, "label": "Export"},
+        ]
+        out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok")))
+        assert out[0] == steps[0]
+        assert out[1] == steps[1]
+        assert out[2]["method"] == "shortmaker.export"
+        assert out[2]["params"]["presetId"] == "tiktok"
+
+    def test_idempotent_on_already_flat_step_lists(self):
+        # A list with no fan-out (single/no target) is returned shape-stable.
+        steps = [{"method": "transcribe.start", "params": {}, "label": "T"}]
+        out = templates.expand_export_steps(steps, {}, {})
+        assert out == steps
+
+    def test_label_carries_preset_for_multi_target_steps(self):
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok", "shorts"]}, "label": "Export"}]
+        out = templates.expand_export_steps(
+            steps, {}, _presets(_preset("tiktok", label="TikTok"), _preset("shorts", label="Shorts"))
+        )
+        assert out[0]["label"] == "Export · TikTok"
+        assert out[1]["label"] == "Export · Shorts"
+
+    def test_export_targets_not_leaked_into_merged_params(self):
+        # The control field that drove the fan-out is consumed, not forwarded to
+        # the export handler (which has no use for it).
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}}]
+        out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok")))
+        assert "exportTargets" not in out[0]["params"]
+
+    def test_multiple_export_steps_each_fan_out(self):
+        steps = [
+            {"method": "shortmaker.export", "params": {"exportTargets": ["tiktok", "shorts"]}, "label": "A"},
+            {"method": "shortmaker.export", "params": {"exportTargets": ["reels"]}, "label": "B"},
+        ]
+        presets = _presets(_preset("tiktok"), _preset("shorts"), _preset("reels"))
+        out = templates.expand_export_steps(steps, {}, presets)
+        assert len(out) == 3
+        assert [s["params"]["presetId"] for s in out] == ["tiktok", "shorts", "reels"]
+
+    def test_partial_preset_only_merges_present_fields(self):
+        # A preset missing a control field (e.g. reframeEngine) must NOT inject a
+        # key — only the fields actually present override defaultControls.
+        steps = [{"method": "shortmaker.export", "params": {"exportTargets": ["bare"]}}]
+        bare = {"id": "bare", "label": "Bare", "maxSec": 40}
+        out = templates.expand_export_steps(steps, {"reframeEngine": "auto"}, {"bare": bare})
+        assert out[0]["params"]["maxSec"] == 40
+        # reframeEngine stays the default-controls value (preset didn't carry one).
+        assert out[0]["params"]["reframeEngine"] == "auto"
+        assert "aspect" not in out[0]["params"]
+
+    def test_source_step_params_preserved_alongside_preset_merge(self):
+        # Non-fan-out params on the export step (e.g. a $N.key ref) survive.
+        steps = [
+            {
+                "method": "shortmaker.export",
+                "params": {"exportTargets": ["tiktok"], "videoId": "v1", "trackId": "$0.track.id"},
+            }
+        ]
+        out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok")))
+        assert out[0]["params"]["videoId"] == "v1"
+        assert out[0]["params"]["trackId"] == "$0.track.id"

--- a/sidecar/tests/test_templates.py
+++ b/sidecar/tests/test_templates.py
@@ -13,11 +13,13 @@ Storage-only + pure logic: no media work, no providers, no jobs (WU3). The
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 import pytest
 from media_studio.features import recipes, templates
-from media_studio.protocol import RpcError
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext, RpcError
 
 
 # --------------------------------------------------------------------------- #
@@ -339,3 +341,284 @@ class TestExpandExportSteps:
         out = templates.expand_export_steps(steps, {}, _presets(_preset("tiktok")))
         assert out[0]["params"]["videoId"] == "v1"
         assert out[0]["params"]["trackId"] == "$0.track.id"
+
+
+# --------------------------------------------------------------------------- #
+# pure: bind_steps_to_source (WU5 — stamp the source videoId on every step)
+# --------------------------------------------------------------------------- #
+class TestBindStepsToSource:
+    def test_stamps_video_id_on_every_step(self):
+        steps = [{"method": "transcribe.start", "params": {}}, {"method": "phase8.select"}]
+        out = templates.bind_steps_to_source(steps, "v9")
+        assert all(s["params"]["videoId"] == "v9" for s in out)
+
+    def test_does_not_clobber_explicit_video_id(self):
+        steps = [{"method": "transcribe.start", "params": {"videoId": "explicit"}}]
+        out = templates.bind_steps_to_source(steps, "v9")
+        assert out[0]["params"]["videoId"] == "explicit"
+
+    def test_preserves_other_params_and_step_fields(self):
+        steps = [{"method": "shortmaker.export", "params": {"count": 3}, "label": "Export"}]
+        out = templates.bind_steps_to_source(steps, "v9")
+        assert out[0]["params"] == {"count": 3, "videoId": "v9"}
+        assert out[0]["label"] == "Export"
+        assert out[0]["method"] == "shortmaker.export"
+
+    def test_does_not_mutate_input_steps(self):
+        steps = [{"method": "transcribe.start", "params": {}}]
+        templates.bind_steps_to_source(steps, "v9")
+        assert steps[0]["params"] == {}  # original untouched (fresh copy)
+
+    def test_empty_steps_yield_empty(self):
+        assert templates.bind_steps_to_source([], "v9") == []
+
+    def test_handles_step_without_params_key(self):
+        out = templates.bind_steps_to_source([{"method": "phase8.select"}], "v9")
+        assert out[0]["params"] == {"videoId": "v9"}
+
+
+# --------------------------------------------------------------------------- #
+# Templates — direct-return CRUD handlers
+# --------------------------------------------------------------------------- #
+def _ctx(registry: JobRegistry | None = None) -> RpcContext:
+    return RpcContext(emit_notification=lambda *_: None, jobs=registry)
+
+
+def _valid_template(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "id": "tpl",
+        "name": "Repurpose",
+        "steps": [{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}}],
+        "defaultControls": {"count": 3},
+        "exportTargets": ["tiktok"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestCrudHandlers:
+    def _svc(self, tmp_path, **kw: Any) -> templates.Templates:
+        return templates.Templates(templates.TemplateStore(tmp_path / "templates.json"), **kw)
+
+    def test_save_normalizes_and_persists(self, tmp_path):
+        svc = self._svc(tmp_path)
+        out = svc.save({"template": _valid_template()}, _ctx())
+        assert out["template"]["name"] == "Repurpose"
+        assert out["template"]["exportTargets"] == ["tiktok"]
+        assert svc.list({}, _ctx())["templates"][0]["name"] == "Repurpose"
+
+    def test_save_requires_object(self, tmp_path):
+        svc = self._svc(tmp_path)
+        with pytest.raises(RpcError):
+            svc.save({"template": "nope"}, _ctx())
+
+    def test_save_rejects_disallowed_method(self, tmp_path):
+        svc = self._svc(tmp_path)
+        with pytest.raises(RpcError):
+            svc.save({"template": _valid_template(steps=[{"method": "shell.exec"}])}, _ctx())
+
+    def test_list_empty(self, tmp_path):
+        assert self._svc(tmp_path).list({}, _ctx())["templates"] == []
+
+    def test_delete_handler(self, tmp_path):
+        svc = self._svc(tmp_path)
+        svc.save({"template": _valid_template()}, _ctx())
+        assert svc.delete({"id": "tpl"}, _ctx())["ok"] is True
+        assert svc.delete({"id": "tpl"}, _ctx())["ok"] is False
+
+    def test_delete_requires_id(self, tmp_path):
+        svc = self._svc(tmp_path)
+        with pytest.raises(RpcError):
+            svc.delete({}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# Templates.apply — single-source run over the EXISTING recipe runner
+# --------------------------------------------------------------------------- #
+class TestApply:
+    def _registry(self):
+        events: list[tuple] = []
+
+        def on_prog(jid, pct, msg):
+            events.append(("progress", jid, pct, msg))
+
+        def on_done(jid, result):
+            events.append(("done", jid, result))
+
+        return JobRegistry(emit_progress=on_prog, emit_done=on_done), events
+
+    def _svc(self, tmp_path, *, methods, presets=None) -> templates.Templates:
+        return templates.Templates(
+            templates.TemplateStore(tmp_path / "templates.json"),
+            methods_provider=lambda: methods,
+            presets_provider=(lambda: presets) if presets is not None else None,
+        )
+
+    def test_apply_requires_template_id(self, tmp_path):
+        svc = self._svc(tmp_path, methods={})
+        with pytest.raises(RpcError):
+            svc.apply({"videoId": "v1"}, _ctx())
+
+    def test_apply_requires_video_id(self, tmp_path):
+        svc = self._svc(tmp_path, methods={})
+        with pytest.raises(RpcError):
+            svc.apply({"templateId": "tpl"}, _ctx())
+
+    def test_apply_unknown_template_raises(self, tmp_path):
+        reg, _ = self._registry()
+        svc = self._svc(tmp_path, methods={})
+        with pytest.raises(RpcError):
+            svc.apply({"templateId": "nope", "videoId": "v1"}, _ctx(reg))
+
+    def test_apply_requires_registry(self, tmp_path):
+        svc = self._svc(tmp_path, methods={}, presets={"tiktok": _preset("tiktok")})
+        svc.save({"template": _valid_template()}, _ctx())
+        with pytest.raises(RpcError):
+            svc.apply({"templateId": "tpl", "videoId": "v1"}, _ctx(None))
+
+    def test_apply_runs_steps_in_order_via_live_registry(self, tmp_path):
+        reg, _ = self._registry()
+        calls: list[tuple[str, dict]] = []
+
+        def transcribe(params, ctx):
+            calls.append(("transcribe", params))
+            return {"ok": True}
+
+        def export(params, ctx):
+            calls.append(("export", params))
+            return {"clips": []}
+
+        presets = {"tiktok": _preset("tiktok")}
+        svc = self._svc(
+            tmp_path, methods={"transcribe.start": transcribe, "shortmaker.export": export}, presets=presets
+        )
+        svc.save(
+            {
+                "template": _valid_template(
+                    steps=[
+                        {"method": "transcribe.start", "params": {}},
+                        {"method": "shortmaker.export", "params": {"exportTargets": ["tiktok"]}},
+                    ]
+                )
+            },
+            _ctx(),
+        )
+        out = svc.apply({"templateId": "tpl", "videoId": "vid42"}, _ctx(reg))
+        assert "jobId" in out
+        reg.get(out["jobId"]).wait(5)
+        assert reg.get(out["jobId"]).status.value == "done"
+        # steps ran in order, each bound to the source video id.
+        assert calls[0][0] == "transcribe"
+        assert calls[0][1]["videoId"] == "vid42"
+        assert calls[1][0] == "export"
+        assert calls[1][1]["videoId"] == "vid42"
+        assert calls[1][1]["presetId"] == "tiktok"
+
+    def test_apply_three_targets_produce_three_export_invocations(self, tmp_path):
+        reg, _ = self._registry()
+        exports: list[str] = []
+
+        def export(params, ctx):
+            exports.append(params["presetId"])
+            return {"clips": []}
+
+        presets = {pid: _preset(pid) for pid in ("tiktok", "reels", "shorts")}
+        svc = self._svc(tmp_path, methods={"shortmaker.export": export}, presets=presets)
+        svc.save(
+            {
+                "template": _valid_template(
+                    steps=[{"method": "shortmaker.export", "params": {"exportTargets": ["tiktok", "reels", "shorts"]}}]
+                )
+            },
+            _ctx(),
+        )
+        out = svc.apply({"templateId": "tpl", "videoId": "v1"}, _ctx(reg))
+        reg.get(out["jobId"]).wait(5)
+        assert reg.get(out["jobId"]).status.value == "done"
+        assert exports == ["tiktok", "reels", "shorts"]
+
+    def test_apply_subjob_export_is_awaited_and_unwrapped(self, tmp_path):
+        reg, _ = self._registry()
+
+        def export(params, ctx):
+            def body(job_ctx):
+                job_ctx.progress(50.0, "half")
+                return {"clips": [params["presetId"]]}
+
+            sub = ctx.jobs.start(body)
+            return {"jobId": sub.id}
+
+        presets = {"tiktok": _preset("tiktok")}
+        svc = self._svc(tmp_path, methods={"shortmaker.export": export}, presets=presets)
+        svc.save({"template": _valid_template()}, _ctx())
+        out = svc.apply({"templateId": "tpl", "videoId": "v1"}, _ctx(reg))
+        reg.get(out["jobId"]).wait(10)
+        job = reg.get(out["jobId"])
+        assert job.status.value == "done"
+        # the inner sub-job result was unwrapped as the step result (recipe runner reuse).
+        assert job.result["results"][0] == {"clips": ["tiktok"]}
+
+    def test_apply_cancellation_propagates_via_existing_path(self, tmp_path):
+        # Cancelling the parent job mid-run surfaces as a cancelled job through the
+        # reused recipe runner's raise_if_cancelled (no new cancel machinery).
+        reg, _ = self._registry()
+        started = {"flag": False}
+
+        def slow_export(params, ctx):
+            def body(job_ctx):
+                started["flag"] = True
+                while not job_ctx.cancelled:
+                    time.sleep(0.01)
+                job_ctx.raise_if_cancelled()
+
+            sub = ctx.jobs.start(body)
+            return {"jobId": sub.id}
+
+        presets = {"tiktok": _preset("tiktok")}
+        svc = self._svc(tmp_path, methods={"shortmaker.export": slow_export}, presets=presets)
+        svc.save({"template": _valid_template()}, _ctx())
+        out = svc.apply({"templateId": "tpl", "videoId": "v1"}, _ctx(reg))
+        while not started["flag"]:  # wait for the sub-job to actually be running
+            reg.get(out["jobId"]).wait(0.01)
+        reg.cancel(out["jobId"])
+        reg.get(out["jobId"]).wait(10)
+        assert reg.get(out["jobId"]).status.value == "cancelled"
+
+    def test_apply_template_without_export_targets_runs_passthrough(self, tmp_path):
+        # A template whose export step names no targets runs the step as-is (no
+        # fan-out) — and the default empty preset catalog is fine.
+        reg, _ = self._registry()
+        calls: list[dict] = []
+
+        def export(params, ctx):
+            calls.append(params)
+            return {"ok": 1}
+
+        svc = templates.Templates(
+            templates.TemplateStore(tmp_path / "templates.json"),
+            methods_provider=lambda: {"shortmaker.export": export},
+        )
+        svc.save(
+            {"template": _valid_template(steps=[{"method": "shortmaker.export", "params": {}}], exportTargets=[])},
+            _ctx(),
+        )
+        out = svc.apply({"templateId": "tpl", "videoId": "v1"}, _ctx(reg))
+        reg.get(out["jobId"]).wait(5)
+        assert reg.get(out["jobId"]).status.value == "done"
+        assert calls[0]["videoId"] == "v1"
+
+
+# --------------------------------------------------------------------------- #
+# register
+# --------------------------------------------------------------------------- #
+def test_register_installs_four_methods(tmp_path):
+    registered: dict[str, Any] = {}
+    templates.register(path=tmp_path / "templates.json", register_fn=lambda n, f: registered.__setitem__(n, f))
+    assert set(registered) == {"templates.list", "templates.save", "templates.delete", "templates.apply"}
+
+
+def test_register_returns_service_bound_to_path(tmp_path):
+    svc = templates.register(path=tmp_path / "templates.json", register_fn=lambda *_: None)
+    assert isinstance(svc, templates.Templates)
+    svc.save({"template": _valid_template()}, _ctx())
+    assert (tmp_path / "templates.json").exists()


### PR DESCRIPTION
## Repurpose — batch queue + templates + multi-platform presets (12 WUs)

Adds the **Repurpose** capability to the media studio: batch-process multiple sources through reusable export templates and multi-platform presets, with a full renderer surface. Branched off `main` independently.

### Work units
- **WU1** — export-preset store with seeds, window clamp, and caption-id guard
- **WU2** — `exportPresets.*` RPC + register wiring
- **WU3** — templates store + normalize + method allowlist
- **WU4** — template export-step preset fan-out
- **WU5** — `templates.*` RPC (list / save / delete / apply) + register wiring
- **WU6** — `batch.py` BatchStore + BatchState/BatchItem model + checkpoint-on-transition
- **WU7** — batch runner with per-source isolation (G-ISO)
- **WU8** — `batch.resume` re-enqueue at source granularity (G-DUR)
- **WU9** — batch consent surface (G-ACK) + visible skip
- **WU10** — `batch.*` RPC (create / start / status / list / cancel / resume / delete) + register wiring
- **WU11** — renderer (rpc client groups + ExportPresets / Template / BatchQueue panels + a11y live-status + Repurpose tab + resume surface)
- **WU12** — cross-cutting verification + PR readiness (gate pass)

### Hub AI-Job alignment
Rides the Hub **AI-Job envelope / pool / consent / budget** infrastructure: batch jobs flow through the shared AI-job envelope, are scheduled via the existing pool, are gated by the consent surface (G-ACK), and respect the budget model.

### Gate status (validated authoritatively on the branch tip, not per-WU reports)
- **Sidecar** — `pytest --cov=media_studio --cov-branch --cov-fail-under=100`: **3256 passed, 100.00% branch coverage**
- **Renderer** — `vitest run --coverage` (thresholds 100): **1235 passed, 100% statements/branches/functions/lines**
- **Lint/format** — ruff check + ruff format clean; biome format clean; oxlint `--deny-warnings` clean
- **Types** — basedpyright 0 errors; tsc (app + render-cli) clean

### Merge note
This branch and three sibling branches each branched off `main` independently and each touches `handlers.register_all`. That is a **merge-time** integration concern (register-all conflict resolution), not a defect in this branch; this branch's own gate is fully green.
