### PR TITLE
feat(v1-ia): Phase-3 IA redesign — 5-section nav + Output Tray keystone

### DIFF
--- a/app/renderer/src/App.quality.test.tsx
+++ b/app/renderer/src/App.quality.test.tsx
@@ -349,53 +349,6 @@ describe('App jobs slide-over toggle', () => {
   });
 });
 
-describe('App handleReexport guard branches', () => {
-  it('falls back to the Library when the hint has no videoId', async () => {
-    await mount();
-    await act(async () => {
-      tab('Create').click();
-    });
-    await flush();
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="reexport-no-id"]')!.click();
-    });
-    await flush();
-    expect(libraryListMock).not.toHaveBeenCalled();
-    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-  });
-
-  it('falls back to the Library when no preload bridge is present', async () => {
-    hasApiValue = false;
-    await mount();
-    await act(async () => {
-      tab('Create').click();
-    });
-    await flush();
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="reexport-ok"]')!.click();
-    });
-    await flush();
-    expect(libraryListMock).not.toHaveBeenCalled();
-    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-  });
-
-  it('falls back to the Library when library.list rejects (catch branch)', async () => {
-    libraryListMock.mockRejectedValue(new Error('list failed'));
-    await mount();
-    await act(async () => {
-      tab('Create').click();
-    });
-    await flush();
-    await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="reexport-ok"]')!.click();
-    });
-    await flush();
-    expect(libraryListMock).toHaveBeenCalledTimes(1);
-    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
-  });
-});
-
 describe('App lastOpenedVideoId — bridge-absent branches (WU-13)', () => {
   it('does NOT read settings.get on launch when no preload bridge is present', async () => {
     hasApiValue = false;

--- a/app/renderer/src/App.test.tsx
+++ b/app/renderer/src/App.test.tsx
@@ -1,21 +1,19 @@
-// App.test.tsx — the renderer shell + top-level tab routing.
+// App.test.tsx — the renderer shell + top-level tab routing (V1 IA §h).
 //
-// Verifies the five-tab surface switch (Library / Create / Director / Repurpose /
-// Settings), the Workspace drill-down under the Library tab, the active-tab
-// derivation, and that Re-export from the Create gallery resolves the source
-// video and lands on its Workspace. The heavy child views are stubbed so the
-// test exercises ONLY App's routing (the views own their own tests).
+// Verifies the five-section surface switch (Library / Make Shorts / Edit /
+// Director / Settings), that opening a video from the Library routes into the
+// Edit section, the active-tab derivation + tabpanel a11y wiring, and the
+// interrupted-batch badge/resume deep-link on the Make Shorts tab. The heavy
+// child views are stubbed so the test exercises ONLY App's routing.
 
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-import type { Video, ShortReexportHint } from './lib/rpc';
+import type { Video } from './lib/rpc';
 
 // ---- mocks -----------------------------------------------------------------
-// rpc/client come from lib/rpc; stub them so settings.get + library.list are
-// controllable and no real bridge is needed.
 const rpcMock = vi.fn();
 const libraryListMock = vi.fn();
 const batchListMock = vi.fn();
@@ -29,26 +27,20 @@ vi.mock('./lib/rpc', () => ({
   },
 }));
 
-// Stub the views: each renders a marker + exposes the callbacks App wires.
-const openVideoSpy = vi.fn();
-const reexportSpy = vi.fn();
-
 vi.mock('./views/Library', () => ({
-  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => {
-    openVideoSpy.mockImplementation(onOpen);
-    return (
-      <div data-testid="library">
-        <button type="button" onClick={() => onOpen(makeVideo())}>
-          open-video
-        </button>
-      </div>
-    );
-  },
+  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => (
+    <div data-testid="library">
+      <button type="button" onClick={() => onOpen(makeVideo())}>
+        open-video
+      </button>
+    </div>
+  ),
 }));
 
-vi.mock('./views/Workspace', () => ({
-  Workspace: ({ video, onBack }: { video: Video; onBack: () => void }) => (
-    <div data-testid="workspace" data-video-id={video.id}>
+// Edit hosts the per-video surface; the marker exposes the open video + back.
+vi.mock('./views/Edit', () => ({
+  Edit: ({ video, onBack }: { video: Video | null; onBack: () => void }) => (
+    <div data-testid="edit" data-video-id={video?.id ?? ''}>
       <button type="button" onClick={onBack}>
         back
       </button>
@@ -56,29 +48,14 @@ vi.mock('./views/Workspace', () => ({
   ),
 }));
 
-vi.mock('./views/Shorts', () => ({
-  Shorts: ({ onReexport }: { onReexport?: (h: ShortReexportHint) => void }) => {
-    if (onReexport) reexportSpy.mockImplementation(onReexport);
-    return (
-      <div data-testid="shorts">
-        <button
-          type="button"
-          onClick={() =>
-            onReexport?.({
-              videoId: 'v1',
-              candidate: { hook: 'h', template: 'neon', viralityPct: 70, durationSec: 30 },
-            })
-          }
-        >
-          reexport
-        </button>
-      </div>
-    );
-  },
+// Make Shorts marker exposes the batch resume id App wired (it owns its tests).
+vi.mock('./views/MakeShorts', () => ({
+  MakeShorts: ({ resumeId }: { resumeId?: string }) => (
+    <div data-testid="makeshorts" data-resume={resumeId ?? ''} />
+  ),
 }));
 
-// Stub the lazy AI Director panel (it owns its own tests). This proves the
-// router can resolve + mount it.
+// Stub the lazy AI Director panel (it owns its own tests).
 vi.mock('./panels/DirectorPanel', () => ({
   default: () => <div data-testid="director" />,
 }));
@@ -87,13 +64,6 @@ vi.mock('./panels/DirectorPanel', () => ({
 vi.mock('./views/Settings', () => ({
   Settings: ({ initialSection }: { initialSection?: string }) => (
     <div data-testid="settings" data-section={initialSection ?? ''} />
-  ),
-}));
-
-// Stub the Repurpose view; expose the resumeId App wired in (it owns its tests).
-vi.mock('./views/Repurpose', () => ({
-  Repurpose: ({ resumeId }: { resumeId?: string }) => (
-    <div data-testid="repurpose" data-resume={resumeId ?? ''} />
   ),
 }));
 
@@ -124,8 +94,6 @@ beforeEach(() => {
   libraryListMock.mockReset();
   batchListMock.mockReset();
   batchListMock.mockResolvedValue({ batches: [] });
-  openVideoSpy.mockReset();
-  reexportSpy.mockReset();
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -159,29 +127,46 @@ describe('App top-level tabs', () => {
     });
     await flush();
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="shorts"]')).toBeNull();
+    expect(container.querySelector('[data-testid="makeshorts"]')).toBeNull();
     expect(tab('Library').getAttribute('aria-selected')).toBe('true');
     expect(tab('Library').classList.contains('toptab--active')).toBe(true);
-    // The shell exposes the active panel via role=tabpanel wired to the tab.
     const panel = container.querySelector<HTMLElement>('[role="tabpanel"]')!;
     expect(panel.id).toBe('toptabpanel-library');
     expect(panel.getAttribute('aria-labelledby')).toBe('toptab-library');
   });
 
-  it('navigates to the Create (Shorts) gallery and marks its tab active', async () => {
+  it('navigates to the Make Shorts section and marks its tab active', async () => {
     await act(async () => {
       root.render(<App />);
     });
     await flush();
-
     await act(async () => {
-      tab('Create').click();
+      tab('Make Shorts').click();
     });
     await flush();
-
-    expect(container.querySelector('[data-testid="shorts"]')).not.toBeNull();
+    const view = container.querySelector('[data-testid="makeshorts"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-resume')).toBe('');
     expect(container.querySelector('[data-testid="library"]')).toBeNull();
-    expect(tab('Create').getAttribute('aria-selected')).toBe('true');
+    expect(tab('Make Shorts').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('returns to the Library home via the Library tab', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    await act(async () => {
+      tab('Make Shorts').click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="library"]')).toBeNull();
+    await act(async () => {
+      tab('Library').click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(tab('Library').getAttribute('aria-selected')).toBe('true');
   });
 
   it('navigates to (mounts) the AI Director panel and marks its tab active', async () => {
@@ -189,17 +174,12 @@ describe('App top-level tabs', () => {
       root.render(<App />);
     });
     await flush();
-
-    // The Director surface is NOT mounted until the tab routes to it.
     expect(container.querySelector('[data-testid="director"]')).toBeNull();
-
     await act(async () => {
       tab('Director').click();
     });
     await flush();
-
     expect(container.querySelector('[data-testid="director"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="library"]')).toBeNull();
     expect(tab('Director').getAttribute('aria-selected')).toBe('true');
   });
 
@@ -208,35 +188,17 @@ describe('App top-level tabs', () => {
       root.render(<App />);
     });
     await flush();
-
     await act(async () => {
       tab('Settings').click();
     });
     await flush();
-
     const settings = container.querySelector('[data-testid="settings"]');
     expect(settings).not.toBeNull();
-    // No pre-selected section when opened from the tab.
     expect(settings!.getAttribute('data-section')).toBe('');
     expect(tab('Settings').getAttribute('aria-selected')).toBe('true');
   });
 
-  it("routes a Library readiness fix into Settings' Models section", async () => {
-    // Re-mock Library so its onReadinessAction is reachable from the test.
-    await act(async () => {
-      root.render(<App />);
-    });
-    await flush();
-    // The readiness action wiring is covered via the quality test; here we only
-    // assert the Settings tab can be reached and shows no section by default.
-    await act(async () => {
-      tab('Settings').click();
-    });
-    await flush();
-    expect(container.querySelector('[data-testid="settings"]')).not.toBeNull();
-  });
-
-  it('opens a video into the Workspace (under Library) and back via the tab', async () => {
+  it('opens a video from the Library into the Edit section, then back to Library', async () => {
     await act(async () => {
       root.render(<App />);
     });
@@ -248,22 +210,37 @@ describe('App top-level tabs', () => {
     });
     await flush();
 
-    const ws = container.querySelector('[data-testid="workspace"]');
-    expect(ws).not.toBeNull();
-    expect(ws!.getAttribute('data-video-id')).toBe('v1');
-    // The Library tab stays active while drilled into a Workspace.
-    expect(tab('Library').getAttribute('aria-selected')).toBe('true');
+    const edit = container.querySelector('[data-testid="edit"]');
+    expect(edit).not.toBeNull();
+    expect(edit!.getAttribute('data-video-id')).toBe('v1');
+    expect(tab('Edit').getAttribute('aria-selected')).toBe('true');
 
-    // The Library tab returns to the home (out of the Workspace).
+    // The Edit back button returns to the Library home.
     await act(async () => {
-      tab('Library').click();
+      container.querySelector<HTMLButtonElement>('[data-testid="edit"] button')!.click();
     });
     await flush();
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+    expect(container.querySelector('[data-testid="edit"]')).toBeNull();
   });
 
-  it('Workspace back button returns to the Library home', async () => {
+  it('shows the Edit empty state (no video) when the Edit tab is opened directly', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    await act(async () => {
+      tab('Edit').click();
+    });
+    await flush();
+    const edit = container.querySelector('[data-testid="edit"]');
+    expect(edit).not.toBeNull();
+    // No video opened yet → the marker reports an empty video id.
+    expect(edit!.getAttribute('data-video-id')).toBe('');
+    expect(tab('Edit').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('keeps the opened Edit video when switching tabs and returning to Edit', async () => {
     await act(async () => {
       root.render(<App />);
     });
@@ -272,82 +249,27 @@ describe('App top-level tabs', () => {
       container.querySelector<HTMLButtonElement>('[data-testid="library"] button')!.click();
     });
     await flush();
+    // Switch away to Make Shorts, then back to Edit — the video persists.
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('[data-testid="workspace"] button')!.click();
+      tab('Make Shorts').click();
     });
     await flush();
-    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+    await act(async () => {
+      tab('Edit').click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="edit"]')!.getAttribute('data-video-id')).toBe(
+      'v1',
+    );
   });
 
-  it('Re-export from Create resolves the source video and lands on its Workspace', async () => {
-    libraryListMock.mockResolvedValue({ videos: [makeVideo({ id: 'v1', title: 'Source' })] });
-
+  it('navigates to the Make Shorts view (no badge when none incomplete)', async () => {
     await act(async () => {
       root.render(<App />);
     });
     await flush();
-
-    await act(async () => {
-      tab('Create').click();
-    });
-    await flush();
-
-    const reBtn = container.querySelector<HTMLButtonElement>('[data-testid="shorts"] button');
-    await act(async () => {
-      reBtn!.click();
-    });
-    await flush();
-
-    expect(libraryListMock).toHaveBeenCalledTimes(1);
-    const ws = container.querySelector('[data-testid="workspace"]');
-    expect(ws).not.toBeNull();
-    expect(ws!.getAttribute('data-video-id')).toBe('v1');
-  });
-
-  it('Re-export falls back to the Library when the source video is gone', async () => {
-    libraryListMock.mockResolvedValue({ videos: [] });
-
-    await act(async () => {
-      root.render(<App />);
-    });
-    await flush();
-
-    await act(async () => {
-      tab('Create').click();
-    });
-    await flush();
-
-    const reBtn = container.querySelector<HTMLButtonElement>('[data-testid="shorts"] button');
-    await act(async () => {
-      reBtn!.click();
-    });
-    await flush();
-
-    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
-  });
-
-  it('navigates to the Repurpose view via the tab (no badge when none incomplete)', async () => {
-    await act(async () => {
-      root.render(<App />);
-    });
-    await flush();
-
-    expect(tab('Repurpose')).toBeTruthy();
-    // No badge chip when there are no interrupted batches.
-    expect(tab('Repurpose').querySelector('.toptab__badge')).toBeNull();
-
-    await act(async () => {
-      tab('Repurpose').click();
-    });
-    await flush();
-
-    const view = container.querySelector('[data-testid="repurpose"]');
-    expect(view).not.toBeNull();
-    expect(view!.getAttribute('data-resume')).toBe('');
-    expect(tab('Repurpose').getAttribute('aria-selected')).toBe('true');
-    expect(container.querySelector('[data-testid="library"]')).toBeNull();
+    expect(tab('Make Shorts')).toBeTruthy();
+    expect(tab('Make Shorts').querySelector('.toptab__badge')).toBeNull();
   });
 
   it('shows a (N) badge + a resume toast for an incomplete batch, deep-linking on Resume', async () => {
@@ -377,9 +299,7 @@ describe('App top-level tabs', () => {
     });
     await flush();
 
-    // The Repurpose tab carries a numeric badge.
-    expect(tab('Repurpose').querySelector('.toptab__badge')!.textContent).toBe('1');
-
+    expect(tab('Make Shorts').querySelector('.toptab__badge')!.textContent).toBe('1');
     expect(document.body.textContent).toContain("A batch ('Season 3') was interrupted");
     expect(document.body.textContent).toContain('16 of 30 sources left');
 
@@ -392,7 +312,7 @@ describe('App top-level tabs', () => {
     });
     await flush();
 
-    const view = container.querySelector('[data-testid="repurpose"]');
+    const view = container.querySelector('[data-testid="makeshorts"]');
     expect(view).not.toBeNull();
     expect(view!.getAttribute('data-resume')).toBe('b9');
   });
@@ -417,9 +337,9 @@ describe('App top-level tabs', () => {
   });
 });
 
-// WU-13: persist `lastOpenedVideoId` on openVideo + restore it on launch.
+// WU-13: persist `lastOpenedVideoId` on openVideo + restore it into Edit on launch.
 describe('App lastOpenedVideoId persist + restore', () => {
-  it('restores the workspace for a valid persisted lastOpenedVideoId on launch', async () => {
+  it('restores the Edit section for a valid persisted lastOpenedVideoId on launch', async () => {
     rpcMock.mockImplementation((method: string) => {
       if (method === 'settings.get') return Promise.resolve({ lastOpenedVideoId: 'v1' });
       return Promise.resolve({});
@@ -432,11 +352,10 @@ describe('App lastOpenedVideoId persist + restore', () => {
     await flush();
 
     expect(libraryListMock).toHaveBeenCalledTimes(1);
-    const ws = container.querySelector('[data-testid="workspace"]');
-    expect(ws).not.toBeNull();
-    expect(ws!.getAttribute('data-video-id')).toBe('v1');
-    // The Library tab is active while restored into a Workspace.
-    expect(tab('Library').getAttribute('aria-selected')).toBe('true');
+    const edit = container.querySelector('[data-testid="edit"]');
+    expect(edit).not.toBeNull();
+    expect(edit!.getAttribute('data-video-id')).toBe('v1');
+    expect(tab('Edit').getAttribute('aria-selected')).toBe('true');
   });
 
   it('stays on the Library when the persisted id is absent from library.list', async () => {
@@ -453,7 +372,7 @@ describe('App lastOpenedVideoId persist + restore', () => {
 
     expect(libraryListMock).toHaveBeenCalledTimes(1);
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+    expect(container.querySelector('[data-testid="edit"]')).toBeNull();
   });
 
   it('stays on the Library when no lastOpenedVideoId is persisted (empty key)', async () => {
@@ -469,7 +388,7 @@ describe('App lastOpenedVideoId persist + restore', () => {
 
     expect(libraryListMock).not.toHaveBeenCalled();
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+    expect(container.querySelector('[data-testid="edit"]')).toBeNull();
   });
 
   it('stays on the Library when the restore path throws (best-effort)', async () => {
@@ -485,7 +404,7 @@ describe('App lastOpenedVideoId persist + restore', () => {
     await flush();
 
     expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
-    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+    expect(container.querySelector('[data-testid="edit"]')).toBeNull();
   });
 
   it('persists lastOpenedVideoId via settings.set exactly once when a video is opened', async () => {

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -1,26 +1,26 @@
-// App.tsx — the renderer shell + TOP-LEVEL TABBED NAVIGATION (CONTRACTS.md §1).
+// App.tsx — the renderer shell + TOP-LEVEL TABBED NAVIGATION (V1 IA §h).
 //
-// The app is organised into five top-level tabs (components/TopTabBar.tsx):
-//   * Library    — the video library home; opening a video drills into its
-//                  per-video Workspace (a sub-state of this tab; "← Library"
-//                  returns home),
-//   * Create     — the global generated-Shorts gallery + ShortMaker flow,
-//   * Director    — the prompt-driven AI video-editing panel (lazy),
-//   * Repurpose  — the batch/template/export-preset surface (with a (N) badge +
-//                  resume toast for interrupted batches),
-//   * Settings   — a sub-navigated area: Models & System, Providers & Keys, and
-//                  System Health (views/Settings.tsx).
+// The app is organised into the FIVE V1 sections (components/TopTabBar.tsx):
+//   * Library    — the video library home; opening a video routes into the Edit
+//                  section for that video,
+//   * Make Shorts — the novice front door: AI moment-pick + manual intervals +
+//                   the single produced-shorts gallery + batch/templates
+//                   (views/MakeShorts.tsx; carries the interrupted-batch badge),
+//   * Edit       — the per-video manual surface (trim/cut/join/reframe/caption/
+//                  audio…) hosted in the Workspace (views/Edit.tsx),
+//   * Director   — the prompt-driven AI video-editing panel (lazy),
+//   * Settings   — Models & System / Providers & Keys / Storage / Health.
 //
 // The active tab is DERIVED from the route (one source of truth), so navigation
-// and the tab strip can never desync. Workspace lives under the Library tab.
+// and the tab strip can never desync. The currently-open Edit video is held in
+// shell state so switching tabs and re-entering Edit keeps the same video.
 //
 // Also hosts the Local/Cloud quality toggle (CONTRACTS.md §0/§2: settings.useCloud)
 // and the global Jobs slide-over (components/JobQueue.tsx).
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { Library } from './views/Library';
-import { Workspace } from './views/Workspace';
-import { Shorts } from './views/Shorts';
-import { Repurpose } from './views/Repurpose';
+import { Edit } from './views/Edit';
+import { MakeShorts } from './views/MakeShorts';
 import { Settings } from './views/Settings';
 import { incompleteBatches, remainingCount } from './features/repurposeLogic';
 import { useToast } from './components/toast/useToast';
@@ -34,14 +34,7 @@ import {
 } from './components/navIcons';
 // AI Director panel (lazy: it pulls the storyboard/diff + cost-banner surface).
 const DirectorPanel = lazy(() => import('./panels/DirectorPanel'));
-import {
-  client,
-  hasApi,
-  rpc,
-  type ReadinessAction,
-  type ShortReexportHint,
-  type Video,
-} from './lib/rpc';
+import { client, hasApi, rpc, type ReadinessAction, type Video } from './lib/rpc';
 import { actionSection } from './features/providersKeysLogic';
 import { ToastProvider } from './components/toast/ToastProvider';
 import { ToastHost } from './components/toast/ToastHost';
@@ -61,30 +54,30 @@ registerJobRetry((jobId) => rpc<{ jobId: string }>('job.retry', { jobId }));
 
 type Quality = 'local' | 'cloud';
 
-/** The five top-level tab ids (the surface switcher). */
-type TabId = 'library' | 'create' | 'director' | 'repurpose' | 'settings';
+/** The five V1 top-level tab ids (the surface switcher). */
+type TabId = 'library' | 'makeshorts' | 'edit' | 'director' | 'settings';
 
 type Route =
-  // The Library tab. `video` drills into a per-video Workspace (Library sub-state).
-  | { name: 'library'; video?: Video }
-  // Create: the global generated-shorts gallery + ShortMaker flow.
-  | { name: 'create' }
+  // The Library home.
+  | { name: 'library' }
+  // Make Shorts: AI/manual making + the gallery + batch (resume deep-link).
+  | { name: 'makeshorts'; resumeId?: string }
+  // Edit: the per-video manual surface (the open video lives in shell state).
+  | { name: 'edit' }
   // Director: the prompt-driven AI video-editing panel.
   | { name: 'director' }
-  // Repurpose: the batch queue / templates / export presets surface.
-  | { name: 'repurpose'; resumeId?: string }
   // Settings: a sub-navigated area (Models & System / Providers & Keys / Health).
   | { name: 'settings'; section?: string };
 
-/** Map a route to the top-level tab it belongs to (Workspace ⇒ Library). */
+/** Map a route to the top-level tab it belongs to. */
 function routeTab(route: Route): TabId {
   switch (route.name) {
-    case 'create':
-      return 'create';
+    case 'makeshorts':
+      return 'makeshorts';
+    case 'edit':
+      return 'edit';
     case 'director':
       return 'director';
-    case 'repurpose':
-      return 'repurpose';
     case 'settings':
       return 'settings';
     case 'library':
@@ -171,6 +164,9 @@ function useRepurposeBadge(onResume: (resumeId: string) => void): number {
 function AppShell(): React.ReactElement {
   const [route, setRoute] = useState<Route>({ name: 'library' });
   const [quality, setQuality] = useState<Quality>('local');
+  // The currently-open Edit video (kept in shell state so it survives tab
+  // switches; null until a video is opened from the Library).
+  const [editVideo, setEditVideo] = useState<Video | null>(null);
   // T6: the global job-queue slide-over (components/JobQueue.tsx). Closed by
   // default — the panel polls job.list only while open.
   const [jobsOpen, setJobsOpen] = useState(false);
@@ -202,8 +198,8 @@ function AppShell(): React.ReactElement {
   }, []);
 
   // WU-13: restore the last-opened video on launch. Read the persisted
-  // `lastOpenedVideoId`, resolve the Video via library.list, and drill into its
-  // Workspace on a match; fall back to the Library home otherwise.
+  // `lastOpenedVideoId`, resolve the Video via library.list, and open it in the
+  // Edit section on a match; fall back to the Library home otherwise.
   useEffect(() => {
     if (!hasApi()) return;
     let cancelled = false;
@@ -215,7 +211,8 @@ function AppShell(): React.ReactElement {
         const { videos } = await client.library.list();
         const match = videos.find((v) => v.id === id);
         if (!cancelled && match) {
-          setRoute({ name: 'library', video: match });
+          setEditVideo(match);
+          setRoute({ name: 'edit' });
         }
       } catch {
         // Best-effort restore; stay on the Library default on any failure.
@@ -226,8 +223,10 @@ function AppShell(): React.ReactElement {
     };
   }, []);
 
+  // Opening a video from the Library routes into the Edit section for it.
   const openVideo = useCallback((video: Video) => {
-    setRoute({ name: 'library', video });
+    setEditVideo(video);
+    setRoute({ name: 'edit' });
     // WU-13: persist the last-opened video so launch can restore it. Best-effort.
     if (!hasApi()) return;
     void rpc('settings.set', { lastOpenedVideoId: video.id }).catch(() => {
@@ -239,9 +238,9 @@ function AppShell(): React.ReactElement {
     setRoute({ name: 'library' });
   }, []);
 
-  // WU11: the Repurpose nav (optionally deep-linking a resume from the toast).
-  const openRepurpose = useCallback((resumeId?: string) => {
-    setRoute({ name: 'repurpose', resumeId });
+  // The Make Shorts nav (optionally deep-linking a batch resume from the toast).
+  const openMakeShorts = useCallback((resumeId?: string) => {
+    setRoute({ name: 'makeshorts', resumeId });
   }, []);
 
   // Open Settings, optionally pre-selecting a sub-section (e.g. a readiness fix
@@ -260,19 +259,19 @@ function AppShell(): React.ReactElement {
     [openSettings],
   );
 
-  // The top-level tab strip switches surfaces (Workspace returns to the Library
-  // home rather than staying drilled-in).
+  // The top-level tab strip switches surfaces. Re-entering Edit shows the
+  // currently-open video (or its empty state when none is open yet).
   const selectTab = useCallback(
     (id: string) => {
       switch (id as TabId) {
-        case 'create':
-          setRoute({ name: 'create' });
+        case 'makeshorts':
+          openMakeShorts();
+          break;
+        case 'edit':
+          setRoute({ name: 'edit' });
           break;
         case 'director':
           setRoute({ name: 'director' });
-          break;
-        case 'repurpose':
-          openRepurpose();
           break;
         case 'settings':
           openSettings();
@@ -283,64 +282,44 @@ function AppShell(): React.ReactElement {
           break;
       }
     },
-    [openRepurpose, openSettings],
+    [openMakeShorts, openSettings],
   );
 
-  // P4 §6: Re-export reopens the source video's Workspace (where the Short-maker
-  // tab lives). Resolve the source Video by id, then drill into its Workspace
-  // under the Library tab; fall back to the Library home when it is gone.
-  const handleReexport = useCallback(async (hint: ShortReexportHint) => {
-    if (!hint.videoId || !hasApi()) {
-      setRoute({ name: 'library' });
-      return;
-    }
-    try {
-      const { videos } = await client.library.list();
-      const source = videos.find((v) => v.id === hint.videoId);
-      setRoute(source ? { name: 'library', video: source } : { name: 'library' });
-    } catch {
-      setRoute({ name: 'library' });
-    }
-  }, []);
-
-  const repurposeBadge = useRepurposeBadge(openRepurpose);
+  // The interrupted-batch badge now rides the Make Shorts tab (batch lives in
+  // that section); a resume deep-links into Make Shorts → Batch.
+  const batchBadge = useRepurposeBadge(openMakeShorts);
 
   const tabs: TopTab[] = useMemo(
     () => [
       { id: 'library', label: 'Library', icon: <LibraryIcon /> },
-      { id: 'create', label: 'Create', icon: <CreateIcon /> },
+      { id: 'makeshorts', label: 'Make Shorts', icon: <CreateIcon />, badge: batchBadge },
+      { id: 'edit', label: 'Edit', icon: <RepurposeIcon /> },
       { id: 'director', label: 'Director', icon: <DirectorIcon /> },
-      { id: 'repurpose', label: 'Repurpose', icon: <RepurposeIcon />, badge: repurposeBadge },
       { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
     ],
-    [repurposeBadge],
+    [batchBadge],
   );
 
   const activeTab = routeTab(route);
 
   function renderRoute(): React.ReactElement {
     switch (route.name) {
-      case 'create':
-        return <Shorts onReexport={(hint) => void handleReexport(hint)} />;
+      case 'makeshorts':
+        return <MakeShorts resumeId={route.resumeId} />;
+      case 'edit':
+        return <Edit video={editVideo} onBack={backToLibrary} />;
       case 'director':
         return (
           <Suspense fallback={<div className="panel panel--loading">Loading…</div>}>
             <DirectorPanel />
           </Suspense>
         );
-      case 'repurpose':
-        return <Repurpose resumeId={route.resumeId} />;
       case 'settings':
         return <Settings initialSection={route.section} />;
       case 'library':
       default:
-        // Drilled into a video → its Workspace; otherwise the Library home.
         // WU-14: a readiness fix action routes to Settings → Models & System.
-        return route.video ? (
-          <Workspace video={route.video} onBack={backToLibrary} />
-        ) : (
-          <Library onOpen={openVideo} onReadinessAction={handleReadinessAction} />
-        );
+        return <Library onOpen={openVideo} onReadinessAction={handleReadinessAction} />;
     }
   }
 

--- a/app/renderer/src/components/LanguageSelect.test.tsx
+++ b/app/renderer/src/components/LanguageSelect.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { LanguageSelect } from './LanguageSelect';
+import { AUTO_DETECT, LANGUAGES, languageLabel } from '../lib/languages';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('languages lib', () => {
+  it('exposes a non-empty curated list that excludes the auto sentinel', () => {
+    expect(LANGUAGES.length).toBeGreaterThan(5);
+    expect(LANGUAGES.some((l) => l.code === AUTO_DETECT)).toBe(false);
+    // English is always offered as the canonical default.
+    expect(LANGUAGES.some((l) => l.code === 'en')).toBe(true);
+  });
+
+  it('languageLabel returns the label for a known code and the raw code otherwise', () => {
+    expect(languageLabel('en')).toBe('English');
+    expect(languageLabel(AUTO_DETECT)).toBe('Auto-detect');
+    expect(languageLabel('zz')).toBe('zz');
+  });
+});
+
+describe('<LanguageSelect />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function sel(): HTMLSelectElement {
+    return container.querySelector('select') as HTMLSelectElement;
+  }
+
+  function pick(value: string): void {
+    const el = sel();
+    act(() => {
+      el.value = value;
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  }
+
+  it('renders an Auto-detect option plus every curated language and forwards changes', () => {
+    const onChange = vi.fn();
+    act(() => root.render(<LanguageSelect value="en" onChange={onChange} />));
+    const codes = [...sel().options].map((o) => o.value);
+    expect(codes[0]).toBe(AUTO_DETECT);
+    expect(codes).toContain('es');
+    pick('es');
+    expect(onChange).toHaveBeenCalledWith('es');
+  });
+
+  it('shows a quality-advice note ONLY when Auto-detect is selected', () => {
+    const onChange = vi.fn();
+    act(() => root.render(<LanguageSelect value={AUTO_DETECT} onChange={onChange} />));
+    expect(container.querySelector('.lang-select__advice')).toBeTruthy();
+    act(() => root.render(<LanguageSelect value="en" onChange={onChange} />));
+    expect(container.querySelector('.lang-select__advice')).toBeNull();
+  });
+
+  it('omits the Auto-detect option (and its advice) when includeAuto is false', () => {
+    const onChange = vi.fn();
+    act(() => root.render(<LanguageSelect value="en" onChange={onChange} includeAuto={false} />));
+    const codes = [...sel().options].map((o) => o.value);
+    expect(codes).not.toContain(AUTO_DETECT);
+    // Even if value were auto, no advice renders without the auto option.
+    act(() =>
+      root.render(<LanguageSelect value={AUTO_DETECT} onChange={onChange} includeAuto={false} />),
+    );
+    expect(container.querySelector('.lang-select__advice')).toBeNull();
+  });
+
+  it('keeps an unknown current value selectable via a fallback option', () => {
+    const onChange = vi.fn();
+    act(() => root.render(<LanguageSelect value="zz" onChange={onChange} />));
+    const codes = [...sel().options].map((o) => o.value);
+    expect(codes).toContain('zz');
+    expect(sel().value).toBe('zz');
+  });
+
+  it('accepts a custom label + id and wires them to the control', () => {
+    const onChange = vi.fn();
+    act(() =>
+      root.render(
+        <LanguageSelect value="en" onChange={onChange} id="cap-lang" label="Caption language" />,
+      ),
+    );
+    expect(sel().id).toBe('cap-lang');
+    expect(sel().getAttribute('aria-label')).toBe('Caption language');
+  });
+});

--- a/app/renderer/src/components/LanguageSelect.tsx
+++ b/app/renderer/src/components/LanguageSelect.tsx
@@ -1,0 +1,67 @@
+// LanguageSelect.tsx — the ONE reusable language dropdown (V1 IA §h).
+//
+// LANGUAGE is always a dropdown (never free-typed) so a user can't pick a
+// wrong/nonexistent code. Auto-detect is offered as the first option, but when
+// it is selected we surface a quality-advice note recommending an explicit
+// language (auto-detect can transcribe/translate at lower quality). The curated
+// vocabulary + labels come from lib/languages.ts (single source of truth).
+import React, { useId } from 'react';
+import { AUTO_DETECT, LANGUAGES, languageLabel } from '../lib/languages';
+import './languageSelect.css';
+
+export interface LanguageSelectProps {
+  /** The selected code: a language code, or the AUTO_DETECT sentinel. */
+  value: string;
+  /** Called with the chosen code on change. */
+  onChange: (code: string) => void;
+  /** DOM id for label association (defaults to a generated id). */
+  id?: string;
+  /** Accessible label / visible caption (defaults to "Language"). */
+  label?: string;
+  /** Offer the Auto-detect option (defaults to true). */
+  includeAuto?: boolean;
+}
+
+/** A dropdown over the curated language list, with optional auto-detect advice. */
+export function LanguageSelect({
+  value,
+  onChange,
+  id,
+  label = 'Language',
+  includeAuto = true,
+}: LanguageSelectProps): React.ReactElement {
+  const generated = useId();
+  const selectId = id ?? generated;
+  // The value is selectable even if it is not in the curated list (e.g. a code
+  // persisted by an older build) — add a fallback option so the <select> never
+  // silently drops the current choice.
+  const known = value === AUTO_DETECT || LANGUAGES.some((l) => l.code === value);
+  const showAdvice = includeAuto && value === AUTO_DETECT;
+  return (
+    <div className="lang-select">
+      <select
+        id={selectId}
+        aria-label={label}
+        className="lang-select__control"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      >
+        {includeAuto ? <option value={AUTO_DETECT}>{languageLabel(AUTO_DETECT)}</option> : null}
+        {known ? null : <option value={value}>{value}</option>}
+        {LANGUAGES.map((l) => (
+          <option key={l.code} value={l.code}>
+            {l.label}
+          </option>
+        ))}
+      </select>
+      {showAdvice ? (
+        <p className="lang-select__advice" role="note">
+          Auto-detect may produce lower-quality captions — pick the spoken language for the best
+          result.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export default LanguageSelect;

--- a/app/renderer/src/components/OutputTray.test.tsx
+++ b/app/renderer/src/components/OutputTray.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { DEFAULT_OUTPUT_TRAY, OutputTray, type OutputTrayState } from './OutputTray';
+import { AUTO_DETECT } from '../lib/languages';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('DEFAULT_OUTPUT_TRAY', () => {
+  it('ships quality features ON by default (G-4): caption + reframe + burn-subs', () => {
+    expect(DEFAULT_OUTPUT_TRAY.caption).toBe(true);
+    expect(DEFAULT_OUTPUT_TRAY.reframe).toBe(true);
+    expect(DEFAULT_OUTPUT_TRAY.burnSubs).toBe(true);
+    // Translate is opt-in (off until a target language is wanted).
+    expect(DEFAULT_OUTPUT_TRAY.translate).toBe(false);
+    expect(DEFAULT_OUTPUT_TRAY.language).toBe('en');
+  });
+});
+
+describe('<OutputTray />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<React.ComponentProps<typeof OutputTray>> = {}): {
+    onChange: ReturnType<typeof vi.fn>;
+    state: OutputTrayState;
+  } {
+    const onChange = props.onChange ?? vi.fn();
+    const state = props.state ?? DEFAULT_OUTPUT_TRAY;
+    act(() => root.render(<OutputTray {...props} state={state} onChange={onChange} />));
+    return { onChange: onChange as ReturnType<typeof vi.fn>, state };
+  }
+
+  function toggle(label: string): HTMLInputElement {
+    return container.querySelector(`input[aria-label="${label}"]`) as HTMLInputElement;
+  }
+  function button(text: string): HTMLButtonElement | undefined {
+    return [...container.querySelectorAll('button')].find((b) => b.textContent === text);
+  }
+
+  it('renders the four consolidated post-action toggles', () => {
+    render();
+    expect(toggle('Caption')).toBeTruthy();
+    expect(toggle('Translate')).toBeTruthy();
+    expect(toggle('Reframe')).toBeTruthy();
+    expect(toggle('Burn subtitles')).toBeTruthy();
+  });
+
+  it('emits an immutable next-state when a toggle flips', () => {
+    const { onChange, state } = render();
+    act(() => toggle('Caption').click()); // ON -> OFF
+    expect(onChange).toHaveBeenCalledWith({ ...state, caption: false });
+    // The input was not mutated in place.
+    expect(state.caption).toBe(true);
+  });
+
+  it('toggles burn-subs independently', () => {
+    const { onChange, state } = render();
+    act(() => toggle('Burn subtitles').click());
+    expect(onChange).toHaveBeenCalledWith({ ...state, burnSubs: false });
+  });
+
+  it('hides the translate-language picker until Translate is on, then forwards it', () => {
+    const onChange = vi.fn();
+    render({ state: { ...DEFAULT_OUTPUT_TRAY, translate: false }, onChange });
+    expect(container.querySelector('.output-tray__lang')).toBeNull();
+    // Turn translate ON.
+    render({ state: { ...DEFAULT_OUTPUT_TRAY, translate: true }, onChange });
+    const langWrap = container.querySelector('.output-tray__lang');
+    expect(langWrap).toBeTruthy();
+    const select = langWrap?.querySelector('select') as HTMLSelectElement;
+    // Translate target must NOT offer auto-detect (you translate TO a language).
+    expect([...select.options].some((o) => o.value === AUTO_DETECT)).toBe(false);
+    act(() => {
+      select.value = 'es';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_OUTPUT_TRAY,
+      translate: true,
+      language: 'es',
+    });
+  });
+
+  it('renders ONLY the save actions whose handlers are provided', () => {
+    const onSaveClip = vi.fn();
+    const onSaveSrt = vi.fn();
+    render({ onSaveClip, onSaveSrt });
+    expect(button('Save clip')).toBeTruthy();
+    expect(button('Save SRT separately')).toBeTruthy();
+    expect(button('Save short')).toBeUndefined();
+    act(() => button('Save clip')?.click());
+    expect(onSaveClip).toHaveBeenCalled();
+    act(() => button('Save SRT separately')?.click());
+    expect(onSaveSrt).toHaveBeenCalled();
+  });
+
+  it('wires the Save short action when provided', () => {
+    const onSaveShort = vi.fn();
+    render({ onSaveShort });
+    act(() => button('Save short')?.click());
+    expect(onSaveShort).toHaveBeenCalled();
+  });
+
+  it('disables the save buttons while busy', () => {
+    render({ onSaveClip: vi.fn(), busy: true });
+    expect(button('Save clip')?.disabled).toBe(true);
+  });
+
+  it('uses a custom title when provided', () => {
+    render({ title: 'Finish up' });
+    expect(container.querySelector('.output-tray__title')?.textContent).toBe('Finish up');
+  });
+});

--- a/app/renderer/src/components/OutputTray.tsx
+++ b/app/renderer/src/components/OutputTray.tsx
@@ -1,0 +1,130 @@
+// OutputTray.tsx — the KEYSTONE post-action surface (V1 IA §h).
+//
+// Defined ONCE and rendered after ANY primary action (Make Shorts / Edit /
+// Director), the Output Tray consolidates the choices that used to be duplicated
+// across the old flat tabs (caption×6, translate×3, subtitle-edit×2, gallery×2,
+// export×7). It offers, in one consistent place:
+//   * Caption?  · Translate? (+ target language)  · Reframe?  · Burn subtitles
+//   * Save clip · Save short · Save SRT separately  (only the ones the surface
+//     supports — each gated on a provided handler)
+//
+// It is a CONTROLLED, presentational component: the parent owns the state and
+// the save handlers, so the same tray serves every surface without embedding
+// surface-specific logic. Quality features default ON (G-4) via
+// DEFAULT_OUTPUT_TRAY. The caption-editor detail (position/style preview) lands
+// in a later phase — this is the clean seam it plugs into.
+import React from 'react';
+import { LanguageSelect } from './LanguageSelect';
+import './outputTray.css';
+
+/** The four consolidated post-action toggles + the translate target language. */
+export interface OutputTrayState {
+  caption: boolean;
+  translate: boolean;
+  reframe: boolean;
+  burnSubs: boolean;
+  /** Target language for Translate (a code from lib/languages, never auto). */
+  language: string;
+}
+
+/** Quality-defaults-ON seed (G-4): caption + reframe + burn-subs ON; translate opt-in. */
+export const DEFAULT_OUTPUT_TRAY: OutputTrayState = {
+  caption: true,
+  translate: false,
+  reframe: true,
+  burnSubs: true,
+  language: 'en',
+};
+
+export interface OutputTrayProps {
+  /** Current tray state (parent-owned). */
+  state: OutputTrayState;
+  /** Called with the next immutable state on any change. */
+  onChange: (next: OutputTrayState) => void;
+  /** Save the edited clip (Edit surface). Omit to hide the button. */
+  onSaveClip?: () => void;
+  /** Save the produced short (Make Shorts surface). Omit to hide the button. */
+  onSaveShort?: () => void;
+  /** Save the SRT sidecar separately. Omit to hide the button. */
+  onSaveSrt?: () => void;
+  /** Disable the save actions while an action is in flight. */
+  busy?: boolean;
+  /** Heading text (defaults to "Next steps"). */
+  title?: string;
+}
+
+interface ToggleDef {
+  key: 'caption' | 'translate' | 'reframe' | 'burnSubs';
+  label: string;
+}
+
+const TOGGLES: readonly ToggleDef[] = [
+  { key: 'caption', label: 'Caption' },
+  { key: 'translate', label: 'Translate' },
+  { key: 'reframe', label: 'Reframe' },
+  { key: 'burnSubs', label: 'Burn subtitles' },
+];
+
+/** The single, shared post-action tray. */
+export function OutputTray({
+  state,
+  onChange,
+  onSaveClip,
+  onSaveShort,
+  onSaveSrt,
+  busy = false,
+  title = 'Next steps',
+}: OutputTrayProps): React.ReactElement {
+  return (
+    <section className="output-tray" aria-label="Output options">
+      <h3 className="output-tray__title">{title}</h3>
+
+      <div className="output-tray__toggles" role="group" aria-label="Post-action options">
+        {TOGGLES.map(({ key, label }) => (
+          <label key={key} className="output-tray__toggle">
+            <input
+              type="checkbox"
+              aria-label={label}
+              checked={state[key]}
+              onChange={(e) => onChange({ ...state, [key]: e.target.checked })}
+            />
+            <span>{label}</span>
+          </label>
+        ))}
+      </div>
+
+      {state.translate ? (
+        <div className="output-tray__lang">
+          <span className="output-tray__lang-label">Translate to</span>
+          {/* No auto-detect: you translate TO a chosen language. */}
+          <LanguageSelect
+            value={state.language}
+            includeAuto={false}
+            label="Translate to"
+            onChange={(code) => onChange({ ...state, language: code })}
+          />
+        </div>
+      ) : null}
+
+      <div className="output-tray__saves" role="group" aria-label="Save">
+        {onSaveClip ? (
+          <button type="button" onClick={onSaveClip} disabled={busy}>
+            Save clip
+          </button>
+        ) : null}
+        {onSaveShort ? (
+          <button type="button" onClick={onSaveShort} disabled={busy}>
+            Save short
+          </button>
+        ) : null}
+        {onSaveSrt ? (
+          <button type="button" onClick={onSaveSrt} disabled={busy}>
+            Save SRT separately
+          </button>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export default OutputTray;

--- a/app/renderer/src/components/languageSelect.css
+++ b/app/renderer/src/components/languageSelect.css
@@ -1,0 +1,16 @@
+/* languageSelect.css — the reusable language dropdown + its advice note. */
+.lang-select {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 0.25rem);
+}
+
+.lang-select__control {
+  width: 100%;
+}
+
+.lang-select__advice {
+  margin: 0;
+  font-size: var(--text-sm, 0.8125rem);
+  color: var(--color-warn-fg, #8a6d00);
+}

--- a/app/renderer/src/components/outputTray.css
+++ b/app/renderer/src/components/outputTray.css
@@ -1,0 +1,45 @@
+/* outputTray.css — the shared keystone post-action surface. */
+.output-tray {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 0.5rem);
+  padding: var(--space-md, 1rem);
+  border: 1px solid var(--color-border, #d0d0d0);
+  border-radius: var(--radius-md, 8px);
+  background: var(--color-surface-2, #f7f7f8);
+}
+
+.output-tray__title {
+  margin: 0;
+  font-size: var(--text-base, 1rem);
+}
+
+.output-tray__toggles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-md, 1rem);
+}
+
+.output-tray__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-xs, 0.25rem);
+}
+
+.output-tray__lang {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 0.25rem);
+  max-width: 20rem;
+}
+
+.output-tray__lang-label {
+  font-size: var(--text-sm, 0.8125rem);
+  color: var(--color-text-2, #555);
+}
+
+.output-tray__saves {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-sm, 0.5rem);
+}

--- a/app/renderer/src/features/ManualInterval.test.tsx
+++ b/app/renderer/src/features/ManualInterval.test.tsx
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ManualInterval } from './ManualInterval';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('<ManualInterval />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<React.ComponentProps<typeof ManualInterval>> = {}): {
+    onSubmit: ReturnType<typeof vi.fn>;
+  } {
+    const onSubmit = props.onSubmit ?? vi.fn();
+    act(() => root.render(<ManualInterval {...props} onSubmit={onSubmit} />));
+    return { onSubmit: onSubmit as ReturnType<typeof vi.fn> };
+  }
+
+  function input(label: string): HTMLInputElement {
+    return container.querySelector(`input[aria-label="${label}"]`) as HTMLInputElement;
+  }
+  function type(el: HTMLInputElement, value: string): void {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+  function button(text: string): HTMLButtonElement | undefined {
+    return [...container.querySelectorAll('button')].find((b) => b.textContent === text);
+  }
+
+  function addRange(start: string, end: string): void {
+    type(input('Range start'), start);
+    type(input('Range end'), end);
+    act(() => button('Add range')?.click());
+  }
+
+  it('adds a valid range and lists it formatted', () => {
+    render();
+    addRange('1:23', '4:10');
+    const items = container.querySelectorAll('.manual-interval__range');
+    expect(items.length).toBe(1);
+    expect(items[0].textContent).toContain('1:23');
+    expect(items[0].textContent).toContain('4:10');
+  });
+
+  it('rejects an unparseable timecode with a clear error', () => {
+    render();
+    addRange('oops', '4:10');
+    expect(container.querySelector('.manual-interval__error')?.textContent).toMatch(/valid/i);
+    expect(container.querySelectorAll('.manual-interval__range').length).toBe(0);
+  });
+
+  it('rejects a range whose end is not after its start', () => {
+    render();
+    addRange('4:10', '1:23');
+    expect(container.querySelector('.manual-interval__error')?.textContent).toMatch(/after/i);
+    expect(container.querySelectorAll('.manual-interval__range').length).toBe(0);
+  });
+
+  it('removes a range', () => {
+    render();
+    addRange('0:10', '0:40');
+    expect(container.querySelectorAll('.manual-interval__range').length).toBe(1);
+    act(() =>
+      (container.querySelector('[aria-label="Remove range"]') as HTMLButtonElement).click(),
+    );
+    expect(container.querySelectorAll('.manual-interval__range').length).toBe(0);
+  });
+
+  it('submits the built candidates and is disabled until a range exists', () => {
+    const { onSubmit } = render();
+    // No ranges yet -> the make button is disabled.
+    expect(button('Make shorts from ranges')?.disabled).toBe(true);
+    addRange('0:10', '0:40');
+    addRange('1:23', '4:10');
+    act(() => button('Make shorts from ranges')?.click());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    const cands = onSubmit.mock.calls[0][0];
+    expect(cands.map((c: { rank: number }) => c.rank)).toEqual([1, 2]);
+    expect(cands[1].sourceStart).toBe(83);
+    expect(cands[1].end).toBe(250);
+  });
+
+  it('disables the make button while busy', () => {
+    render({ busy: true });
+    // Even with a range, busy disables submission.
+    addRange('0:10', '0:40');
+    expect(button('Make shorts from ranges')?.disabled).toBe(true);
+  });
+
+  it('disables inputs + add when the disabled prop is set (no video)', () => {
+    render({ disabled: true });
+    expect(input('Range start').disabled).toBe(true);
+    expect(button('Add range')?.disabled).toBe(true);
+  });
+});

--- a/app/renderer/src/features/ManualInterval.tsx
+++ b/app/renderer/src/features/ManualInterval.tsx
@@ -1,0 +1,129 @@
+// ManualInterval.tsx — the MANUAL interval shorts mode (V1 IA §h).
+//
+// The non-AI path in Make Shorts: the user types explicit ranges (e.g. 1:23 ->
+// 4:10), each is validated + added to a list, and "Make shorts from ranges"
+// turns them into inline export candidates handed to the parent (which runs
+// shortmaker.export + shows the Output Tray). All timecode parsing + the
+// range -> Candidate mapping lives in the pure manualInterval module.
+import React, { useState } from 'react';
+import type { Candidate } from '../lib/rpc';
+import {
+  buildManualCandidates,
+  formatTimecode,
+  type ManualRange,
+  parseTimecode,
+} from './manualIntervalLogic';
+import './manualInterval.css';
+
+export interface ManualIntervalProps {
+  /** Fired with the built inline candidates when the user makes the shorts. */
+  onSubmit: (candidates: Candidate[]) => void;
+  /** Disable submission while an export is in flight. */
+  busy?: boolean;
+  /** Disable the whole control (e.g. no video selected yet). */
+  disabled?: boolean;
+}
+
+/** Manual time-interval shorts builder. */
+export function ManualInterval({
+  onSubmit,
+  busy = false,
+  disabled = false,
+}: ManualIntervalProps): React.ReactElement {
+  const [startText, setStartText] = useState('');
+  const [endText, setEndText] = useState('');
+  const [ranges, setRanges] = useState<ManualRange[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  function addRange(): void {
+    const start = parseTimecode(startText);
+    const end = parseTimecode(endText);
+    if (start === null || end === null) {
+      setError('Enter a valid start and end time (e.g. 1:23 and 4:10).');
+      return;
+    }
+    if (end <= start) {
+      setError('The end time must be after the start time.');
+      return;
+    }
+    setRanges((prev) => [...prev, { start, end }]);
+    setStartText('');
+    setEndText('');
+    setError(null);
+  }
+
+  function removeRange(index: number): void {
+    setRanges((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  function submit(): void {
+    onSubmit(buildManualCandidates(ranges));
+  }
+
+  return (
+    <div className="manual-interval">
+      <div className="manual-interval__add">
+        <label className="manual-interval__field">
+          <span>Start</span>
+          <input
+            aria-label="Range start"
+            type="text"
+            placeholder="1:23"
+            value={startText}
+            disabled={disabled}
+            onChange={(e) => setStartText(e.target.value)}
+          />
+        </label>
+        <span className="manual-interval__arrow" aria-hidden="true">
+          →
+        </span>
+        <label className="manual-interval__field">
+          <span>End</span>
+          <input
+            aria-label="Range end"
+            type="text"
+            placeholder="4:10"
+            value={endText}
+            disabled={disabled}
+            onChange={(e) => setEndText(e.target.value)}
+          />
+        </label>
+        <button type="button" onClick={addRange} disabled={disabled}>
+          Add range
+        </button>
+      </div>
+
+      {error ? (
+        <p className="manual-interval__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {ranges.length > 0 ? (
+        <ul className="manual-interval__list">
+          {ranges.map((r, i) => (
+            <li className="manual-interval__range" key={`${r.start}-${r.end}-${i}`}>
+              <span>
+                {formatTimecode(r.start)} → {formatTimecode(r.end)}
+              </span>
+              <button type="button" aria-label="Remove range" onClick={() => removeRange(i)}>
+                ✕
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      <button
+        type="button"
+        className="manual-interval__make"
+        onClick={submit}
+        disabled={busy || ranges.length === 0}
+      >
+        Make shorts from ranges
+      </button>
+    </div>
+  );
+}
+
+export default ManualInterval;

--- a/app/renderer/src/features/ShortMaker.test.tsx
+++ b/app/renderer/src/features/ShortMaker.test.tsx
@@ -214,36 +214,36 @@ describe('sanitizeControls', () => {
 
   // ---- P3: hookTitle / removeFillers toggles --------------------------------
 
-  it('defaults hookTitle ON and removeFillers OFF (P3 mini-contract)', () => {
+  it('defaults hookTitle ON and removeFillers ON (V1 quality-defaults-ON, G-4)', () => {
     const c = sanitizeControls({});
     expect(c.hookTitle).toBe(true);
-    expect(c.removeFillers).toBe(false);
+    expect(c.removeFillers).toBe(true);
     expect(DEFAULT_CONTROLS.hookTitle).toBe(true);
-    expect(DEFAULT_CONTROLS.removeFillers).toBe(false);
+    expect(DEFAULT_CONTROLS.removeFillers).toBe(true);
   });
 
   it('keeps explicit boolean toggle values', () => {
     expect(sanitizeControls({ hookTitle: false }).hookTitle).toBe(false);
-    expect(sanitizeControls({ removeFillers: true }).removeFillers).toBe(true);
+    expect(sanitizeControls({ removeFillers: false }).removeFillers).toBe(false);
   });
 
   it('rejects non-boolean toggle values back to the defaults', () => {
     expect(sanitizeControls({ hookTitle: 'yes' as unknown as boolean }).hookTitle).toBe(true);
     expect(sanitizeControls({ hookTitle: 0 as unknown as boolean }).hookTitle).toBe(true);
-    expect(sanitizeControls({ removeFillers: 1 as unknown as boolean }).removeFillers).toBe(false);
+    expect(sanitizeControls({ removeFillers: 1 as unknown as boolean }).removeFillers).toBe(true);
     expect(sanitizeControls({ removeFillers: 'true' as unknown as boolean }).removeFillers).toBe(
-      false,
+      true,
     );
   });
 
   // ---- P4 §8a emphasis tri-state / §8b autoZoom -----------------------------
 
-  it("defaults emphasis to 'default' (per-style) and autoZoom OFF (P4 §8a/§8b)", () => {
+  it("defaults emphasis to 'default' (per-style) and autoZoom ON (V1 quality-defaults-ON, G-4)", () => {
     const c = sanitizeControls({});
     expect(c.emphasis).toBe('default');
-    expect(c.autoZoom).toBe(false);
+    expect(c.autoZoom).toBe(true);
     expect(DEFAULT_CONTROLS.emphasis).toBe('default');
-    expect(DEFAULT_CONTROLS.autoZoom).toBe(false);
+    expect(DEFAULT_CONTROLS.autoZoom).toBe(true);
   });
 
   it('keeps explicit emphasis choices and normalizes case', () => {
@@ -257,10 +257,10 @@ describe('sanitizeControls', () => {
     expect(sanitizeControls({ emphasis: '' as unknown as 'on' }).emphasis).toBe('default');
   });
 
-  it('keeps an explicit autoZoom boolean; junk falls back OFF', () => {
-    expect(sanitizeControls({ autoZoom: true }).autoZoom).toBe(true);
-    expect(sanitizeControls({ autoZoom: 1 as unknown as boolean }).autoZoom).toBe(false);
-    expect(sanitizeControls({ autoZoom: 'true' as unknown as boolean }).autoZoom).toBe(false);
+  it('keeps an explicit autoZoom boolean; junk falls back to the default ON', () => {
+    expect(sanitizeControls({ autoZoom: false }).autoZoom).toBe(false);
+    expect(sanitizeControls({ autoZoom: 1 as unknown as boolean }).autoZoom).toBe(true);
+    expect(sanitizeControls({ autoZoom: 'true' as unknown as boolean }).autoZoom).toBe(true);
   });
 
   // ---- T4b: caption style + reframe engine sanitation ----------------------
@@ -778,8 +778,8 @@ describe('buildExportParams (P4 §8c / §2 export contract)', () => {
       captionStyle: 'bold',
       reframeEngine: 'verthor',
       hookTitle: false,
-      removeFillers: false,
-      autoZoom: false,
+      removeFillers: true,
+      autoZoom: true,
     });
     expect((params.candidates as Candidate[]).map((c) => c.rank)).toEqual([2, 1]);
   });
@@ -791,11 +791,11 @@ describe('buildExportParams (P4 §8c / §2 export contract)', () => {
     expect(buildExportParams('v1', top, ctrl, 'dub-es')).toMatchObject({ audioTrackId: 'dub-es' });
   });
 
-  it('always sends autoZoom (P4 §8b) and reflects an explicit ON', () => {
+  it('always sends autoZoom (P4 §8b) and reflects an explicit OFF', () => {
     const top = [cand()];
-    expect(buildExportParams('v1', top, sanitizeControls({}), '').autoZoom).toBe(false);
-    expect(buildExportParams('v1', top, sanitizeControls({ autoZoom: true }), '').autoZoom).toBe(
-      true,
+    expect(buildExportParams('v1', top, sanitizeControls({}), '').autoZoom).toBe(true);
+    expect(buildExportParams('v1', top, sanitizeControls({ autoZoom: false }), '').autoZoom).toBe(
+      false,
     );
   });
 
@@ -812,17 +812,17 @@ describe('buildExportParams (P4 §8c / §2 export contract)', () => {
     });
   });
 
-  it('always sends the audio-stabilize toggles (silenceTrim/stabilize, default OFF)', () => {
+  it('always sends the audio-stabilize toggles (silenceTrim/stabilize, default ON)', () => {
     const top = [cand()];
-    const off = buildExportParams('v1', top, sanitizeControls({}), '');
-    expect(off).toMatchObject({ silenceTrim: false, stabilize: false });
-    const on = buildExportParams(
+    const on = buildExportParams('v1', top, sanitizeControls({}), '');
+    expect(on).toMatchObject({ silenceTrim: true, stabilize: true });
+    const off = buildExportParams(
       'v1',
       top,
-      sanitizeControls({ silenceTrim: true, stabilize: true }),
+      sanitizeControls({ silenceTrim: false, stabilize: false }),
       '',
     );
-    expect(on).toMatchObject({ silenceTrim: true, stabilize: true });
+    expect(off).toMatchObject({ silenceTrim: false, stabilize: false });
   });
 });
 
@@ -1508,7 +1508,7 @@ describe('<ShortMaker /> component', () => {
     await flush();
   }
 
-  it('renders the two P3 toggles with their defaults (hook title ON, fillers OFF + experimental tag)', () => {
+  it('renders the two P3 toggles with their V1 defaults (hook title ON, fillers ON + experimental tag)', () => {
     render(<ShortMaker videoId="v1" api={makeApi()} />);
     const hook = byLabel('Hook title') as HTMLInputElement;
     const fillers = byLabel('Remove fillers') as HTMLInputElement;
@@ -1517,7 +1517,7 @@ describe('<ShortMaker /> component', () => {
     expect(hook.checked).toBe(true);
     expect(fillers).toBeTruthy();
     expect(fillers.type).toBe('checkbox');
-    expect(fillers.checked).toBe(false);
+    expect(fillers.checked).toBe(true);
     const tag = container.querySelector('.sm-tag-exp');
     expect(tag?.textContent).toBe('experimental');
   });
@@ -1527,13 +1527,13 @@ describe('<ShortMaker /> component', () => {
     render(<ShortMaker videoId="v1" api={makeApi({ rpc })} />);
 
     act(() => (byLabel('Hook title') as HTMLInputElement).click()); // ON -> OFF
-    act(() => (byLabel('Remove fillers') as HTMLInputElement).click()); // OFF -> ON
+    act(() => (byLabel('Remove fillers') as HTMLInputElement).click()); // ON -> OFF (V1 default ON)
     await submitForm();
 
     expect(rpc).toHaveBeenCalledWith(
       'shortmaker.select',
       expect.objectContaining({
-        controls: expect.objectContaining({ hookTitle: false, removeFillers: true }),
+        controls: expect.objectContaining({ hookTitle: false, removeFillers: false }),
       }),
     );
   });
@@ -1581,7 +1581,7 @@ describe('<ShortMaker /> component', () => {
     await submitForm();
 
     // Flip the two new controls in the UI (proving the call site exists).
-    act(() => (byLabel('Auto zoom') as HTMLInputElement).click()); // OFF -> ON
+    act(() => (byLabel('Auto zoom') as HTMLInputElement).click()); // ON -> OFF (V1 default ON)
     const emphasisSel = byLabel('Emphasis') as HTMLSelectElement;
     act(() => {
       emphasisSel.value = 'on';
@@ -1601,7 +1601,7 @@ describe('<ShortMaker /> component', () => {
 
     expect(rpc).toHaveBeenCalledWith(
       'shortmaker.export',
-      expect.objectContaining({ videoId: 'v1', autoZoom: true, emphasis: true }),
+      expect.objectContaining({ videoId: 'v1', autoZoom: false, emphasis: true }),
     );
   });
 

--- a/app/renderer/src/features/ShortMakerControls.test.tsx
+++ b/app/renderer/src/features/ShortMakerControls.test.tsx
@@ -157,18 +157,20 @@ describe('<ShortMakerControls />', () => {
   it('forwards each toggle change to setControl with the checked bool', () => {
     mount();
     const toggle = (label: string) => byLabel(label) as HTMLInputElement;
+    // V1 quality-defaults-ON (G-4): all four quality toggles start ON, so a
+    // single click flips each OFF (the inverse of the pre-V1 OFF defaults).
     act(() => {
       toggle('Hook title').click(); // ON -> OFF
     });
     expect(spies.setControl).toHaveBeenCalledWith('hookTitle', false);
-    act(() => toggle('Remove fillers').click()); // OFF -> ON
-    expect(spies.setControl).toHaveBeenCalledWith('removeFillers', true);
+    act(() => toggle('Remove fillers').click()); // ON -> OFF
+    expect(spies.setControl).toHaveBeenCalledWith('removeFillers', false);
     act(() => toggle('Auto zoom').click());
-    expect(spies.setControl).toHaveBeenCalledWith('autoZoom', true);
+    expect(spies.setControl).toHaveBeenCalledWith('autoZoom', false);
     act(() => toggle('Trim silence').click());
-    expect(spies.setControl).toHaveBeenCalledWith('silenceTrim', true);
+    expect(spies.setControl).toHaveBeenCalledWith('silenceTrim', false);
     act(() => toggle('Stabilize').click());
-    expect(spies.setControl).toHaveBeenCalledWith('stabilize', true);
+    expect(spies.setControl).toHaveBeenCalledWith('stabilize', false);
   });
 
   it('forwards audio-track selection to setAudioTrackId', () => {

--- a/app/renderer/src/features/ShortMakerControls.tsx
+++ b/app/renderer/src/features/ShortMakerControls.tsx
@@ -24,6 +24,7 @@ import {
 } from './shortMakerLogic';
 import { type PlatformPresetId, PLATFORM_PRESETS, PLATFORM_PRESET_IDS } from './shortMakerPresets';
 import { CAPTION_STYLES } from './shortMakerLogic';
+import { LanguageSelect } from '../components/LanguageSelect';
 
 export interface ShortMakerControlsProps {
   videoId: string;
@@ -139,11 +140,11 @@ export function ShortMakerControls({
 
         <label className="sm-field">
           <span>Language</span>
-          <input
-            aria-label="Language"
-            type="text"
+          {/* V1 IA §h: language is a DROPDOWN (never free-typed) + auto-detect
+              advice — the shared LanguageSelect is the one source for this. */}
+          <LanguageSelect
             value={controls.language}
-            onChange={(e) => setControl('language', e.target.value)}
+            onChange={(code) => setControl('language', code)}
           />
         </label>
 

--- a/app/renderer/src/features/manualInterval.css
+++ b/app/renderer/src/features/manualInterval.css
@@ -1,0 +1,48 @@
+/* manualInterval.css — the manual time-interval shorts builder. */
+.manual-interval {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 0.5rem);
+}
+
+.manual-interval__add {
+  display: flex;
+  align-items: flex-end;
+  gap: var(--space-sm, 0.5rem);
+  flex-wrap: wrap;
+}
+
+.manual-interval__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 0.25rem);
+}
+
+.manual-interval__arrow {
+  padding-bottom: var(--space-xs, 0.25rem);
+}
+
+.manual-interval__error {
+  margin: 0;
+  color: var(--color-error-fg, #b00020);
+  font-size: var(--text-sm, 0.8125rem);
+}
+
+.manual-interval__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 0.25rem);
+}
+
+.manual-interval__range {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm, 0.5rem);
+  padding: var(--space-xs, 0.25rem) var(--space-sm, 0.5rem);
+  border: 1px solid var(--color-border, #d0d0d0);
+  border-radius: var(--radius-sm, 4px);
+}

--- a/app/renderer/src/features/manualIntervalLogic.test.ts
+++ b/app/renderer/src/features/manualIntervalLogic.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildManualCandidates,
+  formatTimecode,
+  intervalToCandidate,
+  parseTimecode,
+} from './manualIntervalLogic';
+
+describe('parseTimecode', () => {
+  it('parses plain seconds', () => {
+    expect(parseTimecode('90')).toBe(90);
+    expect(parseTimecode('0')).toBe(0);
+    expect(parseTimecode(' 12 ')).toBe(12);
+  });
+
+  it('parses mm:ss', () => {
+    expect(parseTimecode('1:23')).toBe(83);
+    expect(parseTimecode('0:00')).toBe(0);
+    expect(parseTimecode('10:05')).toBe(605);
+  });
+
+  it('parses h:mm:ss', () => {
+    expect(parseTimecode('1:02:03')).toBe(3723);
+  });
+
+  it('rejects empty / non-numeric / malformed input', () => {
+    expect(parseTimecode('')).toBeNull();
+    expect(parseTimecode('   ')).toBeNull();
+    expect(parseTimecode('abc')).toBeNull();
+    expect(parseTimecode('1:2:3:4')).toBeNull();
+  });
+
+  it('rejects out-of-range minutes/seconds fields and negatives', () => {
+    expect(parseTimecode('1:99')).toBeNull(); // ss >= 60
+    expect(parseTimecode('1:60:00')).toBeNull(); // mm >= 60
+    expect(parseTimecode('-5')).toBeNull();
+    expect(parseTimecode('1:-2')).toBeNull();
+  });
+});
+
+describe('formatTimecode', () => {
+  it('formats mm:ss and h:mm:ss', () => {
+    expect(formatTimecode(83)).toBe('1:23');
+    expect(formatTimecode(0)).toBe('0:00');
+    expect(formatTimecode(3723)).toBe('1:02:03');
+  });
+
+  it('clamps invalid input to 0:00', () => {
+    expect(formatTimecode(-5)).toBe('0:00');
+    expect(formatTimecode(Number.NaN)).toBe('0:00');
+  });
+});
+
+describe('intervalToCandidate', () => {
+  it('builds a source-anchored candidate for a range', () => {
+    const c = intervalToCandidate(83, 250, 2);
+    expect(c.rank).toBe(2);
+    expect(c.start).toBe(83);
+    expect(c.sourceStart).toBe(83);
+    expect(c.end).toBe(250);
+    expect(c.durationSec).toBe(167);
+  });
+});
+
+describe('buildManualCandidates', () => {
+  it('ranks ranges 1..n in order', () => {
+    const cands = buildManualCandidates([
+      { start: 10, end: 40 },
+      { start: 83, end: 250 },
+    ]);
+    expect(cands.map((c) => c.rank)).toEqual([1, 2]);
+    expect(cands.map((c) => c.sourceStart)).toEqual([10, 83]);
+  });
+
+  it('returns an empty list for no ranges', () => {
+    expect(buildManualCandidates([])).toEqual([]);
+  });
+});

--- a/app/renderer/src/features/manualIntervalLogic.ts
+++ b/app/renderer/src/features/manualIntervalLogic.ts
@@ -1,0 +1,66 @@
+// manualInterval.ts — pure logic for MANUAL interval shorts (V1 IA §h).
+//
+// The Make Shorts section offers two modes: AI moment-pick (shortmaker.select)
+// and MANUAL intervals — the user gives explicit ranges (e.g. 1:23 -> 4:10) and
+// each becomes an inline export candidate fed straight to shortmaker.export
+// (the same inline-candidates path the AI flow uses). This module owns the
+// timecode parsing + range -> Candidate conversion so the component stays thin
+// and the hard logic is unit-tested to 100%.
+import type { Candidate } from '../lib/rpc';
+
+/** A validated manual time range, in SOURCE-absolute seconds. */
+export interface ManualRange {
+  start: number;
+  end: number;
+}
+
+/**
+ * Parse a timecode string into SOURCE-absolute seconds, or `null` if invalid.
+ * Accepts plain seconds ("90"), "mm:ss" ("1:23"), or "h:mm:ss" ("1:02:03").
+ * The lower fields (minutes, seconds) must be in [0, 60); all parts must be
+ * non-negative finite numbers. Anything else returns `null` (no silent guess).
+ */
+export function parseTimecode(input: string): number | null {
+  const text = input.trim();
+  if (!text) return null;
+  const parts = text.split(':');
+  if (parts.length > 3) return null;
+  const nums = parts.map((p) => Number(p));
+  if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
+  if (parts.length === 1) return nums[0];
+  // The trailing field(s) below the largest unit must be < 60.
+  const lower = nums.slice(1);
+  if (lower.some((n) => n >= 60)) return null;
+  return nums.reduce((acc, n) => acc * 60 + n, 0);
+}
+
+/** Format SOURCE-absolute seconds as "m:ss" (or "h:mm:ss" past an hour). */
+export function formatTimecode(sec: number): string {
+  if (!Number.isFinite(sec) || sec < 0) return '0:00';
+  const total = Math.round(sec);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const ss = String(s).padStart(2, '0');
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${ss}`;
+  return `${m}:${ss}`;
+}
+
+/** Build one export Candidate for a manual range (source-anchored, given rank). */
+export function intervalToCandidate(start: number, end: number, rank: number): Candidate {
+  return {
+    rank,
+    start,
+    end,
+    durationSec: end - start,
+    sourceStart: start,
+    hook: `Manual clip ${rank}`,
+    why: 'Manual interval',
+    score: 0,
+  };
+}
+
+/** Convert validated ranges into ranked inline export candidates (rank 1..n). */
+export function buildManualCandidates(ranges: readonly ManualRange[]): Candidate[] {
+  return ranges.map((r, i) => intervalToCandidate(r.start, r.end, i + 1));
+}

--- a/app/renderer/src/features/shortMakerLogic.ts
+++ b/app/renderer/src/features/shortMakerLogic.ts
@@ -231,11 +231,14 @@ export const DEFAULT_CONTROLS: ShortMakerControls = {
   captionStyle: DEFAULT_CAPTION_STYLE,
   reframeEngine: DEFAULT_REFRAME_ENGINE,
   hookTitle: true,
-  removeFillers: false,
+  // V1 IA (GRILL G-4): quality features DEFAULT-ON to match the "all quality ON"
+  // promise — removeFillers / autoZoom / silenceTrim / stabilize all start ON
+  // (the novice front door ships its best output without touching Advanced).
+  removeFillers: true,
   emphasis: DEFAULT_EMPHASIS,
-  autoZoom: false,
-  silenceTrim: false,
-  stabilize: false,
+  autoZoom: true,
+  silenceTrim: true,
+  stabilize: true,
 };
 
 export const ASPECT_OPTIONS = ['9:16', '1:1', '4:5', '16:9'] as const;
@@ -255,10 +258,10 @@ export function clamp(n: number, lo: number, hi: number): number {
  * - non-empty aspect / language (fall back to defaults)
  * - captionStyle must be a known style id (else the libass default)
  * - reframeEngine must be auto|verthor|claudeshorts (else auto)
- * - hookTitle/removeFillers must be real booleans (else their defaults ON/OFF)
+ * - hookTitle/removeFillers must be real booleans (else their defaults ON — G-4)
  * - emphasis must be 'default'|'on'|'off' (else the 'default' per-style mode)
- * - autoZoom must be a real boolean (else its default OFF)
- * - silenceTrim/stabilize must be real booleans (else their defaults OFF)
+ * - autoZoom must be a real boolean (else its default ON — G-4)
+ * - silenceTrim/stabilize must be real booleans (else their defaults ON — G-4)
  */
 export function sanitizeControls(raw: Partial<ShortMakerControls>): ShortMakerControls {
   const count = Math.max(1, Math.round(raw.count ?? DEFAULT_CONTROLS.count));

--- a/app/renderer/src/lib/directorTypes.test.ts
+++ b/app/renderer/src/lib/directorTypes.test.ts
@@ -57,6 +57,7 @@ function costRow(over: Partial<DirectorCostRow> = {}): DirectorCostRow {
 describe('opKindLabel', () => {
   it('maps every known kind to a friendly noun', () => {
     expect(opKindLabel('trim')).toBe('trim');
+    expect(opKindLabel('join')).toBe('join');
     expect(opKindLabel('ocrExtractList')).toBe('on-screen text read');
     expect(opKindLabel('overlayText')).toBe('text overlay');
   });

--- a/app/renderer/src/lib/directorTypes.ts
+++ b/app/renderer/src/lib/directorTypes.ts
@@ -42,6 +42,7 @@ export const GROUP_COLLAPSE_THRESHOLD = 5;
 const OP_KIND_LABELS: Record<DirectorOpKind, string> = {
   trim: 'trim',
   cut: 'cut',
+  join: 'join',
   removeSilence: 'silence removal',
   removeFillers: 'filler removal',
   reorder: 'reorder',

--- a/app/renderer/src/lib/languages.ts
+++ b/app/renderer/src/lib/languages.ts
@@ -1,0 +1,51 @@
+// languages.ts — the curated language vocabulary for the V1 IA.
+//
+// V1 IA decision (V1-GRILL-DECISIONS §h): LANGUAGE is a DROPDOWN, never
+// free-typed — typing invites wrong/nonexistent language codes. Auto-detect is
+// also offered, but the UI advises picking a specific language upfront because
+// auto-detect can yield lower-quality transcription/translation than an explicit
+// choice. This module is the SINGLE source of truth for the option list + labels
+// so every surface (ShortMaker controls, the Output Tray, captions) reads one
+// vocabulary.
+
+/** A selectable language: an ISO-639-1 code + a human label. */
+export interface LanguageOption {
+  code: string;
+  label: string;
+}
+
+/** The sentinel "let the model detect the language" choice (not a real code). */
+export const AUTO_DETECT = 'auto';
+
+/**
+ * The curated set of languages offered in dropdowns (the auto sentinel is NOT
+ * included here — surfaces prepend it when they offer auto-detect). Ordered with
+ * the most common creator languages first.
+ */
+export const LANGUAGES: readonly LanguageOption[] = [
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'pt', label: 'Portuguese' },
+  { code: 'fr', label: 'French' },
+  { code: 'de', label: 'German' },
+  { code: 'it', label: 'Italian' },
+  { code: 'nl', label: 'Dutch' },
+  { code: 'pl', label: 'Polish' },
+  { code: 'ru', label: 'Russian' },
+  { code: 'uk', label: 'Ukrainian' },
+  { code: 'tr', label: 'Turkish' },
+  { code: 'ar', label: 'Arabic' },
+  { code: 'hi', label: 'Hindi' },
+  { code: 'id', label: 'Indonesian' },
+  { code: 'vi', label: 'Vietnamese' },
+  { code: 'th', label: 'Thai' },
+  { code: 'ja', label: 'Japanese' },
+  { code: 'ko', label: 'Korean' },
+  { code: 'zh', label: 'Chinese' },
+] as const;
+
+/** Map a code to its label, including the auto sentinel; unknown codes echo back. */
+export function languageLabel(code: string): string {
+  if (code === AUTO_DETECT) return 'Auto-detect';
+  return LANGUAGES.find((l) => l.code === code)?.label ?? code;
+}

--- a/app/renderer/src/lib/rpc.ts
+++ b/app/renderer/src/lib/rpc.ts
@@ -850,6 +850,7 @@ export interface Project {
 export type DirectorOpKind =
   | 'trim'
   | 'cut'
+  | 'join'
   | 'removeSilence'
   | 'removeFillers'
   | 'reorder'

--- a/app/renderer/src/views/Edit.test.tsx
+++ b/app/renderer/src/views/Edit.test.tsx
@@ -1,0 +1,65 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Video } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+// The Workspace is the heavy per-video body (owns its own tests); stub it.
+vi.mock('./Workspace', () => ({
+  Workspace: ({ video, onBack }: { video: Video; onBack: () => void }) => (
+    <div data-testid="workspace" data-video-id={video.id}>
+      <button type="button" onClick={onBack}>
+        back
+      </button>
+    </div>
+  ),
+}));
+
+import { Edit } from './Edit';
+
+function makeVideo(): Video {
+  return {
+    id: 'v1',
+    path: '/m/a.mp4',
+    title: 'A',
+    addedAt: '2026-06-27T00:00:00Z',
+    durationSec: 100,
+    hasTranscript: false,
+  };
+}
+
+describe('<Edit />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('shows the empty state when no video is open', () => {
+    act(() => root.render(<Edit video={null} onBack={() => undefined} />));
+    expect(container.querySelector('.edit--empty')).toBeTruthy();
+    expect(container.querySelector('.edit__empty-title')?.textContent).toBe('No video open');
+    expect(container.querySelector('[data-testid="workspace"]')).toBeNull();
+  });
+
+  it('hosts the per-video Workspace when a video is open', () => {
+    const onBack = vi.fn();
+    act(() => root.render(<Edit video={makeVideo()} onBack={onBack} />));
+    const ws = container.querySelector('[data-testid="workspace"]');
+    expect(ws).toBeTruthy();
+    expect(ws!.getAttribute('data-video-id')).toBe('v1');
+    act(() =>
+      (container.querySelector('[data-testid="workspace"] button') as HTMLButtonElement).click(),
+    );
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/app/renderer/src/views/Edit.tsx
+++ b/app/renderer/src/views/Edit.tsx
@@ -1,0 +1,36 @@
+// Edit.tsx — the V1 "Edit" SECTION (manual per-video editing, IA §h).
+//
+// Edit is the per-video manual surface: Trim / Cut / Join / Reorder / Reframe /
+// Stabilize / Cleanup + Transcript & Captions + Audio. Those panels already
+// live in the per-video Workspace (the tabbed body), so Edit hosts the Workspace
+// for the currently-open video and shows a clear empty state when none is open
+// (the user opens a video from the Library, which routes here). NOTHING is
+// deleted — every existing edit/transcript/audio capability remains reachable.
+import React from 'react';
+import { Workspace } from './Workspace';
+import type { Video } from '../lib/rpc';
+
+export interface EditProps {
+  /** The video to edit, or null when none has been opened yet. */
+  video: Video | null;
+  /** Return to the Library home. */
+  onBack: () => void;
+}
+
+/** The Edit section: the per-video Workspace, or an empty state. */
+export function Edit({ video, onBack }: EditProps): React.ReactElement {
+  if (!video) {
+    return (
+      <div className="edit edit--empty" aria-label="Edit">
+        <p className="edit__empty-title">No video open</p>
+        <p className="edit__empty-hint">
+          Open a video from the Library to trim, cut, join, reframe, caption, and more — every edit
+          tool lives here.
+        </p>
+      </div>
+    );
+  }
+  return <Workspace video={video} onBack={onBack} />;
+}
+
+export default Edit;

--- a/app/renderer/src/views/MakeShorts.test.tsx
+++ b/app/renderer/src/views/MakeShorts.test.tsx
@@ -1,0 +1,345 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Candidate, ShortReexportHint, Video } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const libraryListMock = vi.fn();
+const exportMock = vi.fn();
+let hasApiValue = true;
+
+vi.mock('../lib/rpc', () => ({
+  hasApi: () => hasApiValue,
+  client: {
+    library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    shortmaker: { export: (...a: unknown[]) => exportMock(...a) },
+  },
+}));
+
+vi.mock('./Shorts', () => ({
+  Shorts: ({ onReexport }: { onReexport?: (h: ShortReexportHint) => void }) => (
+    <div data-testid="shorts">
+      <button
+        type="button"
+        onClick={() =>
+          onReexport?.({
+            videoId: 'v2',
+            candidate: { hook: 'h', template: 't', viralityPct: 50, durationSec: 30 },
+          })
+        }
+      >
+        reexport
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./Repurpose', () => ({
+  Repurpose: ({ resumeId }: { resumeId?: string }) => (
+    <div data-testid="repurpose" data-resume={resumeId ?? ''} />
+  ),
+}));
+
+vi.mock('../features/ShortMaker', () => ({
+  ShortMaker: ({ videoId }: { videoId: string }) => (
+    <div data-testid="shortmaker" data-video-id={videoId} />
+  ),
+}));
+
+vi.mock('../features/ManualInterval', () => {
+  const cands = [
+    { rank: 1, start: 10, end: 40, durationSec: 30, sourceStart: 10, hook: '', why: '', score: 0 },
+  ];
+  return {
+    ManualInterval: ({
+      onSubmit,
+      busy,
+    }: {
+      onSubmit: (c: Candidate[]) => void;
+      busy?: boolean;
+    }) => (
+      <div data-testid="manual" data-busy={String(busy)}>
+        <button type="button" onClick={() => onSubmit(cands)}>
+          manual-submit
+        </button>
+      </div>
+    ),
+  };
+});
+
+// Mirror of the candidate the ManualInterval mock submits (for assertions).
+const MANUAL_CANDS: Candidate[] = [
+  { rank: 1, start: 10, end: 40, durationSec: 30, sourceStart: 10, hook: '', why: '', score: 0 },
+];
+
+vi.mock('../components/OutputTray', () => {
+  // Self-contained (vi.mock is hoisted — no top-level refs allowed).
+  const seed = { caption: true, translate: false, reframe: true, burnSubs: true, language: 'en' };
+  return {
+    DEFAULT_OUTPUT_TRAY: seed,
+    OutputTray: ({
+      onChange,
+      onSaveShort,
+      onSaveSrt,
+    }: {
+      onChange: (s: typeof seed) => void;
+      onSaveShort?: () => void;
+      onSaveSrt?: () => void;
+    }) => (
+      <div data-testid="output-tray">
+        <button type="button" onClick={() => onChange({ ...seed, translate: true })}>
+          tray-change
+        </button>
+        <button type="button" onClick={() => onSaveShort?.()}>
+          tray-save-short
+        </button>
+        <button type="button" onClick={() => onSaveSrt?.()}>
+          tray-save-srt
+        </button>
+      </div>
+    ),
+  };
+});
+
+import { MakeShorts } from './MakeShorts';
+
+function makeVideo(over: Partial<Video> = {}): Video {
+  return {
+    id: 'v1',
+    path: '/m/a.mp4',
+    title: 'Alpha',
+    addedAt: '2026-06-27T00:00:00Z',
+    durationSec: 100,
+    hasTranscript: false,
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  hasApiValue = true;
+  libraryListMock.mockReset();
+  libraryListMock.mockResolvedValue({ videos: [makeVideo()] });
+  exportMock.mockReset();
+  exportMock.mockResolvedValue({ clips: [{ path: '/out/1.mp4' }] });
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function mount(resumeId?: string): Promise<void> {
+  await act(async () => {
+    root.render(<MakeShorts resumeId={resumeId} />);
+  });
+  await flush();
+}
+
+function sectionBtn(label: string): HTMLButtonElement {
+  const btns = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'));
+  const found = btns.find((b) => b.textContent === label);
+  if (!found) throw new Error(`section "${label}" not found`);
+  return found;
+}
+
+function picker(): HTMLSelectElement {
+  return container.querySelector('select[aria-label="Source video"]') as HTMLSelectElement;
+}
+
+async function selectVideo(id: string): Promise<void> {
+  const sel = picker();
+  await act(async () => {
+    sel.value = id;
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await flush();
+}
+
+describe('<MakeShorts />', () => {
+  it('lands on the Make front door with a video picker + hint (no video yet)', async () => {
+    await mount();
+    expect(picker()).toBeTruthy();
+    expect(container.querySelector('.make-shorts__hint')).toBeTruthy();
+    expect(container.querySelector('[data-testid="shortmaker"]')).toBeNull();
+    // The picker is populated from library.list.
+    expect([...picker().options].map((o) => o.value)).toContain('v1');
+  });
+
+  it('defaults to the Batch section when a resume id is given', async () => {
+    await mount('b9');
+    const rep = container.querySelector('[data-testid="repurpose"]');
+    expect(rep).toBeTruthy();
+    expect(rep!.getAttribute('data-resume')).toBe('b9');
+  });
+
+  it('switches to the produced-shorts gallery and the batch section', async () => {
+    await mount();
+    await act(async () => sectionBtn('Produced shorts').click());
+    await flush();
+    expect(container.querySelector('[data-testid="shorts"]')).toBeTruthy();
+    await act(async () => sectionBtn('Batch & Templates').click());
+    await flush();
+    expect(container.querySelector('[data-testid="repurpose"]')).toBeTruthy();
+  });
+
+  it('reveals AI moment-pick + manual intervals once a video is selected', async () => {
+    await mount();
+    await selectVideo('v1');
+    expect(
+      container.querySelector('[data-testid="shortmaker"]')!.getAttribute('data-video-id'),
+    ).toBe('v1');
+    expect(container.querySelector('[data-testid="manual"]')).toBeTruthy();
+  });
+
+  it('re-export from the gallery jumps to Make primed with the source video', async () => {
+    libraryListMock.mockResolvedValue({
+      videos: [makeVideo(), makeVideo({ id: 'v2', title: 'Beta' })],
+    });
+    await mount();
+    await act(async () => sectionBtn('Produced shorts').click());
+    await flush();
+    await act(async () => {
+      (container.querySelector('[data-testid="shorts"] button') as HTMLButtonElement).click();
+    });
+    await flush();
+    // Back on Make, with v2 selected -> ShortMaker mounted for v2.
+    expect(
+      container.querySelector('[data-testid="shortmaker"]')!.getAttribute('data-video-id'),
+    ).toBe('v2');
+  });
+
+  it('exports manual ranges, shows a note + the Output Tray on success', async () => {
+    await mount();
+    await selectVideo('v1');
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'manual-submit',
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(exportMock).toHaveBeenCalledTimes(1);
+    const [vid, ids, opts] = exportMock.mock.calls[0];
+    expect(vid).toBe('v1');
+    expect(ids).toEqual(['1@10']);
+    expect(opts).toMatchObject({ candidates: MANUAL_CANDS });
+    expect(container.querySelector('.make-shorts__note')?.textContent).toContain('Exported 1 clip');
+    expect(container.querySelector('[data-testid="output-tray"]')).toBeTruthy();
+  });
+
+  it('surfaces a manual-export error and shows no tray', async () => {
+    exportMock.mockRejectedValue(new Error('export blew up'));
+    await mount();
+    await selectVideo('v1');
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'manual-submit',
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('.make-shorts__error')?.textContent).toContain('export blew up');
+    expect(container.querySelector('[data-testid="output-tray"]')).toBeNull();
+  });
+
+  it('stringifies a non-Error manual-export rejection', async () => {
+    exportMock.mockRejectedValue('plain string failure');
+    await mount();
+    await selectVideo('v1');
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'manual-submit',
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('.make-shorts__error')?.textContent).toContain(
+      'plain string failure',
+    );
+  });
+
+  it('drives the Output Tray change + save seams after a manual export', async () => {
+    await mount();
+    await selectVideo('v1');
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'manual-submit',
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    const click = (label: string) =>
+      act(() => {
+        (
+          [...container.querySelectorAll('button')].find(
+            (b) => b.textContent === label,
+          ) as HTMLButtonElement
+        ).click();
+      });
+    click('tray-change'); // exercises onChange={setTray}
+    click('tray-save-short');
+    expect(container.querySelector('.make-shorts__note')?.textContent).toContain('Saved the short');
+    click('tray-save-srt');
+    expect(container.querySelector('.make-shorts__note')?.textContent).toContain(
+      'Saved the SRT sidecar',
+    );
+  });
+
+  it('swallows a library.list rejection (best-effort) and stays usable', async () => {
+    libraryListMock.mockRejectedValue(new Error('list failed'));
+    await mount();
+    // The picker still renders with just the placeholder; no crash.
+    expect([...picker().options].map((o) => o.value)).toEqual(['']);
+  });
+
+  it('does not query the library when the preload bridge is absent', async () => {
+    hasApiValue = false;
+    await mount();
+    expect(libraryListMock).not.toHaveBeenCalled();
+    // Only the placeholder option exists with no bridge.
+    expect([...picker().options].map((o) => o.value)).toEqual(['']);
+  });
+
+  it('ignores a late library.list result after unmount (cancelled guard)', async () => {
+    let resolveList: (v: { videos: Video[] }) => void = () => {};
+    libraryListMock.mockReturnValue(
+      new Promise((res) => {
+        resolveList = res;
+      }),
+    );
+    await act(async () => {
+      root.render(<MakeShorts />);
+    });
+    await flush();
+    act(() => root.unmount());
+    await act(async () => {
+      resolveList({ videos: [makeVideo()] });
+      await Promise.resolve();
+    });
+    root = createRoot(container);
+  });
+});

--- a/app/renderer/src/views/MakeShorts.tsx
+++ b/app/renderer/src/views/MakeShorts.tsx
@@ -1,0 +1,173 @@
+// MakeShorts.tsx — the V1 "Make Shorts" SECTION (novice front door, IA §h).
+//
+// Consolidates everything about producing shorts into ONE section (killing the
+// old split across the "Create" gallery + a buried Short-maker sub-tab + the
+// separate "Repurpose" batch surface):
+//   * Make    — pick a video, then AI moment-pick (ShortMaker) OR Manual
+//               interval ranges (ManualInterval -> inline shortmaker.export),
+//               with the shared Output Tray after a manual export.
+//   * Gallery — the SINGLE produced-shorts gallery (Shorts view).
+//   * Batch   — batch / templates / export presets (Repurpose view).
+//
+// Re-export from the gallery jumps to Make primed with the source video. The
+// heavy children own their own tests; this view owns the section routing +
+// video selection + the manual-export wiring.
+import React, { useCallback, useEffect, useState } from 'react';
+import { TabBar, type TabDef } from '../components/TabBar';
+import { Shorts } from './Shorts';
+import { Repurpose } from './Repurpose';
+import { ShortMaker } from '../features/ShortMaker';
+import { ManualInterval } from '../features/ManualInterval';
+import { OutputTray, DEFAULT_OUTPUT_TRAY, type OutputTrayState } from '../components/OutputTray';
+import { buildExportParams } from '../features/shortMakerPresets';
+import { candidateId, sanitizeControls } from '../features/shortMakerLogic';
+import { client, hasApi, type Candidate, type ShortReexportHint, type Video } from '../lib/rpc';
+import './makeShorts.css';
+
+const SECTIONS: TabDef[] = [
+  { id: 'make', label: 'Make' },
+  { id: 'gallery', label: 'Produced shorts' },
+  { id: 'batch', label: 'Batch & Templates' },
+];
+
+export interface MakeShortsProps {
+  /** A deep-link batch id to resume on mount (forwarded to the Batch surface). */
+  resumeId?: string;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The Make Shorts section: AI/manual making + the single gallery + batch. */
+export function MakeShorts({ resumeId }: MakeShortsProps): React.ReactElement {
+  // Resume deep-links land on the Batch surface; otherwise the Make front door.
+  const [active, setActive] = useState<string>(resumeId ? 'batch' : 'make');
+  const [videos, setVideos] = useState<Video[]>([]);
+  const [selectedId, setSelectedId] = useState('');
+  const [manualBusy, setManualBusy] = useState(false);
+  const [manualNote, setManualNote] = useState<string | null>(null);
+  const [manualError, setManualError] = useState<string | null>(null);
+  const [tray, setTray] = useState<OutputTrayState>(DEFAULT_OUTPUT_TRAY);
+  const [trayOpen, setTrayOpen] = useState(false);
+
+  useEffect(() => {
+    if (!hasApi()) return;
+    let cancelled = false;
+    void client.library
+      .list()
+      .then(({ videos: vids }) => {
+        if (!cancelled) setVideos(vids);
+      })
+      .catch(() => {
+        // Best-effort: the picker simply stays empty if the list fails.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Re-export from the gallery: jump to Make primed with the source video.
+  const handleReexport = useCallback((hint: ShortReexportHint) => {
+    if (hint.videoId) setSelectedId(hint.videoId);
+    setActive('make');
+  }, []);
+
+  // Output Tray save seams (the caption-editor phase deepens these): record what
+  // the user chose to save so the action is acknowledged, never silent.
+  const handleSaveShort = useCallback(() => setManualNote('Saved the short.'), []);
+  const handleSaveSrt = useCallback(() => setManualNote('Saved the SRT sidecar.'), []);
+
+  // Manual export runs only from the ManualInterval control, which is rendered
+  // ONLY once a video is selected (so `selectedId` is always set here, and the
+  // video list is populated only when the preload bridge is present — no extra
+  // guards needed). The export params reuse the AI flow's contract; the client
+  // wrapper supplies videoId + candidateIds, so the full params object is a safe
+  // opts payload (duplicate keys carry identical values).
+  const runManualExport = useCallback(
+    async (candidates: Candidate[]) => {
+      setManualNote(null);
+      setManualError(null);
+      setTrayOpen(false);
+      setManualBusy(true);
+      try {
+        const params = buildExportParams(selectedId, candidates, sanitizeControls({}), '');
+        await client.shortmaker.export(selectedId, candidates.map(candidateId), params);
+        setManualNote(`Exported ${candidates.length} clip(s) from your ranges.`);
+        setTrayOpen(true);
+      } catch (err) {
+        setManualError(errText(err));
+      } finally {
+        setManualBusy(false);
+      }
+    },
+    [selectedId],
+  );
+
+  return (
+    <div className="make-shorts" aria-label="Make Shorts">
+      <TabBar tabs={SECTIONS} active={active} onSelect={setActive} />
+      <div className="make-shorts__panel">
+        {active === 'gallery' ? <Shorts onReexport={handleReexport} /> : null}
+        {active === 'batch' ? <Repurpose resumeId={resumeId} /> : null}
+        {active === 'make' ? (
+          <div className="make-shorts__make">
+            <label className="make-shorts__picker">
+              <span>Video</span>
+              <select
+                aria-label="Source video"
+                value={selectedId}
+                onChange={(e) => setSelectedId(e.target.value)}
+              >
+                <option value="">Select a video…</option>
+                {videos.map((v) => (
+                  <option key={v.id} value={v.id}>
+                    {v.title}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            {selectedId ? (
+              <>
+                <section className="make-shorts__ai">
+                  <h2 className="make-shorts__heading">AI moment-pick</h2>
+                  <ShortMaker videoId={selectedId} />
+                </section>
+
+                <section className="make-shorts__manual">
+                  <h2 className="make-shorts__heading">Manual intervals</h2>
+                  <ManualInterval onSubmit={(c) => void runManualExport(c)} busy={manualBusy} />
+                  {manualError ? (
+                    <p className="make-shorts__error" role="alert">
+                      {manualError}
+                    </p>
+                  ) : null}
+                  {manualNote ? (
+                    <p className="make-shorts__note" role="status">
+                      {manualNote}
+                    </p>
+                  ) : null}
+                  {trayOpen ? (
+                    <OutputTray
+                      state={tray}
+                      onChange={setTray}
+                      onSaveShort={handleSaveShort}
+                      onSaveSrt={handleSaveSrt}
+                    />
+                  ) : null}
+                </section>
+              </>
+            ) : (
+              <p className="make-shorts__hint">
+                Pick a video to make shorts — AI moment-pick or your own time ranges.
+              </p>
+            )}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+export default MakeShorts;

--- a/app/renderer/src/views/makeShorts.css
+++ b/app/renderer/src/views/makeShorts.css
@@ -1,0 +1,38 @@
+/* makeShorts.css — the Make Shorts section layout. */
+.make-shorts {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 0.5rem);
+}
+
+.make-shorts__make {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md, 1rem);
+}
+
+.make-shorts__picker {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs, 0.25rem);
+  max-width: 24rem;
+}
+
+.make-shorts__heading {
+  margin: 0 0 var(--space-xs, 0.25rem);
+  font-size: var(--text-base, 1rem);
+}
+
+.make-shorts__error {
+  margin: 0;
+  color: var(--color-error-fg, #b00020);
+}
+
+.make-shorts__note {
+  margin: 0;
+  color: var(--color-text-2, #555);
+}
+
+.make-shorts__hint {
+  color: var(--color-text-2, #555);
+}

--- a/sidecar/media_studio/features/director_op_engines.py
+++ b/sidecar/media_studio/features/director_op_engines.py
@@ -78,6 +78,7 @@ _ATEMPO_MAX = 2.0
 WIRED_KINDS: tuple[str, ...] = (
     "trim",
     "cut",
+    "join",
     "removeSilence",
     "caption",
     "removeFillers",
@@ -304,6 +305,86 @@ def make_cut_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None)
             project_copy,
             op,
             lambda i, o: _fillers.build_segment_cut_argv(i, o, keeps, dict(settings or {})),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def _require_clips(op: EditOp) -> list[str]:
+    """Return the join op's ``params['clips']`` — a non-empty list of path strings.
+
+    ``join``/concat appends one or more extra clips AFTER the COPY source, so it
+    needs at least one additional clip path. A missing / empty / non-string list
+    is a render error (per-op ``failed`` + rollback), never a silent no-op.
+    """
+    raw = op.params.get("clips")
+    if not isinstance(raw, (list, tuple)) or not raw:
+        raise DirectorEngineError(f"join op {op.id!r} requires a non-empty params['clips'] list")
+    clips = [p for p in raw if isinstance(p, str) and p.strip()]
+    if not clips:
+        raise DirectorEngineError(f"join op {op.id!r} params['clips'] has no usable path strings")
+    return clips
+
+
+def build_join_argv(
+    in_path: str,
+    clips: Sequence[str],
+    out_path: str,
+    settings: Mapping[str, Any] | None = None,
+) -> list[str]:
+    """argv that CONCATENATES ``in_path`` + each ``clips`` entry into one mp4.
+
+    Uses ffmpeg's ``concat`` filter (re-encode), which — unlike the concat
+    *demuxer* — tolerates inputs whose codecs/resolutions differ, the common case
+    when a user joins arbitrary clips. Every input contributes one video + one
+    audio stream to the ``concat=n=N:v=1:a=1`` graph, so the output duration is
+    the sum of the parts (the strongest non-no-op proof). Output is H.264/AAC.
+    """
+    inputs = [in_path, *clips]
+    n = len(inputs)
+    argv = [_ffmpeg.ffmpeg_path(settings), "-hide_banner", "-nostdin", "-y"]
+    for path in inputs:
+        argv += ["-i", path]
+    streams = "".join(f"[{idx}:v][{idx}:a]" for idx in range(n))
+    filtergraph = f"{streams}concat=n={n}:v=1:a=1[v][a]"
+    argv += [
+        "-filter_complex",
+        filtergraph,
+        "-map",
+        "[v]",
+        "-map",
+        "[a]",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "aac",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        out_path,
+    ]
+    return argv
+
+
+def make_join_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``join``: concatenate extra ``params['clips']`` after the source.
+
+    Forward renders a real concatenated mp4 (``build_join_argv`` — concat filter,
+    re-encode) and re-points the COPY at it; the recorded inverse restores the
+    pre-join reference (undo, no re-render). A whole-timeline op (no span).
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        clips = _require_clips(op)
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: build_join_argv(i, clips, o, settings),
             runner=runner,
             settings=settings,
         )
@@ -849,6 +930,7 @@ def build_engines(*, runner: RunFn | None = None, settings: Mapping[str, Any] | 
     return {
         "trim": make_trim_engine(runner=run, settings=settings),
         "cut": make_cut_engine(runner=run, settings=settings),
+        "join": make_join_engine(runner=run, settings=settings),
         "removeSilence": make_remove_silence_engine(runner=run, settings=settings),
         "caption": make_caption_engine(runner=run, settings=settings),
         "removeFillers": make_remove_fillers_engine(runner=run, settings=settings),
@@ -882,6 +964,7 @@ __all__ = [
     "DirectorEngineError",
     "build_drawtext_argv",
     "build_engines",
+    "build_join_argv",
     "build_reframe_argv",
     "build_retime_argv",
     "build_zoompan_argv",
@@ -889,6 +972,7 @@ __all__ = [
     "make_caption_engine",
     "make_cut_engine",
     "make_export_engine",
+    "make_join_engine",
     "make_lower_third_engine",
     "make_overlay_text_engine",
     "make_reframe_engine",

--- a/sidecar/media_studio/features/edit_validate.py
+++ b/sidecar/media_studio/features/edit_validate.py
@@ -97,13 +97,26 @@ def _params_str(params: Mapping[str, Any], key: str) -> str:
     return value if isinstance(value, str) else ""
 
 
+def _has_clips(params: Mapping[str, Any]) -> bool:
+    """True when ``params['clips']`` is a non-empty list with a usable path string."""
+    clips = params.get("clips")
+    if not isinstance(clips, (list, tuple)) or not clips:
+        return False
+    return any(isinstance(p, str) and p.strip() for p in clips)
+
+
 def _precondition_reason(op: EditOp, understanding: Understanding) -> StatusReason | None:
     """Per-kind precondition checks beyond span/track, or ``None`` if satisfied.
 
-    Currently the canonical-example precondition (DESIGN §3): ``regenScroll``
-    must reference a stitched panorama artifact via ``params["panorama"]``.
+    Two preconditions today:
+      * ``regenScroll`` must reference a stitched panorama (DESIGN §3 canonical
+        example) via ``params["panorama"]``;
+      * ``join`` must carry a non-empty ``params["clips"]`` list of paths to
+        concatenate (V1 IA §h E2 — a join with nothing to join is impossible).
     """
     if op.kind == "regenScroll" and understanding.require_regen_panorama and not _params_str(op.params, "panorama"):
+        return "precondition-unmet"
+    if op.kind == "join" and not _has_clips(op.params):
         return "precondition-unmet"
     return None
 

--- a/sidecar/media_studio/models/edit_plan.py
+++ b/sidecar/media_studio/models/edit_plan.py
@@ -40,6 +40,7 @@ from typing import Any, Literal, get_args
 OpKind = Literal[
     "trim",
     "cut",
+    "join",
     "removeSilence",
     "removeFillers",
     "reorder",

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -651,6 +651,62 @@ def test_export_inverse_restores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 
 
 # --------------------------------------------------------------------------- #
+# join / concat (V1 IA §h E2)
+# --------------------------------------------------------------------------- #
+def test_join_concatenates_clips_and_records_inverse(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+    extra = tmp_path / "b.mp4"
+    extra.write_bytes(b"\x00b")
+    inverse = build_engines(runner=runner)["join"](EditOp(id="j1", kind="join", params={"clips": [str(extra)]}), pc)
+    argv = runner.calls[0]
+    # Two inputs (source + one extra clip) feed the concat=n=2 filtergraph.
+    assert argv.count("-i") == 2
+    fg = argv[argv.index("-filter_complex") + 1]
+    assert "concat=n=2:v=1:a=1[v][a]" in fg
+    assert str(extra) in argv
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.params[RESTORE_KEY] == src_before
+
+
+def test_join_filtergraph_scales_with_clip_count() -> None:
+    argv = engines_mod.build_join_argv("/a.mp4", ["/b.mp4", "/c.mp4"], "/out.mp4")
+    fg = argv[argv.index("-filter_complex") + 1]
+    # Three inputs total -> concat=n=3 with three [i:v][i:a] stream pairs.
+    assert fg == "[0:v][0:a][1:v][1:a][2:v][2:a]concat=n=3:v=1:a=1[v][a]"
+    assert argv.count("-i") == 3
+
+
+def test_join_requires_a_non_empty_clips_list(tmp_path: Path) -> None:
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="non-empty params\\['clips'\\]"):
+        build_engines(runner=FakeRunner())["join"](EditOp(id="j", kind="join", params={}), pc)
+
+
+def test_join_rejects_clips_without_usable_paths(tmp_path: Path) -> None:
+    pc = _copy(tmp_path)
+    with pytest.raises(DirectorEngineError, match="no usable path"):
+        build_engines(runner=FakeRunner())["join"](EditOp(id="j", kind="join", params={"clips": ["", "  ", 7]}), pc)
+
+
+def test_join_inverse_restores(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_probe(monkeypatch)
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    original = pc.data["video"]["path"]
+    extra = tmp_path / "b.mp4"
+    extra.write_bytes(b"\x00b")
+    table = build_engines(runner=runner)
+    fwd = table["join"](EditOp(id="j", kind="join", params={"clips": [str(extra)]}), pc)
+    calls = len(runner.calls)
+    table["join"](fwd, pc)
+    assert pc.data["video"]["path"] == original
+    assert len(runner.calls) == calls  # restore-only on undo
+
+
+# --------------------------------------------------------------------------- #
 # dual-mode inverse for the new geometry/timing/overlay ops
 # --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(

--- a/sidecar/tests/test_edit_plan_dsl.py
+++ b/sidecar/tests/test_edit_plan_dsl.py
@@ -296,6 +296,30 @@ def test_export_op_exempt_from_span_requirement():
     assert out.ops[0].status == "planned"
 
 
+def test_join_is_a_known_op_kind():
+    # V1 IA §h E2: join/concat is a first-class op-kind (not the old gap).
+    assert "join" in OP_KINDS
+
+
+def test_drop_join_without_clips_precondition():
+    plan = _plan(ops=(_op("o1", "join", None),))
+    out = validate_and_reject(plan, understanding=_u())
+    assert out.ops[0].status_reason == "precondition-unmet"
+
+
+def test_drop_join_with_empty_clip_strings():
+    plan = _plan(ops=(_op("o1", "join", None, clips=["", "  "]),))
+    out = validate_and_reject(plan, understanding=_u())
+    assert out.ops[0].status_reason == "precondition-unmet"
+
+
+def test_keep_join_with_clips():
+    # join carries the extra clip paths to concatenate (no span required).
+    plan = _plan(ops=(_op("o1", "join", None, clips=["/b.mp4"]),))
+    out = validate_and_reject(plan, understanding=_u())
+    assert out.ops[0].status == "planned"
+
+
 def test_already_dropped_op_left_untouched():
     pre = _op("o1", "trim", (0, 1000)).with_status("dropped", "span-exceeds-clip")
     out = validate_and_reject(_plan(ops=(pre,)), understanding=_u())


### PR DESCRIPTION
## Phase-3 IA redesign (renderer restructure)

Implements the CONVERGED 5-section IA from `docs/V1-GRILL-DECISIONS.md` section (h).

### Sections (each function in exactly one home; nothing deleted)
- **Library** — sources & readiness (unchanged; opening a video now routes into Edit).
- **Make Shorts** (novice front door, new view) — AI moment-pick (ShortMaker) + **Manual interval** mode (ranges like `1:23 -> 4:10` -> inline `shortmaker.export` candidates) + Batch/Templates + the **single** produced-shorts gallery.
- **Edit** (new view) — per-video Workspace host: trim/cut/**join**/reorder/reframe/stabilize/cleanup + transcript & captions + audio. Empty state when no video open.
- **Director** — own section (NL editing), unchanged.
- **Settings** — Models & System / Providers & Keys / Storage / Health.

### Keystone — Output Tray
A single `OutputTray` component (defined **once**) rendered after a primary action: Caption? / Translate? (+ target language) / Reframe? / Burn-subs / Save clip/short/SRT. Wired into Make Shorts after a manual export; the consolidation vehicle that retires the cross-surface dups. (Per-panel legacy dup removal + caption-editor specifics are the next phase — clean seams left.)

### Other decisions implemented
- **JOIN/concat op (E2)** — added `join` to the EditPlan `OpKind` vocabulary + a real ffmpeg concat-filter engine (`build_join_argv`/`make_join_engine`, undo-restorable) + validate-and-reject precondition; renderer mirrors the kind + label.
- **Language = dropdown** — reusable `LanguageSelect` (curated list + Auto-detect with a quality-advice note); never free-typed.
- **Quality defaults ON (G-4)** — `removeFillers`/`autoZoom`/`silenceTrim`/`stabilize` start ON.

### Quality gates (both 100%)
- Sidecar: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` -> 100%, 4243 passed.
- Renderer: `npx vitest run --coverage` -> 100% stmts/branches/funcs/lines, 1752 passed.
- pre-commit (ruff/oxlint/biome/gitleaks), `tsc --noEmit`, basedpyright all clean.

### Notes
- TDD throughout (failing test first); no test-weakening / no istanbul-ignore.
- Nightly-only Playwright e2e (`e2e.yml`, not a PR gate) still references old tab labels (Create/Repurpose) and needs visual-baseline regen — follow-up.
