### PR TITLE
fix(director): wire UI panel + ffmpeg op engines (E2E gaps #8 + deferred ops)

### DIFF
--- a/app/renderer/src/App.test.tsx
+++ b/app/renderer/src/App.test.tsx
@@ -81,6 +81,13 @@ vi.mock('./panels/ModelsSystemPanel', () => ({
   default: () => <div data-testid="models" />,
 }));
 
+// Stub the lazy AI Director panel (it owns its own tests). This proves the
+// router can resolve + mount it; the panel-mount selector mirrors the GUI
+// harness convention (a data-testid the nav must be able to reach).
+vi.mock('./panels/DirectorPanel', () => ({
+  default: () => <div data-testid="director" />,
+}));
+
 // Stub the Repurpose view; expose the resumeId App wired in (it owns its tests).
 vi.mock('./views/Repurpose', () => ({
   Repurpose: ({ resumeId }: { resumeId?: string }) => (
@@ -184,6 +191,27 @@ describe('App route switch', () => {
     expect(container.querySelector('[data-testid="models"]')).not.toBeNull();
     expect(container.querySelector('[data-testid="library"]')).toBeNull();
     expect(nav('Models & System').classList.contains('is-active')).toBe(true);
+  });
+
+  it('navigates to (mounts) the AI Director panel via the header nav', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+
+    // The Director surface is NOT mounted until the nav routes to it.
+    expect(container.querySelector('[data-testid="director"]')).toBeNull();
+
+    await act(async () => {
+      nav('Director').click();
+    });
+    await flush();
+
+    // The router resolved the lazy panel and mounted it (reachability proven).
+    expect(container.querySelector('[data-testid="director"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="library"]')).toBeNull();
+    expect(nav('Director').classList.contains('is-active')).toBe(true);
+    expect(nav('Director').getAttribute('aria-current')).toBe('page');
   });
 
   it('opens a video into the Workspace and back via nav', async () => {

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -16,6 +16,8 @@ import { incompleteBatches, remainingCount } from './features/repurposeLogic';
 import { useToast } from './components/toast/useToast';
 // Phase-8 "Models & System" panel (lazy: it pulls the model-card grid + onboarding).
 const ModelsSystemPanel = lazy(() => import('./panels/ModelsSystemPanel'));
+// AI Director panel (lazy: it pulls the storyboard/diff + cost-banner surface).
+const DirectorPanel = lazy(() => import('./panels/DirectorPanel'));
 import { client, hasApi, rpc, type ShortReexportHint, type Video } from './lib/rpc';
 import { ToastProvider } from './components/toast/ToastProvider';
 import { ToastHost } from './components/toast/ToastHost';
@@ -45,7 +47,9 @@ type Route =
   // system-advanced: the app-global System Health diagnostic screen.
   | { name: 'health' }
   // Phase-8: the app-global "Models & System" graphics-settings panel.
-  | { name: 'models' };
+  | { name: 'models' }
+  // Director: the prompt-driven AI video-editing panel (director.plan/apply/…).
+  | { name: 'director' };
 
 /** Local/Cloud quality toggle. Maps to settings.useCloud (CONTRACTS.md §2). */
 function QualityToggle({
@@ -228,6 +232,11 @@ export function App(): React.ReactElement {
     setRoute({ name: 'models' });
   }, []);
 
+  // Director: the top-level AI Director nav.
+  const openDirector = useCallback(() => {
+    setRoute({ name: 'director' });
+  }, []);
+
   // P4 §6: Re-export reopens the source video's Workspace (where the
   // Short-maker tab lives) so the user can replay the export. Resolve the
   // source Video by id via library.list, then navigate; fall back to the
@@ -260,6 +269,12 @@ export function App(): React.ReactElement {
         return (
           <Suspense fallback={<div className="panel panel--loading">Loading…</div>}>
             <ModelsSystemPanel />
+          </Suspense>
+        );
+      case 'director':
+        return (
+          <Suspense fallback={<div className="panel panel--loading">Loading…</div>}>
+            <DirectorPanel />
           </Suspense>
         );
       case 'library':
@@ -309,6 +324,14 @@ export function App(): React.ReactElement {
               onClick={openModels}
             >
               Models &amp; System
+            </button>
+            <button
+              type="button"
+              className={`app__nav-btn${route.name === 'director' ? ' is-active' : ''}`}
+              aria-current={route.name === 'director' ? 'page' : undefined}
+              onClick={openDirector}
+            >
+              Director
             </button>
           </nav>
           <QualityToggle quality={quality} onChange={changeQuality} />

--- a/sidecar/media_studio/features/director_op_engines.py
+++ b/sidecar/media_studio/features/director_op_engines.py
@@ -45,6 +45,8 @@ from typing import Any
 from media_studio import ffmpeg as _ffmpeg
 from media_studio.features import caption as _caption
 from media_studio.features import fillers as _fillers
+from media_studio.features import reframe as _reframe
+from media_studio.features import shorts as _shorts
 from media_studio.features import silencetrim as _silencetrim
 from media_studio.features.apply_engine import EngineTable, OpEngine
 from media_studio.features.project_copy import ProjectCopy
@@ -59,30 +61,62 @@ RunFn = Callable[..., int]
 #: never re-render). Double-underscored so it can never collide with a planner param.
 RESTORE_KEY = "__directorRestoreVideo__"
 
-#: The op kinds wired to a real ffmpeg engine in v1 (the core renderers).
-WIRED_KINDS: tuple[str, ...] = ("trim", "cut", "removeSilence", "caption")
+#: Default reframe target aspect when an op omits ``params['aspect']`` (the
+#: contract's 1080x1920 vertical short).
+DEFAULT_REFRAME_ASPECT = "9:16"
 
-#: The op kinds NOT yet wired to a real engine in v1 — logged (never silently
-#: skipped) so an op of one of these kinds surfaces as a clear per-op ``failed``
-#: with auto-rollback. ``reframe`` is held back deliberately: its shipped helper
-#: shells ``wsl bash <script>`` (a host->WSL bridge), which is not a portable
-#: in-engine render path; the rest are manifest/track/multi-artifact ops out of
-#: the v1 render scope. (``export`` re-encodes the whole timeline; that lands with
-#: the export WU.)
-DEFERRED_KINDS: tuple[str, ...] = (
+#: atempo accepts a single tempo in [0.5, 2.0]; factors outside are realised by
+#: chaining atempo stages (e.g. 4x -> ``atempo=2.0,atempo=2.0``). These bound one
+#: stage; :func:`_atempo_chain` decomposes any positive factor into legal stages.
+_ATEMPO_MIN = 0.5
+_ATEMPO_MAX = 2.0
+
+#: The op kinds wired to a real ffmpeg engine: the core renderers (trim/cut/
+#: removeSilence/caption) PLUS the ffmpeg-achievable Director ops added here.
+#: Every one of these renders REAL edited media (not a manifest no-op) over the
+#: COPY and records a restore-inverse for undo.
+WIRED_KINDS: tuple[str, ...] = (
+    "trim",
+    "cut",
+    "removeSilence",
+    "caption",
     "removeFillers",
-    "reorder",
-    "retime",
     "reframe",
     "zoomPan",
-    "translateCaption",
+    "retime",
     "overlayText",
     "lowerThird",
+    "translateCaption",
     "export",
+)
+
+#: The op kinds NOT wired to a real engine — each needs a subsystem ffmpeg alone
+#: cannot provide. Logged up front (never silently skipped) so an op of one of
+#: these kinds surfaces as a clear per-op ``failed`` with auto-rollback (the
+#: graceful degradation), never a silent no-op. HONESTLY DEFERRED:
+#:
+#:   * ``stitchPanorama`` -> the panorama/stitch engine (multi-frame mosaic);
+#:   * ``ocrExtractList``  -> an OCR engine (text recognition, not a render);
+#:   * ``regenScroll``     -> the scroll-regen engine (also needs a panorama).
+#:
+#: ``reorder`` is a multi-clip timeline permutation outside the single-clip
+#: render scope of these adapters and is likewise left deferred.
+DEFERRED_KINDS: tuple[str, ...] = (
+    "reorder",
     "stitchPanorama",
     "regenScroll",
     "ocrExtractList",
 )
+
+#: Each deferred kind -> the subsystem it requires. Surfaced verbatim in the
+#: deferral notice (:func:`log_deferred`) so the unwired set names WHY each is
+#: held back, not just THAT it is.
+DEFERRED_SUBSYSTEMS: dict[str, str] = {
+    "reorder": "the timeline clip-reorder engine (multi-clip permutation)",
+    "stitchPanorama": "the panorama/stitch engine",
+    "regenScroll": "the scroll-regen engine (requires a stitched panorama)",
+    "ocrExtractList": "an OCR engine",
+}
 
 
 class DirectorEngineError(RuntimeError):
@@ -325,6 +359,40 @@ def _track_cues(project_copy: ProjectCopy, op: EditOp) -> Sequence[Mapping[str, 
     raise DirectorEngineError(f"caption track {track_id!r} not found in project copy")
 
 
+def _burn_track_engine(
+    op: EditOp,
+    project_copy: ProjectCopy,
+    *,
+    runner: RunFn,
+    settings: Mapping[str, Any] | None,
+) -> EditOp:
+    """Burn the op's target-track cues into the video (libass) + record the inverse.
+
+    The shared forward path for ``caption`` AND ``translateCaption``: both name an
+    existing track (validate-and-reject guarantees it) whose inline cues hold the
+    burnable text — the ORIGINAL cues for ``caption``, the TRANSLATED cues for
+    ``translateCaption`` (the translation having been produced upstream by
+    ``subtitles.translate``, which preserves cue timings/indices and rewrites
+    each cue's ``text``). Whatever text the named track carries is what gets
+    burned, so re-burning a translated track is a real, non-no-op render.
+    """
+    restored = _maybe_restore(op, project_copy)
+    if restored is not None:
+        return restored
+    cues = _track_cues(project_copy, op)
+    out_path = _out_path(project_copy, op)
+    ass_path = out_path.with_suffix(".ass")
+    ass_doc = _caption.build_ass(cues)
+    ass_path.write_text(ass_doc, encoding="utf-8")
+    return _render(
+        project_copy,
+        op,
+        lambda i, o: _caption.build_burn_argv(i, str(ass_path), o, dict(settings or {})),
+        runner=runner,
+        settings=settings,
+    )
+
+
 def make_caption_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
     """Engine for ``caption``: BURN the target track's cues into the video (libass).
 
@@ -335,18 +403,434 @@ def make_caption_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = N
     """
 
     def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        return _burn_track_engine(op, project_copy, runner=runner, settings=settings)
+
+    return engine
+
+
+def make_translate_caption_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``translateCaption``: RE-BURN the target track's TRANSLATED cues.
+
+    Identical render path to ``caption`` (``_burn_track_engine``): the named track
+    already carries the translated cue text (produced by ``subtitles.translate``
+    upstream — it preserves timings and rewrites ``text``), so burning that track
+    hardcodes the translated subtitles onto the video. The translation generation
+    itself is a separate provider-backed job and is NOT re-done here; this op only
+    renders the translated cues that already exist on the track. The inverse
+    restores the pre-burn reference (undo, no re-render).
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        return _burn_track_engine(op, project_copy, runner=runner, settings=settings)
+
+    return engine
+
+
+# --------------------------------------------------------------------------- #
+# geometry / timing / overlay ops (ffmpeg-achievable Director ops)
+# --------------------------------------------------------------------------- #
+def _escape_drawtext(text: str) -> str:
+    r"""Escape ``text`` for an ffmpeg ``drawtext=text=`` value.
+
+    drawtext's parser treats ``\``, ``:``, ``%`` and ``'`` specially (distinct
+    from libass' ``subtitles=`` path escaping). Backslash first, then the rest,
+    so a single literal char never double-escapes. Newlines are dropped (drawtext
+    is single-line; multi-line lower-thirds use separate ops).
+    """
+    out = text.replace("\\", "\\\\")
+    out = out.replace(":", "\\:")
+    out = out.replace("%", "\\%")
+    out = out.replace("'", "\\'")
+    return out.replace("\n", " ").replace("\r", " ")
+
+
+def _require_text(op: EditOp) -> str:
+    """Return the op's ``params['text']`` (a non-empty string) or a render error."""
+    text = op.params.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise DirectorEngineError(f"{op.kind!r} op {op.id!r} requires non-empty params['text']")
+    return text
+
+
+def _aspect_ratio(aspect: str) -> tuple[int, int]:
+    """Parse a ``"W:H"`` (or ``"WxH"``) aspect string into a positive ``(w, h)``.
+
+    A render error for anything malformed, so a bad ``params['aspect']`` degrades
+    to a per-op ``failed`` + rollback rather than a broken filtergraph.
+    """
+    raw = str(aspect).strip().replace("x", ":")
+    parts = raw.split(":")
+    if len(parts) != 2:
+        raise DirectorEngineError(f"reframe aspect must be 'W:H', got {aspect!r}")
+    try:
+        w, h = int(parts[0]), int(parts[1])
+    except ValueError:
+        raise DirectorEngineError(f"reframe aspect must be two integers, got {aspect!r}") from None
+    if w <= 0 or h <= 0:
+        raise DirectorEngineError(f"reframe aspect components must be positive, got {aspect!r}")
+    return w, h
+
+
+def build_reframe_argv(
+    in_path: str,
+    out_path: str,
+    aspect: str,
+    settings: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """argv that CENTER-CROPS ``in_path`` to ``aspect`` then scales to the canvas.
+
+    A pure in-engine crop+scale (NO ``wsl bash`` host bridge): ``crop`` carves a
+    centered ``aspect``-ratio window out of the source frame (driven by ``ih`` so
+    it works for any input size), then ``scale`` resizes it to the contract output
+    dimensions for ``aspect`` (:func:`reframe.output_dimensions`, e.g. 1080x1920
+    for 9:16). The result has the target aspect's dimensions — a real geometry
+    edit, never a no-op. Audio is stream-copied.
+    """
+    aw, ah = _aspect_ratio(aspect)
+    width, height = _reframe.output_dimensions(aspect)
+    vf = f"crop=ih*{aw}/{ah}:ih,scale={width}:{height}"
+    return [
+        _ffmpeg.ffmpeg_path(settings),
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-i",
+        in_path,
+        "-vf",
+        vf,
+        "-c:a",
+        "copy",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        out_path,
+    ]
+
+
+def build_zoompan_argv(
+    in_path: str,
+    out_path: str,
+    *,
+    total_sec: float,
+    dims: tuple[int, int] = (0, 0),
+    settings: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """argv for a slow Ken-Burns ``zoompan`` push-in over the whole clip.
+
+    ``zoompan`` takes a per-input-frame duration ``d`` (the number of OUTPUT
+    frames each input frame expands to); we keep ``d=1`` at a fixed output ``fps``
+    so the zoom advances smoothly across the clip rather than stepping. ``z`` ramps
+    from 1.0 toward 1.5 (capped), giving a visible push-in — a real motion edit.
+
+    ``zoompan`` defaults its output canvas to 1280x720 when ``s=`` is omitted,
+    which would silently rescale (e.g. a 9:16 short -> landscape 720p). So when
+    valid source ``dims`` are known we pin ``s=<w>x<h>`` to PRESERVE the source
+    frame size; a failed probe ((0, 0)) omits ``s=`` rather than emit ``s=0x0``.
+    Audio is stream-copied.
+    """
+    fps = 30
+    frames = max(1, int(round(max(total_sec, 0.0) * fps)))
+    # z ramps from 1.0 to 1.5 across ``frames`` output frames; the comma inside
+    # min() is escaped (``\\,``) so the filter parser does not read it as an option
+    # separator. ``d=1`` + a fixed ``fps`` advance the zoom one step per frame so
+    # the push-in is smooth.
+    zexpr = f"min(1.0+0.5*on/{frames}\\,1.5)"
+    width, height = dims
+    size = f":s={width}x{height}" if width > 0 and height > 0 else ""
+    vf = f"zoompan=z={zexpr}:d=1{size}:fps={fps}"
+    return [
+        _ffmpeg.ffmpeg_path(settings),
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-i",
+        in_path,
+        "-vf",
+        vf,
+        "-c:a",
+        "copy",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        out_path,
+    ]
+
+
+def _atempo_chain(factor: float) -> list[str]:
+    """Decompose a positive playback ``factor`` into legal ``atempo`` stages.
+
+    atempo is bounded to [0.5, 2.0] per stage. Speed-ups > 2.0 chain ``atempo=2.0``
+    repeatedly (then a final remainder); slow-downs < 0.5 chain ``atempo=0.5``.
+    Returns the per-stage tempo strings (e.g. 4.0 -> ['2.0', '2.0']).
+    """
+    stages: list[str] = []
+    remaining = factor
+    while remaining > _ATEMPO_MAX:
+        stages.append(f"{_ATEMPO_MAX}")
+        remaining /= _ATEMPO_MAX
+    while remaining < _ATEMPO_MIN:
+        stages.append(f"{_ATEMPO_MIN}")
+        remaining /= _ATEMPO_MIN
+    stages.append(f"{remaining:.6f}")
+    return stages
+
+
+def build_retime_argv(
+    in_path: str,
+    out_path: str,
+    factor: float,
+    settings: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """argv that RE-TIMES the clip by ``factor`` (video setpts + audio atempo).
+
+    ``factor`` > 1 speeds up (shorter), < 1 slows down (longer). Video PTS scale
+    by ``1/factor`` (``setpts=(1/factor)*PTS``); audio tempo is the matching
+    ``atempo`` chain so picture and sound stay in sync. The output duration is
+    ``source/factor`` — the strongest non-no-op proof.
+    """
+    inv = 1.0 / factor
+    atempo = ",".join(f"atempo={s}" for s in _atempo_chain(factor))
+    filtergraph = f"[0:v]setpts={inv:.6f}*PTS[v];[0:a]{atempo}[a]"
+    return [
+        _ffmpeg.ffmpeg_path(settings),
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-i",
+        in_path,
+        "-filter_complex",
+        filtergraph,
+        "-map",
+        "[v]",
+        "-map",
+        "[a]",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        out_path,
+    ]
+
+
+def build_drawtext_argv(
+    in_path: str,
+    out_path: str,
+    text: str,
+    *,
+    lower_third: bool,
+    settings: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """argv that draws ``text`` onto the video via the ``drawtext`` filter.
+
+    ``overlayText`` centers the text in the frame; ``lowerThird`` anchors it in a
+    lower band over a translucent box (the classic name/title strap). Both rely on
+    fontconfig's default face (no ``fontfile`` needed where fontconfig is present);
+    the text is escaped for the drawtext parser. Audio is stream-copied.
+    """
+    safe = _escape_drawtext(text)
+    if lower_third:
+        draw = (
+            f"drawtext=text='{safe}':fontcolor=white:fontsize=h/18:"
+            "box=1:boxcolor=black@0.5:boxborderw=12:x=(w-text_w)/2:y=h-h/6"
+        )
+    else:
+        draw = (
+            f"drawtext=text='{safe}':fontcolor=white:fontsize=h/12:"
+            "borderw=2:bordercolor=black:x=(w-text_w)/2:y=(h-text_h)/2"
+        )
+    return [
+        _ffmpeg.ffmpeg_path(settings),
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-i",
+        in_path,
+        "-vf",
+        draw,
+        "-c:a",
+        "copy",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        out_path,
+    ]
+
+
+def make_remove_fillers_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``removeFillers``: CUT the op's span of filler words (drop it).
+
+    A span op (validate-and-reject guarantees a valid ``span``): the planner sets
+    the span to the filler range to excise, so this is the same head+tail keep as
+    ``trim`` — the span is removed and the surrounding clip concatenated, shrinking
+    the duration (the same dead-air pipeline as ``removeSilence``/``trim``). The
+    inverse restores the pre-cut reference (undo, no re-render).
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
         restored = _maybe_restore(op, project_copy)
         if restored is not None:
             return restored
-        cues = _track_cues(project_copy, op)
-        out_path = _out_path(project_copy, op)
-        ass_path = out_path.with_suffix(".ass")
-        ass_doc = _caption.build_ass(cues)
-        ass_path.write_text(ass_doc, encoding="utf-8")
+        in_path = _source_path(project_copy)
+        total = _ffmpeg.ffprobe_duration(in_path, dict(settings or {}))
+        keeps = _keep_for_trim(op, total)
         return _render(
             project_copy,
             op,
-            lambda i, o: _caption.build_burn_argv(i, str(ass_path), o, dict(settings or {})),
+            lambda i, o: _fillers.build_segment_cut_argv(i, o, keeps, dict(settings or {})),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_reframe_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``reframe``: center-crop+scale to the target aspect (in-engine).
+
+    Forward renders a real reframed mp4 (``build_reframe_argv`` — crop+scale, NO
+    host->WSL bridge) at the contract dimensions for ``params['aspect']`` (default
+    9:16), re-pointing the COPY at it. The inverse restores the pre-reframe ref.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        aspect = op.params.get("aspect")
+        aspect = aspect if isinstance(aspect, str) and aspect.strip() else DEFAULT_REFRAME_ASPECT
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: build_reframe_argv(i, o, aspect, settings),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_zoom_pan_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``zoomPan``: apply a Ken-Burns ``zoompan`` push-in (motion).
+
+    Forward renders a real zoom/pan mp4 (``build_zoompan_argv``) over the clip and
+    re-points the COPY at it. The inverse restores the pre-zoom reference.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        in_path = _source_path(project_copy)
+        total = _ffmpeg.ffprobe_duration(in_path, dict(settings or {}))
+        dims = _shorts.probe_dims(in_path, dict(settings or {}))
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: build_zoompan_argv(i, o, total_sec=total, dims=dims, settings=settings),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_retime_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``retime``: change playback speed by ``params['factor']``.
+
+    Forward renders a real re-timed mp4 (``build_retime_argv`` — setpts + atempo),
+    re-pointing the COPY. A non-positive or 1.0 factor is a no-op and rejected as a
+    render error. The inverse restores the pre-retime reference.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        raw = op.params.get("factor")
+        try:
+            factor = float(raw)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            raise DirectorEngineError(f"retime op {op.id!r} requires a numeric params['factor']") from None
+        if factor <= 0.0 or factor == 1.0:
+            raise DirectorEngineError(f"retime factor {factor!r} is a no-op (must be > 0 and != 1.0)")
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: build_retime_argv(i, o, factor, settings),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_overlay_text_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``overlayText``: draw ``params['text']`` centered (drawtext).
+
+    Forward renders a real mp4 with the text burned in (``build_drawtext_argv``)
+    and re-points the COPY. The inverse restores the pre-overlay reference.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        text = _require_text(op)
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: build_drawtext_argv(i, o, text, lower_third=False, settings=settings),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_lower_third_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``lowerThird``: draw ``params['text']`` as a lower-third strap.
+
+    Forward renders a real mp4 with a boxed lower-band caption (``build_drawtext_argv``
+    ``lower_third=True``) and re-points the COPY. The inverse restores the prior ref.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        text = _require_text(op)
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: build_drawtext_argv(i, o, text, lower_third=True, settings=settings),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def make_export_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``export``: re-encode/mux the timeline to a delivery mp4.
+
+    A whole-timeline op (no span): re-encodes the current COPY source to H.264/AAC
+    (``ffmpeg.build_convert_argv``), producing a fresh, ffprobe-valid delivery file
+    the COPY is re-pointed at. The inverse restores the pre-export reference.
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: _ffmpeg.build_convert_argv(
+                i, o, {"vcodec": "libx264", "acodec": "aac"}, dict(settings or {})
+            ),
             runner=runner,
             settings=settings,
         )
@@ -369,27 +853,51 @@ def build_engines(*, runner: RunFn | None = None, settings: Mapping[str, Any] | 
         "cut": make_cut_engine(runner=run, settings=settings),
         "removeSilence": make_remove_silence_engine(runner=run, settings=settings),
         "caption": make_caption_engine(runner=run, settings=settings),
+        "removeFillers": make_remove_fillers_engine(runner=run, settings=settings),
+        "reframe": make_reframe_engine(runner=run, settings=settings),
+        "zoomPan": make_zoom_pan_engine(runner=run, settings=settings),
+        "retime": make_retime_engine(runner=run, settings=settings),
+        "overlayText": make_overlay_text_engine(runner=run, settings=settings),
+        "lowerThird": make_lower_third_engine(runner=run, settings=settings),
+        "translateCaption": make_translate_caption_engine(runner=run, settings=settings),
+        "export": make_export_engine(runner=run, settings=settings),
     }
 
 
 def log_deferred(log: Any) -> None:
-    """Log the op kinds NOT yet wired to a real engine (visibility, never silent).
+    """Log the wired kinds + the deferred kinds WITH the subsystem each requires.
 
     Called once when the table is built so a deferred-kind op's eventual per-op
-    ``failed`` is never a surprise — the set of unwired kinds is announced up front.
+    ``failed`` is never a surprise — the unwired set is announced up front, each
+    annotated with the subsystem (``DEFERRED_SUBSYSTEMS``) ffmpeg cannot supply,
+    so the notice reads "requires <subsystem>" rather than a bare kind name.
     """
-    log.info("director.apply real engines wired for %s; deferred (no engine yet): %s", WIRED_KINDS, DEFERRED_KINDS)
+    requires = "; ".join(f"{kind} (requires {DEFERRED_SUBSYSTEMS[kind]})" for kind in DEFERRED_KINDS)
+    log.info("director.apply real engines wired for %s; deferred (no engine yet): %s", WIRED_KINDS, requires)
 
 
 __all__ = [
     "DEFERRED_KINDS",
+    "DEFERRED_SUBSYSTEMS",
     "WIRED_KINDS",
     "RESTORE_KEY",
     "DirectorEngineError",
+    "build_drawtext_argv",
     "build_engines",
+    "build_reframe_argv",
+    "build_retime_argv",
+    "build_zoompan_argv",
     "log_deferred",
     "make_caption_engine",
     "make_cut_engine",
+    "make_export_engine",
+    "make_lower_third_engine",
+    "make_overlay_text_engine",
+    "make_reframe_engine",
+    "make_remove_fillers_engine",
     "make_remove_silence_engine",
+    "make_retime_engine",
+    "make_translate_caption_engine",
     "make_trim_engine",
+    "make_zoom_pan_engine",
 ]

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -79,10 +79,29 @@ def test_build_engines_defaults_runner_to_ffmpeg_run() -> None:
 def test_deferred_kinds_have_no_engine() -> None:
     table = build_engines(runner=FakeRunner())
     assert not (set(DEFERRED_KINDS) & set(table))
-    assert "reframe" in DEFERRED_KINDS  # the host->WSL-bridge op stays deferred
+    # The honestly-deferred subsystem ops stay out of the table; reorder too.
+    assert {"stitchPanorama", "regenScroll", "ocrExtractList", "reorder"} <= set(DEFERRED_KINDS)
+    # The ffmpeg-achievable ops moved INTO the wired table.
+    assert {
+        "reframe",
+        "zoomPan",
+        "retime",
+        "overlayText",
+        "lowerThird",
+        "removeFillers",
+        "translateCaption",
+        "export",
+    } <= set(WIRED_KINDS)
 
 
-def test_log_deferred_announces_unwired_kinds() -> None:
+def test_deferred_subsystems_cover_every_deferred_kind() -> None:
+    # Every deferred kind names the subsystem it requires (no bare deferrals).
+    assert set(engines_mod.DEFERRED_SUBSYSTEMS) == set(DEFERRED_KINDS)
+    assert "panorama" in engines_mod.DEFERRED_SUBSYSTEMS["stitchPanorama"]
+    assert "OCR" in engines_mod.DEFERRED_SUBSYSTEMS["ocrExtractList"]
+
+
+def test_log_deferred_announces_unwired_kinds_with_subsystems() -> None:
     seen: list[tuple[Any, ...]] = []
 
     class _Log:
@@ -91,6 +110,8 @@ def test_log_deferred_announces_unwired_kinds() -> None:
 
     engines_mod.log_deferred(_Log())
     assert seen and "deferred" in seen[0][0]
+    notice = seen[0][-1]  # the "kind (requires <subsystem>)" string
+    assert "stitchPanorama (requires" in notice and "OCR" in notice
 
 
 # --------------------------------------------------------------------------- #
@@ -329,3 +350,332 @@ def test_missing_source_path_is_error(tmp_path: Path) -> None:
     pc = _copy(tmp_path, video={"path": ""})
     with pytest.raises(DirectorEngineError, match="no source path"):
         build_engines(runner=FakeRunner())["trim"](EditOp(id="t", kind="trim", span=(1000, 2000)), pc)
+
+
+# --------------------------------------------------------------------------- #
+# removeFillers (drop the filler span — like trim)
+# --------------------------------------------------------------------------- #
+def test_remove_fillers_cuts_span_and_records_inverse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    op = EditOp(id="rf1", kind="removeFillers", span=(2000, 4000))
+
+    inverse = build_engines(runner=runner)["removeFillers"](op, pc)
+
+    fc = runner.calls[0][runner.calls[0].index("-filter_complex") + 1]
+    # head [0,2.0] + tail [4.0,12.0] kept -> the filler span [2,4] is excised.
+    assert "trim=start=0.000:end=2.000" in fc and "trim=start=4.000:end=12.000" in fc
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_remove_fillers_inverse_restores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    original = pc.data["video"]["path"]
+    table = build_engines(runner=runner)
+    fwd = table["removeFillers"](EditOp(id="rf", kind="removeFillers", span=(1000, 3000)), pc)
+    calls = len(runner.calls)
+    table["removeFillers"](fwd, pc)
+    assert pc.data["video"]["path"] == original
+    assert len(runner.calls) == calls  # restore-only, no re-render
+
+
+# --------------------------------------------------------------------------- #
+# reframe (center-crop + scale to aspect)
+# --------------------------------------------------------------------------- #
+def test_reframe_default_aspect_crops_and_scales(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["reframe"](EditOp(id="r1", kind="reframe", span=(0, 12000)), pc)
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert vf.startswith("crop=ih*9/16:ih,scale=1080:1920")  # default 9:16 -> 1080x1920
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_reframe_custom_aspect(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    build_engines(runner=runner)["reframe"](
+        EditOp(id="r", kind="reframe", span=(0, 12000), params={"aspect": "1:1"}), pc
+    )
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert "crop=ih*1/1:ih" in vf
+
+
+def test_reframe_blank_aspect_falls_back_to_default(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    # A non-str / blank aspect param falls back to the 9:16 default.
+    build_engines(runner=runner)["reframe"](
+        EditOp(id="r", kind="reframe", span=(0, 12000), params={"aspect": "   "}), pc
+    )
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert "crop=ih*9/16:ih" in vf
+
+
+def test_reframe_non_string_aspect_falls_back(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    build_engines(runner=runner)["reframe"](
+        EditOp(id="r", kind="reframe", span=(0, 12000), params={"aspect": 169}), pc
+    )
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert "crop=ih*9/16:ih" in vf
+
+
+@pytest.mark.parametrize(
+    ("aspect", "match"),
+    [
+        ("9", "must be 'W:H'"),
+        ("a:b", "two integers"),
+        ("0:16", "must be positive"),
+    ],
+)
+def test_reframe_bad_aspect_is_error(aspect: str, match: str) -> None:
+    with pytest.raises(DirectorEngineError, match=match):
+        engines_mod.build_reframe_argv("in.mp4", "out.mp4", aspect)
+
+
+# --------------------------------------------------------------------------- #
+# zoomPan (Ken-Burns push-in)
+# --------------------------------------------------------------------------- #
+def _fake_dims(monkeypatch: pytest.MonkeyPatch, value: tuple[int, int] = (320, 240)) -> None:
+    monkeypatch.setattr(engines_mod._shorts, "probe_dims", lambda *_a, **_k: value)
+
+
+def test_zoom_pan_renders_zoompan_filter_preserving_dims(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    _fake_dims(monkeypatch, (1080, 1920))
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["zoomPan"](EditOp(id="z1", kind="zoomPan", span=(0, 12000)), pc)
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert vf.startswith("zoompan=z=min(1.0+0.5*on/")
+    assert ":s=1080x1920" in vf  # source dims PINNED (no silent 1280x720 rescale)
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_zoom_pan_omits_size_when_probe_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # A failed dims probe ((0, 0)) omits s= rather than emitting s=0x0.
+    _fake_probe(monkeypatch)
+    _fake_dims(monkeypatch, (0, 0))
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    build_engines(runner=runner)["zoomPan"](EditOp(id="z", kind="zoomPan", span=(0, 12000)), pc)
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert ":s=" not in vf
+
+
+def test_zoom_pan_zero_duration_clamps_frames() -> None:
+    # total_sec 0 -> frames clamps to >=1 so the expression never divides by zero.
+    argv = engines_mod.build_zoompan_argv("in.mp4", "out.mp4", total_sec=0.0)
+    vf = argv[argv.index("-vf") + 1]
+    assert "on/1\\,1.5" in vf
+    assert ":s=" not in vf  # default dims (0, 0) -> no s=
+
+
+# --------------------------------------------------------------------------- #
+# retime (setpts + atempo)
+# --------------------------------------------------------------------------- #
+def test_retime_speeds_up(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["retime"](
+        EditOp(id="rt1", kind="retime", span=(0, 12000), params={"factor": 2.0}), pc
+    )
+    fg = runner.calls[0][runner.calls[0].index("-filter_complex") + 1]
+    assert "setpts=0.500000*PTS" in fg and "atempo=2.0" in fg
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_retime_no_op_factor_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="no-op"):
+        build_engines(runner=FakeRunner())["retime"](
+            EditOp(id="rt", kind="retime", span=(0, 12000), params={"factor": 1.0}), pc
+        )
+
+
+def test_retime_non_positive_factor_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="no-op"):
+        build_engines(runner=FakeRunner())["retime"](
+            EditOp(id="rt", kind="retime", span=(0, 12000), params={"factor": 0.0}), pc
+        )
+
+
+def test_retime_non_numeric_factor_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="numeric"):
+        build_engines(runner=FakeRunner())["retime"](
+            EditOp(id="rt", kind="retime", span=(0, 12000), params={"factor": "fast"}), pc
+        )
+
+
+def test_atempo_chain_speed_up_beyond_two() -> None:
+    # 5x -> 2.0, 2.0, then the 1.25 remainder.
+    stages = engines_mod._atempo_chain(5.0)
+    assert stages[:2] == ["2.0", "2.0"]
+    assert abs(float(stages[-1]) - 1.25) < 1e-6
+
+
+def test_atempo_chain_slow_down_below_half() -> None:
+    # 0.25x -> 0.5, then a 0.5 remainder.
+    stages = engines_mod._atempo_chain(0.25)
+    assert stages[0] == "0.5"
+    assert abs(float(stages[-1]) - 0.5) < 1e-6
+
+
+# --------------------------------------------------------------------------- #
+# overlayText / lowerThird (drawtext)
+# --------------------------------------------------------------------------- #
+def test_overlay_text_draws_centered(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["overlayText"](
+        EditOp(id="o1", kind="overlayText", span=(0, 12000), params={"text": "Hi"}), pc
+    )
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert vf.startswith("drawtext=text='Hi'") and "box=1" not in vf  # centered, no box
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_lower_third_draws_boxed_band(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    build_engines(runner=runner)["lowerThird"](
+        EditOp(id="l1", kind="lowerThird", span=(0, 12000), params={"text": "Jane Doe"}), pc
+    )
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert "box=1" in vf and "y=h-h/6" in vf  # lower band over a box
+
+
+@pytest.mark.parametrize("kind", ["overlayText", "lowerThird"])
+def test_drawtext_missing_text_is_error(kind: str, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="non-empty"):
+        build_engines(runner=FakeRunner())[kind](EditOp(id="x", kind=kind, span=(0, 12000)), pc)  # type: ignore[arg-type]
+
+
+def test_drawtext_blank_text_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="non-empty"):
+        build_engines(runner=FakeRunner())["overlayText"](
+            EditOp(id="x", kind="overlayText", span=(0, 12000), params={"text": "   "}), pc
+        )
+
+
+def test_escape_drawtext_handles_special_chars() -> None:
+    # backslash, colon, percent, quote, and newline are all neutralised.
+    out = engines_mod._escape_drawtext("a\\b:c 50%'q\nx")
+    assert out == "a\\\\b\\:c 50\\%\\'q x"
+
+
+# --------------------------------------------------------------------------- #
+# translateCaption (re-burn the translated track's cues)
+# --------------------------------------------------------------------------- #
+def test_translate_caption_burns_translated_cues(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    translated = [{"index": 1, "start": 1.0, "end": 3.0, "text": "bonjour"}]
+    pc = _copy(tmp_path, tracks=[{"id": "fr", "lang": "fr", "cues": translated}])
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["translateCaption"](
+        EditOp(id="tc1", kind="translateCaption", params={"track": "fr"}), pc
+    )
+    ass = next(pc.manifest_path.parent.glob("*.ass"))
+    assert "bonjour" in ass.read_text(encoding="utf-8")  # the TRANSLATED text is burned
+    vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
+    assert vf.startswith("subtitles=")
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_translate_caption_missing_track_is_error(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    pc = _copy(tmp_path, tracks=[{"id": "other", "cues": _CUES}])
+    with pytest.raises(DirectorEngineError, match="not found"):
+        build_engines(runner=FakeRunner())["translateCaption"](
+            EditOp(id="tc", kind="translateCaption", params={"track": "fr"}), pc
+        )
+
+
+# --------------------------------------------------------------------------- #
+# export (re-encode/mux passthrough)
+# --------------------------------------------------------------------------- #
+def test_export_re_encodes_and_records_inverse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    inverse = build_engines(runner=runner)["export"](EditOp(id="ex1", kind="export"), pc)
+    argv = runner.calls[0]
+    assert "libx264" in argv and "aac" in argv  # a real re-encode
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_export_inverse_restores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    original = pc.data["video"]["path"]
+    table = build_engines(runner=runner)
+    fwd = table["export"](EditOp(id="ex", kind="export"), pc)
+    calls = len(runner.calls)
+    table["export"](fwd, pc)
+    assert pc.data["video"]["path"] == original
+    assert len(runner.calls) == calls
+
+
+# --------------------------------------------------------------------------- #
+# dual-mode inverse for the new geometry/timing/overlay ops
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("kind", "op_params"),
+    [
+        ("reframe", {"aspect": "9:16"}),
+        ("zoomPan", {}),
+        ("retime", {"factor": 2.0}),
+        ("overlayText", {"text": "hi"}),
+        ("lowerThird", {"text": "hi"}),
+    ],
+)
+def test_inverse_restores_for_new_render_ops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, kind: str, op_params: dict[str, Any]
+) -> None:
+    _fake_probe(monkeypatch)
+    _fake_dims(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    original = pc.data["video"]["path"]
+    table = build_engines(runner=runner)
+    fwd = table[kind](EditOp(id="op", kind=kind, span=(0, 12000), params=op_params), pc)  # type: ignore[arg-type]
+    calls = len(runner.calls)
+    table[kind](fwd, pc)
+    assert pc.data["video"]["path"] == original
+    assert len(runner.calls) == calls  # restore-only on undo

--- a/sidecar/tests/test_director_render_integration.py
+++ b/sidecar/tests/test_director_render_integration.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import pytest
 from media_studio.features import director_op_engines as engines_mod
 from media_studio.features.apply_engine import apply_plan
+from media_studio.features.edit_validate import Understanding, validate_and_reject
 from media_studio.features.project_copy import ProjectCopy
 from media_studio.models.edit_plan import EditOp, EditPlan
 
@@ -86,6 +87,29 @@ def _ffprobe_ok(path: Path) -> float:
     return float(out)
 
 
+def _dims(path: Path) -> tuple[int, int]:
+    """Return the (width, height) of ``path``'s first video stream."""
+    out = subprocess.run(  # noqa: S603 - fixed argv, no shell
+        [
+            "ffprobe",
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height",
+            "-of",
+            "csv=p=0:s=x",
+            str(path),
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    w, h = out.split("x")
+    return int(w), int(h)
+
+
 def _project_copy(tmp_path: Path, src: Path, *, tracks: list | None = None) -> ProjectCopy:
     data: dict = {"video": {"path": str(src)}}
     if tracks is not None:
@@ -143,3 +167,194 @@ def test_caption_burns_real_subtitles(sample: Path, tmp_path: Path) -> None:
     undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
     assert undo.ops_status[0].status == "applied"
     assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+def _apply_one(pc: ProjectCopy, op: EditOp):  # noqa: ANN202 - test helper
+    """Apply a single-op plan with the REAL engines and return ``(result, engines)``."""
+    engines = engines_mod.build_engines()
+    return apply_plan(EditPlan("p", "v", "g", "h", ops=(op,)), project_copy=pc, engines=engines), engines
+
+
+@_SKIP
+def test_reframe_renders_real_target_dimensions(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    assert _dims(Path(source_before)) == (320, 240)  # landscape source
+    op = EditOp(id="rf1", kind="reframe", span=(0, 1500), params={"aspect": "9:16"})
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _dims(rendered) == (1080, 1920)  # NON-no-op: vertical target dims
+    assert _ffprobe_ok(rendered) > 0
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_retime_renders_shorter_duration(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    src_dur = _ffprobe_ok(Path(source_before))
+    op = EditOp(id="rt1", kind="retime", span=(0, 1500), params={"factor": 2.0})
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    # 2x speed-up -> roughly half the duration (NON-no-op): clearly shorter.
+    assert _ffprobe_ok(rendered) < src_dur * 0.75
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_remove_fillers_renders_shorter_duration(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    src_dur = _ffprobe_ok(Path(source_before))
+    # Excise the middle 0.5s of the 1.5s clip.
+    op = EditOp(id="rmf1", kind="removeFillers", span=(500, 1000))
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _ffprobe_ok(rendered) < src_dur  # NON-no-op: a span was cut out
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_zoom_pan_renders_valid_motion(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    op = EditOp(id="zp1", kind="zoomPan", span=(0, 1500))
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _ffprobe_ok(rendered) > 0  # ffprobe-valid re-rasterised mp4
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+@pytest.mark.parametrize("kind", ["overlayText", "lowerThird"])
+def test_drawtext_ops_render_valid_mp4(kind: str, sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    op = EditOp(id="dt1", kind=kind, span=(0, 1500), params={"text": "Real Text 50%"})
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _ffprobe_ok(rendered) > 0  # ffprobe-valid drawtext-burned mp4
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+@pytest.mark.parametrize("kind", ["overlayText", "lowerThird"])
+def test_drawtext_op_survives_validation_then_applies(kind: str, sample: Path, tmp_path: Path) -> None:
+    # INTEGRATED contract: overlayText/lowerThird are _TRACK_KINDS, so a real op
+    # carries BOTH a ``track`` (required by validate_and_reject) AND the ``text``
+    # the drawtext engine renders (matching the golden-plan op shape). This proves
+    # the op survives validation AND renders REAL media end-to-end (not dropped,
+    # not a no-op) — the path the isolated engine tests bypass.
+    pc = _project_copy(tmp_path, sample, tracks=[{"id": "overlay", "kind": "overlay", "cues": []}])
+    source_before = pc.data["video"]["path"]
+    op = EditOp(id="dt1", kind=kind, span=(0, 1500), params={"track": "overlay", "text": "Real 50%"})
+    plan = EditPlan("p", "v", "g", "h", ops=(op,))
+
+    # validate against an understanding where the target track EXISTS.
+    understanding = Understanding(clip_duration_ms=1500, tracks=("overlay",))
+    validated = validate_and_reject(plan, understanding=understanding)
+    assert validated.ops[0].status != "dropped"  # NOT dropped by unknown-track
+
+    engines = engines_mod.build_engines()
+    result = apply_plan(validated, project_copy=pc, engines=engines)
+
+    assert result.ops_status[0].status == "applied"  # rendered, not a no-op
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _ffprobe_ok(rendered) > 0
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_translate_caption_burns_translated_track(sample: Path, tmp_path: Path) -> None:
+    translated = [{"index": 1, "start": 0.2, "end": 1.0, "text": "bonjour"}]
+    pc = _project_copy(tmp_path, sample, tracks=[{"id": "fr", "lang": "fr", "cues": translated}])
+    source_before = pc.data["video"]["path"]
+    op = EditOp(id="tc1", kind="translateCaption", params={"track": "fr"})
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _ffprobe_ok(rendered) > 0
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_export_renders_valid_delivery_mp4(sample: Path, tmp_path: Path) -> None:
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    op = EditOp(id="ex1", kind="export")
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    assert _ffprobe_ok(rendered) > 0  # ffprobe-valid re-encoded delivery
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+@pytest.mark.parametrize("kind", ["stitchPanorama", "regenScroll", "ocrExtractList", "reorder"])
+def test_deferred_kinds_degrade_gracefully(kind: str, sample: Path, tmp_path: Path) -> None:
+    # A deferred-kind op has NO engine -> the op is marked failed and the COPY is
+    # auto-rolled-back: the source manifest is untouched (graceful degradation,
+    # never a crash or a corrupt source).
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    span = None if kind == "reorder" else (0, 1500)
+    op = EditOp(id="d1", kind=kind, span=span, params={"panorama": "p"} if kind == "regenScroll" else {})
+
+    result, _engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "failed"
+    assert "no engine for kind" in (result.ops_status[0].status_reason or "")
+    # Source untouched + COPY still points at the original (rolled back).
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+    assert _ffprobe_ok(Path(source_before)) > 0


### PR DESCRIPTION
## Summary
Closes the two director E2E gaps: the renderer never routed to the DirectorPanel (unreachable), and the apply path's op engines were no-ops. This wires both.

### #8 — DirectorPanel reachability
- `App.tsx`: added `{ name: 'director' }` to the Route union, a lazy `DirectorPanel` import + `Suspense` case, and a "Director" header-nav button (active/`aria-current` state), mirroring the `ModelsSystemPanel` lazy-panel pattern.
- `App.test.tsx`: new reachability test — Director surface is NOT mounted until nav routes to it, then the router resolves the lazy panel and mounts it (`data-testid="director"`), with active + `aria-current="page"` asserted.

### Wired op engines (real ffmpeg/ffprobe, non-no-op)
`reframe`, `zoomPan`, `retime`, `overlayText`, `lowerThird`, `removeFillers`, `translateCaption`, `export` (joining the existing `trim`/`cut`/`removeSilence`/`caption`). Each renders edited media and records an inverse for undo.

### Deferred ops (graceful degradation)
`reorder`, `stitchPanorama`, `regenScroll`, `ocrExtractList` have no ffmpeg-only engine. `DEFERRED_SUBSYSTEMS` names the required subsystem for each; `log_deferred` announces them up front; an op of a deferred kind surfaces as a per-op `failed` with auto-rollback (source manifest untouched) — never a silent no-op.

## Test plan
- Sidecar: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **100% coverage, 3946 passed** (16 real-ffmpeg integration tests asserting ffprobe dims/duration + undo round-trip, plus deferred-kind graceful-degradation tests — none skipped).
- Renderer: `npx vitest run --coverage` → **100% statements/branches/functions/lines, 1499 passed** (Director reachability + DirectorPanel suite).
- Diff vs main scanned for assertion drops: the only removed assertion (`reframe in DEFERRED_KINDS`) is a justified inversion (reframe moved deferred→wired) replaced by a stronger `WIRED_KINDS` membership check. No test-weakening.