### PR TITLE
feat(reframe-v1): Phase 1 — packaging root-cause + dataRoot fallback + loud first-run + no-silent-fallback + self-test + ASS brace fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,9 @@ secrets.local.*
 
 # build artifacts (installer + unpacked) — never commit
 dist/
+# Built installers (NSIS .exe + portable .zip) — large binaries; attach to
+# GitHub Releases, never commit to the repo.
+installers/
 
 # Regenerable build binaries (staged by build/python-embed-setup.ps1 -WithFfmpeg)
 build/ffmpeg/

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -59,6 +59,14 @@ function liveWindows(): BrowserWindow[] {
 
 /** ipc channel carrying `{state, line}` bootstrap progress to the renderer. */
 const BOOTSTRAP_PROGRESS_CHANNEL = 'bootstrap.progress';
+/**
+ * WU-1 FAIL-LOUD: ipc channel carrying the ACTIONABLE first-run failure message
+ * (bootstrap.py's terminal `FAILED:bootstrap …` line, or a spawn-failure
+ * fallback) to the renderer's SidecarBanner. Must match preload.ts
+ * BOOTSTRAP_ERROR_CHANNEL + the renderer bridge `onBootstrapError`. A broken
+ * first run is then visible + actionable instead of a silent empty app.
+ */
+const BOOTSTRAP_ERROR_CHANNEL = 'bootstrap.error';
 
 let bootstrapChild: ChildProcess | null = null;
 
@@ -243,6 +251,20 @@ function broadcastBootstrap(state: 'running' | 'done' | 'error', line: string): 
 }
 
 /**
+ * WU-1 FAIL-LOUD: push the ACTIONABLE first-run failure message to every live
+ * renderer so the SidecarBanner can surface it (what failed + where + how to
+ * fix). Separate from broadcastBootstrap's progress stream because this is the
+ * terminal, user-facing error — not a progress line.
+ */
+function broadcastBootstrapError(message: string): void {
+  for (const win of liveWindows()) {
+    if (!win.webContents.isDestroyed()) {
+      win.webContents.send(BOOTSTRAP_ERROR_CHANNEL, message);
+    }
+  }
+}
+
+/**
  * Spawn `runtime_setup/bootstrap.py` with the bundled embeddable python and
  * relay its progress lines (`[bootstrap] ...` on stderr, the terminal
  * SUCCESS:/FAILED: line on stdout) to the renderer over 'bootstrap.progress'.
@@ -260,6 +282,9 @@ function runFirstRunBootstrap(): Promise<boolean> {
       windowsHide: true,
     });
     bootstrapChild = child;
+    // WU-1 FAIL-LOUD: remember bootstrap.py's terminal actionable failure line
+    // (`FAILED:bootstrap …`) so we can surface it to the UI on a non-zero exit.
+    let lastFailLine = '';
     const relayLines = (stream: NodeJS.ReadableStream | null): void => {
       if (!stream) return;
       let buffer = '';
@@ -273,6 +298,7 @@ function runFirstRunBootstrap(): Promise<boolean> {
           if (line !== '') {
             // eslint-disable-next-line no-console
             console.error(`[bootstrap] ${line}`);
+            if (line.startsWith('FAILED:bootstrap')) lastFailLine = line;
             broadcastBootstrap('running', line);
           }
           nl = buffer.indexOf('\n');
@@ -286,12 +312,26 @@ function runFirstRunBootstrap(): Promise<boolean> {
       // eslint-disable-next-line no-console
       console.error(`[bootstrap] spawn error: ${err.message}`);
       broadcastBootstrap('error', `bootstrap spawn failed: ${err.message}`);
+      broadcastBootstrapError(
+        `First-run setup could not start: ${err.message}. ` +
+          'Reinstall to a writable location, or set MEDIA_STUDIO_PYTHON, then relaunch.',
+      );
       resolveRun(false);
     });
     child.on('exit', (code: number | null) => {
       bootstrapChild = null;
       const ok = code === 0;
       broadcastBootstrap(ok ? 'done' : 'error', `bootstrap exited (code ${code ?? 'null'})`);
+      if (!ok) {
+        // Prefer bootstrap.py's actionable FAILED line; fall back to a generic
+        // but still-actionable message if the process died before printing one.
+        broadcastBootstrapError(
+          lastFailLine !== ''
+            ? lastFailLine
+            : `First-run setup failed (exit ${code ?? 'null'}). Check that the data ` +
+                'folder is writable and has free disk space, then relaunch.',
+        );
+      }
       resolveRun(ok);
     });
   });

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -26,6 +26,7 @@ const SHELL_SHOW_ITEM_CHANNEL = 'shell.showItemInFolder'; // must match app/main
 const DIALOG_PICK_LOGO_CHANNEL = 'dialog.pickLogoFile'; // must match app/main/shellIpc.ts
 const SIDECAR_RESTART_CHANNEL = 'sidecar.restart'; // must match app/main/ipc.ts
 const SIDECAR_STATUS_CHANNEL = 'sidecar.status'; // must match app/main/ipc.ts
+const BOOTSTRAP_ERROR_CHANNEL = 'bootstrap.error'; // must match app/main/main.ts
 const DATA_FOLDER_GET_CHANNEL = 'dataFolder.get'; // must match app/main/dataFolderIpc.ts
 const DATA_FOLDER_PICK_CHANNEL = 'dataFolder.pick'; // must match app/main/dataFolderIpc.ts
 const DATA_FOLDER_SET_CHANNEL = 'dataFolder.set'; // must match app/main/dataFolderIpc.ts
@@ -76,6 +77,14 @@ export interface MediaApi {
   restartSidecar(): Promise<{ ok: boolean }>;
   /** Subscribe to sidecar lifecycle transitions. Returns an unsubscribe fn. */
   onSidecarStatus(cb: (status: SidecarStatus) => void): () => void;
+  /**
+   * WU-1 FAIL-LOUD: subscribe to first-run setup failures. The main process
+   * relays bootstrap.py's terminal `FAILED:bootstrap …` line (an actionable
+   * message: what failed + where + how to fix) so a broken first run surfaces in
+   * the UI instead of leaving an empty, silently-failing app. Returns an
+   * unsubscribe fn.
+   */
+  onBootstrapError(cb: (message: string) => void): () => void;
   /**
    * DATA ROOT: the data folder (models/envs/exports/...) in use THIS session.
    * Resolves with the absolute path the sidecar also derives its tree from.
@@ -134,6 +143,12 @@ const api: MediaApi = {
     const listener = (_event: IpcRendererEvent, status: SidecarStatus): void => cb(status);
     ipcRenderer.on(SIDECAR_STATUS_CHANNEL, listener);
     return () => ipcRenderer.removeListener(SIDECAR_STATUS_CHANNEL, listener);
+  },
+
+  onBootstrapError(cb: (message: string) => void): () => void {
+    const listener = (_event: IpcRendererEvent, message: string): void => cb(message);
+    ipcRenderer.on(BOOTSTRAP_ERROR_CHANNEL, listener);
+    return () => ipcRenderer.removeListener(BOOTSTRAP_ERROR_CHANNEL, listener);
   },
 
   getDataFolder(): Promise<string> {

--- a/app/renderer/src/components/SetupStatusPanel.test.tsx
+++ b/app/renderer/src/components/SetupStatusPanel.test.tsx
@@ -1,0 +1,239 @@
+// SetupStatusPanel.test.tsx — the first-run self-diagnostic surface (WU-2).
+//
+// Consumes `system.selfTest` and renders a clear pass/fail setup-status panel:
+// an overall banner (ready vs blocked), one row per check with its detail + fix
+// hint, a re-run control, and loud, never-silent failure copy. Pins the §WU-2
+// acceptance: an all-green report reads "ready"; a missing required dep surfaces
+// a problem + fix hint; a load failure degrades to a visible alert (never crash).
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { SetupStatusPanel } from './SetupStatusPanel';
+import type { SelfTestCheck, SelfTestReport } from '../lib/rpc';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+/** A typed client stub exposing only `system.selfTest`. */
+function makeClient(selfTest: () => Promise<SelfTestReport>) {
+  return { system: { selfTest: vi.fn(selfTest) } } as unknown as Parameters<
+    typeof SetupStatusPanel
+  >[0]['rpcClient'];
+}
+
+async function flush(turns = 4): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < turns; i += 1) await Promise.resolve();
+  });
+}
+
+function check(over: Partial<SelfTestCheck> = {}): SelfTestCheck {
+  return {
+    id: 'data',
+    label: 'Writable data folder',
+    ok: true,
+    required: true,
+    detail: 'Data folder is writable.',
+    fixHint: '',
+    ...over,
+  };
+}
+
+const OK_REPORT: SelfTestReport = {
+  ok: true,
+  checks: [check(), check({ id: 'device', label: 'Device probe', required: false })],
+  problems: [],
+};
+
+async function mount(
+  report: () => Promise<SelfTestReport>,
+): Promise<ReturnType<typeof makeClient>> {
+  const rpcClient = makeClient(report);
+  await act(async () => {
+    root.render(<SetupStatusPanel rpcClient={rpcClient} />);
+  });
+  await flush();
+  return rpcClient;
+}
+
+describe('<SetupStatusPanel /> — WU-2 first-run diagnostic', () => {
+  it('shows the loading state while the diagnostic is in flight', async () => {
+    let resolve: (v: SelfTestReport) => void = () => {};
+    const rpcClient = makeClient(() => new Promise<SelfTestReport>((res) => (resolve = res)));
+    await act(async () => {
+      root.render(<SetupStatusPanel rpcClient={rpcClient} />);
+    });
+    expect(container.querySelector('.setup-status__loading')).not.toBeNull();
+    // The re-run control is disabled while a check is in flight.
+    expect(container.querySelector<HTMLButtonElement>('[data-action="rerun"]')!.disabled).toBe(
+      true,
+    );
+
+    await act(async () => {
+      resolve(OK_REPORT);
+    });
+    await flush();
+    expect(container.querySelector('.setup-status__loading')).toBeNull();
+  });
+
+  it('renders the all-green ready banner when every check passes', async () => {
+    await mount(() => Promise.resolve(OK_REPORT));
+    const summary = container.querySelector('.setup-status__summary');
+    expect(summary?.classList.contains('is-ok')).toBe(true);
+    expect(summary?.getAttribute('role')).toBe('status');
+    expect(summary?.textContent).toContain('ready');
+    // Two check rows, both marked pass.
+    const rows = container.querySelectorAll('.setup-status__check');
+    expect(rows.length).toBe(2);
+    expect(container.querySelectorAll('[data-state="ok"]').length).toBe(2);
+    // No fix-hint lines on a clean report.
+    expect(container.querySelectorAll('[data-role="fix-hint"]').length).toBe(0);
+  });
+
+  it('reports a missing required dependency with a fix hint, and a non-required warning', async () => {
+    const report: SelfTestReport = {
+      ok: false,
+      checks: [
+        check(),
+        check({
+          id: 'device',
+          label: 'Device probe',
+          required: false,
+          ok: false,
+          detail: 'probe failed',
+          fixHint: 'update driver',
+        }),
+        check({
+          id: 'cv2',
+          label: 'Reframe engine (OpenCV + MediaPipe)',
+          required: true,
+          ok: false,
+          detail: 'missing: cv2',
+          fixHint: 'Reframe needs OpenCV — reinstall the app',
+        }),
+        // A required failure WITHOUT a fix hint exercises the no-hint branch.
+        check({
+          id: 'asr',
+          label: 'Whisper',
+          required: true,
+          ok: false,
+          detail: 'missing: faster_whisper',
+          fixHint: '',
+        }),
+      ],
+      problems: ['x'],
+    };
+    await mount(() => Promise.resolve(report));
+
+    const summary = container.querySelector('.setup-status__summary');
+    expect(summary?.classList.contains('is-blocked')).toBe(true);
+    expect(summary?.getAttribute('role')).toBe('alert');
+
+    const cv2Row = container.querySelector('[data-check-id="cv2"]')!;
+    expect(cv2Row.classList.contains('is-failed')).toBe(true);
+    expect(cv2Row.querySelector('[data-state="failed"]')?.textContent).toBe('Problem');
+    expect(cv2Row.querySelector('[data-role="fix-hint"]')?.textContent).toContain('OpenCV');
+
+    // Non-required device failure reads as a Warning, not a blocking Problem.
+    expect(
+      container.querySelector('[data-check-id="device"] [data-state="failed"]')?.textContent,
+    ).toBe('Warning');
+
+    // The required no-hint failure renders no fix line but still shows its detail.
+    const asrRow = container.querySelector('[data-check-id="asr"]')!;
+    expect(asrRow.querySelector('[data-role="fix-hint"]')).toBeNull();
+    expect(asrRow.querySelector('.setup-status__check-detail')?.textContent).toContain(
+      'faster_whisper',
+    );
+  });
+
+  it('re-runs the diagnostic when the re-run button is clicked', async () => {
+    const reports = [
+      Promise.resolve<SelfTestReport>({
+        ok: false,
+        checks: [check({ ok: false, fixHint: 'fix it' })],
+        problems: ['x'],
+      }),
+      Promise.resolve<SelfTestReport>(OK_REPORT),
+    ];
+    let call = 0;
+    const rpcClient = makeClient(() => reports[call++]);
+    await act(async () => {
+      root.render(<SetupStatusPanel rpcClient={rpcClient} />);
+    });
+    await flush();
+    expect(
+      container.querySelector('.setup-status__summary')?.classList.contains('is-blocked'),
+    ).toBe(true);
+
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-action="rerun"]')!.click();
+    });
+    await flush();
+    expect(rpcClient!.system.selfTest).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('.setup-status__summary')?.classList.contains('is-ok')).toBe(
+      true,
+    );
+  });
+
+  it('surfaces a load error (Error instance) without crashing', async () => {
+    await mount(() => Promise.reject(new Error('sidecar down')));
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert?.textContent).toContain('sidecar down');
+    expect(container.querySelector('.setup-status__summary')).toBeNull();
+  });
+
+  it('stringifies a non-Error load rejection', async () => {
+    await mount(() => Promise.reject('plain failure'));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain failure');
+  });
+
+  it('shows a neutral empty state when the diagnostic resolves to nothing', async () => {
+    await mount(() => Promise.resolve(undefined as unknown as SelfTestReport));
+    expect(container.querySelector('.setup-status__empty')).not.toBeNull();
+    expect(container.querySelector('.setup-status__summary')).toBeNull();
+  });
+
+  it('renders a custom title when provided', async () => {
+    const rpcClient = makeClient(() => Promise.resolve(OK_REPORT));
+    await act(async () => {
+      root.render(<SetupStatusPanel rpcClient={rpcClient} title="First-run check" />);
+    });
+    await flush();
+    expect(container.querySelector('.setup-status__title')?.textContent).toBe('First-run check');
+  });
+
+  it('ignores a late resolve after unmount (no state update warning)', async () => {
+    let resolve: (v: SelfTestReport) => void = () => {};
+    const rpcClient = makeClient(() => new Promise<SelfTestReport>((res) => (resolve = res)));
+    await act(async () => {
+      root.render(<SetupStatusPanel rpcClient={rpcClient} />);
+    });
+    await act(async () => {
+      root.unmount();
+    });
+    await act(async () => {
+      resolve(OK_REPORT);
+    });
+    expect(container.querySelector('.setup-status__summary')).toBeNull();
+    root = createRoot(container);
+  });
+});

--- a/app/renderer/src/components/SetupStatusPanel.tsx
+++ b/app/renderer/src/components/SetupStatusPanel.tsx
@@ -1,0 +1,129 @@
+// SetupStatusPanel.tsx — the first-run self-diagnostic surface (WU-2).
+//
+// Consumes the cheap direct `system.selfTest` RPC and renders a CLEAR pass/fail
+// setup-status panel: an overall banner (ready vs blocked), one row per check
+// with its detail + actionable fix hint, and a re-run control. It reports LOUDLY
+// — a required dependency that is missing (e.g. OpenCV for reframe) shows the
+// problem AND how to fix it, so the user never wanders into a broken render. A
+// load failure degrades to a visible alert; it never crashes the host view.
+//
+// Consumes the FROZEN window.api bridge through the typed `client` from lib/rpc.
+import React, { useCallback, useEffect, useState } from 'react';
+import { client, type SelfTestReport } from '../lib/rpc';
+import './setupStatus.css';
+
+/** Error text from an unknown thrown value (mirrors the sibling panels). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface SetupStatusPanelProps {
+  /** Inject the typed client for tests; defaults to the real lib/rpc client. */
+  rpcClient?: Pick<typeof client, 'system'>;
+  /** Section heading; defaults to a neutral label the host can reuse. */
+  title?: string;
+}
+
+export function SetupStatusPanel({
+  rpcClient,
+  title = 'Setup status',
+}: SetupStatusPanelProps): React.ReactElement {
+  /* v8 ignore next -- the `?? client` default only runs in the real app; every test injects rpcClient. */
+  const api = rpcClient ?? client;
+  const [report, setReport] = useState<SelfTestReport | null>(null);
+  const [error, setError] = useState<string>('');
+  const [loading, setLoading] = useState<boolean>(true);
+  // Bumping the nonce re-triggers the diagnostic effect (the Re-run control).
+  const [nonce, setNonce] = useState<number>(0);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    setError('');
+    setReport(null);
+    Promise.resolve(api.system.selfTest())
+      .then((res) => {
+        if (alive) {
+          setReport(res ?? null);
+          setLoading(false);
+        }
+      })
+      .catch((err: unknown) => {
+        if (alive) {
+          setError(errText(err));
+          setLoading(false);
+        }
+      });
+    return () => {
+      alive = false;
+    };
+  }, [api, nonce]);
+
+  const rerun = useCallback(() => setNonce((n) => n + 1), []);
+
+  return (
+    <section className="setup-status" aria-label={title}>
+      <div className="setup-status__head">
+        <h3 className="setup-status__title">{title}</h3>
+        <button
+          type="button"
+          className="setup-status__rerun"
+          data-action="rerun"
+          onClick={rerun}
+          disabled={loading}
+        >
+          Re-run check
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="setup-status__loading" aria-busy="true">
+          Checking your setup…
+        </div>
+      ) : error ? (
+        <p className="setup-status__error" role="alert">
+          Could not run the setup check: {error}
+        </p>
+      ) : report ? (
+        <>
+          {report.ok ? (
+            <div className="setup-status__summary is-ok" role="status">
+              Everything looks good — your install is ready.
+            </div>
+          ) : (
+            <div className="setup-status__summary is-blocked" role="alert">
+              Some required components are missing — fix the items below before rendering.
+            </div>
+          )}
+
+          <ul className="setup-status__checks">
+            {report.checks.map((c) => (
+              <li
+                key={c.id}
+                className={`setup-status__check ${c.ok ? 'is-ok' : 'is-failed'}`}
+                data-check-id={c.id}
+              >
+                <div className="setup-status__check-head">
+                  <span className="setup-status__check-name">{c.label}</span>
+                  <span className="setup-status__check-state" data-state={c.ok ? 'ok' : 'failed'}>
+                    {c.ok ? 'Pass' : c.required ? 'Problem' : 'Warning'}
+                  </span>
+                </div>
+                <p className="setup-status__check-detail">{c.detail}</p>
+                {c.fixHint && (
+                  <p className="setup-status__check-fix" data-role="fix-hint">
+                    Fix: {c.fixHint}
+                  </p>
+                )}
+              </li>
+            ))}
+          </ul>
+        </>
+      ) : (
+        <p className="setup-status__empty">No diagnostic result available.</p>
+      )}
+    </section>
+  );
+}
+
+export default SetupStatusPanel;

--- a/app/renderer/src/components/SidecarBanner.css
+++ b/app/renderer/src/components/SidecarBanner.css
@@ -25,6 +25,19 @@
   animation: sidecar-banner-drop var(--dur-slow) var(--ease-out);
 }
 
+/* First-run setup FAILURE (WU-1): a louder edge so a broken first run reads as
+   an actionable error, not the routine "Sidecar stopped" recovery strip. The
+   message itself carries the fix; the strip wraps long, multi-clause text. */
+.sidecar-banner--error {
+  border-color: var(--status-error);
+  border-left-width: 4px;
+  max-width: min(720px, calc(100vw - var(--space-5) * 2));
+}
+
+.sidecar-banner--error .sidecar-banner__message {
+  white-space: normal;
+}
+
 @keyframes sidecar-banner-drop {
   from {
     opacity: 0;

--- a/app/renderer/src/components/SidecarBanner.test.tsx
+++ b/app/renderer/src/components/SidecarBanner.test.tsx
@@ -15,6 +15,7 @@ import { SidecarBanner, type SidecarStatus } from './SidecarBanner';
 // ---- bridge fake ------------------------------------------------------------
 
 let statusCb: ((status: SidecarStatus) => void) | null = null;
+let bootstrapErrorCb: ((message: string) => void) | null = null;
 const restartSidecar = vi.fn<() => Promise<{ ok: boolean }>>();
 
 function installBridge(): void {
@@ -29,10 +30,36 @@ function installBridge(): void {
   };
 }
 
+/** Bridge that ALSO relays first-run bootstrap errors (WU-1 FAIL-LOUD). */
+function installBridgeWithBootstrap(): void {
+  (window as unknown as { api?: unknown }).api = {
+    onSidecarStatus: (cb: (status: SidecarStatus) => void) => {
+      statusCb = cb;
+      return () => {
+        statusCb = null;
+      };
+    },
+    restartSidecar,
+    onBootstrapError: (cb: (message: string) => void) => {
+      bootstrapErrorCb = cb;
+      return () => {
+        bootstrapErrorCb = null;
+      };
+    },
+  };
+}
+
 /** Drive a supervisor status push into the mounted banner. */
 function pushStatus(status: SidecarStatus): void {
   act(() => {
     statusCb?.(status);
+  });
+}
+
+/** Drive a first-run bootstrap-error push into the mounted banner. */
+function pushBootstrapError(message: string): void {
+  act(() => {
+    bootstrapErrorCb?.(message);
   });
 }
 
@@ -41,6 +68,7 @@ let root: Root;
 
 beforeEach(() => {
   statusCb = null;
+  bootstrapErrorCb = null;
   restartSidecar.mockReset();
   restartSidecar.mockResolvedValue({ ok: true });
   installBridge();
@@ -172,5 +200,41 @@ describe('SidecarBanner', () => {
     mount();
     // No status pushes possible; renders nothing and does not throw.
     expect(banner()).toBeNull();
+  });
+
+  // ---- WU-1: first-run setup FAIL-LOUD surfacing -----------------------------
+
+  it('surfaces an actionable first-run bootstrap error (role=alert, no Restart)', () => {
+    installBridgeWithBootstrap();
+    mount();
+    expect(banner()).toBeNull();
+    pushBootstrapError(
+      'FAILED:bootstrap permission denied | data root=C:\\Users\\me | fix: pick a writable folder',
+    );
+    const el = banner();
+    expect(el).not.toBeNull();
+    expect(el!.getAttribute('role')).toBe('alert');
+    expect(el!.textContent).toContain('permission denied');
+    expect(el!.textContent).toContain('fix:');
+    // The bootstrap-error banner offers no Restart (the fix is in the message).
+    expect(restartBtn()).toBeNull();
+  });
+
+  it('ignores an empty bootstrap-error message (stays clear)', () => {
+    installBridgeWithBootstrap();
+    mount();
+    pushBootstrapError('');
+    expect(banner()).toBeNull();
+  });
+
+  it('the bootstrap error takes precedence over a sidecar status banner', () => {
+    installBridgeWithBootstrap();
+    mount();
+    pushStatus('down');
+    expect(banner()!.textContent).toContain('Sidecar stopped');
+    pushBootstrapError('FAILED:bootstrap I/O error | fix: free disk space');
+    // The actionable first-run failure replaces the generic status banner.
+    expect(banner()!.textContent).toContain('I/O error');
+    expect(restartBtn()).toBeNull();
   });
 });

--- a/app/renderer/src/components/SidecarBanner.tsx
+++ b/app/renderer/src/components/SidecarBanner.tsx
@@ -17,6 +17,13 @@ export type SidecarStatus = 'running' | 'restarting' | 'down';
 interface SidecarBridge {
   restartSidecar?: () => Promise<{ ok: boolean }>;
   onSidecarStatus?: (cb: (status: SidecarStatus) => void) => () => void;
+  /**
+   * First-run setup failure relay (WU-1 FAIL-LOUD). The main process forwards
+   * bootstrap.py's terminal `FAILED:bootstrap …` line — an ACTIONABLE message
+   * (what failed + where + how to fix) — so a broken first run is never a silent
+   * empty app. Returns an unsubscribe fn.
+   */
+  onBootstrapError?: (cb: (message: string) => void) => () => void;
 }
 
 /** Read the preload-injected bridge without a global Window augmentation. */
@@ -34,6 +41,9 @@ export function SidecarBanner(): React.ReactElement | null {
   // 'running' is the optimistic default: absent any 'down' event the app is fine.
   const [status, setStatus] = useState<SidecarStatus>('running');
   const [busy, setBusy] = useState(false);
+  // First-run setup failure message (WU-1). null = no failure; a non-empty
+  // string is the actionable error to surface (takes precedence over status).
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
 
   useEffect(() => {
     const api = bridge();
@@ -45,6 +55,12 @@ export function SidecarBanner(): React.ReactElement | null {
       setBusy(false);
     });
     return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    const api = bridge();
+    if (!api || typeof api.onBootstrapError !== 'function') return;
+    return api.onBootstrapError((message) => setBootstrapError(message ? message : null));
   }, []);
 
   const onRestart = useCallback(() => {
@@ -63,6 +79,16 @@ export function SidecarBanner(): React.ReactElement | null {
         setBusy(false);
       });
   }, []);
+
+  // First-run setup failure wins: it means there is no sidecar to restart, so we
+  // show the ACTIONABLE message (no Restart button — the fix is in the message).
+  if (bootstrapError !== null) {
+    return (
+      <div className="sidecar-banner sidecar-banner--error" role="alert" aria-live="assertive">
+        <span className="sidecar-banner__message">{bootstrapError}</span>
+      </div>
+    );
+  }
 
   if (status === 'running') return null;
 

--- a/app/renderer/src/components/setupStatus.css
+++ b/app/renderer/src/components/setupStatus.css
@@ -1,0 +1,155 @@
+/* setupStatus.css — the first-run self-diagnostic panel (WU-2).
+ * Layout + status tint only; status is ALWAYS conveyed by visible text (Pass /
+ * Problem / Warning), never hue alone (WCAG 1.4.1). Tokens come from the shared
+ * design system (modelsSystem.css / tokens). */
+
+.setup-status {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.setup-status__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.setup-status__title {
+  margin: 0;
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.setup-status__rerun {
+  appearance: none;
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-pill);
+  background: transparent;
+  color: var(--accent);
+  padding: var(--space-1) var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.setup-status__rerun:hover:not(:disabled) {
+  background: var(--accent-soft);
+  color: var(--accent-hover);
+}
+
+.setup-status__rerun:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.setup-status__rerun:disabled {
+  opacity: 0.5;
+  cursor: progress;
+}
+
+.setup-status__loading {
+  color: var(--text-faint);
+  font-size: var(--type-caption-size);
+}
+
+.setup-status__error {
+  color: var(--status-error);
+  background: var(--status-error-soft);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  margin: 0;
+}
+
+.setup-status__summary {
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  font-weight: var(--type-body-strong-weight, 600);
+}
+
+.setup-status__summary.is-ok {
+  color: var(--status-success);
+  background: var(--status-success-soft);
+}
+
+.setup-status__summary.is-blocked {
+  color: var(--status-error);
+  background: var(--status-error-soft);
+}
+
+.setup-status__checks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.setup-status__check {
+  border: 1px solid var(--surface-edge);
+  border-left: 3px solid var(--surface-edge);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.setup-status__check.is-ok {
+  border-left-color: var(--status-success);
+}
+
+.setup-status__check.is-failed {
+  border-left-color: var(--status-error);
+}
+
+.setup-status__check-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.setup-status__check-name {
+  color: var(--text-primary);
+  font-weight: var(--type-body-strong-weight, 600);
+}
+
+.setup-status__check-state {
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.setup-status__check-state[data-state="ok"] {
+  color: var(--status-success);
+}
+
+.setup-status__check-state[data-state="failed"] {
+  color: var(--status-error);
+}
+
+.setup-status__check-detail {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+}
+
+.setup-status__check-fix {
+  margin: 0;
+  color: var(--accent);
+  font-size: var(--type-caption-size);
+}
+
+.setup-status__empty {
+  color: var(--text-faint);
+  font-size: var(--type-caption-size);
+  margin: 0;
+}

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -595,6 +595,12 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('system.recommend', { commercial: false });
   });
 
+  it('system.selfTest calls the bare method (WU-2 first-run diagnostic)', async () => {
+    const r = installApi();
+    await client.system.selfTest();
+    expect(r).toHaveBeenCalledWith('system.selfTest', undefined);
+  });
+
   it('asr.engines calls the bare method', async () => {
     const r = installApi();
     await client.asr.engines();

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -310,6 +310,37 @@ export interface AsrEngine {
   installed: boolean;
 }
 
+// ---- First-run self-diagnostic (`system.selfTest`, WU-2) ------------------
+//
+// Field names are FROZEN, identical to the sidecar `_self_test_report_to_wire`
+// payload (camelCase on the wire already). Each check validates one slice of a
+// fresh install (data dir / device / reframe deps / ASR / ffmpeg); a `required`
+// check whose `ok` is false blocks a working render, an informational one
+// (`device`) is surfaced but does not flip the overall `ok`.
+
+/** One self-diagnostic check row (`system.selfTest`, WU-2). */
+export interface SelfTestCheck {
+  /** Stable id the panel keys on: `data` | `device` | `cv2` | `asr` | `ffmpeg`. */
+  id: string;
+  label: string;
+  ok: boolean;
+  /** A failure of a required check blocks a working render (informational ones do not). */
+  required: boolean;
+  /** What was probed / what failed (human one-line). */
+  detail: string;
+  /** Actionable remedy, populated only when the check failed (empty on success). */
+  fixHint: string;
+}
+
+/** The full first-run self-diagnostic report (`system.selfTest`, WU-2). */
+export interface SelfTestReport {
+  /** True iff every REQUIRED check passed (a broken install is loudly false). */
+  ok: boolean;
+  checks: SelfTestCheck[];
+  /** Human problem lines (one per failing check, each with its fix hint). */
+  problems: string[];
+}
+
 /**
  * The resolved on-disk data layout (`paths.describe`, WU-1, read-only). Layout
  * only — no key/secret string ever appears here. `subDirs` names the per-feature
@@ -1232,6 +1263,14 @@ export const client = {
         'system.recommend',
         opts?.commercial === undefined ? {} : { commercial: opts.commercial },
       ),
+    /**
+     * `system.selfTest` (WU-2) — the first-run self-diagnostic: validates the
+     * install END-TO-END (writable data dir, device probe, reframe deps, ASR
+     * backend, ffmpeg/ffprobe) and returns a structured pass/fail report with
+     * fix hints. Direct-return; fail-open on the sidecar (a broken probe becomes
+     * a reported problem, never an exception).
+     */
+    selfTest: (): Promise<SelfTestReport> => rpc('system.selfTest'),
   },
 
   /** `asr.engines` — selectable ASR engines (whisper / parakeet) + installed. */

--- a/app/renderer/src/views/Settings.test.tsx
+++ b/app/renderer/src/views/Settings.test.tsx
@@ -35,6 +35,9 @@ vi.mock('../components/PathsPanel', () => ({
   PathsPanel: () => <div data-testid="storage" />,
   default: () => <div data-testid="storage" />,
 }));
+vi.mock('../components/SetupStatusPanel', () => ({
+  SetupStatusPanel: () => <div data-testid="setup" />,
+}));
 
 import { Settings, SETTINGS_SECTIONS } from './Settings';
 
@@ -75,19 +78,32 @@ function subtab(label: string): HTMLButtonElement {
 }
 
 describe('Settings sub-nav', () => {
-  it('exposes the four sub-sections as the extension array', () => {
+  it('exposes the sub-sections as the extension array', () => {
     expect(SETTINGS_SECTIONS.map((s) => s.id)).toEqual([
       'models',
+      'setup',
       'providers',
       'storage',
       'health',
     ]);
     expect(SETTINGS_SECTIONS.map((s) => s.label)).toEqual([
       'Models & System',
+      'Setup',
       'Providers & Keys',
       'Storage',
       'System Health',
     ]);
+  });
+
+  it('opens the Setup section (self-diagnostic) via the sub-tab', async () => {
+    await mount();
+    await act(async () => {
+      subtab('Setup').click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="setup"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="models"]')).toBeNull();
+    expect(subtab('Setup').classList.contains('tab--active')).toBe(true);
   });
 
   it('opens the Storage section (PathsPanel) via the sub-tab', async () => {

--- a/app/renderer/src/views/Settings.tsx
+++ b/app/renderer/src/views/Settings.tsx
@@ -19,6 +19,7 @@ import { TabBar, type TabDef } from '../components/TabBar';
 import { SystemHealth } from '../features/SystemHealth';
 import { ProvidersKeys } from '../features/ProvidersKeys';
 import { PathsPanel, type PathsBridge } from '../components/PathsPanel';
+import { SetupStatusPanel } from '../components/SetupStatusPanel';
 import { client } from '../lib/rpc';
 import { resolveWindowApi } from '../features/shortMakerLogic';
 import './settings.css';
@@ -68,6 +69,14 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
         <ModelsSystemPanel onOpenProviders={() => ctx.goTo('providers')} />
       </Suspense>
     ),
+  },
+  {
+    id: 'setup',
+    label: 'Setup',
+    // WU-2: the first-run self-diagnostic. Validates the install end-to-end
+    // (writable data dir, device probe, reframe deps, ASR backend, ffmpeg) and
+    // reports LOUDLY with fix hints so the user never lands in a broken render.
+    render: () => <SetupStatusPanel title="Setup status" />,
   },
   {
     id: 'providers',

--- a/docs/V1-GRILL-DECISIONS.md
+++ b/docs/V1-GRILL-DECISIONS.md
@@ -1,0 +1,150 @@
+# Reframe V1 — GRILL DECISION QUEUE
+
+> Audit-trail synthesis of the 6 grill-lens reports (ux-simplicity · model-device-tiering ·
+> poly-processing · reliability-no-silent-fallback · packaging-provisioning-wsl · competitive-redteam).
+> Deduped across lenses. Each decision carries a recommended answer + one-line trade-off.
+> This is the working queue for the live grill — walk it one item at a time.
+>
+> Date: 2026-06-27 · Status: DRAFT FOR GRILL · Decision count: **24** (F-1, F-2 + G-1..G-22)
+
+---
+
+## (a) FOUNDATION FRAMING QUESTIONS
+
+These two reframe everything below. Answer them first; several G-decisions collapse depending on the answer.
+
+### F-1 — Audience + ambition
+**Q (verbatim):** "Who is the primary V1 user — a novice creator who wants *paste a video → get shorts* with near-zero configuration — or a power user who wants the full local media studio? And how ambitious is V1: a *ship-now*, reliable, narrow vertical slice, or a feature-parity-with-OpusClip push?"
+
+**Recommended answer:** **Primary user = novice creator; ambition = ship-now reliable narrow slice.** The repo is currently built as a power-user "media studio" (5 top tabs, Short-maker is the 8th of 13 sub-tabs, a 15-control wall) — but the headline V1 promise is "mostly dropdowns, almost no typing, all quality ON." Those are in direct conflict. Pick the novice + ship-now framing for V1; keep the studio surface as an "Advanced" mode, not the front door. Competitive parity (B-roll, avatars, scheduler) is explicitly a V2 ambition, not V1.
+
+**Why this matters:** Every UX, scope, and cut-for-V1 decision below resolves cleanly under "novice + ship-now" and becomes contentious under "power user + parity."
+
+### F-2 — Scope of "works on the user's machine"
+**Q (verbatim):** "Is V1 a self-contained native app that must install and run cleanly on an ordinary Windows box (including odd install locations and a cold first-run) with **no WSL dependency on the default path** — or is a WSL/GPU power path an accepted V1 requirement?"
+
+**Recommended answer:** **Self-contained native, no WSL on the default path.** The default reframe engine is already in-sidecar OpenCV/MediaPipe (P3 flipped the default away from the WSL `verthor` path; `verthor` now raises explicitly instead of silently falling back). The real-world first-run failure was a **packaging** bug (write to a non-writable install dir), not a WSL gap. So V1's "runs on the machine" promise is achievable native-only; keep `verthor`/WSL as explicit opt-in for GPU users. This makes the packaging fix (G-16/G-17) the true unblocker, not a WSL investment.
+
+---
+
+## (b) CATEGORIZED DECISION LIST
+
+Format: **G-N** — Question · *Rec:* recommendation · *Trade-off:* one line.
+
+### SCOPE
+- **G-1** — Promote Short-maker from the 8th-of-13 buried sub-tab to a top-level primary flow (ideally the default landing)? · *Rec:* **Yes — make it the front door.** · *Trade-off:* Demotes the "media studio" identity; power users lose the studio-first IA they may expect.
+- **G-2** — Collapse the 15-control flat wall (`ShortMakerControls.tsx`) into a one-screen "smart defaults + Advanced disclosure"? · *Rec:* **Yes — one screen, ~3 visible choices, rest behind Advanced.** · *Trade-off:* Hides power; advanced users do one extra click to reach knobs.
+- **G-3** — Cut/hide the studio sub-tabs (Diarize / Refine / Tracks / Convert) from the V1 primary surface? · *Rec:* **Hide behind Advanced for V1, do not delete.** · *Trade-off:* Less discoverable for the few who want them; smaller surface to support/QA.
+
+### UX
+- **G-4** — Flip `DEFAULT_CONTROLS` so quality features are ON by default (stabilize / silenceTrim / autoZoom / removeFillers, emphasis)? · *Rec:* **Yes — defaults ON, matching the stated "all quality ON" promise.** · *Trade-off:* Slower per-clip processing and more chances for a quality step to degrade (couple tightly with G-13).
+- **G-5** — Reduce typing — presets-first, dropdowns over free-text where possible? · *Rec:* **Yes — preset row leads; free-text prompt optional/secondary.** · *Trade-off:* Less expressive for users who want prompt-driven moment selection.
+- **G-6** — Add competitor table-stakes that are cheap wins (hook-title generation, sane caption-style default)? · *Rec:* **Add hook-title default + one good caption preset; skip the rest.** · *Trade-off:* Small scope add now vs. clean cut; risk of feature creep if not bounded.
+
+### MODELS / DEVICE
+- **G-7** — Extend (NOT rebuild) `system_advisor.py` to drive auto-preset selection surfaced in the UI? · *Rec:* **Extend — the probe/advisor/recommender + tiers 0/1/2 already exist and produce `recommended_preset`.** · *Trade-off:* Inherits the existing VRAM-budget heuristics (TIGHT_FRACTION=0.85) rather than designing fresh.
+- **G-8** — Keep ASR model auto-selection by device (large-v3-turbo GPU / small CPU)? · *Rec:* **Keep auto; expose as a one-line "using model X because device Y."** · *Trade-off:* CPU-tier users get `small` quality silently unless we surface it.
+- **G-9** — Surface the advisor's `recommended_preset` + proposed model downloads at first run? · *Rec:* **Yes — reuse the existing loud reason strings ("needs ~X MB VRAM, over Y MB budget").** · *Trade-off:* Adds a first-run step; mitigated because the strings already exist.
+
+### POLY-PROCESSING (local/cloud split)
+- **G-10** — Keep cloud opt-in / local-only default for V1 (consent default-deny per data-type)? · *Rec:* **Yes — default local-only; the `AiJob` degradeChain already terminates in local.** · *Trade-off:* Lower out-of-box quality for moment-selection vs. a cloud model; but zero egress surprises.
+- **G-11** — Add a cloud ASR provider, or keep ASR local-only for V1? · *Rec:* **Local-only for V1** (both engines are already local; no cloud ASR seam exists). · *Trade-off:* CPU-tier transcription is slow/lower-quality; cloud ASR would be a clean future poly-processing win.
+- **G-12** — Surface `willEgress` / cost-estimate / degrade notices in the UI? · *Rec:* **Yes — show the "degraded: fell back to local" notice and a pre-run egress badge.** · *Trade-off:* Slightly busier UI; essential for trust if cloud is ever enabled.
+
+### RELIABILITY (no silent fallback)
+- **G-13** — Fix D1: speaker-tracking silently degrading to a dumb center crop (the marquee feature)? · *Rec:* **Yes — top priority. Surface per-clip ("tracking unavailable, used center crop"), never swallow.** `compute_plan` currently catches ALL detection exceptions + trust-gate miss with only a `log.warning`. · *Trade-off:* Some clips will visibly say "degraded" instead of looking fine-but-wrong — that's the point.
+- **G-14** — Make `detect_backend()` return an explicit signal (not silent `"center"`) when cv2 is absent? · *Rec:* **Yes — fail loud at setup; cv2-absent is a provisioning bug, not a per-clip event.** · *Trade-off:* Turns a "works, badly" path into a "blocked until fixed" path — correct for a marquee feature.
+- **G-15** — Audit the remaining quieter degrades introduced by turning all quality steps ON (G-4)? · *Rec:* **Yes — one sweep over stabilize/silence/autoZoom/fillers for swallowed failures.** · *Trade-off:* Extra audit time before V1; prevents a "ships ON but silently no-ops" embarrassment.
+
+### PACKAGING / WSL
+- **G-16** — Fix the first-run root cause: `bootstrap.py` writes `python3XX._pth` into the (non-writable) install dir, unguarded? · *Rec:* **Yes — guard the write, and/or relocate it so the install dir is never written. This is THE unblocker.** · *Trade-off:* Touches the bootstrap path that every install depends on — needs careful testing across install locations.
+- **G-17** — Make first-run fail LOUD + actionable instead of leaving an empty data dir? · *Rec:* **Yes — wrap the bootstrap top-level so PermissionError surfaces as a real error, not exit-1 silence.** · *Trade-off:* None meaningful; strictly better than the current silent empty-dir symptom.
+- **G-18** — Avoid Program-Files-class install dirs being load-bearing for writes (or document/guard)? · *Rec:* **Make the runtime never depend on writing the install dir; data/runtime writes go to the data dir.** · *Trade-off:* Some refactor of where `_pth`/env live; cleaner long-term.
+- **G-19** — Keep `verthor`/WSL as explicit opt-in and ship in-sidecar as the only default path? · *Rec:* **Yes — already the P3 default; do not regress.** · *Trade-off:* GPU power users must opt in; acceptable per F-2.
+
+### SEQUENCING
+- **G-20** — What is the fix-first order for V1? · *Rec:* **(1) Packaging root cause G-16/G-17 → (2) Reliability D1 G-13/G-14 → (3) UX promotion + defaults G-1/G-2/G-4 → (4) cheap competitive wins G-6.** · *Trade-off:* Front-loads invisible plumbing before visible UX; but a beautiful UI on a crashing install or a silently-degrading marquee feature is worthless.
+
+### CUT-FOR-V1
+- **G-21** — Cut true multi-speaker / wide-shot reframe handling (RISK-3, genuinely absent today)? · *Rec:* **Cut to V2 — but be explicit in UI that V1 tracks a single subject.** · *Trade-off:* Competitive gap vs. OpusClip; honesty avoids "it broke on my 2-person clip" reports.
+- **G-22** — Cut B-roll / emoji-triggers / keyword-SFX / AI-avatar / scheduler (Submagic/Captions.ai parity)? · *Rec:* **Cut all to V2.** · *Trade-off:* Feature-list looks thinner than competitors; but each is a multi-week build and a reliability surface.
+
+---
+
+## (c) BETTER IDEAS (surfaced beyond the ask)
+
+- **First-run self-diagnostic / smoke test** that validates the install end-to-end (writes to data dir, probes device, confirms cv2/ASR present) and reports loudly. *Cross-lens convergence: packaging + reliability both independently point here — a single "did the install actually work" gate kills both the empty-data-dir symptom and the cv2-absent silent center-crop at the same place.*
+- **Reuse the advisor's existing loud reason strings in the UX layer.** *Convergence: device lens ("needs ~X MB VRAM, over Y MB budget" strings already exist) + ux lens (novices need to know *why* a preset was chosen).* Near-zero build cost, high trust payoff.
+- **One-click device→quality preset mapping**: advisor tier (0/1/2) auto-sets which quality toggles are ON. *Convergence: device + ux — solves G-4 (defaults ON) and G-7 (auto-preset) jointly without the user touching the 15 controls.*
+- **Per-clip "real / degraded" badge** in the output list (local, telemetry-free). *From reliability lens — makes G-13/G-15 visible without modal-spam.*
+- **"Honest capability" copy** ("V1 follows a single speaker") instead of hiding the multi-speaker gap. *Red-team lens — converts RISK-3 from a bug report into an expectation.*
+- **Pin the planning baseline to merged reality:** `feat/reframe-quality` is already merged as #236; the "unmerged wide-shot fixes" framing is stale. *Red-team lens — prevents re-planning against a wrong baseline.*
+
+---
+
+## (d) RISKS / RED-TEAM — TOP 10
+
+1. **Marquee speaker-tracking silently degrades to center crop** (reliability D1). Users conclude the product is cheap/broken; no signal it degraded. → G-13/G-14.
+2. **First-run crash on non-writable install dir → empty data dir** (packaging root cause, `bootstrap.py` unguarded `_pth` write). Exact match for the reported real-machine failure. → G-16/G-17.
+3. **Buried IA** — Short-maker is the 8th of 13 sub-tabs, ~3 levels deep; novices never find the headline feature. → G-1.
+4. **Defaults OFF contradict the "all quality ON" promise** (stabilize/silence/autoZoom/fillers all `false`). The product undersells itself out of the box. → G-4.
+5. **Multi-speaker / wide-shot handling genuinely absent** — fails on the common 2-person interview clip vs. OpusClip/Submagic. → G-21 (cut + disclose).
+6. **15-control flat wall** is the opposite of "mostly dropdowns, almost no typing" — scares the target novice. → G-2/G-5.
+7. **Cloud egress / consent confusion** if cloud is ever surfaced without the `willEgress`/degrade notices wired into UI. → G-12.
+8. **Scope creep toward OpusClip/Submagic parity** (B-roll, avatars, SFX, scheduler) sinks the ship-now timeline. → G-22.
+9. **CPU-tier ASR is slow/low-quality and silent** (`small` model auto-picked, no cloud ASR option) → bad first impression on weak machines. → G-8/G-11.
+10. **Stale baseline assumption** — planning around "unmerged wide-shot fixes" when #236 is already merged wastes effort and misjudges remaining work. → pin baseline (Better Ideas).
+
+---
+
+## (e) LIVE GRILL ANSWERS (2026-06-27)
+
+- **F-1 = ANSWERED → Novice-first, advanced hidden.** Default = paste video → make shorts, near-zero config, all quality ON. Power features exist behind "Advanced". PLUS user model direction: **easiest = local model via Ollama / LM Studio** (advise install + pull best whisper + LLM), **and/or cloud via OpenRouter** with a **pool/stash of API keys + per-key usage/consumption shown** in the UI. Lean on existing local runners; don't hand-provision.
+- **F-2 = ANSWERED → Native-default, WSL optional + advised.** Native Windows path always works (no WSL required); WSL/verthor = opt-in power path with a tooltip + optional guided setup when it'd genuinely be better.
+- Implications locked: G-1/G-2/G-3 (promote Short-maker to front door + one-screen smart-defaults + Advanced disclosure) = YES. G-4 (quality defaults ON) = YES. G-7/G-8/G-9 (extend system_advisor for device-ranked model recommend + first-run download) = YES, extended to Ollama/LM Studio detect+pull + OpenRouter key-pool+usage. G-10/G-11/G-12 (local-only default, cloud opt-in w/ egress+usage badges) = YES. G-13..G-19 (no-silent-fallback + packaging root-cause) = YES (all). G-20 sequencing = packaging → reliability → UX → cheap wins.
+- **GUI layout = ANSWERED → Single-screen one-shot (option A)** approved ("yeah that's it"). Drop video → dropdowns → Make Shorts → results grid w/ real/degraded badge; Advanced hidden; device+model+ETA status strip.
+- **Caption/output richness = ADDED (user, must build for V1, per best-practice):**
+  - **Language = DROPDOWN selectable (never free-typed)** to avoid wrong/nonexistent languages; Auto-detect also offered BUT if auto yields lower quality than picking upfront, show an ADVICE/warning to pick the language.
+  - **Caption POSITION editor**: options + LIVE PREVIEW on the actual video; caption box draggable / resizable / movable (like CapCut/Submagic), reflecting final on-video position.
+  - **Subtitle STYLE templates**: multiple presets (karaoke + others) — colors, fonts, styling — selectable + PREVIEWABLE on the video BEFORE processing.
+  - **Output options**: save the SRT separately and/or the shorts (for later edits); BURN-IN on/off; all combinations (burn vs soft-mux vs sidecar SRT). A Preferences/Settings area for defaults.
+  - User delegates the detail to best-practice ("you know how these programs are designed") — design per CapCut/Submagic/Descript norms; search/clarify only where genuinely unclear.
+- **Speaker framing = ANSWERED → Fix wide-shot in V1 + multi-speaker-switching on V2 roadmap.** V1 frames the dominant/active single speaker (no empty studio, even in a 2-shot — the fix already asked for). True speaker-SWITCHING (auto-cut between people) deferred to V2 with honest "follows one speaker at a time" copy.
+
+---
+
+## (f) CONVERGED V1 BUILD PLAN (sequenced; ultracode + TDD 100% + visual-verify)
+
+Baseline = merged main (#236), NOT the stale "unmerged wide-shot" framing. Branch: feat/reframe-v1.
+
+- **Phase 1 — UNBLOCK (foundation, highest priority).** Packaging root-cause: guard bootstrap `_pth`/install-dir writes, dataRoot falls back to userData when install dir non-writable, first-run fails LOUD+actionable (no empty-dir silence) [G-16/17/18]. First-run self-diagnostic/smoke (writable data dir + device probe + cv2/ASR present) reported loudly [Better-Idea]. No-silent-fallback sweep: speaker-track degrade → per-clip loud badge [G-13], detect_backend explicit when cv2 absent [G-14], audit stabilize/silence/autoZoom/fillers swallowed failures [G-15].
+- **Phase 2 — MODELS/DEVICE.** Extend system_advisor → device-ranked model recommend surfaced in UI [G-7/8/9]; detect+advise **Ollama / LM Studio** local runners (pull recommended whisper+LLM); **OpenRouter** cloud w/ **API-key pool + per-key usage/consumption** display; ETA + device details (disk/RAM/VRAM/GPU) strip.
+- **Phase 3 — UX REDESIGN (single-screen one-shot).** Promote short-maker to the front door [G-1]; one screen, ~3 dropdowns + Make Shorts + results grid w/ real/degraded badge [G-2]; quality defaults ON [G-4]; Advanced disclosure hides studio tabs [G-3]; **language DROPDOWN** (+auto-detect with quality-advice); presets-first, least typing [G-5].
+- **Phase 4 — CAPTION EDITOR + OUTPUT.** Draggable/resizable **caption position w/ LIVE PREVIEW** on the video; **subtitle STYLE templates** (color/font/styling) previewable before processing; **output options** (burn-in on/off, save SRT separately, save shorts, combinations); Preferences/Settings area. Per CapCut/Submagic/Descript best-practice.
+- **Phase 5 — FRAMING.** Finish wide-shot dominant-speaker fix (no empty studio); add the "single speaker" honest copy; multi-speaker-switching → V2 roadmap doc.
+- **Phase 6 — VERIFY + RELEASE.** Visual-verify samples (extract frames + LOOK); full gate (sidecar+renderer 100%, pre-commit); merge; rebuild installer; cut V1 release. Re-test first-run on a Program-Files-class path.
+
+CUT to V2: multi-speaker switching, B-roll/avatars/SFX/scheduler [G-21/22].
+
+## (g) IA / NAVIGATION REFINEMENT (user, 2026-06-27) — overrides G-3 "hide"
+
+- **KEEP all functionality** (join, cut, trim, translate, diarize, refine, convert, etc.) — do NOT delete/remove. The earlier "hide studio tabs" must NOT eliminate capability.
+- **CONSOLIDATE the 13 flat tabs into clean SECTIONS** + DEDUPLICATE: each function lives in ONE place. NO operation appears redundantly across multiple tabs (e.g. caption-translation must NOT be a standalone on 4 tabs).
+- **Shared ops become CONTEXTUAL OPT-INS after a primary action**, not standalone tabs: after you join / cut / trim / make-shorts, you can opt in to caption it, translate it, burn-subs-or-not, save. Translation/captioning is offered in-context, once.
+- **Primary flows to support** (examples user gave): (a) AI moment-pick shorts; (b) MANUAL time-interval shorts — give a video + specify ranges (e.g. 1:23 → 4:10) to clip; (c) edit ops join/cut/trim; each then offers the contextual caption/translate/save options.
+- **Unified SAVE/OUTPUT**: save the cut, save the shorts, burn subtitles on/off, save SRT separately — all from one consistent output step (ties to (f) Phase 4 output options).
+- **PRINCIPLE:** maximum capability + cohesion, minimum navigation complexity — "everything comes together" without being complex to use. Functional + each section specific (no dead/duplicate tabs).
+- ACTION: Phase 3 becomes an IA redesign (sections + dedup + contextual shared-ops), NOT a hide-behind-Advanced. Scout current tabs→functions→duplication, propose consolidated IA, confirm with user before building.
+
+## (h) IA CONVERGED (proposal a6ee4dad + user sign-off 2026-06-27)
+
+**5 SECTIONS (each function in exactly ONE home; zero duplication):**
+1. **Library** — sources & readiness (library/project/media/readiness/paths).
+2. **Make Shorts** (novice front door, single-screen) — AI moment-pick (shortmaker.select/export, phase8, thumbnail, ranker/feedback) + **Manual interval** mode (ranges 1:23→4:10 via shortmaker.export inline candidates [E3=yes]) + Batch/"make N"/Templates absorbed here [E4=under Make Shorts] + the SINGLE produced-shorts Gallery (absorbs the misnamed "Create" tab + ShortMaker's ProducedShorts).
+3. **Edit** — manual per-video: Trim/Cut/**Join**/Reorder/Reframe/Stabilize/Cleanup (refine silence+filler, stabilize.run) + Transcript&Captions (transcribe, semantic index as a search box, subtitles.generate/edit with the Timeline cue-editor MERGED IN [kills dup#1], diarize, tracks mgmt) + Audio (dub/tts, tracks.audio). **E2 = ADD a first-class join/concat op** (genuine gap in edit_plan.OpKind; user listed "join" as required) — backend op + UI.
+4. **Director = OWN 5th SECTION** (user sign-off) — the only NL editor (director.plan/previewCost/apply/undo/evaluate), same op engines exposed as "describe it"; headline feature.
+5. **Settings** — Models&System (system/asr/providers.catalog/assets) · Providers&Keys (providers/savePresets/spend + **OpenRouter key-pool + per-key usage**) · Storage&Branding (paths + ShortMaker's leaked data-folder/brand-kit MOVED here) · Health. **E6 = keep the global Local/Cloud quality toggle in the header + per-function routing override in Settings/Advanced** (enables poly-processing).
+
+**KEYSTONE = "Output Tray"** (defined ONCE, rendered after any primary action in Make Shorts / Edit / Director): Caption? · Translate? · Reframe? · Burn-subs on/off · [Save clip][Save short][Save SRT separately] · Preset/Package/NLE-export. Kills the cross-surface dups (caption×6, translate×3, silence×4, subtitle-edit×2, gallery×2, export×7).
+
+**E5 = Convert** → Output-step utility (still discoverable). Migration table (old 13 Workspace sub-tabs + 5 top tabs → these 5 sections) is in proposal a6ee4dad. NOTHING removed — all capability kept, just deduplicated + contextual.

--- a/sidecar/media_studio/__main__.py
+++ b/sidecar/media_studio/__main__.py
@@ -13,10 +13,50 @@ Running ``python -m media_studio.rpc`` instead would start the bare core with on
 
 from __future__ import annotations
 
+import site
 import sys
 
 from . import handlers, rpc
 from .job_store import DiskJobStore
+from .settings_store import default_config_dir
+
+#: the first-run env subdir under the data root. Mirrors
+#: ``runtime_setup.bootstrap.SIDECAR_ENV_NAME`` (kept a local literal so the
+#: runtime never imports the build-time ``runtime_setup`` package).
+_SIDECAR_ENV_DIRNAME = "sidecar"
+
+
+def _activate_sidecar_env() -> None:
+    """Put the first-run sidecar env on ``sys.path`` FROM THE DATA ROOT.
+
+    The heavy runtime deps (httpx, numpy, faster-whisper, kokoro-onnx, ...)
+    install into the relocatable DATA ROOT at ``<data root>/envs/sidecar`` —
+    NEVER the install dir. The embeddable interpreter's ``python3XX._pth`` is the
+    *other* mechanism that puts that env on ``sys.path``, but a read-only install
+    dir (e.g. ``C:\\Program Files``) CANNOT have its ``._pth`` rewritten by
+    first-run bootstrap. The runtime therefore MUST NOT depend on that write: we
+    add the env dir via :func:`site.addsitedir` here so its ``site-packages`` and
+    ``.pth`` files resolve whether or not the install dir was writable.
+
+    Idempotent (skips when the dir is already on ``sys.path``) and best-effort
+    (absence is fine on a dev box that runs from a venv; any filesystem probe
+    error returns quietly rather than bricking startup — the ``._pth`` activation
+    may still have succeeded). The data root is resolved the SAME way the rest of
+    the sidecar resolves it (``MEDIA_STUDIO_CONFIG_DIR`` -> ``%APPDATA%`` -> XDG),
+    so it always matches the dir bootstrap provisioned into.
+    """
+    try:
+        env_dir = default_config_dir() / "envs" / _SIDECAR_ENV_DIRNAME
+        if not env_dir.is_dir():
+            return
+        resolved = str(env_dir)
+        if resolved in sys.path:
+            return
+        site.addsitedir(resolved)
+    except OSError:
+        # A malformed/unreadable data-root path must never crash startup; the
+        # ._pth activation (when the install dir was writable) is the fallback.
+        return
 
 
 def _suppress_windows_error_dialogs() -> None:
@@ -83,6 +123,10 @@ def main(argv: list[str] | None = None) -> int:
     by a prior exit reappears as INTERRUPTED (never auto-restarted, §5).
     """
     _suppress_windows_error_dialogs()
+    # Activate the data-root env BEFORE pre-importing natives (they live in it),
+    # so the runtime never depends on a writable install dir (the read-only
+    # Program Files first-run failure this hardening fixes).
+    _activate_sidecar_env()
     _preimport_native_modules()
     svc = handlers.register_all()
     store = DiskJobStore(svc.data_dir / "jobs")

--- a/sidecar/media_studio/features/reframe.py
+++ b/sidecar/media_studio/features/reframe.py
@@ -236,6 +236,7 @@ class ReframeEngine:
         in_path: str,
         out_path: str,
         aspect: str = DEFAULT_ASPECT,
+        on_notice: Callable[[dict[str, str]], None] | None = None,
     ) -> str:
         """Reframe ``in_path`` to vertical and write ``out_path``; return it.
 
@@ -243,7 +244,14 @@ class ReframeEngine:
         FROM A FILE, never piped via ``tr|bash`` on stdin). Output is 1080x1920
         h264 for the default 9:16 aspect. Raises :class:`ReframeError` on a
         non-zero exit code.
+
+        ``on_notice`` is accepted for stage-seam uniformity with the in-sidecar
+        claudeshorts engine (so :func:`shortmaker._lazy_reframe` can thread it to
+        whichever engine is resolved). verthor runs subject tracking INSIDE WSL,
+        so it cannot emit a Python-side speaker-tracking-degrade notice — the
+        parameter is therefore intentionally not invoked here.
         """
+        _ = on_notice  # verthor degrades inside WSL; no Python-side notice to emit
         argv = build_reframe_argv(in_path, out_path, aspect, self._settings)
         if not isinstance(argv, list):  # defensive: never a shell string
             raise TypeError("reframe argv must be a list of strings")

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -112,6 +112,37 @@ class ClaudeShortsReframeError(RuntimeError):
     """Raised when the claudeshorts reframe cannot probe or encode."""
 
 
+class ClaudeShortsBackendUnavailableError(ClaudeShortsReframeError):
+    """No native subject-tracking backend (cv2/mediapipe) is importable.
+
+    This is a SETUP/PROVISIONING failure, NOT a per-clip event: without OpenCV
+    the engine cannot decode frames to track a speaker at all. It is raised as an
+    EXPLICIT signal (never a silent ``center`` fallback) so the job surfaces an
+    actionable "install opencv-python/mediapipe" error rather than silently
+    degrading every clip to a dumb center crop (WU-3 NO-SILENT-FALLBACK).
+    """
+
+
+# Per-clip "speaker tracking was lost" signal (a RUNTIME degrade, distinct from
+# the setup error above). Surfaced via the ``on_notice`` sink so the UI can show a
+# real/degraded badge instead of the degrade being swallowed into a center crop.
+REFRAME_DEGRADED_NOTICE = "reframe.degraded"
+
+
+def make_degraded_notice(reason: str) -> dict[str, str]:
+    """Build the typed per-clip degraded notice (``{type, message, reason}``).
+
+    ``message`` is the human line a job surfaces via ``job.progress``; ``reason``
+    is the specific cause (a detector error, or no trackable subject) so the UI /
+    logs can explain WHY the crop fell back to center.
+    """
+    return {
+        "type": REFRAME_DEGRADED_NOTICE,
+        "message": f"reframe: speaker tracking unavailable ({reason}) — used center crop",
+        "reason": reason,
+    }
+
+
 # --------------------------------------------------------------------------- #
 # aspect handling (kept in sync with features.reframe — see module docstring)
 # --------------------------------------------------------------------------- #
@@ -441,12 +472,18 @@ def probe_video(
 # subject detection (mediapipe -> haar -> center; natives imported lazily)
 # --------------------------------------------------------------------------- #
 def detect_backend(importer: Callable[[str], Any] = importlib.import_module) -> str:
-    """Pick the detection backend: ``mediapipe`` | ``haar`` | ``center``.
+    """Pick the detection backend: ``mediapipe`` | ``haar``.
 
     mediapipe needs cv2 too (frame decode), so the mediapipe backend requires
     BOTH. ``importer`` is injectable so tests exercise the fallback chain with
     no native modules present. NOTE (A6): in production these imports only
     *re-find* modules already loaded by ``__main__._preimport_native_modules``.
+
+    WU-3 NO-SILENT-FALLBACK: when NEITHER mediapipe+cv2 nor cv2 alone is
+    importable, subject tracking is impossible — this raises
+    :class:`ClaudeShortsBackendUnavailableError` (an EXPLICIT setup/provisioning
+    signal) instead of returning a silent ``"center"`` that the rest of the
+    pipeline could not distinguish from a legitimate no-subject clip.
     """
     try:
         importer("mediapipe")
@@ -457,8 +494,12 @@ def detect_backend(importer: Callable[[str], Any] = importlib.import_module) -> 
     try:
         importer("cv2")
         return "haar"
-    except Exception:  # noqa: BLE001
-        return "center"
+    except Exception as exc:  # noqa: BLE001
+        raise ClaudeShortsBackendUnavailableError(
+            "subject tracking requires OpenCV (cv2) — and optionally MediaPipe — "
+            "but neither is importable; install opencv-python (and mediapipe) to "
+            "enable speaker tracking, or this is a provisioning/setup error"
+        ) from exc
 
 
 def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | None, Callable[[], None]]:
@@ -681,27 +722,45 @@ class ClaudeShortsReframeEngine:
         )
 
     def compute_plan(
-        self, in_path: str, aspect: str = DEFAULT_ASPECT
+        self,
+        in_path: str,
+        aspect: str = DEFAULT_ASPECT,
+        on_notice: Callable[[dict[str, str]], None] | None = None,
     ) -> tuple[dict[str, int], list[dict[str, float]], float]:
         """Compute ``(crop_rect, keyframes, durationSec)`` for ``in_path``.
 
         Pure planning (probe + detect + smooth + keyframe), no encoding. The
         returned keyframes list is empty when a single static crop suffices.
+
+        WU-3 NO-SILENT-FALLBACK: when speaker tracking cannot run, the crop still
+        degrades to a center crop (the encode never fails for this), but the
+        degrade is SURFACED through ``on_notice`` (a structured
+        :data:`REFRAME_DEGRADED_NOTICE`) so the UI can show a real/degraded badge
+        — it is never swallowed into a silent center crop. A native-backend SETUP
+        error (:class:`ClaudeShortsBackendUnavailableError`) is NOT a per-clip
+        degrade: it propagates so the job fails loudly (install opencv/mediapipe).
         """
         src_w, src_h, duration = self._prober(in_path)
         crop = centered_crop(src_w, src_h, aspect)
         timestamps = window_timestamps(duration)
         try:
             samples = list(self._detector(in_path, timestamps) or [])
-        except Exception:  # noqa: BLE001 - detection is best-effort by design
-            # "else center": a broken detector degrades to the centered crop —
-            # the encode still runs; only subject tracking is lost.
+        except ClaudeShortsBackendUnavailableError:
+            # SETUP/provisioning failure (no cv2/mediapipe): fail loud, never a
+            # per-clip silent degrade. Re-raise so the job surfaces an actionable
+            # "install opencv/mediapipe" error.
+            raise
+        except Exception as exc:  # noqa: BLE001 - a runtime detector failure -> degrade
+            # A broken detector degrades to the centered crop — the encode still
+            # runs; only subject tracking is lost. SURFACE it (never swallow).
             _log.warning("subject detection failed; using centered crop", exc_info=True)
-            samples = []
+            self._notify_degraded(on_notice, f"subject detection failed: {exc}")
+            return crop, [], duration
         # Trust gate: a couple of stray hits across many windows is detector noise,
         # not a locatable subject -> keep the centered crop rather than tracking it.
         min_hits = max(1, math.ceil(len(timestamps) * MIN_SUBJECT_HIT_FRAC))
         if len(samples) < min_hits:
+            self._notify_degraded(on_notice, "no trackable subject located")
             return crop, [], duration
 
         smoothed = smooth_centers([c for _, c in samples])
@@ -722,6 +781,16 @@ class ClaudeShortsReframeEngine:
         crop = {**crop, "x": int(kfs[0]["x"])}
         return crop, kfs, duration
 
+    @staticmethod
+    def _notify_degraded(on_notice: Callable[[dict[str, str]], None] | None, reason: str) -> None:
+        """Surface a per-clip degraded notice through ``on_notice`` (when wired).
+
+        The degrade is ALSO logged, but the structured notice is what lets the
+        orchestrator/UI render a degraded badge — the "never swallow" contract.
+        """
+        if on_notice is not None:
+            on_notice(make_degraded_notice(reason))
+
     def reframe(
         self,
         in_path: str,
@@ -729,13 +798,16 @@ class ClaudeShortsReframeEngine:
         aspect: str = DEFAULT_ASPECT,
         on_progress: Callable[[float, str], None] | None = None,
         should_cancel: Callable[[], bool] | None = None,
+        on_notice: Callable[[dict[str, str]], None] | None = None,
     ) -> str:
         """Reframe ``in_path`` -> vertical ``out_path`` in ONE ffmpeg pass.
 
         Raises :class:`ClaudeShortsReframeError` on a non-zero encode exit (the
         shortmaker job converts that into the job.done error payload — A6 #3).
+        ``on_notice`` is forwarded to :meth:`compute_plan` so a speaker-tracking
+        degrade surfaces from this one-shot entry point too (WU-3).
         """
-        crop, keyframes, duration = self.compute_plan(in_path, aspect)
+        crop, keyframes, duration = self.compute_plan(in_path, aspect, on_notice=on_notice)
         argv = build_reframe_argv(in_path, out_path, crop, keyframes, aspect, self._settings)
         if not isinstance(argv, list):  # defensive: never a shell string
             raise TypeError("reframe argv must be a list of strings")

--- a/sidecar/media_studio/features/self_test.py
+++ b/sidecar/media_studio/features/self_test.py
@@ -1,0 +1,322 @@
+"""First-run self-diagnostic — validate the install END-TO-END and report LOUDLY.
+
+WU-2: a single ``system.selfTest`` RPC that checks, in one pass over injectable
+probe seams, the things a fresh install needs before it can render a single frame,
+and returns a structured pass/fail report the Electron setup-status panel renders
+1:1. NO silent partial state: every failing capability surfaces a human problem
+line + an actionable fix hint, so the app never proceeds into a broken render.
+
+Checks (the wire ``id`` the panel keys on):
+
+  * ``data``   — the per-user data dir is writable (write+read+delete a probe).
+  * ``device`` — the hardware probe (:mod:`system_advisor`) runs: GPU / VRAM / RAM
+    / free disk (informational — a missing GPU degrades speed, not capability).
+  * ``cv2``    — OpenCV + MediaPipe importable (the reframe subject-tracking core).
+  * ``asr``    — the Whisper ASR backend (``faster_whisper``) importable.
+  * ``ffmpeg`` — ffmpeg + ffprobe resolvable via :mod:`tools_resolver`.
+
+Design mirrors :mod:`system_advisor`: PURE verdict builders + injectable probe
+seams (filesystem write, hardware detect, ``importlib.find_spec``, tool resolve).
+Nothing heavy is ever imported; a probe failure degrades to a reported problem,
+never a crash.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..util import get_logger
+
+log = get_logger("media_studio.features.self_test")
+
+# --------------------------------------------------------------------------- #
+# human copy (labels + fix hints) — surfaced verbatim in the setup-status panel
+# --------------------------------------------------------------------------- #
+DATA_LABEL = "Writable data folder"
+DATA_FIX = "Choose a different data folder in Settings, or fix the folder's permissions, then re-run the check."
+
+DEVICE_LABEL = "Device probe"
+DEVICE_FIX = "Update your GPU driver. The app still works without a GPU — moment-finding just runs slower on CPU."
+
+CV2_LABEL = "Reframe engine (OpenCV + MediaPipe)"
+CV2_FIX = "Reframe needs OpenCV + MediaPipe — reinstall the app or run setup to restore the bundled Python deps."
+
+ASR_LABEL = "Speech-to-text engine (Whisper)"
+ASR_FIX = "The Whisper engine needs faster-whisper — reinstall the app or run setup to restore the bundled Python deps."
+
+FFMPEG_LABEL = "Media tools (FFmpeg)"
+FFMPEG_FIX = "ffmpeg/ffprobe were not found — install FFmpeg and add it to PATH, or set its path in Settings."
+
+# Probe-key module names (a single import-availability family per dependency).
+_CV2_MODULES: tuple[str, ...] = ("cv2", "mediapipe")
+_ASR_MODULES: tuple[str, ...] = ("faster_whisper",)
+_DEP_MODULES: tuple[str, ...] = ("cv2", "mediapipe", "faster_whisper")
+_FFMPEG_TOOLS: tuple[str, ...] = ("ffmpeg", "ffprobe")
+
+#: the probe file the data-dir writability check writes/reads/deletes.
+_PROBE_NAME = ".reframe-selftest-probe"
+_PROBE_TOKEN = "reframe-selftest-ok"
+
+
+# --------------------------------------------------------------------------- #
+# report shape (frozen, JSON-safe for the RPC the UI renders)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class CheckResult:
+    """One self-diagnostic check's verdict for the UI.
+
+    ``required`` marks a check whose failure BLOCKS a working render (data / deps /
+    media tools); an informational check (``device``) is surfaced but does not flip
+    the overall ``ok``. ``fix_hint`` is the actionable remedy, populated only when
+    the check failed (empty on success).
+    """
+
+    id: str
+    label: str
+    ok: bool
+    required: bool
+    detail: str
+    fix_hint: str
+
+
+@dataclass(frozen=True)
+class SelfTestReport:
+    """The full diagnostic result — a JSON-serializable frozen tree for the UI."""
+
+    ok: bool
+    checks: tuple[CheckResult, ...]
+    problems: tuple[str, ...]
+
+
+# --------------------------------------------------------------------------- #
+# pure check builders
+# --------------------------------------------------------------------------- #
+def _mb(value: int | None) -> str:
+    """Render an MB count for the device summary (``None`` -> ``"unknown"``)."""
+    return f"{value} MB" if value is not None else "unknown"
+
+
+def data_check(*, writable: bool, error: str = "") -> CheckResult:
+    """Verdict for the data-dir writability probe (a REQUIRED check)."""
+    if writable:
+        return CheckResult("data", DATA_LABEL, True, True, "Data folder is writable.", "")
+    detail = f"Cannot write to the data folder: {error}" if error else "Cannot write to the data folder."
+    return CheckResult("data", DATA_LABEL, False, True, detail, DATA_FIX)
+
+
+def device_check(
+    *,
+    vram_mb: int | None,
+    ram_mb: int | None,
+    cpu_count: int | None,
+    gpu_present: bool,
+    disk_free_mb: int | None,
+    error: str = "",
+) -> CheckResult:
+    """Verdict for the hardware probe (INFORMATIONAL — never blocks ``ok``)."""
+    if error:
+        return CheckResult("device", DEVICE_LABEL, False, False, f"Device probe failed: {error}", DEVICE_FIX)
+    detail = "; ".join(
+        [
+            f"GPU: {'yes' if gpu_present else 'none'}",
+            f"VRAM: {_mb(vram_mb)}",
+            f"RAM: {_mb(ram_mb)}",
+            f"CPU cores: {cpu_count if cpu_count is not None else 'unknown'}",
+            f"free disk: {_mb(disk_free_mb)}",
+        ]
+    )
+    return CheckResult("device", DEVICE_LABEL, True, False, detail, "")
+
+
+def dependency_check(
+    check_id: str,
+    label: str,
+    fix_hint: str,
+    *,
+    present_map: Mapping[str, bool],
+    modules: Sequence[str],
+) -> CheckResult:
+    """Verdict for a native-dependency family (REQUIRED) from an import-availability map."""
+    missing = [m for m in modules if not present_map.get(m, False)]
+    if not missing:
+        return CheckResult(check_id, label, True, True, f"{label} available.", "")
+    return CheckResult(check_id, label, False, True, f"missing: {', '.join(missing)}", fix_hint)
+
+
+def tool_check(
+    check_id: str,
+    label: str,
+    fix_hint: str,
+    *,
+    paths: Mapping[str, str | None],
+    names: Sequence[str],
+) -> CheckResult:
+    """Verdict for a set of external tools (REQUIRED) from their resolved paths."""
+    missing = [n for n in names if not paths.get(n)]
+    if not missing:
+        return CheckResult(check_id, label, True, True, "; ".join(f"{n}: {paths[n]}" for n in names), "")
+    return CheckResult(check_id, label, False, True, f"not found: {', '.join(missing)}", fix_hint)
+
+
+def build_report(checks: Sequence[CheckResult]) -> SelfTestReport:
+    """Roll a list of checks up to the report: ``ok`` iff all REQUIRED checks pass.
+
+    ``problems`` lists EVERY failing check (required or not) as a human line with
+    its fix hint, so the panel surfaces an informational failure (e.g. no GPU)
+    without flipping the blocking ``ok`` verdict.
+    """
+    checks = tuple(checks)
+    ok = all(c.ok for c in checks if c.required)
+    problems = tuple(
+        f"{c.label}: {c.detail} Fix: {c.fix_hint}" if c.fix_hint else f"{c.label}: {c.detail}"
+        for c in checks
+        if not c.ok
+    )
+    return SelfTestReport(ok=ok, checks=checks, problems=problems)
+
+
+# --------------------------------------------------------------------------- #
+# probe seams (real I/O behind injectable callables; every default fail-open)
+# --------------------------------------------------------------------------- #
+def probe_data_dir(
+    data_dir: str | Path,
+    *,
+    probe_io: Callable[[Path], str] | None = None,
+) -> tuple[bool, str]:
+    """Write+read+delete a probe file under ``data_dir``; return ``(writable, error)``.
+
+    ``probe_io`` is an injectable seam returning the read-back token; the default
+    does the real round-trip. Any failure (permission, full disk) is caught and
+    returned as a human error string — never raised.
+    """
+    runner = probe_io or _default_data_probe_io
+    try:
+        echoed = runner(Path(data_dir))
+    except Exception as exc:
+        log.debug("data-dir writability probe failed", exc_info=True)
+        return False, str(exc)
+    if echoed != _PROBE_TOKEN:
+        return False, "probe file readback mismatch"
+    return True, ""
+
+
+def _default_data_probe_io(data_dir: Path) -> str:
+    """Real round-trip: mkdir -> write -> read -> delete; return the read content."""
+    data_dir.mkdir(parents=True, exist_ok=True)
+    probe = data_dir / _PROBE_NAME
+    probe.write_text(_PROBE_TOKEN, encoding="utf-8")
+    content = probe.read_text(encoding="utf-8")
+    probe.unlink()
+    return content
+
+
+def probe_dependencies(*, find_spec: Callable[[str], object] | None = None) -> dict[str, bool]:
+    """Build the import-availability map for the native deps WITHOUT importing them.
+
+    Uses ``importlib.util.find_spec`` (an injectable seam) so nothing heavy is
+    imported. A bad spec lookup degrades to absent, never raises.
+    """
+    spec_fn = find_spec or _default_find_spec
+    out: dict[str, bool] = {}
+    for module_name in _DEP_MODULES:
+        try:
+            out[module_name] = spec_fn(module_name) is not None
+        except Exception:
+            out[module_name] = False
+    return out
+
+
+def _default_find_spec(module_name: str) -> object:
+    """Default import-availability probe (no actual import)."""
+    return importlib.util.find_spec(module_name)
+
+
+def probe_disk_free_mb(
+    path: str | Path,
+    *,
+    disk_usage: Callable[[Path], object] | None = None,
+) -> int | None:
+    """Free disk space (MB) on ``path``'s volume, or ``None`` when undeterminable."""
+    usage_fn = disk_usage or _default_disk_usage
+    try:
+        usage = usage_fn(Path(path))
+    except Exception:
+        log.debug("disk-usage probe failed", exc_info=True)
+        return None
+    free = getattr(usage, "free", None)
+    if free is None:
+        return None
+    return int(free // (1024 * 1024))
+
+
+def _default_disk_usage(path: Path) -> object:
+    """Default free-space probe via ``shutil.disk_usage``."""
+    return shutil.disk_usage(path)
+
+
+# --------------------------------------------------------------------------- #
+# end-to-end composition
+# --------------------------------------------------------------------------- #
+def run(
+    *,
+    data_dir: str | Path,
+    hardware_probe: object,
+    resolve_tool: Callable[[str], str | None],
+    find_spec: Callable[[str], object] | None = None,
+    probe_io: Callable[[Path], str] | None = None,
+    disk_usage: Callable[[Path], object] | None = None,
+) -> SelfTestReport:
+    """Probe everything and assemble the :class:`SelfTestReport`.
+
+    ``hardware_probe`` is any object with a ``detect()`` returning VRAM/RAM/CPU/GPU
+    facts (the :class:`system_advisor.HardwareProbe`); a probe that raises is
+    reported as a (non-blocking) device failure. ``resolve_tool`` resolves an
+    external tool name to a path (or ``None``). All other heavy probes are behind
+    seams; nothing heavy is imported.
+    """
+    writable, error = probe_data_dir(data_dir, probe_io=probe_io)
+    data = data_check(writable=writable, error=error)
+
+    try:
+        hw: object | None = hardware_probe.detect()  # type: ignore[attr-defined]
+        device_error = ""
+    except Exception as exc:
+        log.debug("hardware probe failed during self-test", exc_info=True)
+        hw = None
+        device_error = str(exc)
+    device = device_check(
+        vram_mb=getattr(hw, "vram_mb", None),
+        ram_mb=getattr(hw, "ram_mb", None),
+        cpu_count=getattr(hw, "cpu_count", None),
+        gpu_present=bool(getattr(hw, "gpu_present", False)),
+        disk_free_mb=probe_disk_free_mb(data_dir, disk_usage=disk_usage),
+        error=device_error,
+    )
+
+    deps = probe_dependencies(find_spec=find_spec)
+    cv2 = dependency_check("cv2", CV2_LABEL, CV2_FIX, present_map=deps, modules=_CV2_MODULES)
+    asr = dependency_check("asr", ASR_LABEL, ASR_FIX, present_map=deps, modules=_ASR_MODULES)
+
+    tool_paths = {name: resolve_tool(name) for name in _FFMPEG_TOOLS}
+    ffmpeg = tool_check("ffmpeg", FFMPEG_LABEL, FFMPEG_FIX, paths=tool_paths, names=_FFMPEG_TOOLS)
+
+    return build_report([data, device, cv2, asr, ffmpeg])
+
+
+__all__ = [
+    "CheckResult",
+    "SelfTestReport",
+    "build_report",
+    "data_check",
+    "dependency_check",
+    "device_check",
+    "probe_data_dir",
+    "probe_dependencies",
+    "probe_disk_free_mb",
+    "run",
+    "tool_check",
+]

--- a/sidecar/media_studio/features/shortmaker.py
+++ b/sidecar/media_studio/features/shortmaker.py
@@ -106,6 +106,8 @@ CutStage = Callable[..., str]
 # remove_fillers(in_path, out_path, words, cues, *, lang, settings)
 #   -> (out_path, remapped_cues, {"fillersRemoved", "fillerSeconds"})
 RemoveFillersStage = Callable[..., tuple[str, list[Cue], dict[str, Any]]]
+# reframe(in_path, out_path, aspect, *, settings, on_notice) -> out_path
+#   (speaker-tracking degrade is surfaced via on_notice — WU-3 no-silent-fallback)
 ReframeStage = Callable[..., str]
 # apply_zoom(in_path, out_path, cues, *, source_start, duration_sec, settings)
 #   -> out_path  (P4 §8b: subtle slow zoom + punch-in at sentence-start beats)
@@ -121,8 +123,9 @@ MuxAudioStage = Callable[..., str]
 #   (audio-stabilize group: ffmpeg vidstab 2-pass; pass-through when libvidstab
 #    is missing — the unavailable notice is surfaced via on_notice, never skipped)
 StabilizeStage = Callable[..., str]
-# trim_silence(in_path, out_path, *, settings) -> (out_path|in_path, removedSec)
-#   (audio-stabilize group: ffmpeg silencedetect -> dead-air re-cut)
+# trim_silence(in_path, out_path, *, settings, on_notice) -> (out_path|in_path, removedSec, keeps)
+#   (audio-stabilize group: ffmpeg silencedetect -> dead-air re-cut; a swallowed
+#    detect/probe failure is surfaced via on_notice — WU-3 no-silent-fallback)
 SilenceTrimStage = Callable[..., tuple[str, float, list[tuple[float, float]]]]
 
 
@@ -237,13 +240,15 @@ def _lazy_remove_fillers(
     return out_path, remapped, stats
 
 
-def _lazy_reframe(in_path, out_path, aspect, *, settings=None) -> str:
+def _lazy_reframe(in_path, out_path, aspect, *, settings=None, on_notice=None) -> str:
     from . import reframe as _reframe
 
     # T4b: settings["reframeEngine"] is the CONCRETE name run_export resolved
     # ("verthor" | "claudeshorts"); "auto" (direct callers) re-resolves here.
+    # WU-3: thread on_notice so the claudeshorts engine's speaker-tracking degrade
+    # surfaces (the verthor engine accepts it for seam uniformity, never calls it).
     engine, _notice = _reframe.get_engine((settings or {}).get("reframeEngine", "auto"), settings or {})
-    return engine.reframe(in_path, out_path, aspect)
+    return engine.reframe(in_path, out_path, aspect, on_notice=on_notice)
 
 
 def _lazy_stabilize(in_path, out_path, *, settings=None, on_notice=None) -> str:
@@ -259,7 +264,9 @@ def _lazy_stabilize(in_path, out_path, *, settings=None, on_notice=None) -> str:
     return _stabilize.stabilize_clip(in_path, out_path, settings=settings, on_notice=on_notice)
 
 
-def _lazy_trim_silence(in_path, out_path, *, settings=None) -> tuple[str, float, list[tuple[float, float]]]:
+def _lazy_trim_silence(
+    in_path, out_path, *, settings=None, on_notice=None
+) -> tuple[str, float, list[tuple[float, float]]]:
     """Dead-air removal pre-step (audio-stabilize group).
 
     Delegates to ``features.silencetrim.trim_clip``: detects silent spans via
@@ -268,10 +275,13 @@ def _lazy_trim_silence(in_path, out_path, *, settings=None) -> tuple[str, float,
     orchestrator remap caption cues onto the compacted timeline. Returns
     ``(in_path, 0.0, [(0, total)])`` when there is no dead air to remove (an
     identity remap, so cues map through unchanged).
+
+    WU-3: ``on_notice`` is threaded so a swallowed detect/probe failure surfaces
+    (the orchestrator routes it to job.progress) instead of silently no-op'ing.
     """
     from . import silencetrim as _silencetrim
 
-    return _silencetrim.trim_clip(in_path, out_path, settings=settings)
+    return _silencetrim.trim_clip(in_path, out_path, settings=settings, on_notice=on_notice)
 
 
 def _lazy_zoom(in_path, out_path, cues, *, source_start, duration_sec, settings=None) -> str:
@@ -824,7 +834,7 @@ def _export_one(
     audio_track: dict[str, Any] | None = None,
     video_id: str = "",
     source_title: str = "",
-    on_notice: Callable[[dict[str, str]], None] | None = None,
+    on_notice: Callable[[dict[str, str]], None],
 ) -> dict[str, Any]:
     """Run CUT (-> SILENCE-TRIM -> STABILIZE -> REMOVE-FILLERS) -> REFRAME -> CAPTION -> EXPORT (-> MUX-AUDIO).
 
@@ -856,8 +866,11 @@ def _export_one(
     When ``audio_track`` is given (A2 ``audioTrackId``), the chosen track's
     [sourceStart, end) window is muxed onto the exported clip as a final stage.
 
-    ``on_notice`` (optional): a sink for typed stage notices (e.g. the stabilize
-    libvidstab-unavailable notice) the orchestrator routes to ``job.progress``.
+    ``on_notice``: a sink for typed stage notices (e.g. the stabilize
+    libvidstab-unavailable notice, or the WU-3 reframe speaker-tracking degrade)
+    the orchestrator routes to ``job.progress``. Required — ``run_export`` always
+    supplies it (the per-export de-duping sink), so stages can surface a skip /
+    degrade without a silent fallback.
     """
     # CUT — frame-accurate carve; persist sourceStart on the clip record (§3).
     source_start = float(candidate.get("sourceStart", candidate.get("start", 0.0)))
@@ -892,7 +905,9 @@ def _export_one(
         from . import fillers as _fillers  # local: shared cue-remap, import-light
 
         trimmed_path = str(out_dir / f"{stem}.trimmed.mp4")
-        stage_clip, silence_removed, silence_keeps = stages.trim_silence(cut_path, trimmed_path, settings=settings)
+        stage_clip, silence_removed, silence_keeps = stages.trim_silence(
+            cut_path, trimmed_path, settings=settings, on_notice=on_notice
+        )
         local_cues = _rebase_cues(caption_cues, source_start)
         caption_cues = _fillers.remap_cues(local_cues, silence_keeps)
         caption_source_start = 0.0
@@ -936,9 +951,19 @@ def _export_one(
         # The de-filled clip is already clip-local; cues are remapped clip-local.
         caption_source_start = 0.0
 
-    # REFRAME — verthor adapter (center-crop fallback handled INSIDE the engine).
+    # REFRAME — claudeshorts/verthor engine (center-crop fallback handled INSIDE
+    # the engine). WU-3 NO-SILENT-FALLBACK: capture a speaker-tracking degrade as a
+    # structured per-clip signal so the UI can show a real/degraded badge — the
+    # marquee tracking must never SILENTLY collapse to a dumb center crop. The
+    # notice is ALSO forwarded to the shared ``on_notice`` sink (job.progress).
     reframed_path = str(out_dir / f"{stem}.reframed.mp4")
-    stages.reframe(stage_clip, reframed_path, aspect, settings=settings)
+    reframe_degraded: dict[str, Any] = {}
+
+    def _reframe_notice(notice: dict[str, str]) -> None:
+        reframe_degraded["notice"] = notice
+        on_notice(notice)
+
+    stages.reframe(stage_clip, reframed_path, aspect, settings=settings, on_notice=_reframe_notice)
     caption_clip = reframed_path
 
     # P4 §8b / C16: AUTO PUNCH-IN ZOOM — inserted BETWEEN reframe and caption
@@ -1052,6 +1077,11 @@ def _export_one(
     # was nothing to trim — mirrors the optional P3-B filler stats shape).
     if silence_removed > 0.0:
         item["silenceRemovedSec"] = round(float(silence_removed), 3)
+    # WU-3: surface the per-clip reframe degraded signal (speaker tracking fell
+    # back to a center crop) so the UI can render a real/degraded badge. Absent
+    # when reframe tracked the subject normally (no false-positive badge).
+    if reframe_degraded:
+        item["reframeDegraded"] = reframe_degraded["notice"]
     return item
 
 
@@ -1173,6 +1203,10 @@ def _clip_payload(item: dict[str, Any]) -> dict[str, Any]:
     if "fillersRemoved" in item:
         clip["fillersRemoved"] = int(item["fillersRemoved"])
         clip["fillerSeconds"] = float(item.get("fillerSeconds", 0.0))
+    # WU-3: the §2 clip payload carries the reframe degraded badge when present
+    # (the UI reads it off the clips list to flag real-vs-degraded tracking).
+    if "reframeDegraded" in item:
+        clip["reframeDegraded"] = item["reframeDegraded"]
     return clip
 
 

--- a/sidecar/media_studio/features/silencetrim.py
+++ b/sidecar/media_studio/features/silencetrim.py
@@ -59,6 +59,37 @@ DEFAULT_MIN_SILENCE_SEC = _boundary.DEFAULT_SILENCE_MIN_SEC  # 0.5 s
 # Leave this much silence on each kept edge so the cut doesn't sound clipped.
 DEFAULT_PAD_SEC = 0.1
 
+# WU-3 NO-SILENT-FALLBACK: when silence-trim cannot run its detection (no ffmpeg,
+# a silencedetect spawn failure, an unprobeable duration) the step previously
+# no-op'd SILENTLY. It now surfaces this typed notice through an ``on_notice`` sink
+# so the skip is REPORTED (the orchestrator routes it to job.progress), never
+# swallowed. Distinct from a legitimate "no dead air to remove" pass-through.
+SILENCE_TRIM_UNAVAILABLE_NOTICE = "silencetrim.unavailable"
+
+# A notice sink mirroring the stabilize pre-step's: receives a {type, message,
+# reason} dict the orchestrator surfaces via job.progress.
+NoticeSink = Callable[[dict[str, str]], None]
+
+
+def make_unavailable_notice(reason: str) -> dict[str, str]:
+    """Build the typed notice emitted when silence-trim is skipped (``{type, message, reason}``).
+
+    ``message`` is the human line a job surfaces via ``job.progress``; ``reason``
+    is the specific cause (no ffmpeg, a detection spawn failure, an unprobeable
+    duration) so the skip is actionable instead of silent.
+    """
+    return {
+        "type": SILENCE_TRIM_UNAVAILABLE_NOTICE,
+        "message": f"silence-trim skipped: {reason}; the clip was passed through unchanged",
+        "reason": reason,
+    }
+
+
+def _notify(on_notice: NoticeSink | None, reason: str) -> None:
+    """Surface the silence-trim unavailable notice through ``on_notice`` (when wired)."""
+    if on_notice is not None:
+        on_notice(make_unavailable_notice(reason))
+
 
 class SilenceTrimError(RuntimeError):
     """Raised when the silence-trim re-cut ffmpeg pass fails (non-zero exit)."""
@@ -163,6 +194,7 @@ def detect_silence_spans(
     noise_db: float = DEFAULT_NOISE_DB,
     min_silence_sec: float = DEFAULT_MIN_SILENCE_SEC,
     run: DetectRunner | None = None,
+    on_notice: NoticeSink | None = None,
 ) -> list[Span]:
     """Detect silent spans in ``in_path`` via ffmpeg ``silencedetect``.
 
@@ -171,12 +203,17 @@ def detect_silence_spans(
     ``subprocess.run`` but is injectable so tests mock the subprocess. A probe
     failure returns ``[]`` (the trim then keeps the whole clip) rather than
     raising — a detection miss must not fail the pipeline.
+
+    WU-3 NO-SILENT-FALLBACK: a detection failure (no resolvable ffmpeg, or a
+    ``silencedetect`` spawn failure) is SURFACED through ``on_notice`` so the
+    skipped trim is reported, not silently swallowed.
     """
     runner = run if run is not None else subprocess.run
     try:
         ffmpeg_bin = ffmpeg.ffmpeg_path(settings)
     except Exception:  # noqa: BLE001 - no ffmpeg resolvable -> no silences
         log.warning("ffmpeg not found for silencedetect on %s", in_path)
+        _notify(on_notice, "ffmpeg not found for silencedetect")
         return []
     argv = _boundary.build_silencedetect_argv(
         in_path,
@@ -188,6 +225,7 @@ def detect_silence_spans(
         completed = runner(argv, capture_output=True, text=True, check=False)
     except Exception as exc:  # noqa: BLE001 - a probe failure must not crash trim
         log.warning("silencedetect failed for %s: %s", in_path, exc)
+        _notify(on_notice, f"silencedetect failed: {exc}")
         return []
     stderr = getattr(completed, "stderr", "") or ""
     return parse_silence_spans(stderr)
@@ -207,6 +245,7 @@ def trim_clip(
     detect_run: DetectRunner | None = None,
     run: RunFn | None = None,
     duration: ProbeFn | None = None,
+    on_notice: NoticeSink | None = None,
 ) -> tuple[str, float, list[Span]]:
     """Trim dead air from ``in_path`` -> ``out_path``; return ``(path, removedSec, keeps)``.
 
@@ -223,6 +262,11 @@ def trim_clip(
     the removed duration). On a pass-through (nothing removed) ``keeps`` is the
     single full-length span ``[(0, total)]`` — an identity remap, so cues map
     through unchanged.
+
+    WU-3 NO-SILENT-FALLBACK: a swallowed failure (an unprobeable duration, or a
+    detection miss forwarded from :func:`detect_silence_spans`) is SURFACED
+    through ``on_notice`` so the skipped trim is reported, never silent. A
+    legitimate "no dead air to remove" pass-through emits NO notice.
     """
     settings = settings or {}
     run = run or ffmpeg.run
@@ -232,6 +276,7 @@ def trim_clip(
         total = float(duration(in_path, settings))
     except Exception:  # noqa: BLE001 - a probe failure means we can't trim safely
         log.warning("duration probe failed for %s; skipping silence-trim", in_path)
+        _notify(on_notice, "duration probe failed")
         return in_path, 0.0, []
     if total <= 0.0:
         return in_path, 0.0, []
@@ -242,6 +287,7 @@ def trim_clip(
         noise_db=noise_db,
         min_silence_sec=min_silence_sec,
         run=detect_run,
+        on_notice=on_notice,
     )
     keeps = keep_spans(silences, total, pad_sec=pad_sec)
     removed = removed_seconds(keeps, total)
@@ -331,6 +377,9 @@ class SilenceTrim:
                 detect_run=detect_run,
                 run=run,
                 duration=duration,
+                # WU-3: surface a swallowed detect/probe failure via job.progress
+                # (the skip is reported, never a silent {removedSec: 0} no-op).
+                on_notice=lambda notice: job_ctx.progress(50, notice["message"]),
             )
             job_ctx.progress(100, f"removed {removed:.1f}s of dead air")
             return {"path": path, "removedSec": removed}
@@ -375,10 +424,12 @@ __all__ = [
     "DEFAULT_MIN_SILENCE_SEC",
     "DEFAULT_NOISE_DB",
     "DEFAULT_PAD_SEC",
+    "SILENCE_TRIM_UNAVAILABLE_NOTICE",
     "SilenceTrim",
     "SilenceTrimError",
     "detect_silence_spans",
     "keep_spans",
+    "make_unavailable_notice",
     "parse_silence_spans",
     "register",
     "removed_seconds",

--- a/sidecar/media_studio/features/subtitles.py
+++ b/sidecar/media_studio/features/subtitles.py
@@ -625,16 +625,43 @@ def escape_ass_text(text: str) -> str:
     """
     out = str(text)
     out = out.replace("\\", "\\\\")  # literal backslash first
-    out = out.replace("{", "(").replace("}", ")")  # kill override-block injection
+    # Neutralize braces to a brace-FREE, reversible escape: '{' -> '\(' and
+    # '}' -> '\)'. The output contains NO raw '{'/'}' so no ASS override block can
+    # be injected (CONTRACTS.md §4), and _unescape_ass_text reverses it losslessly.
+    # ('\' is escaped first, so a literal '(' / ')' is never confused with an
+    # escaped brace, and a literal '\(' encodes as '\\(' — collision-free.)
+    out = out.replace("{", "\\(").replace("}", "\\)")
     out = out.replace("\r\n", "\n").replace("\r", "\n").replace("\n", "\\N")
     return out
 
 
+#: Reverse map for :func:`_unescape_ass_text` — each ``\<key>`` decodes to its
+#: value (inverse of :func:`escape_ass_text`): ``\N``/``\n`` -> newline,
+#: ``\(`` -> ``{``, ``\)`` -> ``}``, ``\\`` -> ``\``.
+_ASS_UNESCAPE: dict[str, str] = {"N": "\n", "n": "\n", "(": "{", ")": "}", "\\": "\\"}
+
+
 def _unescape_ass_text(text: str) -> str:
-    """Inverse of :func:`escape_ass_text` for round-tripping (``\\N`` -> newline)."""
-    out = text.replace("\\N", "\n").replace("\\n", "\n")
-    out = out.replace("\\\\", "\\")
-    return out
+    r"""Inverse of :func:`escape_ass_text`, round-tripping ``\N``/``\{``/``\}``/``\\``.
+
+    A single left-to-right pass consuming each ``\<x>`` escape as a unit, so a
+    literal backslash (escaped as ``\\``) can never collide with a following
+    ``{``/``}``/``N`` (e.g. ``\\{`` decodes to a literal backslash + ``{``).
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n:
+            decoded = _ASS_UNESCAPE.get(text[i + 1])
+            if decoded is not None:
+                out.append(decoded)
+                i += 2
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
 
 
 def to_ass(cues: Sequence[Cue], *, width: int = 1080, height: int = 1920, fontsize: int = 54) -> str:

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -2119,6 +2119,32 @@ class Services:
         )
         return {"recommendation": recommendation}
 
+    def system_self_test(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``system.selfTest()`` -> the first-run diagnostic report. Direct-return.
+
+        WU-2: validates a fresh install END-TO-END and reports LOUDLY so the app
+        never proceeds into a broken render. Composes the PURE
+        :func:`self_test.run` over the runtime services — the data-dir writability
+        probe (write+read+delete under :attr:`data_dir`), the hardware probe seam
+        (:class:`HardwareProbe`, the SAME one ``system.probe``/``advisor`` use), the
+        native-dependency import map (cv2/mediapipe for reframe + the faster-whisper
+        ASR backend, via ``importlib.find_spec`` — nothing heavy is imported), and
+        the ffmpeg/ffprobe chain (:func:`tools_resolver.resolve_tool`). Every probe
+        is fail-open: a failure becomes a reported problem + fix hint, never an
+        exception. Returns the camelCase wire report the setup-status panel renders.
+        """
+        from . import tools_resolver as _tools_resolver  # local: import-light (registers tool assets)
+        from .features import self_test as _self_test  # local: import-light pure
+
+        settings = self.settings.get()
+        probe = self._hardware_probe or self._default_hardware_probe()
+        report = _self_test.run(
+            data_dir=self.data_dir,
+            hardware_probe=probe,
+            resolve_tool=lambda name: _tools_resolver.resolve_tool(name, settings),
+        )
+        return _self_test_report_to_wire(report)
+
     def phase8_signals(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
         """``phase8.signals({videoId, tier?})`` -> ``{jobId}``. Job-based.
 
@@ -3535,6 +3561,29 @@ def _advisor_report_to_wire(report: Any) -> dict[str, Any]:
     }
 
 
+def _self_test_report_to_wire(report: Any) -> dict[str, Any]:
+    """Convert a :class:`self_test.SelfTestReport` to the camelCase wire dict.
+
+    Mirrors the renderer's ``SelfTestReport`` TS type (ok / checks[id,label,ok,
+    required,detail,fixHint] / problems), so the setup-status panel maps it 1:1.
+    """
+    return {
+        "ok": report.ok,
+        "checks": [
+            {
+                "id": c.id,
+                "label": c.label,
+                "ok": c.ok,
+                "required": c.required,
+                "detail": c.detail,
+                "fixHint": c.fix_hint,
+            }
+            for c in report.checks
+        ],
+        "problems": list(report.problems),
+    }
+
+
 def _run_phase8_signals(  # pragma: no cover - heavy Wave-1 signal compute (torch/cv2/transformers); tests inject a fake runner
     media_path: str,
     *,
@@ -3645,6 +3694,9 @@ def register_all(
     # probes (advisor + present-map + local-server detect + asr engines) through
     # the PURE recommender. Makes ZERO provider/LLM calls.
     reg("system.recommend", svc.system_recommend)
+    # WU-2: the first-run self-diagnostic. Direct (no job): pure data-dir/device/
+    # native-dep/ffmpeg probes behind seams — reports LOUDLY, never proceeds broken.
+    reg("system.selfTest", svc.system_self_test)
     # WU-8: the unified read-only readiness roll-up (model tiers + per-function
     # provider key/consent state). Direct (no job): pure installed-state + redacted
     # settings reads — no provider call, no assets.ensure (the read-only invariant).

--- a/sidecar/runtime_setup/bootstrap.py
+++ b/sidecar/runtime_setup/bootstrap.py
@@ -191,6 +191,36 @@ def write_pth(
     return pth
 
 
+def activate_embed_pth(
+    embed_dir: Path | str,
+    env_dir: Path | str,
+    sidecar_src: Path | str | None = None,
+) -> Path | None:
+    """GUARDED ``._pth`` activation — the runtime never depends on this write.
+
+    The embeddable ``._pth`` lives in the INSTALL dir (beside ``python.exe``). On
+    a read-only install location — e.g. ``C:\\Program Files`` — rewriting it
+    raises :class:`PermissionError`/:class:`OSError`. That MUST NOT abort
+    first-run setup: the env itself installs into the writable DATA ROOT, and the
+    sidecar self-activates it from there at startup
+    (:func:`media_studio.__main__._activate_sidecar_env`). So a failed ``._pth``
+    write is a logged, NON-fatal degradation here — never the silent ``exit 1``
+    that produced an empty data dir and made find-shorts/AI fail downstream.
+
+    Returns the written ``._pth`` path, ``None`` when the dir holds no ``._pth``
+    (a full CPython / dev venv), or ``None`` when the install dir is not writable.
+    """
+    try:
+        return write_pth(embed_dir, env_dir, sidecar_src)
+    except OSError as exc:
+        _log(
+            f"install dir not writable — skipping ._pth activation at {embed_dir} "
+            f"({exc}); the sidecar will self-activate the env from the data dir "
+            f"({env_dir}) instead"
+        )
+        return None
+
+
 # --------------------------------------------------------------------------- #
 # pure logic: pip step argv building (mirrors assets.manager's env installer)
 # --------------------------------------------------------------------------- #
@@ -558,7 +588,10 @@ def main(argv: Sequence[str] | None = None) -> int:
             # pip' — caught by the real-bundle bootstrap smoke, not the mocked
             # unit tests.) The chatterbox env install then reuses this same pip.
             env_dir.mkdir(parents=True, exist_ok=True)
-            write_pth(embed_dir, env_dir, _SIDECAR_DIR)
+            # GUARDED: a read-only install dir (Program Files) cannot take the
+            # ._pth write — that is logged + skipped, NOT fatal. The env installs
+            # into the writable data root and the sidecar self-activates it there.
+            activate_embed_pth(embed_dir, env_dir, _SIDECAR_DIR)
             env_dir = install_env(
                 python_exe=python_exe,
                 root=root,
@@ -602,6 +635,36 @@ def main(argv: Sequence[str] | None = None) -> int:
     except KeyboardInterrupt:
         print("FAILED:bootstrap interrupted")
         return 130
+    # FAIL LOUD + ACTIONABLE: an unexpected setup failure (e.g. a PermissionError
+    # writing the data dir, a disk-full OSError) must NOT escape as a bare
+    # traceback / silent exit 1 that leaves an EMPTY data dir — the exact
+    # real-machine failure (Program Files install -> unguarded ._pth write ->
+    # exit 1 -> find-shorts/AI fail silently). Every path here prints a single
+    # terminal FAILED: line naming WHAT failed, WHERE (the data root), and HOW to
+    # fix it; the Electron supervisor relays that line to the UI error channel.
+    except PermissionError as exc:
+        print(
+            f"FAILED:bootstrap permission denied during first-run setup: {exc} | "
+            f"data root={root} | fix: pick a writable data folder in Settings "
+            f"(or set MEDIA_STUDIO_CONFIG_DIR) and relaunch — the runtime never "
+            f"needs to write the install dir"
+        )
+        return 1
+    except OSError as exc:
+        print(
+            f"FAILED:bootstrap I/O error during first-run setup: {exc} | "
+            f"data root={root} | fix: ensure the data folder exists, is writable, "
+            f"and has free disk space, then relaunch"
+        )
+        return 1
+    except Exception as exc:  # noqa: BLE001 - last-resort: never a silent traceback
+        print(
+            f"FAILED:bootstrap unexpected first-run setup error: "
+            f"{type(exc).__name__}: {exc} | data root={root} | "
+            f"fix: retry the launch; if it persists, reinstall to a writable "
+            f"location and report this message"
+        )
+        return 1
 
 
 if __name__ == "__main__":  # pragma: no cover - process entry

--- a/sidecar/tests/test_handlers.py
+++ b/sidecar/tests/test_handlers.py
@@ -605,7 +605,7 @@ def test_shortmaker_export_resolves_cached_candidates(services: Services, ctx: R
             # stabilize is DEFAULT-ON in the reframe path; stub it so no real
             # vidstab/ffmpeg runs (warp-only pass-through for this handler test).
             stabilize=lambda i, o, *, settings=None, on_notice=None: i,
-            reframe=lambda i, o, a, *, settings=None: o,
+            reframe=lambda i, o, a, *, settings=None, on_notice=None: o,
             render_caption=lambda *a, **k: a[2],
             export_clip=lambda i, o, *, settings=None: o,
         ),
@@ -655,7 +655,7 @@ def test_shortmaker_select_caches_candidates(services: Services, ctx: RpcContext
             select_candidates=lambda *a, **k: [cand],
             snap_candidates=lambda cands, *a, **k: (list(cands), []),
             cut_clip=lambda *a, **k: a[1],
-            reframe=lambda i, o, a, *, settings=None: o,
+            reframe=lambda i, o, a, *, settings=None, on_notice=None: o,
             render_caption=lambda *a, **k: a[2],
             export_clip=lambda i, o, *, settings=None: o,
         ),

--- a/sidecar/tests/test_handlers_self_test.py
+++ b/sidecar/tests/test_handlers_self_test.py
@@ -1,0 +1,68 @@
+"""WU-2 — ``system.selfTest`` handler wiring tests.
+
+The handler composes the pure :mod:`media_studio.features.self_test` diagnostic
+over the runtime services: the real ``data_dir`` writability probe (a tmp dir
+here), the injected HardwareProbe seam (no GPU), and the ffmpeg/ffprobe chain via
+:mod:`media_studio.tools_resolver` (monkeypatched so no real ffmpeg is needed). It
+returns the camelCase wire report the Electron setup-status panel renders 1:1.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import handlers, tools_resolver
+from media_studio.handlers import Services
+from media_studio.protocol import RpcContext
+
+
+class _FakeHardwareProbe:
+    def detect(self) -> Any:
+        from media_studio.features.system_advisor import HardwareInfo
+
+        return HardwareInfo(vram_mb=6000, ram_mb=16000, cpu_count=8, gpu_present=True)
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def _services(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data", hardware_probe=_FakeHardwareProbe())
+
+
+def test_register_all_wires_system_self_test(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "system.selfTest" in registered
+
+
+def test_self_test_returns_wire_report(tmp_path: Path, ctx: RpcContext, monkeypatch: Any) -> None:
+    monkeypatch.setattr(tools_resolver, "resolve_tool", lambda name, _s=None: f"/usr/bin/{name}")
+    out = _services(tmp_path).system_self_test({}, ctx)
+
+    assert set(out) == {"ok", "checks", "problems"}
+    assert isinstance(out["ok"], bool)
+    assert [c["id"] for c in out["checks"]] == ["data", "device", "cv2", "asr", "ffmpeg"]
+    a_check = out["checks"][0]
+    assert set(a_check) == {"id", "label", "ok", "required", "detail", "fixHint"}
+    # The tmp data dir is writable and the injected probe + monkeypatched tools pass.
+    by_id = {c["id"]: c for c in out["checks"]}
+    assert by_id["data"]["ok"] is True
+    assert by_id["device"]["ok"] is True
+    assert by_id["ffmpeg"]["ok"] is True
+
+
+def test_self_test_surfaces_missing_ffmpeg(tmp_path: Path, ctx: RpcContext, monkeypatch: Any) -> None:
+    monkeypatch.setattr(tools_resolver, "resolve_tool", lambda name, _s=None: None)
+    out = _services(tmp_path).system_self_test({}, ctx)
+    by_id = {c["id"]: c for c in out["checks"]}
+    assert by_id["ffmpeg"]["ok"] is False
+    assert out["ok"] is False
+    assert any("FFmpeg" in p or "ffmpeg" in p for p in out["problems"])

--- a/sidecar/tests/test_main_entrypoint.py
+++ b/sidecar/tests/test_main_entrypoint.py
@@ -25,6 +25,7 @@ def test_main_composes_and_delegates_to_rpc_main(monkeypatch, tmp_path):
     calls: list[str] = []
 
     monkeypatch.setattr(entry, "_suppress_windows_error_dialogs", lambda: calls.append("suppress"))
+    monkeypatch.setattr(entry, "_activate_sidecar_env", lambda: calls.append("activate"))
     monkeypatch.setattr(entry, "_preimport_native_modules", lambda: calls.append("preimport"))
 
     fake_svc = SimpleNamespace(data_dir=tmp_path)
@@ -46,8 +47,8 @@ def test_main_composes_and_delegates_to_rpc_main(monkeypatch, tmp_path):
 
     rc = entry.main(["--flag"])
     assert rc == 0
-    # ordering: guards FIRST, then registration, then serve
-    assert calls == ["suppress", "preimport", "register"]
+    # ordering: dialog guard, env activation (before natives), pre-import, register
+    assert calls == ["suppress", "activate", "preimport", "register"]
     assert captured["argv"] == ["--flag"]
     # the composition seam carries data_dir: a DiskJobStore at data_dir/jobs
     store = captured["store"]
@@ -57,10 +58,67 @@ def test_main_composes_and_delegates_to_rpc_main(monkeypatch, tmp_path):
 
 def test_main_propagates_rpc_exit_code(monkeypatch, tmp_path):
     monkeypatch.setattr(entry, "_suppress_windows_error_dialogs", lambda: None)
+    monkeypatch.setattr(entry, "_activate_sidecar_env", lambda: None)
     monkeypatch.setattr(entry, "_preimport_native_modules", lambda: None)
     monkeypatch.setattr(entry.handlers, "register_all", lambda: SimpleNamespace(data_dir=tmp_path))
     monkeypatch.setattr(entry.rpc, "main", lambda argv=None, *, store=None: 130)
     assert entry.main() == 130
+
+
+# --------------------------------------------------------------------------- #
+# _activate_sidecar_env — make the runtime independent of the install-dir ._pth
+# (WU-1 packaging hardening: read-only Program Files cannot have its ._pth
+# rewritten, so the env is self-activated from the relocatable DATA ROOT).
+# --------------------------------------------------------------------------- #
+class TestActivateSidecarEnv:
+    def test_adds_existing_env_dir_via_site(self, monkeypatch, tmp_path):
+        """An existing <data root>/envs/sidecar is put on sys.path via
+        site.addsitedir (the install dir is never touched)."""
+        env_dir = tmp_path / "envs" / "sidecar"
+        env_dir.mkdir(parents=True)
+        monkeypatch.setattr(entry, "default_config_dir", lambda: tmp_path)
+        added: list[str] = []
+        monkeypatch.setattr(entry.site, "addsitedir", lambda p: added.append(p))
+        # a clean sys.path snapshot so the "already present" guard does not fire
+        monkeypatch.setattr(entry.sys, "path", ["/somewhere/else"])
+
+        entry._activate_sidecar_env()
+        assert added == [str(env_dir)]
+
+    def test_noop_when_env_dir_absent(self, monkeypatch, tmp_path):
+        """A dev box with no provisioned env (the dir is absent) is a no-op —
+        addsitedir is never called."""
+        monkeypatch.setattr(entry, "default_config_dir", lambda: tmp_path)
+
+        def boom(_p):  # pragma: no cover - must not be reached
+            raise AssertionError("addsitedir must not run when the env dir is absent")
+
+        monkeypatch.setattr(entry.site, "addsitedir", boom)
+        entry._activate_sidecar_env()  # no envs/sidecar under tmp_path -> returns
+
+    def test_idempotent_when_already_on_sys_path(self, monkeypatch, tmp_path):
+        """When the env dir is ALREADY on sys.path (e.g. via the ._pth on a
+        writable install) we do not add it a second time."""
+        env_dir = tmp_path / "envs" / "sidecar"
+        env_dir.mkdir(parents=True)
+        monkeypatch.setattr(entry, "default_config_dir", lambda: tmp_path)
+        monkeypatch.setattr(entry.sys, "path", ["/x", str(env_dir), "/y"])
+
+        def boom(_p):  # pragma: no cover - must not be reached
+            raise AssertionError("addsitedir must not run when already on sys.path")
+
+        monkeypatch.setattr(entry.site, "addsitedir", boom)
+        entry._activate_sidecar_env()  # already present -> returns without adding
+
+    def test_filesystem_error_never_crashes_startup(self, monkeypatch):
+        """A malformed/unreadable data-root path is swallowed (best-effort): the
+        OSError must NOT propagate and crash the sidecar."""
+
+        def raise_os_error():
+            raise OSError("bad data-root path")
+
+        monkeypatch.setattr(entry, "default_config_dir", raise_os_error)
+        entry._activate_sidecar_env()  # returns None, no exception
 
 
 def test_suppress_windows_error_dialogs_non_win32_is_noop(monkeypatch):

--- a/sidecar/tests/test_reframe.py
+++ b/sidecar/tests/test_reframe.py
@@ -210,6 +210,19 @@ def test_reframe_returns_out_path():
     assert out == r"C:\out\clip.mp4"
 
 
+def test_reframe_accepts_on_notice_for_seam_uniformity():
+    # WU-3: the stage seam passes on_notice to whichever engine is resolved. The
+    # verthor adapter runs subject tracking inside WSL (it cannot emit a
+    # Python-side degrade notice), so it ACCEPTS on_notice and never calls it —
+    # but the signature must match so _lazy_reframe can thread it uniformly.
+    runner = _make_runner(returncode=0)
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, runner=runner)
+    notices: list = []
+    out = engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", on_notice=notices.append)
+    assert out == r"C:\out\clip.mp4"
+    assert notices == []
+
+
 def test_reframe_invokes_runner_with_argv_list_no_shell():
     runner = _make_runner(returncode=0)
     engine = ReframeEngine(

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -416,13 +416,26 @@ def test_detect_backend_haar_when_mediapipe_missing():
     assert cs.detect_backend(_importer({"cv2"})) == "haar"
 
 
-def test_detect_backend_mediapipe_without_cv2_falls_to_center():
-    # mediapipe alone cannot decode frames; chain must not stop half-way.
-    assert cs.detect_backend(_importer({"mediapipe"})) == "center"
+def test_detect_backend_mediapipe_without_cv2_raises_setup_error():
+    # mediapipe alone cannot decode frames; cv2 is required. With cv2 absent the
+    # backend is UNAVAILABLE -> an EXPLICIT setup/provisioning error, never a
+    # silent "center" that degrades per-clip (WU-3 NO-SILENT-FALLBACK).
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError) as exc:
+        cs.detect_backend(_importer({"mediapipe"}))
+    assert "cv2" in str(exc.value).lower() or "opencv" in str(exc.value).lower()
 
 
-def test_detect_backend_center_when_nothing_imports():
-    assert cs.detect_backend(_importer(set())) == "center"
+def test_detect_backend_no_natives_raises_setup_error():
+    # No native modules at all -> explicit setup error (fail loud at setup), not a
+    # silent center fallback the rest of the pipeline can't distinguish.
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError):
+        cs.detect_backend(_importer(set()))
+
+
+def test_backend_unavailable_is_a_reframe_error_subclass():
+    # So a single ``except ClaudeShortsReframeError`` at the job boundary still
+    # catches it, but it is DISTINCT from a per-clip degrade (caught separately).
+    assert issubclass(cs.ClaudeShortsBackendUnavailableError, cs.ClaudeShortsReframeError)
 
 
 def test_detect_subject_centers_center_backend_short_circuits():
@@ -620,6 +633,76 @@ def test_engine_detector_failure_degrades_to_center(fake_bins):
     out = eng.reframe("/in.mp4", "/out.mp4")
     assert out == "/out.mp4"
     assert "'437'" in _vf_of(runner.calls[0]["argv"])
+
+
+# --------------------------------------------------------------------------- #
+# WU-3 NO-SILENT-FALLBACK: compute_plan must SURFACE a per-clip degraded signal
+# (never swallow a detection failure / trust-gate miss into a silent center crop)
+# --------------------------------------------------------------------------- #
+def test_compute_plan_detection_exception_surfaces_degraded_notice(fake_bins):
+    """A broken detector still degrades to a center crop, but the degrade is
+    SURFACED via on_notice (structured) instead of being swallowed with a log."""
+
+    def broken(p, t):
+        raise RuntimeError("mediapipe exploded")
+
+    eng, _ = _engine(fake_bins, detector=broken)
+    notices: list[dict] = []
+    crop, kfs, _d = eng.compute_plan("/in.mp4", on_notice=notices.append)
+    # still a centered crop (encode proceeds) ...
+    assert kfs == [] and crop["x"] == 437
+    # ... but the degrade was reported, not silently swallowed.
+    assert len(notices) == 1
+    assert notices[0]["type"] == cs.REFRAME_DEGRADED_NOTICE
+    assert "center crop" in notices[0]["message"].lower()
+    assert "mediapipe exploded" in notices[0]["reason"]
+
+
+def test_compute_plan_trust_gate_miss_surfaces_degraded_notice(fake_bins):
+    """No locatable subject (zero / too-few hits) -> centered crop AND a surfaced
+    'tracking unavailable' notice so the UI can show a degraded badge."""
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [])
+    notices: list[dict] = []
+    crop, kfs, _d = eng.compute_plan("/in.mp4", on_notice=notices.append)
+    assert kfs == [] and crop["x"] == 437
+    assert len(notices) == 1
+    assert notices[0]["type"] == cs.REFRAME_DEGRADED_NOTICE
+    assert "center crop" in notices[0]["message"].lower()
+
+
+def test_compute_plan_subject_found_emits_no_notice(fake_bins):
+    """A clean track must NOT emit a degraded notice (no false 'degraded' badge)."""
+    ts = cs.window_timestamps(8.0)
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [(x, 0.5) for x in ts])
+    notices: list[dict] = []
+    eng.compute_plan("/in.mp4", on_notice=notices.append)
+    assert notices == []
+
+
+def test_compute_plan_backend_unavailable_propagates_not_swallowed(fake_bins):
+    """A native-backend setup error (cv2/mediapipe absent) is a PROVISIONING
+    failure: it must propagate (fail loud at setup), NOT be swallowed into a
+    per-clip center-crop degrade."""
+
+    def no_backend(p, t):
+        raise cs.ClaudeShortsBackendUnavailableError("opencv (cv2) not installed")
+
+    eng, _ = _engine(fake_bins, detector=no_backend)
+    notices: list[dict] = []
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError):
+        eng.compute_plan("/in.mp4", on_notice=notices.append)
+    # not turned into a per-clip degrade notice
+    assert notices == []
+
+
+def test_reframe_threads_on_notice_through_to_compute_plan(fake_bins):
+    """The engine's reframe() forwards on_notice so the degrade surfaces from the
+    one-shot reframe entry point too."""
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [])
+    notices: list[dict] = []
+    eng.reframe("/in.mp4", "/out.mp4", on_notice=notices.append)
+    assert len(notices) == 1
+    assert notices[0]["type"] == cs.REFRAME_DEGRADED_NOTICE
 
 
 def test_engine_passes_total_sec_and_argv_list(fake_bins):

--- a/sidecar/tests/test_runtime_setup.py
+++ b/sidecar/tests/test_runtime_setup.py
@@ -133,6 +133,43 @@ class TestPthActivation:
         assert bs.find_pth_file(tmp_path) == target
 
 
+class TestActivateEmbedPth:
+    """GUARDED ._pth activation: a read-only install dir must NOT crash setup
+    (the runtime self-activates the env from the data dir instead)."""
+
+    def test_writes_pth_when_dir_is_writable(self, tmp_path):
+        embed = tmp_path / "python-embed"
+        embed.mkdir()
+        (embed / "python312._pth").write_text("python312.zip\n.\n#import site\n")
+        written = bs.activate_embed_pth(embed, tmp_path / "env", tmp_path / "src")
+        assert written == embed / "python312._pth"
+        assert "import site" in written.read_text(encoding="utf-8")
+
+    def test_returns_none_for_non_embed_dir(self, tmp_path):
+        # no ._pth (a full CPython / dev venv) — nothing to activate, no error
+        assert bs.activate_embed_pth(tmp_path, tmp_path / "env") is None
+
+    def test_permission_error_is_guarded_not_raised(self, tmp_path, monkeypatch, capsys):
+        # simulate a read-only install dir (e.g. Program Files): the write raises
+        # PermissionError, which activate_embed_pth swallows + logs (returns None).
+        def boom(*_a, **_k):
+            raise PermissionError("install dir is read-only")
+
+        monkeypatch.setattr(bs, "write_pth", boom)
+        result = bs.activate_embed_pth(tmp_path / "install" / "python", tmp_path / "env")
+        assert result is None
+        err = capsys.readouterr().err
+        assert "skipping ._pth activation" in err
+        assert "self-activate the env from the data dir" in err
+
+    def test_generic_oserror_is_guarded(self, tmp_path, monkeypatch):
+        def boom(*_a, **_k):
+            raise OSError("disk gremlin")
+
+        monkeypatch.setattr(bs, "write_pth", boom)
+        assert bs.activate_embed_pth(tmp_path, tmp_path / "env") is None
+
+
 # --------------------------------------------------------------------------- #
 # pip step argv building (mirrors the U4 env installer; NO pip is run)
 # --------------------------------------------------------------------------- #
@@ -424,6 +461,90 @@ class TestMainOrdering:
 
         assert rc == 0
         assert order == ["pth", "install"], "._pth must be written before the pip install"
+
+
+class TestMainReadOnlyInstallDir:
+    """WU-1 root cause: a read-only install dir (Program Files) must NOT abort
+    first-run setup. The ._pth write is skipped (guarded) and the env still
+    provisions into the writable DATA ROOT (``--root``)."""
+
+    def _fake_py(self, tmp_path: Path) -> Path:
+        fake_py = tmp_path / "install" / "python" / "python.exe"
+        fake_py.parent.mkdir(parents=True)
+        fake_py.write_text("", encoding="utf-8")
+        return fake_py
+
+    def test_pth_not_writable_still_provisions_env_in_data_root(self, tmp_path, monkeypatch, capsys):
+        # 1) the install-dir ._pth write fails like a read-only Program Files dir
+        def deny_pth(*_a, **_k):
+            raise PermissionError("Program Files is read-only")
+
+        monkeypatch.setattr(bs, "write_pth", deny_pth)
+
+        # 2) the env install lands in the DATA ROOT (root == tmp_path), proving
+        #    provisioning succeeds THERE even though the install dir is read-only.
+        def fake_install(*, python_exe, root, env_name, req_file, embed_dir=None):
+            env_dir = Path(root) / "envs" / env_name
+            env_dir.mkdir(parents=True, exist_ok=True)
+            (env_dir / "provisioned.marker").write_text("ok", encoding="utf-8")
+            return env_dir
+
+        monkeypatch.setattr(bs, "install_env", fake_install)
+        fake_py = self._fake_py(tmp_path)
+
+        rc = bs.main(["--skip-assets", "--root", str(tmp_path), "--python", str(fake_py)])
+
+        # NOT a silent exit 1: setup completes, the env exists in the data root.
+        assert rc == 0
+        assert (tmp_path / "envs" / "sidecar" / "provisioned.marker").is_file()
+        # the guard logged the read-only skip (actionable, not a crash)
+        assert "skipping ._pth activation" in capsys.readouterr().err
+
+
+class TestMainFailsLoud:
+    """An unexpected first-run failure surfaces a single actionable FAILED line
+    (what + where + how to fix) and exit 1 — never a bare traceback / silent
+    empty data dir."""
+
+    def _fake_py(self, tmp_path: Path) -> Path:
+        fake_py = tmp_path / "py" / "python.exe"
+        fake_py.parent.mkdir(parents=True)
+        fake_py.write_text("", encoding="utf-8")
+        return fake_py
+
+    def test_permission_error_is_actionable(self, tmp_path, monkeypatch, capsys):
+        def boom(**_kwargs):
+            raise PermissionError("denied writing the data dir")
+
+        monkeypatch.setattr(bs, "install_env", boom)
+        rc = bs.main(["--skip-assets", "--root", str(tmp_path), "--python", str(self._fake_py(tmp_path))])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "FAILED:bootstrap permission denied" in out
+        assert str(tmp_path) in out  # WHERE: the data root
+        assert "fix:" in out  # HOW to fix
+
+    def test_oserror_is_actionable(self, tmp_path, monkeypatch, capsys):
+        def boom(**_kwargs):
+            raise OSError("No space left on device")
+
+        monkeypatch.setattr(bs, "install_env", boom)
+        rc = bs.main(["--skip-assets", "--root", str(tmp_path), "--python", str(self._fake_py(tmp_path))])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "FAILED:bootstrap I/O error" in out
+        assert "free disk space" in out
+
+    def test_unexpected_error_is_actionable(self, tmp_path, monkeypatch, capsys):
+        def boom(**_kwargs):
+            raise RuntimeError("totally unexpected")
+
+        monkeypatch.setattr(bs, "install_env", boom)
+        rc = bs.main(["--skip-assets", "--root", str(tmp_path), "--python", str(self._fake_py(tmp_path))])
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "FAILED:bootstrap unexpected first-run setup error" in out
+        assert "RuntimeError: totally unexpected" in out
 
 
 class TestMainChatterbox:

--- a/sidecar/tests/test_self_test.py
+++ b/sidecar/tests/test_self_test.py
@@ -1,0 +1,293 @@
+"""WU-2 — first-run self-diagnostic (``self_test`` pure module) tests.
+
+The diagnostic validates a fresh install END-TO-END and reports LOUDLY: a data-dir
+writability probe, a device probe (system_advisor hardware), the required native
+deps (cv2/mediapipe for reframe, the faster-whisper ASR backend), and ffmpeg/
+ffprobe resolution. Every probe is an INJECTED seam here so the suite touches no
+real GPU, no heavy import, and (mostly) no real filesystem — the §WU-2 acceptance
+criteria are pinned directly on the pure :func:`run` composition:
+
+  * ok-path -> every check green, no problems;
+  * missing cv2 -> a reported problem with an OpenCV fix hint;
+  * non-writable data dir -> a reported problem with a fix hint.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.features import self_test as st
+from media_studio.features.system_advisor import HardwareInfo
+
+
+class _FakeProbe:
+    """A HardwareProbe-shaped seam: ``detect()`` returns a fixed HardwareInfo."""
+
+    def __init__(self, info: HardwareInfo | None = None, *, raises: bool = False) -> None:
+        self._info = info or HardwareInfo(vram_mb=6000, ram_mb=16000, cpu_count=8, gpu_present=True)
+        self._raises = raises
+
+    def detect(self) -> HardwareInfo:
+        if self._raises:
+            raise RuntimeError("nvml exploded")
+        return self._info
+
+
+def _find_spec(present: set[str]):
+    """A find_spec seam: returns a truthy spec only for module names in ``present``."""
+    return lambda name: object() if name in present else None
+
+
+def _disk(free_mb: int):
+    """A disk_usage seam returning an object with a ``.free`` byte count."""
+    return lambda _p: type("U", (), {"free": free_mb * 1024 * 1024})()
+
+
+def _all_present() -> set[str]:
+    return {"cv2", "mediapipe", "faster_whisper"}
+
+
+def _run(tmp_path: Path, **over: Any) -> st.SelfTestReport:
+    base: dict[str, Any] = {
+        "data_dir": tmp_path / "data",
+        "hardware_probe": _FakeProbe(),
+        "resolve_tool": lambda name: f"/usr/bin/{name}",
+        "find_spec": _find_spec(_all_present()),
+        "disk_usage": _disk(50_000),
+    }
+    base.update(over)
+    return st.run(**base)
+
+
+# --------------------------------------------------------------------------- #
+# §WU-2 acceptance — the three falsifiable paths
+# --------------------------------------------------------------------------- #
+def test_ok_path_all_green(tmp_path: Path) -> None:
+    report = _run(tmp_path)
+    assert report.ok is True
+    assert report.problems == ()
+    assert all(c.ok for c in report.checks)
+    assert [c.id for c in report.checks] == ["data", "device", "cv2", "asr", "ffmpeg"]
+
+
+def test_missing_cv2_is_reported_with_fix_hint(tmp_path: Path) -> None:
+    report = _run(tmp_path, find_spec=_find_spec({"mediapipe", "faster_whisper"}))
+    assert report.ok is False
+    cv2 = next(c for c in report.checks if c.id == "cv2")
+    assert cv2.ok is False
+    assert "cv2" in cv2.detail
+    assert "OpenCV" in cv2.fix_hint
+    assert any("OpenCV" in p for p in report.problems)
+
+
+def test_non_writable_data_dir_is_reported(tmp_path: Path) -> None:
+    def boom(_p: Path) -> str:
+        raise PermissionError("read-only file system")
+
+    report = _run(tmp_path, probe_io=boom)
+    assert report.ok is False
+    data = next(c for c in report.checks if c.id == "data")
+    assert data.ok is False
+    assert "read-only file system" in data.detail
+    assert data.fix_hint != ""
+    assert any("read-only file system" in p for p in report.problems)
+
+
+# --------------------------------------------------------------------------- #
+# pure check builders
+# --------------------------------------------------------------------------- #
+def test_data_check_ok() -> None:
+    c = st.data_check(writable=True)
+    assert c.id == "data" and c.ok is True and c.required is True and c.fix_hint == ""
+
+
+def test_data_check_failure_with_error() -> None:
+    c = st.data_check(writable=False, error="disk full")
+    assert c.ok is False and "disk full" in c.detail and c.fix_hint != ""
+
+
+def test_data_check_failure_without_error() -> None:
+    c = st.data_check(writable=False)
+    assert c.ok is False and c.detail and c.fix_hint != ""
+
+
+def test_device_check_ok_summarizes_hardware() -> None:
+    c = st.device_check(vram_mb=6000, ram_mb=16000, cpu_count=8, gpu_present=True, disk_free_mb=50_000)
+    assert c.id == "device" and c.ok is True and c.required is False
+    assert "6000 MB" in c.detail and "50000 MB" in c.detail and "yes" in c.detail
+
+
+def test_device_check_handles_unknown_fields() -> None:
+    c = st.device_check(vram_mb=None, ram_mb=None, cpu_count=None, gpu_present=False, disk_free_mb=None)
+    assert c.ok is True and "unknown" in c.detail and "none" in c.detail
+
+
+def test_device_check_failure_when_probe_raised() -> None:
+    c = st.device_check(
+        vram_mb=None,
+        ram_mb=None,
+        cpu_count=None,
+        gpu_present=False,
+        disk_free_mb=None,
+        error="nvml exploded",
+    )
+    assert c.ok is False and "nvml exploded" in c.detail and c.fix_hint != ""
+
+
+def test_dependency_check_all_present() -> None:
+    c = st.dependency_check(
+        "cv2",
+        "OpenCV + MediaPipe",
+        "reinstall",
+        present_map={"cv2": True, "mediapipe": True},
+        modules=("cv2", "mediapipe"),
+    )
+    assert c.ok is True and c.fix_hint == ""
+
+
+def test_dependency_check_reports_missing() -> None:
+    c = st.dependency_check(
+        "cv2",
+        "OpenCV + MediaPipe",
+        "reinstall",
+        present_map={"cv2": True, "mediapipe": False},
+        modules=("cv2", "mediapipe"),
+    )
+    assert c.ok is False and "mediapipe" in c.detail and c.fix_hint == "reinstall"
+
+
+def test_tool_check_all_present() -> None:
+    c = st.tool_check(
+        "ffmpeg",
+        "FFmpeg",
+        "add to PATH",
+        paths={"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": "/usr/bin/ffprobe"},
+        names=("ffmpeg", "ffprobe"),
+    )
+    assert c.ok is True and "/usr/bin/ffmpeg" in c.detail and c.fix_hint == ""
+
+
+def test_tool_check_reports_missing() -> None:
+    c = st.tool_check(
+        "ffmpeg",
+        "FFmpeg",
+        "add to PATH",
+        paths={"ffmpeg": "/usr/bin/ffmpeg", "ffprobe": None},
+        names=("ffmpeg", "ffprobe"),
+    )
+    assert c.ok is False and "ffprobe" in c.detail and c.fix_hint == "add to PATH"
+
+
+# --------------------------------------------------------------------------- #
+# build_report rollup
+# --------------------------------------------------------------------------- #
+def test_build_report_ok_when_required_pass_even_if_optional_fails() -> None:
+    checks = [
+        st.CheckResult("data", "Data", True, True, "ok", ""),
+        st.CheckResult("device", "Device", False, False, "probe failed", "plug in a GPU"),
+    ]
+    report = st.build_report(checks)
+    # The optional device failure does NOT block ok, but is still surfaced.
+    assert report.ok is True
+    assert any("plug in a GPU" in p for p in report.problems)
+
+
+def test_build_report_not_ok_when_required_fails() -> None:
+    checks = [st.CheckResult("data", "Data", False, True, "no write", "fix perms")]
+    report = st.build_report(checks)
+    assert report.ok is False and report.problems and "fix perms" in report.problems[0]
+
+
+def test_build_report_problem_without_fix_hint() -> None:
+    checks = [st.CheckResult("x", "X", False, True, "broke", "")]
+    report = st.build_report(checks)
+    assert report.problems == ("X: broke",)
+
+
+# --------------------------------------------------------------------------- #
+# probe seams
+# --------------------------------------------------------------------------- #
+def test_probe_data_dir_real_roundtrip(tmp_path: Path) -> None:
+    writable, error = st.probe_data_dir(tmp_path / "fresh")
+    assert writable is True and error == ""
+    # The probe file is cleaned up (no residue).
+    assert list((tmp_path / "fresh").iterdir()) == []
+
+
+def test_probe_data_dir_reports_io_failure(tmp_path: Path) -> None:
+    def boom(_p: Path) -> str:
+        raise OSError("nope")
+
+    writable, error = st.probe_data_dir(tmp_path, probe_io=boom)
+    assert writable is False and "nope" in error
+
+
+def test_probe_data_dir_detects_readback_mismatch(tmp_path: Path) -> None:
+    writable, error = st.probe_data_dir(tmp_path, probe_io=lambda _p: "corrupted")
+    assert writable is False and "mismatch" in error
+
+
+def test_probe_dependencies_with_injected_find_spec() -> None:
+    out = st.probe_dependencies(find_spec=_find_spec({"cv2"}))
+    assert out["cv2"] is True and out["mediapipe"] is False and out["faster_whisper"] is False
+
+
+def test_probe_dependencies_fail_open_on_find_spec_error() -> None:
+    def boom(_name: str) -> object:
+        raise ImportError("broken loader")
+
+    out = st.probe_dependencies(find_spec=boom)
+    assert out == {"cv2": False, "mediapipe": False, "faster_whisper": False}
+
+
+def test_probe_dependencies_default_find_spec_runs() -> None:
+    # Exercises the real importlib seam (no injection); numpy is always installed.
+    out = st.probe_dependencies()
+    assert set(out) == {"cv2", "mediapipe", "faster_whisper"}
+
+
+def test_probe_disk_free_mb_with_seam() -> None:
+    assert st.probe_disk_free_mb(Path("."), disk_usage=_disk(1234)) == 1234
+
+
+def test_probe_disk_free_mb_none_when_no_free_field() -> None:
+    assert st.probe_disk_free_mb(Path("."), disk_usage=lambda _p: object()) is None
+
+
+def test_probe_disk_free_mb_fail_open(tmp_path: Path) -> None:
+    def boom(_p: Path) -> object:
+        raise OSError("statvfs failed")
+
+    assert st.probe_disk_free_mb(tmp_path, disk_usage=boom) is None
+
+
+def test_probe_disk_free_mb_default_runs(tmp_path: Path) -> None:
+    # Exercises the real shutil.disk_usage seam on a real dir.
+    free = st.probe_disk_free_mb(tmp_path)
+    assert free is None or free >= 0
+
+
+# --------------------------------------------------------------------------- #
+# run() composition — device-probe failure path
+# --------------------------------------------------------------------------- #
+def test_run_reports_device_probe_failure(tmp_path: Path) -> None:
+    report = _run(tmp_path, hardware_probe=_FakeProbe(raises=True))
+    device = next(c for c in report.checks if c.id == "device")
+    assert device.ok is False and "nvml exploded" in device.detail
+    # device is optional, so a green data/cv2/asr/ffmpeg still leaves ok True.
+    assert report.ok is True
+
+
+def test_run_uses_real_disk_seam_by_default(tmp_path: Path) -> None:
+    report = _run(tmp_path, disk_usage=None)
+    assert report.ok is True
+
+
+@pytest.mark.parametrize("missing", ["ffmpeg", "ffprobe"])
+def test_run_reports_missing_ffmpeg_tool(tmp_path: Path, missing: str) -> None:
+    report = _run(tmp_path, resolve_tool=lambda name: None if name == missing else f"/b/{name}")
+    ffmpeg = next(c for c in report.checks if c.id == "ffmpeg")
+    assert ffmpeg.ok is False and missing in ffmpeg.detail
+    assert report.ok is False

--- a/sidecar/tests/test_shortmaker.py
+++ b/sidecar/tests/test_shortmaker.py
@@ -54,8 +54,12 @@ class RecordingStages:
         filler_impl=None,
         trim_impl=None,
         stabilize_impl=None,
+        reframe_notice=None,
+        trim_notice=None,
     ):
         self.calls = calls
+        self._reframe_notice = reframe_notice
+        self._trim_notice = trim_notice
         self._select_return = select_return if select_return is not None else []
         self._snap_impl = snap_impl
         self._reframe_impl = reframe_impl
@@ -88,9 +92,11 @@ class RecordingStages:
         )
 
     # -- audio-stabilize group stages --------------------------------------
-    def trim_silence(self, in_path, out_path, *, settings=None):
+    def trim_silence(self, in_path, out_path, *, settings=None, on_notice=None):
         self.calls.append("trim_silence")
         self.trim_args.append((in_path, out_path))
+        if self._trim_notice is not None and on_notice is not None:
+            on_notice(self._trim_notice)
         if self._trim_impl is not None:
             return self._trim_impl(in_path, out_path)
         # Default stub: "removed 2.5s of dead air", returns the new path + keeps.
@@ -147,8 +153,10 @@ class RecordingStages:
         stats = {"fillersRemoved": 1, "fillerSeconds": 0.4}
         return out_path, list(cues), stats
 
-    def reframe(self, in_path, out_path, aspect, *, settings=None):
+    def reframe(self, in_path, out_path, aspect, *, settings=None, on_notice=None):
         self.calls.append("reframe")
+        if self._reframe_notice is not None and on_notice is not None:
+            on_notice(self._reframe_notice)
         if self._reframe_impl is not None:
             return self._reframe_impl(in_path, out_path, aspect)
         return out_path
@@ -928,6 +936,86 @@ def test_run_export_stabilize_unavailable_notice_surfaced(transcript, tmp_path):
     # unavailable notice was surfaced via job.progress (never silently skipped).
     assert "stabilize" in calls
     assert any("libvidstab" in msg for _pct, msg in progress)
+
+
+def test_run_export_reframe_degraded_surfaced_on_clip_and_progress(transcript, tmp_path):
+    """WU-3: when reframe degrades to a center crop (no trackable subject), the
+    per-clip degraded signal is surfaced BOTH on the clip payload/item (so the UI
+    can show a real/degraded badge) AND via job.progress — never swallowed."""
+    calls: list[str] = []
+    progress: list[tuple[int, str]] = []
+    degraded = {
+        "type": "reframe.degraded",
+        "message": "reframe: speaker tracking unavailable — used center crop",
+        "reason": "no trackable subject located",
+    }
+    rec = RecordingStages(calls, reframe_notice=degraded)
+    ctx = JobContext(
+        job_id="j1",
+        _cancel_event=threading.Event(),
+        _emit_progress=lambda jid, pct, msg: progress.append((pct, msg)),
+    )
+    out = sm.run_export(
+        ctx,
+        video_id="v1",
+        candidates=[{"rank": 1, "start": 0.0, "end": 30.0, "sourceStart": 0.0, "score": 9}],
+        load_context=loader_for(str(tmp_path / "src.mp4"), transcript),
+        out_dir=str(tmp_path / "out"),
+        stages=rec.as_stages(),
+        settings={"stabilize": False},
+    )
+    # surfaced on the full item record ...
+    assert out["items"][0]["reframeDegraded"] == degraded
+    # ... AND on the §2 clip payload (the UI badge source) ...
+    assert out["clips"][0]["reframeDegraded"] == degraded
+    # ... AND announced via progress (not silently swallowed).
+    assert any("speaker tracking unavailable" in msg for _pct, msg in progress)
+
+
+def test_run_export_reframe_ok_has_no_degraded_badge(transcript, tmp_path):
+    """A healthy reframe must NOT stamp a degraded badge (no false positive)."""
+    calls: list[str] = []
+    rec = RecordingStages(calls)  # no reframe_notice -> reframe does not degrade
+    out = sm.run_export(
+        make_ctx(),
+        video_id="v1",
+        candidates=[{"rank": 1, "start": 0.0, "end": 30.0, "sourceStart": 0.0, "score": 9}],
+        load_context=loader_for(str(tmp_path / "src.mp4"), transcript),
+        out_dir=str(tmp_path / "out"),
+        stages=rec.as_stages(),
+        settings={"stabilize": False},
+    )
+    assert "reframeDegraded" not in out["items"][0]
+    assert "reframeDegraded" not in out["clips"][0]
+
+
+def test_run_export_silence_trim_unavailable_notice_surfaced(transcript, tmp_path):
+    """WU-3: a swallowed silence-trim failure (e.g. no ffmpeg for silencedetect)
+    is surfaced via job.progress instead of silently no-op'ing the step."""
+    calls: list[str] = []
+    progress: list[tuple[int, str]] = []
+    notice = {
+        "type": "silencetrim.unavailable",
+        "message": "silence-trim skipped: ffmpeg not found; the clip was passed through unchanged",
+        "reason": "ffmpeg not found",
+    }
+    rec = RecordingStages(calls, trim_notice=notice)
+    ctx = JobContext(
+        job_id="j1",
+        _cancel_event=threading.Event(),
+        _emit_progress=lambda jid, pct, msg: progress.append((pct, msg)),
+    )
+    sm.run_export(
+        ctx,
+        video_id="v1",
+        candidates=[_stab_candidate()],
+        load_context=loader_for(str(tmp_path / "src.mp4"), transcript),
+        out_dir=str(tmp_path / "out"),
+        stages=rec.as_stages(),
+        settings={"silenceTrim": True, "stabilize": False},
+    )
+    assert "trim_silence" in calls
+    assert any("silence-trim skipped" in msg for _pct, msg in progress)
 
 
 def test_run_export_silence_trim_excludes_fillers(transcript, tmp_path):
@@ -2408,8 +2496,8 @@ class TestLazyReframeStage:
             def __init__(self):
                 self.calls: list[tuple] = []
 
-            def reframe(self, in_path, out_path, aspect):
-                self.calls.append((in_path, out_path, aspect))
+            def reframe(self, in_path, out_path, aspect, *, on_notice=None):
+                self.calls.append((in_path, out_path, aspect, on_notice))
                 return out_path
 
         engine = FakeEngine()
@@ -2420,10 +2508,14 @@ class TestLazyReframeStage:
             return engine, None
 
         monkeypatch.setattr(reframe, "get_engine", fake_get_engine)
-        out = sm._lazy_reframe("/in.mp4", "/out.reframed.mp4", "9:16", settings={"reframeEngine": "verthor"})
+        sink = lambda n: None  # noqa: E731 - stable identity for the assert
+        out = sm._lazy_reframe(
+            "/in.mp4", "/out.reframed.mp4", "9:16", settings={"reframeEngine": "verthor"}, on_notice=sink
+        )
         assert out == "/out.reframed.mp4"
         assert seen["name"] == "verthor"
-        assert engine.calls == [("/in.mp4", "/out.reframed.mp4", "9:16")]
+        # the on_notice sink is threaded through to the engine's reframe()
+        assert engine.calls == [("/in.mp4", "/out.reframed.mp4", "9:16", sink)]
 
     def test_defaults_to_auto_when_unset(self, monkeypatch):
         import media_studio.features.reframe as reframe
@@ -2431,7 +2523,7 @@ class TestLazyReframeStage:
         seen: dict[str, Any] = {}
 
         class _E:
-            def reframe(self, *a):
+            def reframe(self, *a, on_notice=None):
                 return a[1]
 
         monkeypatch.setattr(reframe, "get_engine", lambda name, settings: seen.update(name=name) or (_E(), None))
@@ -2463,15 +2555,20 @@ class TestLazyTrimSilenceStage:
 
         # trim_clip now also returns the clip-local KEEP spans so the orchestrator
         # can remap caption cues onto the compacted timeline (cue-desync fix).
+        seen: dict[str, Any] = {}
         monkeypatch.setattr(
             silencetrim,
             "trim_clip",
-            lambda i, o, *, settings=None: (o, 3.25, [(0.0, 4.0), (6.0, 12.0)]),
+            lambda i, o, *, settings=None, on_notice=None: (
+                seen.update(on_notice=on_notice) or (o, 3.25, [(0.0, 4.0), (6.0, 12.0)])
+            ),
         )
-        out_path, removed, keeps = sm._lazy_trim_silence("/in.mp4", "/out.trim.mp4", settings={})
+        sink = lambda n: None  # noqa: E731 - stable identity for the assert
+        out_path, removed, keeps = sm._lazy_trim_silence("/in.mp4", "/out.trim.mp4", settings={}, on_notice=sink)
         assert out_path == "/out.trim.mp4"
         assert removed == pytest.approx(3.25)
         assert keeps == [(0.0, 4.0), (6.0, 12.0)]
+        assert seen["on_notice"] is sink  # the notice sink is threaded through
 
 
 class TestLazyZoomStage:
@@ -2611,9 +2708,9 @@ def test_run_export_default_engine_is_claudeshorts_no_wsl(transcript, tmp_path, 
     seen: dict[str, object] = {}
 
     class _CaptureStages(RecordingStages):
-        def reframe(self, in_path, out_path, aspect, *, settings=None):
+        def reframe(self, in_path, out_path, aspect, *, settings=None, on_notice=None):
             seen["engine"] = (settings or {}).get("reframeEngine")
-            return super().reframe(in_path, out_path, aspect, settings=settings)
+            return super().reframe(in_path, out_path, aspect, settings=settings, on_notice=on_notice)
 
     progress: list[tuple[int, str]] = []
     ctx = JobContext(

--- a/sidecar/tests/test_silencetrim.py
+++ b/sidecar/tests/test_silencetrim.py
@@ -152,6 +152,30 @@ class TestDetect:
         monkeypatch.setattr(_ffmpeg, "ffmpeg_path", boom_path)
         assert stm.detect_silence_spans("/in.mp4", settings={}, run=detect_with("")) == []
 
+    # WU-3 NO-SILENT-FALLBACK: a swallowed detection miss must SURFACE a notice.
+    def test_detect_no_ffmpeg_surfaces_notice(self, monkeypatch):
+        from media_studio import ffmpeg as _ffmpeg
+
+        def boom_path(s=None):
+            raise _ffmpeg.FfmpegNotFound("nope")
+
+        monkeypatch.setattr(_ffmpeg, "ffmpeg_path", boom_path)
+        notices: list[dict] = []
+        assert stm.detect_silence_spans("/in.mp4", settings={}, run=detect_with(""), on_notice=notices.append) == []
+        assert len(notices) == 1
+        assert notices[0]["type"] == stm.SILENCE_TRIM_UNAVAILABLE_NOTICE
+        assert "ffmpeg" in notices[0]["reason"].lower()
+
+    def test_detect_failure_surfaces_notice(self, settings):
+        def boom(argv, **kw):
+            raise OSError("ffmpeg died")
+
+        notices: list[dict] = []
+        assert stm.detect_silence_spans("/in.mp4", settings=settings, run=boom, on_notice=notices.append) == []
+        assert len(notices) == 1
+        assert notices[0]["type"] == stm.SILENCE_TRIM_UNAVAILABLE_NOTICE
+        assert "silencedetect" in notices[0]["reason"].lower()
+
 
 # --------------------------------------------------------------------------- #
 # pipeline pre-step adapter
@@ -210,6 +234,47 @@ class TestTrimClip:
         assert path == "/in.mp4" and removed == 0.0
         assert keeps == []  # no timeline -> nothing to remap
 
+    def test_trim_duration_probe_failure_surfaces_notice(self, settings, tmp_path):
+        # WU-3: a probe failure currently passes through silently — it must now
+        # SURFACE a notice so the skip is reported, never swallowed.
+        def boom_duration(p, s=None):
+            raise OSError("ffprobe died")
+
+        notices: list[dict] = []
+        path, removed, keeps = stm.trim_clip(
+            "/in.mp4",
+            str(tmp_path / "out.mp4"),
+            settings=settings,
+            detect_run=detect_with(SILENCE_STDERR),
+            run=RecordingRun(),
+            duration=boom_duration,
+            on_notice=notices.append,
+        )
+        assert path == "/in.mp4" and removed == 0.0 and keeps == []
+        assert len(notices) == 1
+        assert notices[0]["type"] == stm.SILENCE_TRIM_UNAVAILABLE_NOTICE
+        assert "duration" in notices[0]["reason"].lower()
+
+    def test_trim_threads_on_notice_into_detect(self, settings, tmp_path):
+        # The trim adapter forwards on_notice to the detector so a detect-side
+        # swallow (e.g. ffmpeg crash) still surfaces through trim_clip.
+        def boom(argv, **kw):
+            raise OSError("ffmpeg died")
+
+        notices: list[dict] = []
+        path, removed, _keeps = stm.trim_clip(
+            "/in.mp4",
+            str(tmp_path / "out.mp4"),
+            settings=settings,
+            detect_run=boom,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 20.0,
+            on_notice=notices.append,
+        )
+        # no silence detected (detector surfaced + returned []) -> pass-through
+        assert path == "/in.mp4" and removed == 0.0
+        assert len(notices) == 1 and notices[0]["type"] == stm.SILENCE_TRIM_UNAVAILABLE_NOTICE
+
     def test_trim_passthrough_when_duration_unknown(self, settings, tmp_path):
         path, removed, keeps = stm.trim_clip(
             "/in.mp4",
@@ -253,6 +318,28 @@ class TestService:
         job.wait(timeout=5)
         assert job.result["removedSec"] > 4.0
         assert job.result["path"].endswith(".trimmed.mp4")
+
+    def test_trim_service_surfaces_notice_via_progress(self, tmp_path, registry, collected, monkeypatch):
+        # WU-3: a swallowed detect failure (no ffmpeg) must surface via job.progress
+        # from the RPC service too — never a silent {removedSec: 0} no-op.
+        from media_studio import ffmpeg as _ffmpeg
+
+        def boom_path(s=None):
+            raise _ffmpeg.FfmpegNotFound("nope")
+
+        monkeypatch.setattr(_ffmpeg, "ffmpeg_path", boom_path)
+        svc = stm.SilenceTrim(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "trim",
+            settings_provider=lambda: {},
+            run=RecordingRun(),
+            duration=lambda p, s=None: 20.0,
+            detect_run=detect_with(SILENCE_STDERR),
+        )
+        out = svc.trim({"videoId": "v1"}, _rpc_ctx(registry))
+        registry.get(out["jobId"]).wait(timeout=5)
+        msgs = [payload[2] for kind, payload in collected if kind == "progress"]
+        assert any("silence-trim skipped" in m for m in msgs)
 
     def test_trim_unknown_video_raises(self, settings, tmp_path, registry):
         svc = stm.SilenceTrim(

--- a/sidecar/tests/test_subtitles.py
+++ b/sidecar/tests/test_subtitles.py
@@ -409,6 +409,17 @@ def test_escape_ass_text_blocks_override_injection():
     assert "}" not in escaped
 
 
+def test_unescape_ass_text_passes_through_stray_backslashes():
+    # read_ass may parse externally-authored ASS containing backslashes that are
+    # NOT one of the known escapes (\N, \(, \), \\). Such a backslash — and a
+    # trailing backslash with no following char — passes through literally rather
+    # than raising or consuming the next character.
+    assert S._unescape_ass_text("a\\xb") == "a\\xb"  # '\x' is not a known escape
+    assert S._unescape_ass_text("end\\") == "end\\"  # trailing backslash, no next char
+    # And the known escapes still decode (inverse of escape_ass_text):
+    assert S._unescape_ass_text("\\(\\)\\\\\\N") == "{}\\\n"
+
+
 def test_escape_ass_text_converts_newlines():
     assert S.escape_ass_text("a\nb") == "a\\Nb"
     assert S.escape_ass_text("a\r\nb") == "a\\Nb"


### PR DESCRIPTION
## Reframe V1 — Phase 1 (UNBLOCK foundation)

Implements Phase 1 of the converged V1 build plan (docs/V1-GRILL-DECISIONS.md §f/g/h).

### Changes
- **Packaging root-cause [G-16/17/18]**: guard first-run `._pth` write; self-activate env from data root; `dataRoot` falls back to `userData` when install dir is non-writable; first-run fails LOUD + actionable (no empty-dir silence).
- **First-run self-diagnostic [Better-Idea]**: `system.selfTest` WU-2 — writable data dir + device probe + cv2/ASR presence, surfaced via SetupStatusPanel.
- **No-silent-fallback sweep [G-13/14/15]**: surface reframe degrade (`REFRAME_DEGRADED_NOTICE`); `detect_backend()` explicit when cv2 absent; setup/quality-step failures surfaced (stabilize/silence/autoZoom/fillers).
- **ASS subtitle brace fix**: reversible brace-free ASS escape (`\(` `\)`) — round-trips losslessly, keeps zero raw braces (CONTRACTS §4) + coverage test.

### Gates
- Sidecar: 4159 passed, 100% coverage (branch), EXIT=0, "100% reached".
- Renderer: 90 files / 1687 tests, 100% stmts/branches/funcs/lines.
- pre-commit: ruff / oxlint / biome / gitleaks all pass.

All existing functionality preserved (consolidate, never delete).
