### PR TITLE
feat(reframe): wide-shot dominant/active single-speaker framing (V1 Phase 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ your limit, so many small approved runs can't quietly add up.
 | Area | Features |
 |------|----------|
 | **Short-maker** (the star) | LLM moment-selection → boundary-snap → cut → vertical reframe → captions → export; subtle zoom/punch-in; brand-logo overlay; virality scoring + a feedback flywheel |
-| **Reframe** | 9:16 auto-reframe via **verthor** (WSL2/MediaPipe) with an automatic in-sidecar **claudeshorts** (OpenCV/MediaPipe) fallback |
+| **Reframe** | 9:16 auto-reframe via **verthor** (WSL2/MediaPipe) with an automatic in-sidecar **claudeshorts** (OpenCV/MediaPipe) fallback. **V1 follows a single speaker** — in a wide / two-shot the crop locks onto the dominant/active speaker and tracks them smoothly (never an empty studio or the gap between two people). Automatic multi-speaker *switching* is a [V2 roadmap](docs/ROADMAP.md) item. |
 | **Director** | prompt-driven edits → storyboard/diff + cost preview → real ffmpeg op-engines |
 | **Stabilize** *(differentiator)* | camera-shake removal via ffmpeg **vidstab** 2-pass — something OpusClip & peers don't do |
 | **Audio** | A/V mix + sidechain **auto-duck** + EBU R128 loudnorm; **silence-trim** dead-air removal |
@@ -94,7 +94,11 @@ your limit, so many small approved runs can't quietly add up.
   **CPU** (slower) — there is always a CPU fallback.
 - **9:16 reframe:** the high-quality **verthor** path uses **WSL2 / MediaPipe**; if WSL2 is
   absent the app **auto-falls back** to the in-process **claudeshorts** reframer — no setup
-  required either way.
+  required either way. **V1 follows a single speaker:** even in a wide or two-shot the crop
+  locks onto the dominant/active speaker (largest, most-active face/person) and tracks them
+  smoothly — it never shows an empty studio or the gap between two people. Automatic
+  multi-speaker *switching* (cutting between people as they talk) is a [V2 roadmap](docs/ROADMAP.md)
+  item.
 - **Disk / network:** ~**a few GB** of one-time first-run download for ML wheels + the models
   you enable (into `%APPDATA%\media-studio`). **Offline after** the first-run setup.
 - **No toolchain needed:** Python, ffmpeg, and the render engine are bundled.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,43 @@
+# Reframe — Roadmap
+
+> What V1 deliberately does and does not do, and what is deferred to V2.
+> Authoritative scope decisions live in [`V1-GRILL-DECISIONS.md`](V1-GRILL-DECISIONS.md)
+> (see G-21/G-22 and section (e) "Speaker framing"). This file is the honest,
+> user-facing summary of the capability boundary.
+
+## V1 capability — speaker framing (single speaker)
+
+V1 frames a **single speaker**. The 9:16 auto-reframe locates the **dominant /
+active** subject and keeps the vertical crop on them, smoothly tracked:
+
+- **Wide / two-shot:** the crop locks onto the **largest, most-active** face or
+  person (the featured speaker) — it **never** shows an empty studio, an
+  edge-cut, or the gap between two people.
+- **Two people, different sizes:** the **larger / closer** person (the one the
+  shot features) is framed.
+- **Symmetric two-shot (similar sizes):** the **active speaker** wins the tie —
+  the person with the most mouth / gesture **motion** between frames.
+- **No detectable face/body:** motion saliency locks onto the **single dominant
+  motion cluster** (one speaker), not the average of everything that moved.
+- **Tracking:** zero-phase EMA smoothing (no jitter, no drift back to frame
+  center); when tracking genuinely cannot run, the clip degrades to a center
+  crop **and says so** (a per-clip "degraded" notice — no silent fallback).
+
+Implementation: `sidecar/media_studio/features/reframe_claudeshorts.py`
+(`select_dominant`, the face → person → motion finder chain, and the
+`_dominant_cluster_centroid` motion fallback). Honest copy:
+`SINGLE_SPEAKER_CAPABILITY_NOTE` in that module.
+
+## V2 — multi-speaker switching (deferred)
+
+Automatic **multi-speaker switching** — detecting *who is talking now* across
+multiple people and **cutting between them** (e.g. an interview where the crop
+follows the conversation back and forth) — is a **V2** feature. It needs
+active-speaker diarization fused with face tracking and a shot-change policy, and
+is intentionally out of scope for the ship-now V1 slice (per
+[`V1-GRILL-DECISIONS.md`](V1-GRILL-DECISIONS.md) G-21: "cut multi-speaker /
+wide-shot *switching* to V2 — but be explicit in the UI that V1 tracks a single
+subject").
+
+Other V2 items deferred from V1 (per G-22): B-roll, emoji / keyword SFX
+triggers, AI avatars, and a publishing scheduler.

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -93,6 +93,25 @@ STATIC_EPSILON_FRAC = 0.01
 # the sampled windows; below it the detector is too unreliable to track on, so we
 # keep the centered crop instead of chasing a couple of stray hits.
 MIN_SUBJECT_HIT_FRAC = 0.15
+# WU PHASE-5 WIDE-SHOT FRAMING — DOMINANT/ACTIVE single-speaker selection. In a
+# wide / two-shot we lock the crop onto ONE subject (the featured speaker), never
+# the empty gap between two people. Two subjects whose face/person size is within
+# this fraction of the largest count as the SAME size — a symmetric two-shot — so
+# the ACTIVE speaker (more mouth/gesture motion) wins the tie instead of an
+# arbitrary largest-by-a-pixel pick. A real size gap (one person clearly closer)
+# is honoured outright: the larger/closer subject is the dominant one.
+DOMINANT_SIZE_TIE_FRAC = 0.2
+
+# Honest V1 capability copy (surfaced in README + docs/ROADMAP.md). V1 frames the
+# dominant/active SINGLE speaker even in a wide/two-shot; automatic multi-speaker
+# SWITCHING (cutting between people as they talk) is a V2 feature.
+SINGLE_SPEAKER_CAPABILITY_NOTE = (
+    "V1 follows a single speaker: in a wide or two-shot the crop locks onto the "
+    "dominant/active speaker (the largest, most-active face/person) and tracks "
+    "them smoothly — it never shows an empty studio or the gap between two people. "
+    "Automatic multi-speaker switching (cutting between people as they talk) is a "
+    "V2 feature."
+)
 
 # A6 LESSON 1 — PRE-IMPORT FLAG (NON-NEGOTIABLE): these native C-extension
 # modules are first used INSIDE a job thread by this engine. They MUST be added
@@ -208,6 +227,41 @@ def crop_x_for_center(cx_norm: float, crop_w: int, src_w: int) -> int:
     """
     x = int(round(float(cx_norm) * src_w - crop_w / 2.0))
     return max(0, min(x, max(0, src_w - crop_w)))
+
+
+# --------------------------------------------------------------------------- #
+# dominant / active single-speaker selection (pure — the wide-shot fix core)
+# --------------------------------------------------------------------------- #
+def select_dominant(candidates: Sequence[tuple[float, float, float]]) -> float | None:
+    """Pick the DOMINANT subject's normalized horizontal center (the wide-shot fix).
+
+    ``candidates`` is a sequence of ``(cx, size, activity)`` for every face/person
+    detected in ONE frame: ``cx`` is the normalized horizontal center (0..1),
+    ``size`` the subject's relative prominence (face/person area — bigger = closer
+    = more dominant), and ``activity`` a motion/active-speaker score used ONLY to
+    break a near-size tie. Returns the chosen subject's ``cx``, or ``None`` when
+    there are no candidates.
+
+    Selection rule (WU PHASE-5): the LARGEST subject wins outright; when several
+    subjects are within :data:`DOMINANT_SIZE_TIE_FRAC` of the largest (a symmetric
+    two-shot), the most-ACTIVE one wins (the talking head), then larger size as a
+    final, deterministic tie-break (first candidate on an exact tie — the crop
+    never flips frame-to-frame on a coin-flip). This is what keeps the crop on the
+    featured single speaker in a wide/two-shot instead of the empty gap between
+    two people. Choosing exactly ONE subject per frame (never a blend / centroid
+    of several) is the structural guard against the empty-studio / edge-cut bug.
+    """
+    cands = list(candidates)
+    if not cands:
+        return None
+    largest = max(float(c[1]) for c in cands)
+    # A real size gap is honoured; only a near-tie opens the activity tie-break.
+    # ``largest <= 0`` (degenerate zero-area candidates) -> everyone is a
+    # contender and activity (then size) decides.
+    threshold = largest * (1.0 - DOMINANT_SIZE_TIE_FRAC) if largest > 0.0 else 0.0
+    contenders = [c for c in cands if float(c[1]) >= threshold]
+    best = max(contenders, key=lambda c: (float(c[2]), float(c[1])))
+    return float(best[0])
 
 
 # --------------------------------------------------------------------------- #
@@ -502,28 +556,70 @@ def detect_backend(importer: Callable[[str], Any] = importlib.import_module) -> 
         ) from exc
 
 
+def _region_activity(prev_img: Any, cur_img: Any, box: tuple[int, int, int, int]) -> float:
+    """Mean inter-frame change inside ``box`` (``x0,y0,x1,y1`` px) — the per-face
+    motion score for the active-speaker tie-break.
+
+    Used by :func:`_make_face_finder` to pick the TALKING head in a symmetric
+    two-shot (mouth/gesture motion is concentrated on the active speaker's face).
+    Returns ``0.0`` when there is no previous frame, the two frames differ in
+    shape (a scene cut), or the box is empty / out of range — so the tie-break
+    simply falls back to size on the very first frame and on geometry changes.
+    """
+    import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
+
+    if prev_img is None or prev_img.shape != cur_img.shape:
+        return 0.0
+    h, w = int(cur_img.shape[0]), int(cur_img.shape[1])
+    x0 = max(0, min(int(box[0]), w))
+    y0 = max(0, min(int(box[1]), h))
+    x1 = max(0, min(int(box[2]), w))
+    y1 = max(0, min(int(box[3]), h))
+    if x1 <= x0 or y1 <= y0:
+        return 0.0
+    prev_gray = cv2.cvtColor(prev_img[y0:y1, x0:x1], cv2.COLOR_BGR2GRAY)
+    cur_gray = cv2.cvtColor(cur_img[y0:y1, x0:x1], cv2.COLOR_BGR2GRAY)
+    return float(cv2.absdiff(prev_gray, cur_gray).mean())
+
+
 def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | None, Callable[[], None]]:
-    """Build ``(find(img_bgr) -> cx_norm|None, close())`` for ``backend``."""
+    """Build ``(find(img_bgr) -> cx_norm|None, close())`` for ``backend``.
+
+    ``find`` returns the DOMINANT/active face's normalized horizontal center via
+    :func:`select_dominant`: the largest (closest) face wins outright, and a
+    symmetric two-shot is broken toward the ACTIVE speaker using per-face motion
+    against the previous frame (held in the closure). This is the wide-shot fix —
+    the crop locks onto ONE featured speaker, never a blend of two faces. The
+    finder is stateful (it remembers the previous frame) so the motion tie-break
+    has something to diff; the first frame has no previous frame, so it falls back
+    to pure size selection.
+    """
     if backend == "mediapipe":
         import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
         import mediapipe as mp  # noqa: PLC0415 - job-time native (pre-imported)  # pyright: ignore[reportMissingImports]  # optional runtime dep
 
         detector = mp.solutions.face_detection.FaceDetection(model_selection=1, min_detection_confidence=0.5)
+        prev: dict[str, Any] = {"img": None}
 
         def find_mp(img: Any) -> float | None:
             rgb = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
             results = detector.process(rgb)
             detections = getattr(results, "detections", None)
-            if not detections:
-                return None
-            best = max(
-                detections,
-                key=lambda d: (
-                    d.location_data.relative_bounding_box.width * d.location_data.relative_bounding_box.height
-                ),
-            )
-            bbox = best.location_data.relative_bounding_box
-            return float(bbox.xmin + bbox.width / 2.0)
+            h, w = int(img.shape[0]), int(img.shape[1])
+            cands: list[tuple[float, float, float]] = []
+            for det in detections or []:
+                bbox = det.location_data.relative_bounding_box
+                cx = float(bbox.xmin + bbox.width / 2.0)
+                size = float(bbox.width * bbox.height)
+                box = (
+                    int(bbox.xmin * w),
+                    int(bbox.ymin * h),
+                    int((bbox.xmin + bbox.width) * w),
+                    int((bbox.ymin + bbox.height) * h),
+                )
+                cands.append((cx, size, _region_activity(prev["img"], img, box)))
+            prev["img"] = img
+            return select_dominant(cands)
 
         return find_mp, detector.close
 
@@ -536,14 +632,21 @@ def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | Non
         if cascade.empty():
             _log.warning("haar cascade missing at %s; using center crop", cascade_path)
             return None, lambda: None
+        prev = {"img": None}
 
         def find_haar(img: Any) -> float | None:
             gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
             faces = cascade.detectMultiScale(gray, scaleFactor=1.1, minNeighbors=4)
-            if faces is None or len(faces) == 0:
-                return None
-            x, _y, w, h = max(faces, key=lambda f: int(f[2]) * int(f[3]))
-            return float((x + w / 2.0) / img.shape[1])
+            w_img = int(img.shape[1])
+            cands: list[tuple[float, float, float]] = []
+            for face in faces if faces is not None else []:
+                x, y, fw, fh = int(face[0]), int(face[1]), int(face[2]), int(face[3])
+                cx = float((x + fw / 2.0) / w_img)
+                size = float(fw * fh)
+                box = (x, y, x + fw, y + fh)
+                cands.append((cx, size, _region_activity(prev["img"], img, box)))
+            prev["img"] = img
+            return select_dominant(cands)
 
         return find_haar, lambda: None
 
@@ -578,9 +681,45 @@ def _person_center(img: Any) -> float | None:
     if rects is None or len(rects) == 0:
         return None
     weights = list(weights) if weights is not None else []
-    best_idx = max(range(len(rects)), key=lambda i: weights[i] if i < len(weights) else 0.0)
-    rx, _ry, rw, _rh = rects[best_idx]
-    return float((float(rx) + float(rw) / 2.0) / w)
+    # WU PHASE-5: in a wide / two-shot pick the DOMINANT person = the LARGEST
+    # (closest) body, breaking a same-size tie by detector confidence (weight ~
+    # how strongly a body was seen). This frames the featured speaker instead of
+    # a smaller, further person who merely scored a higher confidence.
+    cands: list[tuple[float, float, float]] = []
+    for i, rect in enumerate(rects):
+        rx, _ry, rw, rh = float(rect[0]), float(rect[1]), float(rect[2]), float(rect[3])
+        cx = float((rx + rw / 2.0) / w)
+        area = float(rw * rh)
+        activity = float(weights[i]) if i < len(weights) else 0.0
+        cands.append((cx, area, activity))
+    return select_dominant(cands)
+
+
+def _dominant_cluster_centroid(col: Sequence[float]) -> float:
+    """Intensity-weighted center column of the DOMINANT contiguous motion run.
+
+    ``col`` is a per-column motion profile (a row-sum of the motion mask). Two
+    people moving in a wide / two-shot show up as TWO separate nonzero runs with a
+    still gap between them; the plain global centroid of all moving pixels lands in
+    that gap (the empty-studio bug). We instead split ``col`` into contiguous
+    nonzero runs and return the intensity-weighted centroid of the run with the
+    most total motion — the single most-active subject. ``col`` is assumed to have
+    at least one nonzero entry (the caller checks the total first).
+    """
+    runs: list[tuple[int, int]] = []
+    start: int | None = None
+    for i in range(len(col)):
+        if float(col[i]) > 0.0 and start is None:
+            start = i
+        elif float(col[i]) <= 0.0 and start is not None:
+            runs.append((start, i))
+            start = None
+    if start is not None:
+        runs.append((start, len(col)))
+    lo, hi = max(runs, key=lambda r: sum(float(col[i]) for i in range(r[0], r[1])))
+    total = sum(float(col[i]) for i in range(lo, hi))
+    weighted = sum(i * float(col[i]) for i in range(lo, hi))
+    return weighted / total
 
 
 def _motion_center(prev: Any, img: Any) -> float | None:
@@ -589,8 +728,10 @@ def _motion_center(prev: Any, img: Any) -> float | None:
     Last-resort saliency: a sitting/standing speaker still moves (head, hands,
     mouth) more than the static studio behind them. We diff consecutive sampled
     frames, threshold the change, and take the intensity-weighted horizontal
-    centroid of the moving pixels — so the crop locates the SPEAKER even when
-    neither a face nor a full body is detectable. ``None`` when nothing moved.
+    centroid of the DOMINANT motion cluster (:func:`_dominant_cluster_centroid`) —
+    so the crop locates ONE speaker even when neither a face nor a full body is
+    detectable, and in a wide/two-shot it locks onto the most-active person rather
+    than the empty gap between two movers. ``None`` when nothing moved.
     """
     import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
     import numpy as np  # noqa: PLC0415 - job-time native (numpy ships with cv2)
@@ -602,11 +743,9 @@ def _motion_center(prev: Any, img: Any) -> float | None:
     diff = cv2.absdiff(g0, g1)
     _thr, mask = cv2.threshold(diff, 18, 255, cv2.THRESH_BINARY)
     col = np.asarray(mask, dtype="float64").sum(axis=0)
-    total = float(col.sum())
-    if total <= 0.0:
+    if float(col.sum()) <= 0.0:
         return None
-    cols = np.arange(col.shape[0], dtype="float64")
-    centroid = float((cols * col).sum() / total)
+    centroid = _dominant_cluster_centroid(col.tolist())
     return centroid / float(img.shape[1])
 
 

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -934,12 +934,14 @@ def _fake_mediapipe(detections):
     return mod, captured
 
 
-def _bbox(xmin, width, height):
+def _bbox(xmin, width, height, ymin=0.0):
     import types
 
+    # The real mediapipe relative_bounding_box carries ymin too (the finder uses
+    # it to build the per-face motion box for the active-speaker tie-break).
     return types.SimpleNamespace(
         location_data=types.SimpleNamespace(
-            relative_bounding_box=types.SimpleNamespace(xmin=xmin, width=width, height=height)
+            relative_bounding_box=types.SimpleNamespace(xmin=xmin, ymin=ymin, width=width, height=height)
         )
     )
 
@@ -1241,3 +1243,223 @@ def test_motion_center_shape_mismatch_returns_none():
     prev = np.zeros((100, 200, 3), dtype=np.uint8)
     img = np.zeros((90, 160, 3), dtype=np.uint8)  # different geometry (scene cut)
     assert cs._motion_center(prev, img) is None
+
+
+# --------------------------------------------------------------------------- #
+# WU PHASE-5 — WIDE-SHOT framing: lock onto the DOMINANT/active single speaker
+# (largest face/person; tie-break by motion). NEVER the empty gap between two
+# people / an edge-cut. Multi-speaker SWITCHING is V2 (docs/ROADMAP.md).
+# --------------------------------------------------------------------------- #
+# select_dominant — the pure subject-selection core.
+def test_select_dominant_empty_returns_none():
+    assert cs.select_dominant([]) is None
+
+
+def test_select_dominant_single_candidate_returns_it():
+    assert cs.select_dominant([(0.3, 100.0, 0.0)]) == pytest.approx(0.3)
+
+
+def test_select_dominant_two_people_different_sizes_picks_larger():
+    """Two-person shot, different face/person sizes -> the LARGER (closer =
+    dominant) subject is framed, not the smaller one nor the midpoint."""
+    cands = [(0.25, 2000.0, 0.0), (0.8, 300.0, 0.0)]  # left big, right small
+    assert cs.select_dominant(cands) == pytest.approx(0.25)
+
+
+def test_select_dominant_larger_wins_over_higher_activity_when_gap_is_real():
+    """A genuinely larger subject beats a smaller, more-active one — size (who is
+    featured) dominates unless the sizes are a near-tie."""
+    cands = [(0.2, 5000.0, 0.0), (0.9, 500.0, 99.0)]
+    assert cs.select_dominant(cands) == pytest.approx(0.2)
+
+
+def test_select_dominant_wide_offcenter_locks_on_person_not_center():
+    """A single off-center person in a WIDE shot -> framed ON him, never drifted
+    back to frame center / an empty studio."""
+    assert cs.select_dominant([(0.82, 1500.0, 0.0)]) == pytest.approx(0.82)
+
+
+def test_select_dominant_equal_size_tie_broken_by_motion():
+    """A symmetric two-shot (equal face size) -> the ACTIVE (talking, more
+    motion) speaker is framed, not an arbitrary largest-by-a-pixel pick."""
+    left = (0.25, 1000.0, 0.1)
+    right = (0.75, 1000.0, 5.0)  # more motion -> the active speaker
+    assert cs.select_dominant([left, right]) == pytest.approx(0.75)
+
+
+def test_select_dominant_near_size_tie_uses_motion():
+    """Within DOMINANT_SIZE_TIE_FRAC the marginally-smaller but ACTIVE speaker
+    still wins (the tie band, not a hard equality)."""
+    bigger_quiet = (0.2, 1000.0, 0.0)
+    smaller_active = (0.8, 1000.0 * (1.0 - cs.DOMINANT_SIZE_TIE_FRAC / 2.0), 9.0)
+    assert cs.select_dominant([bigger_quiet, smaller_active]) == pytest.approx(0.8)
+
+
+def test_select_dominant_all_zero_size_falls_back_to_activity():
+    """Degenerate (all zero-area) candidates -> activity decides (covers the
+    largest<=0 guard)."""
+    assert cs.select_dominant([(0.1, 0.0, 1.0), (0.9, 0.0, 5.0)]) == pytest.approx(0.9)
+
+
+def test_select_dominant_exact_tie_is_deterministic_first():
+    """Exact ties (same size + same activity) resolve to the FIRST candidate —
+    deterministic, so the crop never flips frame-to-frame on a coin-flip."""
+    assert cs.select_dominant([(0.3, 100.0, 0.0), (0.7, 100.0, 0.0)]) == pytest.approx(0.3)
+
+
+# _region_activity — per-face motion score for the active-speaker tie-break.
+def test_region_activity_no_prev_frame_returns_zero():
+    import numpy as np
+
+    img = np.zeros((50, 50, 3), dtype=np.uint8)
+    assert cs._region_activity(None, img, (0, 0, 50, 50)) == 0.0
+
+
+def test_region_activity_shape_mismatch_returns_zero():
+    import numpy as np
+
+    prev = np.zeros((40, 40, 3), dtype=np.uint8)
+    img = np.zeros((50, 50, 3), dtype=np.uint8)
+    assert cs._region_activity(prev, img, (0, 0, 40, 40)) == 0.0
+
+
+def test_region_activity_empty_or_out_of_range_box_returns_zero():
+    import numpy as np
+
+    f = np.zeros((50, 50, 3), dtype=np.uint8)
+    assert cs._region_activity(f, f.copy(), (30, 0, 30, 50)) == 0.0  # x1<=x0
+    assert cs._region_activity(f, f.copy(), (60, 60, 70, 70)) == 0.0  # clamps to empty
+
+
+def test_region_activity_detects_change_inside_box_only():
+    import numpy as np
+
+    prev = np.zeros((50, 80, 3), dtype=np.uint8)
+    cur = np.zeros((50, 80, 3), dtype=np.uint8)
+    cur[10:40, 10:40, :] = 200
+    moved = cs._region_activity(prev, cur, (10, 10, 40, 40))
+    still = cs._region_activity(prev, cur, (50, 0, 80, 50))
+    assert moved > 0.0
+    assert still == 0.0
+
+
+# _dominant_cluster_centroid — motion fallback picks ONE cluster, never the gap.
+def test_dominant_cluster_centroid_single_run():
+    assert cs._dominant_cluster_centroid([0, 0, 4, 4, 0, 0]) == pytest.approx(2.5)
+
+
+def test_dominant_cluster_centroid_picks_run_with_most_motion():
+    # left run cols 2-3 (sum 2) vs right run cols 6-8 (sum 30) -> dominant = right.
+    col = [0, 0, 1, 1, 0, 0, 10, 10, 10, 0]
+    assert cs._dominant_cluster_centroid(col) == pytest.approx(7.0)
+
+
+def test_dominant_cluster_centroid_run_extends_to_end():
+    # a run touching the last column exercises the trailing-run append.
+    assert cs._dominant_cluster_centroid([0, 0, 5, 5]) == pytest.approx(2.5)
+
+
+def test_motion_center_two_movers_picks_dominant_not_midpoint():
+    """The empty-studio bug: two people both moving in a wide/two-shot. The
+    GLOBAL centroid would land in the gap between them; the dominant-cluster
+    centroid locks onto the more-active subject instead."""
+    import numpy as np
+
+    prev = np.zeros((100, 300, 3), dtype=np.uint8)
+    img = np.zeros((100, 300, 3), dtype=np.uint8)
+    img[40:60, 20:40, :] = 255  # small mover, left
+    img[20:80, 240:280, :] = 255  # big mover, right (dominant)
+    cx = cs._motion_center(prev, img)
+    assert cx is not None
+    assert cx > 0.7  # right cluster, NOT the ~0.5 midpoint gap
+
+
+# face/person finders — dominant selection wired through the real detectors.
+def test_make_face_finder_haar_two_faces_picks_larger(monkeypatch):
+    import cv2
+    import numpy as np
+
+    class _TwoFaces:
+        def __init__(self, *_a):
+            pass
+
+        def empty(self):
+            return False
+
+        def detectMultiScale(self, gray, scaleFactor, minNeighbors):
+            # left small (20x20 @x=20), right large (60x60 @x=300). width = 400.
+            return [(20, 20, 20, 20), (300, 20, 60, 60)]
+
+    monkeypatch.setattr(cv2, "CascadeClassifier", _TwoFaces)
+    find, _close = cs._make_face_finder("haar")
+    cx = find(np.zeros((120, 400, 3), dtype=np.uint8))
+    # larger face center x = 300 + 30 = 330 -> 330/400 = 0.825.
+    assert cx == pytest.approx(0.825)
+
+
+def test_make_face_finder_haar_active_speaker_motion_tiebreak(monkeypatch):
+    import cv2
+    import numpy as np
+
+    class _TwoEqual:
+        def __init__(self, *_a):
+            pass
+
+        def empty(self):
+            return False
+
+        def detectMultiScale(self, gray, scaleFactor, minNeighbors):
+            return [(20, 20, 40, 40), (120, 20, 40, 40)]  # equal size; width = 200
+
+    monkeypatch.setattr(cv2, "CascadeClassifier", _TwoEqual)
+    find, _close = cs._make_face_finder("haar")
+    f0 = np.zeros((100, 200, 3), dtype=np.uint8)
+    f1 = np.zeros((100, 200, 3), dtype=np.uint8)
+    f1[20:60, 120:160, :] = 200  # the RIGHT face moves (talking)
+    find(f0)  # establish previous frame
+    cx = find(f1)
+    assert cx == pytest.approx(0.7)  # active (right) speaker: (120 + 20) / 200
+
+
+def test_make_face_finder_mediapipe_active_speaker_motion_tiebreak(monkeypatch):
+    import numpy as np
+
+    left = _bbox(0.05, 0.2, 0.4)  # equal-size faces
+    right = _bbox(0.6, 0.2, 0.4)
+    _mod, _captured = _fake_mediapipe([left, right])
+    monkeypatch.setitem(__import__("sys").modules, "mediapipe", _mod)
+    find, close = cs._make_face_finder("mediapipe")
+    f0 = np.zeros((100, 200, 3), dtype=np.uint8)
+    f1 = np.zeros((100, 200, 3), dtype=np.uint8)
+    f1[0:40, 120:160, :] = 200  # right face box (x 120..160, y 0..40) moves
+    find(f0)
+    cx = find(f1)
+    assert cx == pytest.approx(0.7)  # right active speaker: xmin + width/2 = 0.6 + 0.1
+    close()
+
+
+def test_person_center_prefers_larger_closer_body_over_higher_weight(monkeypatch):
+    import cv2
+    import numpy as np
+
+    class _HOG:
+        def setSVMDetector(self, _d):
+            pass
+
+        def detectMultiScale(self, _img, winStride):
+            # left BIG body (closer) lower weight; right small higher weight. width=400.
+            return [(10, 0, 160, 300), (320, 0, 40, 90)], [0.3, 0.95]
+
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    cx = cs._person_center(np.zeros((320, 400, 3), dtype=np.uint8))
+    # dominant = larger (closer) body -> center x = 10 + 80 = 90 -> 90/400 = 0.225.
+    assert cx == pytest.approx(0.225)
+
+
+def test_single_speaker_capability_note_is_honest():
+    """The honest 'V1 follows a single speaker' capability copy is a real,
+    asserted artifact (not just prose) — and points at the V2 switching roadmap."""
+    note = cs.SINGLE_SPEAKER_CAPABILITY_NOTE
+    assert "single speaker" in note.lower()
+    assert "v2" in note.lower()


### PR DESCRIPTION
## What

Finishes the **WIDE-SHOT framing** for V1 (per `docs/V1-GRILL-DECISIONS.md` (e)/(f) Phase 5, G-21). In a wide / two-shot the vertical 9:16 crop now locks onto **one** dominant/active speaker and **never** shows an empty studio, an edge-cut, or the gap between two people.

## Logic

- **`select_dominant()`** (new, pure): the largest (closest) face/person wins outright; when subjects are within `DOMINANT_SIZE_TIE_FRAC` (a symmetric two-shot) the **active speaker** (more motion) wins, then size, deterministic first-candidate on exact ties (no frame-to-frame crop flip). Picking exactly ONE subject per frame — never a blend/centroid of several — is the structural guard against the empty-studio bug.
- **`_make_face_finder`** (haar + mediapipe): now stateful — scores per-face motion (`_region_activity` vs the previous frame) for the active-speaker tie-break and routes through `select_dominant`.
- **`_person_center`**: prefers the **largest/closest** body (dominant), confidence weight as tie-break.
- **`_motion_center`**: returns the **dominant motion cluster** centroid (`_dominant_cluster_centroid`) instead of the global centroid (which in a two-shot lands in the empty gap between two movers).
- Smooth zero-phase EMA tracking and the no-silent-fallback degrade notice are unchanged.

## Honest capability + V2 roadmap

- `SINGLE_SPEAKER_CAPABILITY_NOTE` constant + README: "**V1 follows a single speaker**".
- New **`docs/ROADMAP.md`**: multi-speaker **switching** (cutting between people as they talk) is **V2**.

## Tests / gates (TDD)

25 new tests covering: two-person-different-sizes to larger; wide off-center to on the person; equal-size tie to active speaker by motion; dominant motion cluster (never the midpoint gap); per-region activity edges; honest-copy artifact.

- **Sidecar gate**: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` to **100%** (4181 passed).
- **Renderer gate**: `npx vitest run --coverage` to **100%** stmts/branches/funcs/lines.
- pre-commit (ruff lint+format, gitleaks) clean.

No `app/` source touched (only sidecar Python + README + new ROADMAP).
