### PR TITLE
feat(reframe-v1): Phase 2 — models & device (runner detect, OpenRouter cost, device-ranked reco, device+ETA strip)

### DIFF
--- a/app/renderer/src/components/DeviceModelReco.tsx
+++ b/app/renderer/src/components/DeviceModelReco.tsx
@@ -1,0 +1,52 @@
+// DeviceModelReco.tsx — the device-ranked MODEL recommendation banner
+// (WU-models/device, deliverable G-7/8/9: "recommended for your machine: X
+// because RAM/VRAM Y"). Surfaces the two local picks the sidecar ranked against
+// the probed device — the whisper (ASR) model and the LLM — each with the reason
+// that NAMES the device numbers. Pure presentation; the picks come from
+// models.runners.
+import React from 'react';
+import type { ModelReco } from '../lib/rpc';
+
+export interface DeviceModelRecoProps {
+  /** The device-ranked whisper (ASR) pick + its "because RAM/VRAM Y" reason. */
+  whisper: ModelReco;
+  /** The device-ranked LLM pick + its "because RAM/VRAM Y" reason. */
+  llm: ModelReco;
+}
+
+interface RecoRow {
+  key: string;
+  kind: string;
+  reco: ModelReco;
+}
+
+export function DeviceModelReco({ whisper, llm }: DeviceModelRecoProps): React.ReactElement {
+  const rows: RecoRow[] = [
+    { key: 'whisper', kind: 'Speech (Whisper)', reco: whisper },
+    { key: 'llm', kind: 'Language model', reco: llm },
+  ];
+  return (
+    <section
+      className="device-reco"
+      data-section="device-reco"
+      aria-labelledby="device-reco-heading"
+    >
+      <h3 id="device-reco-heading">Recommended for your machine</h3>
+      <ul className="device-reco__list">
+        {rows.map((row) => (
+          <li key={row.key} className="device-reco__row" data-reco={row.key}>
+            <span className="device-reco__kind">{row.kind}</span>
+            <span className="device-reco__model" data-field="model">
+              {row.reco.label}
+            </span>
+            <span className="device-reco__reason" data-field="reason">
+              {row.reco.reason}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default DeviceModelReco;

--- a/app/renderer/src/components/DeviceStatusStrip.tsx
+++ b/app/renderer/src/components/DeviceStatusStrip.tsx
@@ -1,0 +1,72 @@
+// DeviceStatusStrip.tsx — a compact device + per-job ETA status strip
+// (WU-models/device, deliverable G — "device+ETA status strip"). Shows, at a
+// glance, the four headroom facts a user weighs before a run — FREE DISK, RAM,
+// VRAM, GPU — plus the live per-job ETA when a job is running. Pure presentation:
+// the hardware comes from system.probe and the ETA is passed in by the host.
+import React from 'react';
+import type { HardwareInfo } from '../lib/rpc';
+import { fmtMb } from './advisorMeta';
+
+/** Format an ETA (seconds) as "m:ss", or "—" when there is no running job. */
+export function formatEta(etaSeconds: number | null | undefined): string {
+  if (
+    etaSeconds === null ||
+    etaSeconds === undefined ||
+    !Number.isFinite(etaSeconds) ||
+    etaSeconds < 0
+  ) {
+    return '—';
+  }
+  const total = Math.round(etaSeconds);
+  const mins = Math.floor(total / 60);
+  const secs = total % 60;
+  return `${mins}:${secs.toString().padStart(2, '0')}`;
+}
+
+export interface DeviceStatusStripProps {
+  /** Probed hardware (system.probe). Any field null when undetectable. */
+  hardware: HardwareInfo;
+  /** Live ETA for the active job in seconds, or null/undefined when idle. */
+  etaSeconds?: number | null;
+}
+
+interface Chip {
+  key: string;
+  label: string;
+  value: string;
+}
+
+/** Build the ordered chip list (exported so the chip logic is unit-tested). */
+export function deviceChips(hardware: HardwareInfo, etaSeconds: number | null | undefined): Chip[] {
+  return [
+    { key: 'disk', label: 'Free disk', value: fmtMb(hardware.diskFreeMb ?? null) },
+    { key: 'ram', label: 'RAM', value: fmtMb(hardware.ramMb) },
+    { key: 'vram', label: 'VRAM', value: fmtMb(hardware.vramMb) },
+    { key: 'gpu', label: 'GPU', value: hardware.gpuPresent ? 'yes' : 'none' },
+    { key: 'eta', label: 'ETA', value: formatEta(etaSeconds) },
+  ];
+}
+
+export function DeviceStatusStrip({
+  hardware,
+  etaSeconds,
+}: DeviceStatusStripProps): React.ReactElement {
+  const chips = deviceChips(hardware, etaSeconds);
+  return (
+    <div
+      className="device-strip"
+      data-section="device-strip"
+      role="group"
+      aria-label="Device status"
+    >
+      {chips.map((chip) => (
+        <span key={chip.key} className="device-strip__chip" data-chip={chip.key}>
+          <span className="device-strip__label">{chip.label}</span>
+          <span className="device-strip__value">{chip.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+}
+
+export default DeviceStatusStrip;

--- a/app/renderer/src/components/LocalRunners.tsx
+++ b/app/renderer/src/components/LocalRunners.tsx
@@ -1,0 +1,116 @@
+// LocalRunners.tsx — Ollama / LM Studio detect + recommend + install advice
+// (WU-models/device, deliverable G-1: detect local runners; if present list the
+// recommended whisper+LLM to PULL with a copy-able hint; if absent advise install
+// with the official link — NEVER an auto-install). Pure presentation: the advice
+// rows come from models.runners; copying a pull hint is the only interaction.
+import React, { useCallback, useState } from 'react';
+import type { RunnerAdvice } from '../lib/rpc';
+
+export interface LocalRunnersProps {
+  /** Per-runner detect + recommend + install advice (from models.runners). */
+  runners: RunnerAdvice[];
+  /**
+   * Optional clipboard writer (injected for tests; defaults to the browser
+   * clipboard). Returns a promise; a rejection is swallowed (copy is best-effort).
+   */
+  writeClipboard?: (text: string) => Promise<void>;
+}
+
+/* v8 ignore start -- the real navigator.clipboard default only runs in the app; every test injects writeClipboard. */
+function defaultClipboard(text: string): Promise<void> {
+  if (typeof navigator !== 'undefined' && navigator.clipboard?.writeText) {
+    return navigator.clipboard.writeText(text);
+  }
+  return Promise.resolve();
+}
+/* v8 ignore stop */
+
+export function LocalRunners({ runners, writeClipboard }: LocalRunnersProps): React.ReactElement {
+  const [copied, setCopied] = useState<string>('');
+  const write = writeClipboard ?? defaultClipboard;
+
+  const copyPull = useCallback(
+    (kind: string, pull: string): void => {
+      write(pull)
+        .then(() => setCopied(kind))
+        .catch(() => setCopied(''));
+    },
+    [write],
+  );
+
+  return (
+    <section
+      className="local-runners"
+      data-section="local-runners"
+      aria-labelledby="local-runners-heading"
+    >
+      <h3 id="local-runners-heading">Local model runners</h3>
+      <p className="local-runners__intro">
+        Run models on your own machine with Ollama or LM Studio. We detect them and recommend the
+        best model for your hardware — we never auto-install or pull anything.
+      </p>
+      <ul className="local-runners__list">
+        {runners.map((runner) => (
+          <li
+            key={runner.kind}
+            className={`local-runner${runner.present ? ' is-present' : ''}`}
+            data-runner={runner.kind}
+            data-present={runner.present ? 'true' : 'false'}
+          >
+            <div className="local-runner__head">
+              <span className="local-runner__name">{runner.label}</span>
+              <span className="local-runner__status" data-field="status">
+                {runner.present ? 'Running' : 'Not detected'}
+              </span>
+            </div>
+
+            {runner.present ? (
+              <div className="local-runner__present" data-field="present-detail">
+                {runner.installedModels.length > 0 && (
+                  <p className="local-runner__installed" data-field="installed">
+                    Installed: {runner.installedModels.join(', ')}
+                  </p>
+                )}
+                <p className="local-runner__reco" data-field="reco">
+                  Recommended: {runner.recommendedModel.label} — {runner.recommendedModel.reason}
+                </p>
+                <div className="local-runner__pull">
+                  <code className="local-runner__pull-cmd" data-field="pull">
+                    {runner.recommendedModel.pull}
+                  </code>
+                  <button
+                    type="button"
+                    className="local-runner__copy"
+                    data-action="copy-pull"
+                    data-runner={runner.kind}
+                    onClick={() => copyPull(runner.kind, runner.recommendedModel.pull)}
+                  >
+                    {copied === runner.kind ? 'Copied' : 'Copy'}
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <div className="local-runner__absent" data-field="absent-detail">
+                <p className="local-runner__hint" data-field="install-hint">
+                  {runner.installHint}
+                </p>
+                <a
+                  className="local-runner__install"
+                  data-action="install-link"
+                  data-runner={runner.kind}
+                  href={runner.installUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Get {runner.label}
+                </a>
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+export default LocalRunners;

--- a/app/renderer/src/components/OpenRouterUsage.tsx
+++ b/app/renderer/src/components/OpenRouterUsage.tsx
@@ -1,0 +1,64 @@
+// OpenRouterUsage.tsx — per-key OpenRouter COST rows (WU-models/device,
+// deliverable G-2: per-key usage/consumption shows cost). The calls/tokens axes
+// live in <UsageBars/>; this adds the spend axis OpenRouter uniquely exposes
+// (cumulative credit usage in USD + limit + remaining). Keys are the REDACTED
+// last-4 only — a live key never reaches the renderer. Pure presentation.
+import React from 'react';
+import type { OpenRouterUsageRow } from '../lib/rpc';
+
+/** Format a USD amount as "$1.50", or "—" for an unknown/absent value. */
+export function formatUsd(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) return '—';
+  return `$${value.toFixed(2)}`;
+}
+
+export interface OpenRouterUsageProps {
+  /** Per-key OpenRouter cost rows (already redacted) from providers.openrouterUsage. */
+  rows: OpenRouterUsageRow[];
+}
+
+export function OpenRouterUsage({ rows }: OpenRouterUsageProps): React.ReactElement {
+  if (rows.length === 0) {
+    return (
+      <p className="openrouter-usage-empty" data-openrouter="empty">
+        No OpenRouter cost data — add an OpenRouter key (or check your connection) to see spend
+        here.
+      </p>
+    );
+  }
+  return (
+    <div className="openrouter-usage" data-openrouter="rows" data-row-count={rows.length}>
+      {rows.map((row, i) => (
+        <div
+          className="openrouter-usage__row"
+          key={`${row.provider}:${row.key}:${i}`}
+          data-provider={row.provider}
+          data-free={row.isFreeTier ? 'true' : 'false'}
+        >
+          <span className="openrouter-usage__key">
+            {row.provider} key {row.key}
+          </span>
+          <span
+            className="openrouter-usage__cost"
+            data-field="cost"
+            title="Cumulative credit spend"
+          >
+            {formatUsd(row.costUsd)} spent
+          </span>
+          <span className="openrouter-usage__remaining" data-field="remaining">
+            {row.limitUsd === null
+              ? 'no credit limit'
+              : `${formatUsd(row.remainingUsd)} of ${formatUsd(row.limitUsd)} left`}
+          </span>
+          {row.isFreeTier && (
+            <span className="openrouter-usage__free" data-field="free-tier">
+              free tier
+            </span>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default OpenRouterUsage;

--- a/app/renderer/src/components/deviceModels.test.tsx
+++ b/app/renderer/src/components/deviceModels.test.tsx
@@ -1,0 +1,265 @@
+// deviceModels.test.tsx — render + helper tests for the WU-models/device building
+// blocks: DeviceStatusStrip / DeviceModelReco / LocalRunners / OpenRouterUsage.
+
+// @vitest-environment jsdom
+import React from 'react';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { DeviceStatusStrip, deviceChips, formatEta } from './DeviceStatusStrip';
+import { DeviceModelReco } from './DeviceModelReco';
+import { LocalRunners } from './LocalRunners';
+import { OpenRouterUsage, formatUsd } from './OpenRouterUsage';
+import type { HardwareInfo, ModelReco, OpenRouterUsageRow, RunnerAdvice } from '../lib/rpc';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+async function render(node: React.ReactElement): Promise<void> {
+  await act(async () => {
+    root.render(node);
+  });
+}
+
+const hw: HardwareInfo = {
+  vramMb: 6000,
+  ramMb: 32000,
+  cpuCount: 16,
+  gpuPresent: true,
+  diskFreeMb: 250000,
+};
+
+// --------------------------------------------------------------------------- //
+// DeviceStatusStrip
+// --------------------------------------------------------------------------- //
+describe('formatEta', () => {
+  it('formats seconds as m:ss', () => {
+    expect(formatEta(90)).toBe('1:30');
+    expect(formatEta(0)).toBe('0:00');
+    expect(formatEta(605)).toBe('10:05');
+  });
+  it('returns — for null / undefined / negative / non-finite', () => {
+    expect(formatEta(null)).toBe('—');
+    expect(formatEta(undefined)).toBe('—');
+    expect(formatEta(-5)).toBe('—');
+    expect(formatEta(Number.POSITIVE_INFINITY)).toBe('—');
+  });
+});
+
+describe('deviceChips', () => {
+  it('builds disk/ram/vram/gpu/eta chips from hardware + eta', () => {
+    const chips = deviceChips(hw, 120);
+    const byKey = Object.fromEntries(chips.map((c) => [c.key, c.value]));
+    expect(byKey.gpu).toBe('yes');
+    expect(byKey.eta).toBe('2:00');
+    expect(byKey.disk).not.toBe('—'); // 250000 MB -> a GB string
+  });
+  it('degrades unknown fields to — and gpu none', () => {
+    const blank: HardwareInfo = {
+      vramMb: null,
+      ramMb: null,
+      cpuCount: null,
+      gpuPresent: false,
+    };
+    const byKey = Object.fromEntries(deviceChips(blank, null).map((c) => [c.key, c.value]));
+    expect(byKey.disk).toBe('—'); // diskFreeMb absent
+    expect(byKey.vram).toBe('—');
+    expect(byKey.gpu).toBe('none');
+    expect(byKey.eta).toBe('—');
+  });
+});
+
+describe('<DeviceStatusStrip />', () => {
+  it('renders all five chips with values', async () => {
+    await render(<DeviceStatusStrip hardware={hw} etaSeconds={45} />);
+    const strip = container.querySelector('[data-section="device-strip"]') as HTMLElement;
+    expect(strip).not.toBeNull();
+    expect(strip.querySelector('[data-chip="disk"]')).not.toBeNull();
+    expect(strip.querySelector('[data-chip="eta"]')?.textContent).toContain('0:45');
+    expect(strip.querySelector('[data-chip="gpu"]')?.textContent).toContain('yes');
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// DeviceModelReco
+// --------------------------------------------------------------------------- //
+describe('<DeviceModelReco />', () => {
+  it('renders the whisper + LLM picks with their device reasons', async () => {
+    const whisper: ModelReco = {
+      model: 'large-v3-turbo',
+      label: 'Whisper large-v3-turbo',
+      reason: 'Whisper large-v3-turbo — fits your GPU (6000 MB VRAM)',
+    };
+    const llm: ModelReco = {
+      model: 'qwen2.5:7b',
+      label: 'Qwen2.5 7B',
+      reason: 'Qwen2.5 7B — fits your GPU (6000 MB VRAM)',
+    };
+    await render(<DeviceModelReco whisper={whisper} llm={llm} />);
+    const reco = container.querySelector('[data-section="device-reco"]') as HTMLElement;
+    expect(reco.querySelector('[data-reco="whisper"] [data-field="model"]')?.textContent).toBe(
+      'Whisper large-v3-turbo',
+    );
+    expect(reco.querySelector('[data-reco="llm"] [data-field="reason"]')?.textContent).toContain(
+      '6000 MB VRAM',
+    );
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// LocalRunners
+// --------------------------------------------------------------------------- //
+function runner(over: Partial<RunnerAdvice> = {}): RunnerAdvice {
+  return {
+    kind: 'ollama',
+    label: 'Ollama',
+    present: true,
+    baseUrl: 'http://127.0.0.1:11434/v1',
+    installUrl: 'https://ollama.com/download',
+    installHint: 'Ollama is running — no install needed.',
+    installedModels: ['llama3.2'],
+    recommendedModel: {
+      model: 'qwen2.5:7b',
+      label: 'Qwen2.5 7B',
+      reason: 'Qwen2.5 7B — fits your GPU (6000 MB VRAM)',
+      pull: 'ollama pull qwen2.5:7b',
+    },
+    ...over,
+  };
+}
+
+describe('<LocalRunners />', () => {
+  it('renders a running runner with installed models + a copy-able pull hint', async () => {
+    const writes: string[] = [];
+    const writeClipboard = (t: string): Promise<void> => {
+      writes.push(t);
+      return Promise.resolve();
+    };
+    await render(<LocalRunners runners={[runner()]} writeClipboard={writeClipboard} />);
+    const card = container.querySelector('[data-runner="ollama"]') as HTMLElement;
+    expect(card.getAttribute('data-present')).toBe('true');
+    expect(card.querySelector('[data-field="installed"]')?.textContent).toContain('llama3.2');
+    expect(card.querySelector('[data-field="pull"]')?.textContent).toBe('ollama pull qwen2.5:7b');
+    const copy = card.querySelector('[data-action="copy-pull"]') as HTMLButtonElement;
+    await act(async () => copy.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(writes).toEqual(['ollama pull qwen2.5:7b']);
+    expect(copy.textContent).toBe('Copied');
+  });
+
+  it('omits the installed line when no models are installed', async () => {
+    await render(
+      <LocalRunners
+        runners={[runner({ installedModels: [] })]}
+        writeClipboard={() => Promise.resolve()}
+      />,
+    );
+    expect(container.querySelector('[data-field="installed"]')).toBeNull();
+  });
+
+  it('keeps the button un-copied when the clipboard write rejects', async () => {
+    const writeClipboard = (): Promise<void> => Promise.reject(new Error('denied'));
+    await render(<LocalRunners runners={[runner()]} writeClipboard={writeClipboard} />);
+    const copy = container.querySelector('[data-action="copy-pull"]') as HTMLButtonElement;
+    await act(async () => copy.click());
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(copy.textContent).toBe('Copy'); // copy failed -> never flips to "Copied"
+  });
+
+  it('renders an absent runner with an install hint + official link (no auto-install)', async () => {
+    const absent = runner({
+      kind: 'lmstudio',
+      label: 'LM Studio',
+      present: false,
+      installUrl: 'https://lmstudio.ai',
+      installHint:
+        'LM Studio is not running. Install it from https://lmstudio.ai (we never auto-install).',
+      installedModels: [],
+    });
+    await render(<LocalRunners runners={[absent]} writeClipboard={() => Promise.resolve()} />);
+    const card = container.querySelector('[data-runner="lmstudio"]') as HTMLElement;
+    expect(card.getAttribute('data-present')).toBe('false');
+    const link = card.querySelector('[data-action="install-link"]') as HTMLAnchorElement;
+    expect(link.getAttribute('href')).toBe('https://lmstudio.ai');
+    expect(card.querySelector('[data-field="install-hint"]')?.textContent).toContain(
+      'never auto-install',
+    );
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// OpenRouterUsage
+// --------------------------------------------------------------------------- //
+describe('formatUsd', () => {
+  it('formats / degrades USD amounts', () => {
+    expect(formatUsd(1.5)).toBe('$1.50');
+    expect(formatUsd(0)).toBe('$0.00');
+    expect(formatUsd(null)).toBe('—');
+    expect(formatUsd(undefined)).toBe('—');
+    expect(formatUsd(Number.NaN)).toBe('—');
+  });
+});
+
+describe('<OpenRouterUsage />', () => {
+  it('shows an empty hint when there are no rows', async () => {
+    await render(<OpenRouterUsage rows={[]} />);
+    expect(container.querySelector('[data-openrouter="empty"]')).not.toBeNull();
+  });
+
+  it('renders a paid-tier row with cost + remaining/limit', async () => {
+    const rows: OpenRouterUsageRow[] = [
+      {
+        provider: 'OpenRouter',
+        key: '…WXYZ',
+        costUsd: 1.5,
+        limitUsd: 10,
+        remainingUsd: 8.5,
+        isFreeTier: false,
+      },
+    ];
+    await render(<OpenRouterUsage rows={rows} />);
+    const row = container.querySelector('.openrouter-usage__row') as HTMLElement;
+    expect(row.querySelector('[data-field="cost"]')?.textContent).toContain('$1.50');
+    expect(row.querySelector('[data-field="remaining"]')?.textContent).toContain(
+      '$8.50 of $10.00 left',
+    );
+    expect(row.querySelector('[data-field="free-tier"]')).toBeNull();
+  });
+
+  it('renders a free-tier row with no credit limit', async () => {
+    const rows: OpenRouterUsageRow[] = [
+      {
+        provider: 'OpenRouter',
+        key: '…AAAA',
+        costUsd: 0,
+        limitUsd: null,
+        remainingUsd: null,
+        isFreeTier: true,
+      },
+    ];
+    await render(<OpenRouterUsage rows={rows} />);
+    const row = container.querySelector('.openrouter-usage__row') as HTMLElement;
+    expect(row.querySelector('[data-field="remaining"]')?.textContent).toBe('no credit limit');
+    expect(row.querySelector('[data-field="free-tier"]')).not.toBeNull();
+  });
+});

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -607,6 +607,18 @@ describe('client.system / recipes', () => {
     expect(r).toHaveBeenCalledWith('asr.engines', undefined);
   });
 
+  it('models.runners calls the bare method (WU-models/device)', async () => {
+    const r = installApi();
+    await client.models.runners();
+    expect(r).toHaveBeenCalledWith('models.runners', undefined);
+  });
+
+  it('providers.openrouterUsage calls the bare method (WU-models/device cost)', async () => {
+    const r = installApi();
+    await client.providers.openrouterUsage();
+    expect(r).toHaveBeenCalledWith('providers.openrouterUsage', undefined);
+  });
+
   it('readiness.summary calls the bare method (WU-8 roll-up)', async () => {
     const r = installApi();
     await client.readiness.summary();

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -301,6 +301,60 @@ export interface HardwareInfo {
   ramMb: number | null;
   cpuCount: number | null;
   gpuPresent: boolean;
+  /** FREE disk space (MB) on the data drive, or null when undetectable. */
+  diskFreeMb?: number | null;
+}
+
+/**
+ * WU-models/device: a device-ranked model pick + the "X because RAM/VRAM Y"
+ * reason (`models.runners` -> `whisper` / `llm`). Field names mirror the sidecar
+ * `model_recommend.ModelReco`.
+ */
+export interface ModelReco {
+  model: string;
+  label: string;
+  reason: string;
+}
+
+/** A runner's pull recommendation: a {@link ModelReco} + a copy-able pull hint. */
+export interface RunnerModelReco extends ModelReco {
+  pull: string;
+}
+
+/**
+ * WU-models/device: per-runner (Ollama / LM Studio) detect + recommend + install
+ * advice (`models.runners` -> `runners[]`). Mirrors `model_recommend.RunnerAdvice`.
+ */
+export interface RunnerAdvice {
+  kind: string;
+  label: string;
+  present: boolean;
+  baseUrl: string;
+  installUrl: string;
+  installHint: string;
+  installedModels: string[];
+  recommendedModel: RunnerModelReco;
+}
+
+/** The full `models.runners` payload: device whisper + LLM + per-runner advice. */
+export interface LocalModelPlan {
+  whisper: ModelReco;
+  llm: ModelReco;
+  runners: RunnerAdvice[];
+}
+
+/**
+ * WU-models/device: one OpenRouter key's COST row (`providers.openrouterUsage`).
+ * `key` is the REDACTED last-4 only (no full key crosses RPC). Money is USD.
+ * Mirrors the sidecar `openrouter_usage.OpenRouterUsageRow`.
+ */
+export interface OpenRouterUsageRow {
+  provider: string;
+  key: string;
+  costUsd: number | null;
+  limitUsd: number | null;
+  remainingUsd: number | null;
+  isFreeTier: boolean;
 }
 
 /** One selectable ASR engine row (`asr.engines`). */
@@ -1279,6 +1333,16 @@ export const client = {
   },
 
   /**
+   * `models.*` (WU-models/device) — the local-model brain. `runners` composes the
+   * cheap hardware probe + Ollama/LM Studio detect into a device-ranked whisper +
+   * LLM recommendation and per-runner detect/pull/install advice. Direct-return;
+   * NO provider/LLM call, and it NEVER triggers a pull (the pull hint is advice).
+   */
+  models: {
+    runners: (): Promise<LocalModelPlan> => rpc('models.runners'),
+  },
+
+  /**
    * `readiness.*` — the unified "what works right now" roll-up (WU-8). Strictly
    * read-only: it derives every row from the installed-weight map + redacted
    * settings view, so it triggers no download and opens no socket.
@@ -1338,6 +1402,13 @@ export const client = {
      * NOT a poller). Keys are redacted; req/token units are returned distinctly.
      */
     usage: (): Promise<{ usage: UsageRow[] }> => rpc('providers.usage'),
+    /**
+     * `providers.openrouterUsage` (WU-models/device) — per-key OpenRouter COST
+     * rows (cumulative credit usage USD): the cost axis alongside `usage`'s
+     * calls/tokens. Best-effort; keys are redacted (no full key crosses RPC).
+     */
+    openrouterUsage: (): Promise<{ usage: OpenRouterUsageRow[] }> =>
+      rpc('providers.openrouterUsage'),
     /**
      * `providers.spend` — month-to-date cumulative cloud spend + the configured
      * monthly caps (WU-spend-cap). Read-only; all money is integer cents.

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -24,6 +24,8 @@ import type {
   CatalogResponse,
   ComponentStatus,
   HardwareInfo,
+  LocalModelPlan,
+  OpenRouterUsageRow,
   ReadinessItem,
   Recommendation,
   UsageRow,
@@ -101,6 +103,56 @@ function recommendation(): Recommendation {
   };
 }
 
+// WU-models/device — a device-ranked local-model plan (whisper + LLM picks) + the
+// two known runners (Ollama detected, LM Studio absent w/ install link).
+function localModelPlan(): LocalModelPlan {
+  return {
+    whisper: {
+      model: 'large-v3-turbo',
+      label: 'Whisper large-v3-turbo',
+      reason: 'Whisper large-v3-turbo — fits your GPU (6000 MB VRAM)',
+    },
+    llm: {
+      model: 'qwen2.5:7b',
+      label: 'Qwen2.5 7B',
+      reason: 'Qwen2.5 7B — fits your GPU (6000 MB VRAM)',
+    },
+    runners: [
+      {
+        kind: 'ollama',
+        label: 'Ollama',
+        present: true,
+        baseUrl: 'http://127.0.0.1:11434/v1',
+        installUrl: 'https://ollama.com/download',
+        installHint: 'Ollama is running — no install needed.',
+        installedModels: ['llama3.2'],
+        recommendedModel: {
+          model: 'qwen2.5:7b',
+          label: 'Qwen2.5 7B',
+          reason: 'Qwen2.5 7B — fits your GPU (6000 MB VRAM)',
+          pull: 'ollama pull qwen2.5:7b',
+        },
+      },
+      {
+        kind: 'lmstudio',
+        label: 'LM Studio',
+        present: false,
+        baseUrl: 'http://127.0.0.1:1234/v1',
+        installUrl: 'https://lmstudio.ai',
+        installHint:
+          'LM Studio is not running. Install it from https://lmstudio.ai (we never auto-install).',
+        installedModels: [],
+        recommendedModel: {
+          model: 'qwen2.5:7b',
+          label: 'Qwen2.5 7B',
+          reason: 'Qwen2.5 7B — fits your GPU (6000 MB VRAM)',
+          pull: "Search 'qwen2.5:7b' in the LM Studio model browser to download it",
+        },
+      },
+    ],
+  };
+}
+
 /** The G-B1 typed fallback: empty routing -> the card's "unavailable" state. */
 function unavailableRecommendation(): Recommendation {
   return {
@@ -171,9 +223,12 @@ function makeClient(
     usage?: UsageRow[];
     catalog?: CatalogResponse;
     recommendation?: Recommendation;
+    runners?: LocalModelPlan;
+    openrouterUsage?: OpenRouterUsageRow[];
     initialSettings?: Record<string, unknown>;
     rejectAnalyze?: boolean;
     rejectUsage?: boolean;
+    rejectOpenrouter?: boolean;
     readiness?: ReadinessItem[];
     rejectEnsure?: boolean;
   } = {},
@@ -194,6 +249,12 @@ function makeClient(
       recommend: vi.fn(async (opts?: { commercial?: boolean }) => {
         calls.push({ method: 'system.recommend', args: [opts] });
         return { recommendation: over.recommendation ?? recommendation() };
+      }),
+    },
+    models: {
+      runners: vi.fn(async () => {
+        calls.push({ method: 'models.runners', args: [] });
+        return over.runners ?? localModelPlan();
       }),
     },
     assets: {
@@ -229,6 +290,11 @@ function makeClient(
         calls.push({ method: 'providers.usage', args: [] });
         if (over.rejectUsage) throw new Error('usage failed');
         return { usage: over.usage ?? [] };
+      }),
+      openrouterUsage: vi.fn(async () => {
+        calls.push({ method: 'providers.openrouterUsage', args: [] });
+        if (over.rejectOpenrouter) throw new Error('openrouter usage failed');
+        return { usage: over.openrouterUsage ?? [] };
       }),
       catalog: vi.fn(async () => {
         calls.push({ method: 'providers.catalog', args: [] });
@@ -1727,5 +1793,82 @@ describe('<ModelsSystemPanel /> WU-B3 card', () => {
     expect(container.querySelector('[data-section="recommend"]')).toBeNull();
     // the rest of the analyzed panel still renders (report present).
     expect(container.querySelector('[data-section="preset"]')).not.toBeNull();
+  });
+
+  // ---- WU-models/device: device strip + model reco + local runners ----------
+  it('renders the device status strip + device-ranked reco + local runners after analysis', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    await mount(c);
+    await analyze();
+    // device + ETA status strip (free disk / RAM / VRAM / GPU).
+    expect(container.querySelector('[data-section="device-strip"]')).not.toBeNull();
+    // device-ranked model recommendation ("X because RAM/VRAM Y").
+    const reco = container.querySelector('[data-section="device-reco"]') as HTMLElement;
+    expect(reco.querySelector('[data-reco="whisper"] [data-field="model"]')?.textContent).toBe(
+      'Whisper large-v3-turbo',
+    );
+    // local-runner detect + pull + install advice.
+    const runners = container.querySelector('[data-section="local-runners"]') as HTMLElement;
+    expect(runners.querySelector('[data-runner="ollama"]')?.getAttribute('data-present')).toBe(
+      'true',
+    );
+    const lm = runners.querySelector('[data-runner="lmstudio"] [data-action="install-link"]');
+    expect(lm?.getAttribute('href')).toBe('https://lmstudio.ai');
+    expect(c.calls.some((x) => x.method === 'models.runners')).toBe(true);
+  });
+
+  it('hides the device-models sections before analysis (runners not yet loaded)', async () => {
+    const c = makeClient();
+    await mount(c);
+    expect(container.querySelector('[data-section="device-reco"]')).toBeNull();
+    expect(container.querySelector('[data-section="local-runners"]')).toBeNull();
+  });
+
+  it('shows OpenRouter cost rows from the mount-time read', async () => {
+    const c = makeClient({
+      openrouterUsage: [
+        {
+          provider: 'OpenRouter',
+          key: '…WXYZ',
+          costUsd: 1.5,
+          limitUsd: 10,
+          remainingUsd: 8.5,
+          isFreeTier: false,
+        },
+      ],
+    });
+    await mount(c);
+    const cost = container.querySelector('[data-section="openrouter-usage"]') as HTMLElement;
+    expect(cost.querySelector('[data-field="cost"]')?.textContent).toContain('$1.50');
+  });
+
+  it('shows the OpenRouter empty hint when the cost read rejects', async () => {
+    const c = makeClient({ rejectOpenrouter: true });
+    await mount(c);
+    const cost = container.querySelector('[data-section="openrouter-usage"]') as HTMLElement;
+    expect(cost.querySelector('[data-openrouter="empty"]')).not.toBeNull();
+  });
+
+  it('tolerates a non-array OpenRouter usage payload (degrades to empty)', async () => {
+    const c = makeClient();
+    (c.client.providers.openrouterUsage as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      {} as unknown as { usage: OpenRouterUsageRow[] },
+    );
+    await mount(c);
+    const cost = container.querySelector('[data-section="openrouter-usage"]') as HTMLElement;
+    expect(cost.querySelector('[data-openrouter="empty"]')).not.toBeNull();
+  });
+
+  it('hides the device-models sections when models.runners yields nothing', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    (c.client.models.runners as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      null as unknown as LocalModelPlan,
+    );
+    await mount(c);
+    await analyze();
+    // analysis ran (hardware present) but the local-model plan was empty.
+    expect(container.querySelector('[data-section="hardware"]')).not.toBeNull();
+    expect(container.querySelector('[data-section="device-reco"]')).toBeNull();
+    expect(container.querySelector('[data-section="local-runners"]')).toBeNull();
   });
 });

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -25,6 +25,8 @@ import {
   type CatalogResponse,
   type ComponentStatus,
   type HardwareInfo,
+  type LocalModelPlan,
+  type OpenRouterUsageRow,
   type Recommendation,
   type RoutingBlock,
   type UsageRow,
@@ -35,6 +37,10 @@ import { TierCard } from '../components/TierCard';
 import { ModelCard } from '../components/ModelCard';
 import { ModelsOnboarding } from '../components/ModelsOnboarding';
 import { UsageBars } from '../components/UsageBar';
+import { DeviceStatusStrip } from '../components/DeviceStatusStrip';
+import { DeviceModelReco } from '../components/DeviceModelReco';
+import { LocalRunners } from '../components/LocalRunners';
+import { OpenRouterUsage } from '../components/OpenRouterUsage';
 import { PresetPicker } from '../components/PresetPicker';
 import { FirstRunChooser } from '../components/FirstRunChooser';
 import { ReadinessRollup } from '../components/ReadinessRollup';
@@ -180,6 +186,10 @@ export function ModelsSystemPanel({
   const [downloading, setDownloading] = useState<string | null>(null);
   const [showTour, setShowTour] = useState<boolean>(false);
   const [usage, setUsage] = useState<UsageRow[]>([]);
+  // WU-models/device: local-runner plan (device-ranked whisper+LLM + runner advice)
+  // and per-key OpenRouter COST rows (the cost axis alongside the calls/tokens bars).
+  const [runners, setRunners] = useState<LocalModelPlan | null>(null);
+  const [openrouterUsage, setOpenrouterUsage] = useState<OpenRouterUsageRow[]>([]);
   const [catalog, setCatalog] = useState<CatalogResponse | null>(null);
   const [presetBusy, setPresetBusy] = useState<boolean>(false);
   // WU-B3 device-aware recommendation card + one-click Apply.
@@ -216,12 +226,14 @@ export function ModelsSystemPanel({
       api.providers.catalog().catch(() => null),
       api.asr.engines().catch(() => null),
       api.providers.usage().catch(() => null),
+      api.providers.openrouterUsage().catch(() => null),
     ])
-      .then(([catalogRes, engineRes, usageRes]) => {
+      .then(([catalogRes, engineRes, usageRes, orRes]) => {
         if (alive) {
           if (catalogRes) setCatalog(catalogRes);
           if (engineRes) setEngines(Array.isArray(engineRes.engines) ? engineRes.engines : []);
           if (usageRes) setUsage(Array.isArray(usageRes.usage) ? usageRes.usage : []);
+          if (orRes) setOpenrouterUsage(Array.isArray(orRes.usage) ? orRes.usage : []);
         }
       })
       /* v8 ignore next 2 -- every inner read already .catch()es to null, so the outer Promise.all never rejects; this is a belt-and-braces guard. */
@@ -239,15 +251,17 @@ export function ModelsSystemPanel({
     setError('');
     try {
       const commercial = Boolean(settings.commercial);
-      const [hw, rep, assetRes, engineRes, usageRes, catalogRes, recRes] = await Promise.all([
-        api.system.probe(),
-        api.system.advisor({ commercial }),
-        api.assets.list(),
-        api.asr.engines(),
-        api.providers.usage(),
-        api.providers.catalog(),
-        api.system.recommend({ commercial }),
-      ]);
+      const [hw, rep, assetRes, engineRes, usageRes, catalogRes, recRes, runnersRes] =
+        await Promise.all([
+          api.system.probe(),
+          api.system.advisor({ commercial }),
+          api.assets.list(),
+          api.asr.engines(),
+          api.providers.usage(),
+          api.providers.catalog(),
+          api.system.recommend({ commercial }),
+          api.models.runners(),
+        ]);
       setHardware(hw ?? null);
       setReport(rep ?? null);
       setAssets(Array.isArray(assetRes?.assets) ? assetRes.assets : []);
@@ -255,6 +269,7 @@ export function ModelsSystemPanel({
       setUsage(Array.isArray(usageRes?.usage) ? usageRes.usage : []);
       setCatalog(catalogRes ?? null);
       setRecommendation(recRes?.recommendation ?? null);
+      setRunners(runnersRes ?? null);
       setApplyOutcome('');
       setAnalyzed(true);
       // First-run tour: show once if the user hasn't seen it.
@@ -592,7 +607,19 @@ export function ModelsSystemPanel({
               Re-probe
             </button>
           </div>
+          {/* WU-models/device: the device + per-job ETA status strip (free disk /
+              RAM / VRAM / GPU). ETA is idle here (Settings runs no job). */}
+          <DeviceStatusStrip hardware={hardware} />
         </div>
+      )}
+
+      {/* WU-models/device: device-ranked model recommendation ("X because RAM/VRAM
+          Y") + local-runner (Ollama / LM Studio) detect / pull / install advice. */}
+      {analyzed && runners && (
+        <>
+          <DeviceModelReco whisper={runners.whisper} llm={runners.llm} />
+          <LocalRunners runners={runners.runners} />
+        </>
       )}
 
       {analyzed && report && (
@@ -797,6 +824,12 @@ export function ModelsSystemPanel({
           separately and never combined. Updated from response headers, not a poller.
         </p>
         <UsageBars rows={usage} />
+        {/* WU-models/device: the COST axis (OpenRouter cumulative credit spend),
+            alongside the calls/tokens bars above. Keys are redacted last-4 only. */}
+        <div className="usage-section__cost" data-section="openrouter-usage">
+          <h4 className="usage-section__cost-head">OpenRouter spend</h4>
+          <OpenRouterUsage rows={openrouterUsage} />
+        </div>
       </div>
 
       {catalog && (

--- a/sidecar/media_studio/features/system_advisor.py
+++ b/sidecar/media_studio/features/system_advisor.py
@@ -50,6 +50,7 @@ Verdict = Literal["ok", "degraded", "unavailable"]
 VramProbe = Callable[[], int | None]  # total GPU VRAM in MB, or None if no GPU.
 RamProbe = Callable[[], int | None]  # total system RAM in MB, or None if unknown.
 CpuProbe = Callable[[], int | None]  # logical CPU count, or None if unknown.
+DiskProbe = Callable[[], int | None]  # FREE disk space (MB) on the data drive, or None.
 
 #: VRAM budget headroom: a component whose resident VRAM exceeds this fraction of
 #: the budget is "tight" (``degraded``) even though it nominally fits.
@@ -363,6 +364,7 @@ class HardwareInfo:
     ram_mb: int | None
     cpu_count: int | None
     gpu_present: bool
+    disk_free_mb: int | None = None
 
 
 # --------------------------------------------------------------------------- #
@@ -512,21 +514,25 @@ class HardwareProbe:
         vram_probe: VramProbe | None = None,
         ram_probe: RamProbe | None = None,
         cpu_probe: CpuProbe | None = None,
+        disk_probe: DiskProbe | None = None,
     ) -> None:
         self._vram_probe = vram_probe or default_vram_probe
         self._ram_probe = ram_probe or default_ram_probe
         self._cpu_probe = cpu_probe or default_cpu_probe
+        self._disk_probe = disk_probe or default_disk_probe
 
     def detect(self) -> HardwareInfo:
-        """Run all three seams (each fail-safe) -> a :class:`HardwareInfo`."""
+        """Run all four seams (each fail-safe) -> a :class:`HardwareInfo`."""
         vram = self._call(self._vram_probe)
         ram = self._call(self._ram_probe)
         cpu = self._call(self._cpu_probe)
+        disk = self._call(self._disk_probe)
         return HardwareInfo(
             vram_mb=vram,
             ram_mb=ram,
             cpu_count=cpu,
             gpu_present=vram is not None,
+            disk_free_mb=disk,
         )
 
     @staticmethod
@@ -639,6 +645,20 @@ def default_cpu_probe() -> int | None:
     return os.cpu_count()
 
 
+def default_disk_probe(path: str | None = None) -> int | None:
+    """FREE disk space (MB) on the drive holding ``path`` (defaults to the home dir).
+
+    Uses ``shutil.disk_usage`` (lazy import) so the device+ETA status strip can show
+    how much room is left for model downloads. Fail-safe by contract: the caller
+    wraps it so any error degrades to ``None`` (the strip then reads "not detected").
+    """
+    import shutil  # noqa: PLC0415 - stdlib, lazy for symmetry
+    from pathlib import Path  # noqa: PLC0415 - stdlib, lazy for symmetry
+
+    target = Path(path) if path else Path.home()
+    return int(shutil.disk_usage(target).free // (1024 * 1024))
+
+
 def probe_capabilities(
     *,
     find_spec: Callable[[str], object] | None = None,
@@ -725,6 +745,7 @@ __all__ = [
     "advise",
     "advise_for_hardware",
     "default_cpu_probe",
+    "default_disk_probe",
     "default_ram_probe",
     "default_vram_probe",
     "probe_capabilities",

--- a/sidecar/media_studio/handlers.py
+++ b/sidecar/media_studio/handlers.py
@@ -150,6 +150,7 @@ class Services:
         hardware_probe: Any | None = None,
         phase8_runner: Callable[..., dict[str, Any]] | None = None,
         test_key_transport: Any | None = None,
+        openrouter_usage_transport: Any | None = None,
         now: Callable[[], float] | None = None,
         vlm_clip_frame_loader: Any | None = None,
         vlm_frame_encoder: Any | None = None,
@@ -185,6 +186,10 @@ class Services:
         # WU-keys: the transport providers.testKey uses for its validation ping.
         # None -> the real stdlib urllib transport; tests inject a fake.
         self._test_key_transport = test_key_transport
+        # WU-models/device: the GET transport providers.openrouterUsage uses to read
+        # each OpenRouter key's cumulative credit usage. None -> the real stdlib
+        # urllib GET transport; tests inject a fake so no socket is opened.
+        self._openrouter_usage_transport = openrouter_usage_transport
         # WU-usage-ui: the wall-clock seam used to stamp + stale-flag the cached
         # providers.usage rows. None -> real ``time.time``; tests inject a fake
         # clock so the >10-min stale threshold is deterministic.
@@ -648,6 +653,28 @@ class Services:
         # Persist the merged snapshot so the next launch shows it without polling.
         self.settings.set({"usageCache": {"rows": merged, "checkedAt": next_checked, "savedAt": now}})
         return {"usage": stamped}
+
+    def providers_openrouter_usage(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``providers.openrouterUsage()`` -> ``{usage:[...]}`` per-key COST (WU-models/device).
+
+        The "calls/tokens" axes already live in :meth:`providers_usage` (parsed
+        ``X-RateLimit-*`` headers). This adds the COST axis for OpenRouter: a
+        best-effort ``GET /api/v1/key`` per RAW OpenRouter key (through the injectable
+        ``_openrouter_usage_transport`` GET seam) reporting cumulative credit usage
+        (USD), limit, and remaining. Best-effort + key-safe: a dead key is skipped
+        (never raised), the live key rides ONLY the ``Authorization`` header, and the
+        returned rows carry the REDACTED last-4 only — no full key crosses RPC.
+        """
+        from .models import openrouter_usage as _oru  # local: import-light
+        from .models import provider as _provider_mod  # local: heavy seam (GET transport)
+
+        transport = self._openrouter_usage_transport or _provider_mod.urllib_get_json
+        providers = self.settings.get_raw().get("providers")
+        rows = _oru.fetch_usage(
+            providers if isinstance(providers, list) else [],
+            transport=transport,
+        )
+        return {"usage": rows}
 
     def providers_spend(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
         """``providers.spend()`` -> month-to-date spend + configured caps (WU-spend-cap).
@@ -2012,6 +2039,9 @@ class Services:
             "ramMb": hw.ram_mb,
             "cpuCount": hw.cpu_count,
             "gpuPresent": hw.gpu_present,
+            # WU-models/device: free disk on the data drive feeds the device+ETA
+            # status strip (how much room is left for model downloads).
+            "diskFreeMb": hw.disk_free_mb,
         }
 
     def system_advisor(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
@@ -2118,6 +2148,25 @@ class Services:
             commercial=commercial,
         )
         return {"recommendation": recommendation}
+
+    def models_runners(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``models.runners()`` -> ``{whisper, llm, runners:[...]}``. Direct-return.
+
+        The local-model brain for the "Models & System" panel (WU-models/device):
+        composes the cheap hardware probe (:meth:`system_probe`) + the detected
+        Ollama / LM Studio servers (:meth:`_detect_local_servers`) into a PURE
+        :func:`model_recommend.recommend_local_models` plan — a DEVICE-RANKED whisper
+        + LLM recommendation ("X because RAM/VRAM Y") and per-runner advice (running?
+        which models? the device-fit model to pull + a copy-able pull hint; when
+        absent, the official install link — advice only, NEVER an auto-install).
+        Composes probes ONLY: no LLM/provider call, no pull is triggered here.
+        """
+        from .models import model_recommend as _mr  # local: import-light pure
+
+        hardware = self.system_probe(params, ctx)
+        detected_local = self._detect_local_servers(self.settings.get())
+        plan = _mr.recommend_local_models(hardware, detected_local)
+        return cast("dict[str, Any]", plan)
 
     def system_self_test(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
         """``system.selfTest()`` -> the first-run diagnostic report. Direct-return.
@@ -2281,10 +2330,14 @@ class Services:
         return present
 
     def _default_hardware_probe(self) -> Any:  # pragma: no cover - lazy heavy seam (pynvml/torch); tests inject a fake
-        """Build the real :class:`HardwareProbe` (lazy import; runtime only)."""
+        """Build the real :class:`HardwareProbe` (lazy import; runtime only).
+
+        The free-disk seam is bound to the DATA dir so the device strip reports the
+        room left on the drive model downloads actually land on.
+        """
         from .features import system_advisor as _sa  # noqa: PLC0415 - lazy
 
-        return _sa.HardwareProbe()
+        return _sa.HardwareProbe(disk_probe=lambda: _sa.default_disk_probe(str(self.data_dir)))
 
     def _default_phase8_runner(self) -> Callable[..., dict[str, Any]]:
         """Resolve the real Wave-1 signal-compute runner (lazy; runtime only).
@@ -3694,6 +3747,11 @@ def register_all(
     # probes (advisor + present-map + local-server detect + asr engines) through
     # the PURE recommender. Makes ZERO provider/LLM calls.
     reg("system.recommend", svc.system_recommend)
+    # WU-models/device: the local-model brain — device-ranked whisper + LLM
+    # recommendation + Ollama/LM Studio detect/pull/install advice. Direct-return;
+    # composes the cheap hardware probe + local-server detect through the PURE
+    # model_recommend module. NO LLM/provider call, NO pull is triggered here.
+    reg("models.runners", svc.models_runners)
     # WU-2: the first-run self-diagnostic. Direct (no job): pure data-dir/device/
     # native-dep/ffmpeg probes behind seams — reports LOUDLY, never proceeds broken.
     reg("system.selfTest", svc.system_self_test)
@@ -3754,6 +3812,10 @@ def register_all(
     # burst). The rotation pool already accounts usage from optimistic decrement +
     # parsed 429/X-RateLimit-* headers — this RPC just surfaces it, redacted.
     reg("providers.usage", svc.providers_usage)
+    # WU-models/device: per-key OpenRouter COST rows (cumulative credit usage USD)
+    # — the cost axis alongside providers.usage's calls/tokens. Best-effort GET per
+    # RAW key through the GET-transport seam; no full key ever crosses RPC.
+    reg("providers.openrouterUsage", svc.providers_openrouter_usage)
     # WU-spend-cap: month-to-date cumulative spend + the configured monthly caps
     # (read-only). The persisted ledger is written at job completion; this RPC just
     # surfaces it (+ the soft/hard cap settings) for the renderer's spend view.

--- a/sidecar/media_studio/models/model_recommend.py
+++ b/sidecar/media_studio/models/model_recommend.py
@@ -1,0 +1,279 @@
+"""Device-ranked LOCAL model recommendation + local-runner advice (WU-models/device).
+
+The pure brain behind two V1 surfaces (docs/V1-GRILL-DECISIONS.md (f)/(h)):
+
+  * **Device-ranked model recommendation** ("recommended for your machine: X
+    because RAM/VRAM Y"): given the host's probed VRAM / RAM / GPU, pick the best
+    *whisper* ASR variant AND the best LLM that fits — each with a human reason
+    that NAMES the device numbers. This is the "X because Y" string the renderer
+    surfaces verbatim (deliverable G-7/8/9, extended to local runners).
+  * **Local-runner advice** for Ollama / LM Studio: for each known runner, say
+    whether it is RUNNING (folded in from :func:`local_detect.detect_local_servers`),
+    which model(s) it already serves, the device-fit model to PULL (with a copy-able
+    pull hint), and — when absent — the official INSTALL link (advice, never an
+    auto-install). Detection/recommendation are best-effort and NEVER raise.
+
+PURE + import-light: this module imports nothing heavy, opens no socket, and reads
+no clock. Hardware comes in as the plain ``system.probe`` wire dict
+(``{vramMb, ramMb, gpuPresent}``) and detected servers as the
+:class:`local_detect.PoolEntry` wire dicts — so every input is a JSON-safe value a
+test injects directly (mirrors :mod:`media_studio.features.recommender`).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, TypedDict
+
+# --------------------------------------------------------------------------- #
+# device-ranked model ladders (pure data; best-first within each ladder)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class ModelTier:
+    """One rung of a device-fit ladder: a model + the floor it needs to run.
+
+    ``min_vram_mb`` is the GPU VRAM a fp16/quant load needs; ``min_ram_mb`` the
+    system RAM a CPU run needs. The LAST tier of every ladder is the guaranteed
+    floor (both floors ``0``) so a pick always exists, even on an unknown device.
+    """
+
+    model: str
+    label: str
+    min_vram_mb: int
+    min_ram_mb: int
+
+
+#: Whisper (faster-whisper) ASR variants, best -> floor. VRAM/RAM floors are the
+#: rough resident cost of each model size; large-v3-turbo is the quality pick when
+#: a GPU can hold it, small/base the CPU-friendly floors.
+WHISPER_LADDER: tuple[ModelTier, ...] = (
+    ModelTier("large-v3-turbo", "Whisper large-v3-turbo", min_vram_mb=2000, min_ram_mb=12000),
+    ModelTier("medium", "Whisper medium", min_vram_mb=1200, min_ram_mb=8000),
+    ModelTier("small", "Whisper small", min_vram_mb=600, min_ram_mb=4000),
+    ModelTier("base", "Whisper base", min_vram_mb=0, min_ram_mb=0),
+)
+
+#: LLM (Ollama / LM Studio GGUF) variants, best -> floor. Floors are the rough q4
+#: resident VRAM per model; the 1.5B floor always fits (CPU backstop).
+LLM_LADDER: tuple[ModelTier, ...] = (
+    ModelTier("qwen2.5:14b", "Qwen2.5 14B", min_vram_mb=11000, min_ram_mb=32000),
+    ModelTier("qwen2.5:7b", "Qwen2.5 7B", min_vram_mb=6000, min_ram_mb=16000),
+    ModelTier("qwen2.5:3b", "Qwen2.5 3B", min_vram_mb=3000, min_ram_mb=8000),
+    ModelTier("qwen2.5:1.5b", "Qwen2.5 1.5B", min_vram_mb=0, min_ram_mb=0),
+)
+
+
+# --------------------------------------------------------------------------- #
+# known local runners (pure data)
+# --------------------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class RunnerSpec:
+    """Static facts about one known local runner (Ollama / LM Studio)."""
+
+    kind: str
+    label: str
+    base_url: str
+    install_url: str
+
+
+#: The two well-known OpenAI-compatible local runners V1 advises on. ``base_url``
+#: mirrors :mod:`local_detect`'s probe defaults; ``install_url`` is the official
+#: download page (advice only — V1 NEVER auto-installs a runner).
+RUNNERS: tuple[RunnerSpec, ...] = (
+    RunnerSpec("ollama", "Ollama", "http://127.0.0.1:11434/v1", "https://ollama.com/download"),
+    RunnerSpec("lmstudio", "LM Studio", "http://127.0.0.1:1234/v1", "https://lmstudio.ai"),
+)
+
+
+# --------------------------------------------------------------------------- #
+# typed wire result shapes
+# --------------------------------------------------------------------------- #
+
+
+class ModelReco(TypedDict):
+    """A device-ranked model pick + the "X because RAM/VRAM Y" reason."""
+
+    model: str
+    label: str
+    reason: str
+
+
+class RunnerModelReco(ModelReco):
+    """A runner's pull recommendation: a :class:`ModelReco` + a copy-able pull hint."""
+
+    pull: str
+
+
+class RunnerAdvice(TypedDict):
+    """Per-runner detect + recommend + install advice (the UI's runner card)."""
+
+    kind: str
+    label: str
+    present: bool
+    baseUrl: str
+    installUrl: str
+    installHint: str
+    installedModels: list[str]
+    recommendedModel: RunnerModelReco
+
+
+class LocalModelPlan(TypedDict):
+    """The full local-models plan the ``models.runners`` RPC returns."""
+
+    whisper: ModelReco
+    llm: ModelReco
+    runners: list[RunnerAdvice]
+
+
+# --------------------------------------------------------------------------- #
+# device-fit picking (pure)
+# --------------------------------------------------------------------------- #
+
+
+def _as_int(value: Any) -> int | None:
+    """Coerce a wire number to ``int``, or ``None`` for missing/garbage values."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return int(value)
+
+
+def _device_reason(*, vram_mb: int | None, ram_mb: int | None, gpu_present: bool) -> str:
+    """The "because <device>" clause naming the numbers the pick was made against."""
+    if gpu_present and vram_mb is not None:
+        return f"fits your GPU ({vram_mb} MB VRAM)"
+    if ram_mb is not None:
+        return f"fits your CPU ({ram_mb} MB RAM)"
+    return "device not detected — using the safe baseline"
+
+
+def _fits(tier: ModelTier, *, vram_mb: int | None, ram_mb: int | None, gpu_present: bool) -> bool:
+    """Whether ``tier`` runs on the device (GPU VRAM when present, else CPU RAM)."""
+    if gpu_present and vram_mb is not None:
+        return vram_mb >= tier.min_vram_mb
+    if ram_mb is not None:
+        return ram_mb >= tier.min_ram_mb
+    return tier.min_vram_mb == 0 and tier.min_ram_mb == 0
+
+
+def _pick(ladder: tuple[ModelTier, ...], *, vram_mb: int | None, ram_mb: int | None, gpu_present: bool) -> ModelTier:
+    """The best (highest) ladder rung that fits the device; the floor otherwise.
+
+    Walks best -> worst and returns the first fitting rung. The ladder's last rung
+    is the guaranteed floor (both floors ``0``), so when nothing else fits — or the
+    device is wholly unknown — that floor is returned (a pick always exists).
+    """
+    for tier in ladder:
+        if _fits(tier, vram_mb=vram_mb, ram_mb=ram_mb, gpu_present=gpu_present):
+            return tier
+    return ladder[-1]  # pragma: no cover -- the floor rung always _fits; defensive
+
+
+def _reco_for(ladder: tuple[ModelTier, ...], hardware: dict[str, Any]) -> ModelReco:
+    """Pick a ladder's device-fit model and build its ``{model,label,reason}``."""
+    vram_mb = _as_int(hardware.get("vramMb"))
+    ram_mb = _as_int(hardware.get("ramMb"))
+    gpu_present = bool(hardware.get("gpuPresent"))
+    tier = _pick(ladder, vram_mb=vram_mb, ram_mb=ram_mb, gpu_present=gpu_present)
+    reason = f"{tier.label} — {_device_reason(vram_mb=vram_mb, ram_mb=ram_mb, gpu_present=gpu_present)}"
+    return ModelReco(model=tier.model, label=tier.label, reason=reason)
+
+
+def recommend_whisper(hardware: dict[str, Any]) -> ModelReco:
+    """Device-ranked whisper (ASR) recommendation (the "X because Y" string)."""
+    return _reco_for(WHISPER_LADDER, hardware)
+
+
+def recommend_llm(hardware: dict[str, Any]) -> ModelReco:
+    """Device-ranked LLM recommendation (the runner pull target's "X because Y")."""
+    return _reco_for(LLM_LADDER, hardware)
+
+
+# --------------------------------------------------------------------------- #
+# local-runner advice (pure; folds in detected servers)
+# --------------------------------------------------------------------------- #
+
+
+def _pull_hint(kind: str, model: str) -> str:
+    """The copy-able pull instruction for a runner kind (advice text, no exec)."""
+    if kind == "ollama":
+        return f"ollama pull {model}"
+    return f"Search '{model}' in the LM Studio model browser to download it"
+
+
+def _detected_by_kind(detected_local: list[dict[str, Any]]) -> dict[str, dict[str, Any]]:
+    """Index detected pool-entry dicts by their runner kind (last wins, robust)."""
+    by_kind: dict[str, dict[str, Any]] = {}
+    for entry in detected_local:
+        kind = entry.get("kind") or entry.get("id")
+        if isinstance(kind, str) and kind:
+            by_kind[kind] = entry
+    return by_kind
+
+
+def _runner_advice_for(spec: RunnerSpec, entry: dict[str, Any] | None, llm: ModelReco) -> RunnerAdvice:
+    """Build one runner's advice card from its spec + (optional) detected entry."""
+    present = entry is not None
+    base_url = str(entry.get("base_url") or spec.base_url) if entry is not None else spec.base_url
+    installed_models: list[str] = []
+    if entry is not None:
+        model = entry.get("model")
+        if isinstance(model, str) and model:
+            installed_models.append(model)
+    install_hint = (
+        f"{spec.label} is running — no install needed."
+        if present
+        else f"{spec.label} is not running. Install it from {spec.install_url} (we never auto-install)."
+    )
+    recommended = RunnerModelReco(
+        model=llm["model"],
+        label=llm["label"],
+        reason=llm["reason"],
+        pull=_pull_hint(spec.kind, llm["model"]),
+    )
+    return RunnerAdvice(
+        kind=spec.kind,
+        label=spec.label,
+        present=present,
+        baseUrl=base_url,
+        installUrl=spec.install_url,
+        installHint=install_hint,
+        installedModels=installed_models,
+        recommendedModel=recommended,
+    )
+
+
+def runner_advice(detected_local: list[dict[str, Any]], hardware: dict[str, Any]) -> list[RunnerAdvice]:
+    """Per-known-runner detect + device-fit pull recommendation + install advice."""
+    by_kind = _detected_by_kind(detected_local)
+    llm = recommend_llm(hardware)
+    return [_runner_advice_for(spec, by_kind.get(spec.kind), llm) for spec in RUNNERS]
+
+
+def recommend_local_models(hardware: dict[str, Any], detected_local: list[dict[str, Any]]) -> LocalModelPlan:
+    """Compose the full local-models plan: device whisper + LLM + per-runner advice."""
+    return LocalModelPlan(
+        whisper=recommend_whisper(hardware),
+        llm=recommend_llm(hardware),
+        runners=runner_advice(detected_local, hardware),
+    )
+
+
+__all__ = [
+    "LLM_LADDER",
+    "RUNNERS",
+    "WHISPER_LADDER",
+    "LocalModelPlan",
+    "ModelReco",
+    "ModelTier",
+    "RunnerAdvice",
+    "RunnerModelReco",
+    "RunnerSpec",
+    "recommend_llm",
+    "recommend_local_models",
+    "recommend_whisper",
+    "runner_advice",
+]

--- a/sidecar/media_studio/models/openrouter_usage.py
+++ b/sidecar/media_studio/models/openrouter_usage.py
@@ -1,0 +1,145 @@
+"""OpenRouter per-key COST/credit usage (WU-models/device, deliverable G-2).
+
+The rotation pool's :meth:`provider.RotatingProvider.usage` already surfaces per-key
+*request*/*token* quota from parsed ``X-RateLimit-*`` headers (the "calls" axis) —
+but it has no notion of spend. OpenRouter, uniquely, exposes a cheap authenticated
+``GET /api/v1/key`` that reports the key's cumulative **credit usage (USD)** and
+remaining limit. This module turns that endpoint into per-key cost rows for the
+"Providers & Keys" usage panel, so the user sees *cost* alongside *calls/tokens*.
+
+Design (mirrors :mod:`local_detect`):
+  * PURE + import-light: the HTTP call goes through the SAME injectable
+    :data:`provider.Transport` seam, so **no socket is ever opened under test**.
+  * Best-effort + key-safe: a key that errors is silently skipped (never raised),
+    and the row carries ONLY the REDACTED last-4 — a live key is never logged,
+    never returned, and is sent ONLY in the ``Authorization: Bearer`` header.
+"""
+
+from __future__ import annotations
+
+from typing import Any, TypedDict
+
+from ..util import get_logger
+from .provider import Transport
+from .secrets import redact
+
+log = get_logger("media_studio.models.openrouter_usage")
+
+#: OpenRouter's authenticated key-status endpoint (cumulative credit usage in USD).
+OPENROUTER_KEY_URL: str = "https://openrouter.ai/api/v1/key"
+
+#: How OpenRouter is recognised among the configured providers (any one matches).
+_OPENROUTER_HOST: str = "openrouter.ai"
+_OPENROUTER_IDS: frozenset[str] = frozenset({"openrouter"})
+
+#: Probe timeout (seconds) — a status read should answer fast or be skipped.
+_PROBE_TIMEOUT: float = 4.0
+
+
+class OpenRouterUsageRow(TypedDict):
+    """One OpenRouter key's cost row for the usage UI (no live key, ever)."""
+
+    provider: str
+    key: str  # REDACTED last-4 only
+    costUsd: float | None
+    limitUsd: float | None
+    remainingUsd: float | None
+    isFreeTier: bool
+
+
+def _as_float(value: Any) -> float | None:
+    """Coerce a wire number to ``float``, or ``None`` for missing/garbage/bool."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def parse_key_usage(response: dict[str, Any]) -> dict[str, Any]:
+    """Parse OpenRouter ``GET /api/v1/key`` into ``{costUsd, limitUsd, remainingUsd, isFreeTier}``.
+
+    Shape: ``{"data": {"usage": <usd>, "limit": <usd|null>,
+    "limit_remaining": <usd|null>, "is_free_tier": <bool>}}``. A missing/garbage
+    ``data`` block, or any non-numeric field, degrades that field to ``None``
+    (``isFreeTier`` to ``False``) rather than raising — a partial answer is still
+    useful, a malformed one is not fatal.
+    """
+    data = response.get("data")
+    if not isinstance(data, dict):
+        return {"costUsd": None, "limitUsd": None, "remainingUsd": None, "isFreeTier": False}
+    return {
+        "costUsd": _as_float(data.get("usage")),
+        "limitUsd": _as_float(data.get("limit")),
+        "remainingUsd": _as_float(data.get("limit_remaining")),
+        "isFreeTier": bool(data.get("is_free_tier")),
+    }
+
+
+def is_openrouter(entry: dict[str, Any]) -> bool:
+    """Whether a configured provider entry is OpenRouter (by base URL or id/name)."""
+    base_url = str(entry.get("baseUrl") or "").lower()
+    if _OPENROUTER_HOST in base_url:
+        return True
+    identity = str(entry.get("provider") or entry.get("id") or "").strip().lower()
+    return identity in _OPENROUTER_IDS
+
+
+def _provider_name(entry: dict[str, Any]) -> str:
+    """The display provider name for the row (falls back to id, then 'OpenRouter')."""
+    return str(entry.get("provider") or entry.get("id") or "OpenRouter")
+
+
+def _fetch_one(provider: str, key: str, *, transport: Transport) -> OpenRouterUsageRow | None:
+    """Fetch ONE key's cost row (best-effort). The live key rides only the header.
+
+    Returns ``None`` (and logs at debug) on any transport error so a single dead
+    key never breaks the whole usage read. The returned row's ``key`` is the
+    REDACTED last-4 — the live key never leaves this function.
+    """
+    headers = {"Authorization": f"Bearer {key}"}
+    try:
+        response = transport(OPENROUTER_KEY_URL, {}, headers, _PROBE_TIMEOUT)
+    except Exception as exc:  # noqa: BLE001 - best-effort, must not raise
+        log.debug("OpenRouter usage probe failed for %s (%s): %s", provider, redact(key), exc)
+        return None
+    parsed = parse_key_usage(response)
+    return OpenRouterUsageRow(
+        provider=provider,
+        key=redact(key),
+        costUsd=parsed["costUsd"],
+        limitUsd=parsed["limitUsd"],
+        remainingUsd=parsed["remainingUsd"],
+        isFreeTier=parsed["isFreeTier"],
+    )
+
+
+def fetch_usage(providers: list[dict[str, Any]], *, transport: Transport) -> list[OpenRouterUsageRow]:
+    """Per-key OpenRouter cost rows from the configured (RAW-keyed) providers.
+
+    Scans ``providers`` for OpenRouter entries (:func:`is_openrouter`), probes
+    ``GET /api/v1/key`` per RAW key through the injected ``transport``, and returns
+    one cost row per key that answered. Non-OpenRouter entries, keyless entries,
+    and dead keys are skipped — the function returns ``[]`` (never raises) when
+    nothing is available. No live key is ever returned (rows carry last-4 only).
+    """
+    rows: list[OpenRouterUsageRow] = []
+    for entry in providers:
+        if not isinstance(entry, dict) or not is_openrouter(entry):
+            continue
+        provider = _provider_name(entry)
+        for raw_key in entry.get("apiKeys") or []:
+            key = str(raw_key)
+            if not key:
+                continue
+            row = _fetch_one(provider, key, transport=transport)
+            if row is not None:
+                rows.append(row)
+    return rows
+
+
+__all__ = [
+    "OPENROUTER_KEY_URL",
+    "OpenRouterUsageRow",
+    "fetch_usage",
+    "is_openrouter",
+    "parse_key_usage",
+]

--- a/sidecar/tests/test_handlers_phase8.py
+++ b/sidecar/tests/test_handlers_phase8.py
@@ -68,6 +68,7 @@ class _FakeHardwareProbe:
         vram_mb: int | None = 6000,
         ram_mb: int | None = 16000,
         cpu_count: int | None = 8,
+        disk_free_mb: int | None = 200000,
     ) -> None:
         from media_studio.features.system_advisor import HardwareInfo
 
@@ -76,6 +77,7 @@ class _FakeHardwareProbe:
             ram_mb=ram_mb,
             cpu_count=cpu_count,
             gpu_present=vram_mb is not None,
+            disk_free_mb=disk_free_mb,
         )
 
     def detect(self) -> Any:
@@ -184,7 +186,41 @@ def test_system_probe_returns_hardware_info(tmp_path: Path) -> None:
     svc = _phase8_services(tmp_path)
     direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
     out = svc.system_probe({}, direct)
-    assert out == {"vramMb": 6000, "ramMb": 16000, "cpuCount": 8, "gpuPresent": True}
+    assert out == {
+        "vramMb": 6000,
+        "ramMb": 16000,
+        "cpuCount": 8,
+        "gpuPresent": True,
+        "diskFreeMb": 200000,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# models.runners (WU-models/device) — device-ranked local-model plan + runner advice
+# --------------------------------------------------------------------------- #
+def test_models_runners_composes_device_plan(tmp_path: Path) -> None:
+    # A detected Ollama server + a known device -> device-ranked whisper/LLM picks
+    # and per-runner advice (Ollama present, LM Studio absent with install link).
+    detected = [{"kind": "ollama", "model": "qwen2.5:7b", "base_url": "http://127.0.0.1:11434/v1"}]
+    svc = _phase8_services(tmp_path, local_detector=lambda _s: detected)
+    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
+    out = svc.models_runners({}, direct)
+    assert out["whisper"]["model"] == "large-v3-turbo"  # 6000MB GPU fits turbo
+    assert out["llm"]["model"] == "qwen2.5:7b"  # 6000MB GPU fits 7b
+    by_kind = {r["kind"]: r for r in out["runners"]}
+    assert by_kind["ollama"]["present"] is True
+    assert by_kind["ollama"]["installedModels"] == ["qwen2.5:7b"]
+    assert by_kind["lmstudio"]["present"] is False
+    assert "https://lmstudio.ai" in by_kind["lmstudio"]["installHint"]
+
+
+def test_models_runners_registered(tmp_path: Path) -> None:
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "models.runners" in registered
 
 
 def test_system_advisor_returns_wire_report(tmp_path: Path) -> None:

--- a/sidecar/tests/test_handlers_usage.py
+++ b/sidecar/tests/test_handlers_usage.py
@@ -149,3 +149,64 @@ def test_usage_registered_in_register_all(tmp_path: Path) -> None:
     protocol.METHODS.clear()
     register_all(Services(data_dir=tmp_path))
     assert "providers.usage" in protocol.METHODS
+    assert "providers.openrouterUsage" in protocol.METHODS
+
+
+# --------------------------------------------------------------------------- #
+# providers.openrouterUsage (WU-models/device): per-key COST rows, key-safe
+# --------------------------------------------------------------------------- #
+OR_KEY = "sk-or-live-SECRET-MNOP"
+
+
+def _with_openrouter(svc: Services, keys: list[str] | None = None) -> None:
+    svc.settings.set(
+        {
+            "providers": [
+                {
+                    "id": "openrouter",
+                    "provider": "OpenRouter",
+                    "kind": "cloud",
+                    "baseUrl": "https://openrouter.ai/api/v1",
+                    "model": "deepseek/deepseek-chat:free",
+                    "apiKeys": keys if keys is not None else [OR_KEY],
+                    "enabled": True,
+                    "capabilities": ["text"],
+                    "unit": "req",
+                }
+            ]
+        }
+    )
+
+
+def test_openrouter_usage_returns_cost_rows_no_full_key(tmp_path: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_transport(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        captured["headers"] = headers
+        return {"data": {"usage": 1.5, "limit": 10.0, "limit_remaining": 8.5, "is_free_tier": False}}
+
+    svc = Services(data_dir=tmp_path, openrouter_usage_transport=fake_transport)
+    _with_openrouter(svc)
+    res = svc.providers_openrouter_usage({}, _ctx())
+    rows = res["usage"]
+    assert len(rows) == 1
+    assert rows[0]["provider"] == "OpenRouter"
+    assert rows[0]["costUsd"] == 1.5
+    assert rows[0]["limitUsd"] == 10.0
+    # No full key crosses RPC; the live key rides ONLY the Authorization header.
+    assert OR_KEY not in json.dumps(res)
+    assert captured["headers"]["Authorization"] == f"Bearer {OR_KEY}"
+
+
+def test_openrouter_usage_skips_when_no_openrouter_provider(tmp_path: Path) -> None:
+    def fake_transport(url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        raise AssertionError("no probe should run when no OpenRouter provider is configured")
+
+    svc = Services(data_dir=tmp_path, openrouter_usage_transport=fake_transport)
+    _with_groq(svc)  # only a Groq provider configured
+    assert svc.providers_openrouter_usage({}, _ctx())["usage"] == []
+
+
+def test_openrouter_usage_empty_when_no_providers(tmp_path: Path) -> None:
+    svc = Services(data_dir=tmp_path, openrouter_usage_transport=lambda *a, **k: {})
+    assert svc.providers_openrouter_usage({}, _ctx())["usage"] == []

--- a/sidecar/tests/test_model_recommend.py
+++ b/sidecar/tests/test_model_recommend.py
@@ -1,0 +1,201 @@
+"""Unit tests for media_studio.models.model_recommend (device-ranked local models).
+
+Covers the PURE device-fit picking (whisper + LLM ladders), the "X because
+RAM/VRAM Y" reason strings, and the Ollama / LM Studio runner advice (detect +
+device-fit pull recommendation + install link). Every input is a plain wire dict;
+no socket, no clock, no heavy import.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.models import model_recommend as mr
+
+
+# --------------------------------------------------------------------------- #
+# _as_int coercion
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (8000, 8000),
+        (8000.7, 8000),
+        (None, None),
+        ("8000", None),
+        (True, None),  # bool is not a usable number
+    ],
+)
+def test_as_int(value: Any, expected: int | None) -> None:
+    assert mr._as_int(value) == expected
+
+
+# --------------------------------------------------------------------------- #
+# _device_reason — the three "because" clauses
+# --------------------------------------------------------------------------- #
+def test_device_reason_gpu() -> None:
+    assert mr._device_reason(vram_mb=6000, ram_mb=16000, gpu_present=True) == "fits your GPU (6000 MB VRAM)"
+
+
+def test_device_reason_cpu_when_no_gpu() -> None:
+    assert mr._device_reason(vram_mb=None, ram_mb=16000, gpu_present=False) == "fits your CPU (16000 MB RAM)"
+
+
+def test_device_reason_gpu_present_but_vram_unknown_falls_to_ram() -> None:
+    # gpu_present True but no VRAM number -> CPU/RAM clause (no crash).
+    assert mr._device_reason(vram_mb=None, ram_mb=4000, gpu_present=True) == "fits your CPU (4000 MB RAM)"
+
+
+def test_device_reason_unknown_device() -> None:
+    assert (
+        mr._device_reason(vram_mb=None, ram_mb=None, gpu_present=False)
+        == "device not detected — using the safe baseline"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _fits — GPU vram path / CPU ram path / wholly-unknown floor path
+# --------------------------------------------------------------------------- #
+def test_fits_gpu_vram() -> None:
+    big = mr.LLM_LADDER[0]
+    assert mr._fits(big, vram_mb=12000, ram_mb=None, gpu_present=True) is True
+    assert mr._fits(big, vram_mb=4000, ram_mb=None, gpu_present=True) is False
+
+
+def test_fits_cpu_ram() -> None:
+    small = mr.WHISPER_LADDER[2]  # small
+    assert mr._fits(small, vram_mb=None, ram_mb=4000, gpu_present=False) is True
+    assert mr._fits(small, vram_mb=None, ram_mb=1000, gpu_present=False) is False
+
+
+def test_fits_unknown_device_only_floor() -> None:
+    floor = mr.WHISPER_LADDER[-1]
+    top = mr.WHISPER_LADDER[0]
+    assert mr._fits(floor, vram_mb=None, ram_mb=None, gpu_present=False) is True
+    assert mr._fits(top, vram_mb=None, ram_mb=None, gpu_present=False) is False
+
+
+# --------------------------------------------------------------------------- #
+# recommend_whisper / recommend_llm — device ranking + reason wording
+# --------------------------------------------------------------------------- #
+def test_recommend_whisper_big_gpu_picks_turbo() -> None:
+    reco = mr.recommend_whisper({"vramMb": 8000, "ramMb": 32000, "gpuPresent": True})
+    assert reco["model"] == "large-v3-turbo"
+    assert "GPU (8000 MB VRAM)" in reco["reason"]
+    assert reco["label"] == "Whisper large-v3-turbo"
+
+
+def test_recommend_whisper_cpu_box_picks_small() -> None:
+    reco = mr.recommend_whisper({"vramMb": None, "ramMb": 4000, "gpuPresent": False})
+    assert reco["model"] == "small"
+    assert "CPU (4000 MB RAM)" in reco["reason"]
+
+
+def test_recommend_whisper_unknown_device_picks_floor() -> None:
+    reco = mr.recommend_whisper({})
+    assert reco["model"] == "base"
+    assert "device not detected" in reco["reason"]
+
+
+def test_recommend_llm_mid_gpu_picks_7b() -> None:
+    reco = mr.recommend_llm({"vramMb": 8000, "ramMb": 16000, "gpuPresent": True})
+    assert reco["model"] == "qwen2.5:7b"
+
+
+def test_recommend_llm_low_gpu_picks_3b() -> None:
+    reco = mr.recommend_llm({"vramMb": 4000, "ramMb": 8000, "gpuPresent": True})
+    assert reco["model"] == "qwen2.5:3b"
+
+
+def test_recommend_llm_unknown_picks_floor() -> None:
+    assert mr.recommend_llm({})["model"] == "qwen2.5:1.5b"
+
+
+# --------------------------------------------------------------------------- #
+# _pull_hint — per-runner copy-able instruction
+# --------------------------------------------------------------------------- #
+def test_pull_hint_ollama() -> None:
+    assert mr._pull_hint("ollama", "qwen2.5:7b") == "ollama pull qwen2.5:7b"
+
+
+def test_pull_hint_lmstudio() -> None:
+    assert "LM Studio model browser" in mr._pull_hint("lmstudio", "qwen2.5:7b")
+
+
+# --------------------------------------------------------------------------- #
+# _detected_by_kind — keying robustness
+# --------------------------------------------------------------------------- #
+def test_detected_by_kind_uses_kind_then_id() -> None:
+    detected = [
+        {"kind": "ollama", "model": "llama3.2", "base_url": "http://x/v1"},
+        {"id": "lmstudio", "model": "studio"},  # id fallback
+        {"model": "orphan"},  # neither kind nor id -> skipped
+    ]
+    by_kind = mr._detected_by_kind(detected)
+    assert set(by_kind) == {"ollama", "lmstudio"}
+
+
+# --------------------------------------------------------------------------- #
+# runner_advice — present (with/without model) + absent (install advice)
+# --------------------------------------------------------------------------- #
+def test_runner_advice_present_running_server() -> None:
+    detected = [{"kind": "ollama", "model": "llama3.2", "base_url": "http://127.0.0.1:11434/v1"}]
+    advice = mr.runner_advice(detected, {"vramMb": 8000, "gpuPresent": True})
+    by_kind = {a["kind"]: a for a in advice}
+    ollama = by_kind["ollama"]
+    assert ollama["present"] is True
+    assert ollama["installedModels"] == ["llama3.2"]
+    assert "no install needed" in ollama["installHint"]
+    assert ollama["recommendedModel"]["pull"] == "ollama pull qwen2.5:7b"
+    # The absent runner advises install with the official link.
+    lmstudio = by_kind["lmstudio"]
+    assert lmstudio["present"] is False
+    assert lmstudio["installedModels"] == []
+    assert lmstudio["installUrl"] == "https://lmstudio.ai"
+    assert "https://lmstudio.ai" in lmstudio["installHint"]
+    assert "never auto-install" in lmstudio["installHint"]
+
+
+def test_runner_advice_present_without_model_id() -> None:
+    # A detected server with no usable model id still counts as present (no crash),
+    # just with an empty installedModels list.
+    detected = [{"kind": "ollama", "base_url": "http://127.0.0.1:11434/v1"}]
+    [ollama] = [a for a in mr.runner_advice(detected, {}) if a["kind"] == "ollama"]
+    assert ollama["present"] is True
+    assert ollama["installedModels"] == []
+
+
+def test_runner_advice_present_non_string_model_skipped() -> None:
+    detected = [{"kind": "ollama", "model": 123}]
+    [ollama] = [a for a in mr.runner_advice(detected, {}) if a["kind"] == "ollama"]
+    assert ollama["installedModels"] == []
+
+
+def test_runner_advice_none_detected_uses_default_base_url() -> None:
+    [ollama] = [a for a in mr.runner_advice([], {}) if a["kind"] == "ollama"]
+    assert ollama["baseUrl"] == "http://127.0.0.1:11434/v1"
+    assert ollama["present"] is False
+
+
+# --------------------------------------------------------------------------- #
+# recommend_local_models — the full composed plan
+# --------------------------------------------------------------------------- #
+def test_recommend_local_models_full_plan() -> None:
+    plan = mr.recommend_local_models(
+        {"vramMb": 12000, "ramMb": 32000, "gpuPresent": True},
+        [{"kind": "ollama", "model": "qwen2.5:14b"}],
+    )
+    assert plan["whisper"]["model"] == "large-v3-turbo"
+    assert plan["llm"]["model"] == "qwen2.5:14b"
+    assert [r["kind"] for r in plan["runners"]] == ["ollama", "lmstudio"]
+
+
+def test_module_is_import_light() -> None:
+    # No clock / socket leakage (mirrors the local_detect no-time guard).
+    assert not hasattr(mr, "time")
+    assert not hasattr(mr, "socket")
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/sidecar/tests/test_openrouter_usage.py
+++ b/sidecar/tests/test_openrouter_usage.py
@@ -1,0 +1,154 @@
+"""Unit tests for media_studio.models.openrouter_usage (per-key COST rows).
+
+Probes OpenRouter ``GET /api/v1/key`` through the SAME injectable Transport seam
+the pool uses, so no socket is opened. Asserts: cost/limit parsing, OpenRouter
+detection, best-effort skip on a dead key, keyless/non-OpenRouter skip, and that a
+live key never leaves the row (redacted last-4 only) but DOES ride the Bearer
+header.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.models import openrouter_usage as oru
+from media_studio.models.provider import ProviderError
+
+
+# --------------------------------------------------------------------------- #
+# fakes
+# --------------------------------------------------------------------------- #
+class RecordingTransport:
+    """A fake transport returning a canned response and recording the calls."""
+
+    def __init__(self, response: dict[str, Any] | None = None, error: Exception | None = None) -> None:
+        self.response = response or {}
+        self.error = error
+        self.calls: list[dict[str, Any]] = []
+
+    def __call__(self, url: str, body: dict[str, Any], headers: dict[str, str], timeout: float) -> dict[str, Any]:
+        self.calls.append({"url": url, "body": body, "headers": headers, "timeout": timeout})
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+
+def _key_response(usage: float, limit: float | None, remaining: float | None, free: bool = False) -> dict[str, Any]:
+    return {"data": {"usage": usage, "limit": limit, "limit_remaining": remaining, "is_free_tier": free}}
+
+
+# --------------------------------------------------------------------------- #
+# parse_key_usage
+# --------------------------------------------------------------------------- #
+def test_parse_key_usage_full() -> None:
+    parsed = oru.parse_key_usage(_key_response(1.25, 10.0, 8.75, free=True))
+    assert parsed == {"costUsd": 1.25, "limitUsd": 10.0, "remainingUsd": 8.75, "isFreeTier": True}
+
+
+def test_parse_key_usage_missing_data_all_none() -> None:
+    assert oru.parse_key_usage({}) == {
+        "costUsd": None,
+        "limitUsd": None,
+        "remainingUsd": None,
+        "isFreeTier": False,
+    }
+
+
+def test_parse_key_usage_data_not_a_dict() -> None:
+    assert oru.parse_key_usage({"data": "nope"})["costUsd"] is None
+
+
+def test_parse_key_usage_null_limit_and_garbage_usage() -> None:
+    parsed = oru.parse_key_usage({"data": {"usage": "x", "limit": None, "is_free_tier": True}})
+    assert parsed == {"costUsd": None, "limitUsd": None, "remainingUsd": None, "isFreeTier": True}
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [(1, 1.0), (1.5, 1.5), (None, None), ("1", None), (True, None)],
+)
+def test_as_float(value: Any, expected: float | None) -> None:
+    assert oru._as_float(value) == expected
+
+
+# --------------------------------------------------------------------------- #
+# is_openrouter
+# --------------------------------------------------------------------------- #
+def test_is_openrouter_by_base_url() -> None:
+    assert oru.is_openrouter({"baseUrl": "https://openrouter.ai/api/v1"}) is True
+
+
+def test_is_openrouter_by_id() -> None:
+    assert oru.is_openrouter({"id": "openrouter", "baseUrl": "https://x/v1"}) is True
+
+
+def test_is_openrouter_by_provider_name() -> None:
+    assert oru.is_openrouter({"provider": "OpenRouter"}) is True
+
+
+def test_is_openrouter_false_for_other_provider() -> None:
+    assert oru.is_openrouter({"provider": "Groq", "baseUrl": "https://api.groq.com/v1"}) is False
+
+
+# --------------------------------------------------------------------------- #
+# fetch_usage — the per-key probe
+# --------------------------------------------------------------------------- #
+def test_fetch_usage_returns_cost_row_with_redacted_key() -> None:
+    transport = RecordingTransport(_key_response(2.0, 10.0, 8.0))
+    rows = oru.fetch_usage([{"provider": "OpenRouter", "apiKeys": ["sk-or-LIVEKEY1234"]}], transport=transport)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["provider"] == "OpenRouter"
+    assert row["costUsd"] == 2.0
+    assert row["limitUsd"] == 10.0
+    # The live key never appears in the row — only the redacted last-4.
+    assert row["key"] == "…1234"
+    assert "LIVEKEY" not in row["key"]
+    # ...but it DOES ride the Authorization header (and only there).
+    assert transport.calls[0]["headers"]["Authorization"] == "Bearer sk-or-LIVEKEY1234"
+    assert transport.calls[0]["url"] == oru.OPENROUTER_KEY_URL
+
+
+def test_fetch_usage_skips_non_openrouter_provider() -> None:
+    transport = RecordingTransport(_key_response(2.0, 10.0, 8.0))
+    rows = oru.fetch_usage([{"provider": "Groq", "apiKeys": ["gsk_x"]}], transport=transport)
+    assert rows == []
+    assert transport.calls == []  # no probe issued for a non-OpenRouter provider
+
+
+def test_fetch_usage_skips_keyless_and_blank_keys() -> None:
+    transport = RecordingTransport(_key_response(2.0, 10.0, 8.0))
+    rows = oru.fetch_usage(
+        [
+            {"provider": "OpenRouter", "apiKeys": []},
+            {"provider": "OpenRouter", "apiKeys": [""]},
+        ],
+        transport=transport,
+    )
+    assert rows == []
+
+
+def test_fetch_usage_skips_dead_key_best_effort() -> None:
+    transport = RecordingTransport(error=ProviderError("LLM HTTP 401: unauthorized"))
+    rows = oru.fetch_usage([{"provider": "OpenRouter", "apiKeys": ["sk-or-dead"]}], transport=transport)
+    assert rows == []  # a dead key is skipped, never raised
+
+
+def test_fetch_usage_skips_non_dict_entry() -> None:
+    transport = RecordingTransport(_key_response(2.0, 10.0, 8.0))
+    assert oru.fetch_usage(["not-a-dict"], transport=transport) == []  # type: ignore[list-item]
+
+
+def test_fetch_usage_multiple_keys_same_provider() -> None:
+    transport = RecordingTransport(_key_response(3.0, None, None))
+    rows = oru.fetch_usage(
+        [{"provider": "OpenRouter", "apiKeys": ["sk-or-aaaa", "sk-or-bbbb"]}],
+        transport=transport,
+    )
+    assert [r["key"] for r in rows] == ["…aaaa", "…bbbb"]
+    assert all(r["limitUsd"] is None for r in rows)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run convenience
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/sidecar/tests/test_system_advisor.py
+++ b/sidecar/tests/test_system_advisor.py
@@ -274,9 +274,25 @@ def test_hardware_probe_with_fake_seams() -> None:
         vram_probe=lambda: 6144,
         ram_probe=lambda: 16384,
         cpu_probe=lambda: 8,
+        disk_probe=lambda: 250000,
     )
     hw = probe.detect()
-    assert hw == sa.HardwareInfo(vram_mb=6144, ram_mb=16384, cpu_count=8, gpu_present=True)
+    assert hw == sa.HardwareInfo(vram_mb=6144, ram_mb=16384, cpu_count=8, gpu_present=True, disk_free_mb=250000)
+
+
+def test_default_disk_probe_reads_free_space() -> None:
+    # The default seam reads real free space (MB) on the home drive; with an
+    # explicit path it reads that drive instead. Both return a non-negative int.
+    assert sa.default_disk_probe() >= 0
+    assert sa.default_disk_probe(str(sa.__file__)) >= 0
+
+
+def test_hardware_probe_swallows_failing_disk_seam() -> None:
+    def boom() -> int | None:
+        raise OSError("disk gone")
+
+    probe = sa.HardwareProbe(vram_probe=lambda: 1, ram_probe=lambda: 1, cpu_probe=lambda: 1, disk_probe=boom)
+    assert probe.detect().disk_free_mb is None  # failure mapped to None
 
 
 def test_hardware_probe_no_gpu() -> None:


### PR DESCRIPTION
## Summary
Phase 2 of the Reframe V1 build plan (`docs/V1-GRILL-DECISIONS.md` (f)/(g)/(h)): **Models & Device**. Extends the existing `sidecar/models/` + renderer Settings seams — **all existing functionality is kept** (consolidate, never delete).

Branch: `feat/v1-models` off `main` (post-Phase 1 / #239).

### Deliverables
1. **Ollama / LM Studio detect + recommend + install advice** — reuses `local_detect`, adds `models/model_recommend.py` (pure): per-runner detect, the device-fit model to **pull** (copy-able hint), and the official **install link** when absent (advice only — never auto-installs). New RPC `models.runners`; renderer `LocalRunners`.
2. **OpenRouter key-pool + per-key usage (cost)** — the key-pool already exists (`RotatingProvider`); this adds the **cost** axis via `models/openrouter_usage.py` (`GET /api/v1/key` through the injectable transport seam; cumulative credit USD + limit/remaining). New RPC `providers.openrouterUsage`; renderer `OpenRouterUsage`. The live key rides only the `Authorization` header; rows carry the redacted last-4 only.
3. **Device-ranked model recommendation** — `model_recommend` ranks whisper (ASR) + LLM against probed VRAM/RAM ("recommended for your machine: X because RAM/VRAM Y"); renderer `DeviceModelReco`.
4. **Device + ETA status strip** — `HardwareInfo.disk_free_mb` + `default_disk_probe` wired through `HardwareProbe`; `system.probe` now returns `diskFreeMb`. Renderer `DeviceStatusStrip` (free disk / RAM / VRAM / GPU + per-job ETA).

All wired into renderer Settings -> **Models & System** (`ModelsSystemPanel`); `rpc.ts` gains `models.runners`, `providers.openrouterUsage`, and `diskFreeMb`.

## Rails honoured
- **TDD**, no silent fallbacks, no test-weakening / no coverage-faking ignores (defensive-only `pragma`/`v8 ignore` on genuinely unreachable seams).
- Keys never logged; redacted last-4 only over RPC.

## Test plan
- [x] Sidecar gate: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` -> **100%**, 4212 passed.
- [x] Renderer gate: `npx vitest run --coverage` -> **100%** stmts/branches/funcs/lines, 1709 passed.
- [x] `tsc --noEmit` clean; pre-commit (ruff / ruff-format / oxlint / biome / gitleaks) clean.
