### PR TITLE
chore(installer): buildable electron-builder pipeline (embeddable Python + sidecar bundle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ dist/
 
 # Regenerable build binaries (staged by build/python-embed-setup.ps1 -WithFfmpeg)
 build/ffmpeg/
+# The dedicated py3.14 embeddable for the isolated chatterbox env is large and
+# regenerable by the same prep script — never commit it (mirrors build/ffmpeg/).
+# NOTE: build/python-embed/ (py3.12) IS tracked historically; this only covers 3.14.
+build/python-embed-314/
 
 # Runtime data root (models/exports/envs — relocatable via MEDIA_STUDIO_CONFIG_DIR)
 /data/

--- a/build/make-portable.ps1
+++ b/build/make-portable.ps1
@@ -4,7 +4,12 @@
 # Zips dist/win-unpacked into a portable artifact and enforces the SLIM rules:
 #   * no torch, no model weights (*.gguf/*.onnx/*.safetensors/*.pt), no envs —
 #    heavy bits belong to FIRST RUN (%APPDATA%/media-studio), never the artifact
-#   * total size sanity vs the < ~700 MB target (NSIS ~2 GB ceiling far behind)
+#   * total size sanity vs the slim target (NSIS ~2 GB ceiling far behind). The
+#    UNPACKED tree ships TWO embeddable CPythons (3.12 sidecar + 3.14 chatterbox,
+#    ~100 MB combined) plus ffmpeg/ffprobe (~175 MB) plus the Remotion native
+#    compositor, so the unpacked dir lands ~720 MB; the COMPRESSED artifacts stay
+#    ~200 MB (nsis) / ~265 MB (zip). The slim invariant that matters is the
+#    "no heavy ML payload" set above — the byte target is just a sanity ceiling.
 #
 # Offline; touches only dist/. Output is terminal-state: SUCCESS:/FAILED:.
 
@@ -12,7 +17,12 @@
 param(
     [string]$UnpackedDir = (Join-Path $PSScriptRoot '..\dist\win-unpacked'),
     [string]$OutZip = (Join-Path $PSScriptRoot '..\dist\media-studio-portable-win-x64.zip'),
-    [int]$MaxMB = 700,
+    # Unpacked-tree sanity ceiling. Raised from 700 -> 800 once the build began
+    # shipping the SECOND embeddable CPython (py3.14 chatterbox env) alongside the
+    # py3.12 sidecar embed: two embeds + ffmpeg + the Remotion compositor put the
+    # unpacked dir at ~720 MB. The compressed artifacts are far smaller (~200/265
+    # MB). The real slim guarantee is the "no torch/weights/envs" assertion set.
+    [int]$MaxMB = 800,
     [switch]$SkipZip   # only run the slim checks (CI gate mode)
 )
 

--- a/build/python-embed-setup.ps1
+++ b/build/python-embed-setup.ps1
@@ -32,8 +32,11 @@ param(
     [string]$ChatterboxDest = (Join-Path $PSScriptRoot 'python-embed-314'),
     [string]$ExpectedChatterboxPythonSha256 = '',  # fill in after the first verified run
     [switch]$WithFfmpeg,
-    # Pinned ffmpeg build (gyan.dev essentials; ~80 MB zip). Verify on first run.
-    [string]$FfmpegUrl = 'https://www.gyan.dev/ffmpeg/builds/packages/ffmpeg-7.1.1-essentials_build.zip',
+    # Pinned ffmpeg build (GyanD essentials 7.1.1; ~80 MB zip). Served from the
+    # GyanD GitHub release (durable per-version asset) rather than gyan.dev's
+    # builds/packages/ path, which only keeps the CURRENT release and 404s for an
+    # older pinned version. Verify the sha256 on first run.
+    [string]$FfmpegUrl = 'https://github.com/GyanD/codexffmpeg/releases/download/7.1.1/ffmpeg-7.1.1-essentials_build.zip',
     [string]$ExpectedFfmpegSha256 = '',
     [string]$FfmpegDest = (Join-Path $PSScriptRoot 'ffmpeg'),
     [string]$GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py',


### PR DESCRIPTION
Makes the Windows installer actually build: fixes the dead pinned ffmpeg URL (gyan.dev 404 -> durable GyanD GitHub release, same 7.1.1), raises the stale unpacked-size ceiling 700->800MB (2nd embeddable Python), gitignores the regenerable py3.14 embed dir. Verified: real artifacts built — NSIS .exe (197MB) + portable .zip (263MB); bundles embeddable CPython 3.12+3.14 (no system Python needed); first-run bootstrap proven via PATH-stripped --dry-run. Renderer untouched (1499 tests green).