### PR TITLE
docs: plug-and-play README + v0.1.0 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to Reframe — Media Studio are documented here.
+This project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.1.0] — 2026-06-25
+
+First public release: a plug-and-play, local-first Windows desktop video studio that turns
+long videos into shorts. Download the NSIS installer or portable zip from the
+[Releases page](https://github.com/Prekzursil/Reframe/releases) — Python, ffmpeg, and the
+render engine are bundled, and first run sets up the rest automatically (offline thereafter).
+
+### Highlights
+
+- **AI Provider Hub** — one shared AI substrate for the whole app: a curated, capability-aware
+  model catalog; provider / API-key management; **multi-key auto-rotation** so jobs don't
+  stall on a free-tier `429`; live per-key usage bars; and a single **AI-Job envelope** that
+  gates every cloud call behind explicit consent and a budget. Local models are always the
+  always-available fallback; keys stay on your machine and are never logged.
+- **Five feature bundles** built on the Hub:
+  - **Prompt-driven editing (Director)** — describe an edit, review the storyboard / diff and
+    its cost, then apply real ffmpeg op-engines (reframe, zoom/pan, retime, overlay,
+    lower-third, remove fillers, translate captions, export).
+  - **Repurpose** — batch many sources through one aggregate job, save reusable templates +
+    per-platform export presets (TikTok / Reels / Shorts), and resume after an app restart.
+  - **Intelligence** — clip recommendations, best-frame thumbnails, and local-first semantic
+    search over your library (cloud only with per-data-type consent).
+  - **Editing-refine** — caption-cue remapping after silence-trim and related editing
+    refinements.
+  - **UX quality-of-life** — readiness rollups, onboarding, job-queue and consent affordances.
+- **UI redesign + tabbed navigation** — top-level ARIA tablist:
+  **Library · Create · Director · Repurpose · Settings**, with the per-video Workspace nested
+  under Library (#231).
+- **Providers & Keys panel** — add / redact API keys, capability + cost badges, per-key live
+  usage bars, and per-data-type consent toggles, all in one place (#231).
+- **Monthly cumulative spend cap** — a persisted, month-keyed (UTC) cumulative cost ledger in
+  integer cents under the data root; soft/hard caps wired into every cloud-AI egress path so
+  many small approved runs can't quietly add up. The hard cap refuses egress past the limit
+  (#232).
+- **8 audit bug fixes** shipped with the redesign and follow-ups, including: caption-cue
+  remap after silence-trim, enforced offline on cloud-AI egress, sidecar exit/error listener
+  race guard, race-safe job-store writes, embedder raw-key fix (was redacted → cloud 401),
+  reframe auto-engine WSL-absent fallback to claudeshorts, transcribe device/model auto-detect
+  + CPU fallback, and Director text-consent gating of the edit plan (no transcript leak).
+- **Test harness** — strict 100% line+branch coverage everywhere (sidecar and renderer) under
+  one deterministic `quality` CI gate, plus a permanent **opt-in** E2E suite
+  (real-pipeline + AI + GUI) that runs nightly / on demand without gating PRs.
+
+### Packaging
+
+- Two Windows x64 artifacts: an **NSIS installer** (`.exe`) and a **portable zip**.
+- Slim download (Electron app + bundled CPython 3.12 / 3.14 + ffmpeg + the Remotion render
+  engine); heavy ML wheels and chosen models install on first run into `%APPDATA%\media-studio`
+  (resumable + checksummed). No external prerequisites.
+
+### Known caveats (honest)
+
+- **First run downloads a few GB** of ML wheels + the models you enable; budget time and disk.
+  The app is fully offline only **after** that first-run setup.
+- **GPU is optional** — an NVIDIA GPU + CUDA accelerates transcription, the vision stack, and
+  Chatterbox voice-clone TTS; without one, everything still runs on CPU (slower).
+- **9:16 reframe** uses WSL2 / MediaPipe (verthor) for best quality and auto-falls back to the
+  in-process claudeshorts reframer when WSL2 is absent.
+- Windows x64 only in this release.

--- a/README.md
+++ b/README.md
@@ -1,23 +1,78 @@
 # Reframe — Media Studio
 
-**A local-first desktop video editor that turns long videos into shorts.** Manage your
-videos and do AI things to them — make vertical 9:16 shorts (the star), transcribe,
-generate/edit/translate subtitles, dub, caption, stabilize shaky footage, mix/duck audio,
-trim dead air, detect speakers, and convert formats. Runs **offline** with local models
-(faster-whisper + Qwen3-4B via llama.cpp); an optional cloud key buys higher quality when
-you want it. **No accounts, no telemetry, no cloud dependency.**
+**A local-first desktop video studio that turns long videos into shorts.** Manage your
+library, then do AI things to your footage: make vertical 9:16 shorts (the star),
+prompt-driven edits, batch repurposing, transcribe, generate / edit / translate subtitles,
+dub, caption, stabilize shaky footage, mix / duck audio, trim dead air, detect speakers,
+score moments, and convert formats. Runs **offline** with local models
+(faster-whisper + Qwen3-4B via llama.cpp); optional cloud API keys buy higher quality and
+multimodal models when you want them. **No accounts, no telemetry, no cloud dependency.**
 
-> Reframe ships in two forms from one engine: this **local desktop app** (the focus), and a
-> future **hosted platform** (an OpusClip-style paid service) that reuses the same Python
-> engine behind a SaaS layer. The platform prototype is preserved on the `prototype/hosted-platform`
-> branch + the `snapshot-saas-2026-06-16` tag.
+> **Plug and play.** Download one file from
+> [**Releases**](https://github.com/Prekzursil/Reframe/releases), run it, and the app does
+> its own first-run setup. Python, ffmpeg, and the render engine are **bundled** — there are
+> **no prerequisites to install** by hand.
 
-## What it does
+---
+
+## Download & install (plug-and-play)
+
+Grab the latest from the [**Releases page**](https://github.com/Prekzursil/Reframe/releases)
+and pick one:
+
+| Asset | What it is |
+|-------|------------|
+| `media-studio-0.1.0-win-x64.exe` | **NSIS installer** — double-click, choose an install dir, get a Start-menu / desktop shortcut ("Reframe - Media Studio"). |
+| `media-studio-0.1.0-win-x64.zip` | **Portable** — unzip anywhere and run `Reframe - Media Studio.exe`. No install, no admin. |
+
+**First run does the rest automatically.** The download is **slim** (the app + a bundled
+CPython + ffmpeg + the render engine). On first launch the app downloads the heavier pieces
+(ML wheels and the local models you choose) into your user data dir
+(`%APPDATA%\media-studio`) — resumable and checksummed. Budget a **few GB** of one-time
+download depending on which models you enable. **After that it works fully offline.**
+
+You **do not** need Python, Node, ffmpeg, CUDA, or any toolchain installed — everything the
+app needs to run is in the package or fetched on first run.
+
+---
+
+## The app: a Hub + 5 AI feature bundles, in a tabbed UI
+
+Reframe is one **AI Provider Hub** (the shared substrate) with **five feature bundles** built
+on top, surfaced through a clean top-level **tabbed** interface.
+
+**The Hub** owns everything AI: a curated, capability-aware **model catalog**, **provider /
+API-key management**, **multi-key auto-rotation** (jobs don't stall on a free-tier `429`),
+live **usage bars**, and one **AI-Job envelope** that gates every cloud call behind explicit
+**consent** and a **budget / spend cap**. Local models are always the fallback. The five
+bundles — **prompt-driven editing (Director)**, **repurpose**, **intelligence**,
+**editing-refine**, and **UX quality-of-life** — all plug into this one substrate, so there
+is exactly one place to manage keys, cost, and privacy.
+
+### The tabs
+
+| Tab | What it's for |
+|-----|---------------|
+| **Library** | Your video library home. Add videos; open one to drill into its per-video **Workspace** (transcribe, caption, reframe, stabilize, audio, export…). |
+| **Create** | The short-maker. LLM moment-selection → boundary-snap → cut → vertical 9:16 reframe → captions → export, with the global generated-Shorts gallery. |
+| **Director** | Prompt-driven AI video editing: describe an edit, review the storyboard / diff and its cost, then apply real ffmpeg op-engines (reframe, zoom/pan, retime, overlay, lower-third, remove fillers, translate captions, export). |
+| **Repurpose** | Batch / template / export-preset surface: point a pipeline at many sources, run one aggregate job, resume after a restart, fan out per-platform (TikTok / Reels / Shorts) presets. |
+| **Settings** | Sub-navigated: **Models & System** (pick / download models, hardware tiers, paths), **Providers & Keys** (add / redact API keys, per-key usage bars, consent toggles, **monthly spend cap**), and **System Health** diagnostics. |
+
+**Providers & Keys + spend cap.** Keys live **only on your machine** — never transmitted
+anywhere but the owning provider, never logged. A persisted, month-keyed **cumulative spend
+cap** tracks cloud-AI cost across runs and **hard-blocks** further cloud egress once you hit
+your limit, so many small approved runs can't quietly add up.
+
+---
+
+## Features
 
 | Area | Features |
 |------|----------|
 | **Short-maker** (the star) | LLM moment-selection → boundary-snap → cut → vertical reframe → captions → export; subtle zoom/punch-in; brand-logo overlay; virality scoring + a feedback flywheel |
 | **Reframe** | 9:16 auto-reframe via **verthor** (WSL2/MediaPipe) with an automatic in-sidecar **claudeshorts** (OpenCV/MediaPipe) fallback |
+| **Director** | prompt-driven edits → storyboard/diff + cost preview → real ffmpeg op-engines |
 | **Stabilize** *(differentiator)* | camera-shake removal via ffmpeg **vidstab** 2-pass — something OpusClip & peers don't do |
 | **Audio** | A/V mix + sidechain **auto-duck** + EBU R128 loudnorm; **silence-trim** dead-air removal |
 | **Captions / Subtitles** | generate / edit / translate; **bilingual stacked** subtitles; libass + Remotion karaoke styles; emphasis + Netflix CPS/CPL timing |
@@ -26,6 +81,25 @@ you want it. **No accounts, no telemetry, no cloud dependency.**
 | **Timeline / Export** | per-video workspace; **EDL/CSV NLE export** (Premiere/DaVinci); **package-for-upload** ZIP |
 | **Intelligence** | **clip recommendations** (rank moments to turn into shorts); **best-frame thumbnails** (auto-pick the strongest frame); **semantic search** over your library (local-first embeddings, cloud only with per-data-type consent) |
 | **Pipelines** | saved multi-step **recipes** run in one shot; **system health** diagnostics |
+
+---
+
+## System requirements (honest)
+
+- **OS:** Windows **x64** (Windows 10/11). This release ships Windows installers only.
+- **CPU / RAM:** any modern 64-bit machine runs the app and the CPU pipeline; transcription
+  and the local LLM are noticeably faster with more cores / RAM.
+- **GPU (optional, recommended):** an **NVIDIA GPU + CUDA** accelerates transcription, the
+  vision stack, and **Chatterbox** voice-clone TTS. Without a GPU everything still works on
+  **CPU** (slower) — there is always a CPU fallback.
+- **9:16 reframe:** the high-quality **verthor** path uses **WSL2 / MediaPipe**; if WSL2 is
+  absent the app **auto-falls back** to the in-process **claudeshorts** reframer — no setup
+  required either way.
+- **Disk / network:** ~**a few GB** of one-time first-run download for ML wheels + the models
+  you enable (into `%APPDATA%\media-studio`). **Offline after** the first-run setup.
+- **No toolchain needed:** Python, ffmpeg, and the render engine are bundled.
+
+---
 
 ## Architecture
 
@@ -37,12 +111,18 @@ you want it. **No accounts, no telemetry, no cloud dependency.**
   PySceneDetect (scene cuts). Models are downloaded on demand to the app data dir (never committed).
 - **Contract:** [`CONTRACTS.md`](CONTRACTS.md) is the frozen interface.
 
+> Reframe ships from one engine in two forms: this **local desktop app** (the focus), and a
+> future **hosted platform** (an OpusClip-style paid service) that reuses the same Python
+> engine behind a SaaS layer. The platform prototype is preserved on the
+> `prototype/hosted-platform` branch + the `snapshot-saas-2026-06-16` tag.
+
 ## Quality
 
 A single lean, deterministic **`quality`** gate (one CI check) enforces: Ruff (lint+format),
 Oxlint + Biome (JS/TS), tsc + basedpyright (types), **strict 100% line+branch coverage
 everywhere** (sidecar **and** renderer), Opengrep (SAST), gitleaks (secrets), and osv-scanner
-(deps). See [`QUALITY-CHARTER.md`](QUALITY-CHARTER.md).
+(deps). See [`QUALITY-CHARTER.md`](QUALITY-CHARTER.md). A separate **opt-in** E2E suite
+(real-pipeline + AI + GUI) runs nightly / on demand and does not gate PRs.
 
 ## Develop
 
@@ -53,3 +133,10 @@ cd sidecar && python -m venv .venv && .venv/Scripts/pip install -e ".[dev]" && .
 # app (Node 20)
 cd app && npm install && npm run dev
 ```
+
+Building the Windows installers (NSIS `.exe` + portable `.zip`) is a multi-step,
+network-fetching build documented at the top of [`electron-builder.yml`](electron-builder.yml).
+Built artifacts land in `installers/` (gitignored — binaries are never committed; they ship
+via GitHub Releases).
+
+See [`CHANGELOG.md`](CHANGELOG.md) for release history.


### PR DESCRIPTION
## Summary
Plug-and-play release docs for v0.1.0.

- **README** rewritten as a download-and-run guide: install from Releases (NSIS .exe or portable .zip), automatic first-run model/dep setup, bundled Python (no prereqs), the Hub + 5 AI feature bundles, the tabbed UI (Library/Create/Director/Repurpose/Settings incl. Providers & Keys + monthly spend cap), and honest system requirements (Windows x64; optional NVIDIA GPU; ~few GB first-run download; offline after).
- **CHANGELOG.md** added: v0.1.0 highlights — Hub, 5 bundles, UI redesign + tabs, Providers & Keys, monthly spend cap, 8 audit bug fixes, and the test harness.

## Scope
Docs only — no app code, no bundle contents change. The `quality` gate (the gating check) is unaffected.

## Test plan
- [x] Scoped commit (README.md + CHANGELOG.md only), LF, no `--no-verify`
- [ ] `quality` CI green (gating)