### PR TITLE
fix(director): consent-gate editPlan + wire real apply engines (E2E ship-blockers #6/#7)

### DIFF
--- a/sidecar/media_studio/features/director_op_engines.py
+++ b/sidecar/media_studio/features/director_op_engines.py
@@ -1,0 +1,395 @@
+"""Real ffmpeg op-engine adapters for ``director.apply`` (FIX #7, WU-apply).
+
+``apply_engine.apply_plan`` walks an :class:`EditPlan` over a project COPY and
+dispatches each op to an injected ``{kind: engine}`` table (the seam). v1 shipped
+that table EMPTY (``handlers._director_engines`` returned ``{}``), so EVERY op hit
+the "no engine for kind" path -> ``failed`` -> auto-rollback, and a real client
+got a no-op manifest copy instead of an edited mp4. This module supplies the REAL
+adapters that table needs, so ``director.apply`` actually renders edited media.
+
+Each adapter is an :data:`apply_engine.OpEngine` — ``(EditOp, ProjectCopy) -> EditOp``
+— that:
+
+  * reads the COPY's current source video (``data["video"]["path"]``) — NEVER the
+    untouched source manifest;
+  * renders a REAL edited mp4 (reusing the shipped ffmpeg helpers:
+    ``fillers.build_segment_cut_argv`` for span keeps/cuts, ``silencetrim.trim_clip``
+    for dead-air removal, ``caption.build_ass`` + ``caption.build_burn_argv`` for
+    subtitle burn-in) into the COPY's ``.director-copy`` folder, beside the COPY
+    manifest;
+  * re-points the COPY manifest at the rendered file and returns an INVERSE op
+    that restores the prior reference (no re-render), so ``director.undo`` round-trips.
+
+DUAL-MODE (forward + inverse over the SAME kind): the recorded inverse op routes
+back through ``engines[kind]`` during rollback/undo (``apply_plan`` /
+``_director_inverse_engines``). An inverse op is tagged with the sentinel
+:data:`RESTORE_KEY` in its params; an adapter seeing that sentinel just RESTORES
+the recorded reference and returns the re-inverse — it never re-renders. This
+mirrors the ``params['undo']`` precedent in ``test_apply_engine``.
+
+PURITY / SEAM: the ONE impure thing — the ffmpeg subprocess — is the injected
+``runner`` (default :func:`ffmpeg.run`). Unit tests inject a fake runner that
+stubs the output file (covers the dispatch/manifest/inverse logic + every error
+branch deterministically); a separate ``@pytest.mark.integration`` test uses the
+real runner to prove a ffprobe-valid edited mp4 + undo round-trip. No
+``Provider``/transport/heavy-ML import.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from media_studio import ffmpeg as _ffmpeg
+from media_studio.features import caption as _caption
+from media_studio.features import fillers as _fillers
+from media_studio.features import silencetrim as _silencetrim
+from media_studio.features.apply_engine import EngineTable, OpEngine
+from media_studio.features.project_copy import ProjectCopy
+from media_studio.models.edit_plan import EditOp
+
+#: A runner ``(argv, total_sec) -> exit_code`` — the injected ffmpeg subprocess
+#: seam. Default :func:`ffmpeg.run`; tests inject a fake that stubs the output.
+RunFn = Callable[..., int]
+
+#: The inverse-op sentinel param: when present in ``op.params`` it carries the
+#: video path to RESTORE, so an adapter knows this is the undo direction (restore,
+#: never re-render). Double-underscored so it can never collide with a planner param.
+RESTORE_KEY = "__directorRestoreVideo__"
+
+#: The op kinds wired to a real ffmpeg engine in v1 (the core renderers).
+WIRED_KINDS: tuple[str, ...] = ("trim", "cut", "removeSilence", "caption")
+
+#: The op kinds NOT yet wired to a real engine in v1 — logged (never silently
+#: skipped) so an op of one of these kinds surfaces as a clear per-op ``failed``
+#: with auto-rollback. ``reframe`` is held back deliberately: its shipped helper
+#: shells ``wsl bash <script>`` (a host->WSL bridge), which is not a portable
+#: in-engine render path; the rest are manifest/track/multi-artifact ops out of
+#: the v1 render scope. (``export`` re-encodes the whole timeline; that lands with
+#: the export WU.)
+DEFERRED_KINDS: tuple[str, ...] = (
+    "removeFillers",
+    "reorder",
+    "retime",
+    "reframe",
+    "zoomPan",
+    "translateCaption",
+    "overlayText",
+    "lowerThird",
+    "export",
+    "stitchPanorama",
+    "regenScroll",
+    "ocrExtractList",
+)
+
+
+class DirectorEngineError(RuntimeError):
+    """Raised when a real op-engine cannot render (bad manifest / ffmpeg failure).
+
+    ``apply_plan`` captures this as the op's ``status="failed"`` + reason and
+    auto-rolls-back the COPY (the source manifest was never touched), so a render
+    failure degrades to a no-op edit, never a crash or a corrupt source.
+    """
+
+
+def _video_block(project_copy: ProjectCopy) -> dict[str, Any]:
+    """Return the COPY manifest's mutable ``video`` block (the edited ref lives here)."""
+    video = project_copy.data.get("video")
+    if not isinstance(video, dict):
+        raise DirectorEngineError("project copy has no 'video' block to edit")
+    return video
+
+
+def _source_path(project_copy: ProjectCopy) -> str:
+    """Return the COPY's current source video path (what the next op renders FROM)."""
+    path = _video_block(project_copy).get("path")
+    if not isinstance(path, str) or not path:
+        raise DirectorEngineError("project copy 'video' has no source path")
+    return path
+
+
+def _out_path(project_copy: ProjectCopy, op: EditOp) -> Path:
+    """Resolve a deterministic, per-op output mp4 path inside the COPY folder.
+
+    The render is written BESIDE the COPY manifest (the isolated ``.director-copy``
+    folder), so it can never overwrite the source and persists for undo (which
+    re-points to it without re-rendering).
+    """
+    folder = project_copy.manifest_path.parent
+    src_stem = Path(_source_path(project_copy)).stem
+    return folder / f"{src_stem}.{op.id}.mp4"
+
+
+def _repoint(project_copy: ProjectCopy, new_path: str) -> str:
+    """Point the COPY manifest's video at ``new_path`` AND PERSIST it; return the old path.
+
+    Re-pointing only the in-memory ``data`` is not enough: a real client reads the
+    rendered result from the COPY manifest ON DISK (``ApplyResult.project_copy_path``,
+    which ``copy_project`` wrote ONCE at copy time still pointing at the SOURCE). So
+    we re-write the manifest here — on BOTH the forward render and the undo restore —
+    so the persisted manifest references the rendered edit (forward) or flips back to
+    the source (undo). Without this the edited bytes exist but are orphaned: the
+    returned manifest would still reference the unedited source (the marquee no-op).
+    """
+    video = _video_block(project_copy)
+    old_path = str(video.get("path") or "")
+    video["path"] = new_path
+    project_copy.manifest_path.write_text(json.dumps(project_copy.data, indent=2, ensure_ascii=False), encoding="utf-8")
+    return old_path
+
+
+def _inverse_op(op: EditOp, restore_path: str) -> EditOp:
+    """Build the recorded inverse op: same id/kind, carrying the path to restore.
+
+    Re-feeding this op through the SAME-kind adapter (rollback/undo) restores the
+    pre-op video reference. Marked ``reversible`` so the undo walk is never gated.
+    """
+    return EditOp(
+        id=op.id,
+        kind=op.kind,
+        span=op.span,
+        params={RESTORE_KEY: restore_path},
+        reversible=True,
+        rationale=op.rationale,
+    )
+
+
+def _maybe_restore(op: EditOp, project_copy: ProjectCopy) -> EditOp | None:
+    """If ``op`` is an inverse op (carries the sentinel), restore + return re-inverse.
+
+    Returns the re-inverse op (so a double-undo is itself reversible) when this is
+    the undo direction, or ``None`` when this is a fresh forward op to render.
+    """
+    restore = op.params.get(RESTORE_KEY)
+    if not isinstance(restore, str):
+        return None
+    previous = _repoint(project_copy, restore)
+    return _inverse_op(op, previous)
+
+
+def _render(
+    project_copy: ProjectCopy,
+    op: EditOp,
+    build_argv: Callable[[str, str], list[str]],
+    *,
+    runner: RunFn,
+    settings: Mapping[str, Any] | None,
+) -> EditOp:
+    """Render via ``build_argv(in, out)`` over the COPY source; re-point + record inverse.
+
+    The common forward path for the span/cut renderers: probe the source duration
+    (for progress %), run the built argv through the injected ``runner``, and on a
+    clean exit re-point the manifest at the rendered file. A non-zero exit raises
+    :class:`DirectorEngineError` (captured as the op's ``failed`` status upstream).
+    """
+    in_path = _source_path(project_copy)
+    out_path = _out_path(project_copy, op)
+    argv = build_argv(in_path, str(out_path))
+    total = _ffmpeg.ffprobe_duration(in_path, dict(settings or {}))
+    code = runner(argv, total_sec=total)
+    if code != 0:
+        raise DirectorEngineError(f"ffmpeg exit {code} rendering {op.kind!r} op {op.id!r}")
+    previous = _repoint(project_copy, str(out_path))
+    return _inverse_op(op, previous)
+
+
+def _require_span(op: EditOp) -> tuple[int, int]:
+    """Return the op's span in ms (validate-and-reject guarantees it is present/valid)."""
+    if op.span is None:  # pragma: no cover - validate_and_reject drops span-less span ops first
+        raise DirectorEngineError(f"{op.kind!r} op {op.id!r} requires a span")
+    return op.span
+
+
+def _keep_for_trim(op: EditOp, total_sec: float) -> list[tuple[float, float]]:
+    """Keeps for a ``trim`` op: drop the span, keep everything outside it.
+
+    ``trim`` removes the dead-air / unwanted range ``[start, end]`` and keeps the
+    head ``[0, start)`` + tail ``(end, total]`` (whichever are non-empty). A span
+    covering the whole clip would leave nothing — guarded as a render error.
+    """
+    span = _require_span(op)
+    start_s = span[0] / 1000.0
+    end_s = span[1] / 1000.0
+    keeps: list[tuple[float, float]] = []
+    if start_s > 0.0:
+        keeps.append((0.0, start_s))
+    if end_s < total_sec:
+        keeps.append((end_s, total_sec))
+    if not keeps:
+        raise DirectorEngineError("trim span covers the whole clip (nothing left to keep)")
+    return keeps
+
+
+def _keep_for_cut(op: EditOp) -> list[tuple[float, float]]:
+    """Keeps for a ``cut`` op: keep ONLY the span ``[start, end]`` (discard the rest)."""
+    span = _require_span(op)
+    return [(span[0] / 1000.0, span[1] / 1000.0)]
+
+
+def make_trim_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``trim``: re-cut the clip with the span REMOVED (dead-air drop).
+
+    Forward renders a real mp4 (head + tail concatenated via
+    ``fillers.build_segment_cut_argv``) and re-points the COPY at it; the recorded
+    inverse restores the pre-trim reference (undo, no re-render).
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        in_path = _source_path(project_copy)
+        total = _ffmpeg.ffprobe_duration(in_path, dict(settings or {}))
+        keeps = _keep_for_trim(op, total)
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: _fillers.build_segment_cut_argv(i, o, keeps, dict(settings or {})),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_cut_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``cut``: KEEP only the span, discard the rest (extract a sub-clip).
+
+    Forward renders the kept span via ``fillers.build_segment_cut_argv`` and
+    re-points the COPY; the inverse restores the pre-cut reference.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        keeps = _keep_for_cut(op)
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: _fillers.build_segment_cut_argv(i, o, keeps, dict(settings or {})),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_remove_silence_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``removeSilence``: drop sub-threshold dead air (the "silencetrim").
+
+    Reuses the shipped ``silencetrim.trim_clip`` (detect silent spans -> invert to
+    keeps -> re-cut), so apply rides the SAME dead-air pipeline as ``silence.trim``.
+    When the trim finds nothing to remove it returns the input unchanged; the
+    adapter still re-points to a concrete prior reference, so the inverse always
+    restores a real path.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        in_path = _source_path(project_copy)
+        out_path = _out_path(project_copy, op)
+        result_path, _removed = _silencetrim.trim_clip(
+            in_path,
+            str(out_path),
+            settings=dict(settings or {}),
+            run=runner,
+        )
+        previous = _repoint(project_copy, result_path)
+        return _inverse_op(op, previous)
+
+    return engine
+
+
+def _track_cues(project_copy: ProjectCopy, op: EditOp) -> Sequence[Mapping[str, Any]]:
+    """Return the cues of the caption op's target track from the COPY manifest.
+
+    ``caption`` is a track-bound op (validate-and-reject guarantees ``params['track']``
+    names an EXISTING track), so the burnable content is that track's inline cues
+    (``{index, start, end, text}``, the ``subtitles.new_track`` schema). A track
+    with no cues cannot burn anything -> a render error (never a silent no-op).
+    """
+    track_id = op.params.get("track")
+    tracks = project_copy.data.get("tracks")
+    if isinstance(tracks, Sequence) and not isinstance(tracks, (str, bytes)):
+        for track in tracks:
+            if isinstance(track, Mapping) and track.get("id") == track_id:
+                cues = track.get("cues")
+                if isinstance(cues, Sequence) and not isinstance(cues, (str, bytes)) and cues:
+                    return [c for c in cues if isinstance(c, Mapping)]
+                raise DirectorEngineError(f"caption track {track_id!r} has no cues to burn")
+    raise DirectorEngineError(f"caption track {track_id!r} not found in project copy")
+
+
+def make_caption_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``caption``: BURN the target track's cues into the video (libass).
+
+    Forward builds an ASS document from the track's cues (``caption.build_ass``)
+    and hardcodes it onto the video via ``caption.build_burn_argv`` (the same
+    libass path ``caption.apply`` ships), re-pointing the COPY at the burned mp4.
+    The inverse restores the pre-burn reference (undo, no re-render).
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        cues = _track_cues(project_copy, op)
+        out_path = _out_path(project_copy, op)
+        ass_path = out_path.with_suffix(".ass")
+        ass_doc = _caption.build_ass(cues)
+        ass_path.write_text(ass_doc, encoding="utf-8")
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: _caption.build_burn_argv(i, str(ass_path), o, dict(settings or {})),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def build_engines(*, runner: RunFn | None = None, settings: Mapping[str, Any] | None = None) -> EngineTable:
+    """Build the real ``{kind: engine}`` dispatch table for ``director.apply``.
+
+    Closes each adapter over the injected ``runner`` (default :func:`ffmpeg.run`,
+    the real subprocess) + ``settings`` (ffmpeg binary resolution). Covers the
+    :data:`WIRED_KINDS` core renderers; :data:`DEFERRED_KINDS` are intentionally
+    absent (logged by :func:`log_deferred`), so an op of a deferred kind surfaces
+    as a per-op ``failed`` with auto-rollback (never a silent no-op).
+    """
+    run = runner if runner is not None else _ffmpeg.run
+    return {
+        "trim": make_trim_engine(runner=run, settings=settings),
+        "cut": make_cut_engine(runner=run, settings=settings),
+        "removeSilence": make_remove_silence_engine(runner=run, settings=settings),
+        "caption": make_caption_engine(runner=run, settings=settings),
+    }
+
+
+def log_deferred(log: Any) -> None:
+    """Log the op kinds NOT yet wired to a real engine (visibility, never silent).
+
+    Called once when the table is built so a deferred-kind op's eventual per-op
+    ``failed`` is never a surprise — the set of unwired kinds is announced up front.
+    """
+    log.info("director.apply real engines wired for %s; deferred (no engine yet): %s", WIRED_KINDS, DEFERRED_KINDS)
+
+
+__all__ = [
+    "DEFERRED_KINDS",
+    "WIRED_KINDS",
+    "RESTORE_KEY",
+    "DirectorEngineError",
+    "build_engines",
+    "log_deferred",
+    "make_caption_engine",
+    "make_cut_engine",
+    "make_remove_silence_engine",
+    "make_trim_engine",
+]

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -253,6 +253,7 @@ class Services:
         # one-shot reversal (DESIGN §5/§7.1). A plan that was never applied has no
         # entry here, so ``director.undo`` rejects it (nothing to undo).
         self._director_inverses: dict[str, Any] = {}  # planId -> edit_plan.EditPlan
+        self._director_engines_logged = False  # one-shot deferred-kinds log (FIX #7)
 
     # ===================================================================== #
     # resolvers
@@ -2745,15 +2746,24 @@ class Services:
             )
         return {"perFunction": per_function}
 
-    def _director_engines(self) -> Any:  # pragma: no cover - real engine adapters wire in as the engine WUs land
+    def _director_engines(self) -> Any:
         """The op-kind -> engine dispatch table for ``director.apply`` (the seam).
 
-        Real impls are the shipped engine adapters (silencetrim/fillers/reframe/
-        ocr/stitch/regen), wired as those WUs land; tests inject a fake table. v1
-        ships an empty table (apply over a copy works; unmapped kinds report a
-        per-op ``failed`` with auto-rollback, never a crash).
+        Wires the REAL ffmpeg op-engine adapters (``features.director_op_engines``)
+        so ``director.apply`` actually RENDERS edited media (FIX #7): the core
+        renderers ``trim``/``cut``/``removeSilence``/``caption`` operate on the
+        project COPY and produce real mp4s, each recording an inverse for
+        ``director.undo``. Deferred kinds (logged ONCE on first build) have no
+        engine yet, so an op of one surfaces as a per-op ``failed`` with
+        auto-rollback — never a crash, never a silent no-op. Tests inject a fake
+        table over this seam.
         """
-        return {}
+        from .features import director_op_engines as _engines  # local: import-light pure
+
+        if not self._director_engines_logged:
+            _engines.log_deferred(log)
+            self._director_engines_logged = True
+        return _engines.build_engines(settings=self.settings.get())
 
     def _director_inverse_engines(
         self,

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -2606,6 +2606,62 @@ class Services:
             raise _invalid(f"unknown plan: {plan_id}")
         return entry
 
+    def _editplan_provider_or_refuse(self) -> Any:
+        """Resolve the ``editPlan`` chat provider, gated by per-provider TEXT consent.
+
+        CRITICAL PRIVACY INVARIANT (PLAN §WU-A1/G-A5 — the chat analog of the
+        index-embedder :meth:`_resolve_index_embedder` and the vision
+        :meth:`_resolve_frame_scorer` consent gates): ``build_understanding`` folds
+        the transcript into the planner prompt, so the ``director.plan`` chat egress
+        carries transcript TEXT. The egress provider is therefore BUILT FROM the
+        per-entry TEXT-consent-filtered settings — exactly like the embedder builds
+        its :class:`CloudEmbedder` from :meth:`_resolve_index_embedder`'s filtered
+        pool — so EVERY slot the routed pool may rotate to (primary AND every 429
+        failover) is one whose TEXT consent is granted. Filtering the actual pool
+        (not just an all-or-nothing precheck) is what closes the mixed-consent
+        rotation hole: a non-consented cloud entry is DROPPED before the pool is
+        built, so it can never become the ``prefer`` primary nor a failover target.
+
+        Resolution (mirrors :meth:`_resolve_index_embedder`):
+
+        1. An injected ``_provider`` seam wins outright (tests / a wholesale
+           override) — same as the embedder's injected-``_embedder`` short-circuit.
+        2. Else build the routed ``editPlan`` pool over the TEXT-CONSENT-FILTERED
+           RAW settings (``get_raw()`` keeps the RAW key on the wire for the
+           consented entries; the filter drops every non-consented cloud entry).
+           When the RAW (unfiltered) routed pool HAD a cloud egress target but the
+           filtered pool has NONE, every configured cloud target is non-consented:
+           REFUSE before any chat (a clear refusal, the chat analog of the
+           embedder's local fallback — chat has no in-process local backstop to
+           complete with). Zero bytes leave the machine.
+        3. Else -> the consent-filtered routed pool: a consented cloud entry
+           egresses (RAW key), and a genuinely local/no-cloud config routes local
+           untouched.
+        """
+        if self._provider is not None:
+            return self._provider
+
+        from .models import provider as _provider_mod  # local: heavy seam
+
+        prefer = self._function_prefer("editPlan")
+        raw = self.settings.get_raw()
+        consented_provider = _provider_mod.get_provider(self._text_consented_settings(raw), prefer=prefer)
+
+        builder = getattr(_provider_mod, "build_pool_provider", None)
+        if builder is not None:  # pragma: no branch -- always present off the stub
+            raw_cloud = any(not e.local for e in builder(raw, detect_local=False, prefer=prefer).entries)
+            consented_cloud = any(
+                not e.local
+                for e in builder(self._text_consented_settings(raw), detect_local=False, prefer=prefer).entries
+            )
+            if raw_cloud and not consented_cloud:
+                raise _invalid(
+                    "director.plan would egress transcript text but TEXT consent is "
+                    "revoked for every configured cloud provider; grant per-provider "
+                    "text consent (consent.perProvider[<provider>].text) or route local"
+                )
+        return consented_provider
+
     def director_plan(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
         """``director.plan({videoId, goal})`` -> ``{jobId}``. Job-based.
 
@@ -2614,7 +2670,10 @@ class Services:
         EditPlan under a fresh ``planId``. The ``job.done`` payload is
         ``{planId, editPlan, preview}``. The media-derived understanding is fenced
         as UNTRUSTED DATA by ``build_edit_plan_messages`` (injection mitigation #1);
-        the planner provider is the ``editPlan``-routed pool (no new AI path).
+        the planner provider is the ``editPlan``-routed pool, resolved through the
+        per-provider TEXT-consent gate (:meth:`_editplan_provider_or_refuse`) so the
+        transcript-bearing prompt is NEVER egressed to a non-consented cloud target
+        (no new AI path).
         """
         if ctx.jobs is None:
             raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
@@ -2631,7 +2690,7 @@ class Services:
         from .features import edit_validate as _validate  # local: import-light pure
 
         messages = _prompt.build_edit_plan_messages(goal, media)
-        plan_provider = self._provider if self._provider is not None else self._provider_for_function("editPlan")
+        plan_provider = self._editplan_provider_or_refuse()
 
         def work(_job_ctx: Any, _envelope: Any, provider: Any) -> dict[str, Any]:
             content = provider.chat(list(messages))

--- a/sidecar/tests/e2e_ai2_mock_model.py
+++ b/sidecar/tests/e2e_ai2_mock_model.py
@@ -1,0 +1,285 @@
+"""A local, OpenAI-compatible MOCK model server for the E2E-AI2 integration run.
+
+This is the ONLY fake in the E2E-AI2 suite: a real HTTP server (stdlib
+``http.server``, zero extra deps) that speaks the OpenAI ``/v1`` wire protocol so
+the sidecar's REAL provider/embedder code (``models/provider.py`` /
+``models/embedder.py``) reaches it over a REAL socket with NO injected transport
+and NO cloud key. Everything else in the suite is genuine: real ffmpeg, real
+handler dispatch, real consent/budget gates.
+
+Endpoints:
+  * ``POST /v1/chat/completions`` — a valid OpenAI chat completion. When the
+    system prompt is the Director planner (it carries the EditPlan SECURITY RULE),
+    the assistant content is a valid EditPlan JSON object so ``parse_edit_plan`` +
+    ``validate_and_reject`` accept it. Otherwise a generic completion. Always
+    carries a ``usage`` block.
+  * ``POST /v1/embeddings`` — one deterministic dense vector per input
+    (``{"data":[{"embedding":[...]}]}``), so cosine ranking is well-defined.
+  * The vision path reuses ``/v1/chat/completions`` (the frame scorer issues a
+    chat with image content); the mock returns a frame-index reply so the
+    best-frame picker has a real model verdict.
+
+Every request is COUNTED per endpoint (``hits``) so a test can PROVE egress
+happened — guarding against the silent local-fallback trap where a flow looks
+green but never touched the model.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+_EMBED_DIM = 16
+
+
+def _deterministic_vector(text: str, dim: int = _EMBED_DIM) -> list[float]:
+    """A stable, unit-norm bag-of-words vector for ``text`` (cosine-friendly)."""
+    vec = [0.0] * dim
+    for token in text.split():
+        digest = hashlib.sha256(token.encode("utf-8")).digest()
+        bucket = int.from_bytes(digest[:4], "big") % dim
+        sign = 1.0 if digest[4] & 1 else -1.0
+        vec[bucket] += sign
+    norm = sum(x * x for x in vec) ** 0.5
+    if norm == 0.0:
+        return vec
+    return [x / norm for x in vec]
+
+
+def _is_director_request(body: dict[str, Any]) -> bool:
+    """True when the chat request is the Director planner (EditPlan expected)."""
+    for msg in body.get("messages") or []:
+        if msg.get("role") == "system" and "EditPlan" in str(msg.get("content", "")):
+            return True
+    return False
+
+
+def _is_vision_request(body: dict[str, Any]) -> bool:
+    """True when any message content is multimodal (a list of parts w/ an image)."""
+    for msg in body.get("messages") or []:
+        content = msg.get("content")
+        if isinstance(content, list):
+            for part in content:
+                if isinstance(part, dict) and part.get("type") in ("image_url", "image", "input_image"):
+                    return True
+    return False
+
+
+def _edit_plan_json() -> str:
+    """A valid EditPlan object (kinds from edit_plan.OP_KINDS; spans in ms)."""
+    plan = {
+        "ops": [
+            {
+                "id": "op-1",
+                "kind": "removeSilence",
+                "span": [0, 2000],
+                "params": {},
+                "reversible": True,
+                "rationale": "tighten the opening dead air",
+            },
+            {
+                "id": "op-2",
+                "kind": "trim",
+                "span": [2000, 8000],
+                "params": {},
+                "reversible": True,
+                "rationale": "keep the strongest middle beat",
+            },
+            {
+                "id": "op-3",
+                "kind": "caption",
+                "span": None,
+                "params": {"style": "bold"},
+                "reversible": True,
+                "rationale": "burn captions for silent viewing",
+            },
+        ]
+    }
+    # A <think> block exercises the strip_think parse path on the real parser.
+    return "<think>plan the cuts</think>\n" + json.dumps(plan)
+
+
+class MockModelServer:
+    """A running OpenAI-compatible mock with per-endpoint hit counters.
+
+    Use as a context manager. ``base_url`` is the ``http://127.0.0.1:<port>/v1``
+    string to drop into a provider settings entry's ``baseUrl``.
+    """
+
+    def __init__(self) -> None:
+        self.hits: dict[str, int] = {"chat": 0, "embeddings": 0, "vision": 0}
+        self.last_bodies: dict[str, dict[str, Any]] = {}
+        self.auth_headers: dict[str, str | None] = {}
+        self._lock = threading.Lock()
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:  # silence stderr noise
+                return
+
+            def _read(self) -> dict[str, Any]:
+                length = int(self.headers.get("Content-Length", 0) or 0)
+                raw = self.rfile.read(length) if length else b"{}"
+                try:
+                    return json.loads(raw or b"{}")
+                except (ValueError, json.JSONDecodeError):
+                    return {}
+
+            def _send(self, payload: dict[str, Any], code: int = 200) -> None:
+                out = json.dumps(payload).encode("utf-8")
+                self.send_response(code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(out)))
+                # de-facto usage headers the rotation pool may parse
+                self.send_header("X-RateLimit-Limit", "1000")
+                self.send_header("X-RateLimit-Remaining", "999")
+                self.end_headers()
+                self.wfile.write(out)
+
+            def do_POST(self) -> None:  # noqa: N802 - http.server API
+                body = self._read()
+                path = self.path.split("?", 1)[0]
+                if path.endswith("/embeddings"):
+                    outer._on_embeddings(self, body)
+                elif path.endswith("/chat/completions"):
+                    outer._on_chat(self, body)
+                else:
+                    self._send({"error": f"unknown path: {path}"}, code=404)
+
+        self._handler_cls = Handler
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    # -- request handlers ---------------------------------------------------
+    def _on_embeddings(self, handler: Any, body: dict[str, Any]) -> None:
+        inputs = body.get("input") or []
+        if isinstance(inputs, str):
+            inputs = [inputs]
+        with self._lock:
+            self.hits["embeddings"] += 1
+            self.last_bodies["embeddings"] = body
+            self.auth_headers["embeddings"] = handler.headers.get("Authorization")
+        data = [
+            {"object": "embedding", "index": i, "embedding": _deterministic_vector(str(t))}
+            for i, t in enumerate(inputs)
+        ]
+        handler._send(
+            {
+                "object": "list",
+                "data": data,
+                "model": body.get("model", "mock-embed"),
+                "usage": {"prompt_tokens": 5, "total_tokens": 5},
+            }
+        )
+
+    def _on_chat(self, handler: Any, body: dict[str, Any]) -> None:
+        vision = _is_vision_request(body)
+        with self._lock:
+            self.hits["chat"] += 1
+            if vision:
+                self.hits["vision"] += 1
+            self.last_bodies["chat"] = body
+            self.auth_headers["chat"] = handler.headers.get("Authorization")
+        if _is_director_request(body):
+            content = _edit_plan_json()
+        elif vision:
+            # Best-frame picker asks for the best 1-based frame index; "2" -> idx 1.
+            content = "Frame 2 is the most eye-catching and in-focus."
+        else:
+            content = "This is a mock completion."
+        handler._send(
+            {
+                "id": "chatcmpl-mock",
+                "object": "chat.completion",
+                "model": body.get("model", "mock-chat"),
+                "choices": [
+                    {"index": 0, "message": {"role": "assistant", "content": content}, "finish_reason": "stop"}
+                ],
+                "usage": {"prompt_tokens": 42, "completion_tokens": 12, "total_tokens": 54},
+            }
+        )
+
+    # -- lifecycle ----------------------------------------------------------
+    def __enter__(self) -> MockModelServer:
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler_cls)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    @property
+    def port(self) -> int:
+        assert self._server is not None, "server not started"
+        return self._server.server_address[1]
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"
+
+
+class Always429Server:
+    """A real HTTP server that returns 429 on every chat/embeddings POST.
+
+    Used as the FIRST provider in a rotation test so the REAL
+    :class:`RotatingProvider` hits a genuine 429 over a real socket and fails
+    over to the working :class:`MockModelServer` (the second provider). Counts
+    hits so a test can prove the throttled key was actually tried.
+    """
+
+    def __init__(self) -> None:
+        self.hits = 0
+        self._lock = threading.Lock()
+        outer = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def log_message(self, *args: Any) -> None:
+                return
+
+            def do_POST(self) -> None:  # noqa: N802 - http.server API
+                length = int(self.headers.get("Content-Length", 0) or 0)
+                if length:
+                    self.rfile.read(length)
+                with outer._lock:
+                    outer.hits += 1
+                out = json.dumps({"error": {"message": "rate limit exceeded", "type": "rate_limit"}}).encode("utf-8")
+                self.send_response(429)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(out)))
+                self.send_header("Retry-After", "1")
+                self.end_headers()
+                self.wfile.write(out)
+
+        self._handler_cls = Handler
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+
+    def __enter__(self) -> Always429Server:
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), self._handler_cls)
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+
+    @property
+    def port(self) -> int:
+        assert self._server is not None, "server not started"
+        return self._server.server_address[1]
+
+    @property
+    def base_url(self) -> str:
+        return f"http://127.0.0.1:{self.port}/v1"

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -1,0 +1,331 @@
+"""Unit tests for the real director op-engine adapters (FIX #7).
+
+PURE-logic only: the ONE impure thing — the ffmpeg subprocess — is the injected
+``runner``, replaced here by a fake that STUBS the output file (writes a few
+bytes) and records the argv. So these tests exercise the full adapter logic —
+source resolution, argv build, manifest re-point, recorded inverse, dual-mode
+undo, and every error branch — with NO real ffmpeg, deterministically, carrying
+the 100% line+branch gate. A separate ``@pytest.mark.integration`` test
+(``test_director_render_integration``) proves a real ffprobe-valid mp4 + undo
+round-trip with the DEFAULT runner.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.features import director_op_engines as engines_mod
+from media_studio.features.director_op_engines import (
+    DEFERRED_KINDS,
+    RESTORE_KEY,
+    WIRED_KINDS,
+    DirectorEngineError,
+    build_engines,
+)
+from media_studio.features.project_copy import ProjectCopy
+from media_studio.models.edit_plan import EditOp
+
+CLIP_SEC = 12.0
+
+
+def _copy(tmp_path: Path, *, video: Any = "__src__", tracks: Any = None) -> ProjectCopy:
+    """A ProjectCopy whose manifest folder is real (so renders land on disk)."""
+    src = tmp_path / "src.mp4"
+    src.write_bytes(b"\x00source")
+    data: dict[str, Any] = {"video": {"path": str(src)} if video == "__src__" else video}
+    if tracks is not None:
+        data["tracks"] = tracks
+    manifest = tmp_path / ".director-copy" / "project.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    return ProjectCopy(data=data, manifest_path=manifest)
+
+
+class FakeRunner:
+    """A fake ffmpeg runner: stubs the output file (last argv element) + records calls."""
+
+    def __init__(self, *, code: int = 0) -> None:
+        self.code = code
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Any, total_sec: float = 0.0, **_k: Any) -> int:
+        self.calls.append(list(argv))
+        if self.code == 0:
+            Path(argv[-1]).write_bytes(b"\x00rendered")  # the stubbed render output
+        return self.code
+
+
+def _fake_probe(monkeypatch: pytest.MonkeyPatch, value: float = CLIP_SEC) -> None:
+    monkeypatch.setattr(engines_mod._ffmpeg, "ffprobe_duration", lambda *_a, **_k: value)
+
+
+# --------------------------------------------------------------------------- #
+# build_engines / log_deferred
+# --------------------------------------------------------------------------- #
+def test_build_engines_covers_wired_kinds() -> None:
+    table = build_engines(runner=FakeRunner())
+    assert set(table) == set(WIRED_KINDS)
+    assert "trim" in table and "caption" in table and "removeSilence" in table
+
+
+def test_build_engines_defaults_runner_to_ffmpeg_run() -> None:
+    # No runner -> closes over the real ffmpeg.run (just assert the table builds).
+    table = build_engines()
+    assert set(table) == set(WIRED_KINDS)
+
+
+def test_deferred_kinds_have_no_engine() -> None:
+    table = build_engines(runner=FakeRunner())
+    assert not (set(DEFERRED_KINDS) & set(table))
+    assert "reframe" in DEFERRED_KINDS  # the host->WSL-bridge op stays deferred
+
+
+def test_log_deferred_announces_unwired_kinds() -> None:
+    seen: list[tuple[Any, ...]] = []
+
+    class _Log:
+        def info(self, *args: Any) -> None:
+            seen.append(args)
+
+    engines_mod.log_deferred(_Log())
+    assert seen and "deferred" in seen[0][0]
+
+
+# --------------------------------------------------------------------------- #
+# trim
+# --------------------------------------------------------------------------- #
+def test_trim_renders_and_records_inverse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    op = EditOp(id="t1", kind="trim", span=(2000, 5000))
+
+    inverse = build_engines(runner=runner)["trim"](op, pc)
+
+    out = pc.data["video"]["path"]
+    assert out != src_before  # the COPY was RE-POINTED at the render
+    assert Path(out).exists() and Path(out).read_bytes()  # a real (stubbed) file
+    assert inverse.kind == "trim" and inverse.params[RESTORE_KEY] == src_before
+    # The PERSISTED COPY manifest references the render (not the orphaned source) —
+    # this is what a real client reads back via ApplyResult.project_copy_path.
+    persisted = json.loads(pc.manifest_path.read_text(encoding="utf-8"))
+    assert persisted["video"]["path"] == out
+    # head [0,2.0] + tail [5.0,12.0] kept -> two trim/atrim pairs in the filtergraph.
+    fc = runner.calls[0][runner.calls[0].index("-filter_complex") + 1]
+    assert "trim=start=0.000:end=2.000" in fc and "trim=start=5.000:end=12.000" in fc
+
+
+def test_trim_head_only_when_span_reaches_end(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    build_engines(runner=runner)["trim"](EditOp(id="t", kind="trim", span=(3000, 12000)), pc)
+    fc = runner.calls[0][runner.calls[0].index("-filter_complex") + 1]
+    assert "concat=n=1" in fc  # only the head [0,3.0] kept
+
+
+def test_trim_tail_only_when_span_starts_at_zero(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    build_engines(runner=runner)["trim"](EditOp(id="t", kind="trim", span=(0, 4000)), pc)
+    fc = runner.calls[0][runner.calls[0].index("-filter_complex") + 1]
+    assert "trim=start=4.000:end=12.000" in fc
+
+
+def test_trim_full_span_is_a_render_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="nothing left to keep"):
+        build_engines(runner=FakeRunner())["trim"](EditOp(id="t", kind="trim", span=(0, 12000)), pc)
+
+
+def test_trim_ffmpeg_failure_raises(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="ffmpeg exit 1"):
+        build_engines(runner=FakeRunner(code=1))["trim"](EditOp(id="t", kind="trim", span=(2000, 5000)), pc)
+
+
+# --------------------------------------------------------------------------- #
+# cut
+# --------------------------------------------------------------------------- #
+def test_cut_keeps_only_the_span(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["cut"](EditOp(id="c1", kind="cut", span=(1000, 6000)), pc)
+    fc = runner.calls[0][runner.calls[0].index("-filter_complex") + 1]
+    assert "trim=start=1.000:end=6.000" in fc and "concat=n=1" in fc
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+# --------------------------------------------------------------------------- #
+# removeSilence
+# --------------------------------------------------------------------------- #
+def test_remove_silence_repoints_when_trim_cuts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    op = EditOp(id="s1", kind="removeSilence", span=(0, 12000))
+
+    # Stub trim_clip to "render" a real output file and report a removal.
+    def fake_trim_clip(in_path: str, out_path: str, **_k: Any) -> tuple[str, float]:
+        Path(out_path).write_bytes(b"\x00trimmed")
+        return out_path, 3.0
+
+    monkeypatch.setattr(engines_mod._silencetrim, "trim_clip", fake_trim_clip)
+    inverse = build_engines(runner=FakeRunner())["removeSilence"](op, pc)
+    assert pc.data["video"]["path"] != src_before
+    assert Path(pc.data["video"]["path"]).exists()
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_remove_silence_passthrough_repoints_to_input(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+
+    # Nothing to remove: trim_clip returns the INPUT unchanged (removedSec 0).
+    def fake_trim_clip(in_path: str, out_path: str, **_k: Any) -> tuple[str, float]:
+        return in_path, 0.0
+
+    monkeypatch.setattr(engines_mod._silencetrim, "trim_clip", fake_trim_clip)
+    inverse = build_engines(runner=FakeRunner())["removeSilence"](
+        EditOp(id="s", kind="removeSilence", span=(0, 12000)), pc
+    )
+    # Re-points to the input (a stable concrete ref) so undo restores it identically.
+    assert pc.data["video"]["path"] == src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+# --------------------------------------------------------------------------- #
+# caption (burn the target track's cues)
+# --------------------------------------------------------------------------- #
+_CUES = [{"index": 1, "start": 1.0, "end": 3.0, "text": "hello"}]
+
+
+def test_caption_burns_track_cues(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path, tracks=[{"id": "cap1", "kind": "hard", "cues": _CUES}])
+    src_before = pc.data["video"]["path"]
+    op = EditOp(id="cap-op", kind="caption", params={"track": "cap1"})
+
+    inverse = build_engines(runner=runner)["caption"](op, pc)
+
+    # An ASS file was written and burned via the subtitles filter.
+    ass = next(pc.manifest_path.parent.glob("*.ass"))
+    assert "hello" in ass.read_text(encoding="utf-8")
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert vf.startswith("subtitles=")
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_caption_missing_track_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path, tracks=[{"id": "other", "cues": _CUES}])
+    with pytest.raises(DirectorEngineError, match="not found"):
+        build_engines(runner=FakeRunner())["caption"](EditOp(id="c", kind="caption", params={"track": "cap1"}), pc)
+
+
+def test_caption_no_tracks_block_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)  # no "tracks" key at all
+    with pytest.raises(DirectorEngineError, match="not found"):
+        build_engines(runner=FakeRunner())["caption"](EditOp(id="c", kind="caption", params={"track": "cap1"}), pc)
+
+
+def test_caption_non_mapping_track_skipped(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    # A junk (non-mapping) track entry is skipped; the real track is still found.
+    pc = _copy(tmp_path, tracks=["junk", {"id": "cap1", "cues": _CUES}])
+    inverse = build_engines(runner=FakeRunner())["caption"](
+        EditOp(id="c", kind="caption", params={"track": "cap1"}), pc
+    )
+    assert inverse.params[RESTORE_KEY]
+
+
+def test_caption_empty_cues_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path, tracks=[{"id": "cap1", "cues": []}])
+    with pytest.raises(DirectorEngineError, match="no cues"):
+        build_engines(runner=FakeRunner())["caption"](EditOp(id="c", kind="caption", params={"track": "cap1"}), pc)
+
+
+# --------------------------------------------------------------------------- #
+# dual-mode inverse (undo direction restores, never re-renders)
+# --------------------------------------------------------------------------- #
+def test_inverse_op_restores_without_rendering(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    original = pc.data["video"]["path"]
+    table = build_engines(runner=runner)
+
+    forward_inverse = table["trim"](EditOp(id="t", kind="trim", span=(2000, 5000)), pc)
+    rendered = pc.data["video"]["path"]
+    assert rendered != original
+    calls_after_forward = len(runner.calls)
+
+    # Re-feed the recorded inverse through the SAME-kind engine (rollback/undo).
+    re_inverse = table["trim"](forward_inverse, pc)
+
+    assert pc.data["video"]["path"] == original  # restored
+    assert len(runner.calls) == calls_after_forward  # NO new render (pure restore)
+    assert re_inverse.params[RESTORE_KEY] == rendered  # double-undo is reversible
+
+
+@pytest.mark.parametrize(
+    ("kind", "op_params", "tracks"),
+    [
+        ("cut", {}, None),
+        ("removeSilence", {}, None),
+        ("caption", {"track": "cap1"}, [{"id": "cap1", "cues": _CUES}]),
+    ],
+)
+def test_inverse_restores_for_every_wired_kind(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    kind: str,
+    op_params: dict[str, Any],
+    tracks: Any,
+) -> None:
+    # Each wired adapter's UNDO direction restores the recorded ref WITHOUT a render.
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+
+    def fake_trim_clip(in_path: str, out_path: str, **_k: Any) -> tuple[str, float]:
+        Path(out_path).write_bytes(b"\x00trimmed")
+        return out_path, 1.0
+
+    monkeypatch.setattr(engines_mod._silencetrim, "trim_clip", fake_trim_clip)
+    pc = _copy(tmp_path, tracks=tracks)
+    original = pc.data["video"]["path"]
+    table = build_engines(runner=runner)
+    span = None if kind == "caption" else (1000, 6000)
+    forward_inverse = table[kind](EditOp(id="op", kind=kind, span=span, params=op_params), pc)  # type: ignore[arg-type]
+    calls_after_forward = len(runner.calls)
+
+    table[kind](forward_inverse, pc)  # the recorded inverse: restore-only
+
+    assert pc.data["video"]["path"] == original
+    assert len(runner.calls) == calls_after_forward  # no new render on undo
+
+
+# --------------------------------------------------------------------------- #
+# manifest guards
+# --------------------------------------------------------------------------- #
+def test_missing_video_block_is_error(tmp_path: Path) -> None:
+    pc = _copy(tmp_path, video=None)
+    with pytest.raises(DirectorEngineError, match="no 'video' block"):
+        build_engines(runner=FakeRunner())["trim"](EditOp(id="t", kind="trim", span=(1000, 2000)), pc)
+
+
+def test_missing_source_path_is_error(tmp_path: Path) -> None:
+    pc = _copy(tmp_path, video={"path": ""})
+    with pytest.raises(DirectorEngineError, match="no source path"):
+        build_engines(runner=FakeRunner())["trim"](EditOp(id="t", kind="trim", span=(1000, 2000)), pc)

--- a/sidecar/tests/test_director_render_integration.py
+++ b/sidecar/tests/test_director_render_integration.py
@@ -1,0 +1,145 @@
+"""REAL-ffmpeg integration test for the director op-engines (FIX #7).
+
+These tests use the DEFAULT runner (``ffmpeg.run`` — the real subprocess) over a
+real, tiny ``lavfi testsrc`` clip to PROVE the marquee claim: ``director.apply``
+renders edited media that is ffprobe-valid (not a no-op manifest copy), and
+``director.undo`` round-trips. They are marked ``integration`` (the marker is
+declared in ``pyproject.toml``); the pinned coverage command runs them (no ``-m``
+filter) since ffmpeg is present in that environment. They skip cleanly if ffmpeg
+is unavailable so a no-ffmpeg box never red-fails.
+
+The pure dispatch/branch logic is covered to 100% by ``test_director_op_engines``
+with a fake runner; this file is the empirical render proof, kept tiny (a ~1.5 s
+clip, two ops) so it adds only a couple of seconds to the suite.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from media_studio.features import director_op_engines as engines_mod
+from media_studio.features.apply_engine import apply_plan
+from media_studio.features.project_copy import ProjectCopy
+from media_studio.models.edit_plan import EditOp, EditPlan
+
+pytestmark = pytest.mark.integration
+
+_HAVE_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+_SKIP = pytest.mark.skipif(not _HAVE_FFMPEG, reason="ffmpeg/ffprobe not installed")
+
+_CUES = [{"index": 1, "start": 0.2, "end": 1.0, "text": "real burn"}]
+
+
+def _make_sample(path: Path, *, seconds: float = 1.5) -> None:
+    """Render a tiny real testsrc clip (video + audio) for the engines to edit."""
+    subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only sample generation
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size=320x240:rate=15:duration={seconds}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={seconds}",
+            "-shortest",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            "-t",
+            str(seconds),
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def _ffprobe_ok(path: Path) -> float:
+    """Return the playable duration of ``path`` (a ffprobe-valid mp4 with video)."""
+    out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "csv=p=0",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return float(out)
+
+
+def _project_copy(tmp_path: Path, src: Path, *, tracks: list | None = None) -> ProjectCopy:
+    data: dict = {"video": {"path": str(src)}}
+    if tracks is not None:
+        data["tracks"] = tracks
+    manifest = tmp_path / ".director-copy" / "project.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    return ProjectCopy(data=data, manifest_path=manifest)
+
+
+@pytest.fixture(scope="module")
+def sample(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    if not _HAVE_FFMPEG:  # pragma: no cover - skipped wholesale when ffmpeg absent
+        pytest.skip("ffmpeg not installed")
+    path = tmp_path_factory.mktemp("director-sample") / "sample.mp4"
+    _make_sample(path)
+    return path
+
+
+@_SKIP
+def test_trim_renders_real_valid_mp4_and_undo_round_trips(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    engines = engines_mod.build_engines()  # DEFAULT runner = real ffmpeg
+    op = EditOp(id="trim1", kind="trim", span=(500, 1000))  # drop 0.5s..1.0s
+
+    result = apply_plan(EditPlan("p", "v", "g", "h", ops=(op,)), project_copy=pc, engines=engines)
+
+    assert result.ops_status[0].status == "applied"  # NOT failed (the old bug)
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)  # re-pointed at a NEW file
+    assert _ffprobe_ok(rendered) > 0  # a real, playable edited mp4
+    # The source clip was never mutated (apply writes only the COPY).
+    assert _ffprobe_ok(Path(source_before)) > 0
+
+    # undo: re-apply the recorded inverse -> the COPY points back at the source.
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_caption_burns_real_subtitles(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample, tracks=[{"id": "cap1", "kind": "hard", "cues": _CUES}])
+    source_before = pc.data["video"]["path"]
+    engines = engines_mod.build_engines()
+    op = EditOp(id="cap1", kind="caption", params={"track": "cap1"})
+
+    result = apply_plan(EditPlan("p", "v", "g", "h", ops=(op,)), project_copy=pc, engines=engines)
+
+    assert result.ops_status[0].status == "applied"
+    burned = Path(pc.data["video"]["path"])
+    assert burned != Path(source_before)
+    assert _ffprobe_ok(burned) > 0  # ffprobe-valid burned-in mp4
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)

--- a/sidecar/tests/test_e2e_ai2_director_text_consent.py
+++ b/sidecar/tests/test_e2e_ai2_director_text_consent.py
@@ -1,0 +1,272 @@
+"""E2E: ``director.plan`` chat egress honors per-provider TEXT consent (FIX #6).
+
+Ported from the strict-xfail proof on ``chore/e2e-ai2``
+(``test_hub_director_chat_path_honors_text_consent_xfail``). That xfail documented
+a PRIVACY leak: ``director.plan`` built its editPlan provider via
+``_provider_for_function("editPlan") -> get_provider(get_raw())`` with NO consent
+filter, while ``build_understanding`` folds the TRANSCRIPT into the planner prompt
+-- so with TEXT consent REVOKED the transcript still shipped to the cloud.
+
+These are INTEGRATION tests over the REAL stack: real JSON-RPC dispatch, the real
+``director.*`` handlers, the real consent/budget gates, and the REAL
+:class:`RotatingProvider` HTTP code. The ONLY fake is the model endpoint -- a
+local OpenAI-compatible :class:`MockModelServer` the provider reaches over a real
+socket with no cloud key, COUNTING every chat hit so egress can be PROVEN.
+
+The SECURE behavior (what the editPlan path now does, mirroring the index
+embedder's ``_text_consented_settings`` gate and the vision
+``_frame_consented_vision_settings`` gate):
+
+  * REVOKED text consent -> ``director.plan`` REFUSES before any chat: zero bytes
+    leave the machine (the chat hit counter stays 0). Chat has no in-process local
+    backstop (unlike the embedder's ``LocalEmbedder``), so the gate's no-egress
+    outcome is a clear refusal, not a silent local completion.
+  * GRANTED text consent -> ``director.plan`` egresses for real with the RAW key.
+
+Run: ``python -m pytest sidecar/tests/test_e2e_ai2_director_text_consent.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers, protocol
+from media_studio import library as _library
+from media_studio.handlers import Services
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext
+
+from tests.e2e_ai2_mock_model import MockModelServer
+
+_FFMPEG = shutil.which("ffmpeg")
+_FFPROBE = shutil.which("ffprobe")
+pytestmark = pytest.mark.skipif(
+    not (_FFMPEG and _FFPROBE),
+    reason="ffmpeg/ffprobe required for the E2E director TEXT-consent real-media flow",
+)
+
+_RAW_KEY = "sk-e2e-director-consent-rawkey-9999"
+
+
+# --------------------------------------------------------------------------- #
+# in-process JSON-RPC drive (mirrors the sibling E2E-AI2 suite)
+# --------------------------------------------------------------------------- #
+class Rpc:
+    def __init__(self, svc: Services) -> None:
+        self.svc = svc
+        self.events: list[Any] = []
+        self.jobs = JobRegistry(
+            emit_progress=lambda jid, pct, msg: self.events.append(("progress", jid, pct, msg)),
+            emit_done=lambda jid, result: self.events.append(("done", jid, result)),
+        )
+        self.ctx = RpcContext(emit_notification=lambda obj: None, jobs=self.jobs)
+
+    def _handler(self, method: str) -> Any:
+        fn = protocol.METHODS.get(method)
+        assert fn is not None, f"method not registered: {method}"
+        return fn
+
+    def call(self, method: str, params: dict[str, Any]) -> Any:
+        return self._handler(method)(params, self.ctx)
+
+    def run_job(self, method: str, params: dict[str, Any], *, timeout: float = 30.0) -> dict[str, Any]:
+        out = self.call(method, params)
+        assert isinstance(out, dict) and "jobId" in out, f"{method} did not return a jobId: {out!r}"
+        self.jobs.join(timeout=timeout)
+        done = [e for e in self.events if e[0] == "done" and e[1] == out["jobId"]]
+        assert done, f"{method} job {out['jobId']} never completed: {self.events!r}"
+        return done[-1][2]
+
+
+# --------------------------------------------------------------------------- #
+# real-media fixture (real ffmpeg)
+# --------------------------------------------------------------------------- #
+def _make_sample_mp4(path: Path, *, seconds: int = 6) -> None:
+    """A real 16:9 1280x720 mp4: moving testsrc + a tone (ffprobe-valid)."""
+    res = subprocess.run(
+        [
+            _FFMPEG,
+            "-y",
+            "-loglevel",
+            "error",
+            "-f",
+            "lavfi",
+            "-i",
+            f"testsrc=size=1280x720:rate=24:duration={seconds}",
+            "-f",
+            "lavfi",
+            "-i",
+            f"sine=frequency=440:duration={seconds}",
+            "-c:v",
+            "libx264",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:a",
+            "aac",
+            "-shortest",
+            str(path),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    assert res.returncode == 0, f"ffmpeg failed: {res.stderr}"
+
+
+# --------------------------------------------------------------------------- #
+# settings + project helpers
+# --------------------------------------------------------------------------- #
+def _provider_entry(base_url: str, *, pid: str = "mock") -> dict[str, Any]:
+    return {
+        "id": pid,
+        "provider": pid,  # provider NAME == id so the consent perProvider keys line up
+        "kind": "cloud",
+        "baseUrl": base_url,
+        "model": "mock-model",
+        "apiKeys": [_RAW_KEY],
+        "enabled": True,
+        "capabilities": ["text", "vision"],
+        "unit": "req",
+    }
+
+
+def _routing(*provider_ids: str) -> dict[str, Any]:
+    primary = provider_ids[0]
+    fallback = list(provider_ids[1:])
+    return {
+        "perFunction": {
+            fn: {"provider": primary, "fallback": fallback}
+            for fn in ("index", "editPlan", "vision", "select", "subtitles", "translation")
+        }
+    }
+
+
+def _base_settings(*provider_ids: str, text: bool = True) -> dict[str, Any]:
+    """Routed settings with the (default-ON) budget gate OFF; text consent per ``text``.
+
+    The shipped default ``confirmCloudBudget`` is True, so a non-budget test must
+    turn it OFF or every egress is refused. The egress decision under test here is
+    the TEXT-consent gate, not the budget gate.
+    """
+    consent = {pid: {"text": text, "frames": True} for pid in provider_ids}
+    return {
+        "routing": _routing(*provider_ids),
+        "consent": {"perProvider": consent},
+        "confirmCloudBudget": False,
+        "cloudModel": "mock-model",
+    }
+
+
+def _wire(tmp: Path) -> tuple[Services, Rpc]:
+    svc = Services(data_dir=tmp / "data")
+    protocol.clear_methods()
+    handlers.register_all(services=svc)
+    return svc, Rpc(svc)
+
+
+def _add_video(svc: Services, media: Path) -> str:
+    svc.library = _library.Library(svc.data_dir / "library.json", probe_duration=lambda _p: 6.0)
+    return svc.library.add(str(media))["id"]
+
+
+def _set_transcript(svc: Services, vid: str) -> None:
+    project = svc._load_or_create_project(vid)
+    project.data["transcript"] = {
+        "language": "en",
+        "durationSec": 6.0,
+        "segments": [{"start": 0.0, "end": 2.0, "text": "secret revenue numbers", "words": []}],
+    }
+    project.save()
+
+
+# ========================================================================== #
+# FIX #6 — director.plan chat egress is TEXT-consent gated (was leaking)
+# ========================================================================== #
+def test_director_plan_refuses_when_text_consent_revoked(tmp_path: Path) -> None:
+    """REVOKED text consent -> director.plan ships ZERO transcript bytes to the cloud.
+
+    The secure equivalent of the ``chore/e2e-ai2`` strict xfail: with TEXT consent
+    off, the editPlan chat path is refused BEFORE any egress, so the mock chat
+    endpoint is never reached.
+    """
+    media = tmp_path / "talk.mp4"
+    _make_sample_mp4(media)
+    with MockModelServer() as server:
+        svc, rpc = _wire(tmp_path)
+        rpc.call("providers.upsert", {"provider": _provider_entry(server.base_url)})
+        svc.settings.set(_base_settings("mock"))
+        # REVOKE text consent -- transcript must NOT egress to the cloud planner.
+        rpc.call("providers.setConsent", {"provider": "mock", "text": False})
+        vid = _add_video(svc, media)
+        _set_transcript(svc, vid)
+
+        # SECURE expectation: the gate fires synchronously, refusing the run.
+        with pytest.raises(Exception) as exc:  # noqa: PT011 - typed RpcError surfaced as a generic raise
+            rpc.call("director.plan", {"videoId": vid, "goal": "tighten"})
+        assert "consent" in str(exc.value).lower(), f"refusal was not the text-consent gate: {exc.value!r}"
+        assert server.hits["chat"] == 0, "director.plan egressed transcript text despite TEXT consent revoked"
+
+
+def test_director_plan_never_egresses_to_a_non_consented_provider_in_a_mixed_pool(tmp_path: Path) -> None:
+    """Per-entry gate: a NON-consented cloud entry is never the egress target.
+
+    The mixed-consent rotation hole: two cloud providers, TEXT consent granted to
+    ONLY one, and the editPlan route deliberately PREFERS the NON-consented one. A
+    boolean all-or-nothing check would pass (one entry is consented) yet still
+    egress the transcript to the non-consented primary (or fail over to it on a
+    429). The SECURE behavior drops the non-consented entry BEFORE the pool is
+    built, so the transcript can only ever reach the consented provider.
+    """
+    media = tmp_path / "talk.mp4"
+    _make_sample_mp4(media)
+    with MockModelServer() as no_srv, MockModelServer() as yes_srv:
+        svc, rpc = _wire(tmp_path)
+        rpc.call("providers.upsert", {"provider": _provider_entry(no_srv.base_url, pid="no")})
+        rpc.call("providers.upsert", {"provider": _provider_entry(yes_srv.base_url, pid="yes")})
+        # Consent: ONLY "yes" may receive text; routing PREFERS the non-consented "no".
+        svc.settings.set(
+            {
+                "routing": _routing("no", "yes"),
+                "consent": {"perProvider": {"yes": {"text": True}, "no": {"text": False}}},
+                "confirmCloudBudget": False,
+                "cloudModel": "mock-model",
+            }
+        )
+        vid = _add_video(svc, media)
+        _set_transcript(svc, vid)
+
+        done = rpc.run_job("director.plan", {"videoId": vid, "goal": "tighten"})
+
+        assert no_srv.hits["chat"] == 0, (
+            "transcript egressed to the NON-consented provider despite revoked text consent"
+        )
+        assert yes_srv.hits["chat"] >= 1, "the consented provider was never reached"
+        assert [op["kind"] for op in done["editPlan"]["ops"]] == ["removeSilence", "trim", "caption"]
+        assert yes_srv.auth_headers.get("chat") == f"Bearer {_RAW_KEY}", "consented egress did not send the RAW key"
+
+
+def test_director_plan_egresses_when_text_consent_granted(tmp_path: Path) -> None:
+    """GRANTED text consent -> the editPlan chat path egresses for real with the RAW key.
+
+    The consented-path control: the fix must NOT block a user who DID opt in. The
+    chat reaches the mock and the response is parsed into a validated EditPlan; the
+    egress carries the RAW key (the get_raw() factory contract).
+    """
+    media = tmp_path / "talk.mp4"
+    _make_sample_mp4(media)
+    with MockModelServer() as server:
+        svc, rpc = _wire(tmp_path)
+        rpc.call("providers.upsert", {"provider": _provider_entry(server.base_url)})
+        svc.settings.set(_base_settings("mock", text=True))
+        vid = _add_video(svc, media)
+        _set_transcript(svc, vid)
+
+        done = rpc.run_job("director.plan", {"videoId": vid, "goal": "tighten into a punchy short"})
+
+        assert server.hits["chat"] >= 1, "consent granted but the chat never reached the mock"
+        assert isinstance(done.get("planId"), str) and done["planId"]
+        assert [op["kind"] for op in done["editPlan"]["ops"]] == ["removeSilence", "trim", "caption"]
+        assert server.auth_headers.get("chat") == f"Bearer {_RAW_KEY}", "consented egress did not send the RAW key"

--- a/sidecar/tests/test_handlers_director.py
+++ b/sidecar/tests/test_handlers_director.py
@@ -195,21 +195,58 @@ def test_director_plan_fences_media_as_untrusted_data(tmp_path: Path) -> None:
     assert fence_start < token_at < fence_end
 
 
-def test_director_plan_uses_editplan_routed_provider(tmp_path: Path) -> None:
+def test_director_plan_builds_editplan_provider_over_text_consented_settings(tmp_path: Path) -> None:
+    """director.plan resolves its planner via the editPlan route over CONSENT-FILTERED settings.
+
+    The transcript-bearing chat egress is built from
+    ``_text_consented_settings(get_raw())`` honoring ``routing.perFunction["editPlan"]``
+    (the per-entry TEXT-consent gate, FIX #6) — NOT the unfiltered
+    ``_provider_for_function`` path. A non-consented cloud entry must be DROPPED
+    before the pool is built so it can never become the prefer-primary nor a 429
+    failover target.
+    """
     svc = _services(tmp_path)  # no injected legacy provider -> routing resolves
+    # Two cloud providers; text consent granted ONLY to "yes"; editPlan prefers "yes".
+    svc.settings.set(
+        {
+            "providers": [
+                {
+                    "id": "yes",
+                    "provider": "yes",
+                    "baseUrl": "https://yes.example/v1",
+                    "model": "m",
+                    "apiKeys": ["sk-yes"],
+                },
+                {"id": "no", "provider": "no", "baseUrl": "https://no.example/v1", "model": "m", "apiKeys": ["sk-no"]},
+            ],
+            "consent": {"perProvider": {"yes": {"text": True}, "no": {"text": False}}},
+            "routing": {"perFunction": {"editPlan": {"provider": "yes"}}},
+            "confirmCloudBudget": False,  # isolate the consent gate from the budget gate
+        }
+    )
     vid = _add_project(svc)
     ctx = _director_ctx()
-    seen: dict[str, str] = {}
+    seen: dict[str, Any] = {}
     canned = CannedProvider()
 
-    def fake_route(function: str) -> Any:
-        seen["function"] = function
+    def fake_get_provider(settings: dict[str, Any], *, prefer: str | None = None, **_kw: Any) -> Any:
+        seen["settings"] = settings
+        seen["prefer"] = prefer
         return canned
 
-    svc._provider_for_function = fake_route  # type: ignore[method-assign]
-    svc.director_plan({"videoId": vid, "goal": "g"}, ctx)
-    _done_result(ctx)
-    assert seen["function"] == "editPlan"
+    import media_studio.models.provider as _pmod
+
+    monkeypatched = _pmod.get_provider
+    _pmod.get_provider = fake_get_provider  # type: ignore[assignment]
+    try:
+        svc.director_plan({"videoId": vid, "goal": "g"}, ctx)
+        _done_result(ctx)
+    finally:
+        _pmod.get_provider = monkeypatched  # type: ignore[assignment]
+
+    assert seen["prefer"] == "yes", "editPlan route was not honored"
+    provider_ids = [p["id"] for p in seen["settings"]["providers"]]
+    assert provider_ids == ["yes"], f"non-consented cloud entry not filtered out: {provider_ids!r}"
 
 
 def test_director_plan_unknown_video_rejected(tmp_path: Path) -> None:

--- a/sidecar/tests/test_handlers_director.py
+++ b/sidecar/tests/test_handlers_director.py
@@ -26,6 +26,8 @@ from __future__ import annotations
 
 import ast
 import json
+import shutil
+import subprocess
 from pathlib import Path
 from typing import Any
 
@@ -409,3 +411,121 @@ def test_director_feature_module_is_pure() -> None:
         elif isinstance(node, ast.ImportFrom) and node.module:
             imported.append(node.module)
     assert not any("provider" in name.lower() for name in imported), imported
+
+
+# --------------------------------------------------------------------------- #
+# FIX #7: _director_engines wires the REAL ffmpeg adapters (was an empty {})
+# --------------------------------------------------------------------------- #
+def test_director_engines_wires_real_adapters(tmp_path: Path) -> None:
+    from media_studio.features import director_op_engines as _engines
+
+    svc = _services(tmp_path)  # NO injected engines -> exercises the real seam
+    table = svc._director_engines()
+    # The marquee bug was an EMPTY table (every op failed -> no-op manifest copy);
+    # the fix returns the real core renderers so apply actually renders media.
+    assert set(table) == set(_engines.WIRED_KINDS)
+    assert callable(table["trim"]) and callable(table["caption"])
+
+
+def test_director_engines_logs_deferred_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[Any] = []
+    monkeypatch.setattr(handlers.log, "info", lambda *a, **_k: calls.append(a))
+    svc = _services(tmp_path)
+    svc._director_engines()
+    svc._director_engines()  # second build must NOT re-log (one-shot flag)
+    deferred_logs = [a for a in calls if a and isinstance(a[0], str) and "deferred" in a[0]]
+    assert len(deferred_logs) == 1
+
+
+# --------------------------------------------------------------------------- #
+# FIX #7 (real ffmpeg): director.apply RENDERS a real edited mp4 the persisted
+# manifest references, and director.undo round-trips — the full handler spine.
+# --------------------------------------------------------------------------- #
+_HAVE_FFMPEG = shutil.which("ffmpeg") is not None and shutil.which("ffprobe") is not None
+
+
+def _ffprobe_video_duration(path: str) -> float:
+    out = subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only probe
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "format=duration",
+            "-of",
+            "csv=p=0",
+            path,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    return float(out)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(not _HAVE_FFMPEG, reason="ffmpeg/ffprobe not installed")
+def test_director_apply_then_undo_renders_real_media_end_to_end(tmp_path: Path) -> None:
+    # A REAL 1.5 s sample the director will edit (replaces the placeholder talk.mp4).
+    svc = _services(tmp_path, provider=CannedProvider())
+    sample = tmp_path / "talk.mp4"
+    subprocess.run(  # noqa: S603 - fixed argv, no shell, test-only sample render
+        [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "testsrc=size=320x240:rate=15:duration=1.5",
+            "-f",
+            "lavfi",
+            "-i",
+            "sine=duration=1.5",
+            "-shortest",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            "-t",
+            "1.5",
+            str(sample),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    vid = _add_project(svc)  # registers the (now real) talk.mp4
+    source_path = svc._load_or_create_project(vid).data["video"]["path"]
+
+    ctx = _director_ctx()
+    svc.director_plan({"videoId": vid, "goal": "tighten the intro"}, ctx)
+    plan_id = _done_result(ctx)["planId"]
+
+    # apply: real engines render the valid trim op (o1, span [0,1000]).
+    ctx2 = _director_ctx()
+    svc.director_apply({"planId": plan_id}, ctx2)
+    applied = _done_result(ctx2)
+    statuses = {op["id"]: op["status"] for op in applied["opsStatus"]}
+    assert statuses["o1"] == "applied"  # NOT failed (the old empty-table bug)
+
+    # The PERSISTED copy manifest references a real, ffprobe-valid edited mp4 that
+    # is NOT the source (validity alone is insufficient — the source is valid too).
+    copy_manifest = json.loads(Path(applied["projectCopyPath"]).read_text(encoding="utf-8"))
+    edited = copy_manifest["video"]["path"]
+    assert edited != source_path
+    assert _ffprobe_video_duration(edited) > 0
+    assert _ffprobe_video_duration(edited) < _ffprobe_video_duration(source_path)  # trim shortened it
+    # The source manifest was never mutated.
+    assert svc._load_or_create_project(vid).data["video"]["path"] == source_path
+
+    # undo: re-applies the recorded inverse over a FRESH copy via the inverse-engine
+    # seam -> the persisted copy manifest flips back to the source reference.
+    ctx3 = _director_ctx()
+    svc.director_undo({"planId": plan_id}, ctx3)
+    undone = _done_result(ctx3)
+    undo_manifest = json.loads(Path(undone["projectCopyPath"]).read_text(encoding="utf-8"))
+    assert undo_manifest["video"]["path"] == source_path


### PR DESCRIPTION
## Summary
Closes two E2E ship-blockers in the Director feature.

### #6 — consent-gate `editPlan` chat egress (was leaking transcript)
`director.plan` built its planner provider via `_provider_for_function("editPlan")` with NO consent filter. `build_understanding` folds the transcript into the prompt, so a revoked-TEXT-consent config still egressed transcript TEXT to the cloud planner. New `_editplan_provider_or_refuse()` builds the editPlan pool over the TEXT-consent-FILTERED settings (mirrors the index-embedder / frame-scorer consent gates): every non-consented cloud entry is DROPPED before the pool is built, so it can never be the primary nor a 429 failover target. If every configured cloud target is non-consented, it REFUSES before any chat — zero bytes leave the machine.

### #7 — wire real ffmpeg apply engines (was a no-op empty table)
`_director_engines()` shipped an empty table, so `director.apply` reported per-op `failed` for every kind. Now wires `features.director_op_engines` so the core renderers (`trim`/`cut`/`removeSilence`/`caption`) operate on the project COPY and produce real, ffprobe-valid mp4s, each recording an inverse for `director.undo`. Deferred kinds (no engine yet) are logged once and surface as a per-op `failed` with auto-rollback — never a crash, never a silent no-op.

## Verification
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100`: **3898 passed, 100.00% coverage** (lines + branches).
- #6: revoked TEXT consent -> `director.plan` refuses before any chat; localhost mock asserts `hits["chat"] == 0`. Mixed-pool test proves the non-consented provider is never the egress target.
- #7: real `ffmpeg.run` subprocess + real `ffprobe` assert the edited mp4 is valid and shorter than source (real trim, not a copy); undo restores the original path.

## Deferred ops (no engine yet)
removeFillers, reorder, retime, reframe, zoomPan, translateCaption, overlayText, lowerThird, export, stitchPanorama, regenScroll, ocrExtractList — each surfaces as a per-op `failed` with auto-rollback (no crash).