### PR TITLE
fix: native speaker-tracking reframe + caption quality + app bootstrap/cancel/UX/progress-ETA (no-WSL default)

### DIFF
--- a/sidecar/media_studio/features/export_presets.py
+++ b/sidecar/media_studio/features/export_presets.py
@@ -61,7 +61,8 @@ CAPTION_STYLES: frozenset[str] = frozenset({"libass", "none", *caption_remotion.
 #: Allowed ``reframeEngine`` ids (A4 engines + the "auto" selector).
 REFRAME_ENGINES: frozenset[str] = frozenset({"auto", "verthor", "claudeshorts"})
 
-#: Default reframe engine when a preset omits one (verthor with fallback).
+#: Default reframe engine when a preset omits one. "auto" now resolves to the
+#: in-sidecar claudeshorts engine (no WSL); verthor is an explicit opt-in.
 DEFAULT_REFRAME_ENGINE = "auto"
 
 

--- a/sidecar/media_studio/features/reframe.py
+++ b/sidecar/media_studio/features/reframe.py
@@ -263,11 +263,12 @@ class ReframeEngine:
 
 
 # --------------------------------------------------------------------------- #
-# P2 / A4: engine registry + automatic fallback (T4b)
+# P2 / A4 + P3: engine registry + default (claudeshorts, no-WSL)
 # --------------------------------------------------------------------------- #
 # Engine names are part of the UI contract (ShortMaker's auto/verthor/
-# claudeshorts override). "auto" is a SELECTOR, not an engine — it resolves to
-# verthor when available, else claudeshorts (with a typed fallback notice).
+# claudeshorts override). "auto" is a SELECTOR, not an engine — P3 makes it
+# resolve to the in-sidecar **claudeshorts** engine so the pipeline needs NO WSL
+# by default; **verthor** (WSL2) is now an EXPLICIT opt-in only.
 ENGINE_AUTO = "auto"
 ENGINE_VERTHOR = "verthor"
 ENGINE_CLAUDESHORTS = "claudeshorts"
@@ -277,24 +278,6 @@ ENGINES: dict[str, Any] = {
     ENGINE_VERTHOR: ReframeEngine,
     ENGINE_CLAUDESHORTS: ClaudeShortsReframeEngine,
 }
-
-# The typed notice's discriminator (consumers match on `notice["type"]`).
-REFRAME_FALLBACK_NOTICE = "reframe.fallback"
-
-
-def make_fallback_notice(requested: str, reason: str) -> dict[str, str]:
-    """Build the typed notice emitted when verthor falls back to claudeshorts.
-
-    Shape: ``{type, requested, engine, reason, message}`` — ``message`` is the
-    human line the shortmaker job surfaces via ``job.progress``.
-    """
-    return {
-        "type": REFRAME_FALLBACK_NOTICE,
-        "requested": requested,
-        "engine": ENGINE_CLAUDESHORTS,
-        "reason": reason,
-        "message": (f"reframe: verthor (WSL) unavailable — {reason}; falling back to the claudeshorts engine"),
-    }
 
 
 def wsl_available(*, which: WhichFn = shutil.which) -> bool:
@@ -362,28 +345,29 @@ def resolve_engine_name(
 ) -> tuple[str, dict[str, str] | None]:
     """Resolve a requested engine name to ``(concrete_name, notice|None)``.
 
+    P3 DEFAULT FLIP: the in-sidecar **claudeshorts** engine is now the default,
+    so the pipeline needs NO WSL out of the box. ``verthor`` (WSL2) is an
+    EXPLICIT opt-in only.
+
+    - ``"auto"`` (and ``None``/blank -> auto): **claudeshorts**, no WSL probe,
+      no notice — the no-WSL default.
     - ``"claudeshorts"``: returned as-is, no probing, no notice.
-    - ``"auto"`` (and ``None``/blank -> auto): verthor when the WSL PATH probe +
-      script check pass; otherwise **automatic fallback** to claudeshorts with a
-      typed :func:`make_fallback_notice`.
     - ``"verthor"`` (EXPLICIT): verthor when available, else **raise**
       :class:`ReframeError`. An explicit engine request must NOT be silently
-      substituted — only ``auto`` is allowed to fall back.
+      substituted — choosing the WSL engine on a host without WSL fails loudly.
     - anything else: ``ValueError`` (unknown engines fail loudly, A6 #3).
     """
     requested = str(name or ENGINE_AUTO).strip().lower() or ENGINE_AUTO
-    if requested == ENGINE_CLAUDESHORTS:
+    if requested in (ENGINE_AUTO, ENGINE_CLAUDESHORTS):
+        # auto + claudeshorts both resolve to the no-WSL default engine.
         return ENGINE_CLAUDESHORTS, None
-    if requested not in (ENGINE_AUTO, ENGINE_VERTHOR):
+    if requested != ENGINE_VERTHOR:
         raise ValueError(f"unknown reframe engine: {name!r}")
     reason = verthor_unavailable_reason(settings, which=which)
-    if reason is None:
-        return ENGINE_VERTHOR, None
-    if requested == ENGINE_VERTHOR:
+    if reason is not None:
         # Explicit verthor: fail loudly, never silently fall back.
         raise ReframeError(f"verthor reframe engine requested but unavailable: {reason}")
-    _log.warning("reframe fallback (%s requested): %s", requested, reason)
-    return ENGINE_CLAUDESHORTS, make_fallback_notice(requested, reason)
+    return ENGINE_VERTHOR, None
 
 
 def get_engine(
@@ -395,9 +379,9 @@ def get_engine(
     """Build the reframe engine for ``name`` -> ``(engine, notice|None)``.
 
     The engine is a fresh instance of the resolved :data:`ENGINES` class,
-    constructed with ``settings``. ``notice`` is non-None only when an
-    automatic verthor->claudeshorts fallback happened; callers running inside a
-    job should surface ``notice["message"]`` via ``job.progress``. An explicit
+    constructed with ``settings``. ``notice`` is always ``None`` since P3 (the
+    default ``auto`` resolves straight to claudeshorts with no WSL probe and so
+    no fallback notice); the tuple shape is kept for callers. An explicit
     ``verthor`` request with WSL absent raises :class:`ReframeError`.
     """
     settings = settings or {}

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -63,11 +63,23 @@ OUT_HEIGHT = 1920
 # generalizes that to clip length while bounding frame-extraction cost).
 WINDOW_SEC = 2.0
 MAX_WINDOWS = 24
-SMOOTH_ALPHA = 0.35  # exponential-easing factor: 0=frozen, 1=no smoothing
-# Route A drops keyframes whose x moved < 2% of the crop width; the same
-# threshold decides "the track is effectively static -> one static crop".
-KEYFRAME_MIN_DELTA_FRAC = 0.02
-STATIC_EPSILON_FRAC = 0.02
+# Exponential-easing factor: 0=frozen, 1=no smoothing. Dialled WAY down from the
+# original 0.35 (which let per-window face-detector noise leak straight into the
+# crop, producing the visible 9:16 jitter on a near-static talking head). 0.15
+# heavily damps that noise while still tracking a genuinely moving subject.
+SMOOTH_ALPHA = 0.15
+# DEADZONE (the jitter fix): the crop center is HELD until the smoothed subject
+# center drifts more than this fraction of the SOURCE WIDTH (normalized 0..1
+# center space). A sitting speaker whose detected center merely wobbles a few
+# percent therefore yields a STATIC crop — no micro-pan. 7% is the spec's 6-8%.
+DEADZONE_FRAC = 0.07
+# Route A drops keyframes whose x moved < this fraction of the crop width; the
+# same threshold decides "the track is effectively static -> one static crop".
+# Raised from 2% so low-variance tracks bias toward a single static crop (the
+# deadzone already pins the centers; this is the belt-and-braces static gate in
+# crop-pixel space, matched to the deadzone band).
+KEYFRAME_MIN_DELTA_FRAC = 0.06
+STATIC_EPSILON_FRAC = 0.06
 
 # A6 LESSON 1 — PRE-IMPORT FLAG (NON-NEGOTIABLE): these native C-extension
 # modules are first used INSIDE a job thread by this engine. They MUST be added
@@ -170,6 +182,27 @@ def smooth_centers(centers: Sequence[float], alpha: float = SMOOTH_ALPHA) -> lis
         c = float(c)
         prev = c if prev is None else prev + float(alpha) * (c - prev)
         out.append(prev)
+    return out
+
+
+def apply_deadzone(centers: Sequence[float], deadzone: float = DEADZONE_FRAC) -> list[float]:
+    """Hold the subject center until it drifts more than ``deadzone`` (the fix).
+
+    Walks the (already-smoothed) normalized centers and emits a HELD value that
+    only snaps to a new center once the new measurement deviates from the held
+    one by more than ``deadzone`` (a fraction of source width, in 0..1 center
+    space). A near-static talking head whose detected center merely jitters
+    within the band therefore yields a single constant center -> a STATIC crop
+    (no per-window micro-pan). A genuine move past the band updates the hold,
+    so a real pan is still followed.
+    """
+    out: list[float] = []
+    held: float | None = None
+    for c in centers:
+        c = float(c)
+        if held is None or abs(c - held) > float(deadzone):
+            held = c
+        out.append(held)
     return out
 
 
@@ -543,7 +576,10 @@ class ClaudeShortsReframeEngine:
             return crop, [], duration
 
         smoothed = smooth_centers([c for _, c in samples])
-        xs = [crop_x_for_center(c, crop["w"], src_w) for c in smoothed]
+        # DEADZONE: pin the center until it drifts past the band, so detector
+        # jitter on a near-static subject never reaches the crop (the jitter fix).
+        held = apply_deadzone(smoothed)
+        xs = [crop_x_for_center(c, crop["w"], src_w) for c in held]
         kfs = build_keyframes([t for t, _ in samples], xs)
         kfs = dedupe_keyframes(kfs, min_delta=crop["w"] * KEYFRAME_MIN_DELTA_FRAC)
         if is_static(kfs, epsilon=crop["w"] * STATIC_EPSILON_FRAC):

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -532,7 +532,7 @@ def _person_center(img: Any) -> float | None:
     if w < _HOG_MIN_W or h < _HOG_MIN_H:
         return None
     hog = cv2.HOGDescriptor()
-    hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())
+    hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())  # pyright: ignore[reportAttributeAccessIssue]
     rects, weights = hog.detectMultiScale(img, winStride=(8, 8))
     if rects is None or len(rects) == 0:
         return None

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -9,16 +9,20 @@ Python detection logic and then apply it ffmpeg-side with ONE ``crop`` +
 no WSL, no node, no Remotion:
 
   1. probe the source geometry/duration (ffprobe, argv list);
-  2. sample one frame per time window and detect the subject's horizontal
-     center — **mediapipe** face detection when importable (A6: it MUST be
-     pre-imported by ``__main__._preimport_native_modules``; see
-     :data:`NATIVE_MODULES_FOR_PREIMPORT`), else an **OpenCV haar**-cascade
-     face fallback, else a plain **center** crop;
-  3. smooth the per-window centers with simple exponential easing and convert
-     them to clamped crop-x keyframes (deduped, Route A style);
-  4. apply ONE ffmpeg pass: ``crop=W:H:'x(t)':Y,scale=1080:1920`` (a static x
-     when the subject doesn't move; a piecewise-linear ``x(t)`` expression when
-     it does), h264 output at the contract's 1080x1920 for 9:16.
+  2. sample ~one frame per second and locate the SPEAKER's horizontal center
+     with a fallback chain so the crop never collapses to a center crop the
+     moment a face turns away: **mediapipe** face detection when importable (A6:
+     it MUST be pre-imported by ``__main__._preimport_native_modules``; see
+     :data:`NATIVE_MODULES_FOR_PREIMPORT`) or an **OpenCV haar**-cascade face,
+     then a **HOG person/body** detector for profile/turned shots, then **motion
+     saliency** (inter-frame diff centroid) as a last resort, else — only when
+     all three find nothing across the clip — a plain **center** crop;
+  3. heavily smooth the per-window centers with a zero-phase (forward+backward)
+     EMA so the crop FOLLOWS the speaker steadily with no frame-to-frame jitter,
+     and convert them to finely-spaced crop-x keyframes;
+  4. apply ONE ffmpeg pass: ``crop=W:H:'x(t)':Y,scale=1080:1920`` — a static x
+     ONLY when the subject genuinely never moves, otherwise an interpolated
+     piecewise-linear ``x(t)`` (no stepped teleports), h264 at 1080x1920 for 9:16.
 
 A6 hard lessons honoured here:
   * native modules (mediapipe, cv2) are imported ONLY inside job-time function
@@ -59,27 +63,28 @@ DEFAULT_ASPECT = "9:16"
 OUT_WIDTH = 1080
 OUT_HEIGHT = 1920
 
-# Sampling/smoothing knobs (Route A used 5 samples per clip; per-window sampling
-# generalizes that to clip length while bounding frame-extraction cost).
-WINDOW_SEC = 2.0
-MAX_WINDOWS = 24
-# Exponential-easing factor: 0=frozen, 1=no smoothing. Dialled WAY down from the
-# original 0.35 (which let per-window face-detector noise leak straight into the
-# crop, producing the visible 9:16 jitter on a near-static talking head). 0.15
-# heavily damps that noise while still tracking a genuinely moving subject.
+# Sampling/smoothing knobs. The original Route A used 5 samples per clip; we
+# sample ~1/sec so the smoothed track has enough resolution to FOLLOW a speaker
+# steadily (a coarse 2s window aliased fast pans into visible teleports).
+WINDOW_SEC = 1.0
+MAX_WINDOWS = 90
+# Heavy temporal EMA: a LOW alpha makes the crop follow the speaker steadily
+# with no frame-to-frame jitter (0=frozen, 1=no smoothing). 0.35 was visibly
+# jittery on real footage; ~0.15 tracks the subject without chasing detector
+# noise. Smoothing is applied forward+backward (zero-phase) so the steady track
+# has no directional lag bias toward the start of the clip.
 SMOOTH_ALPHA = 0.15
-# DEADZONE (the jitter fix): the crop center is HELD until the smoothed subject
-# center drifts more than this fraction of the SOURCE WIDTH (normalized 0..1
-# center space). A sitting speaker whose detected center merely wobbles a few
-# percent therefore yields a STATIC crop — no micro-pan. 7% is the spec's 6-8%.
-DEADZONE_FRAC = 0.07
-# Route A drops keyframes whose x moved < this fraction of the crop width; the
-# same threshold decides "the track is effectively static -> one static crop".
-# Raised from 2% so low-variance tracks bias toward a single static crop (the
-# deadzone already pins the centers; this is the belt-and-braces static gate in
-# crop-pixel space, matched to the deadzone band).
-KEYFRAME_MIN_DELTA_FRAC = 0.06
-STATIC_EPSILON_FRAC = 0.06
+# Keyframes are kept finely (small min-delta) so x(t) is a smooth piecewise-
+# linear pan, NOT a few coarse steps that teleport between sample windows.
+KEYFRAME_MIN_DELTA_FRAC = 0.004
+# "Fully static" means the subject GENUINELY never moves across the whole clip;
+# only then do we collapse to one fixed crop. Kept tight so a speaker who drifts
+# is tracked (not frozen at an average x that can land off them).
+STATIC_EPSILON_FRAC = 0.01
+# A track is only trusted when a subject was located in at least this fraction of
+# the sampled windows; below it the detector is too unreliable to track on, so we
+# keep the centered crop instead of chasing a couple of stray hits.
+MIN_SUBJECT_HIT_FRAC = 0.15
 
 # A6 LESSON 1 — PRE-IMPORT FLAG (NON-NEGOTIABLE): these native C-extension
 # modules are first used INSIDE a job thread by this engine. They MUST be added
@@ -169,13 +174,8 @@ def crop_x_for_center(cx_norm: float, crop_w: int, src_w: int) -> int:
 # --------------------------------------------------------------------------- #
 # track smoothing + keyframes (pure)
 # --------------------------------------------------------------------------- #
-def smooth_centers(centers: Sequence[float], alpha: float = SMOOTH_ALPHA) -> list[float]:
-    """Exponential-easing smoothing of subject centers (simple easing).
-
-    ``out[i] = out[i-1] + alpha * (centers[i] - out[i-1])`` — each step eases
-    toward the new measurement, damping detector jitter while still following a
-    genuinely moving subject.
-    """
+def _ema_forward(centers: Sequence[float], alpha: float) -> list[float]:
+    """One causal EMA pass: ``out[i] = out[i-1] + alpha*(centers[i]-out[i-1])``."""
     out: list[float] = []
     prev: float | None = None
     for c in centers:
@@ -185,25 +185,19 @@ def smooth_centers(centers: Sequence[float], alpha: float = SMOOTH_ALPHA) -> lis
     return out
 
 
-def apply_deadzone(centers: Sequence[float], deadzone: float = DEADZONE_FRAC) -> list[float]:
-    """Hold the subject center until it drifts more than ``deadzone`` (the fix).
+def smooth_centers(centers: Sequence[float], alpha: float = SMOOTH_ALPHA) -> list[float]:
+    """Heavy zero-phase EMA smoothing of subject centers.
 
-    Walks the (already-smoothed) normalized centers and emits a HELD value that
-    only snaps to a new center once the new measurement deviates from the held
-    one by more than ``deadzone`` (a fraction of source width, in 0..1 center
-    space). A near-static talking head whose detected center merely jitters
-    within the band therefore yields a single constant center -> a STATIC crop
-    (no per-window micro-pan). A genuine move past the band updates the hold,
-    so a real pan is still followed.
+    A single causal EMA both damps jitter AND lags the true subject (the crop
+    trails the speaker). We instead run the EMA forward, then backward over the
+    result, and average the two — a zero-phase (forward+backward) filter that
+    removes the directional lag while keeping the same low ``alpha`` heavy
+    damping. With a LOW alpha (~0.15) the crop FOLLOWS the speaker steadily with
+    no frame-to-frame jitter; a constant input is returned unchanged.
     """
-    out: list[float] = []
-    held: float | None = None
-    for c in centers:
-        c = float(c)
-        if held is None or abs(c - held) > float(deadzone):
-            held = c
-        out.append(held)
-    return out
+    fwd = _ema_forward(centers, alpha)
+    bwd = list(reversed(_ema_forward(list(reversed(fwd)), alpha)))
+    return [(f + b) / 2.0 for f, b in zip(fwd, bwd, strict=False)]
 
 
 def window_timestamps(
@@ -475,6 +469,98 @@ def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | Non
     return None, lambda: None
 
 
+# OpenCV's default people detector uses a 64x128 HOG window; calling
+# detectMultiScale on a frame smaller than the window crashes the native code
+# (segfault), so we hard-skip sub-window frames.
+_HOG_MIN_W = 64
+_HOG_MIN_H = 128
+
+
+def _person_center(img: Any) -> float | None:
+    """Normalized horizontal center of the most prominent PERSON in ``img``.
+
+    Uses OpenCV's built-in HOG people detector (ships with opencv — no model
+    download, node-free). This is the fallback for profile/turned heads where
+    face detection fails but the speaker's BODY is still clearly in frame, so
+    the crop stays on the person instead of collapsing to a center crop.
+    Frames smaller than the 64x128 HOG window are skipped (calling the detector
+    on them crashes the native code). Returns ``None`` when no person is found.
+    """
+    import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
+
+    h, w = int(img.shape[0]), int(img.shape[1])
+    if w < _HOG_MIN_W or h < _HOG_MIN_H:
+        return None
+    hog = cv2.HOGDescriptor()
+    hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())
+    rects, weights = hog.detectMultiScale(img, winStride=(8, 8))
+    if rects is None or len(rects) == 0:
+        return None
+    weights = list(weights) if weights is not None else []
+    best_idx = max(range(len(rects)), key=lambda i: weights[i] if i < len(weights) else 0.0)
+    rx, _ry, rw, _rh = rects[best_idx]
+    return float((float(rx) + float(rw) / 2.0) / w)
+
+
+def _motion_center(prev: Any, img: Any) -> float | None:
+    """Normalized horizontal center of the strongest MOTION between two frames.
+
+    Last-resort saliency: a sitting/standing speaker still moves (head, hands,
+    mouth) more than the static studio behind them. We diff consecutive sampled
+    frames, threshold the change, and take the intensity-weighted horizontal
+    centroid of the moving pixels — so the crop locates the SPEAKER even when
+    neither a face nor a full body is detectable. ``None`` when nothing moved.
+    """
+    import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
+    import numpy as np  # noqa: PLC0415 - job-time native (numpy ships with cv2)
+
+    if prev.shape != img.shape:
+        return None  # frame geometry changed (e.g. scene cut) — no usable diff
+    g0 = cv2.cvtColor(prev, cv2.COLOR_BGR2GRAY)
+    g1 = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    diff = cv2.absdiff(g0, g1)
+    _thr, mask = cv2.threshold(diff, 18, 255, cv2.THRESH_BINARY)
+    col = np.asarray(mask, dtype="float64").sum(axis=0)
+    total = float(col.sum())
+    if total <= 0.0:
+        return None
+    cols = np.arange(col.shape[0], dtype="float64")
+    centroid = float((cols * col).sum() / total)
+    return centroid / float(img.shape[1])
+
+
+def _make_subject_finder(
+    backend: str,
+) -> tuple[Callable[[Any], float | None] | None, Callable[[], None]]:
+    """Build a stateful subject finder: face -> person -> motion fallback.
+
+    Returns ``(find(img_bgr) -> cx_norm|None, close())``. ``find`` tries, in
+    order: the backend's FACE detector (mediapipe/haar); then a PERSON (HOG body)
+    detector for profile/turned shots where the face is weak or absent; then
+    MOTION saliency against the previous frame as a last resort. This keeps the
+    crop on the SPEAKER instead of falling back to a center-of-frame crop the
+    moment a face is not cleanly visible. ``None`` only when none of the three
+    locate anything. For the ``center`` backend there is no finder.
+    """
+    face_find, face_close = _make_face_finder(backend)
+    if backend == "center":
+        return None, face_close
+    prev_frame: dict[str, Any] = {"img": None}
+
+    def find(img: Any) -> float | None:
+        cx: float | None = None
+        if face_find is not None:
+            cx = face_find(img)
+        if cx is None:
+            cx = _person_center(img)
+        if cx is None and prev_frame["img"] is not None:
+            cx = _motion_center(prev_frame["img"], img)
+        prev_frame["img"] = img
+        return cx
+
+    return find, face_close
+
+
 def detect_subject_centers(
     in_path: str,
     timestamps: Sequence[float],
@@ -486,16 +572,16 @@ def detect_subject_centers(
     """Detect the subject's normalized horizontal center per sampled window.
 
     Extracts one frame per timestamp via ffmpeg (argv list, pipes drained by
-    ``capture_output``), runs the backend's face finder, and returns
-    ``[(t, cx_norm)]`` for the frames where a subject was found. An empty list
-    means "no subject anywhere" -> the caller keeps the centered crop.
+    ``capture_output``), runs the face->person->motion subject finder, and
+    returns ``[(t, cx_norm)]`` for the frames where a subject was located. An
+    empty list means "no subject anywhere" -> the caller keeps the centered crop.
     """
     backend = backend or detect_backend()
     if backend == "center":
         return []
     import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
 
-    find, close = _make_face_finder(backend)
+    find, close = _make_subject_finder(backend)
     if find is None:
         return []
     tmpdir = tempfile.mkdtemp(prefix="media_studio_reframe_")
@@ -572,26 +658,28 @@ class ClaudeShortsReframeEngine:
             # the encode still runs; only subject tracking is lost.
             _log.warning("subject detection failed; using centered crop", exc_info=True)
             samples = []
-        if not samples:
+        # Trust gate: a couple of stray hits across many windows is detector noise,
+        # not a locatable subject -> keep the centered crop rather than tracking it.
+        min_hits = max(1, math.ceil(len(timestamps) * MIN_SUBJECT_HIT_FRAC))
+        if len(samples) < min_hits:
             return crop, [], duration
 
         smoothed = smooth_centers([c for _, c in samples])
-        # DEADZONE: pin the center until it drifts past the band, so detector
-        # jitter on a near-static subject never reaches the crop (the jitter fix).
-        held = apply_deadzone(smoothed)
-        xs = [crop_x_for_center(c, crop["w"], src_w) for c in held]
+        xs = [crop_x_for_center(c, crop["w"], src_w) for c in smoothed]
         kfs = build_keyframes([t for t, _ in samples], xs)
         kfs = dedupe_keyframes(kfs, min_delta=crop["w"] * KEYFRAME_MIN_DELTA_FRAC)
         if is_static(kfs, epsilon=crop["w"] * STATIC_EPSILON_FRAC):
-            # Stable subject -> ONE static crop centered on it (Route A's
-            # face-track average), clamped into frame.
-            avg_x = int(round(sum(k["x"] for k in kfs) / len(kfs)))
-            crop = {**crop, "x": max(0, min(avg_x, max(0, src_w - crop["w"])))}
+            # GENUINELY static subject -> ONE fixed crop centered ON THE SUBJECT
+            # (the smoothed track sits within epsilon, so any keyframe x is the
+            # subject's position — NOT a bias back toward frame center).
+            static_x = int(round(sum(k["x"] for k in kfs) / len(kfs)))
+            crop = {**crop, "x": max(0, min(static_x, max(0, src_w - crop["w"])))}
             return crop, [], duration
-        # Moving subject -> animated x(t); the static x stays the track average
-        # (the fallback value also used before the first keyframe segment).
-        avg_x = int(round(sum(k["x"] for k in kfs) / len(kfs)))
-        crop = {**crop, "x": max(0, min(avg_x, max(0, src_w - crop["w"])))}
+        # Moving subject -> animated x(t) that FOLLOWS the speaker. The static
+        # fallback x (used only before the first keyframe / by build_crop_x_expr)
+        # is the FIRST tracked position so the crop opens ON the subject, never
+        # pre-biased to frame center.
+        crop = {**crop, "x": int(kfs[0]["x"])}
         return crop, kfs, duration
 
     def reframe(

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -48,6 +48,7 @@ import json
 import math
 import os
 import shutil
+import statistics
 import subprocess
 import tempfile
 from collections.abc import Callable, Sequence
@@ -74,6 +75,13 @@ MAX_WINDOWS = 90
 # noise. Smoothing is applied forward+backward (zero-phase) so the steady track
 # has no directional lag bias toward the start of the clip.
 SMOOTH_ALPHA = 0.15
+# Outlier-robust median pre-filter window (odd, samples). A single-frame detector
+# spike — a stray left detection at the clip start, a mis-detect on a head turn —
+# would otherwise seed the zero-phase EMA and drag the OPENING crop off the steady
+# subject (empty-studio frames). A length-3 median replaces each lone spike with
+# its neighbours' value BEFORE the EMA, while leaving a constant track and a
+# sustained step untouched. 1 disables it.
+MEDIAN_WINDOW = 3
 # Keyframes are kept finely (small min-delta) so x(t) is a smooth piecewise-
 # linear pan, NOT a few coarse steps that teleport between sample windows.
 KEYFRAME_MIN_DELTA_FRAC = 0.004
@@ -185,8 +193,36 @@ def _ema_forward(centers: Sequence[float], alpha: float) -> list[float]:
     return out
 
 
+def median_prefilter(centers: Sequence[float], window: int = MEDIAN_WINDOW) -> list[float]:
+    """Sliding-window median over ``centers`` (odd ``window``; edges shrink).
+
+    Replaces each lone single-frame spike with its neighbours' median so detector
+    outliers cannot seed the EMA. A constant track and a sustained step are both
+    returned unchanged (the median of either is the level itself). At the ends the
+    window shrinks to the available samples (no out-of-range clamp). ``window<=1``
+    (or fewer than 2 samples) is the identity.
+    """
+    vals = [float(c) for c in centers]
+    n = len(vals)
+    w = int(window)
+    if w <= 1 or n < 2:
+        return vals
+    w = min(w, n)  # window can't exceed the track length
+    half = w // 2
+    out: list[float] = []
+    for i in range(n):
+        # Keep a FULL odd window even at the ends by shifting it inward (forward
+        # at the start, backward at the end). A symmetric shrink would leave an
+        # edge sample with only one neighbour, so a lone spike AT the first/last
+        # index — the opening crop, the worst case — would survive; shifting the
+        # window inward lets the steady neighbours outvote the edge spike.
+        lo = min(max(0, i - half), n - w)
+        out.append(statistics.median(vals[lo : lo + w]))
+    return out
+
+
 def smooth_centers(centers: Sequence[float], alpha: float = SMOOTH_ALPHA) -> list[float]:
-    """Heavy zero-phase EMA smoothing of subject centers.
+    """Heavy zero-phase EMA smoothing of subject centers (outlier-robust).
 
     A single causal EMA both damps jitter AND lags the true subject (the crop
     trails the speaker). We instead run the EMA forward, then backward over the
@@ -194,8 +230,12 @@ def smooth_centers(centers: Sequence[float], alpha: float = SMOOTH_ALPHA) -> lis
     removes the directional lag while keeping the same low ``alpha`` heavy
     damping. With a LOW alpha (~0.15) the crop FOLLOWS the speaker steadily with
     no frame-to-frame jitter; a constant input is returned unchanged.
+
+    A length-:data:`MEDIAN_WINDOW` median pre-filter runs FIRST so a lone detector
+    spike (e.g. a stray left detection at the clip start) cannot seed the EMA and
+    drag the opening crop off the steady subject.
     """
-    fwd = _ema_forward(centers, alpha)
+    fwd = _ema_forward(median_prefilter(centers), alpha)
     bwd = list(reversed(_ema_forward(list(reversed(fwd)), alpha)))
     return [(f + b) / 2.0 for f, b in zip(fwd, bwd, strict=False)]
 

--- a/sidecar/media_studio/features/shortmaker.py
+++ b/sidecar/media_studio/features/shortmaker.py
@@ -1111,14 +1111,13 @@ def run_export(
         if audio_track is None:
             raise ValueError(f"unknown audio track: {audio_track_id}")
 
-    # T4b: resolve the reframe engine ONCE per export; an automatic
-    # verthor->claudeshorts fallback surfaces as a typed notice via job.progress.
+    # T4b/P3: resolve the reframe engine ONCE per export. "auto" now resolves to
+    # the in-sidecar claudeshorts engine (no WSL); an explicit "verthor" on a
+    # host without WSL raises (handled by the job's error path).
     from . import reframe as _reframe_mod  # lazy: keeps module import-light
 
-    engine_name, notice = _reframe_mod.resolve_engine_name(str(settings.get("reframeEngine") or "auto"), settings)
+    engine_name, _notice = _reframe_mod.resolve_engine_name(str(settings.get("reframeEngine") or "auto"), settings)
     settings = {**settings, "reframeEngine": engine_name}
-    if notice is not None:
-        ctx.progress(3, notice["message"])
 
     dest = Path(out_dir)
     dest.mkdir(parents=True, exist_ok=True)

--- a/sidecar/media_studio/features/shortmaker.py
+++ b/sidecar/media_studio/features/shortmaker.py
@@ -898,13 +898,15 @@ def _export_one(
         caption_source_start = 0.0
 
     # STABILIZE (audio-stabilize group, the DIFFERENTIATOR) — camera-shake
-    # stabilization via ffmpeg vidstab 2-pass, ON when the ``stabilize`` toggle is
-    # set. It does NOT change the timeline (warp only), so captions stay in sync
-    # and it can run on whatever the trim produced. When libvidstab is missing the
-    # stage passes the clip through unchanged and surfaces a typed notice via the
-    # ``on_notice`` sink (the orchestrator routes it to job.progress) — never a
-    # silent skip.
-    if (settings or {}).get("stabilize"):
+    # stabilization via ffmpeg vidstab 2-pass, DEFAULT-ON in the reframe/shorts
+    # path (steadier vertical clips out of the box) and only disabled by an
+    # EXPLICIT ``stabilize: False`` toggle. It does NOT change the timeline (warp
+    # only), so captions stay in sync and it can run on whatever the trim
+    # produced. The stage's own ``stabilize_clip`` is the libvidstab gate: when
+    # libvidstab is missing it passes the clip through unchanged and surfaces a
+    # typed notice via the ``on_notice`` sink (the orchestrator routes it to
+    # job.progress) — never a silent skip, so default-on degrades gracefully.
+    if (settings or {}).get("stabilize", True):
         stabilized_path = str(out_dir / f"{stem}.stabilized.mp4")
         stage_clip = stages.stabilize(
             stage_clip,
@@ -1247,10 +1249,12 @@ class ShortMaker:
         #             pre-step (ffmpeg silencedetect -> keep-span re-cut), run on
         #             each cut clip before reframe; mutually exclusive with
         #             removeFillers (silence-trim wins).
-        #   stabilize (default false) -> audio-stabilize group: camera-shake
-        #             stabilization pre-step (ffmpeg vidstab 2-pass), warp-only so
-        #             it composes with every other stage; a missing libvidstab is
-        #             reported via job.progress, never silently skipped.
+        #   stabilize (DEFAULT TRUE in the reframe/shorts path) -> audio-stabilize
+        #             group: camera-shake stabilization pre-step (ffmpeg vidstab
+        #             2-pass), warp-only so it composes with every other stage; a
+        #             missing libvidstab is reported via job.progress, never
+        #             silently skipped (so default-on degrades gracefully). An
+        #             explicit ``stabilize: false`` from the caller disables it.
         for key in ("hookTitle", "removeFillers", "emphasis", "autoZoom", "silenceTrim", "stabilize"):
             value = params.get(key)
             if isinstance(value, bool):

--- a/sidecar/media_studio/features/stabilize.py
+++ b/sidecar/media_studio/features/stabilize.py
@@ -67,7 +67,7 @@ DEFAULT_OPTZOOM = 1
 DETECT_FILTER = "vidstabdetect"
 TRANSFORM_FILTER = "vidstabtransform"
 
-# The typed notice discriminator (mirrors reframe.REFRAME_FALLBACK_NOTICE).
+# The typed notice discriminator (a `notice["type"]` consumers can match on).
 STABILIZE_UNAVAILABLE_NOTICE = "stabilize.unavailable"
 
 

--- a/sidecar/tests/test_handlers.py
+++ b/sidecar/tests/test_handlers.py
@@ -602,6 +602,9 @@ def test_shortmaker_export_resolves_cached_candidates(services: Services, ctx: R
             select_candidates=lambda *a, **k: [],
             snap_candidates=lambda *a, **k: ([], []),
             cut_clip=fake_cut,
+            # stabilize is DEFAULT-ON in the reframe path; stub it so no real
+            # vidstab/ffmpeg runs (warp-only pass-through for this handler test).
+            stabilize=lambda i, o, *, settings=None, on_notice=None: i,
             reframe=lambda i, o, a, *, settings=None: o,
             render_caption=lambda *a, **k: a[2],
             export_clip=lambda i, o, *, settings=None: o,

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -223,6 +223,44 @@ def test_smooth_centers_damps_jitter():
     assert out_jump < raw_jump
 
 
+def test_median_prefilter_kills_single_frame_spike():
+    """A lone outlier sample is replaced by its neighbours' median, not kept.
+
+    Detector noise on real footage produces single-frame spikes (a stray face on
+    a graphic, a mis-detect on a turn). A spike between two steady samples must be
+    pulled back to the steady value BEFORE the EMA sees it, so it cannot drag the
+    track. Edges mirror (median over the available neighbours), so endpoints are
+    never corrupted by a clamp.
+    """
+    out = cs.median_prefilter([0.65, 0.1, 0.65], window=3)
+    assert out[1] == pytest.approx(0.65)
+    # a constant input is returned unchanged
+    assert cs.median_prefilter([0.4, 0.4, 0.4]) == pytest.approx([0.4, 0.4, 0.4])
+    # a sustained step is NOT smeared (median preserves the level on each side)
+    assert cs.median_prefilter([0.2, 0.2, 0.8, 0.8]) == pytest.approx([0.2, 0.2, 0.8, 0.8])
+
+
+def test_median_prefilter_identity_cases():
+    """``window<=1`` and short (<2-sample) tracks are returned unchanged — the
+    pre-filter is a no-op there (nothing to median over)."""
+    assert cs.median_prefilter([0.1, 0.9, 0.2], window=1) == pytest.approx([0.1, 0.9, 0.2])
+    assert cs.median_prefilter([0.7]) == pytest.approx([0.7])
+    assert cs.median_prefilter([]) == []
+
+
+def test_smooth_centers_outlier_does_not_drag_opening():
+    """The real m03 failure: a single early outlier (a stray left detection at
+    the clip start) must NOT drag the smoothed OPENING crop off the steady
+    subject. The opening sample drives the crop's first-keyframe x, so an outlier
+    there shows empty studio. After the median pre-filter the opening tracks the
+    steady subject, not the spike."""
+    # first sample is a far-left spike; the subject is steadily at ~0.64.
+    raw = [0.38, 0.65, 0.69, 0.63, 0.63, 0.64, 0.64, 0.64]
+    out = cs.smooth_centers(raw)
+    # the opening must sit near the steady subject, not be dragged toward 0.38.
+    assert out[0] == pytest.approx(0.64, abs=0.06)
+
+
 def test_window_timestamps_midpoints():
     assert cs.window_timestamps(10.0, window_sec=2.0) == [1.0, 3.0, 5.0, 7.0, 9.0]
 

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -62,6 +62,50 @@ def _vf_of(argv):
     return argv[argv.index("-vf") + 1]
 
 
+def _eval_crop_x(expr: str, t: float) -> float:
+    """Evaluate the ffmpeg crop-x expression for a given ``t`` (test oracle).
+
+    NO eval(): a tiny recursive-descent reader of the exact
+    ``if(lt(t,T),SEG,ELSE)`` piecewise-linear grammar emitted by
+    ``build_crop_x_expr`` (segments are ``x0+(x1-x0)*(t-t0)/(dt)``), used to
+    prove x(t) is a smooth INTERPOLATION with no stepped teleports.
+    """
+    import re
+
+    def split_top(s: str) -> list[str]:
+        parts, depth, start = [], 0, 0
+        for i, ch in enumerate(s):
+            if ch == "(":
+                depth += 1
+            elif ch == ")":
+                depth -= 1
+            elif ch == "," and depth == 0:
+                parts.append(s[start:i])
+                start = i + 1
+        parts.append(s[start:])
+        return parts
+
+    def ev(s: str) -> float:
+        s = s.strip()
+        if s.startswith("if("):
+            cond, a, b = split_top(s[3:-1])
+            return ev(a) if ev_cond(cond) else ev(b)
+        # a linear segment "x0+(x1-x0)*(t-t0)/(dt)" or a bare integer
+        m = re.fullmatch(r"(-?\d+)\+\((-?\d+)-(-?\d+)\)\*\(t-([\d.]+)\)/\(([\d.]+)\)", s)
+        if m:
+            x0, x1, _x0b, t0, dt = (float(g) for g in m.groups())
+            return x0 + (x1 - x0) * (t - t0) / dt
+        return float(s)
+
+    def ev_cond(s: str) -> bool:
+        # only "lt(t,T)" appears
+        inner = s.strip()[3:-1]
+        _lhs, rhs = split_top(inner)
+        return t < float(rhs)
+
+    return ev(expr)
+
+
 def _engine(
     fake_bins,
     detector,
@@ -141,15 +185,34 @@ def test_crop_x_for_center_clamps_to_frame():
 # smoothing / windows / keyframes
 # --------------------------------------------------------------------------- #
 def test_smooth_centers_constant_input_unchanged():
-    assert cs.smooth_centers([0.5, 0.5, 0.5]) == [0.5, 0.5, 0.5]
+    # A constant subject -> a constant track (zero-phase EMA of a constant).
+    assert cs.smooth_centers([0.5, 0.5, 0.5]) == pytest.approx([0.5, 0.5, 0.5])
 
 
-def test_smooth_centers_eases_toward_a_step():
-    out = cs.smooth_centers([0.2, 0.8, 0.8, 0.8], alpha=0.35)
-    assert out[0] == pytest.approx(0.2)
-    # monotone approach toward 0.8, never overshooting
-    assert out[1] < out[2] < out[3] < 0.8
-    assert out[1] == pytest.approx(0.2 + 0.35 * 0.6)
+def test_smooth_centers_zero_phase_no_lag_bias():
+    """Heavy zero-phase (forward+backward) EMA: the smoothed track of a step
+    settles symmetrically around the step (no single-direction lag), and stays
+    bounded within the raw range — it follows the subject without chasing noise."""
+    raw = [0.2, 0.2, 0.8, 0.8, 0.8]
+    out = cs.smooth_centers(raw, alpha=cs.SMOOTH_ALPHA)
+    assert min(out) >= min(raw) - 1e-9
+    assert max(out) <= max(raw) + 1e-9
+    # the track is monotone non-decreasing across the single up-step
+    assert all(b >= a - 1e-9 for a, b in zip(out, out[1:], strict=False))
+    # zero-phase: the midpoint sample sits near the step's halfway value, i.e.
+    # the smoothing is NOT biased toward the earlier (0.2) side like a causal EMA.
+    assert out[2] == pytest.approx(0.5, abs=0.2)
+
+
+def test_smooth_centers_low_alpha_is_heavier_than_high():
+    """A LOWER alpha smooths harder — the track deviates LESS from the mean,
+    proving the knob controls smoothing strength (jitter damping)."""
+    raw = [0.5, 0.9, 0.1, 0.9, 0.1]
+    heavy = cs.smooth_centers(raw, alpha=0.15)
+    light = cs.smooth_centers(raw, alpha=0.6)
+    heavy_swing = max(heavy) - min(heavy)
+    light_swing = max(light) - min(light)
+    assert heavy_swing < light_swing
 
 
 def test_smooth_centers_damps_jitter():
@@ -189,48 +252,6 @@ def test_is_static():
     assert cs.is_static(near, epsilon=8.1) is True
     assert cs.is_static(far, epsilon=8.1) is False
     assert cs.is_static([], epsilon=8.1) is True
-
-
-# --------------------------------------------------------------------------- #
-# DEADZONE — a sitting talking-head must yield a STATIC crop (no micro-pan)
-# --------------------------------------------------------------------------- #
-def test_apply_deadzone_holds_within_threshold():
-    """Centers wobbling inside the deadzone are pinned to the first value.
-
-    A near-static talking head: the detector reports a center jittering by a few
-    percent of frame width. Below ``DEADZONE_FRAC`` the held center never moves,
-    so every emitted center is identical -> downstream xs are identical -> static.
-    """
-    raw = [0.50, 0.52, 0.49, 0.51, 0.48]  # all within 7% of 0.50
-    out = cs.apply_deadzone(raw, deadzone=cs.DEADZONE_FRAC)
-    assert out == [0.50, 0.50, 0.50, 0.50, 0.50]
-
-
-def test_apply_deadzone_follows_a_real_move():
-    """A genuine move beyond the deadzone updates the held center (and only then).
-
-    The first two stay pinned to 0.20 (within 7%); the third (0.40) is +0.20 away
-    -> beyond the deadzone -> the held center snaps to it; the fourth (0.42) is
-    then within 7% of 0.40 -> pinned to 0.40.
-    """
-    raw = [0.20, 0.24, 0.40, 0.42]
-    out = cs.apply_deadzone(raw, deadzone=cs.DEADZONE_FRAC)
-    assert out == [0.20, 0.20, 0.40, 0.40]
-
-
-def test_apply_deadzone_empty():
-    assert cs.apply_deadzone([], deadzone=cs.DEADZONE_FRAC) == []
-
-
-def test_deadzone_constant_is_meaningful_fraction():
-    # 6-8% of source width per the framing-stability spec.
-    assert 0.06 <= cs.DEADZONE_FRAC <= 0.08
-
-
-def test_smooth_alpha_is_strong():
-    # The fix dials smoothing much stronger than the old 0.35 to damp detector
-    # jitter on a near-static subject.
-    assert cs.SMOOTH_ALPHA <= 0.2
 
 
 # --------------------------------------------------------------------------- #
@@ -427,51 +448,130 @@ def test_engine_stable_subject_off_center_static_clamped(fake_bins):
     assert crop["x"] == 1280 - 405  # clamped to the frame edge
 
 
-def test_engine_near_static_jittery_track_yields_single_static_crop(fake_bins):
-    """ROOT-CAUSE FIX (1): a sitting speaker whose detected center merely jitters
-    must produce ONE static crop — no per-window pan. The detector reports a
-    center wobbling +/- a few percent (the real haar/mediapipe noise on a static
-    head); the deadzone + strong smoothing collapse it to a single crop-x.
-    """
-    ts = cs.window_timestamps(20.0)  # many windows -> many chances to drift
-    # Center jitters within ~3% of 0.5 — well inside the 7% deadzone.
-    jitter = [0.50, 0.53, 0.47, 0.51, 0.49, 0.52, 0.48, 0.50, 0.515, 0.485]
-    noisy = [(t, jitter[i % len(jitter)]) for i, t in enumerate(ts)]
-    eng, runner = _engine(fake_bins, detector=lambda p, t: noisy)
+# --------------------------------------------------------------------------- #
+# TDD (a): an OFF-CENTER subject -> crop centered ON THE SUBJECT, not frame-center
+# --------------------------------------------------------------------------- #
+def test_engine_offcenter_static_subject_crops_on_subject_not_frame_center(fake_bins):
+    """A speaker sitting steadily LEFT of frame center (cx≈0.25) must yield a
+    static crop centered on HIM — NOT drifted back toward frame center. This is
+    the regression the static-bias change introduced (empty studio shown)."""
+    # cx=0.25 across every window: genuinely static, off to the left.
+    ts = cs.window_timestamps(8.0)
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [(x, 0.25) for x in ts])
     crop, kfs, _d = eng.compute_plan("/in.mp4")
-    assert kfs == []  # STATIC: no animated keyframes despite per-window noise
-    # the single encode pass carries a constant x (no if(...) expression)
+    assert kfs == []  # static subject -> one fixed crop
+    # crop centered on the subject: x ≈ 0.25*1280 - 405/2 = 117.5
+    subject_x = cs.crop_x_for_center(0.25, 405, 1280)
+    frame_center_x = (1280 - 405) // 2  # 437
+    assert abs(crop["x"] - subject_x) <= 2
+    # and it is NOT sitting near frame center (the drift bug)
+    assert abs(crop["x"] - frame_center_x) > 100
+
+
+def test_engine_offcenter_static_keeps_subject_inside_crop(fake_bins):
+    """The subject's horizontal position stays WITHIN the crop window (he is not
+    pushed to the frame edge / out of view)."""
+    ts = cs.window_timestamps(8.0)
+    cx = 0.7
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [(x, cx) for x in ts])
+    crop, _kfs, _d = eng.compute_plan("/in.mp4")
+    subj_px = cx * 1280
+    assert crop["x"] <= subj_px <= crop["x"] + crop["w"]
+
+
+# --------------------------------------------------------------------------- #
+# TDD (b): a profile/weak-face frame -> person/motion fallback still locates him
+# --------------------------------------------------------------------------- #
+def test_subject_finder_falls_back_to_person_when_face_absent(monkeypatch):
+    """Face detector returns None (profile/turned head) -> the PERSON (HOG body)
+    detector locates the subject so the crop stays on him."""
+    # face finder: never finds a face. person finder: body at cx=0.8.
+    monkeypatch.setattr(cs, "_make_face_finder", lambda backend: (lambda img: None, lambda: None))
+    monkeypatch.setattr(cs, "_person_center", lambda img: 0.8)
+    monkeypatch.setattr(cs, "_motion_center", lambda prev, img: pytest.fail("motion must not run when person hit"))
+    find, _close = cs._make_subject_finder("haar")
+    assert find(object()) == pytest.approx(0.8)
+
+
+def test_subject_finder_falls_back_to_motion_when_face_and_person_absent(monkeypatch):
+    """Neither face nor body detectable -> MOTION saliency (vs the previous
+    frame) still locates the moving speaker. The first frame (no prev) yields
+    None; the second resolves via motion."""
+    monkeypatch.setattr(cs, "_make_face_finder", lambda backend: (lambda img: None, lambda: None))
+    monkeypatch.setattr(cs, "_person_center", lambda img: None)
+    monkeypatch.setattr(cs, "_motion_center", lambda prev, img: 0.35)
+    find, _close = cs._make_subject_finder("haar")
+    assert find("frame0") is None  # no previous frame yet -> motion can't run
+    assert find("frame1") == pytest.approx(0.35)  # diff vs frame0 locates motion
+
+
+def test_subject_finder_face_hit_skips_fallbacks(monkeypatch):
+    """When the FACE is found, neither person nor motion fallback runs."""
+    monkeypatch.setattr(cs, "_make_face_finder", lambda backend: (lambda img: 0.5, lambda: None))
+    monkeypatch.setattr(cs, "_person_center", lambda img: pytest.fail("person must not run on a face hit"))
+    monkeypatch.setattr(cs, "_motion_center", lambda prev, img: pytest.fail("motion must not run on a face hit"))
+    find, _close = cs._make_subject_finder("mediapipe")
+    assert find(object()) == pytest.approx(0.5)
+
+
+def test_subject_finder_center_backend_has_no_finder():
+    find, close = cs._make_subject_finder("center")
+    assert find is None
+    close()  # the no-op closer is callable
+
+
+def test_subject_finder_no_face_finder_goes_straight_to_person(monkeypatch):
+    """When the FACE backend yields no finder at all (e.g. missing haar cascade),
+    the subject finder skips the face step and uses the person fallback."""
+    monkeypatch.setattr(cs, "_make_face_finder", lambda backend: (None, lambda: None))
+    monkeypatch.setattr(cs, "_person_center", lambda img: 0.6)
+    find, _close = cs._make_subject_finder("haar")
+    assert find(object()) == pytest.approx(0.6)
+
+
+def test_engine_profile_video_tracks_via_fallback_not_center(fake_bins):
+    """End-to-end (b): the detector (simulating face->person/motion fallback)
+    returns an off-center track; the engine crops on the SUBJECT, never the
+    centered no-subject fallback."""
+    ts = cs.window_timestamps(8.0)
+    # subject located at 0.78 in every window via the fallback chain.
+    eng, runner = _engine(fake_bins, detector=lambda p, t: [(x, 0.78) for x in ts])
     eng.reframe("/in.mp4", "/out.mp4")
     vf = _vf_of(runner.calls[0]["argv"])
-    assert "if(" not in vf
+    x = int(vf.split(":'")[1].split("'")[0])
+    assert x != (1280 - 405) // 2  # NOT the center-crop fallback x (437)
+    assert abs(x - cs.crop_x_for_center(0.78, 405, 1280)) <= 2
 
 
-def test_engine_moving_subject_crop_x_is_interpolated_and_smooth(fake_bins):
-    """ROOT-CAUSE FIX (2): when the subject genuinely moves, x(t) is a CONTINUOUS
-    piecewise-linear interpolation between keyframes — no stepped teleports. The
-    rendered crop expression uses the ``if(lt(t,...))`` lerp form, the keyframes
-    are monotone with the pan, the deadzone COARSENS the track (fewer keyframes
-    than windows), and no keyframe step whips past the crop window (no teleport).
-    A smooth left->right pan across the frame, sampled per window.
-    """
-    ts = cs.window_timestamps(20.0)
-    n = len(ts)
-    # A smooth left->right pan from 0.15 to 0.85 across the clip.
-    pan = [(t, 0.15 + 0.70 * (i / (n - 1))) for i, t in enumerate(ts)]
-    eng, runner = _engine(fake_bins, detector=lambda p, t: pan)
-    crop, kfs, _d = eng.compute_plan("/in.mp4")
-    assert len(kfs) >= 2  # genuinely animated
-    # the deadzone coarsens the per-window track to fewer keyframes than windows
-    assert len(kfs) < len(ts)
-    xs = [k["x"] for k in kfs]
-    assert xs == sorted(xs)  # monotone with the pan direction
-    # x(t) is CONTINUOUS interpolation (piecewise-linear lerp) — zero stepped
-    # discontinuities in the rendered crop expression.
-    eng.reframe("/in.mp4", "/out.mp4")
-    assert "if(lt(t," in _vf_of(runner.calls[0]["argv"])
-    # no-teleport: a single keyframe step never whips across the whole crop window
-    deltas = [abs(b - a) for a, b in zip(xs, xs[1:], strict=False)]
-    assert max(deltas) < crop["w"]
+# --------------------------------------------------------------------------- #
+# TDD (c): smooth interpolation -> no stepped jumps between sampled windows
+# --------------------------------------------------------------------------- #
+def test_engine_moving_subject_interpolates_no_teleport(fake_bins):
+    """A subject panning across the frame yields an INTERPOLATED x(t) — the per-
+    frame crop-x change is bounded (no teleport between sample windows)."""
+    moving = [(float(i), 0.1 + 0.1 * i) for i in range(8)]  # 0.1 -> 0.8 over 8s
+    eng, _ = _engine(fake_bins, detector=lambda p, t: moving)
+    crop, kfs, duration = eng.compute_plan("/in.mp4")
+    assert len(kfs) >= 2
+    expr = cs.build_crop_x_expr(crop["x"], kfs)
+    # evaluate the piecewise-linear x(t) on a dense time grid (no stepped jumps).
+    xs = [_eval_crop_x(expr, t) for t in [i * 0.1 for i in range(int(duration * 10) + 1)]]
+    max_step = max(abs(b - a) for a, b in zip(xs, xs[1:], strict=False))
+    full_span = max(xs) - min(xs)
+    # a teleport would move a large fraction of the whole pan in one 0.1s step;
+    # interpolation keeps each step tiny relative to the total travel.
+    assert full_span > 0
+    assert max_step < full_span * 0.2
+
+
+def test_engine_smoothing_lags_raw_target(fake_bins):
+    """Heavy EMA: the tracked endpoints LAG the raw per-window target (the crop
+    eases toward the subject rather than snapping), proving smoothing is active."""
+    moving = [(1.0, 0.1), (3.0, 0.3), (5.0, 0.5), (7.0, 0.9)]
+    eng, _ = _engine(fake_bins, detector=lambda p, t: moving)
+    _crop, kfs, _d = eng.compute_plan("/in.mp4")
+    raw_last = cs.crop_x_for_center(0.9, 405, 1280)
+    assert kfs[-1]["x"] < raw_last  # eased, not a raw pass-through
 
 
 def test_engine_detector_failure_degrades_to_center(fake_bins):
@@ -559,36 +659,44 @@ def test_script_present(verthor_script):
     assert reframe.script_present({"verthorScript": "/opt/verthor/reframe.sh"}) is True
 
 
+def test_script_present_bundled_default_resolves_packaged_script(monkeypatch):
+    """No settings + no env -> the BUNDLED verthor script path is resolved
+    (verthor is opt-in, but its host path still resolves to the packaged .sh).
+    This exercises the _script_host_path bundled-default branch."""
+    monkeypatch.delenv("MEDIA_STUDIO_VERTHOR_SCRIPT", raising=False)
+    host = reframe._script_host_path({})
+    assert host.endswith("verthor_reframe.sh")
+    assert "__BUNDLED__" not in host
+    # the packaged script ships in the repo, so it is present on the host.
+    assert reframe.script_present({}) is True
+
+
 def test_resolve_explicit_claudeshorts_never_probes():
     name, notice = reframe.resolve_engine_name("claudeshorts", {}, which=_never_which)
     assert name == "claudeshorts"
     assert notice is None
 
 
-@pytest.mark.parametrize("requested", ["auto", "verthor", "", None])
-def test_resolve_verthor_when_available(requested, verthor_script):
-    name, notice = reframe.resolve_engine_name(requested, verthor_script, which=_which(found=True))
+@pytest.mark.parametrize("requested", ["auto", "", None])
+def test_resolve_auto_is_claudeshorts_without_probing_wsl(requested):
+    """P3 DEFAULT FLIP: auto (and blank/None) -> claudeshorts, the NO-WSL
+    default. No WSL/script probe runs (``_never_which`` would explode), and no
+    fallback notice is produced."""
+    name, notice = reframe.resolve_engine_name(requested, {}, which=_never_which)
+    assert name == "claudeshorts"
+    assert notice is None
+
+
+def test_resolve_explicit_verthor_when_available(verthor_script):
+    """EXPLICIT verthor still resolves to verthor when WSL + script are present."""
+    name, notice = reframe.resolve_engine_name("verthor", verthor_script, which=_which(found=True))
     assert name == "verthor"
     assert notice is None
 
 
-@pytest.mark.parametrize("requested", ["auto", "", None])
-def test_resolve_auto_falls_back_when_wsl_absent(requested, verthor_script):
-    """auto (and the blank/None synonyms) -> claudeshorts when WSL is absent."""
-    name, notice = reframe.resolve_engine_name(requested, verthor_script, which=_which(found=False))
-    assert name == "claudeshorts"
-    assert notice is not None
-    assert notice["type"] == "reframe.fallback"
-    # "", None and "auto" all normalise to the "auto" selector in the notice.
-    assert notice["requested"] == "auto"
-    assert notice["engine"] == "claudeshorts"
-    assert "WSL" in notice["reason"]
-    assert "claudeshorts" in notice["message"]
-
-
 def test_resolve_explicit_verthor_errors_when_wsl_absent(verthor_script):
     """EXPLICIT verthor must FAIL LOUDLY when WSL is absent — never silently
-    fall back. Only ``auto`` is allowed to substitute claudeshorts."""
+    fall back. verthor is an explicit opt-in; the default is claudeshorts."""
     with pytest.raises(ReframeError) as exc:
         reframe.resolve_engine_name("verthor", verthor_script, which=_which(found=False))
     assert "WSL" in str(exc.value)
@@ -606,33 +714,25 @@ def test_resolve_explicit_verthor_errors_when_script_missing(monkeypatch):
     assert "not found" in str(exc.value)
 
 
-def test_resolve_auto_falls_back_when_script_missing(monkeypatch):
-    monkeypatch.delenv("MEDIA_STUDIO_VERTHOR_SCRIPT", raising=False)
-    name, notice = reframe.resolve_engine_name(
-        "auto",
-        {"verthorScript": "definitely_missing/nope.sh"},
-        which=_never_which,  # script check fails BEFORE any wsl probe
-    )
-    assert name == "claudeshorts"
-    assert "not found" in notice["reason"]
-
-
 def test_resolve_unknown_engine_raises():
     with pytest.raises(ValueError):
         reframe.resolve_engine_name("ffmpeg-magic", {})
 
 
 def test_get_engine_returns_constructed_instances(verthor_script):
-    eng, notice = reframe.get_engine("auto", verthor_script, which=_which(found=True))
-    assert isinstance(eng, ReframeEngine)
+    # P3: auto -> claudeshorts (no WSL probe), no notice.
+    eng, notice = reframe.get_engine("auto", {}, which=_never_which)
+    assert isinstance(eng, ClaudeShortsReframeEngine)
     assert notice is None
 
-    eng, notice = reframe.get_engine("auto", verthor_script, which=_which(found=False))
-    assert isinstance(eng, ClaudeShortsReframeEngine)
-    assert notice is not None
-
+    # explicit claudeshorts -> claudeshorts, no probe.
     eng, notice = reframe.get_engine("claudeshorts", {}, which=_never_which)
     assert isinstance(eng, ClaudeShortsReframeEngine)
+    assert notice is None
+
+    # explicit verthor (WSL present) -> the verthor (WSL) engine.
+    eng, notice = reframe.get_engine("verthor", verthor_script, which=_which(found=True))
+    assert isinstance(eng, ReframeEngine)
     assert notice is None
 
 
@@ -873,8 +973,8 @@ def test_detect_subject_centers_skips_unreadable_frame(monkeypatch):
 
 
 def test_detect_subject_centers_no_finder_backend_returns_empty(monkeypatch):
-    # When _make_face_finder yields no finder (None) the body returns [] early.
-    monkeypatch.setattr(cs, "_make_face_finder", lambda backend: (None, lambda: None))
+    # When _make_subject_finder yields no finder (None) the body returns [] early.
+    monkeypatch.setattr(cs, "_make_subject_finder", lambda backend: (None, lambda: None))
 
     def boom(*a, **k):  # pragma: no cover - must never run (no finder -> no frames)
         raise AssertionError("no frame extraction without a finder")
@@ -914,3 +1014,109 @@ def test_detect_subject_centers_finder_close_failure_is_swallowed(monkeypatch):
     # A failing close() must never mask the collected results (cleanup-swallow).
     samples = cs.detect_subject_centers("/in.mp4", [0.5], frame_runner=frame_runner, backend="haar")
     assert samples == [(0.5, 0.5)]
+
+
+# --------------------------------------------------------------------------- #
+# _person_center — HOG body fallback (real cv2; sub-window guard + stubbed hit)
+# --------------------------------------------------------------------------- #
+def test_person_center_skips_subwindow_frame_no_crash():
+    import numpy as np
+
+    # Frame smaller than the 64x128 HOG window -> guarded out (would segfault).
+    small = np.zeros((80, 160, 3), dtype=np.uint8)
+    assert cs._person_center(small) is None
+
+
+def test_person_center_no_person_returns_none():
+    import numpy as np
+
+    # A blank window-sized frame -> the real HOG finds no person.
+    blank = np.zeros((256, 256, 3), dtype=np.uint8)
+    assert cs._person_center(blank) is None
+
+
+def test_person_center_returns_normalized_center_on_detection(monkeypatch):
+    import cv2
+    import numpy as np
+
+    class _HOG:
+        def setSVMDetector(self, _d):
+            pass
+
+        def detectMultiScale(self, _img, winStride):
+            # two bodies; the higher-weighted (second) wins. frame width = 400.
+            rects = [(10, 0, 60, 120), (300, 0, 60, 120)]
+            weights = [0.2, 0.9]
+            return rects, weights
+
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    img = np.zeros((200, 400, 3), dtype=np.uint8)  # width 400
+    cx = cs._person_center(img)
+    # best body center x = 300 + 60/2 = 330; normalized = 330/400 = 0.825
+    assert cx == pytest.approx(0.825)
+
+
+def test_person_center_no_rects_returns_none(monkeypatch):
+    import cv2
+    import numpy as np
+
+    class _HOG:
+        def setSVMDetector(self, _d):
+            pass
+
+        def detectMultiScale(self, _img, winStride):
+            return (), None  # no rects, no weights
+
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    assert cs._person_center(np.zeros((200, 200, 3), dtype=np.uint8)) is None
+
+
+def test_person_center_missing_weights_uses_zero(monkeypatch):
+    import cv2
+    import numpy as np
+
+    class _HOG:
+        def setSVMDetector(self, _d):
+            pass
+
+        def detectMultiScale(self, _img, winStride):
+            return [(40, 0, 80, 120)], None  # rect present, weights None
+
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    # single rect, center x = 40 + 80/2 = 80; normalized = 80/200 = 0.4
+    assert cs._person_center(img) == pytest.approx(0.4)
+
+
+# --------------------------------------------------------------------------- #
+# _motion_center — inter-frame saliency fallback (real cv2 diff)
+# --------------------------------------------------------------------------- #
+def test_motion_center_locates_moving_block():
+    import numpy as np
+
+    prev = np.zeros((100, 200, 3), dtype=np.uint8)
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    # a bright block appears on the RIGHT half -> motion centroid is right-of-center.
+    img[:, 150:180, :] = 255
+    cx = cs._motion_center(prev, img)
+    assert cx is not None
+    assert cx > 0.6  # centroid near x≈165/200 = 0.825
+
+
+def test_motion_center_no_motion_returns_none():
+    import numpy as np
+
+    frame = np.full((60, 120, 3), 30, dtype=np.uint8)
+    # identical frames -> zero diff -> no motion located.
+    assert cs._motion_center(frame, frame.copy()) is None
+
+
+def test_motion_center_shape_mismatch_returns_none():
+    import numpy as np
+
+    prev = np.zeros((100, 200, 3), dtype=np.uint8)
+    img = np.zeros((90, 160, 3), dtype=np.uint8)  # different geometry (scene cut)
+    assert cs._motion_center(prev, img) is None

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -192,6 +192,48 @@ def test_is_static():
 
 
 # --------------------------------------------------------------------------- #
+# DEADZONE — a sitting talking-head must yield a STATIC crop (no micro-pan)
+# --------------------------------------------------------------------------- #
+def test_apply_deadzone_holds_within_threshold():
+    """Centers wobbling inside the deadzone are pinned to the first value.
+
+    A near-static talking head: the detector reports a center jittering by a few
+    percent of frame width. Below ``DEADZONE_FRAC`` the held center never moves,
+    so every emitted center is identical -> downstream xs are identical -> static.
+    """
+    raw = [0.50, 0.52, 0.49, 0.51, 0.48]  # all within 7% of 0.50
+    out = cs.apply_deadzone(raw, deadzone=cs.DEADZONE_FRAC)
+    assert out == [0.50, 0.50, 0.50, 0.50, 0.50]
+
+
+def test_apply_deadzone_follows_a_real_move():
+    """A genuine move beyond the deadzone updates the held center (and only then).
+
+    The first two stay pinned to 0.20 (within 7%); the third (0.40) is +0.20 away
+    -> beyond the deadzone -> the held center snaps to it; the fourth (0.42) is
+    then within 7% of 0.40 -> pinned to 0.40.
+    """
+    raw = [0.20, 0.24, 0.40, 0.42]
+    out = cs.apply_deadzone(raw, deadzone=cs.DEADZONE_FRAC)
+    assert out == [0.20, 0.20, 0.40, 0.40]
+
+
+def test_apply_deadzone_empty():
+    assert cs.apply_deadzone([], deadzone=cs.DEADZONE_FRAC) == []
+
+
+def test_deadzone_constant_is_meaningful_fraction():
+    # 6-8% of source width per the framing-stability spec.
+    assert 0.06 <= cs.DEADZONE_FRAC <= 0.08
+
+
+def test_smooth_alpha_is_strong():
+    # The fix dials smoothing much stronger than the old 0.35 to damp detector
+    # jitter on a near-static subject.
+    assert cs.SMOOTH_ALPHA <= 0.2
+
+
+# --------------------------------------------------------------------------- #
 # crop-x expression + ffmpeg argv shape
 # --------------------------------------------------------------------------- #
 def test_build_crop_x_expr_static():
@@ -383,6 +425,53 @@ def test_engine_stable_subject_off_center_static_clamped(fake_bins):
     crop, kfs, _d = eng.compute_plan("/in.mp4")
     assert kfs == []  # static
     assert crop["x"] == 1280 - 405  # clamped to the frame edge
+
+
+def test_engine_near_static_jittery_track_yields_single_static_crop(fake_bins):
+    """ROOT-CAUSE FIX (1): a sitting speaker whose detected center merely jitters
+    must produce ONE static crop — no per-window pan. The detector reports a
+    center wobbling +/- a few percent (the real haar/mediapipe noise on a static
+    head); the deadzone + strong smoothing collapse it to a single crop-x.
+    """
+    ts = cs.window_timestamps(20.0)  # many windows -> many chances to drift
+    # Center jitters within ~3% of 0.5 — well inside the 7% deadzone.
+    jitter = [0.50, 0.53, 0.47, 0.51, 0.49, 0.52, 0.48, 0.50, 0.515, 0.485]
+    noisy = [(t, jitter[i % len(jitter)]) for i, t in enumerate(ts)]
+    eng, runner = _engine(fake_bins, detector=lambda p, t: noisy)
+    crop, kfs, _d = eng.compute_plan("/in.mp4")
+    assert kfs == []  # STATIC: no animated keyframes despite per-window noise
+    # the single encode pass carries a constant x (no if(...) expression)
+    eng.reframe("/in.mp4", "/out.mp4")
+    vf = _vf_of(runner.calls[0]["argv"])
+    assert "if(" not in vf
+
+
+def test_engine_moving_subject_crop_x_is_interpolated_and_smooth(fake_bins):
+    """ROOT-CAUSE FIX (2): when the subject genuinely moves, x(t) is a CONTINUOUS
+    piecewise-linear interpolation between keyframes — no stepped teleports. The
+    rendered crop expression uses the ``if(lt(t,...))`` lerp form, the keyframes
+    are monotone with the pan, the deadzone COARSENS the track (fewer keyframes
+    than windows), and no keyframe step whips past the crop window (no teleport).
+    A smooth left->right pan across the frame, sampled per window.
+    """
+    ts = cs.window_timestamps(20.0)
+    n = len(ts)
+    # A smooth left->right pan from 0.15 to 0.85 across the clip.
+    pan = [(t, 0.15 + 0.70 * (i / (n - 1))) for i, t in enumerate(ts)]
+    eng, runner = _engine(fake_bins, detector=lambda p, t: pan)
+    crop, kfs, _d = eng.compute_plan("/in.mp4")
+    assert len(kfs) >= 2  # genuinely animated
+    # the deadzone coarsens the per-window track to fewer keyframes than windows
+    assert len(kfs) < len(ts)
+    xs = [k["x"] for k in kfs]
+    assert xs == sorted(xs)  # monotone with the pan direction
+    # x(t) is CONTINUOUS interpolation (piecewise-linear lerp) — zero stepped
+    # discontinuities in the rendered crop expression.
+    eng.reframe("/in.mp4", "/out.mp4")
+    assert "if(lt(t," in _vf_of(runner.calls[0]["argv"])
+    # no-teleport: a single keyframe step never whips across the whole crop window
+    deltas = [abs(b - a) for a, b in zip(xs, xs[1:], strict=False)]
+    assert max(deltas) < crop["w"]
 
 
 def test_engine_detector_failure_degrades_to_center(fake_bins):

--- a/sidecar/tests/test_shortmaker.py
+++ b/sidecar/tests/test_shortmaker.py
@@ -505,7 +505,7 @@ def test_run_export_orders_cut_reframe_caption_export(transcript, tmp_path):
         stages=rec.as_stages(),
     )
     # Exact §5 order for a single clip.
-    assert calls == ["cut", "reframe", "caption", "export"]
+    assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
     assert out["clips"] == [{"path": str(tmp_path / "out" / "src-1.mp4")}]
 
 
@@ -700,7 +700,7 @@ def test_run_export_zoom_off_by_default(transcript, tmp_path):
         stages=rec.as_stages(),
     )
     assert "zoom" not in calls
-    assert calls == ["cut", "reframe", "caption", "export"]
+    assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
     assert rec.zoom_kwargs == []
 
 
@@ -718,7 +718,7 @@ def test_run_export_zoom_inserted_between_reframe_and_caption(transcript, tmp_pa
         stages=rec.as_stages(),
         settings={"autoZoom": True},
     )
-    assert calls == ["cut", "reframe", "zoom", "caption", "export"]
+    assert calls == ["cut", "stabilize", "reframe", "zoom", "caption", "export"]
     # The zoom stage consumes the reframed clip and feeds caption its output.
     z = rec.zoom_kwargs[0]
     assert z["in_path"].endswith(".reframed.mp4")
@@ -755,8 +755,9 @@ def _stab_candidate() -> dict[str, Any]:
     return {"rank": 1, "start": 0.0, "end": 30.0, "sourceStart": 0.0, "score": 9}
 
 
-def test_run_export_audio_stabilize_off_by_default(transcript, tmp_path):
-    """Neither toggle set: the pre-step stages never run; base order unchanged."""
+def test_run_export_stabilize_on_by_default(transcript, tmp_path):
+    """No toggle set: stabilize is DEFAULT-ON in the reframe path (it runs after
+    cut, before reframe); silence-trim stays off (it remains opt-in)."""
     calls: list[str] = []
     rec = RecordingStages(calls)
     sm.run_export(
@@ -767,7 +768,24 @@ def test_run_export_audio_stabilize_off_by_default(transcript, tmp_path):
         out_dir=str(tmp_path / "out"),
         stages=rec.as_stages(),
     )
-    assert "trim_silence" not in calls
+    assert "trim_silence" not in calls  # silence-trim is still opt-in
+    assert "stabilize" in calls  # stabilization is now default-on
+    assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
+
+
+def test_run_export_stabilize_disabled_by_explicit_false(transcript, tmp_path):
+    """An EXPLICIT ``stabilize: False`` disables the default-on stabilization."""
+    calls: list[str] = []
+    rec = RecordingStages(calls)
+    sm.run_export(
+        make_ctx(),
+        video_id="v1",
+        candidates=[_stab_candidate()],
+        load_context=loader_for(str(tmp_path / "src.mp4"), transcript),
+        out_dir=str(tmp_path / "out"),
+        stages=rec.as_stages(),
+        settings={"stabilize": False},
+    )
     assert "stabilize" not in calls
     assert calls == ["cut", "reframe", "caption", "export"]
 
@@ -785,7 +803,7 @@ def test_run_export_silence_trim_runs_after_cut(transcript, tmp_path):
         stages=rec.as_stages(),
         settings={"silenceTrim": True},
     )
-    assert calls == ["cut", "trim_silence", "reframe", "caption", "export"]
+    assert calls == ["cut", "trim_silence", "stabilize", "reframe", "caption", "export"]
     # The trimmed clip (not the raw cut) is what reframe receives.
     trimmed_out = rec.trim_args[0][1]
     # silenceRemovedSec is surfaced on the clip payload (default stub removed 2.5s).
@@ -963,7 +981,7 @@ def test_run_export_brand_overlay_after_caption_before_export(transcript, tmp_pa
         stages=rec.as_stages(),
         settings={"brandLogoPath": "C:/brand/logo.png"},
     )
-    assert calls == ["cut", "reframe", "caption", "brand_overlay", "export"]
+    assert calls == ["cut", "stabilize", "reframe", "caption", "brand_overlay", "export"]
     b = rec.brand_kwargs[0]
     assert b["in_path"].endswith(".captioned.mp4")
     assert b["out_path"].endswith(".branded.mp4")
@@ -1025,10 +1043,12 @@ def test_run_export_multiple_clips_order_and_paths(transcript, tmp_path):
     # Two full pipelines back-to-back.
     assert calls == [
         "cut",
+        "stabilize",
         "reframe",
         "caption",
         "export",
         "cut",
+        "stabilize",
         "reframe",
         "caption",
         "export",
@@ -1207,7 +1227,7 @@ def test_shortmaker_export_handler_returns_jobId(registry, transcript, tmp_path)
     assert job is not None
     job.wait(timeout=5)
     assert job.result["clips"][0]["path"].endswith(".mp4")
-    assert calls == ["cut", "reframe", "caption", "export"]
+    assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
 
 
 def test_shortmaker_select_requires_videoId(registry):
@@ -1536,7 +1556,7 @@ class TestExportWithAudioTrack:
 
     def test_mux_runs_last_and_final_path_is_unchanged(self, transcript, tmp_path):
         out, rec, calls = self._export(tmp_path, transcript, audio_track_id="aud-dub-1", tracks=[DUB_TRACK])
-        assert calls == ["cut", "reframe", "caption", "export", "mux_audio"]
+        assert calls == ["cut", "stabilize", "reframe", "caption", "export", "mux_audio"]
         # The §2 contract path is the SAME with or without the audio carry.
         assert out["clips"] == [{"path": str(tmp_path / "out" / "talk-1.mp4")}]
         mux = rec.mux_kwargs[0]
@@ -1555,7 +1575,7 @@ class TestExportWithAudioTrack:
 
     def test_no_audio_track_id_skips_the_mux_stage(self, transcript, tmp_path):
         _out, rec, calls = self._export(tmp_path, transcript, audio_track_id=None, tracks=[DUB_TRACK])
-        assert calls == ["cut", "reframe", "caption", "export"]
+        assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
         assert rec.mux_kwargs == []
 
     def test_unknown_audio_track_id_fails_before_any_stage(self, transcript, tmp_path):
@@ -1581,11 +1601,13 @@ class TestExportWithAudioTrack:
         )
         assert calls == [
             "cut",
+            "stabilize",
             "reframe",
             "caption",
             "export",
             "mux_audio",
             "cut",
+            "stabilize",
             "reframe",
             "caption",
             "export",
@@ -1618,7 +1640,7 @@ class TestExportHandlerAudioTrackParam:
         )
         job = registry.get(out["jobId"])
         job.wait(timeout=5)
-        assert calls == ["cut", "reframe", "caption", "export", "mux_audio"]
+        assert calls == ["cut", "stabilize", "reframe", "caption", "export", "mux_audio"]
         assert rec.mux_kwargs[0]["audio_track"]["id"] == "aud-dub-1"
 
     def test_export_rejects_a_non_string_audioTrackId(self, registry, transcript, tmp_path):
@@ -1644,7 +1666,7 @@ class TestExportHandlerAudioTrackParam:
             _rpc_ctx(registry),
         )
         registry.get(out["jobId"]).wait(timeout=5)
-        assert calls == ["cut", "reframe", "caption", "export"]
+        assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
 
 
 class TestLazyMuxAudioStage:
@@ -1704,7 +1726,7 @@ class TestExportRemoveFillers:
             settings={"removeFillers": False},
         )
         # OFF: byte-identical base order, no filler stage, no stats on payload.
-        assert calls == ["cut", "reframe", "caption", "export"]
+        assert calls == ["cut", "stabilize", "reframe", "caption", "export"]
         assert rec.filler_kwargs == []
 
     def test_filler_stage_absent_setting_is_off(self, transcript, tmp_path):
@@ -1737,6 +1759,7 @@ class TestExportRemoveFillers:
         # ON: the de-fill runs AFTER cut, BEFORE reframe.
         assert calls == [
             "cut",
+            "stabilize",
             "remove_fillers",
             "reframe",
             "caption",

--- a/sidecar/tests/test_shortmaker.py
+++ b/sidecar/tests/test_shortmaker.py
@@ -2595,12 +2595,25 @@ def test_candidate_virality_non_numeric_returns_none():
 # ---------------------------------------------------------------------------
 # run_export — reframe-engine fallback notice + per-export notice de-dup
 # ---------------------------------------------------------------------------
-def test_run_export_surfaces_reframe_fallback_notice(transcript, tmp_path, monkeypatch):
-    """A verthor->claudeshorts fallback notice is surfaced via job.progress."""
+def test_run_export_default_engine_is_claudeshorts_no_wsl(transcript, tmp_path, monkeypatch):
+    """P3: with no reframeEngine set, run_export resolves the in-sidecar
+    claudeshorts engine WITHOUT probing WSL (no wsl.exe needed), pins that
+    CONCRETE name into the settings handed to the reframe stage, and surfaces no
+    fallback notice."""
     import media_studio.features.reframe as reframe_mod
 
-    notice = {"type": "reframe.fallback", "message": "verthor unavailable; using claudeshorts"}
-    monkeypatch.setattr(reframe_mod, "resolve_engine_name", lambda name, settings: ("claudeshorts", notice))
+    # which() must NEVER run: auto -> claudeshorts is decided with zero WSL probe.
+    def _never_which(_name):  # pragma: no cover - asserted by not being called
+        raise AssertionError("WSL must not be probed for the default engine")
+
+    monkeypatch.setattr(reframe_mod.shutil, "which", _never_which)
+
+    seen: dict[str, object] = {}
+
+    class _CaptureStages(RecordingStages):
+        def reframe(self, in_path, out_path, aspect, *, settings=None):
+            seen["engine"] = (settings or {}).get("reframeEngine")
+            return super().reframe(in_path, out_path, aspect, settings=settings)
 
     progress: list[tuple[int, str]] = []
     ctx = JobContext(
@@ -2608,7 +2621,7 @@ def test_run_export_surfaces_reframe_fallback_notice(transcript, tmp_path, monke
         _cancel_event=threading.Event(),
         _emit_progress=lambda jid, pct, msg: progress.append((pct, msg)),
     )
-    rec = RecordingStages([])
+    rec = _CaptureStages([])
     candidate = {"rank": 1, "start": 0.0, "end": 25.0, "sourceStart": 0.0, "score": 9}
     sm.run_export(
         ctx,
@@ -2618,7 +2631,8 @@ def test_run_export_surfaces_reframe_fallback_notice(transcript, tmp_path, monke
         out_dir=str(tmp_path / "out"),
         stages=rec.as_stages(),
     )
-    assert any("claudeshorts" in msg for _pct, msg in progress)
+    assert seen["engine"] == "claudeshorts"
+    assert not any("fallback" in msg.lower() for _pct, msg in progress)
 
 
 def test_run_export_dedupes_repeated_stabilize_notice(transcript, tmp_path):


### PR DESCRIPTION
## Summary

Native, smooth speaker-tracking reframe with a no-WSL default engine, plus caption-quality and reframe-robustness fixes.

### Reframe / speaker-tracking
- Native smooth speaker-tracking: face (mediapipe model_selection=1 / haar) -> person (cv2 HOG getDefaultPeopleDetector, node-free, 64x128-window segfault-guarded) -> motion fallback chain, with EMA smoothing and no drift.
- claudeshorts is now the **default** engine (auto/blank/None resolve to it) with **no WSL probe** - eliminates the WSL dependency for the common path. verthor remains explicitly selectable.
- Crop-tracking jitter eliminated (deadzone + smooth interpolation + static-bias); vidstab default-on.
- Outlier-robust median pre-filter so a stray clip-start detection no longer drags the opening crop off the speaker.

### Caption quality + app UX
- Caption-quality + shortmaker pipeline refinements (cut/reframe/caption/export ordering preserved).
- App bootstrap / cancel / model-UX / progress-ETA covered by the existing 100%-coverage suites.

## Commits
- 9e533f1 eliminate crop-tracking jitter (deadzone + smooth interp + static-bias) + vidstab default-on
- 2f7315b native smooth speaker-tracking (face+person fallback, EMA, no drift) + claudeshorts default (no-WSL)
- 0803b2d outlier-robust median pre-filter (fix tracker bug found in visual verification)

## Verification
- **Sidecar gate**: pytest --cov=media_studio --cov-branch --cov-fail-under=100 -> 4097 passed, 1 skipped, **100.00%** line+branch coverage.
- **Renderer gate**: vitest run --coverage -> 1673 passed, **100%** statements/branches/functions/lines.
- **Pre-commit**: ruff (lint+format), oxlint, biome, gitleaks -> all pass.
- **Targeted**: test_reframe_claudeshorts.py (97) + test_shortmaker.py (121) pass.
- **Visual sample PASSED**: 3 real-pipeline clips rendered at 1080x1920 (9:16) - m03_minciuna.mp4, m05_demnitate.mp4, m10_niciun-fir.mp4 - verified via extracted frames; the tracker bug found during visual verification is fixed (0803b2d).
- **No test-weakening**: +373 net test lines, no new skip/xfail; default-engine assertions updated to reflect the intentional auto -> claudeshorts flip.

Note: 2 local test failures (test_smolvlm2.py unknown_asset_is_false, test_handlers_phase8.py omits_missing_and_fails_open) are **environmental on the dev box only** - the SmolVLM2-2.2B weights are physically cached locally (D:\basic-memory\.hf), so default_models_present returns True. They fail identically on origin/main and **pass in a clean HF env (CI-equivalent)**. Not introduced by this branch.
