### PR TITLE
style(director): ruff format director_op_engines (fix main gate-lint-format)

### DIFF
--- a/sidecar/media_studio/features/director_op_engines.py
+++ b/sidecar/media_studio/features/director_op_engines.py
@@ -828,9 +828,7 @@ def make_export_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = No
         return _render(
             project_copy,
             op,
-            lambda i, o: _ffmpeg.build_convert_argv(
-                i, o, {"vcodec": "libx264", "acodec": "aac"}, dict(settings or {})
-            ),
+            lambda i, o: _ffmpeg.build_convert_argv(i, o, {"vcodec": "libx264", "acodec": "aac"}, dict(settings or {})),
             runner=runner,
             settings=settings,
         )

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -426,9 +426,7 @@ def test_reframe_non_string_aspect_falls_back(tmp_path: Path, monkeypatch: pytes
     _fake_probe(monkeypatch)
     runner = FakeRunner()
     pc = _copy(tmp_path)
-    build_engines(runner=runner)["reframe"](
-        EditOp(id="r", kind="reframe", span=(0, 12000), params={"aspect": 169}), pc
-    )
+    build_engines(runner=runner)["reframe"](EditOp(id="r", kind="reframe", span=(0, 12000), params={"aspect": 169}), pc)
     vf = runner.calls[0][runner.calls[0].index("-vf") + 1]
     assert "crop=ih*9/16:ih" in vf
 


### PR DESCRIPTION
PR #227 landed director_op_engines.py + test_director_op_engines.py lint-clean but not ruff-format-ted, turning main's gate-lint-format red. Pure formatting fix (ruff 0.15.17, same as CI); ruff format --check + ruff check both clean; no logic change.