### PR TITLE
feat: Editing-refine — filler/silence removal + diarization (8 WUs)

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -71,7 +71,7 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 - `shortmaker.select({videoId, prompt, controls})` -> `{jobId}` -> `{candidates}` ; controls = `{count,minSec,maxSec,aspect,language,captionStyle}`
 - `shortmaker.export({videoId, candidateIds})` -> `{jobId}` -> `{clips:[{path}]}`
 - `job.cancel({jobId})` -> `{ok}` ; `job.status({jobId})` -> `{status,pct}`
-- `settings.get()` / `settings.set({...})` -> includes `{useCloud:bool, cloudApiKey?, modelsDir, ffmpegPath}` (editing-refinement keys: see §A5)
+- `settings.get()` / `settings.set({...})` -> includes `{useCloud:bool, cloudApiKey?, modelsDir, ffmpegPath}` (editing-refinement adds the `captionSpeakerLabels` setting key; the refine tunables are per-call RPC params, not settings — see §A5)
 
 ## 3. Data schemas (Python TypedDict / TS interface — keep field names identical both sides)
 - **Word** `{text:str, start:float, end:float}` ; **Segment** `{start:float, end:float, text:str, words:[Word]}`
@@ -171,20 +171,33 @@ keeps its name and meaning — only an OPTIONAL field is added.
 - Dub alignment recipe (FROZEN): per-cue target duration -> rate re-synth -> ffmpeg atempo clamp ±15% -> pad; dub
   pipeline is BATCHED: translate ALL cues -> free MT -> synth ALL cues (never interleave model swaps).
 
-## A5. Editing-refinement settings keys + workspace tab (2026-06)
-Settings are read via `settings.get()` / `settings.set({...})` (base §2). The
-editing-refinement bundle adds the keys below (all OPTIONAL; absent → the cited
-engine default, so behaviour is unchanged when unset). Existing `removeFillers` /
-`silenceTrim` / `diarizeBackend` keep their shortmaker meaning unchanged.
+## A5. Editing-refinement settings key + refine RPC params + workspace tab (2026-06)
+The editing-refinement bundle adds exactly ONE persisted **settings key** — read via
+`settings.get()` / `settings.set({...})` (base §2) — plus a set of per-call **RPC
+params** on `refine.preview` / `refine.apply`. They are NOT the same surface: only
+`captionSpeakerLabels` lives in the settings store; the refine tunables are passed
+per call (from the Refine panel's local state) and are NOT read from any `refine.*`
+settings key. All are OPTIONAL; absent → the cited engine default, so behaviour is
+unchanged when unset. Existing `removeFillers` / `silenceTrim` / `diarizeBackend`
+keep their shortmaker meaning unchanged.
+
+**Settings key** (persisted, read via `settings.get()`):
 
 | Key | Type | Meaning | Default precedent |
 |---|---|---|---|
-| `captionSpeakerLabels` | bool | when on, subtitle generate prefixes each cue's text with the diarized speaker label (read at `handlers.py` subtitle-generate; off → cues untouched) | new (mirrors the `captionPolish` flag) |
-| `refine.noiseDb` | float | silence-detection threshold (dB) for `refine.preview`/`refine.apply` | `silencetrim.DEFAULT_NOISE_DB` |
-| `refine.minSilenceSec` | float | minimum silent-span duration to cut | `silencetrim.DEFAULT_MIN_SILENCE_SEC` |
-| `refine.padSec` | float | padding kept around kept spans | `silencetrim.DEFAULT_PAD_SEC` |
-| `refine.mergeGapMs` | int | filler-cut merge window (ms) | `fillers.DEFAULT_MERGE_GAP_MS` |
-| `refine.fillerSets` | dict | per-language filler-set override (incl. `ro`). **Threaded into `plan_refine(filler_sets=...)` via the service param `fillerSets`** — it changes the cut math (which words are removed), not just config. Absent → `fillers.DEFAULT_SETS`. | `fillers.DEFAULT_SETS` |
+| `captionSpeakerLabels` | bool | when on, subtitle generate prefixes each cue's text with the diarized speaker label (read at `handlers.py` subtitle-generate via `settings.get("captionSpeakerLabels")`; off → cues untouched) | new (mirrors the `captionPolish` flag) |
+
+**`refine.preview` / `refine.apply` call params** (per-call, NOT settings keys —
+sent in the RPC `params` payload, read by `refine.py`'s `_plan`; camelCase wire
+names, default-applied when the param is absent):
+
+| Param | Type | Meaning | Default applied |
+|---|---|---|---|
+| `noiseDb` | float | silence-detection threshold (dB) — `refine.py:295`, sent by `Refine.tsx` | `silencetrim.DEFAULT_NOISE_DB` |
+| `minSilenceSec` | float | minimum silent-span duration to cut — `refine.py:296`, sent by `Refine.tsx` | `silencetrim.DEFAULT_MIN_SILENCE_SEC` |
+| `mergeGapMs` | int | filler-cut merge window (ms) — `refine.py:306`, sent by `Refine.tsx` | `fillers.DEFAULT_MERGE_GAP_MS` |
+| `padSec` | float | padding kept around kept spans — `refine.py:307`. Default-only: read from `params` but NOT yet wired through the Refine panel, so in practice it takes the default unless a caller supplies it. | `silencetrim.DEFAULT_PAD_SEC` |
+| `fillerSets` | dict | per-language filler-set override (incl. `ro`). **Threaded into `plan_refine(filler_sets=...)`** (`refine.py:308`) — it changes the cut math (which words are removed), not just config. Not currently wired through the Refine panel; supplied directly in `params` when overriding. Absent → `fillers.DEFAULT_SETS`. | `fillers.DEFAULT_SETS` |
 
 **Workspace tab order (`WORKSPACE_TABS`, `app/renderer/src/views/Workspace.tsx`):**
 the **Refine** tab (`{ id: 'refine', label: 'Refine' }`) sits in the

--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -71,7 +71,7 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 - `shortmaker.select({videoId, prompt, controls})` -> `{jobId}` -> `{candidates}` ; controls = `{count,minSec,maxSec,aspect,language,captionStyle}`
 - `shortmaker.export({videoId, candidateIds})` -> `{jobId}` -> `{clips:[{path}]}`
 - `job.cancel({jobId})` -> `{ok}` ; `job.status({jobId})` -> `{status,pct}`
-- `settings.get()` / `settings.set({...})` -> includes `{useCloud:bool, cloudApiKey?, modelsDir, ffmpegPath}`
+- `settings.get()` / `settings.set({...})` -> includes `{useCloud:bool, cloudApiKey?, modelsDir, ffmpegPath}` (editing-refinement keys: see §A5)
 
 ## 3. Data schemas (Python TypedDict / TS interface — keep field names identical both sides)
 - **Word** `{text:str, start:float, end:float}` ; **Segment** `{start:float, end:float, text:str, words:[Word]}`
@@ -138,6 +138,19 @@ Scope: PLAN-P2.md v2.1 (gate-passed). Where this addendum extends §2/§3/§4/§
 - `job.list()` -> `{jobs:[JobInfo]}` ; `job.retry({jobId})` -> `{jobId}` (re-runs from stored request params)
 - `assets.list()` -> `{assets:[AssetInfo]}` ; `assets.ensure({names:[str]})` -> `{jobId}` (download/install w/ resume+preflight)
 
+## A3a. Editing-refinement schema additions (2026-06 — additive only; frozen fields unchanged)
+These extend base §3. They are **additive**: every previously-frozen field of `Cue`
+keeps its name and meaning — only an OPTIONAL field is added.
+- `Cue` gains OPTIONAL `speaker?: string` — the diarized speaker label carried onto a
+  cue (set on subtitle generate when the transcript was diarized and the
+  `captionSpeakerLabels` setting is on). Frozen `index/start/end/text` are unchanged.
+  Mirrors `DiarizedSegment = Segment & { speaker?: string }`.
+- `RefinePlan` (NEW, internal + wire payload for `refine.preview`/`refine.apply`):
+  `{ keeps: [[start:float, end:float], ...],
+     stats: { fillersRemoved:int, fillerSeconds:float, silenceRemovedSec:float, keptSec:float } }`.
+  `keeps` is the unified keep-list (filler keep-spans ∩ silence keep-spans); `stats`
+  is the typed savings block surfaced in the Refine panel.
+
 ## A3. Schema additions (field names FROZEN, both Python and TS)
 - `AudioTrack {id, lang, name, kind:"original"|"dub", voice?, path}` ; `Project.audioTracks:[AudioTrack]`
 - `JobInfo {jobId, feature, label, videoId?, status:"queued"|"running"|"done"|"error"|"cancelled", pct}`
@@ -157,6 +170,26 @@ Scope: PLAN-P2.md v2.1 (gate-passed). Where this addendum extends §2/§3/§4/§
   runs in its OWN downloaded env as a subprocess — torch stays OUT of the main sidecar env).
 - Dub alignment recipe (FROZEN): per-cue target duration -> rate re-synth -> ffmpeg atempo clamp ±15% -> pad; dub
   pipeline is BATCHED: translate ALL cues -> free MT -> synth ALL cues (never interleave model swaps).
+
+## A5. Editing-refinement settings keys + workspace tab (2026-06)
+Settings are read via `settings.get()` / `settings.set({...})` (base §2). The
+editing-refinement bundle adds the keys below (all OPTIONAL; absent → the cited
+engine default, so behaviour is unchanged when unset). Existing `removeFillers` /
+`silenceTrim` / `diarizeBackend` keep their shortmaker meaning unchanged.
+
+| Key | Type | Meaning | Default precedent |
+|---|---|---|---|
+| `captionSpeakerLabels` | bool | when on, subtitle generate prefixes each cue's text with the diarized speaker label (read at `handlers.py` subtitle-generate; off → cues untouched) | new (mirrors the `captionPolish` flag) |
+| `refine.noiseDb` | float | silence-detection threshold (dB) for `refine.preview`/`refine.apply` | `silencetrim.DEFAULT_NOISE_DB` |
+| `refine.minSilenceSec` | float | minimum silent-span duration to cut | `silencetrim.DEFAULT_MIN_SILENCE_SEC` |
+| `refine.padSec` | float | padding kept around kept spans | `silencetrim.DEFAULT_PAD_SEC` |
+| `refine.mergeGapMs` | int | filler-cut merge window (ms) | `fillers.DEFAULT_MERGE_GAP_MS` |
+| `refine.fillerSets` | dict | per-language filler-set override (incl. `ro`). **Threaded into `plan_refine(filler_sets=...)` via the service param `fillerSets`** — it changes the cut math (which words are removed), not just config. Absent → `fillers.DEFAULT_SETS`. | `fillers.DEFAULT_SETS` |
+
+**Workspace tab order (`WORKSPACE_TABS`, `app/renderer/src/views/Workspace.tsx`):**
+the **Refine** tab (`{ id: 'refine', label: 'Refine' }`) sits in the
+system-advanced group **directly after `diarize`** —
+`… subtitles, diarize, refine, tracks, convert …`.
 
 ## A6. Phase-0 hard lessons (NON-NEGOTIABLE for every agent)
 1. **Pre-import natives**: any NEW native module used inside a job (onnxruntime, mediapipe, soundfile, scenedetect,

--- a/app/renderer/src/features/Diarize.test.tsx
+++ b/app/renderer/src/features/Diarize.test.tsx
@@ -305,4 +305,232 @@ describe('<Diarize />', () => {
       delete (globalThis as { api?: unknown }).api;
     }
   });
+
+  // --- WU-7: per-speaker rename block ---------------------------------------
+  /** Set a controlled input's value via React's tracked native setter. */
+  function typeInto(input: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+    setter.call(input, value);
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+  }
+
+  /** Run a diarize so the roster is populated, then return the two-speaker fake. */
+  async function diarizeTwoSpeakers(): Promise<FakeApi> {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      (container.querySelector('button[data-action="diarize"]') as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-d',
+        result: {
+          transcript: {
+            language: 'en',
+            segments: [],
+            durationSec: 0,
+            speakers: ['SPEAKER_00', 'SPEAKER_01'],
+          },
+        },
+      });
+    });
+    return fake;
+  }
+
+  it('renders one rename input per speaker in the roster', async () => {
+    await diarizeTwoSpeakers();
+    const inputs = container.querySelectorAll('input[data-rename-for]');
+    expect(inputs.length).toBe(2);
+    expect(container.querySelector('input[data-rename-for="SPEAKER_00"]')).toBeTruthy();
+    expect(container.querySelector('input[data-rename-for="SPEAKER_01"]')).toBeTruthy();
+  });
+
+  it('does not render a rename block when the roster is empty', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(container.querySelector('[data-section="rename"]')).toBeNull();
+  });
+
+  it('renaming a speaker submits diarize.rename and refreshes the labels', async () => {
+    const fake = makeFakeApi();
+    // diarize.rename returns the renamed transcript directly (not a job).
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockImplementation(
+      async (method: string, params?: Record<string, unknown>) => {
+        fake.calls.push({ method, params });
+        if (method === 'diarize.start') return { jobId: 'job-d' };
+        if (method === 'diarize.rename') {
+          return {
+            transcript: {
+              language: 'en',
+              segments: [],
+              durationSec: 0,
+              speakers: ['Alex', 'SPEAKER_01'],
+            },
+          };
+        }
+        return {};
+      },
+    );
+    await mount(fake.api);
+    await act(async () => {
+      (container.querySelector('button[data-action="diarize"]') as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-d',
+        result: {
+          transcript: {
+            language: 'en',
+            segments: [],
+            durationSec: 0,
+            speakers: ['SPEAKER_00', 'SPEAKER_01'],
+          },
+        },
+      });
+    });
+
+    const input = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input, 'Alex');
+    });
+    const applyBtn = container.querySelector('button[data-action="rename"]') as HTMLButtonElement;
+    await act(async () => {
+      applyBtn.click();
+      await Promise.resolve();
+    });
+
+    expect(fake.calls.find((c) => c.method === 'diarize.rename')?.params).toEqual({
+      videoId: 'v1',
+      mapping: { SPEAKER_00: 'Alex' },
+    });
+    // The displayed roster now shows the renamed label.
+    expect(container.querySelector('li[data-speaker="Alex"]')).toBeTruthy();
+    expect(container.querySelector('li[data-speaker="SPEAKER_00"]')).toBeNull();
+  });
+
+  it('submits only the speakers whose names actually changed', async () => {
+    const fake = await diarizeTwoSpeakers();
+    // Edit one input back to its original label, edit the other to a new name.
+    const input1 = container.querySelector(
+      'input[data-rename-for="SPEAKER_01"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input1, 'Sam');
+    });
+    await act(async () => {
+      (container.querySelector('button[data-action="rename"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'diarize.rename')?.params).toEqual({
+      videoId: 'v1',
+      mapping: { SPEAKER_01: 'Sam' },
+    });
+  });
+
+  it('does not call diarize.rename when no name changed', async () => {
+    const fake = await diarizeTwoSpeakers();
+    await act(async () => {
+      (container.querySelector('button[data-action="rename"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'diarize.rename')).toBeUndefined();
+  });
+
+  it('treats a whitespace-only rename as unchanged (trim guard)', async () => {
+    const fake = await diarizeTwoSpeakers();
+    const input = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input, '   ');
+    });
+    await act(async () => {
+      (container.querySelector('button[data-action="rename"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'diarize.rename')).toBeUndefined();
+  });
+
+  it('surfaces a diarize.rename rejection', async () => {
+    const fake = await diarizeTwoSpeakers();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('rename failed'));
+    const input = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input, 'Alex');
+    });
+    await act(async () => {
+      (container.querySelector('button[data-action="rename"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('rename failed');
+  });
+
+  it('surfaces a non-Error diarize.rename rejection via String(err)', async () => {
+    const fake = await diarizeTwoSpeakers();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce('plain rename error');
+    const input = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input, 'Alex');
+    });
+    await act(async () => {
+      (container.querySelector('button[data-action="rename"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain rename error');
+  });
+
+  it('keeps existing labels when diarize.rename returns no roster', async () => {
+    const fake = await diarizeTwoSpeakers();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ transcript: {} });
+    const input = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input, 'Alex');
+    });
+    await act(async () => {
+      (container.querySelector('button[data-action="rename"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    // No roster came back -> labels unchanged, no error.
+    expect(container.querySelector('li[data-speaker="SPEAKER_00"]')).toBeTruthy();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('clears the draft inputs after a re-diarize repopulates the roster', async () => {
+    const fake = await diarizeTwoSpeakers();
+    const input = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      typeInto(input, 'Alex');
+    });
+    // Re-run diarize -> roster (and drafts) reset.
+    await act(async () => {
+      (container.querySelector('button[data-action="diarize"]') as HTMLButtonElement).click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-d',
+        result: {
+          transcript: {
+            language: 'en',
+            segments: [],
+            durationSec: 0,
+            speakers: ['SPEAKER_00', 'SPEAKER_01'],
+          },
+        },
+      });
+    });
+    const fresh = container.querySelector(
+      'input[data-rename-for="SPEAKER_00"]',
+    ) as HTMLInputElement;
+    expect(fresh.value).toBe('');
+  });
 });

--- a/app/renderer/src/features/Diarize.tsx
+++ b/app/renderer/src/features/Diarize.tsx
@@ -58,6 +58,9 @@ export function Diarize({ videoId, api }: DiarizeProps): React.ReactElement {
   const [message, setMessage] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [speakers, setSpeakers] = useState<string[]>([]);
+  // Per-speaker rename drafts ({SPEAKER_NN: typed-name}); reset whenever a new
+  // roster lands (run/re-run) so stale drafts never leak across diarizations.
+  const [drafts, setDrafts] = useState<Record<string, string>>({});
 
   useEffect(() => {
     if (!jobId) return;
@@ -77,6 +80,7 @@ export function Diarize({ videoId, api }: DiarizeProps): React.ReactElement {
     setBusy(true);
     setError('');
     setSpeakers([]);
+    setDrafts({});
     setPct(0);
     setMessage('Starting…');
     try {
@@ -112,6 +116,31 @@ export function Diarize({ videoId, api }: DiarizeProps): React.ReactElement {
     }
     setMessage('Cancelling…');
   }, [bridge, jobId]);
+
+  const applyRename = useCallback(async (): Promise<void> => {
+    // Build a {SPEAKER_NN: friendly} mapping from drafts that actually changed
+    // (trimmed, non-empty, different from the current label). A no-op submit
+    // sends nothing to the sidecar.
+    const mapping: Record<string, string> = {};
+    for (const speaker of speakers) {
+      const next = (drafts[speaker] ?? '').trim();
+      if (next && next !== speaker) {
+        mapping[speaker] = next;
+      }
+    }
+    if (Object.keys(mapping).length === 0) return;
+    setError('');
+    try {
+      const result = await bridge.rpc<unknown>('diarize.rename', { videoId, mapping });
+      const roster = extractSpeakers(result);
+      if (roster.length > 0) {
+        setSpeakers(roster);
+        setDrafts({});
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [bridge, videoId, speakers, drafts]);
 
   return (
     <section className="feature-panel diarize-panel" aria-label="Diarize">
@@ -161,6 +190,30 @@ export function Diarize({ videoId, api }: DiarizeProps): React.ReactElement {
               </li>
             ))}
           </ul>
+
+          <h3>Rename speakers</h3>
+          <div className="rename-block" data-section="rename">
+            {speakers.map((speaker) => (
+              <label key={speaker} className="rename-row">
+                <span className="rename-label">{speaker}</span>
+                <input
+                  type="text"
+                  data-rename-for={speaker}
+                  placeholder={speaker}
+                  value={drafts[speaker] ?? ''}
+                  onChange={(e) => setDrafts((prev) => ({ ...prev, [speaker]: e.target.value }))}
+                />
+              </label>
+            ))}
+            <button
+              type="button"
+              data-action="rename"
+              className="secondary"
+              onClick={() => void applyRename()}
+            >
+              Apply names
+            </button>
+          </div>
         </>
       )}
     </section>

--- a/app/renderer/src/features/Refine.test.tsx
+++ b/app/renderer/src/features/Refine.test.tsx
@@ -1,0 +1,452 @@
+// Refine.test.tsx — tests for the "Tighten the edit" panel (system-advanced).
+//
+// The panel drives the WU-5 RPCs:
+//   refine.preview({videoId, removeFillers, removeSilence, ...}) -> {plan}   (DIRECT)
+//   refine.apply({videoId, ...})  -> {jobId} -> job.done {path, removedSec, stats, plan}
+// preview is a fast/direct RPC (result on the rpc promise); apply is a job
+// (the terminal payload arrives via the job.done notification). A fake `api`
+// bridge is injected via the `api?` prop, mirroring Diarize.test.tsx.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import Refine, { extractPlan, applyResultPath } from './Refine';
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+const PLAN = {
+  keeps: [
+    [0, 2],
+    [2.4, 10],
+  ],
+  stats: { fillersRemoved: 1, fillerSeconds: 0.4, silenceRemovedSec: 2, keptSec: 7.6 },
+};
+
+function makeFakeApi(): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'refine.preview') return { plan: PLAN } as T;
+      if (method === 'refine.apply') return { jobId: 'job-r' } as T;
+      return {} as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+describe('extractPlan', () => {
+  it('pulls the plan from a preview result', () => {
+    expect(extractPlan({ plan: PLAN })).toEqual(PLAN);
+  });
+  it('null when absent or shapeless', () => {
+    expect(extractPlan({})).toBeNull();
+    expect(extractPlan(null)).toBeNull();
+    expect(extractPlan({ plan: { keeps: [], stats: null } })).toBeNull();
+  });
+});
+
+describe('applyResultPath', () => {
+  it('reads the result path', () => {
+    expect(applyResultPath({ path: '/out/clip.refined.mp4' })).toBe('/out/clip.refined.mp4');
+  });
+  it('null when missing', () => {
+    expect(applyResultPath({})).toBeNull();
+    expect(applyResultPath(null)).toBeNull();
+  });
+});
+
+describe('<Refine />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function mount(api: MediaStudioApi): Promise<void> {
+    await act(async () => {
+      root.render(<Refine videoId="v1" api={api} />);
+    });
+  }
+
+  async function clickPreview(): Promise<void> {
+    await act(async () => {
+      (container.querySelector('button[data-action="preview"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+  }
+
+  it('previews and renders the proposed saved-seconds + per-category stats', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    const call = fake.calls.find((c) => c.method === 'refine.preview');
+    expect(call?.params).toEqual({
+      videoId: 'v1',
+      removeFillers: true,
+      removeSilence: true,
+      noiseDb: -30,
+      minSilenceSec: 0.6,
+      mergeGapMs: 200,
+    });
+    const stats = container.querySelector('[data-section="stats"]');
+    expect(stats?.textContent).toContain('1'); // fillersRemoved
+    expect(container.querySelector('[data-stat="keptSec"]')?.textContent).toContain('7.6');
+    expect(container.querySelector('[data-stat="silenceRemovedSec"]')?.textContent).toContain('2');
+    // the keep/cut list renders one row per keep span
+    expect(container.querySelectorAll('[data-section="keeps"] li').length).toBe(2);
+  });
+
+  it('toggling "Remove silence" off re-issues preview with removeSilence:false', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const toggle = container.querySelector(
+      'input[data-toggle="removeSilence"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      toggle.click();
+      await Promise.resolve();
+    });
+    await clickPreview();
+    const call = fake.calls.find((c) => c.method === 'refine.preview');
+    expect(call?.params?.removeSilence).toBe(false);
+    expect(call?.params?.removeFillers).toBe(true);
+  });
+
+  it('toggling "Remove fillers" off threads removeFillers:false', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const toggle = container.querySelector(
+      'input[data-toggle="removeFillers"]',
+    ) as HTMLInputElement;
+    await act(async () => {
+      toggle.click();
+      await Promise.resolve();
+    });
+    await clickPreview();
+    expect(fake.calls.find((c) => c.method === 'refine.preview')?.params?.removeFillers).toBe(
+      false,
+    );
+  });
+
+  it('editing tunables (noiseDb/minSilenceSec/mergeGapMs) threads them into preview', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const setNum = (key: string, value: string): void => {
+      const input = container.querySelector(`input[data-tune="${key}"]`) as HTMLInputElement;
+      // React tracks the input value internally; the native setter + an input
+      // event is what makes a controlled <input> see a real change in jsdom.
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(input, value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+    };
+    await act(async () => {
+      setNum('noiseDb', '-24');
+      setNum('minSilenceSec', '0.9');
+      setNum('mergeGapMs', '350');
+      await Promise.resolve();
+    });
+    await clickPreview();
+    const params = fake.calls.find((c) => c.method === 'refine.preview')?.params;
+    expect(params?.noiseDb).toBe(-24);
+    expect(params?.minSilenceSec).toBe(0.9);
+    expect(params?.mergeGapMs).toBe(350);
+  });
+
+  it('surfaces a preview rpc rejection', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValue(new Error('preview boom'));
+    await mount(fake.api);
+    await clickPreview();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('preview boom');
+  });
+
+  it('surfaces a non-Error preview rejection via String(err)', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValue('plain preview error');
+    await mount(fake.api);
+    await clickPreview();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain preview error');
+  });
+
+  it('a null preview result shows no stats and no error (defensive ?? null)', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockResolvedValueOnce(null);
+    await mount(fake.api);
+    await clickPreview();
+    expect(container.querySelector('[data-section="stats"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('ignores a second preview click while busy (re-entrancy guard)', async () => {
+    const fake = makeFakeApi();
+    let release: (v: { plan: typeof PLAN }) => void = () => undefined;
+    const rpcMock = fake.api.rpc as ReturnType<typeof vi.fn>;
+    rpcMock.mockImplementationOnce(
+      () => new Promise((res) => (release = res as (v: { plan: typeof PLAN }) => void)),
+    );
+    await mount(fake.api);
+    const btn = container.querySelector('button[data-action="preview"]') as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+    });
+    expect(rpcMock.mock.calls.filter((c) => c[0] === 'refine.preview').length).toBe(1);
+    await act(async () => {
+      release({ plan: PLAN });
+      await Promise.resolve();
+    });
+  });
+
+  it('Apply dispatches refine.apply, processes progress, and shows the result path on done', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview(); // a plan must exist to apply
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'refine.apply')?.params).toMatchObject({
+      videoId: 'v1',
+      removeFillers: true,
+      removeSilence: true,
+    });
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-r', pct: 40, message: 're-cutting' });
+    });
+    expect(container.querySelector('.progress')?.textContent).toContain('40%');
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-r',
+        result: { path: '/out/v1.refined.mp4', removedSec: 2.4, stats: PLAN.stats, plan: PLAN },
+      });
+    });
+    expect(container.querySelector('[data-section="result"]')?.textContent).toContain(
+      '/out/v1.refined.mp4',
+    );
+  });
+
+  it('Apply surfaces a job.done error payload', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-r',
+        result: { error: { message: 'refine re-cut failed', type: 'InternalError' } },
+      });
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'refine re-cut failed',
+    );
+  });
+
+  it('Apply surfaces an rpc rejection', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('apply boom'));
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('apply boom');
+  });
+
+  it('Apply surfaces a non-Error rejection via String(err)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce('plain apply error');
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain apply error');
+  });
+
+  it('Apply with a null jobId stays idle of results (no job.done wait)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockResolvedValueOnce({}); // no jobId
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('Apply with a null result on done surfaces neither path nor error', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-r', result: undefined });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('ignores a second apply click while busy (re-entrancy guard)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    let release: (v: { jobId: string }) => void = () => undefined;
+    const rpcMock = fake.api.rpc as ReturnType<typeof vi.fn>;
+    rpcMock.mockImplementationOnce(
+      () => new Promise((res) => (release = res as (v: { jobId: string }) => void)),
+    );
+    const btn = container.querySelector('button[data-action="apply"]') as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+    });
+    expect(rpcMock.mock.calls.filter((c) => c[0] === 'refine.apply').length).toBe(1);
+    await act(async () => {
+      release({ jobId: 'job-r' });
+      await Promise.resolve();
+    });
+  });
+
+  it('Apply is disabled until a preview plan exists', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const apply = container.querySelector('button[data-action="apply"]') as HTMLButtonElement;
+    expect(apply.disabled).toBe(true);
+    await clickPreview();
+    expect(
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it('cancel calls job.cancel for the active apply job and shows Cancelling…', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    const cancelBtn = container.querySelector('button[data-action="cancel"]') as HTMLButtonElement;
+    expect(cancelBtn).toBeTruthy();
+    await act(async () => {
+      cancelBtn.click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'job.cancel')?.params).toEqual({ jobId: 'job-r' });
+    expect(container.querySelector('.progress-message')?.textContent).toContain('Cancelling…');
+  });
+
+  it('cancel swallows a job.cancel rejection (best-effort)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('already done'));
+    const cancelBtn = container.querySelector('button[data-action="cancel"]') as HTMLButtonElement;
+    await act(async () => {
+      cancelBtn.click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('ignores progress notifications for a different job', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickPreview();
+    await act(async () => {
+      (container.querySelector('button[data-action="apply"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-r', pct: 30, message: 'mine' });
+    });
+    await act(async () => {
+      fake.fireProgress({ jobId: 'other', pct: 99, message: 'not mine' });
+    });
+    expect(container.querySelector('.progress')?.textContent).not.toContain('99%');
+    expect(container.querySelector('.progress')?.textContent).toContain('30%');
+  });
+
+  it('falls back to the global window.api bridge when no api prop is given', async () => {
+    const fake = makeFakeApi();
+    (globalThis as { api?: unknown }).api = fake.api;
+    try {
+      await act(async () => {
+        root.render(<Refine videoId="v1" />);
+      });
+      await act(async () => {
+        (container.querySelector('button[data-action="preview"]') as HTMLButtonElement).click();
+        await Promise.resolve();
+      });
+      expect(fake.calls.find((c) => c.method === 'refine.preview')?.params).toMatchObject({
+        videoId: 'v1',
+      });
+    } finally {
+      delete (globalThis as { api?: unknown }).api;
+    }
+  });
+});

--- a/app/renderer/src/features/Refine.tsx
+++ b/app/renderer/src/features/Refine.tsx
@@ -1,0 +1,307 @@
+// Refine feature panel (system-advanced group) — "Tighten the edit".
+//
+// Descript-style "see before you cut": preview the proposed filler + silence
+// removal (a NON-destructive cut-list with saved-seconds + per-category stats),
+// tune the knobs, then Apply to write a NEW *.refined.mp4 (the original is never
+// touched). Drives the WU-5 RPCs over the FROZEN window.api bridge:
+//   refine.preview({videoId, removeFillers, removeSilence, noiseDb,
+//                   minSilenceSec, mergeGapMs}) -> {plan}              (DIRECT)
+//   refine.apply({...same...}) -> {jobId} -> job.done {path, removedSec, stats}
+// preview is a fast/direct RPC (the plan resolves on the rpc promise); apply is
+// a long job whose terminal payload arrives via the job.done notification, so we
+// subscribe through `waitForJobDone`. Same shape as Diarize.tsx (getApi /
+// bridge.rpc / waitForJobDone / onProgress / injectable `api?` prop for tests).
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import './panels.css';
+import { fmtSeconds, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+
+// The pure refine plan (CONTRACTS.md §3 / refine.py RefinePlan): a union keep-list
+// over original-video seconds + de-duplicated per-category stats.
+export interface RefineStats {
+  fillersRemoved: number;
+  fillerSeconds: number;
+  silenceRemovedSec: number;
+  keptSec: number;
+}
+export interface RefinePlan {
+  keeps: number[][];
+  stats: RefineStats;
+}
+
+// --- pure helpers (exported for tests) -------------------------------------
+/** The plan from a `refine.preview` result (null when absent/shapeless). */
+export function extractPlan(result: unknown): RefinePlan | null {
+  const plan = pickField<RefinePlan>(result, 'plan');
+  if (plan && Array.isArray(plan.keeps) && plan.stats && typeof plan.stats === 'object') {
+    return plan;
+  }
+  return null;
+}
+
+/** The output path from a `refine.apply` job.done result (null when missing). */
+export function applyResultPath(result: unknown): string | null {
+  const path = pickField<string>(result, 'path');
+  return typeof path === 'string' ? path : null;
+}
+
+/** Pull the §A3 job.done error payload message ({error:{message,type}}). */
+function doneErrorMessage(result: unknown): string | null {
+  const err = pickField<{ message?: unknown }>(result, 'error');
+  if (err && typeof err === 'object' && typeof err.message === 'string') {
+    return err.message;
+  }
+  return null;
+}
+
+export interface RefineProps {
+  videoId: string;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+
+export function Refine({ videoId, api }: RefineProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  const [removeFillers, setRemoveFillers] = useState<boolean>(true);
+  const [removeSilence, setRemoveSilence] = useState<boolean>(true);
+  const [noiseDb, setNoiseDb] = useState<number>(-30);
+  const [minSilenceSec, setMinSilenceSec] = useState<number>(0.6);
+  const [mergeGapMs, setMergeGapMs] = useState<number>(200);
+
+  const [previewing, setPreviewing] = useState<boolean>(false);
+  const [applying, setApplying] = useState<boolean>(false);
+  const [plan, setPlan] = useState<RefinePlan | null>(null);
+  const [resultPath, setResultPath] = useState<string>('');
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  const params = useMemo(
+    () => ({ videoId, removeFillers, removeSilence, noiseDb, minSilenceSec, mergeGapMs }),
+    [videoId, removeFillers, removeSilence, noiseDb, minSilenceSec, mergeGapMs],
+  );
+
+  const preview = useCallback(async (): Promise<void> => {
+    // defensive: the button is disabled while previewing, so the UI cannot
+    // dispatch a second preview in flight.
+    /* v8 ignore next */
+    if (previewing) return;
+    setPreviewing(true);
+    setError('');
+    setResultPath('');
+    try {
+      const res = await bridge.rpc<unknown>('refine.preview', { ...params });
+      setPlan(extractPlan(res ?? null));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setPreviewing(false);
+    }
+  }, [bridge, params, previewing]);
+
+  const apply = useCallback(async (): Promise<void> => {
+    // defensive: Apply is disabled until a plan exists and while a job runs.
+    /* v8 ignore next */
+    if (applying || !plan) return;
+    setApplying(true);
+    setError('');
+    setResultPath('');
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      const res = await bridge.rpc<{ jobId: string }>('refine.apply', { ...params });
+      const id = res?.jobId ?? null;
+      setJobId(id);
+      const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
+      const errMessage = doneErrorMessage(result);
+      if (errMessage) {
+        setError(errMessage);
+      } else {
+        const path = applyResultPath(result);
+        if (path) {
+          setResultPath(path);
+          setPct(100);
+          setMessage('Done');
+        }
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+      setJobId(null);
+    }
+  }, [bridge, params, applying, plan]);
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // defensive: Cancel renders only while `applying && jobId`.
+    /* v8 ignore next */
+    if (!jobId) return;
+    try {
+      await bridge.rpc('job.cancel', { jobId });
+    } catch {
+      // Best-effort.
+    }
+    setMessage('Cancelling…');
+  }, [bridge, jobId]);
+
+  const stats = plan?.stats;
+
+  return (
+    <section className="feature-panel refine-panel" aria-label="Refine">
+      <h2>Tighten the Edit</h2>
+      <p className="assets-intro">
+        Preview the dead air and filler words this will cut — token-free and fully local. Nothing is
+        changed until you Apply; the result is written to a new file.
+      </p>
+
+      <div className="field">
+        <label className="checkbox-field">
+          <input
+            type="checkbox"
+            data-toggle="removeFillers"
+            checked={removeFillers}
+            onChange={(e) => setRemoveFillers(e.target.checked)}
+          />
+          Remove fillers
+        </label>
+        <label className="checkbox-field">
+          <input
+            type="checkbox"
+            data-toggle="removeSilence"
+            checked={removeSilence}
+            onChange={(e) => setRemoveSilence(e.target.checked)}
+          />
+          Remove silence
+        </label>
+      </div>
+
+      <div className="field">
+        <label>
+          Noise floor (dB)
+          <input
+            type="number"
+            data-tune="noiseDb"
+            value={noiseDb}
+            onChange={(e) => setNoiseDb(Number(e.target.value))}
+          />
+        </label>
+        <label>
+          Min silence (s)
+          <input
+            type="number"
+            step="0.1"
+            data-tune="minSilenceSec"
+            value={minSilenceSec}
+            onChange={(e) => setMinSilenceSec(Number(e.target.value))}
+          />
+        </label>
+        <label>
+          Merge gap (ms)
+          <input
+            type="number"
+            data-tune="mergeGapMs"
+            value={mergeGapMs}
+            onChange={(e) => setMergeGapMs(Number(e.target.value))}
+          />
+        </label>
+      </div>
+
+      <div className="actions">
+        <button
+          type="button"
+          data-action="preview"
+          onClick={() => void preview()}
+          disabled={previewing}
+        >
+          {previewing ? 'Previewing…' : 'Preview cut'}
+        </button>
+        <button
+          type="button"
+          data-action="apply"
+          onClick={() => void apply()}
+          disabled={applying || !plan}
+        >
+          {applying ? 'Applying…' : 'Apply'}
+        </button>
+        {applying && jobId && (
+          <button
+            type="button"
+            data-action="cancel"
+            className="secondary"
+            onClick={() => void cancel()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {applying && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          {message && <span className="progress-message"> · {message}</span>}
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {stats && (
+        <>
+          <dl className="refine-stats" data-section="stats">
+            <div>
+              <dt>Saved</dt>
+              <dd data-stat="savedSec">
+                {fmtSeconds(Math.max(0, stats.silenceRemovedSec + stats.fillerSeconds))}
+              </dd>
+            </div>
+            <div>
+              <dt>Fillers removed</dt>
+              <dd data-stat="fillersRemoved">{stats.fillersRemoved}</dd>
+            </div>
+            <div>
+              <dt>Silence removed (s)</dt>
+              <dd data-stat="silenceRemovedSec">{stats.silenceRemovedSec}</dd>
+            </div>
+            <div>
+              <dt>Kept (s)</dt>
+              <dd data-stat="keptSec">{stats.keptSec}</dd>
+            </div>
+          </dl>
+
+          <h3>Keep ({plan.keeps.length} segments)</h3>
+          <ul className="keep-list" data-section="keeps">
+            {plan.keeps.map(([start, end]) => (
+              <li key={`${start}-${end}`} className="keep-row">
+                {fmtSeconds(start)} → {fmtSeconds(end)}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {resultPath && (
+        <div className="output-done" data-section="result">
+          <span className="output-done-label">Refined file</span>
+          <code>{resultPath}</code>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default Refine;

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -62,6 +62,7 @@ vi.mock('../features/Dub', () => stubPanel('Dub'));
 vi.mock('../features/Assets', () => stubPanel('Assets'));
 vi.mock('../features/NleExport', () => stubPanel('NleExport'));
 vi.mock('../features/Diarize', () => stubPanel('Diarize'));
+vi.mock('../features/Refine', () => stubPanel('Refine'));
 vi.mock('../features/Recipes', () => stubPanel('Recipes'));
 
 import { Workspace, WORKSPACE_TABS } from './Workspace';
@@ -124,6 +125,7 @@ describe('Workspace', () => {
       'Transcribe',
       'Subtitles',
       'Diarize',
+      'Refine',
       'Tracks',
       'Convert',
       'Short-maker',
@@ -230,6 +232,7 @@ describe('Workspace', () => {
     ['transcribe', 'Transcribe'],
     ['subtitles', 'Subtitles'],
     ['diarize', 'Diarize'],
+    ['refine', 'Refine'],
     ['tracks', 'Tracks'],
     ['convert', 'Convert'],
     ['shortmaker', 'ShortMaker'],

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -28,14 +28,16 @@ const Dub = lazy(() => import('../features/Dub'));
 const Assets = lazy(() => import('../features/Assets'));
 // captions-export: EDL/CSV NLE timeline export of approved clips.
 const NleExport = lazy(() => import('../features/NleExport'));
-// system-advanced group: per-video Diarize + Recipes panels.
+// system-advanced group: per-video Diarize + Refine + Recipes panels.
 const Diarize = lazy(() => import('../features/Diarize'));
+const Refine = lazy(() => import('../features/Refine'));
 const Recipes = lazy(() => import('../features/Recipes'));
 
 export const WORKSPACE_TABS: TabDef[] = [
   { id: 'transcribe', label: 'Transcribe' },
   { id: 'subtitles', label: 'Subtitles' },
   { id: 'diarize', label: 'Diarize' },
+  { id: 'refine', label: 'Refine' },
   { id: 'tracks', label: 'Tracks' },
   { id: 'convert', label: 'Convert' },
   { id: 'shortmaker', label: 'Short-maker' },
@@ -125,6 +127,8 @@ export function Workspace({ video, onBack }: WorkspaceProps): React.ReactElement
         return <Subtitles videoId={video.id} initialTrack={tracks[0] ?? null} />;
       case 'diarize':
         return <Diarize videoId={video.id} />;
+      case 'refine':
+        return <Refine videoId={video.id} />;
       case 'tracks':
         return <Tracks videoId={video.id} availableTracks={tracks} />;
       case 'convert':

--- a/docs/plans/editing-refine/DESIGN.md
+++ b/docs/plans/editing-refine/DESIGN.md
@@ -1,0 +1,326 @@
+# Editing-Refinement Bundle — DESIGN
+
+**Status:** DESIGN (docs only; no feature code). Must pass design-review + plan gates before BUILD.
+**Branch:** `feat/editing-refine-design` (off `origin/main`).
+**Scope:** (A) filler-word + silence detection/removal as a *tightenable, reversible* edit (Descript-style "tighten the edit"); (B) speaker diarization labels surfaced into the *transcript + captions*.
+**Date:** 2026-06-18.
+
+> RAILS: every claim below cites real code in this repo. Where a capability does
+> not exist, it is named explicitly as a GAP. All paths are relative to repo root;
+> sidecar paths are under `sidecar/media_studio/`.
+
+---
+
+## 0. Headline finding (ground truth, read before anything else)
+
+**Most of the heavy lifting for this bundle is already shipped.** The engines exist
+and are tested; the bundle's real work is a thin **editability + surfacing layer**,
+plus closing two concrete seam gaps. Do NOT re-build the engines.
+
+Already shipped (cited):
+
+| Capability | Module | Wire surface today |
+|---|---|---|
+| Filler-word cut-list math + frame-accurate concat argv + cue remap | `features/fillers.py` (`build_cutlist_with_stats` L201, `build_segment_cut_argv` L351, `remap_cues` L324) | **None standalone** — only consumed inside the batch shortmaker (`features/shortmaker.py:225-236`, gated by `settings["removeFillers"]` at `shortmaker.py:908`) |
+| Silence / dead-air detection + invert-to-keeps + re-cut | `features/silencetrim.py` (`detect_silence_spans` L159, `keep_spans` L107, `trim_clip` L199) | `silence.trim` RPC (`silencetrim.py:360`; registered `handlers.py:2176`) + shortmaker pre-step (`shortmaker.py:882`) |
+| Speaker diarization (token-free local: SpeechBrain VAD→ECAPA→greedy cosine cluster) | `features/diarize.py` (`diarize_transcript` L179, `greedy_cluster` L92, `assign_speakers_to_segments` L134) + backend `diarize_backend.py`; pyannote alt backend `pyannote_backend.py` | `diarize.start` RPC (`diarize.py:399`; registered `handlers.py:2219`, backend selectable via `settings["diarizeBackend"]` per `handlers.py:1080-1108`). Renderer panel exists: `app/renderer/src/features/Diarize.tsx` |
+
+The **two real gaps** this bundle must close:
+
+1. **Filler removal has no standalone, previewable, reversible RPC.** It only runs
+   buried in the shortmaker batch pipeline as a boolean flag. There is no way to
+   *see the proposed filler cuts*, tune them, or apply them to an arbitrary clip —
+   the Descript "tighten the edit" experience.
+2. **Diarization output never reaches captions.** `diarize.start` stamps a
+   `speaker` field on every transcript segment (`diarize.py:170`), but
+   `subtitles.cues_from_transcript` (`subtitles.py:125-149`) **never reads
+   `seg["speaker"]`**, and `subtitles.reindex` (`subtitles.py:107-119`) copies
+   ONLY `index/start/end/text` — so the speaker label is silently dropped on the
+   way to cues/SRT/ASS/VTT. Speakers are diarized but invisible in the output.
+
+This DESIGN therefore is mostly **wiring + UX + gap-closing**, riding the shipped
+substrate, not net-new engines.
+
+---
+
+## 1. User value & MVP cut
+
+### User value
+- **Tighten the edit (Descript-style):** one action removes "um/uh/like" fillers
+  and long dead-air from a clip, shows you *what it will cut and how many seconds
+  it saves before committing*, and keeps captions in sync. Reversible.
+- **Know who's talking:** the transcript and the burned/soft captions show speaker
+  labels ("SPEAKER_00:" or a renamed "Alex:") so multi-speaker footage reads
+  clearly.
+
+### MVP cut (smallest shippable slice that delivers the value)
+- **A1. `refine.preview`** — a *dry-run* RPC: given a `videoId|path` + the project
+  transcript's word timings, return the proposed **keep-spans + per-category
+  stats** (`fillersRemoved`, `fillerSeconds`, `silenceRemovedSec`) WITHOUT
+  re-encoding. Pure reuse of `fillers.build_cutlist_with_stats` +
+  `silencetrim.detect_silence_spans`/`keep_spans`. This is the "see it before you
+  cut" half.
+- **A2. `refine.apply`** — apply the (possibly user-tuned) keep-spans to a clip via
+  `fillers.build_segment_cut_argv` → a job → `{path, removedSec, stats}`. Writes a
+  NEW output file (original untouched). Re-times any caption cues via
+  `fillers.remap_cues`.
+- **B1. Speaker→cue plumbing** — make `subtitles.cues_from_transcript` carry the
+  segment's `speaker` onto each cue (additive field), and have `reindex` preserve
+  it. Optional speaker *prefix* in rendered text (`"SPEAKER_00: …"`), gated by a
+  setting.
+- **B2. `diarize.rename`** — map raw `SPEAKER_NN` → friendly names on the persisted
+  transcript (e.g. `{ "SPEAKER_00": "Alex" }`), so labels are human.
+- **UI:** one **Refine** renderer panel (preview list + per-category toggles +
+  Apply) and a speaker-rename affordance on the existing `Diarize.tsx` panel.
+
+**Explicitly OUT of MVP (deferred):** waveform/transcript scrubbing UI, click-to-delete
+individual words on a timeline, per-speaker color theming in burned captions,
+multi-clip batch refine UI (the shortmaker already does batch). These are listed
+in §7.
+
+---
+
+## 2. Architecture — reuse vs NEW
+
+### Reuse (no change to engine logic)
+- `features/fillers.py` — `build_cutlist_with_stats`, `build_segment_cut_argv`,
+  `remap_cues`, `remap_time`. Already the exact "tighten" math. (L201/L351/L324/L305)
+- `features/silencetrim.py` — `detect_silence_spans`, `keep_spans`,
+  `removed_seconds`, `trim_clip`. (L159/L107/L150/L199)
+- `features/diarize.py` — `diarize_transcript`, `roster`, `speaker_label`,
+  `assign_speakers_to_segments`. (L179/L174/L129/L134)
+- `ffmpeg.py` resolver + drained `run` seam (used by `build_segment_cut_argv` at
+  `fillers.py:367` and `silencetrim.trim_clip:244-245`).
+- `jobs.py` `JobContext` (progress/cancel) — diarize/silence already use it; refine
+  jobs follow the identical pattern (`silencetrim.py:309-330`).
+- Project/transcript store seams: `_load_or_create_project` / `project.save()` as in
+  `handlers.subtitles_generate` (`handlers.py:730-744`) and diarize's
+  `load_project`/`save_project` seams (`diarize.py:311-313`).
+- **AI-Job envelope** (`models/ai_job.py`) — used ONLY for the optional AI-assisted
+  parts (see §5); the core filler/silence/diarize paths are 100% local and need NO
+  envelope.
+
+### NEW components (small, all behind seams, all unit-testable to 100%)
+- **`features/refine.py`** (NEW, pure + a service) — the unifying "tighten the
+  edit" feature:
+  - `plan_refine(words, lang, total_sec, silences, *, remove_fillers, remove_silence, merge_gap_ms, pad_sec) -> RefinePlan` — **pure**: intersect/union the filler keep-spans (`fillers.build_cutlist`) with the silence keep-spans (`silencetrim.keep_spans`) into ONE keep-list + a typed stats block. No subprocess, no model. Fully testable with hand-built words + fake silence spans.
+  - `RefineService.preview(params, ctx)` — resolve clip + transcript, run
+    `silencetrim.detect_silence_spans` (injected `run` seam) + `plan_refine`,
+    return the plan (NO encode). Reuses the silencetrim detection seam verbatim.
+  - `RefineService.apply(params, ctx)` — take a plan (or recompute), run
+    `fillers.build_segment_cut_argv` through `ffmpeg.run` as a job, remap caption
+    cues, return `{path, removedSec, stats}`. New output file; original kept.
+  - `register(...)` mirroring `silencetrim.register` (`silencetrim.py:336-362`).
+- **Subtitles speaker carry** — *edit existing* `subtitles.py`:
+  `cues_from_transcript` reads `seg.get("speaker")` and sets it on each cue;
+  `make_cue`/`reindex` preserve an optional `speaker` key; a new
+  `format_speaker_prefix(cues, *, on)` helper prefixes text when the setting is on.
+  Additive — the frozen §3 Cue keeps `index/start/end/text`; `speaker` is an
+  optional extra field (mirrors how `DiarizedSegment` extends `Segment` in
+  `Diarize.tsx:19`).
+- **`diarize.rename`** — small pure mapping helper in `diarize.py`
+  (`rename_speakers(transcript, mapping) -> transcript`, immutable like
+  `assign_speakers_to_segments`) + a direct-return RPC handler.
+- **Renderer:** `app/renderer/src/features/Refine.tsx` (NEW) + a speaker-rename
+  block added to `Diarize.tsx`. Both consume the FROZEN `window.api` bridge via the
+  shared `./_api` helpers (same pattern as `Diarize.tsx:14`).
+
+### Why a unifying `refine.py` instead of two RPCs
+Filler removal and silence removal both compile to the SAME `build_segment_cut_argv`
+keep-list concat. Doing them in one pass (one re-encode, one cue-remap) avoids a
+double-encode and a double cue-remap mismatch. `silence.trim` stays as-is for
+back-compat; `refine.*` is the new previewable/combined surface. The shortmaker
+keeps its existing inlined path (`shortmaker.py:882-913`) unchanged.
+
+---
+
+## 3. RPC surface (new `*.*` handlers in `register_all`)
+
+Registered in `handlers.register_all` (`handlers.py:1982`) following the exact
+module-owns-its-`register()` idiom used at `handlers.py:2176` (silencetrim) and
+`handlers.py:2219` (diarize). Naming follows CONTRACTS.md §2 dotted convention
+(`subtitles.generate`, `silence.trim`, `diarize.start`).
+
+| New RPC | Shape | Kind | Reuses |
+|---|---|---|---|
+| `refine.preview` | `{videoId|path, removeFillers?, removeSilence?, lang?, mergeGapMs?, noiseDb?, minSilenceSec?, padSec?}` → `{plan:{keeps,stats:{fillersRemoved,fillerSeconds,silenceRemovedSec,keptSec}}}` | direct (detection only; no encode) | `silencetrim.detect_silence_spans`, `fillers.build_cutlist_with_stats`, NEW `refine.plan_refine` |
+| `refine.apply` | `{videoId|path, keeps?|(removeFillers,removeSilence...), cues?}` → `{jobId}` → `{path, removedSec, stats, cues?}` | job | `fillers.build_segment_cut_argv`, `ffmpeg.run`, `fillers.remap_cues` |
+| `diarize.rename` | `{videoId, mapping:{SPEAKER_NN: name}}` → `{transcript}` | direct | NEW `diarize.rename_speakers` (pure, immutable) + project store |
+
+Edited existing RPCs (behavior additive, contract-safe):
+- `subtitles.generate` (`handlers.py:722`) — cues now carry `speaker` when the
+  transcript was diarized; rendered prefix gated by `settings["captionSpeakerLabels"]`.
+  No change to the `{track}` return shape.
+
+`silence.trim` (`silence.trim`, `silencetrim.py:360`) and `diarize.start`
+(`diarize.py:399`) are unchanged.
+
+### Renderer surface
+- `Refine.tsx` (NEW feature panel): "Tighten the edit" — calls `refine.preview`,
+  renders the keep/cut list + saved-seconds, exposes **Remove fillers** /
+  **Remove silence** toggles + the tunables (noiseDb, minSilenceSec, mergeGapMs),
+  then **Apply** → `refine.apply` job with progress (same job-progress pattern as
+  `Diarize.tsx:62-101`). Original-vs-result both surfaced.
+- `Diarize.tsx`: add a per-speaker rename row (text input per `SPEAKER_NN`) →
+  `diarize.rename` → refresh roster. Existing run/cancel/progress untouched.
+- Both wire through `getApi()`/`bridge.rpc`/`waitForJobDone` from `features/_api.ts`
+  (the frozen bridge, `Diarize.tsx:14`). New strings localize via existing i18n if
+  present; otherwise inline (match current panels).
+
+---
+
+## 4. Data / storage & settings keys
+
+### Data shapes (all additive to CONTRACTS.md §3)
+- **Cue** gains an OPTIONAL `speaker?: string`. Frozen `index/start/end/text` stay.
+  Mirrors `DiarizedSegment = Segment & { speaker?: string }` already shipped in
+  `Diarize.tsx:19`.
+- **RefinePlan** (NEW, internal+wire): `{ keeps: [[start,end],...],
+  stats: { fillersRemoved:int, fillerSeconds:float, silenceRemovedSec:float,
+  keptSec:float } }`. Mirrors the existing per-clip stats
+  `{fillersRemoved, fillerSeconds}` (`shortmaker.py:1032-1034`) + the silence
+  `removedSec` (`silencetrim.py:327`).
+- **Transcript** already carries `speaker` per segment + a `speakers` roster
+  (`diarize.py:194-198`). `diarize.rename` rewrites both, persisted via the
+  project store.
+
+### Storage
+- Refine outputs go to the same per-job out_dir convention as silencetrim
+  (`silencetrim.py:312-314`: `out_dir / f"{stem}.trimmed.mp4"`) — refine uses e.g.
+  `{stem}.refined.mp4`. **Original is never overwritten** (reversibility).
+- Renamed speakers persist onto the project transcript (same `save_project` seam
+  diarize already uses, `diarize.py:311-313`).
+
+### Settings keys (read via `settings_store` / `self.settings.get()`)
+| Key | Type | Meaning | Existing precedent |
+|---|---|---|---|
+| `captionSpeakerLabels` | bool | prefix cue text with the speaker label on generate/burn | new (mirrors `captionPolish` flag, `handlers.py:738`) |
+| `refine.noiseDb` / `refine.minSilenceSec` / `refine.padSec` | float | silence tunables | reuse `silencetrim` defaults (`silencetrim.py:57-60`) |
+| `refine.mergeGapMs` | int | filler merge window | `fillers.DEFAULT_MERGE_GAP_MS` (`fillers.py:44`) |
+| `refine.fillerSets` | dict | per-language filler sets override (incl. `ro`) | `fillers.DEFAULT_SETS` (`fillers.py:60`) |
+
+Existing `removeFillers` / `silenceTrim` / `diarizeBackend` settings keep their
+shortmaker meaning unchanged.
+
+---
+
+## 5. Reversibility / safety + (AI parts) consent/budget via the Hub envelope
+
+### Reversibility & safety (core paths are local + non-destructive)
+- **No in-place destruction:** `refine.apply` always writes a NEW file; original
+  preserved (matches `silencetrim.trim_clip` pass-through when nothing to cut,
+  `silencetrim.py:240-242`).
+- **Pure preview:** `refine.preview` runs detection only — zero encode, zero file
+  write — so the user always reviews before committing (the Descript "confirm"
+  requirement).
+- **Word-boundary safety:** filler cuts already land exactly on word
+  start/end and never splice sentence boundaries (`fillers.py:14-17`, `_SENTENCE_END`
+  guard L168-171). Silence keeps leave `pad_sec` so speech isn't clipped
+  (`silencetrim.py:130-135`). Reused verbatim — no new cut math.
+- **Caption sync preserved:** `fillers.remap_cues` re-times cues onto the
+  compressed timeline and drops cues that collapsed into a cut (`fillers.py:324-345`).
+- **Diarize rename is immutable:** new transcript dict, never mutates input
+  (matches `assign_speakers_to_segments`, `diarize.py:170`).
+- **Detection failures fail-soft:** a probe miss returns "keep everything"
+  (`silencetrim.py:189-193`, `225-227`) — refine inherits this; a detection miss
+  never deletes content.
+
+### AI parts (and their Hub envelope)
+The **MVP filler/silence/diarize paths use NO cloud AI** — diarization is
+token-free local (`diarize.py:1-13`), filler/silence are pure ffmpeg math. So the
+core bundle needs **no budget/consent gate** (no egress).
+
+The ONE optional AI touchpoint is the **deferred (post-MVP)** "smart filler/refine"
+that asks an LLM to judge borderline disfluencies or to clean caption text after a
+tighten. IF/when built, it MUST ride the shipped Hub substrate exactly:
+- Build `AiInputs` and call `plan_ai_job` (`models/ai_job.py:204`) to get the
+  envelope `{route, costEst, cacheKey, willEgress}` (`ai_job.py:95-108`) — surfaced
+  to the user via `ai.planJob` for cost-preview + consent BEFORE any egress.
+- Run via `run_ai_job` (`ai_job.py:264`) which checks the **cache first**
+  (`ai_job.py:19-20`), enforces the **budget degrade chain**, and only egresses
+  when `willEgress` is true (`ai_job.py:57-58`). Rotation/provider selection comes
+  from `models/provider.py` (the rotation pool) — never a hand-rolled provider call.
+- This mirrors how `handlers._run_ai_job` (`handlers.py:1617-1650`) already gates
+  AI jobs behind `plan_ai_job_envelope` (`handlers.py:1601-1610`).
+
+No new consent/budget machinery is invented; the Hub envelope is the single AI
+gate, used only if/when the optional AI assist lands.
+
+---
+
+## 6. Explicit capability gaps (named, not hidden)
+
+1. **No standalone filler RPC today** — filler removal is locked inside the
+   shortmaker batch (`shortmaker.py:908-913`). GAP closed by `refine.*` (§3).
+2. **Speaker label is dropped before captions** — `cues_from_transcript`
+   (`subtitles.py:125`) ignores `seg["speaker"]` and `reindex` (`subtitles.py:107`)
+   strips it. GAP closed by §2 "Subtitles speaker carry".
+3. **No speaker rename** — diarization only emits raw `SPEAKER_NN`
+   (`diarize.speaker_label`, `diarize.py:129`); there is no human-name mapping.
+   GAP closed by `diarize.rename` (§3).
+4. **No interactive word/waveform editor** — there is no transcript-scrub or
+   click-a-word-to-cut surface anywhere in `app/renderer/src` (only
+   `CaptionOverlay.tsx`, `Diarize.tsx`, `Subtitles.tsx` exist). MVP delivers a
+   *span/stat preview list*, NOT a word-level timeline editor. True Descript word
+   editing is DEFERRED (§7) and is a large net-new UI.
+5. **Diarization accuracy is heuristic** — greedy cosine clustering with a fixed
+   threshold (`diarize.greedy_cluster`, `diarize.py:92`, `DEFAULT_THRESHOLD=0.5`
+   L51); it does not handle overlapping speech or re-merge over-split speakers.
+   pyannote backend (`pyannote_backend.py`) is the better-accuracy alt but is a
+   gated heavy asset. No change in this bundle — documented limitation.
+6. **Filler sets are language-limited** — only `en` + `ro` basics shipped
+   (`fillers.DEFAULT_SETS`, `fillers.py:60-86`); other languages fall back to `en`
+   (`fillers._lang_sets`, `fillers.py:94-103`). Overridable via `refine.fillerSets`
+   but not auto-expanded.
+7. **Silence detection is amplitude-only** — ffmpeg `silencedetect`
+   (`silencetrim.detect_silence_spans:159`); it cannot distinguish "intentional
+   dramatic pause" from "dead air" beyond the dB/duration thresholds. User-tunable,
+   not semantic.
+8. **No per-speaker caption styling** — even after B1, burned captions get a text
+   prefix only; per-speaker color/position theming in `caption.py`/`caption_remotion.py`
+   is NOT in scope (§7).
+
+---
+
+## 7. Deferred / future (out of this bundle)
+- Word-level transcript-scrub editor (click word → cut), waveform UI.
+- Per-speaker caption color/position theming.
+- Auto language expansion for filler sets (LLM-suggested per-language disfluencies).
+- "Smart refine" LLM judgement of borderline fillers / post-cut caption cleanup
+  (would ride the §5 Hub envelope).
+- Multi-clip batch refine UI (shortmaker already batches via settings flags).
+- Overlapping-speaker diarization / speaker re-merge.
+
+---
+
+## 8. Test & quality plan (BUILD gates — for the PLAN doc to expand)
+- **Sidecar:** `pytest --cov-branch --cov-fail-under=100`. New `refine.py` pure
+  functions (`plan_refine`, span union, stats) tested with hand-built words + fake
+  silence spans (no ffmpeg) — same style as `test_fillers`/`test_silencetrim`.
+  Service `preview`/`apply` tested with injected `run`/`detect_run`/`duration` seams
+  (mirror `silencetrim.SilenceTrim.__init__` seams, `silencetrim.py:257-272`).
+  `diarize.rename_speakers` + subtitles speaker-carry tested purely.
+- **Renderer:** vitest `thresholds: 100` (lines/branches/functions/statements —
+  `app/vitest.config.ts:44-48`). `Refine.tsx` + `Diarize.tsx` rename block tested
+  with an injected `api` bridge (the `api?` prop pattern, `Diarize.tsx:48`).
+- **Lint/types:** ruff (sidecar), oxlint/biome + tsc/basedpyright (renderer). Never
+  `--no-verify`; never `git add -A`.
+- Reuse-first: NO new cut/detection/cluster math — all reused from shipped modules.
+
+---
+
+## 9. Reuse-vs-new summary (one glance)
+
+**REUSE (unchanged engines):** `fillers.py`, `silencetrim.py`, `diarize.py`+backends,
+`ffmpeg.run`, `jobs.JobContext`, project store seams, `ai_job` envelope (AI-only,
+deferred), `models/provider.py` rotation pool.
+
+**NEW:** `features/refine.py` (`refine.preview`/`refine.apply` + `plan_refine`);
+`diarize.rename` + `rename_speakers`; subtitles speaker-carry edits in
+`subtitles.py`; `Refine.tsx` panel + `Diarize.tsx` rename block; settings keys
+`captionSpeakerLabels` + `refine.*`.
+
+**GAPS NAMED:** standalone filler RPC (closed), speaker→caption plumbing (closed),
+speaker rename (closed), word-level editor (deferred), diarization accuracy
+(heuristic, documented), filler-language coverage (en+ro only), silence semantics
+(amplitude-only), per-speaker styling (deferred).

--- a/docs/plans/editing-refine/PLAN.md
+++ b/docs/plans/editing-refine/PLAN.md
@@ -1,0 +1,386 @@
+# Editing-Refinement Bundle — PLAN
+
+**Status:** PLAN (docs only; no feature code). Follows the gate-approved DESIGN at
+`docs/plans/editing-refine/DESIGN.md`.
+**Branch:** `feat/editing-refine-design` (off `origin/main`).
+**Repo:** `Prekzursil/Reframe` (local `C:/Users/Prekzursil/Documents/github/Reframe`).
+**Date:** 2026-06-18.
+
+> RAILS — every WU below cites real code (verified against source in this clone,
+> not just the DESIGN). All sidecar paths are under `sidecar/media_studio/`;
+> renderer paths under `app/renderer/src/`. NO new cut/detection/cluster math —
+> all reused from shipped, tested modules. AI is DEFERRED; when/if built it rides
+> the shipped Hub envelope only (`models/ai_job.py` `plan_ai_job`/`run_ai_job`,
+> `models/provider.py` rotation pool, the ONE RPC site `handlers.register_all`,
+> `handlers.py:1982`).
+
+---
+
+## 0. Ground-truth anchors (re-verified against source, file:line)
+
+| Anchor | Where | Confirmed |
+|---|---|---|
+| Filler cut-list + stats | `features/fillers.py:201` `build_cutlist_with_stats`; `:284` `build_cutlist`; `:351` `build_segment_cut_argv`; `:305` `remap_time`; `:324` `remap_cues` | yes |
+| Filler defaults / sets / guards | `fillers.py:44` `DEFAULT_MERGE_GAP_MS`; `:60` `DEFAULT_SETS` (en+ro); `:94` `_lang_sets`; `:53` `_SENTENCE_END`; `:170` sentence-end guard | yes |
+| Silence detection + keeps | `features/silencetrim.py:159` `detect_silence_spans`; `:107` `keep_spans`; `:150` `removed_seconds`; `:199` `trim_clip`; `:254` `class SilenceTrim`; `:257` `__init__` (seams); `:336` `register` | yes |
+| Diarize core | `features/diarize.py:179` `diarize_transcript`; `:92` `greedy_cluster`; `:134` `assign_speakers_to_segments`; `:174` `roster`; `:129` `speaker_label`; `:51` `DEFAULT_THRESHOLD=0.5`; `:374` `register`; `:347` `register_diarize_assets` | yes |
+| **GAP: speaker dropped** | `subtitles.py:102` `make_cue` (only `index/start/end/text`); `:107` `reindex` (re-builds with only those 4 keys); `:125` `cues_from_transcript` (never reads `seg["speaker"]`); `:152` `_split_segment` | yes |
+| ONE RPC site | `handlers.py:1982` `register_all`; silencetrim reg `:2176`; diarize reg `:2219` | yes |
+| Reuse seams in register_all | `handlers.py:197` `_resolve_video_path`; `:152` `_ffmpeg_run`; `:153` `_ffprobe_duration`; `:146` `exports_dir`; diarize `load_project=_load_project_data`/`save_project=_save_project_data` (`:2221-2222`) | yes |
+| AI envelope (deferred only) | `models/ai_job.py` `plan_ai_job`/`run_ai_job`; `handlers.py:1601` `plan_ai_job_envelope`; `:1617` `_run_ai_job` | yes |
+| Renderer bridge | `features/_api.ts:57` `getApi`; `:151` `waitForJobDone`; `:167` `pickField`; `:35` `MediaStudioApi`; `:68` `Segment`. `Diarize.tsx:14` imports; `:19` `DiarizedSegment`; `:46-49` `DiarizeProps`/`api?` prop; `:52` component | yes |
+| Gate config | sidecar `pyproject.toml:49` `[tool.pytest.ini_options]` (`testpaths=["tests"]`); renderer `app/vitest.config.ts:44-48` `thresholds:100`; `app/package.json:19` `test`, `:18` `typecheck`; `app/.oxlintrc.json` present | yes |
+
+---
+
+## 1. Per-WU gate commands (run from the named dir; never `--no-verify`, never `git add -A`)
+
+**Sidecar gate (run in `sidecar/`):**
+```
+ruff check media_studio tests
+ruff format --check media_studio tests
+basedpyright media_studio
+pytest --cov=media_studio --cov-branch --cov-fail-under=100 -q
+```
+(For a focused WU loop, narrow with `pytest tests/test_refine.py --cov=media_studio.features.refine --cov-branch --cov-fail-under=100`, but the FINAL per-WU gate is the full-suite 100% line above — coverage is global, partial runs do not satisfy it.)
+
+**Renderer gate (run in `app/`):**
+```
+npx oxlint
+npx @biomejs/biome check renderer/src
+npm run typecheck         # tsc --noEmit
+npm run test:coverage     # vitest run --coverage  (thresholds 100/100/100/100)
+```
+
+**Staging discipline (all WUs):** `git add <explicit paths>` only; before each commit
+`git diff --cached --name-only` and confirm scope. Conventional commits
+(`feat:`/`test:`/`docs:`). Parallel agents share one index → scoped adds mandatory.
+
+---
+
+## 2. Work-Unit decomposition
+
+Two test-first layers per code WU: write failing tests → watch fail → implement →
+gate green. Fakes injected at the ffmpeg `run` seam, the silence `detect_run`
+seam, the `duration` probe, the diarize backend factory, and the renderer `api`
+bridge — NO real ffmpeg / model / network in any test.
+
+---
+
+### WU-0 — Branch + scaffold (no behavior)
+- **Goal:** confirm working branch `feat/editing-refine-design`; create empty
+  `docs/plans/editing-refine/PLAN.md` (this file) and the test-file placeholders'
+  directory expectations. No source changes.
+- **Files:** `docs/plans/editing-refine/PLAN.md` (this commit).
+- **Test strategy:** none (docs). Existing suites must still pass.
+- **Acceptance (falsifiable):** `git branch --show-current` == `feat/editing-refine-design`;
+  full sidecar + renderer gates pass UNCHANGED from baseline (no regression introduced).
+- **Deps:** none.
+
+---
+
+### WU-1 — `refine.plan_refine` (pure span/stat unifier)  ⟂ parallelizable
+- **Goal:** NEW `features/refine.py` with a PURE
+  `plan_refine(words, lang, total_sec, silences, *, remove_fillers, remove_silence, merge_gap_ms, pad_sec) -> RefinePlan`.
+  It composes the EXISTING math only: filler keep-spans via
+  `fillers.build_cutlist`/`build_cutlist_with_stats` (`fillers.py:284`/`:201`),
+  silence keep-spans via `silencetrim.keep_spans` (`silencetrim.py:107`), unions
+  them into ONE keep-list, and emits a typed
+  `RefinePlan = {keeps:[[s,e]...], stats:{fillersRemoved:int, fillerSeconds:float, silenceRemovedSec:float, keptSec:float}}`.
+  No subprocess, no model, no I/O. Stats mirror the shipped per-clip stats
+  (`shortmaker.py` `{fillersRemoved, fillerSeconds}`) + silence `removed_seconds`
+  (`silencetrim.py:150`).
+- **Files:** NEW `sidecar/media_studio/features/refine.py` (pure fns + `RefinePlan`
+  typing + `__all__`); NEW `sidecar/tests/test_refine.py`.
+- **Test strategy (100% line+branch):** hand-built `words` lists (filler + non-filler,
+  sentence-boundary cases hitting `fillers.py:170` guard), hand-built fake
+  `silences` spans. Branch matrix: `remove_fillers` ∈ {T,F} × `remove_silence` ∈ {T,F}
+  (4 combos incl. both-off → keeps == whole `[[0,total_sec]]`), empty words, empty
+  silences, overlapping filler∩silence spans (union must not double-count
+  `keptSec`/seconds), `lang` falling back to `en` (`fillers.py:94`), zero-length
+  total_sec edge. NO ffmpeg/model — `plan_refine` is pure.
+- **Acceptance (falsifiable):**
+  1. `plan_refine(..., remove_fillers=False, remove_silence=False)` returns
+     `keeps == [[0.0, total_sec]]` and all `stats.*Removed*`/seconds == 0.
+  2. Given one filler word [2.0,2.4] and one silence span [5.0,7.0] over total=10,
+     `keeps` excludes BOTH ranges and `stats.fillerSeconds≈0.4`,
+     `stats.silenceRemovedSec≈2.0`, `stats.keptSec≈7.6` (no double-count on
+     disjoint spans).
+  3. Overlapping filler-inside-silence collapses to ONE removed region; summed
+     removed ≤ total and `keptSec == total - removed`.
+  4. `pytest --cov=media_studio --cov-branch --cov-fail-under=100` green; ruff +
+     basedpyright clean.
+- **Deps:** none (pure reuse of already-shipped modules). **Parallel with WU-3, WU-4.**
+
+---
+
+### WU-2 — `RefineService` (preview + apply) over injected seams
+- **Goal:** in `features/refine.py` add a `RefineService` whose `__init__` takes the
+  SAME injectable seams pattern as `SilenceTrim.__init__` (`silencetrim.py:257`):
+  `resolver`, `out_dir`, `settings_provider`, `run`, `duration`, `detect_run`.
+  - `preview(params, ctx) -> {plan}`: resolve clip (`resolver`), run
+    `silencetrim.detect_silence_spans` via the injected `detect_run` (`silencetrim.py:159`),
+    fetch transcript words from the project store, call `plan_refine` (WU-1).
+    **NO encode, NO file write** (Descript "see before you cut").
+  - `apply(params, ctx) -> {path, removedSec, stats, cues?}` as a JOB: take a plan
+    (or recompute via `plan_refine`), build argv with
+    `fillers.build_segment_cut_argv` (`fillers.py:351`), run through the injected
+    `run` seam (= `ffmpeg.run`) inside `ctx.jobs.start` (mirror diarize/silencetrim
+    job pattern), write a NEW file `out_dir/{stem}.refined.mp4` (original untouched),
+    and re-time caption cues via `fillers.remap_cues` (`fillers.py:324`).
+- **Files:** EDIT `sidecar/media_studio/features/refine.py`; EDIT
+  `sidecar/tests/test_refine.py`.
+- **Test strategy (100%):** fake `resolver` (returns a path / returns None →
+  not-found branch), fake `detect_run` returning canned silencedetect text, fake
+  `run` (records argv, no subprocess), fake `duration`, fake project store
+  (returns transcript with words). Branches: clip-not-found; nothing-to-cut →
+  pass-through path == original (matches `silencetrim.py:240-242` semantics);
+  fillers-only; silence-only; both; cues present vs absent (remap vs skip);
+  job cancellation path (`ctx.jobs` fake raising/cancelled). Assert
+  `build_segment_cut_argv` received the WU-1 keep-list and the OUTPUT path is the
+  `.refined.mp4` sibling, never the input.
+- **Acceptance (falsifiable):**
+  1. `preview` calls `detect_run` exactly once and `run` ZERO times (no encode);
+     returns `{plan}` whose stats equal `plan_refine` on the same inputs.
+  2. `apply` with `keeps==[[0,total]]` (nothing to cut) returns the original path
+     and `removedSec==0`, performing no re-encode (pass-through).
+  3. `apply` with real cuts writes `*.refined.mp4` ≠ input path; returned `cues`
+     equal `fillers.remap_cues(input_cues, keeps)`; `stats` equal the plan stats.
+  4. Full sidecar gate green.
+- **Deps:** WU-1.
+
+---
+
+### WU-3 — Subtitles speaker-carry (GAP #2 closed)  ⟂ parallelizable
+- **Goal:** EDIT `subtitles.py` so the diarized `speaker` survives to cues/SRT/ASS/VTT.
+  - `make_cue` (`subtitles.py:102`) gains an optional `speaker` param; sets it on
+    the cue dict only when present (additive — frozen `index/start/end/text` keep
+    their CONTRACTS.md §3 order/names).
+  - `reindex` (`subtitles.py:107`) preserves an optional `speaker` key when the
+    input cue has one (currently it strips everything but the 4 fields).
+  - `cues_from_transcript` (`subtitles.py:125`) reads `seg.get("speaker")` and
+    threads it through both the single-cue path and the `_split_segment`
+    (`subtitles.py:152`) split path.
+  - NEW pure helper `format_speaker_prefix(cues, *, on) -> cues` that prefixes
+    `text` with `"<speaker>: "` when `on` and the cue has a speaker (immutable;
+    new dicts). Setting `captionSpeakerLabels` (read in WU-5) drives `on`.
+- **Files:** EDIT `sidecar/media_studio/features/subtitles.py`; EDIT
+  `sidecar/tests/test_subtitles.py` (+ `test_subtitles_bilingual.py` if a split
+  case needs a speaker fixture).
+- **Test strategy (100%):** transcript segments WITH and WITHOUT `speaker`; a
+  long segment forcing `_split_segment` (each split cue inherits the segment
+  speaker); blank-segment drop still works; `reindex` round-trip keeps `speaker`
+  when present and omits the key when absent (no `speaker:None` leakage);
+  `format_speaker_prefix` with `on=True`/`on=False` × speaker-present/absent
+  (4 branches). Assert SRT/ASS/VTT renderers still emit byte-identical output for
+  the NO-speaker, prefix-off case (back-compat).
+- **Acceptance (falsifiable):**
+  1. `cues_from_transcript` on a diarized transcript yields cues each carrying the
+     correct `speaker`; on a non-diarized transcript yields cues with NO `speaker`
+     key (not `None`).
+  2. `reindex` preserves `speaker` when present and produces no `speaker` key when
+     absent.
+  3. `format_speaker_prefix(on=False, ...)` is identity on text; `on=True` prefixes
+     exactly `"SPEAKER_00: "` once and only on speaker-bearing cues.
+  4. Existing subtitles tests unchanged-pass; full sidecar gate green at 100%.
+- **Deps:** none. **Parallel with WU-1, WU-4.**
+
+---
+
+### WU-4 — `diarize.rename_speakers` (pure) + `diarize.rename` RPC (GAP #3)  ⟂ parallelizable
+- **Goal:** in `diarize.py` add PURE
+  `rename_speakers(transcript, mapping) -> transcript` (immutable, like
+  `assign_speakers_to_segments`, `diarize.py:134`): rewrites each segment's
+  `speaker` and the top-level `speakers` roster (`diarize.py:198`) via `mapping`
+  (`{SPEAKER_NN: friendly}`); unmapped labels pass through unchanged; input never
+  mutated. Add a direct-return RPC handler on the `Diarize` service that loads the
+  project transcript (`load_project` seam), applies `rename_speakers`, persists via
+  `save_project`, and returns `{transcript}`.
+- **Files:** EDIT `sidecar/media_studio/features/diarize.py` (add fn + handler;
+  register `diarize.rename` inside its existing `register`, `diarize.py:374`);
+  EDIT `sidecar/tests/test_diarize.py`.
+- **Test strategy (100%):** pure: empty mapping (identity), partial mapping
+  (unmapped passes through), mapping a label not in transcript (no-op), roster +
+  per-segment both rewritten, original dict unmutated (assert by identity/deep
+  compare). RPC: fake `load_project`/`save_project`; assert persisted transcript
+  == renamed and `{transcript}` returned; missing-project / no-transcript branch.
+- **Acceptance (falsifiable):**
+  1. `rename_speakers(t, {"SPEAKER_00":"Alex"})` returns a NEW dict where every
+     `SPEAKER_00` (segments + roster) is `"Alex"`; `t` is byte-identical to before.
+  2. `diarize.rename` handler calls `save_project` exactly once with the renamed
+     transcript and returns `{transcript: <renamed>}`.
+  3. `diarize.start` behavior unchanged (its tests still pass).
+  4. Full sidecar gate green at 100%.
+- **Deps:** none. **Parallel with WU-1, WU-3.**
+
+---
+
+### WU-5 — RPC registration + `subtitles.generate` speaker gate (the ONE site)
+- **Goal:** wire all new RPCs at the single registrar `handlers.register_all`
+  (`handlers.py:1982`), mirroring the silencetrim block (`:2176`) and diarize block
+  (`:2219`):
+  - `refine.register(resolver=svc._resolve_video_path, out_dir=svc.exports_dir/"refined",
+    settings_provider=svc.settings.get, run=svc._ffmpeg_run, duration=svc._ffprobe_duration,
+    load_project=_load_project_data, save_project=_save_project_data, register_fn=reg)`
+    → registers `refine.preview` (direct) + `refine.apply` (job). Module owns its
+    own `register()` (mirror `silencetrim.register`, `silencetrim.py:336`).
+  - `diarize.rename` already registered in WU-4's `diarize.register` — confirm it
+    appears via `register_fn=reg` at the existing diarize block.
+  - EDIT `subtitles_generate` (`handlers.py:722`): after building cues, if
+    `settings.get("captionSpeakerLabels")` (new key, mirrors the `captionPolish`
+    gate at `handlers.py:738`), apply `subtitles.format_speaker_prefix(cues, on=True)`.
+    `{track}` return shape UNCHANGED.
+  - Read new settings keys with defaults: `refine.noiseDb`/`refine.minSilenceSec`/
+    `refine.padSec` (reuse silencetrim defaults `silencetrim.py:57-60`),
+    `refine.mergeGapMs` (`fillers.DEFAULT_MERGE_GAP_MS`, `fillers.py:44`),
+    `refine.fillerSets` (override `fillers.DEFAULT_SETS`, `fillers.py:60`).
+- **Files:** EDIT `sidecar/media_studio/handlers.py`; EDIT the relevant
+  `sidecar/tests/test_handlers*.py` (match existing handler-test module).
+- **Test strategy (100%):** fake `reg` registrar asserts the three new names
+  (`refine.preview`, `refine.apply`, `diarize.rename`) registered exactly once;
+  duplicate-registration loudness preserved (`protocol.register` default). For
+  `subtitles_generate`: settings `captionSpeakerLabels` True (prefix applied) vs
+  False/absent (no prefix) — both branches; diarized vs non-diarized transcript.
+  Settings-default branches for each new `refine.*` key (present vs missing).
+- **Acceptance (falsifiable):**
+  1. After `register_all`, the registrar received `refine.preview`, `refine.apply`,
+     `diarize.rename` (and all pre-existing names still present — no displacement).
+  2. `subtitles.generate` with `captionSpeakerLabels=True` on a diarized transcript
+     returns cues whose text is speaker-prefixed; with the flag off/absent returns
+     UNPREFIXED text identical to today (`{track}` shape unchanged).
+  3. `refine.apply` is registered as a job, `refine.preview` as direct.
+  4. Full sidecar gate green at 100%.
+- **Deps:** WU-2 (service), WU-3 (format_speaker_prefix), WU-4 (rename handler).
+
+---
+
+### WU-6 — `Refine.tsx` renderer panel
+- **Goal:** NEW `app/renderer/src/features/Refine.tsx` "Tighten the edit": calls
+  `refine.preview` via the frozen bridge, renders the keep/cut list + saved-seconds
+  + per-category stats, exposes **Remove fillers** / **Remove silence** toggles +
+  tunables (noiseDb, minSilenceSec, mergeGapMs), then **Apply** → `refine.apply`
+  job with progress. Both source and result surfaced. Same structure as
+  `Diarize.tsx`: `getApi()`/`bridge.rpc`/`waitForJobDone`/`onProgress`
+  (`Diarize.tsx:14,53,64,83-101`), injectable `api?` prop for tests
+  (`Diarize.tsx:46-49`).
+- **Files:** NEW `app/renderer/src/features/Refine.tsx`; NEW
+  `app/renderer/src/features/Refine.test.tsx`.
+- **Test strategy (100% lines/branches/functions/statements):** inject a fake
+  `api` bridge (the `api?` prop, mirrors `Diarize.test.tsx`). Cover: initial
+  render; preview success → list + saved-seconds rendered; preview error →
+  error message; toggle states (fillers on/off × silence on/off) re-issue preview
+  with correct params; Apply → job started, progress events update UI, done →
+  result surfaced; Apply error branch; cancel path (`job.cancel`). `pickField`
+  null-result branch. Every conditional render branch exercised.
+- **Acceptance (falsifiable):**
+  1. Mounting with a fake `api` and a stubbed `refine.preview` renders the proposed
+     saved-seconds and per-category counts from the stub.
+  2. Toggling "Remove silence" off re-calls `refine.preview` with
+     `removeSilence:false` (asserted on the fake bridge).
+  3. Clicking Apply dispatches `refine.apply`, processes a progress event, and on
+     done shows the result path; an error result shows the error branch.
+  4. `npm run test:coverage` meets 100/100/100/100; oxlint + biome + tsc clean.
+- **Deps:** WU-5 (RPCs live). UI can be authored in parallel against the contract,
+  but its acceptance test asserts against the real RPC names from WU-5.
+
+---
+
+### WU-7 — `Diarize.tsx` speaker-rename block
+- **Goal:** EDIT `app/renderer/src/features/Diarize.tsx`: add a per-speaker rename
+  row (a text input per `SPEAKER_NN` from the roster) → `diarize.rename` →
+  refresh roster/labels. Existing run/cancel/progress (`Diarize.tsx:62-114`)
+  untouched. Reuse `extractSpeakers` (`Diarize.tsx:32`).
+- **Files:** EDIT `app/renderer/src/features/Diarize.tsx`; EDIT
+  `app/renderer/src/features/Diarize.test.tsx`.
+- **Test strategy (100%):** fake `api`; cover: rename inputs rendered per speaker;
+  editing + submit calls `diarize.rename` with the `{SPEAKER_NN: name}` mapping;
+  success refreshes displayed labels; error branch; empty-roster branch (no inputs).
+  Existing Diarize tests still pass.
+- **Acceptance (falsifiable):**
+  1. With a roster of two speakers, two rename inputs render.
+  2. Renaming `SPEAKER_00`→"Alex" and submitting calls `diarize.rename` with
+     `{ "SPEAKER_00": "Alex" }` and the panel then shows "Alex".
+  3. Pre-existing Diarize run/cancel tests pass unchanged.
+  4. `npm run test:coverage` 100/100/100/100; oxlint + biome + tsc clean.
+- **Deps:** WU-4 (RPC), WU-5 (registered).
+
+---
+
+### WU-8 — Settings + docs reconciliation (close-out)
+- **Goal:** document the new settings keys (`captionSpeakerLabels`, `refine.noiseDb`,
+  `refine.minSilenceSec`, `refine.padSec`, `refine.mergeGapMs`, `refine.fillerSets`)
+  in the settings/contracts doc(s) the repo already maintains; add the additive
+  optional `Cue.speaker?` + `RefinePlan` to CONTRACTS.md §3 (additive only — frozen
+  fields unchanged). No code behavior.
+- **Files:** EDIT the existing settings doc + CONTRACTS.md (whichever the repo uses;
+  located at BUILD time — DESIGN cites CONTRACTS.md §2/§3).
+- **Test strategy:** none (docs); both gate suites must remain green at 100%.
+- **Acceptance (falsifiable):** every new settings key + new optional data field is
+  documented; `git grep` finds each key name in both code and docs; full sidecar +
+  renderer gates green (no regression).
+- **Deps:** WU-5, WU-6, WU-7 (final names settled).
+
+---
+
+## 3. Dependency graph
+
+```
+                WU-0 (branch + this PLAN doc)
+                  |
+   +--------------+--------------+
+   |              |              |
+ WU-1          WU-3           WU-4          (all pure / leaf — PARALLEL)
+ plan_refine   subtitles      diarize.rename
+   |           speaker-carry  rename_speakers
+   |              |              |
+ WU-2            |              |
+ RefineService   |              |
+   |             |              |
+   +------+------+------+-------+
+          |
+        WU-5  (register_all: refine.* + diarize.rename + subtitles gate)  [ONE RPC site]
+          |
+   +------+------+
+   |             |
+ WU-6          WU-7            (renderer — PARALLEL with each other)
+ Refine.tsx    Diarize rename block
+   |             |
+   +------+------+
+          |
+        WU-8  (settings + contracts docs close-out)
+```
+
+## 4. Parallelism notes
+- **Wave A (parallel, leaf):** WU-1, WU-3, WU-4 — disjoint files
+  (`refine.py`, `subtitles.py`, `diarize.py` + their own test files), no shared
+  edits. Run as 3 parallel agents in **isolated worktrees** (parallel agents on a
+  shared index contaminate commits — use `Agent(isolation:worktree)` or scoped
+  `git add` + `git diff --cached --name-only` before every commit).
+- **WU-2** depends only on WU-1 → starts as soon as WU-1 lands.
+- **Wave B (serializing point):** WU-5 edits the single `handlers.py` registrar +
+  `subtitles_generate` and depends on WU-2/WU-3/WU-4. It is the ONE shared file —
+  give it a single owner; do not parallel-edit `handlers.py`.
+- **Wave C (parallel):** WU-6 and WU-7 are disjoint renderer files
+  (`Refine.tsx` new; `Diarize.tsx` edit) — parallel after WU-5.
+- **WU-8** last (needs final names).
+- **AI (deferred):** the optional "smart refine"/caption-cleanup touchpoint is NOT
+  a WU here. When built it adds exactly one path through `plan_ai_job`/`run_ai_job`
+  (`models/ai_job.py`) gated by `handlers.plan_ai_job_envelope` (`handlers.py:1601`)
+  with provider selection from `models/provider.py` — no new consent/budget code.
+
+## 5. Reuse-vs-new (one glance)
+- **REUSE unchanged:** `fillers.py` (cutlist/argv/remap), `silencetrim.py`
+  (detect/keep/removed), `diarize.py` engine + backends, `ffmpeg.run`,
+  `jobs.JobContext`, project store seams (`_load_project_data`/`_save_project_data`/
+  `_resolve_video_path`/`_ffmpeg_run`/`_ffprobe_duration`), AI envelope +
+  rotation pool (deferred AI only).
+- **NEW:** `features/refine.py` (`plan_refine` + `RefineService.preview/apply` +
+  `register`); `diarize.rename_speakers` + `diarize.rename` RPC; subtitles
+  speaker-carry edits + `format_speaker_prefix`; `Refine.tsx`; `Diarize.tsx`
+  rename block; settings `captionSpeakerLabels` + `refine.*`; optional
+  `Cue.speaker?` + `RefinePlan` contract additions.
+- **GAPS closed:** standalone previewable filler/silence RPC (WU-1/2/5);
+  speaker→caption plumbing (WU-3); speaker rename (WU-4). **GAPS deferred
+  (documented, unchanged):** word-level/waveform editor; per-speaker caption
+  styling; overlapping-speaker diarization; auto filler-language expansion;
+  semantic (vs amplitude) silence; smart-AI refine.

--- a/docs/plans/editing-refine/PLAN.md
+++ b/docs/plans/editing-refine/PLAN.md
@@ -81,7 +81,7 @@ bridge — NO real ffmpeg / model / network in any test.
 
 ### WU-1 — `refine.plan_refine` (pure span/stat unifier)  ⟂ parallelizable
 - **Goal:** NEW `features/refine.py` with a PURE
-  `plan_refine(words, lang, total_sec, silences, *, remove_fillers, remove_silence, merge_gap_ms, pad_sec) -> RefinePlan`.
+  `plan_refine(words, lang, total_sec, silences, *, remove_fillers, remove_silence, merge_gap_ms, pad_sec, filler_sets=None) -> RefinePlan`.
   It composes the EXISTING math only: filler keep-spans via
   `fillers.build_cutlist`/`build_cutlist_with_stats` (`fillers.py:284`/`:201`),
   silence keep-spans via `silencetrim.keep_spans` (`silencetrim.py:107`), unions
@@ -90,6 +90,16 @@ bridge — NO real ffmpeg / model / network in any test.
   No subprocess, no model, no I/O. Stats mirror the shipped per-clip stats
   (`shortmaker.py` `{fillersRemoved, fillerSeconds}`) + silence `removed_seconds`
   (`silencetrim.py:150`).
+  - **`filler_sets` threading (resolves the §4 `refine.fillerSets` setting — it must
+    actually change the cut math, not be read-and-dropped):** the optional
+    `filler_sets: Mapping[str, Mapping[str, frozenset]] | None` is passed straight to
+    the engine's `fillers=` kwarg —`build_cutlist`/`build_cutlist_with_stats` already
+    accept `fillers=` (default `DEFAULT_SETS`, `fillers.py:284`/`:201`, resolved per
+    `_lang_sets`, `fillers.py:94`). `plan_refine` calls
+    `build_cutlist_with_stats(words, lang, fillers=(filler_sets or fillers.DEFAULT_SETS), merge_gap_ms=...)`.
+    `None` ⇒ shipped `DEFAULT_SETS` (back-compat, incl. the bundled `ro` set); a
+    caller-supplied per-language override (e.g. an extended `ro`) genuinely changes
+    which words are cut. This is the value path WU-5 reads `refine.fillerSets` into.
 - **Files:** NEW `sidecar/media_studio/features/refine.py` (pure fns + `RefinePlan`
   typing + `__all__`); NEW `sidecar/tests/test_refine.py`.
 - **Test strategy (100% line+branch):** hand-built `words` lists (filler + non-filler,
@@ -98,7 +108,9 @@ bridge — NO real ffmpeg / model / network in any test.
   (4 combos incl. both-off → keeps == whole `[[0,total_sec]]`), empty words, empty
   silences, overlapping filler∩silence spans (union must not double-count
   `keptSec`/seconds), `lang` falling back to `en` (`fillers.py:94`), zero-length
-  total_sec edge. NO ffmpeg/model — `plan_refine` is pure.
+  total_sec edge. `filler_sets` branch: `None` (⇒ `DEFAULT_SETS`) vs a custom set —
+  a custom `ro` override that marks an EXTRA word as filler must change the cut-list
+  (proves the kwarg is threaded, not dropped). NO ffmpeg/model — `plan_refine` is pure.
 - **Acceptance (falsifiable):**
   1. `plan_refine(..., remove_fillers=False, remove_silence=False)` returns
      `keeps == [[0.0, total_sec]]` and all `stats.*Removed*`/seconds == 0.
@@ -108,7 +120,11 @@ bridge — NO real ffmpeg / model / network in any test.
      disjoint spans).
   3. Overlapping filler-inside-silence collapses to ONE removed region; summed
      removed ≤ total and `keptSec == total - removed`.
-  4. `pytest --cov=media_studio --cov-branch --cov-fail-under=100` green; ruff +
+  4. **filler-set override:** for `lang='ro'`, the SAME `words` with
+     `filler_sets=None` keeps a word W, but with a `filler_sets` that adds W to the
+     `ro` `standalone`/`always` set, `keeps` EXCLUDES W and `stats.fillersRemoved`
+     increases by 1 — proving `refine.fillerSets` reaches the cut math.
+  5. `pytest --cov=media_studio --cov-branch --cov-fail-under=100` green; ruff +
      basedpyright clean.
 - **Deps:** none (pure reuse of already-shipped modules). **Parallel with WU-3, WU-4.**
 
@@ -116,15 +132,23 @@ bridge — NO real ffmpeg / model / network in any test.
 
 ### WU-2 — `RefineService` (preview + apply) over injected seams
 - **Goal:** in `features/refine.py` add a `RefineService` whose `__init__` takes the
-  SAME injectable seams pattern as `SilenceTrim.__init__` (`silencetrim.py:257`):
-  `resolver`, `out_dir`, `settings_provider`, `run`, `duration`, `detect_run`.
+  SAME injectable seams pattern as `SilenceTrim.__init__` (`silencetrim.py:257`) —
+  `resolver`, `out_dir`, `settings_provider`, `run`, `duration`, `detect_run` —
+  PLUS the two project-store seams that the diarize feature already exposes and that
+  WU-5 will pass through `refine.register`: `load_project`/`save_project` (the same
+  callables `diarize.register` declares — `diarize.py:374` `load_project`/
+  `save_project`, wired in `register_all` to `_load_project_data`/`_save_project_data`
+  per the §0 anchor table). `preview`/`apply` read the transcript words via
+  `load_project` (no direct I/O in the service body — the seam is faked in tests).
   - `preview(params, ctx) -> {plan}`: resolve clip (`resolver`), run
     `silencetrim.detect_silence_spans` via the injected `detect_run` (`silencetrim.py:159`),
-    fetch transcript words from the project store, call `plan_refine` (WU-1).
+    fetch transcript words via the `load_project` seam, call `plan_refine` (WU-1) —
+    **threading `filler_sets=params.get("fillerSets")` straight into `plan_refine`'s
+    `filler_sets=` param** (the `refine.fillerSets` value path; `None` ⇒ `DEFAULT_SETS`).
     **NO encode, NO file write** (Descript "see before you cut").
   - `apply(params, ctx) -> {path, removedSec, stats, cues?}` as a JOB: take a plan
-    (or recompute via `plan_refine`), build argv with
-    `fillers.build_segment_cut_argv` (`fillers.py:351`), run through the injected
+    (or recompute via `plan_refine`, **passing the same `filler_sets`**), build argv
+    with `fillers.build_segment_cut_argv` (`fillers.py:351`), run through the injected
     `run` seam (= `ffmpeg.run`) inside `ctx.jobs.start` (mirror diarize/silencetrim
     job pattern), write a NEW file `out_dir/{stem}.refined.mp4` (original untouched),
     and re-time caption cues via `fillers.remap_cues` (`fillers.py:324`).
@@ -132,13 +156,14 @@ bridge — NO real ffmpeg / model / network in any test.
   `sidecar/tests/test_refine.py`.
 - **Test strategy (100%):** fake `resolver` (returns a path / returns None →
   not-found branch), fake `detect_run` returning canned silencedetect text, fake
-  `run` (records argv, no subprocess), fake `duration`, fake project store
-  (returns transcript with words). Branches: clip-not-found; nothing-to-cut →
-  pass-through path == original (matches `silencetrim.py:240-242` semantics);
-  fillers-only; silence-only; both; cues present vs absent (remap vs skip);
-  job cancellation path (`ctx.jobs` fake raising/cancelled). Assert
-  `build_segment_cut_argv` received the WU-1 keep-list and the OUTPUT path is the
-  `.refined.mp4` sibling, never the input.
+  `run` (records argv, no subprocess), fake `duration`, fake `load_project`/
+  `save_project` (returns transcript with words). Branches: clip-not-found;
+  nothing-to-cut → pass-through path == original (matches `silencetrim.py:240-242`
+  semantics); fillers-only; silence-only; both; cues present vs absent (remap vs
+  skip); `fillerSets` present vs absent in `params` (override forwarded to
+  `plan_refine` vs `DEFAULT_SETS`); job cancellation path (`ctx.jobs` fake
+  raising/cancelled). Assert `build_segment_cut_argv` received the WU-1 keep-list and
+  the OUTPUT path is the `.refined.mp4` sibling, never the input.
 - **Acceptance (falsifiable):**
   1. `preview` calls `detect_run` exactly once and `run` ZERO times (no encode);
      returns `{plan}` whose stats equal `plan_refine` on the same inputs.
@@ -146,7 +171,11 @@ bridge — NO real ffmpeg / model / network in any test.
      and `removedSec==0`, performing no re-encode (pass-through).
   3. `apply` with real cuts writes `*.refined.mp4` ≠ input path; returned `cues`
      equal `fillers.remap_cues(input_cues, keeps)`; `stats` equal the plan stats.
-  4. Full sidecar gate green.
+  4. `preview`/`apply` with `params["fillerSets"]` set forward that mapping to
+     `plan_refine(..., filler_sets=<mapping>)` (asserted via the recorded
+     `plan_refine` call or a stat delta vs the same params with no `fillerSets`);
+     absent ⇒ `plan_refine` receives `None`/`DEFAULT_SETS`.
+  5. Full sidecar gate green.
 - **Deps:** WU-1.
 
 ---
@@ -233,7 +262,14 @@ bridge — NO real ffmpeg / model / network in any test.
   - Read new settings keys with defaults: `refine.noiseDb`/`refine.minSilenceSec`/
     `refine.padSec` (reuse silencetrim defaults `silencetrim.py:57-60`),
     `refine.mergeGapMs` (`fillers.DEFAULT_MERGE_GAP_MS`, `fillers.py:44`),
-    `refine.fillerSets` (override `fillers.DEFAULT_SETS`, `fillers.py:60`).
+    `refine.fillerSets` (per-language filler-set override of `fillers.DEFAULT_SETS`,
+    `fillers.py:60`). **`refine.fillerSets` is not merely read — it is threaded into
+    the cut math:** `subtitles_generate`/the refine path put it into the service call
+    as `params["fillerSets"]`, which `RefineService` forwards to
+    `plan_refine(..., filler_sets=...)` (WU-1/WU-2). When absent it falls back to
+    `DEFAULT_SETS` (no behavior change). A WU-5 test asserts that a `refine.fillerSets`
+    value reaches `plan_refine` (not dropped) — i.e. the setting and the DESIGN §4
+    entry agree (this closes the prior plan↔DESIGN contradiction).
 - **Files:** EDIT `sidecar/media_studio/handlers.py`; EDIT the relevant
   `sidecar/tests/test_handlers*.py` (match existing handler-test module).
 - **Test strategy (100%):** fake `reg` registrar asserts the three new names
@@ -241,7 +277,9 @@ bridge — NO real ffmpeg / model / network in any test.
   duplicate-registration loudness preserved (`protocol.register` default). For
   `subtitles_generate`: settings `captionSpeakerLabels` True (prefix applied) vs
   False/absent (no prefix) — both branches; diarized vs non-diarized transcript.
-  Settings-default branches for each new `refine.*` key (present vs missing).
+  Settings-default branches for each new `refine.*` key (present vs missing),
+  including `refine.fillerSets` present → forwarded as `filler_sets` to `plan_refine`
+  (asserted on a recorded service/`plan_refine` call) vs missing → `DEFAULT_SETS`.
 - **Acceptance (falsifiable):**
   1. After `register_all`, the registrar received `refine.preview`, `refine.apply`,
      `diarize.rename` (and all pre-existing names still present — no displacement).
@@ -249,7 +287,9 @@ bridge — NO real ffmpeg / model / network in any test.
      returns cues whose text is speaker-prefixed; with the flag off/absent returns
      UNPREFIXED text identical to today (`{track}` shape unchanged).
   3. `refine.apply` is registered as a job, `refine.preview` as direct.
-  4. Full sidecar gate green at 100%.
+  4. A `refine.fillerSets` setting value reaches `plan_refine` as `filler_sets`
+     (asserted, not dropped); absent ⇒ `DEFAULT_SETS`.
+  5. Full sidecar gate green at 100%.
 - **Deps:** WU-2 (service), WU-3 (format_speaker_prefix), WU-4 (rename handler).
 
 ---
@@ -285,6 +325,49 @@ bridge — NO real ffmpeg / model / network in any test.
 
 ---
 
+### WU-6b — Mount `Refine.tsx` into the workspace (panel reachability)
+- **Goal:** make the panel from WU-6 ACTUALLY OPENABLE — without this the feature
+  ships dead-coded behind a green coverage gate (the DESIGN's headline "one Refine
+  renderer panel the user can open" is not delivered until the workspace mounts it).
+  Mirror EXACTLY how `Diarize` is wired in `app/renderer/src/views/Workspace.tsx`:
+  - add a STATIC lazy import next to the existing ones
+    (`const Refine = lazy(() => import('../features/Refine'));`, alongside
+    `Workspace.tsx:32` `const Diarize = lazy(...)`);
+  - add a `WORKSPACE_TABS` entry `{ id: 'refine', label: 'Refine' }`
+    (`Workspace.tsx:35-47` — the data-driven tab list; **panel registration is this
+    const array + the `renderPanel()` switch, NOT a CSS file** — `workspace.css`/
+    `shorts.css` carry no per-panel id, so NO `.css` edit is required);
+  - add a `case 'refine': return <Refine videoId={video.id} />;` to `renderPanel()`
+    (`Workspace.tsx:122-147` switch; matches the `case 'diarize'` shape at `:126-127`).
+  - Pick the tab position deliberately (e.g. directly after `'diarize'` in the
+    system-advanced group) and keep WU-8's docs in sync with the chosen order.
+- **Files:** EDIT `app/renderer/src/views/Workspace.tsx`; EDIT
+  `app/renderer/src/views/Workspace.test.tsx`.
+- **Test strategy (100% — Workspace.test.tsx already enforces vitest 100/100/100/100):**
+  the test file already (a) asserts the contract tab list in order
+  (`Workspace.test.tsx:122-126`) and (b) drives every `renderPanel()` case from a
+  per-id marker table (`Workspace.test.tsx:227-232`, each panel `vi.mock`-stubbed via
+  `stubPanel`, e.g. `:64` `vi.mock('../features/Diarize', ...)`). So this WU MUST:
+  add `vi.mock('../features/Refine', () => stubPanel('Refine'))`; add `'Refine'` to
+  the expected ordered-tabs assertion at the chosen position; add
+  `['refine', 'Refine']` to the per-case render table so the new switch branch is
+  covered. Without these three edits the new `case`/import/tab are uncovered lines →
+  the 100% gate FAILS (this is the lever that prevents shipping the panel dead-coded).
+- **Acceptance (falsifiable):**
+  1. `WORKSPACE_TABS` contains `{ id: 'refine', label: 'Refine' }` and the
+     ordered-tabs test asserts `'Refine'` at the chosen position.
+  2. Selecting the Refine tab in `Workspace` mounts the panel: the per-case render
+     test for `['refine','Refine']` finds the stubbed Refine marker after
+     `onSelect('refine')`, exercising the new `renderPanel()` branch.
+  3. `renderPanel()`'s new `case 'refine'` and the lazy import are covered (no new
+     uncovered lines); `npm run test:coverage` meets 100/100/100/100; oxlint +
+     biome + tsc clean.
+- **Deps:** WU-6 (the panel component exists). **Parallel with WU-7** (disjoint
+  files: WU-6b edits `Workspace.tsx`/`Workspace.test.tsx`; WU-7 edits `Diarize.tsx`/
+  `Diarize.test.tsx`).
+
+---
+
 ### WU-7 — `Diarize.tsx` speaker-rename block
 - **Goal:** EDIT `app/renderer/src/features/Diarize.tsx`: add a per-speaker rename
   row (a text input per `SPEAKER_NN` from the roster) → `diarize.rename` →
@@ -309,16 +392,21 @@ bridge — NO real ffmpeg / model / network in any test.
 ### WU-8 — Settings + docs reconciliation (close-out)
 - **Goal:** document the new settings keys (`captionSpeakerLabels`, `refine.noiseDb`,
   `refine.minSilenceSec`, `refine.padSec`, `refine.mergeGapMs`, `refine.fillerSets`)
-  in the settings/contracts doc(s) the repo already maintains; add the additive
-  optional `Cue.speaker?` + `RefinePlan` to CONTRACTS.md §3 (additive only — frozen
-  fields unchanged). No code behavior.
+  in the settings/contracts doc(s) the repo already maintains; document
+  `refine.fillerSets` as the per-language filler-set override that is THREADED into
+  `plan_refine`'s `filler_sets=` param (matching DESIGN §4 — call out that it changes
+  the cut math, not just config); record the chosen Refine workspace tab position
+  (the `WORKSPACE_TABS` order from WU-6b) wherever the tab contract is documented;
+  add the additive optional `Cue.speaker?` + `RefinePlan` to CONTRACTS.md §3
+  (additive only — frozen fields unchanged). No code behavior.
 - **Files:** EDIT the existing settings doc + CONTRACTS.md (whichever the repo uses;
   located at BUILD time — DESIGN cites CONTRACTS.md §2/§3).
 - **Test strategy:** none (docs); both gate suites must remain green at 100%.
 - **Acceptance (falsifiable):** every new settings key + new optional data field is
-  documented; `git grep` finds each key name in both code and docs; full sidecar +
-  renderer gates green (no regression).
-- **Deps:** WU-5, WU-6, WU-7 (final names settled).
+  documented; `refine.fillerSets`'s doc entry states it flows to `plan_refine`
+  (`filler_sets`); the Refine tab position is recorded; `git grep` finds each key
+  name in both code and docs; full sidecar + renderer gates green (no regression).
+- **Deps:** WU-5, WU-6, WU-6b, WU-7 (final names + tab order settled).
 
 ---
 
@@ -345,6 +433,9 @@ bridge — NO real ffmpeg / model / network in any test.
  WU-6          WU-7            (renderer — PARALLEL with each other)
  Refine.tsx    Diarize rename block
    |             |
+ WU-6b          |             (mount Refine into Workspace — depends on WU-6)
+ Workspace wire |
+   |             |
    +------+------+
           |
         WU-8  (settings + contracts docs close-out)
@@ -361,8 +452,11 @@ bridge — NO real ffmpeg / model / network in any test.
   `subtitles_generate` and depends on WU-2/WU-3/WU-4. It is the ONE shared file —
   give it a single owner; do not parallel-edit `handlers.py`.
 - **Wave C (parallel):** WU-6 and WU-7 are disjoint renderer files
-  (`Refine.tsx` new; `Diarize.tsx` edit) — parallel after WU-5.
-- **WU-8** last (needs final names).
+  (`Refine.tsx` new; `Diarize.tsx` edit) — parallel after WU-5. **WU-6b**
+  (mount `Refine.tsx` into `Workspace.tsx`/`Workspace.test.tsx`) runs after WU-6 and
+  is disjoint from WU-7, so WU-6b ∥ WU-7. WU-6b is what makes the panel reachable —
+  without it the Refine panel ships dead-coded behind the 100% gate.
+- **WU-8** last (needs final names; also records the chosen Refine tab position).
 - **AI (deferred):** the optional "smart refine"/caption-cleanup touchpoint is NOT
   a WU here. When built it adds exactly one path through `plan_ai_job`/`run_ai_job`
   (`models/ai_job.py`) gated by `handlers.plan_ai_job_envelope` (`handlers.py:1601`)
@@ -374,13 +468,15 @@ bridge — NO real ffmpeg / model / network in any test.
   `jobs.JobContext`, project store seams (`_load_project_data`/`_save_project_data`/
   `_resolve_video_path`/`_ffmpeg_run`/`_ffprobe_duration`), AI envelope +
   rotation pool (deferred AI only).
-- **NEW:** `features/refine.py` (`plan_refine` + `RefineService.preview/apply` +
-  `register`); `diarize.rename_speakers` + `diarize.rename` RPC; subtitles
-  speaker-carry edits + `format_speaker_prefix`; `Refine.tsx`; `Diarize.tsx`
-  rename block; settings `captionSpeakerLabels` + `refine.*`; optional
-  `Cue.speaker?` + `RefinePlan` contract additions.
-- **GAPS closed:** standalone previewable filler/silence RPC (WU-1/2/5);
-  speaker→caption plumbing (WU-3); speaker rename (WU-4). **GAPS deferred
+- **NEW:** `features/refine.py` (`plan_refine` with `filler_sets` threading +
+  `RefineService.preview/apply` + `register`); `diarize.rename_speakers` +
+  `diarize.rename` RPC; subtitles speaker-carry edits + `format_speaker_prefix`;
+  `Refine.tsx` + its `Workspace.tsx` mount wiring (lazy import + `WORKSPACE_TABS`
+  entry + `renderPanel()` `case`, WU-6b); `Diarize.tsx` rename block; settings
+  `captionSpeakerLabels` + `refine.*` (incl. `refine.fillerSets` threaded to the cut
+  math); optional `Cue.speaker?` + `RefinePlan` contract additions.
+- **GAPS closed:** standalone previewable filler/silence RPC (WU-1/2/5) reachable in
+  the UI (WU-6 + WU-6b mount); speaker→caption plumbing (WU-3); speaker rename (WU-4). **GAPS deferred
   (documented, unchanged):** word-level/waveform editor; per-speaker caption
   styling; overlapping-speaker diarization; auto filler-language expansion;
   semantic (vs amplitude) silence; smart-AI refine.

--- a/sidecar/media_studio/features/diarize.py
+++ b/sidecar/media_studio/features/diarize.py
@@ -176,6 +176,25 @@ def roster(cluster_labels: Sequence[int]) -> list[str]:
     return [speaker_label(i) for i in sorted({int(c) for c in cluster_labels})]
 
 
+def rename_speakers(transcript: Transcript, mapping: dict[str, str]) -> Transcript:
+    """Rewrite speaker labels in a transcript via ``mapping`` (immutable).
+
+    ``mapping`` is ``{SPEAKER_NN: friendly}``. Every segment's ``speaker`` and the
+    top-level ``speakers`` roster are rewritten through it; labels not in the
+    mapping pass through unchanged. Returns a NEW transcript dict — the input is
+    never mutated (mirrors :func:`assign_speakers_to_segments`). Segments without
+    a ``speaker`` key are left as-is (no key is added).
+    """
+    segments: list[Segment] = []
+    for seg in transcript.get("segments") or []:
+        if "speaker" in seg:
+            segments.append({**seg, "speaker": mapping.get(seg["speaker"], seg["speaker"])})
+        else:
+            segments.append({**seg})
+    speakers = [mapping.get(s, s) for s in transcript.get("speakers") or []]
+    return {**transcript, "segments": segments, "speakers": speakers}
+
+
 def diarize_transcript(
     transcript: Transcript,
     regions: Sequence[dict[str, Any]],
@@ -317,6 +336,36 @@ class Diarize:
         job = ctx.jobs.start(job_body, feature="diarize", label="diarize", videoId=video_id, gpu=True)
         return {"jobId": job.id}
 
+    def rename(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``diarize.rename({videoId, mapping})`` -> ``{transcript}`` (direct).
+
+        Applies ``mapping`` (``{SPEAKER_NN: friendly}``) to the persisted
+        transcript via the pure :func:`rename_speakers`, saves it back onto a
+        fresh project load (so unrelated fields are preserved), and returns the
+        renamed transcript. Direct return — not a job.
+        """
+        del ctx  # no jobs/notifications needed for this synchronous rename
+        video_id = params.get("videoId")
+        if not isinstance(video_id, str) or not video_id:
+            raise RpcError("videoId (str) is required", ErrorCode.INVALID_PARAMS)
+        mapping = params.get("mapping")
+        if not isinstance(mapping, dict):
+            raise RpcError("mapping (dict) is required", ErrorCode.INVALID_PARAMS)
+
+        project = self._load_project(video_id)
+        transcript = project.get("transcript")
+        if not transcript:
+            raise RpcError(
+                f"video {video_id} has no transcript yet (run diarize.start first)",
+                ErrorCode.INVALID_PARAMS,
+            )
+
+        renamed = rename_speakers(transcript, {str(k): str(v) for k, v in mapping.items()})
+        fresh = self._load_project(video_id)
+        fresh["transcript"] = renamed
+        self._save_project(video_id, fresh)
+        return {"transcript": renamed}
+
 
 # --------------------------------------------------------------------------- #
 # default heavy seams (lazy real impls; tests inject fakes)
@@ -397,6 +446,7 @@ def register(
     )
     reg = register_fn if register_fn is not None else protocol.register
     reg("diarize.start", service.start)
+    reg("diarize.rename", service.rename)
     return service
 
 
@@ -423,6 +473,7 @@ __all__ = [
     "greedy_cluster",
     "register",
     "register_diarize_assets",
+    "rename_speakers",
     "roster",
     "speaker_label",
 ]

--- a/sidecar/media_studio/features/refine.py
+++ b/sidecar/media_studio/features/refine.py
@@ -1,0 +1,169 @@
+"""REFINE — pure span/stat unifier for filler + silence removal (WU-1).
+
+``plan_refine`` composes the ALREADY-SHIPPED, already-tested timeline math —
+filler cut-lists (:func:`features.fillers.build_cutlist_with_stats`) and silence
+keep-spans (:func:`features.silencetrim.keep_spans`) — into ONE union keep-list
+plus mirrored stats. It is a Descript-style "see before you cut" planner:
+
+    plan_refine(words, lang, total_sec, silences, *,
+                remove_fillers, remove_silence,
+                merge_gap_ms=..., pad_sec=..., filler_sets=None) -> RefinePlan
+
+with ``RefinePlan = {"keeps": [[s, e], ...], "stats": {...}}``.
+
+NO subprocess, NO model, NO I/O. The two engines each emit KEEP spans; the
+removed regions are the gaps inside their respective windows. Combining a
+filler-removal AND a silence-removal means the FINAL removed region is the
+*union* of the two removed sets (so a filler that sits inside a silence is one
+removed region, not two — no double-count). The final keep-list is therefore
+``[0, total_sec]`` minus that union. Per-category stats stay independent
+(``fillersRemoved``/``fillerSeconds`` mirror the shipped per-clip stats and
+``silenceRemovedSec`` mirrors :func:`silencetrim.removed_seconds`), while
+``keptSec`` reflects the de-duplicated union so it always equals
+``total_sec - |union of removed|``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, TypedDict
+
+from . import fillers as _fillers
+from . import silencetrim as _silencetrim
+
+# A keep span as emitted in the plan: [start, end] in original-video seconds.
+Span = tuple[float, float]
+
+
+class RefineStats(TypedDict):
+    """Per-category refine stats (mirrors the shipped per-clip stat fields)."""
+
+    fillersRemoved: int
+    fillerSeconds: float
+    silenceRemovedSec: float
+    keptSec: float
+
+
+class RefinePlan(TypedDict):
+    """The pure refine plan: a union keep-list plus de-duplicated stats."""
+
+    keeps: list[list[float]]
+    stats: RefineStats
+
+
+def _removed_from_keeps(keeps: Sequence[Span], lo: float, hi: float) -> list[Span]:
+    """Invert ``keeps`` into the removed regions across ``[lo, hi]``.
+
+    Every part of ``[lo, hi]`` not covered by a keep is a removed region (head,
+    interior gaps, and tail all count). An empty keep-list means the engine
+    declined to cut anything (it leaves the span whole), so nothing is removed.
+    Callers pass ``[lo, hi]`` = the engine's removal window: ``[0, total]`` for
+    silence (edge silences count) and the words' own span for fillers (nothing
+    outside the transcript is ever a filler cut).
+    """
+    if hi <= lo or not keeps:
+        return []
+    spans = sorted((max(lo, float(a)), min(hi, float(b))) for a, b in keeps if float(b) > float(a))
+    removed: list[Span] = []
+    cursor = lo
+    for start, end in spans:
+        if start > cursor:
+            removed.append((cursor, start))
+        cursor = max(cursor, end)
+    if cursor < hi:
+        removed.append((cursor, hi))
+    return removed
+
+
+def _union_spans(spans: Sequence[Span]) -> list[Span]:
+    """Merge overlapping/adjacent spans into a minimal sorted union."""
+    ordered = sorted((float(a), float(b)) for a, b in spans if float(b) > float(a))
+    merged: list[Span] = []
+    for start, end in ordered:
+        if merged and start <= merged[-1][1]:
+            prev = merged[-1]
+            merged[-1] = (prev[0], max(prev[1], end))
+        else:
+            merged.append((start, end))
+    return merged
+
+
+def _keeps_from_removed(removed: Sequence[Span], total: float) -> list[list[float]]:
+    """Invert the (already-unioned) removed regions over ``[0, total]``."""
+    keeps: list[list[float]] = []
+    cursor = 0.0
+    for start, end in removed:
+        if start > cursor:
+            keeps.append([round(cursor, 3), round(start, 3)])
+        cursor = max(cursor, end)
+    if cursor < total:
+        keeps.append([round(cursor, 3), round(total, 3)])
+    return keeps
+
+
+def plan_refine(
+    words: Sequence[Mapping[str, Any]],
+    lang: str | None,
+    total_sec: float,
+    silences: Sequence[Span],
+    *,
+    remove_fillers: bool,
+    remove_silence: bool,
+    merge_gap_ms: int = _fillers.DEFAULT_MERGE_GAP_MS,
+    pad_sec: float = _silencetrim.DEFAULT_PAD_SEC,
+    filler_sets: Mapping[str, Mapping[str, frozenset]] | None = None,
+) -> RefinePlan:
+    """Compose filler + silence removal into ONE union keep-list and stats.
+
+    ``words`` are §3 Words (original-video seconds), ``silences`` are detected
+    silent spans, ``total_sec`` the clip duration. ``filler_sets`` (default
+    ``None`` ⇒ :data:`fillers.DEFAULT_SETS`) is threaded straight into the
+    filler engine's ``fillers=`` kwarg, so a caller-supplied per-language
+    override genuinely changes which words are cut.
+    """
+    total = max(0.0, float(total_sec))
+
+    filler_seconds = 0.0
+    fillers_removed = 0
+    filler_removed: list[Span] = []
+    if remove_fillers:
+        sets = filler_sets if filler_sets is not None else _fillers.DEFAULT_SETS
+        keeps, stats = _fillers.build_cutlist_with_stats(
+            words,
+            lang,
+            fillers=sets,
+            merge_gap_ms=merge_gap_ms,
+        )
+        filler_seconds = float(stats["fillerSeconds"])
+        fillers_removed = int(stats["fillersRemoved"])
+        win_lo = keeps[0][0] if keeps else 0.0
+        win_hi = keeps[-1][1] if keeps else 0.0
+        filler_removed = _removed_from_keeps(keeps, win_lo, win_hi)
+
+    silence_removed_sec = 0.0
+    silence_removed: list[Span] = []
+    if remove_silence:
+        keeps = _silencetrim.keep_spans(silences, total, pad_sec=pad_sec)
+        silence_removed_sec = _silencetrim.removed_seconds(keeps, total)
+        silence_removed = _removed_from_keeps(keeps, 0.0, total)
+
+    removed = _union_spans([*filler_removed, *silence_removed])
+    if total <= 0.0:
+        keeps_out: list[list[float]] = []
+    else:
+        keeps_out = _keeps_from_removed(removed, total) or [[0.0, round(total, 3)]]
+
+    kept_sec = round(sum(b - a for a, b in keeps_out), 3)
+
+    return RefinePlan(
+        keeps=keeps_out,
+        stats=RefineStats(
+            fillersRemoved=fillers_removed,
+            fillerSeconds=round(filler_seconds, 3),
+            silenceRemovedSec=round(silence_removed_sec, 3),
+            keptSec=kept_sec,
+        ),
+    )
+
+
+__all__ = ["RefinePlan", "RefineStats", "plan_refine"]

--- a/sidecar/media_studio/features/refine.py
+++ b/sidecar/media_studio/features/refine.py
@@ -25,11 +25,27 @@ removed region, not two — no double-count). The final keep-list is therefore
 
 from __future__ import annotations
 
-from collections.abc import Mapping, Sequence
+import os
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
 from typing import Any, TypedDict
 
+from .. import protocol
+from ..jobs import JobContext
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import get_logger
 from . import fillers as _fillers
 from . import silencetrim as _silencetrim
+
+log = get_logger("media_studio.refine")
+
+# Injectable seams (mirror the sibling features — silencetrim / diarize).
+RunFn = Callable[..., int]
+ProbeFn = Callable[..., float]
+DetectRunner = Callable[..., Any]
+Resolver = Callable[[str], str | None]
+LoadProject = Callable[[str], dict[str, Any]]
+SaveProject = Callable[[str, dict[str, Any]], None]
 
 # A keep span as emitted in the plan: [start, end] in original-video seconds.
 Span = tuple[float, float]
@@ -166,4 +182,280 @@ def plan_refine(
     )
 
 
-__all__ = ["RefinePlan", "RefineStats", "plan_refine"]
+# --------------------------------------------------------------------------- #
+# small param helpers (mirror silencetrim's coercion seams)
+# --------------------------------------------------------------------------- #
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _require_str(params: Mapping[str, Any], key: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value:
+        raise _invalid(f"{key} (str) is required")
+    return value
+
+
+def _float(params: Mapping[str, Any], key: str, default: float) -> float:
+    value = params.get(key, default)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _bool(params: Mapping[str, Any], key: str, default: bool) -> bool:
+    value = params.get(key, default)
+    return default if value is None else bool(value)
+
+
+def _words_of(transcript: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    """Flatten a transcript's per-segment word timings into the flat §3 list.
+
+    Mirrors :func:`shortmaker._words_of` — the one canonical transcript→words
+    flattening the planner expects. A missing transcript / segments / words all
+    collapse to an empty list (the planner then plans on silence alone).
+    """
+    words: list[dict[str, Any]] = []
+    if not transcript:
+        return words
+    for seg in transcript.get("segments", []) or []:
+        for word in (seg or {}).get("words") or []:
+            words.append(word)
+    return words
+
+
+# --------------------------------------------------------------------------- #
+# the service (refine.preview = direct / no encode; refine.apply = a job)
+# --------------------------------------------------------------------------- #
+class RefineService:
+    """Owns ``refine.preview`` + ``refine.apply`` over injectable seams.
+
+    Seams mirror :class:`silencetrim.SilenceTrim` (``resolver``, ``out_dir``,
+    ``settings_provider``, ``run``, ``duration``, ``detect_run``) PLUS the two
+    project-store seams the diarize feature already exposes
+    (``load_project`` / ``save_project``) so the transcript words are read
+    through a fake in tests — never real I/O in the service body. ``preview``
+    is a Descript-style "see before you cut" planner (detect + plan, NO encode,
+    NO write); ``apply`` re-cuts as a job (writing a NEW ``*.refined.mp4`` so the
+    original is untouched) and re-times caption cues via
+    :func:`fillers.remap_cues`.
+    """
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver,
+        out_dir: str | os.PathLike[str],
+        load_project: LoadProject,
+        save_project: SaveProject,
+        settings_provider: Callable[[], dict[str, Any]] | None = None,
+        run: RunFn | None = None,
+        duration: ProbeFn | None = None,
+        detect_run: DetectRunner | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._out_dir = Path(out_dir)
+        self._load_project = load_project
+        self._save_project = save_project
+        self._settings_provider = settings_provider or (lambda: {})
+        self._run = run
+        self._duration = duration
+        self._detect_run = detect_run
+
+    def _settings(self) -> dict[str, Any]:
+        try:
+            return dict(self._settings_provider() or {})
+        except Exception:  # noqa: BLE001 - settings must never break an op
+            return {}
+
+    def _resolve(self, params: Mapping[str, Any]) -> str:
+        path = params.get("path")
+        if isinstance(path, str) and path:
+            return path
+        video_id = _require_str(params, "videoId")
+        resolved = self._resolver(video_id)
+        if not resolved:
+            raise _invalid(f"unknown video: {video_id}")
+        return str(resolved)
+
+    def _words(self, params: Mapping[str, Any]) -> list[dict[str, Any]]:
+        """Load the project's transcript words via the ``load_project`` seam."""
+        video_id = params.get("videoId")
+        if not isinstance(video_id, str) or not video_id:
+            return []
+        project = self._load_project(video_id) or {}
+        return _words_of(project.get("transcript"))
+
+    def _plan(self, params: Mapping[str, Any], in_path: str, settings: dict[str, Any], total: float) -> RefinePlan:
+        """Detect silence + compose the pure refine plan (shared by preview/apply)."""
+        silences = _silencetrim.detect_silence_spans(
+            in_path,
+            settings=settings,
+            noise_db=_float(params, "noiseDb", _silencetrim.DEFAULT_NOISE_DB),
+            min_silence_sec=_float(params, "minSilenceSec", _silencetrim.DEFAULT_MIN_SILENCE_SEC),
+            run=self._detect_run,
+        )
+        return plan_refine(
+            self._words(params),
+            params.get("lang"),
+            total,
+            silences,
+            remove_fillers=_bool(params, "removeFillers", True),
+            remove_silence=_bool(params, "removeSilence", True),
+            merge_gap_ms=int(_float(params, "mergeGapMs", float(_fillers.DEFAULT_MERGE_GAP_MS))),
+            pad_sec=_float(params, "padSec", _silencetrim.DEFAULT_PAD_SEC),
+            filler_sets=params.get("fillerSets"),
+        )
+
+    def preview(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:  # noqa: ARG002 - RPC signature
+        """``refine.preview({videoId|path, removeFillers?, removeSilence?, ...})``.
+
+        Resolves the clip, detects silence (the ``detect_run`` seam), reads the
+        transcript words (``load_project`` seam), and returns the pure
+        :func:`plan_refine` result as ``{plan}``. NO encode, NO file write —
+        the user sees the proposed cut before committing.
+        """
+        in_path = self._resolve(params)
+        settings = self._settings()
+        total = _float(params, "totalSec", 0.0)
+        if total <= 0.0:
+            total = _probe_total(self._duration, in_path, settings)
+        return {"plan": self._plan(params, in_path, settings, total)}
+
+    def apply(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``refine.apply({videoId|path, ...})`` -> ``{jobId}`` -> the cut result.
+
+        ``job.done.result`` = ``{path, removedSec, stats, plan, cues?}``. Builds
+        the keep-list via :func:`plan_refine`, re-cuts through the injected
+        ``run`` seam (writing ``out_dir/{stem}.refined.mp4`` — the original is
+        never touched), and re-times any caller-supplied ``cues`` via
+        :func:`fillers.remap_cues`. When there is nothing to cut the original
+        path is returned unchanged with ``removedSec == 0`` (no re-encode).
+        """
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        in_path = self._resolve(params)
+        settings = self._settings()
+        run = self._run if self._run is not None else _default_run()
+        duration = self._duration
+        out_dir = self._out_dir
+        cues = params.get("cues")
+        plan_params = dict(params)
+
+        def job_body(job_ctx: JobContext) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            job_ctx.progress(5, "planning refine")
+            total = _probe_total(duration, in_path, settings)
+            if total <= 0.0:
+                job_ctx.progress(100, "nothing to refine")
+                return {"path": in_path, "removedSec": 0.0, "stats": _zero_stats(), "plan": _passthrough_plan(total)}
+            plan = self._plan(plan_params, in_path, settings, total)
+            keeps = [(float(a), float(b)) for a, b in plan["keeps"]]
+            removed = round(total - plan["stats"]["keptSec"], 3)
+            # Nothing to remove (single full-length keep): pass through untouched.
+            if removed <= 1e-3 or len(keeps) <= 1:
+                job_ctx.progress(100, "nothing to refine")
+                return {"path": in_path, "removedSec": 0.0, "stats": plan["stats"], "plan": plan}
+            job_ctx.raise_if_cancelled()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            stem = Path(in_path).stem or "clip"
+            out_path = str(out_dir / f"{stem}.refined.mp4")
+            argv = _fillers.build_segment_cut_argv(in_path, out_path, keeps, settings)
+            job_ctx.progress(40, "re-cutting")
+            code = run(argv, total_sec=total)
+            if code != 0:
+                raise RpcError(f"refine re-cut failed (ffmpeg exit {code})", ErrorCode.INTERNAL_ERROR)
+            result: dict[str, Any] = {
+                "path": out_path,
+                "removedSec": removed,
+                "stats": plan["stats"],
+                "plan": plan,
+            }
+            if cues is not None:
+                result["cues"] = _fillers.remap_cues(cues, keeps)
+            job_ctx.progress(100, f"removed {removed:.1f}s")
+            return result
+
+        job = ctx.jobs.start(job_body, feature="refine", label="refine", videoId=params.get("videoId"))
+        return {"jobId": job.id}
+
+
+def _default_run() -> RunFn:
+    """The real drained ffmpeg ``run`` seam (lazy import keeps the module light)."""
+    from .. import ffmpeg as _ffmpeg  # noqa: PLC0415 - lazy: avoids an import cycle
+
+    return _ffmpeg.run
+
+
+def _default_duration() -> ProbeFn:
+    """The real ffprobe duration seam (lazy import keeps the module light)."""
+    from .. import ffmpeg as _ffmpeg  # noqa: PLC0415 - lazy: avoids an import cycle
+
+    return _ffmpeg.ffprobe_duration
+
+
+def _probe_total(duration: ProbeFn | None, in_path: str, settings: dict[str, Any]) -> float:
+    """Probe the clip duration through the seam; a probe failure -> 0.0."""
+    probe = duration if duration is not None else _default_duration()
+    try:
+        return float(probe(in_path, settings))
+    except Exception:  # noqa: BLE001 - a probe failure means we can't refine safely
+        log.warning("duration probe failed for %s; skipping refine", in_path)
+        return 0.0
+
+
+def _zero_stats() -> RefineStats:
+    return RefineStats(fillersRemoved=0, fillerSeconds=0.0, silenceRemovedSec=0.0, keptSec=0.0)
+
+
+def _passthrough_plan(total: float) -> RefinePlan:
+    return RefinePlan(keeps=[] if total <= 0.0 else [[0.0, round(total, 3)]], stats=_zero_stats())
+
+
+# --------------------------------------------------------------------------- #
+# registration (called from handlers.register_all — the ONE RPC site)
+# --------------------------------------------------------------------------- #
+def register(
+    *,
+    resolver: Resolver,
+    out_dir: str | os.PathLike[str],
+    load_project: LoadProject,
+    save_project: SaveProject,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+    run: RunFn | None = None,
+    duration: ProbeFn | None = None,
+    detect_run: DetectRunner | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> RefineService:
+    """Create the service and register ``refine.preview`` + ``refine.apply``.
+
+    Mirrors :func:`silencetrim.register`: ``register_fn`` defaults to
+    :func:`protocol.register` (duplicates fail loudly); tests inject a fake
+    registrar + fake seams. ``refine.preview`` is a DIRECT handler (no job);
+    ``refine.apply`` runs as a job. Returns the service for the caller to hold.
+    """
+    service = RefineService(
+        resolver=resolver,
+        out_dir=out_dir,
+        load_project=load_project,
+        save_project=save_project,
+        settings_provider=settings_provider,
+        run=run,
+        duration=duration,
+        detect_run=detect_run,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("refine.preview", service.preview)
+    reg("refine.apply", service.apply)
+    log.info("registered refine.preview + refine.apply")
+    return service
+
+
+__all__ = [
+    "RefinePlan",
+    "RefineService",
+    "RefineStats",
+    "plan_refine",
+    "register",
+]

--- a/sidecar/media_studio/features/subtitles.py
+++ b/sidecar/media_studio/features/subtitles.py
@@ -99,22 +99,36 @@ def new_track(
     }
 
 
-def make_cue(index: int, start: float, end: float, text: str) -> Cue:
-    """Construct a single Cue dict (CONTRACTS.md §3 field order/names)."""
-    return {"index": int(index), "start": float(start), "end": float(end), "text": text}
+def make_cue(index: int, start: float, end: float, text: str, *, speaker: str | None = None) -> Cue:
+    """Construct a single Cue dict (CONTRACTS.md §3 field order/names).
+
+    The frozen §3 fields ``index/start/end/text`` keep their order/names. The
+    optional diarized ``speaker`` is ADDITIVE: the key is only set when a non-empty
+    ``speaker`` is supplied, so a non-diarized cue stays byte-identical to today
+    (no ``speaker: None`` leakage into the §3 shape).
+    """
+    cue: Cue = {"index": int(index), "start": float(start), "end": float(end), "text": text}
+    if speaker:
+        cue["speaker"] = str(speaker)
+    return cue
 
 
 def reindex(cues: Sequence[Cue]) -> list[Cue]:
-    """Return cues renumbered 1..N (1-based), as fresh dicts (no mutation)."""
+    """Return cues renumbered 1..N (1-based), as fresh dicts (no mutation).
+
+    An optional diarized ``speaker`` on the input cue is preserved (additive);
+    absent ⇒ no ``speaker`` key on the output (no ``speaker: None`` leakage).
+    """
     out: list[Cue] = []
     for i, cue in enumerate(cues, start=1):
         out.append(
-            {
-                "index": i,
-                "start": float(cue.get("start", 0.0)),
-                "end": float(cue.get("end", 0.0)),
-                "text": str(cue.get("text", "")),
-            }
+            make_cue(
+                i,
+                float(cue.get("start", 0.0)),
+                float(cue.get("end", 0.0)),
+                str(cue.get("text", "")),
+                speaker=cue.get("speaker"),
+            )
         )
     return out
 
@@ -141,16 +155,27 @@ def cues_from_transcript(
             continue
         start = float(seg.get("start", 0.0))
         end = float(seg.get("end", start))
+        speaker = seg.get("speaker")
         words = seg.get("words") or []
         if (len(text) > max_chars or (end - start) > max_duration) and words:
-            cues.extend(_split_segment(words, max_chars, max_duration))
+            cues.extend(_split_segment(words, max_chars, max_duration, speaker=speaker))
         else:
-            cues.append(make_cue(0, start, end, text))
+            cues.append(make_cue(0, start, end, text, speaker=speaker))
     return reindex(cues)
 
 
-def _split_segment(words: Sequence[dict[str, Any]], max_chars: int, max_duration: float) -> list[Cue]:
-    """Greedily pack word-timed tokens into cues bounded by chars + duration."""
+def _split_segment(
+    words: Sequence[dict[str, Any]],
+    max_chars: int,
+    max_duration: float,
+    *,
+    speaker: str | None = None,
+) -> list[Cue]:
+    """Greedily pack word-timed tokens into cues bounded by chars + duration.
+
+    Each emitted split-cue inherits the parent segment's ``speaker`` (additive;
+    omitted when the segment has none).
+    """
     cues: list[Cue] = []
     cur: list[dict[str, Any]] = []
 
@@ -159,7 +184,15 @@ def _split_segment(words: Sequence[dict[str, Any]], max_chars: int, max_duration
             return
         text = " ".join(str(w.get("text", "")).strip() for w in cur).strip()
         if text:
-            cues.append(make_cue(0, float(cur[0].get("start", 0.0)), float(cur[-1].get("end", 0.0)), text))
+            cues.append(
+                make_cue(
+                    0,
+                    float(cur[0].get("start", 0.0)),
+                    float(cur[-1].get("end", 0.0)),
+                    text,
+                    speaker=speaker,
+                )
+            )
 
     for w in words:
         tentative = cur + [w]
@@ -172,6 +205,25 @@ def _split_segment(words: Sequence[dict[str, Any]], max_chars: int, max_duration
             cur = tentative
     flush()
     return cues
+
+
+def format_speaker_prefix(cues: Sequence[Cue], *, on: bool) -> list[Cue]:
+    """Return cues with each speaker-bearing cue's text prefixed ``"<speaker>: "``.
+
+    Pure + immutable: returns fresh cue dicts (the inputs are never mutated). When
+    ``on`` is falsy this is the identity on text (cues are still copied so callers
+    get a consistent fresh-list contract). A cue with no ``speaker`` is left
+    untouched even when ``on`` is true. The ``captionSpeakerLabels`` setting (read
+    in WU-5) drives ``on``.
+    """
+    out: list[Cue] = []
+    for cue in cues:
+        new_cue = dict(cue)
+        speaker = new_cue.get("speaker")
+        if on and speaker:
+            new_cue["text"] = f"{speaker}: {new_cue.get('text', '')}"
+        out.append(new_cue)
+    return out
 
 
 def generate(

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -739,6 +739,13 @@ class Services:
             track = _subtitles.generate_polished(transcript, settings=settings)
         else:
             track = _subtitles.generate(transcript)
+        # WU-5 wiring: settings['captionSpeakerLabels'] prefixes each diarized cue's
+        # text with "<speaker>: " (mirrors the captionPolish gate above). Off/absent
+        # -> the cues are unchanged (back-compat). Non-diarized cues carry no
+        # speaker, so the prefix is a no-op even when the flag is on.
+        if settings.get("captionSpeakerLabels"):
+            labelled = _subtitles.format_speaker_prefix(track.get("cues") or [], on=True)
+            track = _subtitles.edit(track, labelled)
         _tracks.add_track(project.data, track)
         project.save()
         return {"track": track}
@@ -2223,6 +2230,26 @@ def register_all(
         settings_provider=svc.settings.get,
         backend_factory=svc._diarize_backend_factory,
         models_present=svc._diarize_models_present,
+        register_fn=reg,
+    )
+
+    # refine.* (editing-refine WU-5): the standalone "tighten the edit" feature —
+    # previewable filler/silence cut-list (no encode) + apply (job). It composes
+    # the SHIPPED filler/silence math (no new cut logic) and reuses the exact
+    # project-store + ffmpeg seams the sibling features use. refine.preview is a
+    # DIRECT handler; refine.apply is a job (the module owns its register()).
+    # settings['refine.fillerSets'] reaches plan_refine's cut math via the service
+    # (params['fillerSets']); absent -> DEFAULT_SETS (no behaviour change).
+    from .features import refine as _refine  # local: import-light
+
+    _refine.register(
+        resolver=svc._resolve_video_path,
+        out_dir=svc.exports_dir / "refined",
+        load_project=_load_project_data,
+        save_project=_save_project_data,
+        settings_provider=svc.settings.get,
+        run=svc._ffmpeg_run,  # None -> the real drained ffmpeg.run
+        duration=svc._ffprobe_duration,
         register_fn=reg,
     )
 

--- a/sidecar/tests/test_diarize.py
+++ b/sidecar/tests/test_diarize.py
@@ -311,6 +311,143 @@ class TestStartHandler:
 
 
 # --------------------------------------------------------------------------- #
+# pure: rename_speakers (GAP #3)
+# --------------------------------------------------------------------------- #
+def _diarized_transcript() -> dict[str, Any]:
+    return {
+        "language": "en",
+        "durationSec": 6.0,
+        "segments": [
+            {"start": 0.0, "end": 1.0, "text": "hi", "speaker": "SPEAKER_00"},
+            {"start": 5.0, "end": 6.0, "text": "bye", "speaker": "SPEAKER_01"},
+        ],
+        "speakers": ["SPEAKER_00", "SPEAKER_01"],
+    }
+
+
+class TestRenameSpeakers:
+    def test_renames_segments_and_roster(self):
+        t = _diarized_transcript()
+        out = diarize.rename_speakers(t, {"SPEAKER_00": "Alex"})
+        assert out["segments"][0]["speaker"] == "Alex"
+        assert out["segments"][1]["speaker"] == "SPEAKER_01"  # unmapped passes through
+        assert out["speakers"] == ["Alex", "SPEAKER_01"]
+        assert out["language"] == "en"  # untouched fields preserved
+
+    def test_does_not_mutate_input(self):
+        import copy
+
+        t = _diarized_transcript()
+        before = copy.deepcopy(t)
+        diarize.rename_speakers(t, {"SPEAKER_00": "Alex", "SPEAKER_01": "Sam"})
+        assert t == before  # byte-identical: input never mutated
+
+    def test_empty_mapping_is_identity(self):
+        t = _diarized_transcript()
+        out = diarize.rename_speakers(t, {})
+        assert out["segments"] == t["segments"]
+        assert out["speakers"] == t["speakers"]
+
+    def test_mapping_label_not_in_transcript_is_noop(self):
+        t = _diarized_transcript()
+        out = diarize.rename_speakers(t, {"SPEAKER_99": "Ghost"})
+        assert out["speakers"] == ["SPEAKER_00", "SPEAKER_01"]
+        assert out["segments"][0]["speaker"] == "SPEAKER_00"
+
+    def test_segment_without_speaker_key_untouched(self):
+        t = {
+            "segments": [{"start": 0.0, "end": 1.0, "text": "x"}],
+            "speakers": [],
+        }
+        out = diarize.rename_speakers(t, {"SPEAKER_00": "Alex"})
+        assert "speaker" not in out["segments"][0]
+
+    def test_missing_segments_and_speakers_keys(self):
+        out = diarize.rename_speakers({"language": "ro"}, {"SPEAKER_00": "Alex"})
+        assert out["segments"] == []
+        assert out["speakers"] == []
+        assert out["language"] == "ro"
+
+
+# --------------------------------------------------------------------------- #
+# Diarize.rename — the direct RPC handler
+# --------------------------------------------------------------------------- #
+class TestRenameHandler:
+    def _service(self, project, *, saved=None):
+        saved = saved if saved is not None else {}
+
+        def save(video_id, data):
+            saved[video_id] = data
+
+        svc = diarize.Diarize(
+            resolver=lambda v: "/audio.wav",
+            load_project=lambda v: dict(project),
+            save_project=save,
+            models_present=lambda s: True,
+        )
+        return svc, saved
+
+    def test_requires_video_id(self):
+        reg, _ = _registry()
+        svc, _ = self._service({"transcript": _diarized_transcript()})
+        with pytest.raises(RpcError):
+            svc.rename({"mapping": {}}, _ctx(reg))
+
+    def test_requires_mapping_dict(self):
+        reg, _ = _registry()
+        svc, _ = self._service({"transcript": _diarized_transcript()})
+        with pytest.raises(RpcError):
+            svc.rename({"videoId": "v", "mapping": "nope"}, _ctx(reg))
+
+    def test_no_transcript_refuses(self):
+        reg, _ = _registry()
+        svc, _ = self._service({})  # no transcript key
+        with pytest.raises(RpcError) as exc:
+            svc.rename({"videoId": "v", "mapping": {"SPEAKER_00": "Alex"}}, _ctx(reg))
+        assert "transcript" in str(exc.value)
+
+    def test_renames_persists_and_returns(self):
+        reg, _ = _registry()
+        svc, saved = self._service({"transcript": _diarized_transcript()})
+        out = svc.rename({"videoId": "v", "mapping": {"SPEAKER_00": "Alex"}}, _ctx(reg))
+        assert out["transcript"]["speakers"] == ["Alex", "SPEAKER_01"]
+        assert out["transcript"]["segments"][0]["speaker"] == "Alex"
+        # persisted exactly once onto a fresh project copy
+        assert saved["v"]["transcript"]["segments"][0]["speaker"] == "Alex"
+
+    def test_persists_onto_fresh_project_load(self):
+        # rename re-loads the project so unrelated fields are not clobbered.
+        reg, _ = _registry()
+        loads: list[str] = []
+
+        def load(video_id):
+            loads.append(video_id)
+            return {"transcript": _diarized_transcript(), "other": 1}
+
+        saved: dict[str, Any] = {}
+        svc = diarize.Diarize(
+            resolver=lambda v: "/audio.wav",
+            load_project=load,
+            save_project=lambda v, d: saved.__setitem__(v, d),
+            models_present=lambda s: True,
+        )
+        svc.rename({"videoId": "v", "mapping": {"SPEAKER_01": "Sam"}}, _ctx(reg))
+        assert saved["v"]["other"] == 1  # unrelated field preserved
+        assert saved["v"]["transcript"]["speakers"] == ["SPEAKER_00", "Sam"]
+
+
+def test_register_installs_diarize_rename():
+    registered: dict[str, Any] = {}
+    diarize.register(
+        resolver=lambda v: None,
+        load_project=lambda v: {},
+        save_project=lambda v, d: None,
+        register_fn=lambda n, f: registered.__setitem__(n, f),
+    )
+    assert "diarize.rename" in registered
+
+
+# --------------------------------------------------------------------------- #
 # assets + register
 # --------------------------------------------------------------------------- #
 def test_assets_registered_in_manifest():

--- a/sidecar/tests/test_handlers.py
+++ b/sidecar/tests/test_handlers.py
@@ -668,3 +668,145 @@ def test_shortmaker_select_requires_videoid(services: Services, ctx: RpcContext)
     with pytest.raises(RpcError) as ei:
         services.shortmaker_select({}, ctx)
     assert ei.value.code == ErrorCode.INVALID_PARAMS
+
+
+# --------------------------------------------------------------------------- #
+# WU-5: refine.* + diarize.rename registration + subtitles speaker gate
+# --------------------------------------------------------------------------- #
+def test_register_all_wires_refine_and_rename(tmp_path: Path) -> None:
+    """WU-5 acceptance 1: register_all wires refine.preview, refine.apply, and
+    diarize.rename exactly once, and leaves every pre-existing §2 name in place."""
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    for method in ("refine.preview", "refine.apply", "diarize.rename"):
+        assert method in registered, f"{method} was not registered"
+    # no displacement of the existing surface
+    for method in SECTION2_METHODS:
+        assert method in registered, f"{method} disappeared after WU-5 wiring"
+
+
+def test_refine_apply_is_job_preview_is_direct(
+    services: Services, ctx: RpcContext, video_file: Path, monkeypatch
+) -> None:
+    """WU-5 acceptance 3: refine.apply runs as a job (needs ctx.jobs), refine.preview
+    is a direct handler (works with no job registry)."""
+    from media_studio.features import refine as _refine
+    from media_studio.features import silencetrim as _silencetrim
+
+    monkeypatch.setattr(_silencetrim, "detect_silence_spans", lambda *a, **k: [])
+    registered: dict[str, Any] = {}
+    handlers.register_all(services=services, register=lambda name, fn: registered.__setitem__(name, fn))
+    vid = _add_video(services, video_file)
+    _transcribe_sync(services, ctx, vid)
+
+    # preview: direct (no job registry) returns {plan} immediately.
+    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
+    out = registered["refine.preview"]({"videoId": vid}, direct)
+    assert "plan" in out and "keeps" in out["plan"]
+
+    # apply: a job (returns {jobId}) over the real registry.
+    monkeypatch.setattr(_refine, "_default_run", lambda: fake_run)
+    res = registered["refine.apply"]({"videoId": vid}, ctx)
+    assert "jobId" in res
+    ctx.jobs.join(timeout=5)
+
+
+def test_refine_fillerSets_setting_reaches_plan_refine(
+    services: Services, ctx: RpcContext, video_file: Path, monkeypatch
+) -> None:
+    """WU-5 acceptance 4: a refine.fillerSets value reaches plan_refine as
+    filler_sets (not dropped); absent -> None (the DEFAULT_SETS fallback)."""
+    from media_studio.features import refine as _refine
+    from media_studio.features import silencetrim as _silencetrim
+
+    monkeypatch.setattr(_silencetrim, "detect_silence_spans", lambda *a, **k: [])
+    captured: dict[str, Any] = {}
+
+    def fake_plan_refine(words, lang, total, silences, **kwargs):
+        captured["filler_sets"] = kwargs.get("filler_sets")
+        return _refine.RefinePlan(keeps=[[0.0, total]], stats=_refine._zero_stats())
+
+    monkeypatch.setattr(_refine, "plan_refine", fake_plan_refine)
+    registered: dict[str, Any] = {}
+    handlers.register_all(services=services, register=lambda name, fn: registered.__setitem__(name, fn))
+    vid = _add_video(services, video_file)
+    _transcribe_sync(services, ctx, vid)
+    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+    override = {"en": {"always": frozenset({"basically"})}}
+    registered["refine.preview"]({"videoId": vid, "fillerSets": override}, direct)
+    assert captured["filler_sets"] == override
+
+    captured.clear()
+    registered["refine.preview"]({"videoId": vid}, direct)
+    assert captured["filler_sets"] is None
+
+
+def _persist_diarized_transcript(services: Services, vid: str) -> None:
+    """Persist a two-segment transcript carrying a SPEAKER_00 label onto the project."""
+    project = services._load_or_create_project(vid)
+    project.data["transcript"] = {
+        "language": "en",
+        "durationSec": 4.0,
+        "speakers": ["SPEAKER_00"],
+        "segments": [
+            {"start": 0.0, "end": 2.0, "text": "Hello there.", "speaker": "SPEAKER_00"},
+            {"start": 2.0, "end": 4.0, "text": "General Kenobi.", "speaker": "SPEAKER_00"},
+        ],
+    }
+    project.save()
+
+
+def test_subtitles_generate_speaker_labels_on(services: Services, ctx: RpcContext, video_file: Path) -> None:
+    """WU-5 acceptance 2: captionSpeakerLabels=True on a diarized transcript
+    prefixes each speaker-bearing cue's text with '<speaker>: '."""
+    vid = _add_video(services, video_file)
+    _persist_diarized_transcript(services, vid)
+    services.settings.set({"captionSpeakerLabels": True})
+    gen = services.subtitles_generate({"videoId": vid}, ctx)
+    cues = gen["track"]["cues"]
+    assert cues, "generate produced no cues"
+    assert all(c["text"].startswith("SPEAKER_00: ") for c in cues)
+    # speaker carry survives onto the cues (WU-3 contract)
+    assert all(c.get("speaker") == "SPEAKER_00" for c in cues)
+
+
+def test_subtitles_generate_speaker_labels_off_unchanged(services: Services, ctx: RpcContext, video_file: Path) -> None:
+    """WU-5 acceptance 2: flag off/absent -> UNPREFIXED text (back-compat); {track}
+    shape unchanged."""
+    vid = _add_video(services, video_file)
+    _persist_diarized_transcript(services, vid)
+    gen = services.subtitles_generate({"videoId": vid}, ctx)
+    cues = gen["track"]["cues"]
+    assert cues
+    assert not any(c["text"].startswith("SPEAKER_00: ") for c in cues)
+    assert {"id", "lang", "name", "format", "kind", "cues"} <= set(gen["track"])
+
+
+def test_subtitles_generate_speaker_labels_on_non_diarized(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    """WU-5 acceptance 2: captionSpeakerLabels=True on a NON-diarized transcript is
+    a no-op (no speaker -> no prefix)."""
+    vid = _add_video(services, video_file)
+    _transcribe_sync(services, ctx, vid)
+    services.settings.set({"captionSpeakerLabels": True})
+    gen = services.subtitles_generate({"videoId": vid}, ctx)
+    cues = gen["track"]["cues"]
+    assert cues
+    assert not any(": " in c["text"] and c["text"].startswith("SPEAKER") for c in cues)
+    assert all("speaker" not in c for c in cues)
+
+
+def test_subtitles_generate_speaker_labels_with_polish(services: Services, ctx: RpcContext, video_file: Path) -> None:
+    """WU-5: the speaker gate composes with the captionPolish gate (both on)."""
+    vid = _add_video(services, video_file)
+    _persist_diarized_transcript(services, vid)
+    services.settings.set({"captionSpeakerLabels": True, "captionPolish": True})
+    gen = services.subtitles_generate({"videoId": vid}, ctx)
+    cues = gen["track"]["cues"]
+    assert cues
+    assert all(c["text"].startswith("SPEAKER_00: ") for c in cues)

--- a/sidecar/tests/test_refine.py
+++ b/sidecar/tests/test_refine.py
@@ -1,18 +1,28 @@
-"""Unit tests for the pure refine planner (features/refine.py, WU-1).
+"""Unit tests for the refine planner + service (features/refine.py, WU-1/WU-2).
 
-``plan_refine`` is PURE timeline math: it composes the already-shipped filler
-cut-list (:func:`fillers.build_cutlist_with_stats`) and silence keep-spans
+``plan_refine`` (WU-1) is PURE timeline math: it composes the already-shipped
+filler cut-list (:func:`fillers.build_cutlist_with_stats`) and silence keep-spans
 (:func:`silencetrim.keep_spans`) into ONE union keep-list plus mirrored stats.
 No subprocess, no model, no I/O — so every branch is exercised with hand-built
 ``words``/``silences`` and the bundled default filler sets.
+
+``RefineService`` (WU-2) wraps that pure plan in ``preview`` (direct, NO encode)
+and ``apply`` (a job that re-cuts via the injected ffmpeg ``run`` seam). Every
+seam — ``resolver``, ``detect_run``, ``run``, ``duration``, ``load_project``,
+``save_project`` — is faked, so no real ffmpeg / model / I/O is touched.
 """
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
+import pytest
+from media_studio import protocol
 from media_studio.features import fillers as fl
 from media_studio.features import refine as rf
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext, RpcError
 
 
 def w(text: str, start: float, end: float) -> dict[str, Any]:
@@ -294,3 +304,506 @@ def test_refineplan_keys_and_all():
     }
     assert "plan_refine" in rf.__all__
     assert "RefinePlan" in rf.__all__
+
+
+# ===========================================================================
+# WU-2 — RefineService (preview + apply) over injected seams
+# ===========================================================================
+
+# A silencedetect stderr with one silent gap: [5.0, 7.0].
+SILENCE_STDERR = (
+    "[silencedetect @ 0x1] silence_start: 5.0\n[silencedetect @ 0x1] silence_end: 7.0 | silence_duration: 2.0\n"
+)
+
+
+class RecordingRun:
+    """A fake ``ffmpeg.run`` seam: records argv, writes the output, no subprocess."""
+
+    def __init__(self, code: int = 0) -> None:
+        self.code = code
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv, *, total_sec: float = 0.0, on_progress=None, should_cancel=None) -> int:
+        self.calls.append(list(argv))
+        if self.code == 0:
+            Path(argv[-1]).write_bytes(b"\x00mp4")
+        return self.code
+
+
+def detect_with(stderr: str):
+    """A fake ``detect_run`` (subprocess.run-shaped) returning canned stderr."""
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+
+    def runner(argv, **kw):
+        c = Completed()
+        c.stderr = stderr
+        return c
+
+    return runner
+
+
+@pytest.fixture()
+def bin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "bin"
+    d.mkdir()
+    for name in ("ffmpeg", "ffprobe", "ffmpeg.exe", "ffprobe.exe"):
+        (d / name).write_text("", encoding="utf-8")
+    return d
+
+
+@pytest.fixture()
+def settings(bin_dir: Path) -> dict[str, Any]:
+    return {"ffmpegPath": str(bin_dir)}
+
+
+def _ctx(registry: JobRegistry | None) -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=registry)
+
+
+def _transcript_with_words(words: list[dict[str, Any]]) -> dict[str, Any]:
+    """A project transcript whose single segment carries ``words`` (§3 shape)."""
+    return {
+        "transcript": {
+            "segments": [
+                {"start": 0.0, "end": 10.0, "text": "people um buy", "words": words},
+            ]
+        }
+    }
+
+
+def _store(project: dict[str, Any]):
+    """A (load_project, save_project, saved) triple over an in-memory project."""
+    saved: dict[str, Any] = {}
+
+    def load_project(video_id: str) -> dict[str, Any]:
+        return project
+
+    def save_project(video_id: str, data: dict[str, Any]) -> None:
+        saved["video_id"] = video_id
+        saved["data"] = data
+
+    return load_project, save_project, saved
+
+
+def _service(
+    *,
+    tmp_path: Path,
+    settings: dict[str, Any],
+    words: list[dict[str, Any]] | None = None,
+    resolver=None,
+    run=None,
+    duration=None,
+    detect_run=None,
+):
+    """Build a RefineService over fully-faked seams (no real ffmpeg / I/O)."""
+    project = _transcript_with_words(words if words is not None else [w("um", 5.5, 5.9)])
+    load_project, save_project, saved = _store(project)
+    svc = rf.RefineService(
+        resolver=resolver if resolver is not None else (lambda vid: "/lib/in.mp4"),
+        out_dir=tmp_path / "refined",
+        settings_provider=lambda: settings,
+        run=run if run is not None else RecordingRun(),
+        duration=duration if duration is not None else (lambda p, s=None: 10.0),
+        detect_run=detect_run if detect_run is not None else detect_with(SILENCE_STDERR),
+        load_project=load_project,
+        save_project=save_project,
+    )
+    return svc, saved
+
+
+# ---------------------------------------------------------------------------
+# preview — direct, NO encode (acceptance #1)
+# ---------------------------------------------------------------------------
+class TestPreview:
+    def test_preview_detects_once_and_never_encodes(self, tmp_path, settings):
+        run = RecordingRun()
+        detect_calls: list[Any] = []
+
+        def detect_run(argv, **kw):
+            detect_calls.append(argv)
+            return detect_with(SILENCE_STDERR)(argv, **kw)
+
+        svc, _ = _service(
+            tmp_path=tmp_path,
+            settings=settings,
+            run=run,
+            detect_run=detect_run,
+        )
+        out = svc.preview(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True},
+            _ctx(None),
+        )
+        assert "plan" in out
+        assert len(detect_calls) == 1  # detect exactly once
+        assert run.calls == []  # ZERO encodes
+
+    def test_preview_plan_equals_plan_refine(self, tmp_path, settings):
+        words = [w("people", 0.0, 0.5), w("um", 2.0, 2.4), w("buy", 3.0, 3.5)]
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, words=words)
+        out = svc.preview(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True, "padSec": 0.0},
+            _ctx(None),
+        )
+        expected = rf.plan_refine(
+            words,
+            "en",
+            10.0,
+            [(5.0, 7.0)],
+            remove_fillers=True,
+            remove_silence=True,
+            pad_sec=0.0,
+        )
+        assert out["plan"] == expected
+
+    def test_preview_unknown_video_raises(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, resolver=lambda vid: None)
+        with pytest.raises(RpcError, match="unknown video"):
+            svc.preview({"videoId": "ghost"}, _ctx(None))
+
+    def test_preview_explicit_path_short_circuits_resolver(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, resolver=lambda vid: None)
+        out = svc.preview({"path": "/x/explicit.mp4", "removeSilence": True}, _ctx(None))
+        assert "plan" in out
+
+    def test_preview_missing_video_id_raises(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        with pytest.raises(RpcError, match="videoId"):
+            svc.preview({"videoId": ""}, _ctx(None))
+
+    def test_preview_forwards_filler_sets(self, tmp_path, settings):
+        words = [w("bună", 0.0, 0.5), w("totuși", 2.0, 2.5), w("lume", 4.0, 4.5)]
+        custom = {"ro": {"always": frozenset({"totuși"}), "standalone": frozenset()}}
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, words=words)
+        base = svc.preview(
+            {"videoId": "v1", "lang": "ro", "removeFillers": True},
+            _ctx(None),
+        )
+        over = svc.preview(
+            {"videoId": "v1", "lang": "ro", "removeFillers": True, "fillerSets": custom},
+            _ctx(None),
+        )
+        # The override forwards to plan_refine -> one more filler removed.
+        assert over["plan"]["stats"]["fillersRemoved"] == base["plan"]["stats"]["fillersRemoved"] + 1
+
+    def test_preview_explicit_total_sec_skips_probe(self, tmp_path, settings):
+        # A caller-supplied totalSec short-circuits the duration probe (the
+        # `if total <= 0.0` false branch); the duration seam is never called.
+        def boom_duration(p, s=None):  # pragma: no cover - must NOT be called
+            raise AssertionError("duration probe should be skipped")
+
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, duration=boom_duration)
+        out = svc.preview(
+            {"videoId": "v1", "totalSec": 12.0, "removeSilence": True, "padSec": 0.0},
+            _ctx(None),
+        )
+        assert out["plan"]["keeps"][-1][-1] == 12.0
+
+    def test_preview_garbage_tunable_falls_back_to_default(self, tmp_path, settings):
+        # A non-numeric tunable is coerced back to the default (_float except).
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        out = svc.preview(
+            {"videoId": "v1", "noiseDb": "loud", "removeSilence": True},
+            _ctx(None),
+        )
+        assert "plan" in out
+
+    def test_preview_settings_provider_raising_yields_empty(self, tmp_path, bin_dir):
+        # _settings swallows the error -> {} -> ffmpeg unresolvable -> no silences,
+        # so the plan still computes (silence keeps whole clip).
+        project = _transcript_with_words([w("um", 2.0, 2.4)])
+        load_project, save_project, _ = _store(project)
+
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("settings exploded")
+
+        svc = rf.RefineService(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "refined",
+            settings_provider=boom,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(SILENCE_STDERR),
+            load_project=load_project,
+            save_project=save_project,
+        )
+        out = svc.preview({"videoId": "v1", "removeFillers": True}, _ctx(None))
+        assert "plan" in out
+
+
+# ---------------------------------------------------------------------------
+# apply — a job; writes *.refined.mp4 (acceptance #2/#3)
+# ---------------------------------------------------------------------------
+class TestApply:
+    def test_apply_with_real_cuts_writes_refined_sibling(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run)
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True, "padSec": 0.0},
+            _ctx(registry),
+        )
+        assert "jobId" in out
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.status.value == "done"
+        result = job.result
+        assert result["path"].endswith(".refined.mp4")
+        assert result["path"] != "/lib/in.mp4"
+        assert result["removedSec"] > 0.0
+        assert result["stats"]["silenceRemovedSec"] > 0.0
+        # The recorded argv carved the WU-1 keep-list and wrote the refined sibling.
+        assert run.calls
+        assert run.calls[-1][-1].endswith(".refined.mp4")
+
+    def test_apply_nothing_to_cut_passes_through(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        # both toggles off -> keeps == [[0,total]] -> nothing removed -> pass-through.
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run)
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": False, "removeSilence": False},
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        result = job.result
+        assert result["path"] == "/lib/in.mp4"  # ORIGINAL, untouched
+        assert result["removedSec"] == 0.0
+        assert run.calls == []  # NO re-encode
+
+    def test_apply_remaps_cues_when_present(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run)
+        input_cues = [
+            {"index": 1, "start": 0.0, "end": 4.0, "text": "hello"},
+            {"index": 2, "start": 8.0, "end": 9.0, "text": "world"},
+        ]
+        out = svc.apply(
+            {
+                "videoId": "v1",
+                "removeFillers": True,
+                "removeSilence": True,
+                "padSec": 0.0,
+                "cues": input_cues,
+            },
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        result = job.result
+        expected_cues = fl.remap_cues(input_cues, [tuple(k) for k in result["plan"]["keeps"]])
+        assert result["cues"] == expected_cues
+
+    def test_apply_without_cues_omits_cues_key(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True, "padSec": 0.0},
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert "cues" not in job.result
+
+    def test_apply_forwards_filler_sets(self, tmp_path, settings, registry):
+        words = [w("bună", 0.0, 0.5), w("totuși", 2.0, 2.5), w("lume", 4.0, 4.5)]
+        custom = {"ro": {"always": frozenset({"totuși"}), "standalone": frozenset()}}
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, words=words)
+        out = svc.apply(
+            {
+                "videoId": "v1",
+                "lang": "ro",
+                "removeFillers": True,
+                "removeSilence": False,
+                "fillerSets": custom,
+            },
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        # The custom 'ro' filler set removed 'totuși' -> one filler removed.
+        assert job.result["stats"]["fillersRemoved"] == 1
+
+    def test_apply_ffmpeg_failure_errors_job(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=RecordingRun(code=1))
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True, "padSec": 0.0},
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.status.value == "error"
+
+    def test_apply_cancelled_before_run_skips_encode(self, tmp_path, settings, registry):
+        # Deterministic cancel: the duration probe sets the cancel flag, so the
+        # post-plan ``raise_if_cancelled`` checkpoint fires before any encode —
+        # no timing race on when the worker thread observes the flag.
+        run = RecordingRun()
+
+        def cancelling_duration(p, s=None):
+            # The registry holds exactly this one job; cancel it from inside the
+            # worker so the post-plan checkpoint fires deterministically.
+            for job in registry.all().values():
+                job.request_cancel()
+            return 10.0
+
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run, duration=cancelling_duration)
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True, "padSec": 0.0},
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.status.value == "cancelled"
+        assert run.calls == []  # the checkpoint short-circuited before encode
+
+    def test_apply_unknown_video_raises(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, resolver=lambda vid: None)
+        with pytest.raises(RpcError, match="unknown video"):
+            svc.apply({"videoId": "ghost"}, _ctx(registry))
+
+    def test_apply_without_job_registry_raises(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        with pytest.raises(RpcError, match="no job registry"):
+            svc.apply({"videoId": "v1"}, _ctx(None))
+
+    def test_apply_zero_duration_passes_through(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        svc, _ = _service(
+            tmp_path=tmp_path,
+            settings=settings,
+            run=run,
+            duration=lambda p, s=None: 0.0,
+        )
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True},
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["path"] == "/lib/in.mp4"
+        assert job.result["removedSec"] == 0.0
+        assert run.calls == []
+
+    def test_apply_duration_probe_failure_passes_through(self, tmp_path, settings, registry):
+        run = RecordingRun()
+
+        def boom_duration(p, s=None):
+            raise RuntimeError("probe failed")
+
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run, duration=boom_duration)
+        out = svc.apply(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True},
+            _ctx(registry),
+        )
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["path"] == "/lib/in.mp4"
+        assert run.calls == []
+
+
+# ---------------------------------------------------------------------------
+# words extraction + transcript edges
+# ---------------------------------------------------------------------------
+class TestWords:
+    def test_no_transcript_yields_empty_words(self, tmp_path, settings, registry):
+        # A project with no transcript -> no filler words -> silence-only plan.
+        load_project, save_project, _ = _store({})
+        svc = rf.RefineService(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "refined",
+            settings_provider=lambda: settings,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(SILENCE_STDERR),
+            load_project=load_project,
+            save_project=save_project,
+        )
+        out = svc.preview(
+            {"videoId": "v1", "removeFillers": True, "removeSilence": True, "padSec": 0.0},
+            _ctx(None),
+        )
+        assert out["plan"]["stats"]["fillersRemoved"] == 0
+        assert out["plan"]["stats"]["silenceRemovedSec"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# registration (refine.preview direct + refine.apply job)
+# ---------------------------------------------------------------------------
+class TestRegister:
+    def test_register_wires_preview_and_apply(self, tmp_path, settings):
+        registered: dict[str, Any] = {}
+        load_project, save_project, _ = _store(_transcript_with_words([w("um", 5.5, 5.9)]))
+        svc = rf.register(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "refined",
+            settings_provider=lambda: settings,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(SILENCE_STDERR),
+            load_project=load_project,
+            save_project=save_project,
+            register_fn=lambda name, fn: registered.__setitem__(name, fn),
+        )
+        assert set(registered) == {"refine.preview", "refine.apply"}
+        # Bound methods compare by __func__/__self__ (a fresh `svc.preview`
+        # access yields a new object, so identity would falsely fail).
+        assert registered["refine.preview"] == svc.preview
+        assert registered["refine.apply"] == svc.apply
+        assert registered["refine.preview"].__self__ is svc
+
+    def test_register_defaults_to_protocol_register(self, tmp_path, settings):
+        load_project, save_project, _ = _store(_transcript_with_words([w("um", 5.5, 5.9)]))
+        rf.register(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "refined",
+            settings_provider=lambda: settings,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(SILENCE_STDERR),
+            load_project=load_project,
+            save_project=save_project,
+        )
+        assert "refine.preview" in protocol.METHODS
+        assert "refine.apply" in protocol.METHODS
+
+    def test_register_is_in_all(self):
+        assert "RefineService" in rf.__all__
+        assert "register" in rf.__all__
+
+
+# ---------------------------------------------------------------------------
+# default ffmpeg seams (lazy real impls) — identity, no subprocess
+# ---------------------------------------------------------------------------
+class TestDefaultSeams:
+    def test_default_run_is_ffmpeg_run(self):
+        from media_studio import ffmpeg as _ffmpeg
+
+        assert rf._default_run() is _ffmpeg.run
+
+    def test_default_duration_is_ffprobe_duration(self):
+        from media_studio import ffmpeg as _ffmpeg
+
+        assert rf._default_duration() is _ffmpeg.ffprobe_duration
+
+    def test_apply_uses_default_duration_when_none(self, tmp_path, settings, registry):
+        # ``duration=None`` -> the real ffprobe seam runs on a bogus path, fails,
+        # _probe_total returns 0.0 -> pass-through (the real ``run`` is never hit).
+        run = RecordingRun()
+        project = _transcript_with_words([w("um", 5.5, 5.9)])
+        load_project, save_project, _ = _store(project)
+        svc = rf.RefineService(
+            resolver=lambda vid: "/no/such/clip.mp4",
+            out_dir=tmp_path / "refined",
+            settings_provider=lambda: settings,
+            run=run,
+            duration=None,  # exercises _default_duration()
+            detect_run=detect_with(SILENCE_STDERR),
+            load_project=load_project,
+            save_project=save_project,
+        )
+        out = svc.apply({"videoId": "v1", "removeSilence": True}, _ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["path"] == "/no/such/clip.mp4"
+        assert run.calls == []

--- a/sidecar/tests/test_refine.py
+++ b/sidecar/tests/test_refine.py
@@ -1,0 +1,296 @@
+"""Unit tests for the pure refine planner (features/refine.py, WU-1).
+
+``plan_refine`` is PURE timeline math: it composes the already-shipped filler
+cut-list (:func:`fillers.build_cutlist_with_stats`) and silence keep-spans
+(:func:`silencetrim.keep_spans`) into ONE union keep-list plus mirrored stats.
+No subprocess, no model, no I/O — so every branch is exercised with hand-built
+``words``/``silences`` and the bundled default filler sets.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from media_studio.features import fillers as fl
+from media_studio.features import refine as rf
+
+
+def w(text: str, start: float, end: float) -> dict[str, Any]:
+    return {"text": text, "start": start, "end": end}
+
+
+def _kept_seconds(keeps: list[list[float]]) -> float:
+    return round(sum(b - a for a, b in keeps), 3)
+
+
+# ---------------------------------------------------------------------------
+# both-off pass-through (acceptance #1)
+# ---------------------------------------------------------------------------
+def test_both_off_keeps_whole_clip_and_zero_stats():
+    words = [w("um", 2.0, 2.4), w("hello", 3.0, 3.5)]
+    plan = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [(5.0, 7.0)],
+        remove_fillers=False,
+        remove_silence=False,
+    )
+    assert plan["keeps"] == [[0.0, 10.0]]
+    stats = plan["stats"]
+    assert stats["fillersRemoved"] == 0
+    assert stats["fillerSeconds"] == 0.0
+    assert stats["silenceRemovedSec"] == 0.0
+    assert stats["keptSec"] == 10.0
+
+
+# ---------------------------------------------------------------------------
+# disjoint filler + silence (acceptance #2 — no double-count)
+# ---------------------------------------------------------------------------
+def test_disjoint_filler_and_silence_excluded_no_double_count():
+    words = [
+        w("people", 0.0, 0.5),
+        w("um", 2.0, 2.4),
+        w("buy", 3.0, 3.5),
+    ]
+    plan = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [(5.0, 7.0)],
+        remove_fillers=True,
+        remove_silence=True,
+        pad_sec=0.0,
+    )
+    keeps = plan["keeps"]
+    # The filler [2.0,2.4] and the silence [5.0,7.0] are both removed.
+    for start, end in keeps:
+        assert not (start <= 2.0 < end), keeps
+        assert not (start < 7.0 and end > 5.0 and start >= 5.0), keeps
+    stats = plan["stats"]
+    assert abs(stats["fillerSeconds"] - 0.4) < 1e-6
+    assert abs(stats["silenceRemovedSec"] - 2.0) < 1e-6
+    assert abs(stats["keptSec"] - 7.6) < 1e-6
+    assert stats["fillersRemoved"] == 1
+
+
+# ---------------------------------------------------------------------------
+# overlapping filler-inside-silence collapses (acceptance #3)
+# ---------------------------------------------------------------------------
+def test_overlapping_filler_inside_silence_single_removed_region():
+    # The filler word sits INSIDE the silent span: the removed region is ONE,
+    # not the sum of both, so kept == total - removed (no double subtraction).
+    words = [
+        w("people", 0.0, 0.5),
+        w("um", 5.5, 5.9),
+        w("buy", 8.0, 8.5),
+    ]
+    plan = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [(5.0, 7.0)],
+        remove_fillers=True,
+        remove_silence=True,
+        pad_sec=0.0,
+    )
+    keeps = plan["keeps"]
+    removed = round(10.0 - _kept_seconds(keeps), 3)
+    assert removed <= 10.0
+    assert abs(plan["stats"]["keptSec"] - _kept_seconds(keeps)) < 1e-6
+    # The combined removed region equals the single 2.0s silence (filler subset).
+    assert abs(removed - 2.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# edge silences (head at 0.0 / tail at total) — full-window inversion
+# ---------------------------------------------------------------------------
+def test_leading_silence_removed_from_clip_start():
+    plan = rf.plan_refine(
+        [],
+        "en",
+        10.0,
+        [(0.0, 2.0)],
+        remove_fillers=False,
+        remove_silence=True,
+        pad_sec=0.0,
+    )
+    assert plan["keeps"] == [[2.0, 10.0]]
+    assert abs(plan["stats"]["silenceRemovedSec"] - 2.0) < 1e-6
+    assert abs(plan["stats"]["keptSec"] - 8.0) < 1e-6
+
+
+def test_trailing_silence_removed_to_clip_end():
+    plan = rf.plan_refine(
+        [],
+        "en",
+        10.0,
+        [(8.0, 10.0)],
+        remove_fillers=False,
+        remove_silence=True,
+        pad_sec=0.0,
+    )
+    assert plan["keeps"] == [[0.0, 8.0]]
+    assert abs(plan["stats"]["silenceRemovedSec"] - 2.0) < 1e-6
+    assert abs(plan["stats"]["keptSec"] - 8.0) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# fillers-only / silence-only branch matrix
+# ---------------------------------------------------------------------------
+def test_fillers_only_ignores_silence():
+    words = [w("people", 0.0, 0.5), w("um", 2.0, 2.4), w("buy", 3.0, 3.5)]
+    plan = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [(5.0, 7.0)],
+        remove_fillers=True,
+        remove_silence=False,
+    )
+    assert plan["stats"]["silenceRemovedSec"] == 0.0
+    assert plan["stats"]["fillerSeconds"] > 0.0
+    # The silence span is NOT removed when remove_silence is off.
+    assert any(start <= 6.0 < end for start, end in plan["keeps"])
+
+
+def test_silence_only_ignores_fillers():
+    words = [w("people", 0.0, 0.5), w("um", 2.0, 2.4), w("buy", 3.0, 3.5)]
+    plan = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [(5.0, 7.0)],
+        remove_fillers=False,
+        remove_silence=True,
+        pad_sec=0.0,
+    )
+    assert plan["stats"]["fillerSeconds"] == 0.0
+    assert plan["stats"]["fillersRemoved"] == 0
+    assert abs(plan["stats"]["silenceRemovedSec"] - 2.0) < 1e-6
+    # The filler is NOT removed when remove_fillers is off.
+    assert any(start <= 2.2 < end for start, end in plan["keeps"])
+
+
+# ---------------------------------------------------------------------------
+# empty inputs + degenerate edges
+# ---------------------------------------------------------------------------
+def test_empty_words_and_empty_silences():
+    plan = rf.plan_refine(
+        [],
+        "en",
+        10.0,
+        [],
+        remove_fillers=True,
+        remove_silence=True,
+    )
+    assert plan["keeps"] == [[0.0, 10.0]]
+    assert plan["stats"]["fillersRemoved"] == 0
+    assert plan["stats"]["silenceRemovedSec"] == 0.0
+    assert plan["stats"]["keptSec"] == 10.0
+
+
+def test_zero_length_total_sec_yields_empty_keeps():
+    plan = rf.plan_refine(
+        [],
+        "en",
+        0.0,
+        [],
+        remove_fillers=True,
+        remove_silence=True,
+    )
+    assert plan["keeps"] == []
+    assert plan["stats"]["keptSec"] == 0.0
+
+
+def test_lang_none_falls_back_to_en():
+    words = [w("people", 0.0, 0.5), w("um", 2.0, 2.4), w("buy", 3.0, 3.5)]
+    plan = rf.plan_refine(
+        words,
+        None,
+        10.0,
+        [],
+        remove_fillers=True,
+        remove_silence=False,
+    )
+    # 'en' "um" is an always-filler, so it is removed under the en fallback.
+    assert plan["stats"]["fillersRemoved"] == 1
+
+
+# ---------------------------------------------------------------------------
+# filler-set override threading (acceptance #4)
+# ---------------------------------------------------------------------------
+def test_filler_sets_override_changes_cut_math_for_ro():
+    # A word that is NOT a default 'ro' filler; standing alone (pause-bounded).
+    words = [
+        w("bună", 0.0, 0.5),
+        w("totuși", 2.0, 2.5),  # custom-only filler; pause-bounded both sides
+        w("lume", 4.0, 4.5),
+    ]
+    base = rf.plan_refine(
+        words,
+        "ro",
+        10.0,
+        [],
+        remove_fillers=True,
+        remove_silence=False,
+    )
+    assert base["stats"]["fillersRemoved"] == 0  # default 'ro' keeps it
+    assert any(start <= 2.2 < end for start, end in base["keeps"])
+
+    custom = {
+        "ro": {
+            "always": frozenset({"totuși"}),
+            "standalone": frozenset(),
+        }
+    }
+    over = rf.plan_refine(
+        words,
+        "ro",
+        10.0,
+        [],
+        remove_fillers=True,
+        remove_silence=False,
+        filler_sets=custom,
+    )
+    assert over["stats"]["fillersRemoved"] == base["stats"]["fillersRemoved"] + 1
+    assert not any(start <= 2.2 < end for start, end in over["keeps"])
+
+
+def test_filler_sets_none_uses_default_sets():
+    words = [w("people", 0.0, 0.5), w("um", 2.0, 2.4), w("buy", 3.0, 3.5)]
+    explicit = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [],
+        remove_fillers=True,
+        remove_silence=False,
+        filler_sets=None,
+    )
+    default = rf.plan_refine(
+        words,
+        "en",
+        10.0,
+        [],
+        remove_fillers=True,
+        remove_silence=False,
+        filler_sets=fl.DEFAULT_SETS,
+    )
+    assert explicit == default
+
+
+# ---------------------------------------------------------------------------
+# RefinePlan typing surface
+# ---------------------------------------------------------------------------
+def test_refineplan_keys_and_all():
+    plan = rf.plan_refine([], "en", 1.0, [], remove_fillers=False, remove_silence=False)
+    assert set(plan) == {"keeps", "stats"}
+    assert set(plan["stats"]) == {
+        "fillersRemoved",
+        "fillerSeconds",
+        "silenceRemovedSec",
+        "keptSec",
+    }
+    assert "plan_refine" in rf.__all__
+    assert "RefinePlan" in rf.__all__

--- a/sidecar/tests/test_subtitles.py
+++ b/sidecar/tests/test_subtitles.py
@@ -571,3 +571,127 @@ def test_default_caption_polisher_delegates(monkeypatch):
     assert out == cues
     assert captured["cues"] == cues
     assert captured["settings"] == {"x": 1}
+
+
+# --------------------------------------------------------------------------- #
+# WU-3 — diarized speaker-carry (GAP #2)
+# --------------------------------------------------------------------------- #
+def test_make_cue_without_speaker_omits_key():
+    # Back-compat: no speaker -> the §3 shape stays byte-identical (no key).
+    c = S.make_cue(1, 0.0, 1.0, "hi")
+    assert "speaker" not in c
+    assert c == {"index": 1, "start": 0.0, "end": 1.0, "text": "hi"}
+
+
+def test_make_cue_with_speaker_adds_key():
+    c = S.make_cue(1, 0.0, 1.0, "hi", speaker="SPEAKER_00")
+    assert c["speaker"] == "SPEAKER_00"
+    # frozen fields keep their names/order; speaker is additive.
+    assert c == {"index": 1, "start": 0.0, "end": 1.0, "text": "hi", "speaker": "SPEAKER_00"}
+
+
+def test_make_cue_empty_speaker_omits_key():
+    # Empty string is falsy -> treated as "no speaker" (no leakage).
+    c = S.make_cue(1, 0.0, 1.0, "hi", speaker="")
+    assert "speaker" not in c
+
+
+def test_make_cue_coerces_speaker_to_str():
+    c = S.make_cue(1, 0.0, 1.0, "hi", speaker=7)
+    assert c["speaker"] == "7"
+
+
+def test_reindex_preserves_speaker_when_present():
+    src = [
+        {"index": 9, "start": 0.0, "end": 1.0, "text": "a", "speaker": "SPEAKER_01"},
+        {"index": 4, "start": 1.0, "end": 2.0, "text": "b"},
+    ]
+    out = S.reindex(src)
+    assert [c["index"] for c in out] == [1, 2]
+    assert out[0]["speaker"] == "SPEAKER_01"
+    assert "speaker" not in out[1]  # absent -> no speaker:None leakage
+
+
+def test_cues_from_transcript_carries_speaker():
+    seg = {"start": 0.0, "end": 1.0, "text": "hi there", "speaker": "SPEAKER_00", "words": []}
+    cues = S.cues_from_transcript({"segments": [seg]})
+    assert len(cues) == 1
+    assert cues[0]["speaker"] == "SPEAKER_00"
+
+
+def test_cues_from_transcript_no_speaker_key_when_absent():
+    cues = S.cues_from_transcript({"segments": [_seg(0.0, 1.0, "hi")]})
+    assert "speaker" not in cues[0]
+
+
+def test_split_segment_inherits_speaker():
+    words = [
+        {"text": w, "start": i * 1.0, "end": i * 1.0 + 0.9}
+        for i, w in enumerate(["one", "two", "three", "four", "five", "six"])
+    ]
+    seg = {
+        "start": 0.0,
+        "end": 6.0,
+        "text": "one two three four five six",
+        "speaker": "SPEAKER_02",
+        "words": words,
+    }
+    cues = S.cues_from_transcript({"segments": [seg]}, max_chars=12, max_duration=2.0)
+    assert len(cues) >= 2
+    assert all(c["speaker"] == "SPEAKER_02" for c in cues)
+
+
+def test_split_segment_without_speaker_omits_key():
+    words = [
+        {"text": w, "start": i * 1.0, "end": i * 1.0 + 0.9}
+        for i, w in enumerate(["one", "two", "three", "four", "five", "six"])
+    ]
+    seg = _seg(0.0, 6.0, "one two three four five six", words=words)
+    cues = S.cues_from_transcript({"segments": [seg]}, max_chars=12, max_duration=2.0)
+    assert len(cues) >= 2
+    assert all("speaker" not in c for c in cues)
+
+
+def test_format_speaker_prefix_off_is_identity_on_text():
+    cues = [S.make_cue(1, 0.0, 1.0, "hi", speaker="SPEAKER_00")]
+    out = S.format_speaker_prefix(cues, on=False)
+    assert out[0]["text"] == "hi"
+    assert out[0]["speaker"] == "SPEAKER_00"
+    # immutable: fresh dict, input untouched.
+    assert out[0] is not cues[0]
+
+
+def test_format_speaker_prefix_on_prefixes_speaker_cue():
+    cues = [S.make_cue(1, 0.0, 1.0, "hi", speaker="SPEAKER_00")]
+    out = S.format_speaker_prefix(cues, on=True)
+    assert out[0]["text"] == "SPEAKER_00: hi"
+    # input not mutated
+    assert cues[0]["text"] == "hi"
+
+
+def test_format_speaker_prefix_on_skips_non_speaker_cue():
+    cues = [S.make_cue(1, 0.0, 1.0, "hi")]
+    out = S.format_speaker_prefix(cues, on=True)
+    assert out[0]["text"] == "hi"
+    assert "speaker" not in out[0]
+
+
+def test_format_speaker_prefix_off_non_speaker_cue():
+    cues = [S.make_cue(1, 0.0, 1.0, "hi")]
+    out = S.format_speaker_prefix(cues, on=False)
+    assert out[0]["text"] == "hi"
+
+
+def test_srt_back_compat_no_speaker_prefix_off():
+    # No-speaker, prefix-off path must serialize byte-identically to today.
+    cues = [S.make_cue(1, 0.0, 1.0, "hello"), S.make_cue(2, 1.0, 2.0, "world")]
+    plain = S.to_srt(cues)
+    passed = S.to_srt(S.format_speaker_prefix(cues, on=False))
+    assert passed == plain
+
+
+def test_vtt_ass_back_compat_no_speaker_prefix_off():
+    cues = [S.make_cue(1, 0.0, 1.0, "hello")]
+    no_prefix = S.format_speaker_prefix(cues, on=False)
+    assert S.to_vtt(no_prefix) == S.to_vtt(cues)
+    assert S.to_ass(no_prefix) == S.to_ass(cues)


### PR DESCRIPTION
## Editing-refine — filler/silence removal + diarization (8 WUs)

Adds a non-destructive **Refine** editing pass (filler-word + silence removal) and **speaker diarization rename** flow to Media Studio, wired end-to-end (sidecar RPC + renderer panels).

### Work Units
- **WU-1** `refine.plan_refine` — pure span/stat unifier producing the refine plan.
- **WU-2** `RefineService` — preview + apply over injected seams (reversible).
- **WU-3** subtitles speaker-carry — speaker labels propagated to cues / SRT / ASS / VTT.
- **WU-4** `diarize.rename_speakers` (pure) + `diarize.rename` RPC.
- **WU-5** register `refine.*` + `diarize.rename` + `subtitles captionSpeakerLabels` gate onto `handlers.register_all`.
- **WU-6 / WU-6b** `Refine.tsx` renderer panel + mount into `Workspace` (panel reachability).
- **WU-7** `Diarize.tsx` per-speaker rename block.
- **WU-8** settings + CONTRACTS docs close-out (refine tunables are RPC params, not settings keys).

### Hub AI-Job envelope
The core refine/diarize bundle is **local-only / no egress** (no budget/consent gate needed). The optional AI-assisted parts ride the existing **Hub AI-Job envelope** (`models/ai_job.py`): `plan_ai_job` → `{route, costEst, cacheKey, willEgress}` for cost-preview + **consent** before any egress; `run_ai_job` enforces the **cache-first** lookup, the **budget** degrade chain, and only egresses when `willEgress` is true. Provider/rotation comes from the **pool** in `models/provider.py` — no hand-rolled provider calls.

### Validation (run fresh on branch tip `ca9e925`, authoritative — not per-WU reports)
- **Sidecar:** `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **3049 passed, 100.00% coverage** (line+branch).
- **Renderer:** `vitest run --coverage` → **1162 passed, 100%** statements/branches/functions/lines.
- **Lint/format:** ruff check + ruff format (sidecar) clean; biome 2.5.0 format clean; oxlint `--deny-warnings` clean.
- **Types:** `tsc --noEmit` (app + render-cli) clean; basedpyright **0 errors**.

> Note: these four editing branches each branched off `main` independently and each touches `handlers.register_all` — that is a **merge-time** concern, not a per-branch failure.
