### PR TITLE
feat: monthly cumulative spend cap (blocks cloud-AI past a user limit)

### DIFF
--- a/app/renderer/src/features/ProvidersKeys.test.tsx
+++ b/app/renderer/src/features/ProvidersKeys.test.tsx
@@ -11,11 +11,13 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import { ProvidersKeys, type ProvidersKeysProps } from './ProvidersKeys';
+import type { SpendCapClient } from './SpendCap';
 import type {
   CatalogResponse,
   ProviderConsent,
   ProvidersListResponse,
   SetConsentResponse,
+  SpendInfo,
   TestKeyResult,
   UsageRow,
 } from '../lib/rpc';
@@ -135,11 +137,26 @@ function makeApi(over: ApiOverrides = {}): ProvidersKeysProps['rpcClient'] {
   } as unknown as ProvidersKeysProps['rpcClient'];
 }
 
+/** A no-op spend client for the panel tests (SpendCap has its own dedicated suite). */
+function makeSpendClient(): SpendCapClient {
+  const spend: SpendInfo = {
+    month: '2026-06',
+    monthToDateCents: 0,
+    softLimitCents: 0,
+    hardLimitCents: 0,
+    enforceHardLimit: false,
+  };
+  return {
+    providers: { spend: () => Promise.resolve(spend) },
+    settings: { set: vi.fn(() => Promise.resolve({})) },
+  };
+}
+
 async function mount(
   props: Partial<ProvidersKeysProps> & { rpcClient: ProvidersKeysProps['rpcClient'] },
 ): Promise<void> {
   await act(async () => {
-    root.render(<ProvidersKeys {...props} />);
+    root.render(<ProvidersKeys spendClient={makeSpendClient()} {...props} />);
   });
   await flush();
 }
@@ -184,7 +201,7 @@ describe('ProvidersKeys — load + empty state', () => {
         }),
     });
     await act(async () => {
-      root.render(<ProvidersKeys rpcClient={api} />);
+      root.render(<ProvidersKeys spendClient={makeSpendClient()} rpcClient={api} />);
     });
     await act(async () => root.unmount());
     // Resolving now is a no-op (alive === false).
@@ -205,7 +222,7 @@ describe('ProvidersKeys — load + empty state', () => {
         }),
     });
     await act(async () => {
-      root.render(<ProvidersKeys rpcClient={api} />);
+      root.render(<ProvidersKeys spendClient={makeSpendClient()} rpcClient={api} />);
     });
     await act(async () => root.unmount());
     await act(async () => {

--- a/app/renderer/src/features/ProvidersKeys.tsx
+++ b/app/renderer/src/features/ProvidersKeys.tsx
@@ -30,6 +30,7 @@ import { AddKeyRow } from '../components/AddKeyRow';
 import { ProviderKeyRow } from '../components/ProviderKeyRow';
 import { ConsentToggle, type ConsentType } from '../components/ConsentToggle';
 import { UsageBars } from '../components/UsageBar';
+import { SpendCap, type SpendCapClient } from './SpendCap';
 import {
   client,
   type CatalogEntry,
@@ -75,6 +76,12 @@ export interface ProvidersKeysProps {
   rpcClient?: Pick<typeof client, 'providers'> & {
     settings?: { get?: () => Promise<SettingsConsentRead> };
   };
+  /**
+   * Inject the Monthly spend-cap control's client for tests. Optional: the real
+   * {@link SpendCap} falls back to the live lib/rpc client when omitted, so the
+   * app needs no wiring here — only tests pass a mock.
+   */
+  spendClient?: SpendCapClient;
   /**
    * Open the Models & System section (where per-function provider routing lives).
    * Optional; rendered as a quiet secondary link when wired.
@@ -228,7 +235,11 @@ function PickerOption({ option, configured, busy, onAdd }: PickerOptionProps): R
 /**
  * Providers & Keys — the full key + consent management surface (WU-PROVIDERS).
  */
-export function ProvidersKeys({ rpcClient, onOpenModels }: ProvidersKeysProps): React.ReactElement {
+export function ProvidersKeys({
+  rpcClient,
+  spendClient,
+  onOpenModels,
+}: ProvidersKeysProps): React.ReactElement {
   /* v8 ignore next -- the `?? client` default only runs in the real app; every test injects rpcClient. */
   const api = rpcClient ?? client;
 
@@ -506,6 +517,9 @@ export function ProvidersKeys({ rpcClient, onOpenModels }: ProvidersKeysProps): 
         <h3 className="providers-keys__usage-title">Usage</h3>
         <UsageBars rows={usage} />
       </section>
+
+      {/* Monthly spend cap — the budget control (self-contained read/write). */}
+      <SpendCap rpcClient={spendClient} />
 
       {onOpenModels ? (
         <button type="button" className="providers-keys__models-link" onClick={onOpenModels}>

--- a/app/renderer/src/features/SpendCap.test.tsx
+++ b/app/renderer/src/features/SpendCap.test.tsx
@@ -1,0 +1,332 @@
+// SpendCap.test.tsx — the Monthly spend-cap control (WU-spend-cap). Covers load
+// (seed from providers.spend), every zone render (no-cap / ok / near / blocked),
+// the bounded-vs-unbounded meter, editing soft/hard/enforce, save → settings.set
+// + refetch (success + error), the saved indicator, and the alive-guard paths.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { SpendCap, type SpendCapClient } from './SpendCap';
+import type { SpendInfo } from '../lib/rpc';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function setInputValue(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+}
+
+function toggleCheckbox(el: HTMLInputElement, value: boolean): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'checked')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event('click', { bubbles: true }));
+}
+
+function spendInfo(over: Partial<SpendInfo> = {}): SpendInfo {
+  return {
+    month: '2026-06',
+    monthToDateCents: 0,
+    softLimitCents: 0,
+    hardLimitCents: 0,
+    enforceHardLimit: false,
+    ...over,
+  };
+}
+
+interface Overrides {
+  spend?: () => Promise<SpendInfo>;
+  set?: ReturnType<typeof vi.fn>;
+}
+
+function makeApi(over: Overrides = {}): {
+  api: SpendCapClient;
+  set: ReturnType<typeof vi.fn>;
+  spend: ReturnType<typeof vi.fn>;
+} {
+  const spend = vi.fn(over.spend ?? (() => Promise.resolve(spendInfo())));
+  const set = over.set ?? vi.fn(() => Promise.resolve({}));
+  return { api: { providers: { spend }, settings: { set } }, set, spend };
+}
+
+async function mount(api: SpendCapClient): Promise<void> {
+  await act(async () => {
+    root.render(<SpendCap rpcClient={api} />);
+  });
+  await flush();
+}
+
+const $ = (sel: string): Element | null => container.querySelector(sel);
+
+describe('SpendCap — load + zero/empty state', () => {
+  it('shows a loading state then the no-cap state when nothing is configured', async () => {
+    let resolveSpend: (v: SpendInfo) => void = () => {};
+    const { api } = makeApi({
+      spend: () =>
+        new Promise<SpendInfo>((res) => {
+          resolveSpend = res;
+        }),
+    });
+    await act(async () => {
+      root.render(<SpendCap rpcClient={api} />);
+    });
+    expect($('.spend-cap__loading')).not.toBeNull();
+    await act(async () => {
+      resolveSpend(spendInfo());
+    });
+    await flush();
+    expect($('.spend-cap__loading')).toBeNull();
+    expect($('.spend-cap__meter')?.getAttribute('data-zone')).toBe('no-cap');
+    expect(container.textContent).toContain('No spend cap set');
+    // No bounded bar in the no-cap state.
+    expect($('.spend-cap__track')).toBeNull();
+    // The readout still shows month-to-date + the month key.
+    expect($('.spend-cap__readout-value')?.textContent).toBe('$0.00');
+    expect($('.spend-cap__readout-month')?.textContent).toBe('2026-06');
+  });
+
+  it('seeds the inputs + toggle from the configured caps', async () => {
+    const { api } = makeApi({
+      spend: () =>
+        Promise.resolve(
+          spendInfo({ softLimitCents: 1000, hardLimitCents: 5000, enforceHardLimit: true }),
+        ),
+    });
+    await mount(api);
+    expect(($('#spend-cap-soft') as HTMLInputElement).value).toBe('10.00');
+    expect(($('#spend-cap-hard') as HTMLInputElement).value).toBe('50.00');
+    expect(($('#spend-cap-enforce') as HTMLInputElement).checked).toBe(true);
+  });
+
+  it('surfaces a load error and shows no meter', async () => {
+    const { api } = makeApi({ spend: () => Promise.reject(new Error('boom')) });
+    await mount(api);
+    expect($('[role="alert"]')?.textContent).toBe('boom');
+    expect($('.spend-cap__meter')).toBeNull();
+  });
+
+  it('stringifies a non-Error rejection', async () => {
+    const { api } = makeApi({ spend: () => Promise.reject('nope') });
+    await mount(api);
+    expect($('[role="alert"]')?.textContent).toBe('nope');
+  });
+});
+
+describe('SpendCap — zone rendering', () => {
+  it('ok zone: bounded meter under the soft cap', async () => {
+    const { api } = makeApi({
+      spend: () =>
+        Promise.resolve(
+          spendInfo({ monthToDateCents: 2500, softLimitCents: 4000, hardLimitCents: 5000 }),
+        ),
+    });
+    await mount(api);
+    const meter = $('.spend-cap__meter');
+    expect(meter?.getAttribute('data-zone')).toBe('ok');
+    const track = $('.spend-cap__track');
+    expect(track).not.toBeNull();
+    expect(track?.getAttribute('aria-valuenow')).toBe('50');
+    expect(track?.getAttribute('aria-valuetext')).toContain('$25.00 of $50.00');
+    expect(($('.spend-cap__fill') as HTMLElement).style.width).toBe('50%');
+    expect(container.textContent).toContain('Within budget');
+  });
+
+  it('near zone: at/over the soft cap, under the hard cap', async () => {
+    const { api } = makeApi({
+      spend: () =>
+        Promise.resolve(
+          spendInfo({ monthToDateCents: 4500, softLimitCents: 4000, hardLimitCents: 8000 }),
+        ),
+    });
+    await mount(api);
+    expect($('.spend-cap__meter')?.getAttribute('data-zone')).toBe('near');
+    expect(container.textContent).toContain('Near the soft cap');
+    // The non-color glyph is present (color is never the only signal).
+    expect($('.spend-cap__status-glyph')?.textContent).toBe('⚠');
+  });
+
+  it('blocked zone (enforced): at the hard cap, full bar, blocked copy', async () => {
+    const { api } = makeApi({
+      spend: () =>
+        Promise.resolve(
+          spendInfo({
+            monthToDateCents: 8000,
+            softLimitCents: 4000,
+            hardLimitCents: 8000,
+            enforceHardLimit: true,
+          }),
+        ),
+    });
+    await mount(api);
+    expect($('.spend-cap__meter')?.getAttribute('data-zone')).toBe('blocked');
+    expect(($('.spend-cap__fill') as HTMLElement).style.width).toBe('100%');
+    expect(container.textContent).toContain('new cloud runs are blocked');
+    expect($('.spend-cap__status-glyph')?.textContent).toBe('⛔');
+  });
+
+  it('blocked zone (not enforced): over the hard cap but runs proceed', async () => {
+    const { api } = makeApi({
+      spend: () =>
+        Promise.resolve(
+          spendInfo({
+            monthToDateCents: 9000,
+            hardLimitCents: 8000,
+            enforceHardLimit: false,
+          }),
+        ),
+    });
+    await mount(api);
+    expect($('.spend-cap__meter')?.getAttribute('data-zone')).toBe('blocked');
+    expect(container.textContent).toContain('not enforced');
+  });
+
+  it('soft-only cap renders a bounded bar against the soft ceiling', async () => {
+    const { api } = makeApi({
+      spend: () => Promise.resolve(spendInfo({ monthToDateCents: 500, softLimitCents: 1000 })),
+    });
+    await mount(api);
+    expect($('.spend-cap__track')?.getAttribute('aria-valuenow')).toBe('50');
+    expect($('.spend-cap__track')?.getAttribute('aria-valuetext')).toContain('$5.00 of $10.00');
+  });
+});
+
+describe('SpendCap — edit + save', () => {
+  it('edits soft/hard/enforce and saves the converted cents through settings.set, then refetches', async () => {
+    const fresh = spendInfo({
+      softLimitCents: 1500,
+      hardLimitCents: 6000,
+      enforceHardLimit: true,
+    });
+    const spend = vi
+      .fn(() => Promise.resolve(spendInfo()))
+      .mockResolvedValueOnce(spendInfo())
+      .mockResolvedValueOnce(fresh);
+    const set = vi.fn(() => Promise.resolve({}));
+    const api: SpendCapClient = { providers: { spend }, settings: { set } };
+    await act(async () => {
+      root.render(<SpendCap rpcClient={api} />);
+    });
+    await flush();
+
+    setInputValue($('#spend-cap-soft') as HTMLInputElement, '15');
+    setInputValue($('#spend-cap-hard') as HTMLInputElement, '60');
+    toggleCheckbox($('#spend-cap-enforce') as HTMLInputElement, true);
+    await flush();
+
+    await act(async () => {
+      ($('.spend-cap__save') as HTMLButtonElement).click();
+    });
+    await flush();
+
+    expect(set).toHaveBeenCalledWith({
+      monthlySoftLimitCents: 1500,
+      monthlyHardLimitCents: 6000,
+      enforceMonthlyHardLimit: true,
+    });
+    // Refetched: the inputs now reflect the persisted values, "Saved" is shown.
+    expect(spend).toHaveBeenCalledTimes(2);
+    expect(($('#spend-cap-soft') as HTMLInputElement).value).toBe('15.00');
+    expect($('.spend-cap__saved')).not.toBeNull();
+  });
+
+  it('surfaces a save error and shows no saved indicator', async () => {
+    const { api } = makeApi({ set: vi.fn(() => Promise.reject(new Error('write failed'))) });
+    await mount(api);
+    await act(async () => {
+      ($('.spend-cap__save') as HTMLButtonElement).click();
+    });
+    await flush();
+    expect($('[role="alert"]')?.textContent).toBe('write failed');
+    expect($('.spend-cap__saved')).toBeNull();
+  });
+
+  it('disables the inputs + save button while saving', async () => {
+    let resolveSet: (v: unknown) => void = () => {};
+    const set = vi.fn(
+      () =>
+        new Promise((res) => {
+          resolveSet = res;
+        }),
+    );
+    const { api } = makeApi({ set });
+    await mount(api);
+    await act(async () => {
+      ($('.spend-cap__save') as HTMLButtonElement).click();
+    });
+    await flush();
+    const btn = $('.spend-cap__save') as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.textContent).toBe('Saving…');
+    expect(($('#spend-cap-soft') as HTMLInputElement).disabled).toBe(true);
+    // Let it settle so the unmount in afterEach is clean.
+    await act(async () => {
+      resolveSet({});
+    });
+    await flush();
+  });
+});
+
+describe('SpendCap — alive guards', () => {
+  it('ignores a late spend resolve after unmount', async () => {
+    let resolveSpend: (v: SpendInfo) => void = () => {};
+    const { api } = makeApi({
+      spend: () =>
+        new Promise<SpendInfo>((res) => {
+          resolveSpend = res;
+        }),
+    });
+    await act(async () => {
+      root.render(<SpendCap rpcClient={api} />);
+    });
+    await act(async () => root.unmount());
+    await act(async () => {
+      resolveSpend(spendInfo({ softLimitCents: 1000 }));
+    });
+    await flush();
+    expect($('.spend-cap__meter')).toBeNull();
+    root = createRoot(container);
+  });
+
+  it('ignores a late spend reject after unmount', async () => {
+    let rejectSpend: (e: Error) => void = () => {};
+    const { api } = makeApi({
+      spend: () =>
+        new Promise<SpendInfo>((_res, rej) => {
+          rejectSpend = rej;
+        }),
+    });
+    await act(async () => {
+      root.render(<SpendCap rpcClient={api} />);
+    });
+    await act(async () => root.unmount());
+    await act(async () => {
+      rejectSpend(new Error('late'));
+    });
+    await flush();
+    expect($('[role="alert"]')).toBeNull();
+    root = createRoot(container);
+  });
+});

--- a/app/renderer/src/features/SpendCap.tsx
+++ b/app/renderer/src/features/SpendCap.tsx
@@ -1,0 +1,292 @@
+// SpendCap.tsx — the "Monthly spend cap" control inside Providers & Keys
+// (WU-spend-cap). The budget surface for cloud-AI egress: soft + hard dollar
+// limits, an enforce-hard toggle, and a clear MONTH-TO-DATE spend readout with a
+// progress meter that visibly WARNS near/over the soft cap and shows a BLOCKED
+// state at the hard cap.
+//
+// Wiring: reads `providers.spend` (one read drives BOTH the MTD readout AND the
+// input defaults — the RPC returns the configured caps too), writes through
+// `settings.set` (top-level shallow merge of monthlySoftLimitCents /
+// monthlyHardLimitCents / enforceMonthlyHardLimit) then refetches.
+//
+// Design (gate-2 invariants, mirrors UsageBar):
+//   * the zone (ok / near / blocked) is conveyed by TEXT + ICON, never hue-only;
+//   * every control has an explicit <label htmlFor> + aria wiring; the meter is
+//     role="meter" with aria-valuetext;
+//   * a fully-unconfigured install (both caps 0) shows a helpful zero/empty state
+//     ("No spend cap set …"), not a broken bar;
+//   * dark-theme tokens only; reduced motion respected (CSS).
+//
+// Pure money/zone math lives in spendCapLogic.ts (separately unit-tested).
+import React, { useCallback, useEffect, useState } from 'react';
+import './spendCap.css';
+import { client, type SpendInfo } from '../lib/rpc';
+import {
+  centsToDollars,
+  dollarsToCents,
+  formatDollars,
+  progressCeilingCents,
+  progressPercent,
+  spendZone,
+  zoneGlyph,
+  zoneMessage,
+} from './spendCapLogic';
+
+/** Error text from an unknown thrown value (mirrors the sibling panels). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The injectable RPC slice this control needs (defaults to the real client). */
+export type SpendCapClient = {
+  providers: { spend: () => Promise<SpendInfo> };
+  settings: { set: (values: Record<string, unknown>) => Promise<unknown> };
+};
+
+export interface SpendCapProps {
+  /** Inject the typed client for tests; defaults to the real lib/rpc client. */
+  rpcClient?: SpendCapClient;
+}
+
+/** The month-to-date readout + progress meter (presentation only). */
+function SpendMeter({ info }: { info: SpendInfo }): React.ReactElement {
+  const zone = spendZone(info);
+  const ceiling = progressCeilingCents(info);
+  const pct = progressPercent(info);
+  const glyph = zoneGlyph(zone);
+  const mtd = formatDollars(info.monthToDateCents);
+  const bounded = ceiling > 0;
+  const valueText = bounded
+    ? `${mtd} of ${formatDollars(ceiling)} this month`
+    : `${mtd} this month (no cap)`;
+
+  return (
+    <div className="spend-cap__meter" data-zone={zone}>
+      <div className="spend-cap__readout">
+        <span className="spend-cap__readout-label">Month to date</span>
+        <span className="spend-cap__readout-value" data-mtd={info.monthToDateCents}>
+          {mtd}
+        </span>
+        <span className="spend-cap__readout-month">{info.month}</span>
+      </div>
+      {bounded ? (
+        <div
+          className="spend-cap__track"
+          role="meter"
+          aria-label="Month-to-date spend against your cap"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={pct}
+          aria-valuetext={valueText}
+          data-zone={zone}
+        >
+          <div className="spend-cap__fill" data-zone={zone} style={{ width: `${pct}%` }} />
+        </div>
+      ) : null}
+      <p className="spend-cap__status" data-zone={zone} role="status">
+        <span className="spend-cap__status-glyph" aria-hidden="true">
+          {glyph}
+        </span>
+        <span className="spend-cap__status-text">{zoneMessage(zone, info.enforceHardLimit)}</span>
+      </p>
+    </div>
+  );
+}
+
+/**
+ * Monthly spend cap — the full budget control. Loads `providers.spend` once
+ * (seeds BOTH the readout and the input defaults), edits soft/hard dollar limits
+ * + the enforce toggle locally, and saves through `settings.set`.
+ */
+export function SpendCap({ rpcClient }: SpendCapProps): React.ReactElement {
+  /* v8 ignore next -- the `?? client` default only runs in the real app; every test injects rpcClient. */
+  const api = rpcClient ?? client;
+
+  const [info, setInfo] = useState<SpendInfo | null>(null);
+  const [soft, setSoft] = useState('0.00');
+  const [hard, setHard] = useState('0.00');
+  const [enforce, setEnforce] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState('');
+  const [saved, setSaved] = useState(false);
+
+  // Seed the form + readout from the single spend read.
+  const load = useCallback(
+    (signal: { alive: boolean }) => {
+      setLoading(true);
+      setError('');
+      Promise.resolve(api.providers.spend())
+        .then((s) => {
+          if (!signal.alive) return;
+          setInfo(s);
+          setSoft(centsToDollars(s.softLimitCents));
+          setHard(centsToDollars(s.hardLimitCents));
+          setEnforce(s.enforceHardLimit);
+          setLoading(false);
+        })
+        .catch((err: unknown) => {
+          if (!signal.alive) return;
+          setError(errText(err));
+          setLoading(false);
+        });
+    },
+    [api],
+  );
+
+  useEffect(() => {
+    const signal = { alive: true };
+    load(signal);
+    return () => {
+      signal.alive = false;
+    };
+  }, [load]);
+
+  // Persist the caps, then refetch so the readout reflects the new ceilings.
+  const save = useCallback(async (): Promise<void> => {
+    setSaving(true);
+    setError('');
+    setSaved(false);
+    try {
+      await api.settings.set({
+        monthlySoftLimitCents: dollarsToCents(soft),
+        monthlyHardLimitCents: dollarsToCents(hard),
+        enforceMonthlyHardLimit: enforce,
+      });
+      const fresh = await api.providers.spend();
+      setInfo(fresh);
+      setSoft(centsToDollars(fresh.softLimitCents));
+      setHard(centsToDollars(fresh.hardLimitCents));
+      setEnforce(fresh.enforceHardLimit);
+      setSaved(true);
+    } catch (err) {
+      setError(errText(err));
+    } finally {
+      setSaving(false);
+    }
+  }, [api, soft, hard, enforce]);
+
+  if (loading) {
+    return (
+      <section className="spend-cap" aria-label="Monthly spend cap">
+        <div className="spend-cap__loading" aria-busy="true">
+          Loading spend…
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="spend-cap" aria-labelledby="spend-cap-title">
+      <header className="spend-cap__header">
+        <h3 id="spend-cap-title" className="spend-cap__title">
+          Monthly spend cap
+        </h3>
+        <p className="spend-cap__hint">
+          Cap how much cloud-AI processing can cost per month. The soft limit warns you as you
+          approach it; the hard limit can block new cloud runs once reached.
+        </p>
+      </header>
+
+      {error ? (
+        <p className="spend-cap__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {/* info is always set once loaded (load sets it before clearing loading). */}
+      {info ? <SpendMeter info={info} /> : null}
+
+      <div className="spend-cap__fields">
+        <div className="spend-cap__field">
+          <label className="spend-cap__label" htmlFor="spend-cap-soft">
+            Soft limit (warn)
+          </label>
+          <div className="spend-cap__money">
+            <span className="spend-cap__money-sign" aria-hidden="true">
+              $
+            </span>
+            <input
+              id="spend-cap-soft"
+              className="spend-cap__input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.01"
+              value={soft}
+              disabled={saving}
+              aria-describedby="spend-cap-soft-help"
+              onChange={(e) => setSoft(e.target.value)}
+            />
+          </div>
+          <p id="spend-cap-soft-help" className="spend-cap__field-help">
+            Show a warning once month-to-date spend reaches this amount. Leave 0 for no warning.
+          </p>
+        </div>
+
+        <div className="spend-cap__field">
+          <label className="spend-cap__label" htmlFor="spend-cap-hard">
+            Hard limit (block)
+          </label>
+          <div className="spend-cap__money">
+            <span className="spend-cap__money-sign" aria-hidden="true">
+              $
+            </span>
+            <input
+              id="spend-cap-hard"
+              className="spend-cap__input"
+              type="number"
+              inputMode="decimal"
+              min={0}
+              step="0.01"
+              value={hard}
+              disabled={saving}
+              aria-describedby="spend-cap-hard-help"
+              onChange={(e) => setHard(e.target.value)}
+            />
+          </div>
+          <p id="spend-cap-hard-help" className="spend-cap__field-help">
+            The monthly ceiling enforcement uses. Leave 0 for no ceiling.
+          </p>
+        </div>
+      </div>
+
+      <div className="spend-cap__enforce">
+        <input
+          id="spend-cap-enforce"
+          className="spend-cap__enforce-input"
+          type="checkbox"
+          checked={enforce}
+          disabled={saving}
+          onChange={(e) => setEnforce(e.target.checked)}
+        />
+        <label className="spend-cap__enforce-label" htmlFor="spend-cap-enforce">
+          Block new cloud runs at the hard limit
+        </label>
+        <p className="spend-cap__enforce-help">
+          When off, the hard limit is shown for reference but cloud runs still proceed over it.
+        </p>
+      </div>
+
+      <div className="spend-cap__actions">
+        <button
+          type="button"
+          className="spend-cap__save"
+          disabled={saving}
+          aria-disabled={saving}
+          title={saving ? 'Saving…' : undefined}
+          onClick={() => void save()}
+        >
+          {saving ? 'Saving…' : 'Save spend cap'}
+        </button>
+        {saved && !saving ? (
+          <span className="spend-cap__saved" role="status" data-saved="true">
+            <span aria-hidden="true">✓</span> Saved
+          </span>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export default SpendCap;

--- a/app/renderer/src/features/spendCap.css
+++ b/app/renderer/src/features/spendCap.css
@@ -1,0 +1,310 @@
+/* spendCap.css — the Monthly spend-cap control inside Providers & Keys
+   (features/SpendCap.tsx, WU-spend-cap). Tokens only; dark theme + the global
+   :focus-visible ring (components/shell.css) are inherited; reduced motion is
+   respected. The zone state (ok / near / blocked) is carried by TEXT + ICON;
+   color here is a redundant reinforcement, never the only signal. */
+
+.spend-cap {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--edge);
+}
+
+.spend-cap__loading {
+  padding: var(--space-5);
+  color: var(--text-muted);
+  text-align: center;
+}
+
+.spend-cap__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.spend-cap__title {
+  margin: 0;
+  font-size: var(--type-caption-size);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-secondary);
+}
+
+.spend-cap__hint {
+  margin: 0;
+  max-width: 60ch;
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+}
+
+.spend-cap__error {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--status-error);
+  border-radius: var(--radius-sm);
+  background: var(--status-error-soft);
+  color: var(--text-primary);
+  font-size: var(--type-caption-size);
+}
+
+/* --- month-to-date readout + meter -------------------------------------- */
+
+.spend-cap__meter {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+}
+
+.spend-cap__readout {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.spend-cap__readout-label {
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.spend-cap__readout-value {
+  font-family: var(--font-mono);
+  font-size: var(--type-display-size);
+  font-weight: var(--type-display-weight);
+  letter-spacing: var(--type-display-tracking);
+  color: var(--text-primary);
+}
+
+.spend-cap__readout-month {
+  margin-left: auto;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption-size);
+  color: var(--text-faint);
+}
+
+.spend-cap__track {
+  position: relative;
+  height: 8px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-deep);
+  overflow: hidden;
+}
+
+.spend-cap__fill {
+  height: 100%;
+  border-radius: var(--radius-pill);
+  background: var(--status-success);
+  transition: width var(--dur-base) var(--ease-out);
+}
+
+.spend-cap__fill[data-zone="no-cap"],
+.spend-cap__fill[data-zone="ok"] {
+  background: var(--status-success);
+}
+
+.spend-cap__fill[data-zone="near"] {
+  background: var(--status-warn);
+}
+
+.spend-cap__fill[data-zone="blocked"] {
+  background: var(--status-error);
+}
+
+.spend-cap__status {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+}
+
+.spend-cap__status[data-zone="near"] {
+  color: var(--status-warn);
+}
+
+.spend-cap__status[data-zone="blocked"] {
+  color: var(--status-error);
+}
+
+.spend-cap__status-glyph {
+  flex: none;
+  font-size: 13px;
+  line-height: 1.2;
+}
+
+/* --- soft / hard fields -------------------------------------------------- */
+
+.spend-cap__fields {
+  display: flex;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+}
+
+.spend-cap__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+  min-width: 200px;
+}
+
+.spend-cap__label {
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.spend-cap__money {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: 0 var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  transition: border-color var(--dur-fast) var(--ease-out);
+}
+
+.spend-cap__money:hover {
+  border-color: var(--edge-strong);
+}
+
+.spend-cap__money:focus-within {
+  border-color: var(--accent-edge);
+}
+
+.spend-cap__money-sign {
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.spend-cap__input {
+  flex: 1;
+  width: 100%;
+  padding: 7px 0;
+  border: none;
+  background: transparent;
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 13px;
+}
+
+.spend-cap__input:focus {
+  outline: none;
+}
+
+.spend-cap__input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spend-cap__field-help {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+}
+
+/* --- enforce toggle ------------------------------------------------------ */
+
+.spend-cap__enforce {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: var(--space-1) var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+}
+
+.spend-cap__enforce-input {
+  cursor: pointer;
+}
+
+.spend-cap__enforce-input:disabled {
+  cursor: not-allowed;
+}
+
+.spend-cap__enforce-label {
+  color: var(--text-secondary);
+  font-size: var(--type-body-size);
+  cursor: pointer;
+}
+
+.spend-cap__enforce-help {
+  grid-column: 2;
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+}
+
+/* --- actions ------------------------------------------------------------- */
+
+.spend-cap__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.spend-cap__save {
+  padding: 7px 16px;
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--accent-ink);
+  font-family: var(--font-ui);
+  font-size: 12px;
+  font-weight: 700;
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    opacity var(--dur-fast) var(--ease-out);
+}
+
+.spend-cap__save:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.spend-cap__save:active:not(:disabled) {
+  background: var(--accent-pressed);
+}
+
+.spend-cap__save:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.spend-cap__saved {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--status-success);
+  font-size: var(--type-caption-size);
+  font-weight: 600;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .spend-cap__fill,
+  .spend-cap__money,
+  .spend-cap__save {
+    transition: none;
+  }
+}

--- a/app/renderer/src/features/spendCapLogic.test.ts
+++ b/app/renderer/src/features/spendCapLogic.test.ts
@@ -1,0 +1,173 @@
+// spendCapLogic.test.ts — the pure money/zone helpers for the Monthly spend cap.
+
+import { describe, it, expect } from 'vitest';
+import type { SpendInfo } from '../lib/rpc';
+import {
+  centsToDollars,
+  dollarsToCents,
+  formatDollars,
+  progressCeilingCents,
+  progressFraction,
+  progressPercent,
+  spendZone,
+  zoneGlyph,
+  zoneMessage,
+  type SpendZone,
+} from './spendCapLogic';
+
+function info(over: Partial<SpendInfo> = {}): SpendInfo {
+  return {
+    month: '2026-06',
+    monthToDateCents: 0,
+    softLimitCents: 0,
+    hardLimitCents: 0,
+    enforceHardLimit: false,
+    ...over,
+  };
+}
+
+describe('centsToDollars / formatDollars', () => {
+  it('renders a 2-dp dollar string', () => {
+    expect(centsToDollars(1250)).toBe('12.50');
+    expect(centsToDollars(100)).toBe('1.00');
+    expect(centsToDollars(5)).toBe('0.05');
+  });
+
+  it('coerces zero / negative / non-finite to 0.00', () => {
+    expect(centsToDollars(0)).toBe('0.00');
+    expect(centsToDollars(-500)).toBe('0.00');
+    expect(centsToDollars(Number.NaN)).toBe('0.00');
+    expect(centsToDollars(Number.POSITIVE_INFINITY)).toBe('0.00');
+  });
+
+  it('rounds fractional cents to the nearest cent', () => {
+    expect(centsToDollars(1250.6)).toBe('12.51');
+  });
+
+  it('formatDollars prefixes a $', () => {
+    expect(formatDollars(1250)).toBe('$12.50');
+    expect(formatDollars(0)).toBe('$0.00');
+  });
+});
+
+describe('dollarsToCents', () => {
+  it('parses a dollar string to integer cents', () => {
+    expect(dollarsToCents('12.50')).toBe(1250);
+    expect(dollarsToCents('1')).toBe(100);
+    expect(dollarsToCents('0.05')).toBe(5);
+  });
+
+  it('rounds to the nearest cent', () => {
+    expect(dollarsToCents('12.005')).toBe(1201);
+    expect(dollarsToCents('0.004')).toBe(0);
+  });
+
+  it('coerces blank / non-numeric / negative / zero to 0', () => {
+    expect(dollarsToCents('')).toBe(0);
+    expect(dollarsToCents('abc')).toBe(0);
+    expect(dollarsToCents('-5')).toBe(0);
+    expect(dollarsToCents('0')).toBe(0);
+  });
+});
+
+describe('spendZone', () => {
+  it('no-cap when neither soft nor hard is set', () => {
+    expect(spendZone(info({ monthToDateCents: 999 }))).toBe('no-cap');
+  });
+
+  it('ok when under the soft cap', () => {
+    expect(spendZone(info({ monthToDateCents: 500, softLimitCents: 1000 }))).toBe('ok');
+  });
+
+  it('ok when only a hard cap is set and MTD is under it', () => {
+    expect(spendZone(info({ monthToDateCents: 500, hardLimitCents: 1000 }))).toBe('ok');
+  });
+
+  it('near at/over the soft cap but under the hard cap', () => {
+    expect(
+      spendZone(info({ monthToDateCents: 1000, softLimitCents: 1000, hardLimitCents: 5000 })),
+    ).toBe('near');
+    expect(
+      spendZone(info({ monthToDateCents: 1200, softLimitCents: 1000, hardLimitCents: 5000 })),
+    ).toBe('near');
+  });
+
+  it('blocked at/over the hard cap (hard wins over soft)', () => {
+    expect(
+      spendZone(info({ monthToDateCents: 5000, softLimitCents: 1000, hardLimitCents: 5000 })),
+    ).toBe('blocked');
+    expect(
+      spendZone(info({ monthToDateCents: 9000, softLimitCents: 1000, hardLimitCents: 5000 })),
+    ).toBe('blocked');
+  });
+
+  it('clamps a negative MTD to 0 before classifying', () => {
+    expect(spendZone(info({ monthToDateCents: -100, softLimitCents: 1000 }))).toBe('ok');
+  });
+
+  it('treats a zero/absent soft as not-set even with a hard cap', () => {
+    expect(
+      spendZone(info({ monthToDateCents: 100, softLimitCents: 0, hardLimitCents: 1000 })),
+    ).toBe('ok');
+  });
+});
+
+describe('progressCeilingCents / progressFraction / progressPercent', () => {
+  it('uses the hard cap as the ceiling when set', () => {
+    expect(progressCeilingCents(info({ softLimitCents: 1000, hardLimitCents: 5000 }))).toBe(5000);
+  });
+
+  it('falls back to the soft cap when only soft is set', () => {
+    expect(progressCeilingCents(info({ softLimitCents: 1000 }))).toBe(1000);
+  });
+
+  it('reports a zero ceiling when neither is set', () => {
+    expect(progressCeilingCents(info())).toBe(0);
+  });
+
+  it('fraction is 0 with no ceiling', () => {
+    expect(progressFraction(info({ monthToDateCents: 500 }))).toBe(0);
+  });
+
+  it('fraction is MTD / ceiling, clamped to [0,1]', () => {
+    expect(progressFraction(info({ monthToDateCents: 2500, hardLimitCents: 5000 }))).toBe(0.5);
+    expect(progressFraction(info({ monthToDateCents: -100, hardLimitCents: 5000 }))).toBe(0);
+    expect(progressFraction(info({ monthToDateCents: 9000, hardLimitCents: 5000 }))).toBe(1);
+  });
+
+  it('percent is a whole number 0..100', () => {
+    expect(progressPercent(info({ monthToDateCents: 2500, hardLimitCents: 5000 }))).toBe(50);
+    expect(progressPercent(info({ monthToDateCents: 1234, hardLimitCents: 5000 }))).toBe(25);
+    expect(progressPercent(info())).toBe(0);
+  });
+});
+
+describe('zoneGlyph', () => {
+  it('maps each zone to a distinct non-color glyph', () => {
+    const glyphs: Record<SpendZone, string> = {
+      'no-cap': zoneGlyph('no-cap'),
+      ok: zoneGlyph('ok'),
+      near: zoneGlyph('near'),
+      blocked: zoneGlyph('blocked'),
+    };
+    expect(glyphs.blocked).toBe('⛔');
+    expect(glyphs.near).toBe('⚠');
+    expect(glyphs.ok).toBe('✓');
+    expect(glyphs['no-cap']).toBe('ℹ');
+    // All four glyphs are distinct (the icon carries the signal, not color).
+    expect(new Set(Object.values(glyphs)).size).toBe(4);
+  });
+});
+
+describe('zoneMessage', () => {
+  it('blocked copy distinguishes enforced vs not-enforced', () => {
+    expect(zoneMessage('blocked', true)).toContain('blocked');
+    expect(zoneMessage('blocked', false)).toContain('not enforced');
+  });
+
+  it('near / ok / no-cap copy', () => {
+    expect(zoneMessage('near', false)).toContain('Near the soft cap');
+    expect(zoneMessage('ok', false)).toContain('Within budget');
+    expect(zoneMessage('no-cap', false)).toContain('No spend cap set');
+  });
+});

--- a/app/renderer/src/features/spendCapLogic.ts
+++ b/app/renderer/src/features/spendCapLogic.ts
@@ -1,0 +1,123 @@
+// spendCapLogic.ts — pure helpers for the Monthly spend-cap control (WU-spend-cap).
+//
+// The sidecar `providers.spend` RPC + the `monthly*Cents` settings keys speak
+// integer CENTS; the UI speaks DOLLARS. All cents<->dollars conversion, the
+// spend-zone classification (the visible near/over-cap warning state), and the
+// progress-fraction math live here as small, independently unit-tested pure
+// functions — so the React component (SpendCap.tsx) stays thin presentation and
+// the gate's 100% branch coverage is reachable without DOM gymnastics.
+//
+// Design invariants honored by the consumer (SpendCap.tsx):
+//   * the spend STATE is conveyed by TEXT + ICON, never hue alone (WCAG 1.4.1);
+//   * a fully-unconfigured install (both caps 0) reads as a benign "no cap" —
+//     the backend explicitly returns zero/false there.
+
+import type { SpendInfo } from '../lib/rpc';
+
+/** The visible month-to-date spend state, ordered low->high severity. */
+export type SpendZone =
+  | 'no-cap' // no soft AND no hard cap configured — informational only
+  | 'ok' // under the soft cap (or under hard when only hard is set)
+  | 'near' // at/over the soft cap but under the hard cap (warning)
+  | 'blocked'; // at/over the hard cap (over-limit; new cloud runs refused if enforced)
+
+/** Cents -> a fixed 2-dp dollar STRING for an input value ("12.5" cents=1250 -> "12.50"). */
+export function centsToDollars(cents: number): string {
+  if (!Number.isFinite(cents) || cents <= 0) return '0.00';
+  return (Math.round(cents) / 100).toFixed(2);
+}
+
+/** Cents -> a "$12.50" display string (compact, no thousands grouping). */
+export function formatDollars(cents: number): string {
+  return `$${centsToDollars(cents)}`;
+}
+
+/**
+ * A dollar input STRING -> integer cents. Blank / non-numeric / negative all
+ * coerce to 0 (a defensive, never-throws boundary), and fractional cents round
+ * to the nearest cent ("12.005" -> 1201 is intentionally avoided: 12.005*100 =
+ * 1200.4999.. so Math.round gives 1200; we round the cents, not the dollars).
+ */
+export function dollarsToCents(value: string): number {
+  const n = Number.parseFloat(value);
+  if (!Number.isFinite(n) || n <= 0) return 0;
+  return Math.round(n * 100);
+}
+
+/**
+ * Classify the month-to-date spend against the configured caps. A cap of 0 (or
+ * absent) means "not set" for that tier. Precedence: hard (blocked) wins over
+ * soft (near); with neither set, the view is informational ("no-cap").
+ */
+export function spendZone(info: SpendInfo): SpendZone {
+  const soft = info.softLimitCents > 0 ? info.softLimitCents : 0;
+  const hard = info.hardLimitCents > 0 ? info.hardLimitCents : 0;
+  const mtd = Math.max(0, info.monthToDateCents);
+  if (soft === 0 && hard === 0) return 'no-cap';
+  if (hard > 0 && mtd >= hard) return 'blocked';
+  if (soft > 0 && mtd >= soft) return 'near';
+  return 'ok';
+}
+
+/**
+ * The progress denominator (cents): the hard cap when set, else the soft cap.
+ * Returns 0 when neither is configured (the caller then renders an MTD-only view
+ * with no bounded bar).
+ */
+export function progressCeilingCents(info: SpendInfo): number {
+  if (info.hardLimitCents > 0) return info.hardLimitCents;
+  if (info.softLimitCents > 0) return info.softLimitCents;
+  return 0;
+}
+
+/**
+ * Bar fill fraction (0..1), clamped. Zero ceiling -> 0 (no bounded bar). An MTD
+ * over the ceiling clamps to a full bar (the over-limit state carries its own
+ * text/icon signal, so the bar never reads >100%).
+ */
+export function progressFraction(info: SpendInfo): number {
+  const ceiling = progressCeilingCents(info);
+  if (ceiling <= 0) return 0;
+  const frac = Math.max(0, info.monthToDateCents) / ceiling;
+  return Math.min(1, frac);
+}
+
+/** Whole-number progress percent (0..100) for aria-valuenow + width. */
+export function progressPercent(info: SpendInfo): number {
+  return Math.round(progressFraction(info) * 100);
+}
+
+/** The non-color glyph per zone (so the state is never signalled by hue alone). */
+export function zoneGlyph(zone: SpendZone): string {
+  switch (zone) {
+    case 'blocked':
+      return '⛔';
+    case 'near':
+      return '⚠';
+    case 'ok':
+      return '✓';
+    default:
+      return 'ℹ';
+  }
+}
+
+/**
+ * Plain-language status line for the current zone. `enforceHardLimit` only
+ * changes the BLOCKED copy: enforced -> new cloud runs are refused; not enforced
+ * -> over the cap, but runs are still allowed (the user set a soft ceiling only,
+ * or left enforcement off).
+ */
+export function zoneMessage(zone: SpendZone, enforceHardLimit: boolean): string {
+  switch (zone) {
+    case 'blocked':
+      return enforceHardLimit
+        ? 'Hard cap reached — new cloud runs are blocked until next month or a higher cap.'
+        : 'Over the hard cap — not enforced, so cloud runs still proceed. Turn on enforcement to block them.';
+    case 'near':
+      return 'Near the soft cap — approaching your monthly budget.';
+    case 'ok':
+      return 'Within budget this month.';
+    default:
+      return 'No spend cap set — cloud spend is unlimited. Set a cap to stay on budget.';
+  }
+}

--- a/app/renderer/src/features/spendCapLogic.ts
+++ b/app/renderer/src/features/spendCapLogic.ts
@@ -34,9 +34,9 @@ export function formatDollars(cents: number): string {
 
 /**
  * A dollar input STRING -> integer cents. Blank / non-numeric / negative all
- * coerce to 0 (a defensive, never-throws boundary), and fractional cents round
- * to the nearest cent ("12.005" -> 1201 is intentionally avoided: 12.005*100 =
- * 1200.4999.. so Math.round gives 1200; we round the cents, not the dollars).
+ * coerce to 0 (a defensive, never-throws boundary), and sub-cent precision is
+ * rounded to the nearest whole cent (`Math.round(dollars * 100)` — e.g.
+ * "12.005" -> 1201, "0.004" -> 0).
  */
 export function dollarsToCents(value: string): number {
   const n = Number.parseFloat(value);

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -619,6 +619,12 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('providers.usage', undefined);
   });
 
+  it('providers.spend calls the bare method (WU-spend-cap)', async () => {
+    const r = installApi();
+    await client.providers.spend();
+    expect(r).toHaveBeenCalledWith('providers.spend', undefined);
+  });
+
   it('providers.* presets forward their params (WU-presets)', async () => {
     const r = installApi();
     await client.providers.catalog();

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -415,6 +415,26 @@ export interface ProvidersListResponse {
 }
 
 /**
+ * `providers.spend` payload (WU-spend-cap): the persisted monthly cumulative
+ * spend ledger plus the configured caps, for the Monthly spend-cap control.
+ * ALL money is integer CENTS (the UI converts to dollars). `month` is the
+ * current UTC month key ("YYYY-MM"). With the default off/0 settings every cap
+ * reads zero/false (a benign "no cap" view). Read-only: it never mutates state.
+ */
+export interface SpendInfo {
+  /** The current UTC month the ledger is keyed by, e.g. "2026-06". */
+  month: string;
+  /** Cumulative cloud spend this month, in integer cents. */
+  monthToDateCents: number;
+  /** The non-blocking warning ceiling (cents); 0 = not set. */
+  softLimitCents: number;
+  /** The blocking ceiling (cents); 0 = not set. */
+  hardLimitCents: number;
+  /** Master switch: only when true does an over-hard-cap run get refused. */
+  enforceHardLimit: boolean;
+}
+
+/**
  * `providers.testKey` result (WU-keys): a validation ping through the provider
  * seam. The key is NEVER echoed back — only `ok`, the declared `capabilities`,
  * and a SCRUBBED `error` string on failure (the live key is stripped at the
@@ -1279,6 +1299,11 @@ export const client = {
      * NOT a poller). Keys are redacted; req/token units are returned distinctly.
      */
     usage: (): Promise<{ usage: UsageRow[] }> => rpc('providers.usage'),
+    /**
+     * `providers.spend` — month-to-date cumulative cloud spend + the configured
+     * monthly caps (WU-spend-cap). Read-only; all money is integer cents.
+     */
+    spend: (): Promise<SpendInfo> => rpc('providers.spend'),
     /** `providers.catalog` — the static curated model catalog (WU-catalog). */
     catalog: (): Promise<CatalogResponse> => rpc('providers.catalog'),
     /** `providers.applyPreset` — resolve a smart preset into routing (WU-presets). */

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -649,6 +649,26 @@ class Services:
         self.settings.set({"usageCache": {"rows": merged, "checkedAt": next_checked, "savedAt": now}})
         return {"usage": stamped}
 
+    def providers_spend(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.spend()`` -> month-to-date spend + configured caps (WU-spend-cap).
+
+        Surfaces the persisted monthly cumulative spend ledger for the renderer:
+        the current month, the month-to-date total (cents), and the three
+        configured caps (``monthlySoftLimitCents`` / ``monthlyHardLimitCents`` /
+        ``enforceMonthlyHardLimit``). Read-only: it never records or mutates state.
+        With the default off/0 settings every cap reads zero/false so an
+        unconfigured install shows a benign "no cap" view.
+        """
+        ledger = self._spend_ledger()
+        settings = self.settings.get()
+        return {
+            "month": ledger.current_month(),
+            "monthToDateCents": ledger.month_to_date(),
+            "softLimitCents": int(settings.get("monthlySoftLimitCents") or 0),
+            "hardLimitCents": int(settings.get("monthlyHardLimitCents") or 0),
+            "enforceHardLimit": bool(settings.get("enforceMonthlyHardLimit")),
+        }
+
     # ===================================================================== #
     # providers.* presets + per-function routing (WU-presets / PH3)
     # ===================================================================== #
@@ -1388,7 +1408,9 @@ class Services:
             model=str(settings.get("cloudEmbedModel") or settings.get("cloudModel") or ""),
         )
         envelope = self._plan_index_envelope(inputs)
-        self._enforce_cloud_budget_ack(
+        # WU-spend-cap: the index embedding egress is gated (ack + monthly hard cap)
+        # and metered exactly like _run_ai_job — it is a cloud egress path too.
+        self._enforce_egress_gates(
             envelope,
             params.get("confirmBudget") if isinstance(params.get("confirmBudget"), str) else None,
         )
@@ -1405,6 +1427,7 @@ class Services:
             feature="index",
             label="index.build",
             videoId=video_id,
+            on_egress=self._record_egress_cost,
         )
         return {"jobId": job.id}
 
@@ -1484,7 +1507,8 @@ class Services:
             model=str(settings.get("cloudEmbedModel") or settings.get("cloudModel") or ""),
         )
         envelope = self._plan_index_envelope(inputs)
-        self._enforce_cloud_budget_ack(
+        # WU-spend-cap: gate the query-embedding egress (ack + monthly hard cap).
+        self._enforce_egress_gates(
             envelope,
             params.get("confirmBudget") if isinstance(params.get("confirmBudget"), str) else None,
         )
@@ -1502,6 +1526,13 @@ class Services:
             embedder = self._resolve_index_embedder(settings)
             query_vec = embedder.embed([query])[0]
             cache.put(cache_key, query_vec)
+            # WU-spend-cap record-at-completion: the synchronous query embed just
+            # ran; record its cost iff it egressed (a cloud route). A cache hit
+            # (above) re-embeds nothing and so is never recorded. _record_egress_cost
+            # is a zero-record for a local-only envelope, but gating here keeps the
+            # local-route path from touching the ledger at all.
+            if envelope.route.willEgress:
+                self._record_egress_cost(envelope)
 
         # Guard the cross-route mismatch (PLAN §WU-A5 (d) error contract; WU-A4's
         # search defers the dimension check to its caller — this is that caller). The
@@ -2495,6 +2526,79 @@ class Services:
         # FACTORY PATH (PLAN §WU-keys): the pool is built from RAW keys.
         return builder(self.settings.get_raw(), detect_local=False)
 
+    def _spend_ledger(self) -> Any:
+        """The persisted monthly spend ledger (WU-spend-cap), under the data root.
+
+        A single JSON document at ``data_dir/spend-ledger.json`` (alongside the
+        other persisted state), keyed by calendar month. The handler's injectable
+        ``_now`` clock is threaded in so the month-key derivation is deterministic
+        under test and matches the rest of the Hub's wall-clock seam.
+        """
+        from .models.spend_ledger import SpendLedger  # local: import-light pure
+
+        return SpendLedger(self.data_dir / "spend-ledger.json", clock=self._now)
+
+    def _estimate_job_cents(self, envelope: Any) -> int:
+        """The estimated cost (cents) of running ``envelope``, or 0 if non-egressing.
+
+        A run that will not egress (cache hit / local-only pool) costs nothing. For
+        an egressing cloud run the estimate is the planned request count times the
+        documented placeholder per-request rate (the catalog has no structured
+        numeric price yet — see ``spend_ledger.PLACEHOLDER_CENTS_PER_REQUEST``). The
+        SAME helper feeds both the pre-egress hard-cap check and the completion
+        record, so the predicted and recorded costs always agree.
+        """
+        from .models.spend_ledger import PLACEHOLDER_CENTS_PER_REQUEST  # local: pure
+
+        if not envelope.route.willEgress:
+            return 0
+        return int(envelope.costEst.requests) * PLACEHOLDER_CENTS_PER_REQUEST
+
+    def _enforce_monthly_hard_cap(self, envelope: Any) -> None:
+        """Refuse an egressing run that would push month-to-date over the hard cap.
+
+        Fires ONLY when ``enforceMonthlyHardLimit`` is on AND the planned run would
+        egress AND ``month_to_date + this-job-estimate`` exceeds
+        ``monthlyHardLimitCents``. This is INDEPENDENT of the ``confirmCloudBudget``
+        ack gate (the two are orthogonal: a per-run ack does not waive the monthly
+        ceiling). A non-egressing run costs nothing and is never refused.
+        """
+        settings = self.settings.get()
+        if not settings.get("enforceMonthlyHardLimit"):
+            return
+        job_cents = self._estimate_job_cents(envelope)
+        if job_cents <= 0:
+            return
+        hard_cap = settings.get("monthlyHardLimitCents")
+        if not isinstance(hard_cap, (int, float)) or isinstance(hard_cap, bool) or hard_cap <= 0:
+            return
+        ledger = self._spend_ledger()
+        projected = ledger.month_to_date() + job_cents
+        if projected > hard_cap:
+            raise _invalid(f"monthly spend cap ${hard_cap / 100:.2f} reached")
+
+    def _enforce_egress_gates(self, envelope: Any, ack: str | None) -> None:
+        """Run BOTH pre-egress gates for ``envelope`` (the single egress chokepoint).
+
+        Every cloud-egress path (``_run_ai_job`` and the ``index.*`` embedding
+        routes) calls this so the gates can never be applied unevenly: the per-run
+        ``confirmCloudBudget`` ack gate AND the independent monthly hard cap. Both
+        are no-ops for a non-egressing (local-only / cache-hit) envelope.
+        """
+        self._enforce_cloud_budget_ack(envelope, ack)
+        self._enforce_monthly_hard_cap(envelope)
+
+    def _record_egress_cost(self, envelope: Any) -> None:
+        """Record ``envelope``'s estimated cost in the spend ledger (WU-spend-cap).
+
+        The single recording site shared by the job-bus path (via ``run_ai_job``'s
+        ``on_egress`` callback) and the synchronous ``index.search`` query embed.
+        ``_estimate_job_cents`` returns 0 for a non-egressing envelope, so calling
+        this for a local-only run is a harmless zero-record; callers gate on
+        ``willEgress`` first so a local run records nothing at all.
+        """
+        self._spend_ledger().record(self._estimate_job_cents(envelope))
+
     def plan_ai_job_envelope(self, inputs: Any) -> Any:
         """Assemble an :class:`ai_job.AiJob` envelope for ``inputs`` (PURE, no calls).
 
@@ -2554,7 +2658,9 @@ class Services:
         )
         envelope = self.plan_ai_job_envelope(inputs)
         if enforce_budget:
-            self._enforce_cloud_budget_ack(envelope, ack)
+            # WU-spend-cap: the per-run ack gate AND the independent monthly hard
+            # cap both run here before any egress (the shared egress chokepoint).
+            self._enforce_egress_gates(envelope, ack)
 
         def _factory() -> Any:
             if provider is not None:
@@ -2573,6 +2679,10 @@ class Services:
             feature=feature,
             label=label,
             videoId=videoId,
+            # WU-spend-cap record-at-completion: fired ONLY after a run that
+            # actually egressed (a real cloud call, including degrade-to-local) —
+            # never on a cache hit, local-only run, cancel, or error.
+            on_egress=self._record_egress_cost if enforce_budget else None,
         )
 
     def _enforce_cloud_budget_ack(self, envelope: Any, ack: str | None) -> None:
@@ -2621,7 +2731,37 @@ class Services:
             request=request,
             capability=str(params.get("capability") or "text"),
         )
-        return self.plan_ai_job_envelope(inputs).planned()
+        envelope = self.plan_ai_job_envelope(inputs)
+        planned = envelope.planned()
+        warning = self._soft_spend_warning(envelope)
+        if warning is not None:
+            planned["spendWarning"] = warning
+        return planned
+
+    def _soft_spend_warning(self, envelope: Any) -> dict[str, Any] | None:
+        """A non-blocking soft-cap warning for ``ai.planJob``, or ``None``.
+
+        Returns a warning payload when ``monthlySoftLimitCents`` is set (> 0) AND
+        the projected month-to-date (current MTD + this job's estimate) exceeds it.
+        This NEVER blocks — it is surfaced in the plan/envelope so the renderer can
+        nudge the user; the hard cap (``_enforce_monthly_hard_cap``) is the only
+        thing that refuses a run.
+        """
+        settings = self.settings.get()
+        soft_cap = settings.get("monthlySoftLimitCents")
+        if not isinstance(soft_cap, (int, float)) or isinstance(soft_cap, bool) or soft_cap <= 0:
+            return None
+        ledger = self._spend_ledger()
+        month_to_date = ledger.month_to_date()
+        projected = month_to_date + self._estimate_job_cents(envelope)
+        if projected <= soft_cap:
+            return None
+        return {
+            "softLimitCents": int(soft_cap),
+            "monthToDateCents": month_to_date,
+            "projectedCents": projected,
+            "message": f"monthly soft spend limit ${soft_cap / 100:.2f} exceeded",
+        }
 
     # ===================================================================== #
     # director.* (WU-plan-rpc) — the RPC spine onto the shipped AI substrate.
@@ -3562,6 +3702,10 @@ def register_all(
     # burst). The rotation pool already accounts usage from optimistic decrement +
     # parsed 429/X-RateLimit-* headers — this RPC just surfaces it, redacted.
     reg("providers.usage", svc.providers_usage)
+    # WU-spend-cap: month-to-date cumulative spend + the configured monthly caps
+    # (read-only). The persisted ledger is written at job completion; this RPC just
+    # surfaces it (+ the soft/hard cap settings) for the renderer's spend view.
+    reg("providers.spend", svc.providers_spend)
     # WU-presets (PH3): smart presets + per-function override + first-run chooser.
     # applyPreset resolves a preset over the curated catalog into routing.perFunction;
     # setFunctionModel overrides one slot; firstRun is the local-vs-cloud chooser

--- a/sidecar/media_studio/models/ai_job.py
+++ b/sidecar/media_studio/models/ai_job.py
@@ -260,6 +260,14 @@ def _preview_text(cost: Budget, cache_hit: bool) -> str:
 # by ``provider_factory`` and handed in so degrade-tracking still applies.
 AiWork = Callable[[Any, AiJob, Any], dict[str, Any]]
 
+# A completion hook fired with the planned envelope AFTER a run that actually
+# egressed (a real cloud call — including one that degraded to local). It is NOT
+# fired on a cache hit, a local-only pool, a cancel-before-call, or a provider
+# error. The handler passes a closure that records the run's cost in the
+# spend ledger (WU-spend-cap record-at-completion); the default ``None`` keeps the
+# substrate persistence-free for every non-billed caller.
+OnEgress = Callable[[AiJob], None]
+
 
 def run_ai_job(
     envelope: AiJob,
@@ -272,6 +280,7 @@ def run_ai_job(
     feature: str = "ai",
     label: str = "AI",
     videoId: str | None = None,  # noqa: N803 - wire-name kwarg (matches JobRegistry)
+    on_egress: OnEgress | None = None,
 ) -> Any:
     """Run ``envelope`` on a ``jobs`` job; return the created :class:`jobs.Job`.
 
@@ -298,12 +307,12 @@ def run_ai_job(
             return {"cancelled": True}
         ctx.progress(0.0, "planning")
         if work is not None:
-            return _execute_work(ctx, envelope, provider_factory, work)
+            return _execute_work(ctx, envelope, provider_factory, work, on_egress)
         cached = cache.get(envelope.cacheKey)
         if cached is not None:
             ctx.progress(100.0, "cache hit")
             return {"result": cached, "cacheHit": True, "degraded": False}
-        return _execute_uncached(ctx, envelope, provider_factory, cache)
+        return _execute_uncached(ctx, envelope, provider_factory, cache, on_egress)
 
     return jobs.start(job_body, feature=feature, label=label, videoId=videoId)
 
@@ -313,12 +322,15 @@ def _execute_work(
     envelope: AiJob,
     provider_factory: ProviderFactory,
     work: AiWork,
+    on_egress: OnEgress | None = None,
 ) -> dict[str, Any]:
     """Run a custom ``work`` body with a degrade-aware provider; return its result.
 
     The provider is built once and a ``degraded`` notice is emitted if the run
     fell through to the local backstop, so the handler-specific work inherits the
-    same graceful-degradation visibility as the default chat path.
+    same graceful-degradation visibility as the default chat path. When the run
+    would egress (a cloud pool), ``on_egress`` is fired AFTER the work completes
+    so the cost is recorded only for a run that ran to completion.
     """
     provider = provider_factory()
     degraded_flag = {"hit_local": False}
@@ -326,6 +338,7 @@ def _execute_work(
     result = work(ctx, envelope, provider)
     if degraded_flag["hit_local"]:
         ctx.progress(99.0, "degraded: fell back to local")
+    _fire_on_egress(envelope, on_egress)
     return result
 
 
@@ -334,8 +347,15 @@ def _execute_uncached(
     envelope: AiJob,
     provider_factory: ProviderFactory,
     cache: AiCache,
+    on_egress: OnEgress | None = None,
 ) -> dict[str, Any]:
-    """Build the provider, run the chat, store the result, and flag degradation."""
+    """Build the provider, run the chat, store the result, and flag degradation.
+
+    Reached ONLY on a real cache miss (``job_body`` returns earlier on a hit), so
+    firing ``on_egress`` here after the chat records cost exclusively for a run
+    that genuinely called a provider — a runtime cache hit, a cancel-before-call,
+    and a provider error each return / raise before the record line.
+    """
     provider = provider_factory()
     degraded_flag = {"hit_local": False}
     _subscribe_degrade(provider, degraded_flag)
@@ -347,7 +367,21 @@ def _execute_uncached(
         ctx.progress(90.0, "degraded: fell back to local")
     cache.put(envelope.cacheKey, result)
     ctx.progress(100.0, "done")
+    _fire_on_egress(envelope, on_egress)
     return {"result": result, "cacheHit": False, "degraded": degraded_flag["hit_local"]}
+
+
+def _fire_on_egress(envelope: AiJob, on_egress: OnEgress | None) -> None:
+    """Invoke ``on_egress`` iff a callback is set AND the run would egress.
+
+    A local-only pool (``willEgress`` False) never sends bytes off the machine and
+    therefore costs nothing — it is not recorded even though the local provider
+    ran. A degraded-to-local run kept ``willEgress`` True (it attempted cloud) and
+    IS recorded: for a spend ceiling, over-counting stops the user sooner (the safe
+    direction) and keeps the record decision free of the degrade flag.
+    """
+    if on_egress is not None and envelope.route.willEgress:
+        on_egress(envelope)
 
 
 def _subscribe_degrade(provider: Any, flag: dict[str, bool]) -> None:

--- a/sidecar/media_studio/models/spend_ledger.py
+++ b/sidecar/media_studio/models/spend_ledger.py
@@ -1,0 +1,153 @@
+"""Persisted month-keyed cumulative spend ledger (WU-spend-cap).
+
+The per-run budget gate (``models.budget`` + ``handlers._enforce_cloud_budget_ack``)
+answers "does THIS run fit?", but nothing remembers what earlier approved runs
+already cost — so many small cloud-AI jobs accumulate unbounded spend across a
+month. This module is the persisted memory that closes that gap: a single JSON
+document, keyed by calendar month (``"YYYY-MM"``), holding the cumulative cost in
+**integer cents** for each month.
+
+  * :func:`month_key` derives the ``"YYYY-MM"`` bucket for a unix timestamp (UTC,
+    so the month boundary is stable regardless of the host timezone).
+  * :class:`SpendLedger` records each cloud-AI job's actual-or-estimated cost at
+    COMPLETION (:meth:`record`) and answers month-to-date spend
+    (:meth:`month_to_date`). The clock is injected so tests are deterministic; the
+    file round-trips atomically (temp + ``os.replace``) and a corrupt/missing/
+    malformed file degrades to an empty ledger rather than crashing — mirroring
+    :class:`settings_store.SettingsStore`.
+
+Pure logic + filesystem I/O only: NO heavy-ML imports, NO network, NO provider.
+The cost VALUE is supplied by the caller (the handler derives a cents estimate);
+this module never prices a model — it only stores and sums what it is given.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+import os
+import time
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..util import get_logger
+
+log = get_logger("media_studio.spend_ledger")
+
+#: The on-disk document version (future-proofing; readers tolerate its absence).
+_LEDGER_VERSION = 1
+
+#: DOCUMENTED PLACEHOLDER rate: the nominal cost (in cents) attributed to a single
+#: cloud-AI request when the catalog carries no structured numeric price (every
+#: curated model today is FREE/FREEMIUM with only a human ``free_limits`` string —
+#: see ``ai_job.CatalogFreeCapAdapter``). The monthly cap needs a NON-ZERO per-job
+#: cost or an enabled hard cap could never trip; this constant is that falsifiable
+#: stand-in (mirrors ``budget.DEFAULT_TARGET_JOB_SIZE``). Replace it with a real
+#: per-model price once the catalog gains structured pricing; do not scatter the
+#: magic number into callers — derive every job estimate from this one place.
+PLACEHOLDER_CENTS_PER_REQUEST: int = 1
+
+
+def month_key(now_seconds: float) -> str:
+    """The ``"YYYY-MM"`` calendar-month bucket for a unix timestamp (UTC).
+
+    UTC is used deliberately so the month boundary is identical across hosts and
+    does not drift with the local timezone or DST — the ledger is a stable,
+    machine-independent record.
+    """
+    moment = _dt.datetime.fromtimestamp(now_seconds, tz=_dt.UTC)
+    return f"{moment.year:04d}-{moment.month:02d}"
+
+
+class SpendLedger:
+    """A JSON-backed, month-keyed cumulative spend store (integer cents).
+
+    The document shape is ``{"version": 1, "months": {"YYYY-MM": <cents:int>}}``.
+    ``record`` folds a cost into a month's running total; ``month_to_date`` reads
+    one month's total (defaulting to the clock's current month). The clock is an
+    injected ``() -> float`` seam (defaults to :func:`time.time`).
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self._clock: Callable[[], float] = clock or time.time
+
+    # ---- I/O ---------------------------------------------------------------
+    def _read(self) -> dict[str, Any]:
+        """Load the ledger document, degrading any read failure to ``{}``.
+
+        A missing file, unreadable file, invalid JSON, or non-object payload all
+        yield an empty document so a corrupt ledger can never brick a job — the
+        next :meth:`record` simply rewrites a clean file.
+        """
+        if not self.path.exists():
+            return {}
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as exc:
+            log.warning("spend ledger unreadable (%s); using empty ledger", exc)
+            return {}
+        return data if isinstance(data, dict) else {}
+
+    def _write(self, data: dict[str, Any]) -> None:
+        """Atomically persist ``data`` (temp file + ``os.replace``)."""
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    @staticmethod
+    def _months(data: dict[str, Any]) -> dict[str, Any]:
+        """The ``months`` sub-map, tolerating its absence / a non-dict value."""
+        months = data.get("months")
+        return months if isinstance(months, dict) else {}
+
+    # ---- public surface ----------------------------------------------------
+    def current_month(self) -> str:
+        """The clock's current ``"YYYY-MM"`` month bucket."""
+        return month_key(self._clock())
+
+    def month_to_date(self, now_month: str | None = None) -> int:
+        """Cumulative spend (cents) for ``now_month`` (defaults to this month).
+
+        A month with no recorded spend — or a stored value that is not a finite
+        number — reads as ``0``.
+        """
+        month = now_month if now_month is not None else self.current_month()
+        value = self._months(self._read()).get(month)
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            return 0
+        return int(value)
+
+    def record(self, cost_cents: float, month: str | None = None) -> int:
+        """Add ``cost_cents`` to ``month``'s running total; return the new total.
+
+        ``month`` defaults to the clock's current month. The cost is coerced to a
+        non-negative integer (cents are whole-number money; a negative cost is a
+        programming error and raises ``ValueError``). The fold is read-modify-write
+        against the persisted document so concurrent instances each see the latest
+        on-disk total.
+        """
+        cents = int(cost_cents)
+        if cents < 0:
+            raise ValueError("spend cost must be non-negative")
+        target = month if month is not None else self.current_month()
+        data = self._read()
+        months = dict(self._months(data))
+        previous = months.get(target)
+        prior = int(previous) if isinstance(previous, (int, float)) and not isinstance(previous, bool) else 0
+        new_total = prior + cents
+        months[target] = new_total
+        data["version"] = _LEDGER_VERSION
+        data["months"] = months
+        self._write(data)
+        return new_total
+
+
+__all__ = ["SpendLedger", "month_key"]

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -67,6 +67,19 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     # estimate when the request pins no size. Mirrors budget.DEFAULT_TARGET_JOB_SIZE;
     # a DOCUMENTED placeholder until the user pins N (one 60-min source -> N shorts).
     "defaultTargetJobSize": _budget.DEFAULT_TARGET_JOB_SIZE,
+    # WU-spend-cap: persisted monthly cumulative spend ceiling (single-user; no org
+    # dimension). The per-run budget gate only sizes ONE run; these caps bound the
+    # MONTH-TO-DATE total accumulated across many approved cloud-AI runs (recorded
+    # in the spend_ledger at job completion). All three default OFF/0 so the cap is
+    # backward-compatible: an existing install caps nothing until the user opts in.
+    #   * monthlySoftLimitCents: when month-to-date + this job's estimate exceeds
+    #     this, the plan/envelope carries a non-blocking soft WARNING (UI nudge).
+    #   * monthlyHardLimitCents: the ceiling the hard gate enforces (cents).
+    #   * enforceMonthlyHardLimit: master switch; only when True does an over-cap
+    #     cloud run get REFUSED before egress. 0 caps + False = no enforcement.
+    "monthlySoftLimitCents": 0,
+    "monthlyHardLimitCents": 0,
+    "enforceMonthlyHardLimit": False,
     # Provider Hub presets + per-function routing (WU-presets / PH3). ``routing``
     # holds the resolved per-function provider choice; each function's seam prefers
     # its configured provider (pool fallback). ``perFunction[<fn>]`` is a

--- a/sidecar/tests/test_ai_job.py
+++ b/sidecar/tests/test_ai_job.py
@@ -523,6 +523,152 @@ def test_run_custom_work_honors_precancel(tmp_path: Any) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# run_ai_job — on_egress completion callback (WU-spend-cap record-at-completion)
+# --------------------------------------------------------------------------- #
+def test_on_egress_fires_after_a_real_cloud_run(tmp_path: Any) -> None:
+    """A miss against a cloud pool egresses → the callback fires exactly once."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)  # cloud pool, fresh content -> willEgress True
+    harness = JobHarness()
+    fired: list[AiJob] = []
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: SpyProvider("ans"),
+        cache=cache,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert len(fired) == 1
+    assert fired[0] is env
+
+
+def test_on_egress_records_on_degraded_to_local(tmp_path: Any) -> None:
+    """A run that fell through to local still egressed (attempted cloud) → record."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    fired: list[AiJob] = []
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: DegradingProvider("local-ans"),
+        cache=cache,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert len(fired) == 1
+
+
+def test_on_egress_skipped_for_local_only_pool(tmp_path: Any) -> None:
+    """A local-only pool never egresses → the callback must NOT fire."""
+    cache = AiCache(store_dir=tmp_path)
+    env = plan_ai_job(_inputs(content="loc"), pool=_local_only_pool(), catalog=FakeCatalog(), cache=cache)
+    assert env.route.willEgress is False
+    harness = JobHarness()
+    fired: list[AiJob] = []
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: SpyProvider("ans"),
+        cache=cache,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert fired == []
+
+
+def test_on_egress_skipped_on_cache_hit(tmp_path: Any) -> None:
+    """A cache hit returns before the provider → no egress, no record."""
+    cache = AiCache(store_dir=tmp_path)
+    inputs = _inputs(content="hot")
+    env = plan_ai_job(inputs, pool=_cloud_pool(), catalog=FakeCatalog(), cache=cache)
+    cache.put(env.cacheKey, "stored")  # populate AFTER planning -> runtime hit
+    harness = JobHarness()
+    fired: list[AiJob] = []
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: SpyProvider("SHOULD-NOT-RUN"),
+        cache=cache,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert fired == []
+
+
+def test_on_egress_skipped_when_provider_errors(tmp_path: Any) -> None:
+    """A provider exception aborts before the record point → ledger untouched."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    fired: list[AiJob] = []
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: RaisingProvider(),
+        cache=cache,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert fired == []
+
+
+def test_on_egress_fires_for_custom_work_cloud_run(tmp_path: Any) -> None:
+    """The custom-work path also records when it egressed over a cloud pool."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    fired: list[AiJob] = []
+
+    def work(ctx: Any, envelope: AiJob, provider: Any) -> dict[str, Any]:
+        return {"candidates": [provider.chat(list(envelope.inputs.messages))]}
+
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: SpyProvider("ranked"),
+        cache=cache,
+        work=work,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert len(fired) == 1
+
+
+def test_on_egress_skipped_for_custom_work_local_only(tmp_path: Any) -> None:
+    """Custom work over a local-only pool does not egress → no record."""
+    cache = AiCache(store_dir=tmp_path)
+    env = plan_ai_job(_inputs(content="cw-loc"), pool=_local_only_pool(), catalog=FakeCatalog(), cache=cache)
+    harness = JobHarness()
+    fired: list[AiJob] = []
+
+    def work(ctx: Any, envelope: AiJob, provider: Any) -> dict[str, Any]:
+        return {"track": provider.chat(list(envelope.inputs.messages))}
+
+    run_ai_job(
+        env,
+        jobs=harness.registry,
+        provider_factory=lambda: SpyProvider("ans"),
+        cache=cache,
+        work=work,
+        on_egress=fired.append,
+    )
+    harness.registry.join(timeout=5)
+    assert fired == []
+
+
+def test_run_without_on_egress_is_unchanged(tmp_path: Any) -> None:
+    """The default (no on_egress) path runs exactly as before — backward compat."""
+    cache = AiCache(store_dir=tmp_path)
+    env = _env(cache)
+    harness = JobHarness()
+    run_ai_job(env, jobs=harness.registry, provider_factory=lambda: SpyProvider("ans"), cache=cache)
+    harness.registry.join(timeout=5)
+    assert harness.done[-1][1]["result"] == "ans"
+
+
+# --------------------------------------------------------------------------- #
 # CatalogFreeCapAdapter (WAVE-1 carryforward #1)
 # --------------------------------------------------------------------------- #
 def test_catalog_adapter_reports_uncapped() -> None:

--- a/sidecar/tests/test_handlers_spend_cap.py
+++ b/sidecar/tests/test_handlers_spend_cap.py
@@ -1,0 +1,459 @@
+"""Tests for the WU-spend-cap handler surface (monthly cumulative spend ceiling).
+
+The per-run budget gate (test_handlers_budget_preflight) only sizes ONE run; this
+WU bounds the MONTH-TO-DATE total accrued across many approved cloud-AI runs:
+
+  * a hard-cap REFUSAL before egress when ``enforceMonthlyHardLimit`` and
+    ``month_to_date + this-job-estimate`` exceeds ``monthlyHardLimitCents``
+    (independent of the ``confirmCloudBudget`` ack gate);
+  * a non-blocking soft WARNING merged into ``ai.planJob`` output when over the
+    soft cap;
+  * recording each egressing run's estimated cost in the spend ledger at
+    completion;
+  * the ``providers.spend`` RPC returning month-to-date + the configured caps;
+  * backward compatibility: defaults off/0 cap and warn nothing.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.handlers import Services
+from media_studio.jobs import JobRegistry
+from media_studio.models.ai_cache import Message
+from media_studio.models.spend_ledger import SpendLedger
+from media_studio.protocol import RpcContext, RpcError
+
+# 2026-06-21 00:00:00 UTC -> month "2026-06".
+_JUN_2026 = 1781913600.0
+
+
+class _CloudEntry:
+    provider = "Groq"
+    local = False
+
+
+class _LocalEntry:
+    provider = "local"
+    local = True
+
+
+class _CloudPool:
+    entries = (_CloudEntry(), _LocalEntry())
+
+
+class SpyProvider:
+    def __init__(self, reply: str = "answer") -> None:
+        self.reply = reply
+        self.calls: list[Any] = []
+
+    def chat(self, messages: Sequence[Message], **_kwargs: Any) -> str:
+        self.calls.append(list(messages))
+        return self.reply
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+@pytest.fixture
+def svc(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data", provider=SpyProvider(), library=None, now=lambda: _JUN_2026)
+
+
+def _cloud(svc: Services) -> None:
+    """Force an egressing (cloud) pool so willEgress is True."""
+    svc._ai_pool = lambda: _CloudPool()  # type: ignore[method-assign]
+
+
+def _envelope(svc: Services, content: str = "q") -> Any:
+    from media_studio.models import ai_job as _ai_job
+
+    inputs = _ai_job.AiInputs(messages=({"role": "user", "content": content},), model="m")
+    return svc.plan_ai_job_envelope(inputs)
+
+
+# --------------------------------------------------------------------------- #
+# the cents estimate seam — non-zero for a real cloud run
+# --------------------------------------------------------------------------- #
+def test_job_cents_estimate_is_non_zero_for_cloud_run(svc: Services) -> None:
+    _cloud(svc)
+    env = _envelope(svc)
+    assert svc._estimate_job_cents(env) > 0
+
+
+def test_job_cents_estimate_is_zero_for_local_only(svc: Services) -> None:
+    env = _envelope(svc)  # default local-only pool
+    assert env.route.willEgress is False
+    assert svc._estimate_job_cents(env) == 0
+
+
+# --------------------------------------------------------------------------- #
+# the spend ledger accessor
+# --------------------------------------------------------------------------- #
+def test_spend_ledger_lives_under_data_dir(svc: Services) -> None:
+    ledger = svc._spend_ledger()
+    assert isinstance(ledger, SpendLedger)
+    assert ledger.path == svc.data_dir / "spend-ledger.json"
+
+
+def test_spend_ledger_uses_the_injected_clock(svc: Services) -> None:
+    ledger = svc._spend_ledger()
+    assert ledger.current_month() == "2026-06"
+
+
+# --------------------------------------------------------------------------- #
+# hard-cap refusal (synchronous, before egress)
+# --------------------------------------------------------------------------- #
+def _run(svc: Services, provider: Any = None) -> tuple[JobRegistry, list[Any]]:
+    done: list[Any] = []
+    registry = JobRegistry(lambda *_a: None, lambda jid, res: done.append(res))
+    rctx = RpcContext(emit_notification=lambda obj: None, jobs=registry)
+    job = svc._run_ai_job(
+        rctx,
+        messages=[{"role": "user", "content": "go"}],
+        model="m",
+        provider=provider or SpyProvider("ok"),
+        work=None,
+        feature="ai",
+        label="AI",
+        ack=None,
+    )
+    registry.join(timeout=5)
+    return registry, done, job  # type: ignore[return-value]
+
+
+def test_hard_cap_refuses_when_over_ceiling(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 50, "confirmCloudBudget": False})
+    # Pre-load the ledger AT the cap so this job (cost >= 1) tips it strictly over.
+    svc._spend_ledger().record(50)
+    rctx = RpcContext(emit_notification=lambda obj: None, jobs=JobRegistry(lambda *_a: None, lambda *_a: None))
+    with pytest.raises(RpcError, match=r"monthly spend cap \$0\.50 reached"):
+        svc._run_ai_job(
+            rctx,
+            messages=[{"role": "user", "content": "go"}],
+            model="m",
+            provider=SpyProvider("ok"),
+            work=None,
+            feature="ai",
+            label="AI",
+            ack=None,
+        )
+
+
+def test_hard_cap_allows_projected_exactly_at_ceiling(svc: Services) -> None:
+    # projected == cap is NOT "exceeded" -> the run proceeds (strict >).
+    _cloud(svc)
+    svc.settings.set({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 50, "confirmCloudBudget": False})
+    svc._spend_ledger().record(49)  # +1 job estimate -> projected 50 == cap
+    _registry, done, job = _run(svc, SpyProvider("ok"))
+    assert job.finished
+    assert done[-1]["result"] == "ok"
+
+
+def test_hard_cap_ignored_when_limit_is_zero(svc: Services) -> None:
+    # enforce ON but cap 0 -> treated as unconfigured -> no refusal.
+    _cloud(svc)
+    svc.settings.set({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 0, "confirmCloudBudget": False})
+    svc._spend_ledger().record(9999)
+    _registry, done, job = _run(svc, SpyProvider("ok"))
+    assert job.finished
+
+
+def test_hard_cap_proceeds_when_under_ceiling(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 100000, "confirmCloudBudget": False})
+    _registry, done, job = _run(svc, SpyProvider("ok"))
+    assert job.finished
+    assert done[-1]["result"] == "ok"
+
+
+def test_hard_cap_not_enforced_when_switch_off(svc: Services) -> None:
+    _cloud(svc)
+    # Cap is tiny + already exceeded, but enforcement is OFF -> the run proceeds.
+    svc.settings.set({"enforceMonthlyHardLimit": False, "monthlyHardLimitCents": 1, "confirmCloudBudget": False})
+    svc._spend_ledger().record(9999)
+    _registry, done, job = _run(svc, SpyProvider("ok"))
+    assert job.finished
+    assert done[-1]["result"] == "ok"
+
+
+def test_hard_cap_ignores_local_only_run(svc: Services) -> None:
+    # No cloud pool -> local-only -> never egresses -> never refused, even over cap.
+    svc.settings.set({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 1, "confirmCloudBudget": False})
+    svc._spend_ledger().record(9999)
+    _registry, done, job = _run(svc, SpyProvider("loc"))
+    assert job.finished
+
+
+def test_hard_cap_independent_of_confirm_cloud_budget(svc: Services) -> None:
+    # confirmCloudBudget is ON (would require an ack), but we pass the matching ack;
+    # the hard cap must STILL refuse the over-cap run.
+    _cloud(svc)
+    svc.settings.set({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 1, "confirmCloudBudget": True})
+    svc._spend_ledger().record(9999)
+    env = _envelope(svc)
+    rctx = RpcContext(emit_notification=lambda obj: None, jobs=JobRegistry(lambda *_a: None, lambda *_a: None))
+    with pytest.raises(RpcError, match="monthly spend cap"):
+        svc._run_ai_job(
+            rctx,
+            messages=[{"role": "user", "content": "q"}],
+            model="m",
+            provider=SpyProvider("ok"),
+            work=None,
+            feature="ai",
+            label="AI",
+            ack=env.cacheKey,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# record-at-completion (the on_egress closure)
+# --------------------------------------------------------------------------- #
+def test_completed_cloud_run_records_cost(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"confirmCloudBudget": False})
+    before = svc._spend_ledger().month_to_date()
+    assert before == 0
+    _registry, done, job = _run(svc, SpyProvider("ok"))
+    assert job.finished
+    after = svc._spend_ledger().month_to_date()
+    assert after > 0
+
+
+def test_local_only_run_records_nothing(svc: Services) -> None:
+    svc.settings.set({"confirmCloudBudget": False})
+    _registry, done, job = _run(svc, SpyProvider("loc"))
+    assert job.finished
+    assert svc._spend_ledger().month_to_date() == 0
+
+
+# --------------------------------------------------------------------------- #
+# soft-cap warning on ai.planJob (non-blocking)
+# --------------------------------------------------------------------------- #
+def test_soft_warning_present_when_over_soft_cap(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"monthlySoftLimitCents": 10})
+    svc._spend_ledger().record(20)  # already over the soft cap
+    out = svc.ai_plan_job({"messages": [{"role": "user", "content": "hi"}], "model": "m"}, ctx=_rctx())
+    assert "spendWarning" in out
+    assert out["spendWarning"]["softLimitCents"] == 10
+    assert out["spendWarning"]["monthToDateCents"] == 20
+
+
+def test_no_soft_warning_when_under_soft_cap(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"monthlySoftLimitCents": 100000})
+    out = svc.ai_plan_job({"messages": [{"role": "user", "content": "hi"}], "model": "m"}, ctx=_rctx())
+    assert "spendWarning" not in out
+
+
+def test_no_soft_warning_when_soft_cap_disabled(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"monthlySoftLimitCents": 0})
+    svc._spend_ledger().record(99999)
+    out = svc.ai_plan_job({"messages": [{"role": "user", "content": "hi"}], "model": "m"}, ctx=_rctx())
+    assert "spendWarning" not in out
+
+
+def test_no_soft_warning_for_local_only_plan(svc: Services) -> None:
+    # local-only -> zero job estimate; MTD alone under cap -> no warning.
+    svc.settings.set({"monthlySoftLimitCents": 100})
+    out = svc.ai_plan_job({"messages": [{"role": "user", "content": "hi"}], "model": "m"}, ctx=_rctx())
+    assert "spendWarning" not in out
+
+
+# --------------------------------------------------------------------------- #
+# providers.spend RPC
+# --------------------------------------------------------------------------- #
+def test_providers_spend_reports_mtd_and_caps(svc: Services) -> None:
+    svc.settings.set({"monthlySoftLimitCents": 500, "monthlyHardLimitCents": 2000, "enforceMonthlyHardLimit": True})
+    svc._spend_ledger().record(123)
+    out = svc.providers_spend({}, _rctx())
+    assert out["month"] == "2026-06"
+    assert out["monthToDateCents"] == 123
+    assert out["softLimitCents"] == 500
+    assert out["hardLimitCents"] == 2000
+    assert out["enforceHardLimit"] is True
+
+
+def test_providers_spend_defaults_are_off(svc: Services) -> None:
+    out = svc.providers_spend({}, _rctx())
+    assert out["monthToDateCents"] == 0
+    assert out["softLimitCents"] == 0
+    assert out["hardLimitCents"] == 0
+    assert out["enforceHardLimit"] is False
+
+
+def test_providers_spend_registered_in_register_all(tmp_path: Path) -> None:
+    from media_studio import handlers, protocol
+
+    svc = Services(data_dir=tmp_path / "data", provider=SpyProvider(), library=None)
+    handlers.register_all(svc)
+    assert "providers.spend" in protocol.METHODS
+
+
+# --------------------------------------------------------------------------- #
+# backward compatibility: defaults off => no cap, no warning, but still records
+# --------------------------------------------------------------------------- #
+def test_defaults_do_not_cap_or_warn(svc: Services) -> None:
+    _cloud(svc)
+    svc.settings.set({"confirmCloudBudget": False})
+    # Defaults: enforceMonthlyHardLimit False, both caps 0. Even with a big prior
+    # spend, the run is neither refused nor warned.
+    svc._spend_ledger().record(1_000_000)
+    out = svc.ai_plan_job({"messages": [{"role": "user", "content": "hi"}], "model": "m"}, ctx=_rctx())
+    assert "spendWarning" not in out
+    _registry, done, job = _run(svc, SpyProvider("ok"))
+    assert job.finished
+    assert done[-1]["result"] == "ok"
+
+
+def _rctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+# --------------------------------------------------------------------------- #
+# index.* egress paths — the OTHER cloud chokepoint (build job + sync search)
+# These prove the monthly cap + recording also cover index embedding egress, not
+# just _run_ai_job (a willEgress-only coverage gate would miss a bypassing path).
+# --------------------------------------------------------------------------- #
+class _SpyTransport:
+    """A fake ``/v1/embeddings`` transport: returns a fixed-dim vector per input."""
+
+    def __init__(self) -> None:
+        self.calls: list[Any] = []
+
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        self.calls.append(body)
+        inputs = body.get("input") or []
+        return {"data": [{"embedding": [float(len(str(t))), 1.0]} for t in inputs]}
+
+
+def _index_cloud_settings() -> dict[str, Any]:
+    """Cloud index route with TEXT consent granted so willEgress is True."""
+    return {
+        "confirmCloudBudget": False,
+        "providers": [
+            {
+                "id": "openai",
+                "provider": "OpenAI",
+                "kind": "cloud",
+                "baseUrl": "https://example/v1",
+                "model": "text-embedding-3-small",
+                "apiKeys": ["sk-index-key-1234"],
+                "enabled": True,
+                "capabilities": ["text"],
+                "unit": "req",
+            }
+        ],
+        "routing": {"perFunction": {"index": {"provider": "openai", "fallback": []}}},
+        "consent": {"perProvider": {"OpenAI": {"text": True}}},
+    }
+
+
+def _index_svc(tmp_path: Path, spy: _SpyTransport) -> tuple[Services, str]:
+    from media_studio import library as _library
+
+    svc = Services(data_dir=tmp_path / "data", provider=SpyProvider(), embed_transport=spy, now=lambda: _JUN_2026)
+    media = tmp_path / "talk.mp4"
+    media.write_bytes(b"\x00fake")
+    svc.library = _library.Library(svc.data_dir / "library.json", probe_duration=lambda _p: 30.0)
+    vid = svc.library.add(str(media))["id"]
+    project = svc._load_or_create_project(vid)
+    project.data["transcript"] = {
+        "language": "en",
+        "durationSec": 30.0,
+        "segments": [{"start": 0.0, "end": 5.0, "text": "pricing talk"}],
+    }
+    project.save()
+    return svc, vid
+
+
+def _index_ctx() -> RpcContext:
+    events: list[Any] = []
+    jobs = JobRegistry(
+        emit_progress=lambda *_a: None,
+        emit_done=lambda jid, result: events.append(result),
+    )
+    rctx = RpcContext(emit_notification=lambda obj: None, jobs=jobs)
+    rctx.events = events  # type: ignore[attr-defined]
+    return rctx
+
+
+def test_index_build_cloud_run_records_spend(tmp_path: Path) -> None:
+    spy = _SpyTransport()
+    svc, vid = _index_svc(tmp_path, spy)
+    svc.settings.set(_index_cloud_settings())
+    assert svc._spend_ledger().month_to_date() == 0
+    ctx = _index_ctx()
+    svc.index_build({"videoId": vid}, ctx)
+    ctx.jobs.join(timeout=5)
+    assert spy.calls, "consent granted but no cloud egress happened"
+    assert svc._spend_ledger().month_to_date() > 0
+
+
+def test_index_build_hard_cap_refuses_before_egress(tmp_path: Path) -> None:
+    spy = _SpyTransport()
+    svc, vid = _index_svc(tmp_path, spy)
+    settings = _index_cloud_settings()
+    settings.update({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 1})
+    svc.settings.set(settings)
+    svc._spend_ledger().record(9999)
+    with pytest.raises(RpcError, match="monthly spend cap"):
+        svc.index_build({"videoId": vid}, _index_ctx())
+    assert spy.calls == [], "index build egressed despite being over the hard cap"
+
+
+def test_index_search_cloud_query_records_spend(tmp_path: Path) -> None:
+    spy = _SpyTransport()
+    svc, vid = _index_svc(tmp_path, spy)
+    svc.settings.set(_index_cloud_settings())
+    # Build first (also records); then isolate the search-side record.
+    ctx = _index_ctx()
+    svc.index_build({"videoId": vid}, ctx)
+    ctx.jobs.join(timeout=5)
+    after_build = svc._spend_ledger().month_to_date()
+    spy.calls.clear()
+    svc.index_search({"videoId": vid, "query": "pricing talk"}, _index_ctx())
+    assert spy.calls, "search query did not egress"
+    assert svc._spend_ledger().month_to_date() > after_build
+
+
+def test_index_search_hard_cap_refuses_before_egress(tmp_path: Path) -> None:
+    spy = _SpyTransport()
+    svc, vid = _index_svc(tmp_path, spy)
+    svc.settings.set(_index_cloud_settings())
+    # Build under-cap so the index exists, then tighten the cap before searching.
+    ctx = _index_ctx()
+    svc.index_build({"videoId": vid}, ctx)
+    ctx.jobs.join(timeout=5)
+    spy.calls.clear()
+    settings = _index_cloud_settings()
+    settings.update({"enforceMonthlyHardLimit": True, "monthlyHardLimitCents": 1})
+    svc.settings.set(settings)
+    svc._spend_ledger().record(9999)
+    with pytest.raises(RpcError, match="monthly spend cap"):
+        svc.index_search({"videoId": vid, "query": "pricing talk"}, _index_ctx())
+    assert spy.calls == [], "index search egressed despite being over the hard cap"
+
+
+def test_index_search_cache_hit_records_nothing(tmp_path: Path) -> None:
+    spy = _SpyTransport()
+    svc, vid = _index_svc(tmp_path, spy)
+    svc.settings.set(_index_cloud_settings())
+    ctx = _index_ctx()
+    svc.index_build({"videoId": vid}, ctx)
+    ctx.jobs.join(timeout=5)
+    # First search egresses + records; a repeat identical query hits the cache.
+    svc.index_search({"videoId": vid, "query": "repeat me"}, _index_ctx())
+    mtd_after_first = svc._spend_ledger().month_to_date()
+    spy.calls.clear()
+    svc.index_search({"videoId": vid, "query": "repeat me"}, _index_ctx())
+    assert spy.calls == [], "a cached query re-embedded"
+    assert svc._spend_ledger().month_to_date() == mtd_after_first

--- a/sidecar/tests/test_settings_store.py
+++ b/sidecar/tests/test_settings_store.py
@@ -229,6 +229,30 @@ def test_qol_defaults_present_exact(store: SettingsStore) -> None:
     assert out["savePresets"] == {"presets": {}, "active": ""}
 
 
+# --------------------------------------------------------------------------- #
+# WU-spend-cap: monthly cumulative spend-cap settings (additive, default-off)
+# --------------------------------------------------------------------------- #
+def test_spend_cap_defaults_present_and_off(store: SettingsStore) -> None:
+    """The spend-cap keys land OFF/0 so the cap is backward-compatibly disabled."""
+    out = store.get()
+    assert out["monthlySoftLimitCents"] == 0
+    assert out["monthlyHardLimitCents"] == 0
+    assert out["enforceMonthlyHardLimit"] is False
+
+
+def test_spend_cap_keys_are_user_settable(store: SettingsStore) -> None:
+    out = store.set(
+        {
+            "monthlySoftLimitCents": 500,
+            "monthlyHardLimitCents": 2000,
+            "enforceMonthlyHardLimit": True,
+        }
+    )
+    assert out["monthlySoftLimitCents"] == 500
+    assert out["monthlyHardLimitCents"] == 2000
+    assert out["enforceMonthlyHardLimit"] is True
+
+
 def test_export_defaults_exact_acceptance(store: SettingsStore) -> None:
     """Acceptance pin: DEFAULT_SETTINGS['exportDefaults'] is exactly the §spec dict."""
     assert DEFAULT_SETTINGS["exportDefaults"] == {

--- a/sidecar/tests/test_spend_ledger.py
+++ b/sidecar/tests/test_spend_ledger.py
@@ -1,0 +1,172 @@
+"""Unit tests for media_studio.models.spend_ledger (WU-spend-cap, persisted half).
+
+The spend ledger is a month-keyed cumulative cost store persisted as a single
+JSON document under the data root (alongside other persisted state). It records
+each cloud-AI job's actual-or-estimated cost (in integer cents) at completion and
+answers "how much have I spent this month?" so the submission gate can enforce a
+monthly hard cap and warn at a soft cap.
+
+It is small + pure-with-IO (no heavy imports): the clock is injected so the
+month-key derivation is deterministic, and the file round-trips atomically with a
+corrupt/missing fallback to an empty ledger (mirrors SettingsStore).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from media_studio.models.spend_ledger import SpendLedger, month_key
+
+
+class _FakeClock:
+    """A settable monotonic-ish clock: returns the unix seconds it is told to."""
+
+    def __init__(self, value: float) -> None:
+        self.value = value
+
+    def __call__(self) -> float:
+        return self.value
+
+
+# UTC reference points (seconds since epoch).
+# 2026-06-21 00:00:00 UTC -> month "2026-06".
+_JUN_2026 = 1781913600.0
+# 2026-07-01 00:00:00 UTC -> month "2026-07".
+_JUL_2026 = 1782950400.0
+# 2027-01-15 12:00:00 UTC -> month "2027-01".
+_JAN_2027 = 1800100800.0
+
+
+class TestMonthKey:
+    def test_month_key_formats_year_dash_month(self):
+        assert month_key(_JUN_2026) == "2026-06"
+
+    def test_month_key_rolls_into_next_month(self):
+        assert month_key(_JUL_2026) == "2026-07"
+
+    def test_month_key_rolls_into_next_year(self):
+        assert month_key(_JAN_2027) == "2027-01"
+
+
+class TestRecordAndMonthToDate:
+    def test_empty_ledger_month_to_date_is_zero(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        assert ledger.month_to_date() == 0
+
+    def test_record_accumulates_within_a_month(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        ledger.record(150)
+        ledger.record(75)
+        assert ledger.month_to_date() == 225
+
+    def test_record_uses_clock_month_by_default(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        ledger.record(40)
+        assert ledger.month_to_date("2026-06") == 40
+        assert ledger.month_to_date("2026-07") == 0
+
+    def test_record_into_an_explicit_month(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        ledger.record(500, month="2026-07")
+        assert ledger.month_to_date("2026-06") == 0
+        assert ledger.month_to_date("2026-07") == 500
+
+    def test_month_to_date_defaults_to_clock_month(self, tmp_path):
+        clock = _FakeClock(_JUN_2026)
+        ledger = SpendLedger(tmp_path / "spend.json", clock=clock)
+        ledger.record(99)
+        # Advance the clock into July: the June spend no longer counts toward MTD.
+        clock.value = _JUL_2026
+        assert ledger.month_to_date() == 0
+        assert ledger.month_to_date("2026-06") == 99
+
+
+class TestRollover:
+    def test_separate_months_are_isolated(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        ledger.record(100, month="2026-06")
+        ledger.record(250, month="2026-07")
+        assert ledger.month_to_date("2026-06") == 100
+        assert ledger.month_to_date("2026-07") == 250
+
+    def test_record_persists_across_instances(self, tmp_path):
+        path = tmp_path / "spend.json"
+        first = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        first.record(321)
+        reopened = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        assert reopened.month_to_date() == 321
+
+
+class TestPersistenceRobustness:
+    def test_atomic_write_leaves_valid_json(self, tmp_path):
+        path = tmp_path / "spend.json"
+        ledger = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        ledger.record(12)
+        data = json.loads(path.read_text(encoding="utf-8"))
+        assert data["months"]["2026-06"] == 12
+
+    def test_no_temp_file_left_behind(self, tmp_path):
+        path = tmp_path / "spend.json"
+        ledger = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        ledger.record(7)
+        assert not path.with_name(path.name + ".tmp").exists()
+
+    def test_corrupt_file_falls_back_to_empty(self, tmp_path):
+        path = tmp_path / "spend.json"
+        path.write_text("{ this is not json", encoding="utf-8")
+        ledger = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        assert ledger.month_to_date() == 0
+        # And a subsequent record overwrites the corrupt file cleanly.
+        ledger.record(33)
+        assert ledger.month_to_date() == 33
+
+    def test_non_dict_json_falls_back_to_empty(self, tmp_path):
+        path = tmp_path / "spend.json"
+        path.write_text("[1, 2, 3]", encoding="utf-8")
+        ledger = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        assert ledger.month_to_date() == 0
+
+    def test_missing_months_block_is_tolerated(self, tmp_path):
+        path = tmp_path / "spend.json"
+        path.write_text(json.dumps({"version": 1}), encoding="utf-8")
+        ledger = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        assert ledger.month_to_date() == 0
+
+    def test_non_numeric_stored_month_value_is_treated_as_zero(self, tmp_path):
+        path = tmp_path / "spend.json"
+        path.write_text(json.dumps({"months": {"2026-06": "oops"}}), encoding="utf-8")
+        ledger = SpendLedger(path, clock=_FakeClock(_JUN_2026))
+        assert ledger.month_to_date() == 0
+        ledger.record(5)
+        assert ledger.month_to_date() == 5
+
+
+class TestRecordValidation:
+    def test_negative_cost_is_rejected(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        with pytest.raises(ValueError):
+            ledger.record(-1)
+
+    def test_record_coerces_float_cents_to_int(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        ledger.record(10.9)
+        # Truncates toward zero (int()): cents are whole-number money.
+        assert ledger.month_to_date() == 10
+
+    def test_zero_cost_record_is_a_noop_total(self, tmp_path):
+        ledger = SpendLedger(tmp_path / "spend.json", clock=_FakeClock(_JUN_2026))
+        ledger.record(0)
+        assert ledger.month_to_date() == 0
+
+
+class TestDefaultClock:
+    def test_default_clock_is_wall_time(self, tmp_path, monkeypatch):
+        # No injected clock -> the module uses time.time; patch it so the test is
+        # deterministic and the default-arg branch is exercised.
+        import media_studio.models.spend_ledger as mod
+
+        monkeypatch.setattr(mod.time, "time", lambda: _JUN_2026)
+        ledger = SpendLedger(tmp_path / "spend.json")
+        ledger.record(60)
+        assert ledger.month_to_date() == 60


### PR DESCRIPTION
## Summary

Adds a **persisted, month-keyed cumulative spend cap** for cloud-AI egress. The existing per-run budget gate only sizes ONE run; many small approved cloud jobs could accumulate unbounded spend across a month. This closes that gap with a JSON ledger (integer cents, keyed `YYYY-MM`) recorded at job completion, plus soft (warn) and hard (refuse) monthly ceilings, surfaced in the Providers & Keys budget area.

### Backend (`sidecar/`)
- `models/spend_ledger.py` — atomic JSON ledger; corrupt/missing file degrades to empty; injected clock for determinism; UTC month boundary.
- `handlers.py` — single egress chokepoint (`_enforce_egress_gates`) running BOTH the per-run ack gate AND the independent monthly hard cap before any egress; `_record_egress_cost` at completion; `providers.spend` read-only RPC (MTD + caps); non-blocking `spendWarning` on `ai.planJob` when over the soft cap.
- `ai_job.py` — `on_egress` completion hook fired ONLY after a run that actually egressed (not on cache hit / local-only / cancel / error).
- `settings_store.py` — three new settings all default **OFF/0** (`monthlySoftLimitCents` / `monthlyHardLimitCents` / `enforceMonthlyHardLimit`) so an existing install caps nothing until the user opts in (backward compatible).

### Renderer (`app/`)
- `SpendCap.tsx` + `spendCap.css` + `spendCapLogic.ts` — Monthly spend cap control in Providers & Keys: month-to-date readout, progress meter (role="meter", warn/blocked zones conveyed by text+icon not hue-only), soft/hard dollar inputs, enforce-hard toggle.
- `lib/rpc.ts` — `SpendInfo` type + `providers.spend()`.

## Adversarial verification
- **Hard cap REFUSES** a would-exceed cloud run (raises before egress), even when a per-run budget ack is present; enforced on `index.build`/`index.search` paths too; never refuses a local-only run; 0 cap treated as unconfigured.
- **Soft cap WARNS** (non-blocking) when projected MTD exceeds the soft limit; absent when under / disabled / local-only.
- **Default-off is backward compatible** — an unconfigured install caps and warns nothing (still records spend for the readout).
- **UI shows MTD + caps** — confirmed rendered.

## Test plan
- [x] Sidecar: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` — 4015 passed, **100% line+branch**.
- [x] Renderer: `vitest run --coverage` — 1653 passed, **100% statements/branches/functions/lines**.
- [x] Pre-commit (`ruff` lint+format, `oxlint`, `biome-format`, `gitleaks`) — all pass, no auto-fixes.
- [x] Diff vs main reviewed — no test-weakening (only additive tests; the 3 changed pre-existing test lines wire the new `spendClient` prop).
