### PR TITLE
fix(index): embedder uses raw apiKey (was redacted -> cloud 401)

### DIFF
--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -1311,7 +1311,12 @@ class Services:
         transcript = project.data.get("transcript")
         if not transcript:
             raise _invalid(f"video {video_id} has no transcript yet (run transcribe.start first)")
-        settings = dict(self.settings.get())
+        # FACTORY PATH: the embedder resolution below reaches CloudEmbedder, which
+        # needs the RAW apiKey on the wire — mirror the vision/director factories
+        # (get_raw() at _provider_for_function/_resolve_frame_scorer). get_raw()
+        # only un-redacts apiKey; consent/routing/budget semantics are identical to
+        # get() (settings_store.get just last-4-redacts providers[].apiKeys).
+        settings = dict(self.settings.get_raw())
 
         def work(job_ctx: Any, _envelope: Any, _provider: Any) -> dict[str, Any]:
             from .features import semantic_index as _si  # local: import-light (pure)
@@ -1432,7 +1437,10 @@ class Services:
         if index is None:
             raise _invalid(f"video {video_id} has no semantic index yet (run index.build first)")
 
-        settings = dict(self.settings.get())
+        # FACTORY PATH: the query-embedder resolution below reaches CloudEmbedder,
+        # which needs the RAW apiKey on the wire — get_raw() mirrors the vision/
+        # director factories and only un-redacts apiKey (consent/routing identical).
+        settings = dict(self.settings.get_raw())
         # Plan the budget envelope over the TEXT-consented settings so willEgress
         # reflects what would actually leave the box after the consent filter, then
         # enforce the ack BEFORE any embedding call (zero egress on an unacked run).

--- a/sidecar/tests/test_handlers_index.py
+++ b/sidecar/tests/test_handlers_index.py
@@ -503,3 +503,50 @@ def test_resolve_index_embedder_injected_wins(tmp_path: Path) -> None:
     emb = RecordingEmbedder()
     svc = _services(tmp_path, embedder=emb)
     assert svc._resolve_index_embedder(_cloud_settings(text_consent=True)) is emb
+
+
+# --------------------------------------------------------------------------- #
+# REGRESSION (bug #5): the settings-DRIVEN index egress (no injected embedder)
+# must carry the RAW apiKey to the wire, not the REDACTED last-4 form.
+#
+# Mirrors the e2e-ai2 strict-xfail companion
+# ``test_intel_semantic_settings_driven_egress_redacted_key_bug`` as a PASSING
+# regression: the call sites resolved the embedder over ``self.settings.get()``
+# (which redacts ``apiKeys`` to ``…1234``), so ``CloudEmbedder`` built an
+# ``Authorization: Bearer …1234`` header — a corrupted key (non-latin-1 ellipsis
+# crashes locally / 401 on a real cloud). The vision/director factories correctly
+# use ``get_raw()`` (handlers.py); the embedder path now does too. The unit
+# consent tests above missed this because they assert on the egressed TEXT
+# (``body["input"]``), never on the egressed KEY (``headers["Authorization"]``).
+# --------------------------------------------------------------------------- #
+_RAW_INDEX_KEY: str = "sk-index-key-1234"
+_REDACTED_INDEX_KEY: str = "…1234"  # secrets.redact_keys(...) of _RAW_INDEX_KEY
+
+
+def test_index_build_egresses_raw_apikey_not_redacted(tmp_path: Path) -> None:
+    spy = SpyTransport()
+    svc = _services(tmp_path, embed_transport=spy)
+    _set_settings(svc, _cloud_settings(text_consent=True))
+    vid = _add_video_with_transcript(svc, tmp_path)
+    ctx = _ctx()
+    svc.index_build({"videoId": vid}, ctx)
+    ctx.jobs.join(timeout=5)
+    _done_result(ctx)
+    assert spy.calls, "consent granted but no egress happened (embedder wired wrong)"
+    auth = spy.calls[0]["headers"]["Authorization"]
+    assert auth == f"Bearer {_RAW_INDEX_KEY}", auth
+    assert _REDACTED_INDEX_KEY not in auth
+
+
+def test_index_search_egresses_raw_apikey_not_redacted(tmp_path: Path) -> None:
+    spy = SpyTransport()
+    svc = _services(tmp_path, embed_transport=spy)
+    vid = _add_video_with_transcript(svc, tmp_path)
+    _set_settings(svc, _cloud_settings(text_consent=True))
+    _build_then_clear_spy(svc, spy, vid)
+
+    svc.index_search({"videoId": vid, "query": "find pricing"}, _ctx())
+    assert spy.calls, "consent granted but query never egressed"
+    auth = spy.calls[0]["headers"]["Authorization"]
+    assert auth == f"Bearer {_RAW_INDEX_KEY}", auth
+    assert _REDACTED_INDEX_KEY not in auth


### PR DESCRIPTION
## Bug #5 — semantic-index embedder used REDACTED keys on real cloud egress

`index_build` (~handlers.py:1321) and `index_search` (~:1459) resolved the embedder via `_resolve_index_embedder` over settings sourced from `self.settings.get()`, which **redacts** `providers[].apiKeys` to the last-4 form (e.g. `…1234`). The resulting `CloudEmbedder` built an `Authorization: Bearer …1234` header, so the real `/v1/embeddings` egress sent a **corrupted key** — a non-latin-1 ellipsis that crashes locally (`UnicodeEncodeError`) / would be 401-rejected by a real cloud server.

The vision/director factories already do this correctly via `get_raw()` (`_provider_for_function` handlers.py:833, `_resolve_frame_scorer` :1025). The index embedder path now mirrors them.

## Fix (minimal — 2 lines)

`index_build`/`index_search` resolve the embedder over `self.settings.get_raw()` instead of `get()`. `get_raw()` differs from `get()` **only** by un-redacting `providers[].apiKeys` (see `settings_store.get`), so consent / routing / budget semantics are byte-for-byte identical. The budget-planning seam `_plan_index_envelope` is deliberately left on `get()` — it only computes `willEgress` and the redacted key is still truthy, so pool materialization (and thus planning) is unaffected and no key egresses there.

## Test (additive, TDD)

Regression port of the `chore/e2e-ai2` strict-xfail `test_intel_semantic_settings_driven_egress_redacted_key_bug`, re-created as a **passing** non-ffmpeg regression in `tests/test_handlers_index.py` (mirroring its existing `SpyTransport`/`embed_transport` pattern). Two tests assert the **raw** key reaches the wire (`headers["Authorization"] == "Bearer sk-index-key-1234"`, and the `…1234` redacted form is absent) on both the build and search settings-driven paths. The existing consent tests missed this because they assert on the egressed *text* (`body["input"]`), never the egressed *key*.

- Confirmed **FAILS pre-fix** (`Bearer …1234`), **PASSES post-fix**.

## Gate

- `pytest --cov=media_studio --cov-branch --cov-fail-under=100`: **100% line+branch** (3867 passed); handlers.py 100%.
- ruff check + format: clean.
- basedpyright: **0 errors** (50 pre-existing optional-ML-import warnings, none in changed files).