### PR TITLE
revert: dependabot #217 sidecar pip bump (broke chatterbox torch cu128 GPU pin)

### DIFF
--- a/sidecar/pyproject.toml
+++ b/sidecar/pyproject.toml
@@ -18,9 +18,9 @@ dependencies = [
   "httpx>=0.27",           # HTTP client for the llama.cpp OpenAI-compatible server (§7)
   # P2 (T2, A6 lesson 5: PINNED). ⚠ human: verify current releases at install
   # time. chatterbox-tts/torch must NOT be added here (isolated env asset only).
-  "kokoro-onnx==0.5.0",    # A4: the onnx build — NEVER the torch `kokoro` package
-  "onnxruntime==1.27.0",   # kokoro-onnx backend (or onnxruntime-gpu, same pin)
-  "edge-tts==7.2.8",       # hosted TTS engine (network only at runtime)
+  "kokoro-onnx==0.4.9",    # A4: the onnx build — NEVER the torch `kokoro` package
+  "onnxruntime==1.20.1",   # kokoro-onnx backend (or onnxruntime-gpu, same pin)
+  "edge-tts==7.0.0",       # hosted TTS engine (network only at runtime)
 ]
 
 [project.optional-dependencies]

--- a/sidecar/requirements.lock.txt
+++ b/sidecar/requirements.lock.txt
@@ -18,7 +18,7 @@ av==17.1.0
     # via faster-whisper
 babel==2.18.0
     # via csvw
-certifi==2026.6.17
+certifi==2026.5.20
     # via
     #   edge-tts
     #   httpcore
@@ -43,7 +43,7 @@ ctranslate2==4.8.0
     # via faster-whisper
 dlinfo==2.0.0
     # via phonemizer-fork
-edge-tts==7.2.8
+edge-tts==7.0.0
     # via media-studio-sidecar (sidecar/pyproject.toml)
 espeakng-loader==0.2.4
     # via kokoro-onnx
@@ -69,7 +69,7 @@ httpx==0.28.1
     # via
     #   media-studio-sidecar (sidecar/pyproject.toml)
     #   huggingface-hub
-huggingface-hub==1.20.1
+huggingface-hub==1.19.0
     # via
     #   faster-whisper
     #   tokenizers
@@ -88,7 +88,7 @@ jsonschema==4.26.0
     # via csvw
 jsonschema-specifications==2025.9.1
     # via jsonschema
-kokoro-onnx==0.5.0
+kokoro-onnx==0.4.9
     # via media-studio-sidecar (sidecar/pyproject.toml)
 language-tags==1.3.1
     # via csvw
@@ -96,7 +96,7 @@ markdown-it-py==4.2.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
-mpmath==1.4.1
+mpmath==1.3.0
     # via sympy
 multidict==6.7.1
     # via
@@ -109,7 +109,7 @@ numpy==2.4.6
     #   onnxruntime
     #   opencv-python
     #   scenedetect
-onnxruntime==1.27.0
+onnxruntime==1.20.1
     # via
     #   media-studio-sidecar (sidecar/pyproject.toml)
     #   faster-whisper
@@ -178,12 +178,12 @@ termcolor==3.3.0
     # via csvw
 tokenizers==0.23.1
     # via faster-whisper
-tqdm==4.68.3
+tqdm==4.68.2
     # via
     #   faster-whisper
     #   huggingface-hub
     #   scenedetect
-typer==0.26.7
+typer==0.25.1
     # via huggingface-hub
 typing-extensions==4.15.0
     # via

--- a/sidecar/runtime_setup/requirements-chatterbox.txt
+++ b/sidecar/runtime_setup/requirements-chatterbox.txt
@@ -21,5 +21,5 @@
 # LIST, so a bootstrap-built env only counts as the installed "chatterbox-env"
 # asset when the pin order matches. Keep both in sync.
 chatterbox-tts==0.1.7
-torch==2.12.1
-torchaudio==2.11.0+cu128
+torch==2.10.0+cu128
+torchaudio==2.10.0+cu128

--- a/sidecar/runtime_setup/requirements-sidecar.txt
+++ b/sidecar/runtime_setup/requirements-sidecar.txt
@@ -14,15 +14,15 @@ opencv-python==4.13.0.92
 httpx==0.28.1
 numpy==2.4.6
 av==17.1.0
-onnxruntime==1.27.0
-huggingface_hub==1.20.1
+onnxruntime==1.26.0
+huggingface_hub==1.19.0
 tokenizers==0.23.1
 
 # TTS (kokoro default engine — the onnx build, NEVER the torch pip package; A4)
 # CONTRACT-NOTE: kokoro-onnx is not in the dev venv yet (T2 lane); 0.4.9 is the
 # pinned choice per the T5 brief ("latest pinned by exact version you choose").
-kokoro-onnx==0.5.0
+kokoro-onnx==0.4.9
 
 # CUDA runtime wheels for ctranslate2/onnxruntime GPU paths (pins = dev venv)
 nvidia-cublas-cu12==12.9.2.10
-nvidia-cudnn-cu12==9.23.2.1
+nvidia-cudnn-cu12==9.23.1.3


### PR DESCRIPTION
dependabot #217 bumped the chatterbox torch pin 2.10.0+cu128 -> 2.12.1 (dropping the CUDA build) + nvidia-cudnn, regressing the GPU stack; the test_runtime_setup.py pin-guard correctly failed. Reverting to restore the verified-green main + correct GPU pins. Safe sidecar bumps can be re-applied carefully later, preserving +cu128.