### PR TITLE
feat(v1): caption position/style editor + output options + preferences (P4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to Reframe — Media Studio are documented here.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added — V1 Caption editor + output (Phase 4)
+
+- **Caption position editor** — a draggable / resizable caption box with a live preview on a
+  real video frame, so the caption lands exactly where you place it on the export. The box is
+  stored normalised (resolution-independent) and converted to ASS alignment + margins by the
+  sidecar; quick Top / Center / Bottom band buttons re-seat it.
+- **Subtitle style templates** — a previewable swatch picker (karaoke + the OpusClip-style
+  premium looks), each rendered with its real palette / font / box / outline, previewed both
+  as swatches and live on the video before processing.
+- **Output options in the Output Tray** — subtitle delivery is now a real choice (burn-in /
+  soft track / separate file / none) honoured by the export pipeline (burn is no longer
+  hard-coded), alongside save cut / save short / save SRT for every combination.
+- **Preferences** — a Settings → Caption defaults area persists the default caption style,
+  position, subtitle delivery, and language; Make Shorts seeds new clips from it.
+
 ## [0.1.0] — 2026-06-25
 
 First public release: a plug-and-play, local-first Windows desktop video studio that turns

--- a/app/renderer/src/components/CaptionBox.test.tsx
+++ b/app/renderer/src/components/CaptionBox.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CaptionBox } from './CaptionBox';
+import {
+  DEFAULT_CAPTION_BOX,
+  moveBox,
+  resizeBox,
+  type CaptionBox as Box,
+} from '../lib/captionPosition';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+/** Dispatch a pointer event (jsdom has no PointerEvent ctor — use MouseEvent). */
+function pointer(el: Element, type: string, x: number, y: number, pointerId = 7): void {
+  const ev = new MouseEvent(type, { bubbles: true, clientX: x, clientY: y });
+  Object.defineProperty(ev, 'pointerId', { value: pointerId });
+  act(() => {
+    el.dispatchEvent(ev);
+  });
+}
+
+/** Stub the frame's measured size so fractional deltas are deterministic. */
+function stubFrame(container: HTMLElement, width: number, height: number): void {
+  const frame = container.querySelector('.caption-box-frame') as HTMLElement;
+  frame.getBoundingClientRect = () =>
+    ({ width, height, top: 0, left: 0, right: width, bottom: height, x: 0, y: 0 }) as DOMRect;
+}
+
+describe('<CaptionBox />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+  const start: Box = { x: 0.2, y: 0.2, w: 0.4, h: 0.4 };
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<React.ComponentProps<typeof CaptionBox>> = {}): {
+    onChange: ReturnType<typeof vi.fn>;
+  } {
+    const onChange = props.onChange ?? vi.fn();
+    act(() => root.render(<CaptionBox box={props.box ?? start} {...props} onChange={onChange} />));
+    return { onChange: onChange as ReturnType<typeof vi.fn> };
+  }
+
+  const box = (): HTMLElement =>
+    container.querySelector('[data-testid="caption-box"]') as HTMLElement;
+  const handle = (h: string): HTMLElement =>
+    container.querySelector(`[data-handle="${h}"]`) as HTMLElement;
+
+  it('renders the box + all eight resize handles', () => {
+    render();
+    expect(box()).toBeTruthy();
+    expect(container.querySelectorAll('.caption-box__handle')).toHaveLength(8);
+    expect(container.querySelector('.caption-box-frame')?.getAttribute('aria-label')).toBe(
+      'Caption position',
+    );
+  });
+
+  it('renders a custom label and children', () => {
+    act(() =>
+      root.render(
+        <CaptionBox box={start} onChange={vi.fn()} label="Where">
+          <span className="sample">Hi</span>
+        </CaptionBox>,
+      ),
+    );
+    expect(container.querySelector('.caption-box-frame')?.getAttribute('aria-label')).toBe('Where');
+    expect(container.querySelector('.sample')?.textContent).toBe('Hi');
+  });
+
+  it('drags the body to move the box', () => {
+    const { onChange } = render();
+    stubFrame(container, 100, 100);
+    pointer(box(), 'pointerdown', 0, 0);
+    pointer(box(), 'pointermove', 50, 0); // +0.5 x
+    expect(onChange).toHaveBeenLastCalledWith(moveBox(start, 0.5, 0));
+    pointer(box(), 'pointerup', 50, 0);
+  });
+
+  it('drags a handle to resize the box', () => {
+    const { onChange } = render();
+    stubFrame(container, 100, 100);
+    pointer(handle('e'), 'pointerdown', 0, 0);
+    pointer(box(), 'pointermove', 10, 0); // +0.1 width
+    expect(onChange).toHaveBeenLastCalledWith(resizeBox(start, 'e', 0.1, 0));
+  });
+
+  it('ignores pointer move when no drag is active', () => {
+    const { onChange } = render();
+    stubFrame(container, 100, 100);
+    pointer(box(), 'pointermove', 50, 50);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('treats an unmeasured frame (zero size) as no movement', () => {
+    const { onChange } = render();
+    stubFrame(container, 0, 0);
+    pointer(box(), 'pointerdown', 0, 0);
+    pointer(box(), 'pointermove', 50, 50);
+    expect(onChange).toHaveBeenLastCalledWith(moveBox(start, 0, 0));
+  });
+
+  it('uses pointer capture when the element supports it', () => {
+    render();
+    stubFrame(container, 100, 100);
+    const capture = vi.fn();
+    const release = vi.fn();
+    box().setPointerCapture = capture;
+    box().releasePointerCapture = release;
+    pointer(box(), 'pointerdown', 0, 0);
+    expect(capture).toHaveBeenCalledWith(7);
+    pointer(box(), 'pointerup', 0, 0);
+    expect(release).toHaveBeenCalledWith(7);
+  });
+
+  it('does not interact when disabled (no handles, no onChange)', () => {
+    const { onChange } = render({ disabled: true });
+    expect(container.querySelectorAll('.caption-box__handle')).toHaveLength(0);
+    expect(box().className).toContain('is-readonly');
+    stubFrame(container, 100, 100);
+    pointer(box(), 'pointerdown', 0, 0);
+    pointer(box(), 'pointermove', 50, 0);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('ignores a pointer up with no active drag', () => {
+    render();
+    // pointerup with nothing started — exercises the early return.
+    expect(() => pointer(box(), 'pointerup', 0, 0)).not.toThrow();
+  });
+
+  it('defaults to the shared default box geometry when seeded with it', () => {
+    const { onChange } = render({ box: DEFAULT_CAPTION_BOX });
+    stubFrame(container, 200, 200);
+    pointer(box(), 'pointerdown', 0, 0);
+    pointer(box(), 'pointermove', 0, 20); // +0.1 y
+    expect(onChange).toHaveBeenLastCalledWith(moveBox(DEFAULT_CAPTION_BOX, 0, 0.1));
+  });
+});

--- a/app/renderer/src/components/CaptionBox.tsx
+++ b/app/renderer/src/components/CaptionBox.tsx
@@ -1,0 +1,131 @@
+// CaptionBox.tsx — the draggable / resizable caption region (P4 §4 position editor).
+//
+// A controlled overlay placed inside a relatively-positioned preview frame (over
+// the Player). The user drags the box body to MOVE the caption region and drags
+// a handle to RESIZE it; the geometry is normalised (fractions of the frame) so
+// it maps 1:1 onto the 1080x1920 export. All math is the pure
+// `lib/captionPosition` helpers — this component only converts pointer pixels to
+// fractional deltas against the measured frame and forwards onChange.
+//
+// `children` render INSIDE the box (the live caption sample), so what the user
+// drags is exactly what the caption will look like on the video.
+import React, { useRef } from 'react';
+import {
+  type CaptionBox as Box,
+  type ResizeHandle,
+  RESIZE_HANDLES,
+  boxToCss,
+  moveBox,
+  resizeBox,
+} from '../lib/captionPosition';
+import './captionBox.css';
+
+export interface CaptionBoxProps {
+  /** The normalised caption box (parent-owned). */
+  box: Box;
+  /** Called with the next box on every drag/resize step. */
+  onChange: (box: Box) => void;
+  /** The live caption sample rendered inside the box. */
+  children?: React.ReactNode;
+  /** Read-only preview (no drag/resize) when true. */
+  disabled?: boolean;
+  /** Accessible label for the editor region. */
+  label?: string;
+}
+
+/** Active drag state (null when idle). `handle` null = move the whole box. */
+interface DragState {
+  handle: ResizeHandle | null;
+  startX: number;
+  startY: number;
+  startBox: Box;
+  /** The element that captured the pointer (released on pointer-up). */
+  el: Element;
+  pointerId: number;
+}
+
+/** Fractional delta of a pointer move against the frame size (0 when unmeasured). */
+function frac(deltaPx: number, sizePx: number): number {
+  return sizePx > 0 ? deltaPx / sizePx : 0;
+}
+
+export function CaptionBox({
+  box,
+  onChange,
+  children,
+  disabled = false,
+  label = 'Caption position',
+}: CaptionBoxProps): React.ReactElement {
+  const frameRef = useRef<HTMLDivElement | null>(null);
+  const drag = useRef<DragState | null>(null);
+
+  const begin =
+    (handle: ResizeHandle | null) =>
+    (e: React.PointerEvent): void => {
+      if (disabled) return;
+      e.preventDefault();
+      e.stopPropagation();
+      drag.current = {
+        handle,
+        startX: e.clientX,
+        startY: e.clientY,
+        startBox: box,
+        el: e.currentTarget,
+        pointerId: e.pointerId,
+      };
+      // setPointerCapture is absent in jsdom — guard so tests + real Chromium both run.
+      e.currentTarget.setPointerCapture?.(e.pointerId);
+    };
+
+  const onPointerMove = (e: React.PointerEvent): void => {
+    const d = drag.current;
+    if (!d) return;
+    const frame = frameRef.current;
+    // The frame is the element receiving this move, so it is always mounted here.
+    /* v8 ignore next -- runtime-only guard; frameRef is set whenever a drag is active */
+    if (!frame) return;
+    const rect = frame.getBoundingClientRect();
+    const dx = frac(e.clientX - d.startX, rect.width);
+    const dy = frac(e.clientY - d.startY, rect.height);
+    onChange(d.handle ? resizeBox(d.startBox, d.handle, dx, dy) : moveBox(d.startBox, dx, dy));
+  };
+
+  const onPointerUp = (): void => {
+    const d = drag.current;
+    if (!d) return;
+    drag.current = null;
+    d.el.releasePointerCapture?.(d.pointerId);
+  };
+
+  return (
+    <div
+      className="caption-box-frame"
+      ref={frameRef}
+      role="group"
+      aria-label={label}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+    >
+      <div
+        className={`caption-box${disabled ? ' is-readonly' : ''}`}
+        style={boxToCss(box)}
+        data-testid="caption-box"
+        onPointerDown={begin(null)}
+      >
+        <div className="caption-box__content">{children}</div>
+        {!disabled &&
+          RESIZE_HANDLES.map((h) => (
+            <span
+              key={h}
+              className={`caption-box__handle caption-box__handle--${h}`}
+              data-handle={h}
+              aria-label={`Resize ${h}`}
+              onPointerDown={begin(h)}
+            />
+          ))}
+      </div>
+    </div>
+  );
+}
+
+export default CaptionBox;

--- a/app/renderer/src/components/CaptionDesigner.test.tsx
+++ b/app/renderer/src/components/CaptionDesigner.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CaptionDesigner } from './CaptionDesigner';
+import { DEFAULT_CAPTION_DESIGN, type CaptionDesign } from '../lib/captionDesign';
+import { bandBox, moveBox } from '../lib/captionPosition';
+import type { Cue } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const WIN = { start: 10, end: 20 };
+const CUES: Cue[] = [
+  { index: 0, start: 11, end: 12, text: 'Hello' },
+  { index: 1, start: 12, end: 13, text: 'world' },
+];
+
+/** Drive the Player's onTimeUpdate by setting the <video> time + firing timeupdate. */
+function tick(container: HTMLElement, t: number): void {
+  const video = container.querySelector('video') as HTMLVideoElement;
+  Object.defineProperty(video, 'currentTime', { value: t, configurable: true });
+  act(() => video.dispatchEvent(new Event('timeupdate')));
+}
+
+describe('<CaptionDesigner />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<React.ComponentProps<typeof CaptionDesigner>> = {}): {
+    onChange: ReturnType<typeof vi.fn>;
+    design: CaptionDesign;
+  } {
+    const onChange = props.onChange ?? vi.fn();
+    const design = props.design ?? DEFAULT_CAPTION_DESIGN;
+    act(() =>
+      root.render(
+        <CaptionDesigner
+          videoId="v1"
+          window={WIN}
+          cues={CUES}
+          {...props}
+          design={design}
+          onChange={onChange}
+        />,
+      ),
+    );
+    return { onChange: onChange as ReturnType<typeof vi.fn>, design };
+  }
+
+  it('mounts the player, position box, band buttons, and style picker', () => {
+    render();
+    expect(container.querySelector('video')).toBeTruthy();
+    expect(container.querySelector('[data-testid="caption-box"]')).toBeTruthy();
+    expect(container.querySelectorAll('.caption-designer__band')).toHaveLength(3);
+    expect(container.querySelector('.caption-style-picker')).toBeTruthy();
+  });
+
+  it('shows a placeholder before any caption word is active', () => {
+    render();
+    expect(container.querySelector('.caption-designer__hint')?.textContent).toBe('Caption preview');
+  });
+
+  it('renders the live word-highlighted line at the current time', () => {
+    render({ design: { style: 'karaoke', box: DEFAULT_CAPTION_DESIGN.box } });
+    tick(container, 11.5); // inside cue 0 "Hello"
+    const line = container.querySelector('.caption-designer__line');
+    expect(line?.textContent).toContain('Hello');
+    // The active word carries the template's active background.
+    const spans = line?.querySelectorAll('span');
+    expect(spans && spans.length).toBeGreaterThan(0);
+  });
+
+  it('uppercases the live line for an uppercase template', () => {
+    render({ design: { style: 'bold', box: DEFAULT_CAPTION_DESIGN.box } });
+    tick(container, 11.5);
+    const line = container.querySelector('.caption-designer__line') as HTMLElement;
+    expect(line.style.textTransform).toBe('uppercase');
+  });
+
+  it('renders the hook title slot when provided', () => {
+    render({ hookTitle: '  Big hook  ' });
+    expect(container.querySelector('.caption-designer__hook')?.textContent).toBe('Big hook');
+  });
+
+  it('shows "No captions" for the none style', () => {
+    render({ design: { style: 'none', box: DEFAULT_CAPTION_DESIGN.box } });
+    tick(container, 11.5);
+    expect(container.querySelector('.caption-designer__hint')?.textContent).toBe('No captions');
+  });
+
+  it('changes the style via the picker', () => {
+    const { onChange, design } = render();
+    act(() => (container.querySelector('[data-style="neon"]') as HTMLButtonElement).click());
+    expect(onChange).toHaveBeenCalledWith({ ...design, style: 'neon' });
+  });
+
+  it('re-seats the box to a band via the quick buttons', () => {
+    const { onChange, design } = render();
+    const topBtn = [...container.querySelectorAll('.caption-designer__band')].find(
+      (b) => b.textContent === 'Top',
+    ) as HTMLButtonElement;
+    act(() => topBtn.click());
+    expect(onChange).toHaveBeenCalledWith({ ...design, box: bandBox('top') });
+  });
+
+  it('moves the caption box by dragging it', () => {
+    const { onChange, design } = render();
+    const frame = container.querySelector('.caption-box-frame') as HTMLElement;
+    frame.getBoundingClientRect = () =>
+      ({
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+      }) as DOMRect;
+    const boxEl = container.querySelector('[data-testid="caption-box"]') as HTMLElement;
+    const fire = (type: string, x: number, y: number): void => {
+      const ev = new MouseEvent(type, { bubbles: true, clientX: x, clientY: y });
+      Object.defineProperty(ev, 'pointerId', { value: 1 });
+      act(() => boxEl.dispatchEvent(ev));
+    };
+    fire('pointerdown', 0, 0);
+    fire('pointermove', 10, 0); // +0.1 x
+    expect(onChange).toHaveBeenLastCalledWith({ ...design, box: moveBox(design.box, 0.1, 0) });
+  });
+
+  it('marks the active band button from the box position', () => {
+    render({ design: { style: 'libass', box: bandBox('center') } });
+    const centerBtn = [...container.querySelectorAll('.caption-designer__band')].find(
+      (b) => b.textContent === 'Center',
+    ) as HTMLButtonElement;
+    expect(centerBtn.getAttribute('aria-pressed')).toBe('true');
+  });
+});

--- a/app/renderer/src/components/CaptionDesigner.tsx
+++ b/app/renderer/src/components/CaptionDesigner.tsx
@@ -1,0 +1,138 @@
+// CaptionDesigner.tsx — the caption EDITOR with live preview on a real frame (P4 §4).
+//
+// Brings the position editor (CaptionBox) and the style picker
+// (CaptionStylePicker) together over a real video frame (Player), so the user
+// designs exactly how captions look AND where they sit before processing:
+//   * the Player plays the candidate's window (a real frame, not a mock);
+//   * the CaptionBox draws a draggable/resizable caption region over it, with a
+//     LIVE word-highlighted sample (the same activeLine/word-colour math the
+//     export overlay uses) rendered INSIDE the box at the chosen style;
+//   * quick band buttons (Top/Center/Bottom) re-seat the box to a template band;
+//   * the CaptionStylePicker swaps the look, previewed both as swatches and on
+//     the actual video.
+//
+// Controlled: the parent owns the CaptionDesign and gets onChange.
+import React, { useState } from 'react';
+import { Player, type PlayerWindow } from './Player';
+import { CaptionBox } from './CaptionBox';
+import { CaptionStylePicker } from './CaptionStylePicker';
+import { activeLine, wordColor } from './CaptionOverlay';
+import { captionVisualFor, isNoCaption } from '../lib/captionTemplates';
+import { type CaptionBand, bandBox, boxBand } from '../lib/captionPosition';
+import type { CaptionDesign } from '../lib/captionDesign';
+import type { CaptionStyleOption } from '../features/shortMakerLogic';
+import type { Cue } from '../lib/rpc';
+import './captionDesigner.css';
+
+export interface CaptionDesignerProps {
+  /** Library video id for the preview frame. */
+  videoId?: string;
+  /** Direct src override (wins over videoId). */
+  src?: string;
+  /** The candidate's source-absolute preview window. */
+  window: PlayerWindow;
+  /** Word-level caption cues (source-absolute seconds). */
+  cues: Cue[];
+  /** The current caption design (parent-owned). */
+  design: CaptionDesign;
+  /** Called with the next design on style/position change. */
+  onChange: (design: CaptionDesign) => void;
+  /** Optional hook headline shown above the caption sample. */
+  hookTitle?: string;
+  /** Override the style catalog (defaults to the full set). */
+  styles?: readonly CaptionStyleOption[];
+}
+
+const BANDS: readonly { id: CaptionBand; label: string }[] = [
+  { id: 'top', label: 'Top' },
+  { id: 'center', label: 'Center' },
+  { id: 'bottom', label: 'Bottom' },
+];
+
+export function CaptionDesigner({
+  videoId,
+  src,
+  window: win,
+  cues,
+  design,
+  onChange,
+  hookTitle,
+  styles,
+}: CaptionDesignerProps): React.ReactElement {
+  const [currentTime, setCurrentTime] = useState(win.start);
+
+  const visual = captionVisualFor(design.style);
+  const none = isNoCaption(design.style);
+  const words = none ? [] : activeLine(cues, win, currentTime - win.start);
+  const band = boxBand(design.box);
+  const title = (hookTitle ?? '').trim();
+
+  return (
+    <div className="caption-designer" aria-label="Caption editor">
+      <div className="caption-designer__phone">
+        <Player videoId={videoId} src={src} window={win} controls onTimeUpdate={setCurrentTime} />
+        <CaptionBox box={design.box} onChange={(box) => onChange({ ...design, box })}>
+          <div className="caption-designer__sample" data-style={design.style}>
+            {title && (
+              <div
+                className="caption-designer__hook"
+                style={{ fontFamily: visual.fontFamily, color: visual.textColor }}
+              >
+                {title}
+              </div>
+            )}
+            {none ? (
+              <span className="caption-designer__hint">No captions</span>
+            ) : words.length > 0 ? (
+              <span
+                className="caption-designer__line"
+                style={{
+                  fontFamily: visual.fontFamily,
+                  textTransform: visual.uppercase ? 'uppercase' : 'none',
+                }}
+              >
+                {words.map((w, i) => (
+                  <span
+                    key={`${w.text}-${w.start}-${i}`}
+                    style={{
+                      color: wordColor(w, visual),
+                      backgroundColor: w.active ? visual.activeBackground : 'transparent',
+                    }}
+                  >
+                    {w.text}
+                  </span>
+                ))}
+              </span>
+            ) : (
+              <span className="caption-designer__hint" style={{ fontFamily: visual.fontFamily }}>
+                Caption preview
+              </span>
+            )}
+          </div>
+        </CaptionBox>
+      </div>
+
+      <div className="caption-designer__bands" role="group" aria-label="Caption band">
+        {BANDS.map((b) => (
+          <button
+            key={b.id}
+            type="button"
+            className={`caption-designer__band${band === b.id ? ' is-active' : ''}`}
+            aria-pressed={band === b.id}
+            onClick={() => onChange({ ...design, box: bandBox(b.id) })}
+          >
+            {b.label}
+          </button>
+        ))}
+      </div>
+
+      <CaptionStylePicker
+        value={design.style}
+        styles={styles}
+        onChange={(style) => onChange({ ...design, style })}
+      />
+    </div>
+  );
+}
+
+export default CaptionDesigner;

--- a/app/renderer/src/components/CaptionPreferences.test.tsx
+++ b/app/renderer/src/components/CaptionPreferences.test.tsx
@@ -1,0 +1,220 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CaptionPreferences, type SettingsBridge } from './CaptionPreferences';
+import { PREFERENCE_KEYS } from '../lib/captionPreferences';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+interface Deferred<T> {
+  promise: Promise<T>;
+  resolve: (v: T) => void;
+  reject: (e: unknown) => void;
+}
+function deferred<T>(): Deferred<T> {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = async (): Promise<void> => {
+  await act(async () => {
+    await Promise.resolve();
+  });
+};
+
+describe('<CaptionPreferences />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function mountWith(rpc: SettingsBridge): void {
+    act(() => root.render(<CaptionPreferences rpc={rpc} />));
+  }
+
+  const swatch = (id: string): HTMLButtonElement =>
+    container.querySelector(`[data-style="${id}"]`) as HTMLButtonElement;
+  const subSelect = (): HTMLSelectElement =>
+    container.querySelector('select[aria-label="Default subtitle delivery"]') as HTMLSelectElement;
+  const saveBtn = (): HTMLButtonElement =>
+    [...container.querySelectorAll('button')].find((b) =>
+      (b.textContent ?? '').startsWith('Sav'),
+    ) as HTMLButtonElement;
+
+  it('loads + reflects persisted preferences', async () => {
+    const rpc: SettingsBridge = {
+      get: vi.fn().mockResolvedValue({
+        [PREFERENCE_KEYS.style]: 'hormozi',
+        [PREFERENCE_KEYS.subtitleMode]: 'sidecar',
+        [PREFERENCE_KEYS.language]: 'pt',
+      }),
+      set: vi.fn(),
+    };
+    mountWith(rpc);
+    await flush();
+    expect(swatch('hormozi').getAttribute('aria-pressed')).toBe('true');
+    expect(subSelect().value).toBe('sidecar');
+  });
+
+  it('shows an error when loading fails', async () => {
+    const rpc: SettingsBridge = {
+      get: vi.fn().mockRejectedValue(new Error('boom')),
+      set: vi.fn(),
+    };
+    mountWith(rpc);
+    await flush();
+    expect(container.querySelector('.caption-prefs__error')?.textContent).toContain('boom');
+  });
+
+  it('saves the current preferences (and shows the in-flight state)', async () => {
+    const d = deferred<Record<string, unknown>>();
+    const set = vi.fn().mockReturnValue(d.promise);
+    const rpc: SettingsBridge = { get: vi.fn().mockResolvedValue({}), set };
+    mountWith(rpc);
+    await flush();
+    // Change the style first so the save carries it.
+    act(() => swatch('neon').click());
+    act(() => saveBtn().click());
+    // While the set promise is pending the button is busy.
+    expect(saveBtn().textContent).toBe('Saving…');
+    expect(saveBtn().disabled).toBe(true);
+    await act(async () => {
+      d.resolve({});
+      await Promise.resolve();
+    });
+    expect(set).toHaveBeenCalledWith(expect.objectContaining({ [PREFERENCE_KEYS.style]: 'neon' }));
+    expect(container.querySelector('.caption-prefs__status')?.textContent).toBe(
+      'Preferences saved.',
+    );
+  });
+
+  it('shows an error when saving fails (non-Error rejection)', async () => {
+    const rpc: SettingsBridge = {
+      get: vi.fn().mockResolvedValue({}),
+      // A plain-string rejection exercises the non-Error errText path.
+      set: vi.fn().mockRejectedValue('nope-string'),
+    };
+    mountWith(rpc);
+    await flush();
+    await act(async () => {
+      saveBtn().click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.caption-prefs__error')?.textContent).toContain('nope-string');
+  });
+
+  it('changes subtitle mode + language', async () => {
+    const rpc: SettingsBridge = { get: vi.fn().mockResolvedValue({}), set: vi.fn() };
+    mountWith(rpc);
+    await flush();
+    act(() => {
+      subSelect().value = 'softmux';
+      subSelect().dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(subSelect().value).toBe('softmux');
+    const lang = container.querySelector(
+      'select[aria-label="Default language"]',
+    ) as HTMLSelectElement;
+    act(() => {
+      lang.value = 'fr';
+      lang.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(lang.value).toBe('fr');
+  });
+
+  it('shows a "No captions" sample for the none style', async () => {
+    const rpc: SettingsBridge = {
+      get: vi.fn().mockResolvedValue({ [PREFERENCE_KEYS.style]: 'none' }),
+      set: vi.fn(),
+    };
+    mountWith(rpc);
+    await flush();
+    expect(container.querySelector('.caption-prefs__sample')?.textContent).toBe('No captions');
+  });
+
+  it('moves the default position box by dragging it', async () => {
+    const set = vi.fn().mockResolvedValue({});
+    const rpc: SettingsBridge = { get: vi.fn().mockResolvedValue({}), set };
+    mountWith(rpc);
+    await flush();
+    const frame = container.querySelector('.caption-box-frame') as HTMLElement;
+    frame.getBoundingClientRect = () =>
+      ({
+        width: 100,
+        height: 100,
+        top: 0,
+        left: 0,
+        right: 100,
+        bottom: 100,
+        x: 0,
+        y: 0,
+      }) as DOMRect;
+    const boxEl = container.querySelector('[data-testid="caption-box"]') as HTMLElement;
+    const fire = (type: string, x: number, y: number): void => {
+      const ev = new MouseEvent(type, { bubbles: true, clientX: x, clientY: y });
+      Object.defineProperty(ev, 'pointerId', { value: 1 });
+      act(() => boxEl.dispatchEvent(ev));
+    };
+    fire('pointerdown', 0, 0);
+    fire('pointermove', 0, 10); // move down 0.1
+    await act(async () => {
+      saveBtn().click();
+      await Promise.resolve();
+    });
+    const savedBox = set.mock.calls[0][0][PREFERENCE_KEYS.box] as { y: number };
+    expect(savedBox.y).toBeGreaterThan(0.76);
+  });
+
+  it('ignores a late load resolve after unmount', async () => {
+    const d = deferred<Record<string, unknown>>();
+    const rpc: SettingsBridge = { get: () => d.promise, set: vi.fn() };
+    mountWith(rpc);
+    act(() => root.unmount());
+    await act(async () => {
+      d.resolve({ [PREFERENCE_KEYS.style]: 'neon' });
+      await Promise.resolve();
+    });
+    // No throw / no swatch (unmounted) — the alive guard skipped setState.
+    expect(container.querySelector('[data-style="neon"]')).toBeNull();
+  });
+
+  it('ignores a late load error after unmount', async () => {
+    const d = deferred<Record<string, unknown>>();
+    const rpc: SettingsBridge = { get: () => d.promise, set: vi.fn() };
+    mountWith(rpc);
+    act(() => root.unmount());
+    await act(async () => {
+      d.reject(new Error('late'));
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.caption-prefs__error')).toBeNull();
+  });
+
+  it('defaults to the live client settings rpc when none injected', async () => {
+    // Render WITHOUT an rpc prop -> uses client.settings, which reads window.api.
+    const win = globalThis as unknown as { window?: { api?: unknown } };
+    const prev = win.window?.api;
+    win.window = win.window ?? {};
+    (win.window as { api?: unknown }).api = {
+      rpc: vi.fn().mockResolvedValue({ [PREFERENCE_KEYS.style]: 'bold' }),
+    };
+    act(() => root.render(<CaptionPreferences />));
+    await flush();
+    expect(swatch('bold').getAttribute('aria-pressed')).toBe('true');
+    (win.window as { api?: unknown }).api = prev;
+  });
+});

--- a/app/renderer/src/components/CaptionPreferences.tsx
+++ b/app/renderer/src/components/CaptionPreferences.tsx
@@ -1,0 +1,159 @@
+// CaptionPreferences.tsx — the Preferences/Settings area for caption + output
+// DEFAULTS (P4 §4). Set the caption style + position, subtitle delivery, and
+// language every new short starts from; persisted to the settings store so the
+// Make Shorts flow + Output Tray seed from one place.
+//
+// The settings RPC is injected (defaults to the live client) so the panel is
+// unit-testable without a backend. The position box edits over a static preview
+// frame (no Player needed in Settings); the live video preview lives in the
+// Make Shorts caption editor.
+import React, { useCallback, useEffect, useState } from 'react';
+import { CaptionStylePicker } from './CaptionStylePicker';
+import { CaptionBox } from './CaptionBox';
+import { LanguageSelect } from './LanguageSelect';
+import { captionVisualFor, isNoCaption } from '../lib/captionTemplates';
+import {
+  type CaptionPreferences as Prefs,
+  DEFAULT_PREFERENCES,
+  preferencesPatch,
+  readPreferences,
+} from '../lib/captionPreferences';
+import { SUBTITLE_MODES, SUBTITLE_MODE_META, type SubtitleMode } from '../lib/outputOptions';
+import { client } from '../lib/rpc';
+import './captionPreferences.css';
+
+/** The settings store slice this panel needs (injectable for tests). */
+export interface SettingsBridge {
+  get: () => Promise<Record<string, unknown>>;
+  set: (values: Record<string, unknown>) => Promise<Record<string, unknown>>;
+}
+
+export interface CaptionPreferencesProps {
+  /** The settings RPC (defaults to the live client). */
+  rpc?: SettingsBridge;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export function CaptionPreferences({
+  rpc = client.settings,
+}: CaptionPreferencesProps): React.ReactElement {
+  const [prefs, setPrefs] = useState<Prefs>(DEFAULT_PREFERENCES);
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState('');
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    let alive = true;
+    rpc
+      .get()
+      .then((raw) => {
+        if (alive) setPrefs(readPreferences(raw));
+      })
+      .catch((err) => {
+        if (alive) setError(`Could not load preferences: ${errText(err)}`);
+      });
+    return () => {
+      alive = false;
+    };
+  }, [rpc]);
+
+  const save = useCallback(async () => {
+    setSaving(true);
+    setStatus('');
+    setError('');
+    try {
+      await rpc.set(preferencesPatch(prefs));
+      setStatus('Preferences saved.');
+    } catch (err) {
+      setError(`Could not save preferences: ${errText(err)}`);
+    } finally {
+      setSaving(false);
+    }
+  }, [rpc, prefs]);
+
+  const visual = captionVisualFor(prefs.design.style);
+
+  return (
+    <section className="caption-prefs panel" aria-label="Caption defaults">
+      <h2 className="caption-prefs__title">Caption &amp; output defaults</h2>
+      <p className="caption-prefs__hint">
+        These defaults seed every new short — you can still tweak each clip in Make Shorts.
+      </p>
+
+      <div className="caption-prefs__group">
+        <h3>Default position</h3>
+        <div className="caption-prefs__frame">
+          <CaptionBox
+            box={prefs.design.box}
+            onChange={(box) => setPrefs((p) => ({ ...p, design: { ...p.design, box } }))}
+          >
+            <span
+              className="caption-prefs__sample"
+              style={{ color: visual.activeColor, fontFamily: visual.fontFamily }}
+            >
+              {isNoCaption(prefs.design.style) ? 'No captions' : 'Aa'}
+            </span>
+          </CaptionBox>
+        </div>
+      </div>
+
+      <div className="caption-prefs__group">
+        <h3>Default style</h3>
+        <CaptionStylePicker
+          value={prefs.design.style}
+          onChange={(style) => setPrefs((p) => ({ ...p, design: { ...p.design, style } }))}
+        />
+      </div>
+
+      <div className="caption-prefs__group caption-prefs__row">
+        <label htmlFor="prefs-subtitle-mode">Subtitles</label>
+        <select
+          id="prefs-subtitle-mode"
+          aria-label="Default subtitle delivery"
+          value={prefs.subtitleMode}
+          onChange={(e) =>
+            setPrefs((p) => ({ ...p, subtitleMode: e.target.value as SubtitleMode }))
+          }
+        >
+          {SUBTITLE_MODES.map((mode) => (
+            <option key={mode} value={mode}>
+              {SUBTITLE_MODE_META[mode].label}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="caption-prefs__group caption-prefs__row">
+        <span>Default language</span>
+        <LanguageSelect
+          value={prefs.language}
+          includeAuto={false}
+          label="Default language"
+          onChange={(code) => setPrefs((p) => ({ ...p, language: code }))}
+        />
+      </div>
+
+      <div className="caption-prefs__actions">
+        <button type="button" onClick={() => void save()} disabled={saving}>
+          {saving ? 'Saving…' : 'Save defaults'}
+        </button>
+      </div>
+
+      {status ? (
+        <p className="caption-prefs__status" role="status">
+          {status}
+        </p>
+      ) : null}
+      {error ? (
+        <p className="caption-prefs__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+    </section>
+  );
+}
+
+export default CaptionPreferences;

--- a/app/renderer/src/components/CaptionStylePicker.test.tsx
+++ b/app/renderer/src/components/CaptionStylePicker.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CaptionStylePicker, sampleStyle } from './CaptionStylePicker';
+import { captionVisualFor } from '../lib/captionTemplates';
+import { CAPTION_STYLES } from '../features/shortMakerLogic';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('sampleStyle', () => {
+  it('applies box background + outline stroke for a boxed/outlined template', () => {
+    const hormozi = sampleStyle(captionVisualFor('hormozi')); // box: true
+    expect(hormozi.backgroundColor).not.toBe('transparent');
+    const neon = sampleStyle(captionVisualFor('neon')); // outline: true
+    expect(neon.WebkitTextStroke).toContain('0.6px');
+    expect(neon.textShadow).toBe('none');
+  });
+
+  it('uses transparent background + shadow for a plain template', () => {
+    const clean = sampleStyle(captionVisualFor('clean')); // box:false, outline:false
+    expect(clean.backgroundColor).toBe('transparent');
+    expect(clean.WebkitTextStroke).toBeUndefined();
+    expect(clean.textShadow).toContain('0 1px 2px');
+    expect(clean.textTransform).toBe('none');
+  });
+
+  it('uppercases an uppercase template', () => {
+    expect(sampleStyle(captionVisualFor('bold')).textTransform).toBe('uppercase');
+  });
+});
+
+describe('<CaptionStylePicker />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function render(props: Partial<React.ComponentProps<typeof CaptionStylePicker>> = {}): {
+    onChange: ReturnType<typeof vi.fn>;
+  } {
+    const onChange = props.onChange ?? vi.fn();
+    act(() =>
+      root.render(
+        <CaptionStylePicker value={props.value ?? 'karaoke'} {...props} onChange={onChange} />,
+      ),
+    );
+    return { onChange: onChange as ReturnType<typeof vi.fn> };
+  }
+
+  const swatch = (id: string): HTMLButtonElement =>
+    container.querySelector(`[data-style="${id}"]`) as HTMLButtonElement;
+
+  it('renders a swatch for every catalog style', () => {
+    render();
+    expect(container.querySelectorAll('.caption-style-swatch')).toHaveLength(CAPTION_STYLES.length);
+    expect(container.querySelector('.caption-style-picker')?.getAttribute('aria-label')).toBe(
+      'Caption style',
+    );
+  });
+
+  it('marks the selected style as pressed', () => {
+    render({ value: 'hormozi' });
+    expect(swatch('hormozi').getAttribute('aria-pressed')).toBe('true');
+    expect(swatch('hormozi').className).toContain('is-active');
+    expect(swatch('karaoke').getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('renders a "No captions" placeholder for the none style and a sample otherwise', () => {
+    render();
+    expect(swatch('none').querySelector('.caption-style-swatch__none')?.textContent).toBe(
+      'No captions',
+    );
+    expect(swatch('karaoke').querySelector('.caption-style-swatch__sample')?.textContent).toBe(
+      'Aa',
+    );
+  });
+
+  it('emits the chosen style id on click', () => {
+    const { onChange } = render();
+    act(() => swatch('neon').click());
+    expect(onChange).toHaveBeenCalledWith('neon');
+  });
+
+  it('accepts a custom style subset + label', () => {
+    render({ styles: [{ id: 'bold', engine: 'remotion', label: 'Bold' }], label: 'Pick a look' });
+    expect(container.querySelectorAll('.caption-style-swatch')).toHaveLength(1);
+    expect(container.querySelector('.caption-style-picker')?.getAttribute('aria-label')).toBe(
+      'Pick a look',
+    );
+  });
+});

--- a/app/renderer/src/components/CaptionStylePicker.tsx
+++ b/app/renderer/src/components/CaptionStylePicker.tsx
@@ -1,0 +1,79 @@
+// CaptionStylePicker.tsx — selectable + PREVIEWABLE subtitle style templates (P4 §4).
+//
+// A swatch grid of the caption style templates (karaoke + the OpusClip-style
+// premium looks + the libass classic + "no captions"). Each swatch renders a
+// LIVE sample styled with that template's real palette/font/box/outline (the
+// same `lib/captionTemplates` visuals the on-video overlay uses), so the user
+// sees how a style looks BEFORE processing — and the selected style also drives
+// the live overlay on the actual video frame.
+//
+// Controlled + presentational: the parent owns `value` and gets `onChange(id)`.
+import React from 'react';
+import { type CaptionTemplateVisual, captionVisualFor, isNoCaption } from '../lib/captionTemplates';
+import { CAPTION_STYLES, type CaptionStyleOption } from '../features/shortMakerLogic';
+import './captionStylePicker.css';
+
+/** The CSS for a swatch's sample line, from the template visual (mirrors overlay). */
+export function sampleStyle(visual: CaptionTemplateVisual): React.CSSProperties {
+  return {
+    fontFamily: visual.fontFamily,
+    color: visual.activeColor,
+    textTransform: visual.uppercase ? 'uppercase' : 'none',
+    backgroundColor: visual.box ? visual.backgroundColor : 'transparent',
+    WebkitTextStroke: visual.outline ? `0.6px ${visual.shadowColor}` : undefined,
+    textShadow: visual.outline ? 'none' : `0 1px 2px ${visual.shadowColor}`,
+  };
+}
+
+export interface CaptionStylePickerProps {
+  /** The selected style id (parent-owned). */
+  value: string;
+  /** Called with the chosen style id. */
+  onChange: (id: string) => void;
+  /** The styles to show (defaults to the full caption catalog). */
+  styles?: readonly CaptionStyleOption[];
+  /** Accessible label for the group. */
+  label?: string;
+}
+
+/** Sample caption text shown on each styled swatch. */
+const SAMPLE_TEXT = 'Aa';
+
+export function CaptionStylePicker({
+  value,
+  onChange,
+  styles = CAPTION_STYLES,
+  label = 'Caption style',
+}: CaptionStylePickerProps): React.ReactElement {
+  return (
+    <div className="caption-style-picker" role="group" aria-label={label}>
+      {styles.map((style) => {
+        const active = style.id === value;
+        const visual = captionVisualFor(style.id);
+        return (
+          <button
+            key={style.id}
+            type="button"
+            className={`caption-style-swatch${active ? ' is-active' : ''}`}
+            data-style={style.id}
+            aria-pressed={active}
+            onClick={() => onChange(style.id)}
+          >
+            <span className="caption-style-swatch__preview">
+              {isNoCaption(style.id) ? (
+                <span className="caption-style-swatch__none">No captions</span>
+              ) : (
+                <span className="caption-style-swatch__sample" style={sampleStyle(visual)}>
+                  {SAMPLE_TEXT}
+                </span>
+              )}
+            </span>
+            <span className="caption-style-swatch__label">{style.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+export default CaptionStylePicker;

--- a/app/renderer/src/components/OutputTray.test.tsx
+++ b/app/renderer/src/components/OutputTray.test.tsx
@@ -8,10 +8,10 @@ import { AUTO_DETECT } from '../lib/languages';
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
 describe('DEFAULT_OUTPUT_TRAY', () => {
-  it('ships quality features ON by default (G-4): caption + reframe + burn-subs', () => {
+  it('ships quality features ON by default (G-4): caption + reframe + burn subtitles', () => {
     expect(DEFAULT_OUTPUT_TRAY.caption).toBe(true);
     expect(DEFAULT_OUTPUT_TRAY.reframe).toBe(true);
-    expect(DEFAULT_OUTPUT_TRAY.burnSubs).toBe(true);
+    expect(DEFAULT_OUTPUT_TRAY.subtitleMode).toBe('burn');
     // Translate is opt-in (off until a target language is wanted).
     expect(DEFAULT_OUTPUT_TRAY.translate).toBe(false);
     expect(DEFAULT_OUTPUT_TRAY.language).toBe('en');
@@ -49,12 +49,11 @@ describe('<OutputTray />', () => {
     return [...container.querySelectorAll('button')].find((b) => b.textContent === text);
   }
 
-  it('renders the four consolidated post-action toggles', () => {
+  it('renders the consolidated post-action toggles', () => {
     render();
     expect(toggle('Caption')).toBeTruthy();
     expect(toggle('Translate')).toBeTruthy();
     expect(toggle('Reframe')).toBeTruthy();
-    expect(toggle('Burn subtitles')).toBeTruthy();
   });
 
   it('emits an immutable next-state when a toggle flips', () => {
@@ -65,10 +64,26 @@ describe('<OutputTray />', () => {
     expect(state.caption).toBe(true);
   });
 
-  it('toggles burn-subs independently', () => {
-    const { onChange, state } = render();
-    act(() => toggle('Burn subtitles').click());
-    expect(onChange).toHaveBeenCalledWith({ ...state, burnSubs: false });
+  it('shows the subtitle-delivery selector only while Caption is on and forwards it', () => {
+    const onChange = vi.fn();
+    // Caption OFF -> no subtitle delivery selector.
+    render({ state: { ...DEFAULT_OUTPUT_TRAY, caption: false }, onChange });
+    expect(container.querySelector('.output-tray__subs')).toBeNull();
+    // Caption ON -> the four delivery modes are offered.
+    render({ state: { ...DEFAULT_OUTPUT_TRAY, caption: true }, onChange });
+    const select = container.querySelector(
+      'select[aria-label="Subtitle delivery"]',
+    ) as HTMLSelectElement;
+    expect([...select.options].map((o) => o.value)).toEqual(['burn', 'softmux', 'sidecar', 'none']);
+    act(() => {
+      select.value = 'sidecar';
+      select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT_OUTPUT_TRAY,
+      caption: true,
+      subtitleMode: 'sidecar',
+    });
   });
 
   it('hides the translate-language picker until Translate is on, then forwards it', () => {

--- a/app/renderer/src/components/OutputTray.tsx
+++ b/app/renderer/src/components/OutputTray.tsx
@@ -15,24 +15,26 @@
 // in a later phase — this is the clean seam it plugs into.
 import React from 'react';
 import { LanguageSelect } from './LanguageSelect';
+import { SUBTITLE_MODES, SUBTITLE_MODE_META, type SubtitleMode } from '../lib/outputOptions';
 import './outputTray.css';
 
-/** The four consolidated post-action toggles + the translate target language. */
+/** The consolidated post-action toggles + subtitle delivery + translate language. */
 export interface OutputTrayState {
   caption: boolean;
   translate: boolean;
   reframe: boolean;
-  burnSubs: boolean;
+  /** How subtitles ride the export (burn / soft track / separate file / none). */
+  subtitleMode: SubtitleMode;
   /** Target language for Translate (a code from lib/languages, never auto). */
   language: string;
 }
 
-/** Quality-defaults-ON seed (G-4): caption + reframe + burn-subs ON; translate opt-in. */
+/** Quality-defaults-ON seed (G-4): caption + reframe ON, burn subtitles; translate opt-in. */
 export const DEFAULT_OUTPUT_TRAY: OutputTrayState = {
   caption: true,
   translate: false,
   reframe: true,
-  burnSubs: true,
+  subtitleMode: 'burn',
   language: 'en',
 };
 
@@ -54,7 +56,7 @@ export interface OutputTrayProps {
 }
 
 interface ToggleDef {
-  key: 'caption' | 'translate' | 'reframe' | 'burnSubs';
+  key: 'caption' | 'translate' | 'reframe';
   label: string;
 }
 
@@ -62,7 +64,6 @@ const TOGGLES: readonly ToggleDef[] = [
   { key: 'caption', label: 'Caption' },
   { key: 'translate', label: 'Translate' },
   { key: 'reframe', label: 'Reframe' },
-  { key: 'burnSubs', label: 'Burn subtitles' },
 ];
 
 /** The single, shared post-action tray. */
@@ -92,6 +93,29 @@ export function OutputTray({
           </label>
         ))}
       </div>
+
+      {state.caption ? (
+        <div className="output-tray__subs">
+          <label className="output-tray__subs-label" htmlFor="output-tray-subtitle-mode">
+            Subtitles
+          </label>
+          <select
+            id="output-tray-subtitle-mode"
+            aria-label="Subtitle delivery"
+            value={state.subtitleMode}
+            onChange={(e) => onChange({ ...state, subtitleMode: e.target.value as SubtitleMode })}
+          >
+            {SUBTITLE_MODES.map((mode) => (
+              <option key={mode} value={mode}>
+                {SUBTITLE_MODE_META[mode].label}
+              </option>
+            ))}
+          </select>
+          <span className="output-tray__subs-help">
+            {SUBTITLE_MODE_META[state.subtitleMode].help}
+          </span>
+        </div>
+      ) : null}
 
       {state.translate ? (
         <div className="output-tray__lang">

--- a/app/renderer/src/components/captionBox.css
+++ b/app/renderer/src/components/captionBox.css
@@ -1,0 +1,90 @@
+/* CaptionBox — draggable/resizable caption region overlay (P4 §4). */
+
+.caption-box-frame {
+  position: absolute;
+  inset: 0;
+  z-index: 3;
+  touch-action: none;
+}
+
+.caption-box {
+  position: absolute;
+  box-sizing: border-box;
+  border: 1.5px dashed rgba(255, 255, 255, 0.85);
+  border-radius: 6px;
+  background: rgba(0, 120, 255, 0.08);
+  cursor: move;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 24px;
+  min-height: 16px;
+}
+
+.caption-box.is-readonly {
+  cursor: default;
+  border-style: solid;
+  border-color: rgba(255, 255, 255, 0.4);
+  background: transparent;
+}
+
+.caption-box__content {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  pointer-events: none;
+  overflow: hidden;
+}
+
+.caption-box__handle {
+  position: absolute;
+  width: 12px;
+  height: 12px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+  border-radius: 50%;
+  z-index: 1;
+}
+
+.caption-box__handle--nw {
+  top: -6px;
+  left: -6px;
+  cursor: nwse-resize;
+}
+.caption-box__handle--n {
+  top: -6px;
+  left: calc(50% - 6px);
+  cursor: ns-resize;
+}
+.caption-box__handle--ne {
+  top: -6px;
+  right: -6px;
+  cursor: nesw-resize;
+}
+.caption-box__handle--w {
+  top: calc(50% - 6px);
+  left: -6px;
+  cursor: ew-resize;
+}
+.caption-box__handle--e {
+  top: calc(50% - 6px);
+  right: -6px;
+  cursor: ew-resize;
+}
+.caption-box__handle--sw {
+  bottom: -6px;
+  left: -6px;
+  cursor: nesw-resize;
+}
+.caption-box__handle--s {
+  bottom: -6px;
+  left: calc(50% - 6px);
+  cursor: ns-resize;
+}
+.caption-box__handle--se {
+  bottom: -6px;
+  right: -6px;
+  cursor: nwse-resize;
+}

--- a/app/renderer/src/components/captionDesigner.css
+++ b/app/renderer/src/components/captionDesigner.css
@@ -1,0 +1,79 @@
+/* CaptionDesigner — caption editor with live preview on a real frame (P4 §4). */
+
+.caption-designer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.caption-designer__phone {
+  position: relative;
+  width: 270px;
+  max-width: 100%;
+  aspect-ratio: 9 / 16;
+  margin: 0 auto;
+  background: #000;
+  border-radius: 14px;
+  overflow: hidden;
+}
+
+.caption-designer__phone video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.caption-designer__sample {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+}
+
+.caption-designer__hook {
+  font-weight: 800;
+  font-size: 13px;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+}
+
+.caption-designer__line {
+  font-weight: 800;
+  font-size: 15px;
+  line-height: 1.1;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  justify-content: center;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+}
+
+.caption-designer__hint {
+  font-size: 12px;
+  color: rgba(255, 255, 255, 0.85);
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+}
+
+.caption-designer__bands {
+  display: flex;
+  gap: 6px;
+  justify-content: center;
+}
+
+.caption-designer__band {
+  padding: 4px 12px;
+  border: 1px solid var(--border, #2a2a33);
+  border-radius: 6px;
+  background: #14141a;
+  color: #c9c9d4;
+  cursor: pointer;
+}
+
+.caption-designer__band.is-active {
+  border-color: var(--accent, #4c8dff);
+  color: #fff;
+}

--- a/app/renderer/src/components/captionPreferences.css
+++ b/app/renderer/src/components/captionPreferences.css
@@ -1,0 +1,62 @@
+/* CaptionPreferences — caption + output defaults panel (P4 §4). */
+
+.caption-prefs {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.caption-prefs__title {
+  margin: 0;
+}
+
+.caption-prefs__hint {
+  margin: 0;
+  color: var(--color-text-2, #777);
+  font-size: 0.875rem;
+}
+
+.caption-prefs__group {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.caption-prefs__group h3 {
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.caption-prefs__row {
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+}
+
+.caption-prefs__frame {
+  position: relative;
+  width: 220px;
+  aspect-ratio: 9 / 16;
+  border-radius: 12px;
+  background: linear-gradient(160deg, #2a2a38, #0d0d12);
+  overflow: hidden;
+}
+
+.caption-prefs__sample {
+  font-weight: 800;
+  font-size: 18px;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+}
+
+.caption-prefs__actions {
+  display: flex;
+  gap: 8px;
+}
+
+.caption-prefs__status {
+  color: var(--color-success, #2e7d32);
+}
+
+.caption-prefs__error {
+  color: var(--color-error, #c62828);
+}

--- a/app/renderer/src/components/captionStylePicker.css
+++ b/app/renderer/src/components/captionStylePicker.css
@@ -1,0 +1,54 @@
+/* CaptionStylePicker — previewable caption style swatch grid (P4 §4). */
+
+.caption-style-picker {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(96px, 1fr));
+  gap: 8px;
+}
+
+.caption-style-swatch {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px;
+  border: 1.5px solid var(--border, #2a2a33);
+  border-radius: 8px;
+  background: #14141a;
+  cursor: pointer;
+  text-align: center;
+}
+
+.caption-style-swatch.is-active {
+  border-color: var(--accent, #4c8dff);
+  box-shadow: 0 0 0 1px var(--accent, #4c8dff);
+}
+
+.caption-style-swatch__preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 44px;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #2b2b38, #101016);
+}
+
+.caption-style-swatch__sample {
+  font-weight: 800;
+  font-size: 22px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  line-height: 1;
+}
+
+.caption-style-swatch__none {
+  font-size: 12px;
+  color: #8a8a99;
+}
+
+.caption-style-swatch__label {
+  font-size: 11px;
+  color: #c9c9d4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/app/renderer/src/components/outputTray.css
+++ b/app/renderer/src/components/outputTray.css
@@ -26,6 +26,24 @@
   gap: var(--space-xs, 0.25rem);
 }
 
+.output-tray__subs {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm, 0.5rem);
+}
+
+.output-tray__subs-label {
+  font-size: var(--text-sm, 0.8125rem);
+  color: var(--color-text-2, #555);
+}
+
+.output-tray__subs-help {
+  font-size: var(--text-sm, 0.8125rem);
+  color: var(--color-text-2, #777);
+  flex-basis: 100%;
+}
+
 .output-tray__lang {
   display: flex;
   flex-direction: column;

--- a/app/renderer/src/features/shortMakerPresets.ts
+++ b/app/renderer/src/features/shortMakerPresets.ts
@@ -21,6 +21,8 @@ import {
   displayVirality,
   CAPTION_STYLE_OPTIONS,
 } from './shortMakerLogic';
+import type { CaptionBox } from '../lib/captionPosition';
+import type { SubtitleMode } from '../lib/outputOptions';
 
 // ---------------------------------------------------------------------------
 // P4 §7 — candidate sort (rank ↔ virality).
@@ -141,12 +143,24 @@ export function topByVirality(candidates: readonly Candidate[], n: number): Cand
  * 'on'/'off' send an explicit `emphasis` bool; 'default' OMITS the key so the
  * sidecar's `resolve_emphasis` per-style default applies (ON for OpusClip-style
  * templates, OFF for clean/minimal) — sending nothing is the contract default.
+ *
+ * P4 §4 caption editor: the optional `output` slice carries the caption POSITION
+ * box + the subtitle DELIVERY mode (burn / soft track / sidecar / none). Each is
+ * sent only when provided so the existing AI/batch callers (no editor) are
+ * byte-identical; the sidecar honours `subtitleMode` (burn vs not, skip for
+ * none/sidecar) + `captionPosition` (ASS alignment/margins).
  */
+export interface ExportOutputOptions {
+  captionPosition?: CaptionBox;
+  subtitleMode?: SubtitleMode;
+}
+
 export function buildExportParams(
   videoId: string,
   candidates: readonly Candidate[],
   controls: ShortMakerControls,
   audioTrackId: string,
+  output: ExportOutputOptions = {},
 ): Record<string, unknown> {
   return {
     videoId,
@@ -165,6 +179,8 @@ export function buildExportParams(
     stabilize: controls.stabilize,
     ...(controls.emphasis === 'default' ? {} : { emphasis: controls.emphasis === 'on' }),
     ...(audioTrackId ? { audioTrackId } : {}),
+    ...(output.subtitleMode ? { subtitleMode: output.subtitleMode } : {}),
+    ...(output.captionPosition ? { captionPosition: output.captionPosition } : {}),
   };
 }
 

--- a/app/renderer/src/lib/captionDesign.test.ts
+++ b/app/renderer/src/lib/captionDesign.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_CAPTION_DESIGN,
+  SAMPLE_CAPTION_PHRASE,
+  captionDesignWire,
+  sampleCaptionCues,
+  sanitizeCaptionDesign,
+} from './captionDesign';
+import { DEFAULT_CAPTION_BOX, boxToWire } from './captionPosition';
+import { DEFAULT_CAPTION_STYLE } from '../features/shortMakerLogic';
+
+describe('sanitizeCaptionDesign', () => {
+  it('keeps a valid style + clamps the box', () => {
+    const d = sanitizeCaptionDesign({ style: 'karaoke', box: { x: 0.1, y: 0.2, w: 0.5, h: 0.2 } });
+    expect(d.style).toBe('karaoke');
+    expect(d.box).toEqual({ x: 0.1, y: 0.2, w: 0.5, h: 0.2 });
+  });
+
+  it('falls back to the default style for an unknown id', () => {
+    expect(sanitizeCaptionDesign({ style: 'bogus' }).style).toBe(DEFAULT_CAPTION_STYLE);
+  });
+
+  it('defaults the whole design for null / non-string style / missing box', () => {
+    expect(sanitizeCaptionDesign(null)).toEqual(DEFAULT_CAPTION_DESIGN);
+    expect(sanitizeCaptionDesign(undefined)).toEqual(DEFAULT_CAPTION_DESIGN);
+    expect(sanitizeCaptionDesign({ style: 42 as unknown as string })).toEqual(
+      DEFAULT_CAPTION_DESIGN,
+    );
+  });
+});
+
+describe('captionDesignWire', () => {
+  it('emits the style id + a wire-rounded box', () => {
+    const wire = captionDesignWire({ style: 'neon', box: { x: 0.123456, y: 0.2, w: 0.5, h: 0.2 } });
+    expect(wire).toEqual({
+      captionStyle: 'neon',
+      captionPosition: boxToWire({ x: 0.123456, y: 0.2, w: 0.5, h: 0.2 }),
+    });
+  });
+
+  it('round-trips the default design', () => {
+    expect(captionDesignWire(DEFAULT_CAPTION_DESIGN)).toEqual({
+      captionStyle: DEFAULT_CAPTION_STYLE,
+      captionPosition: boxToWire(DEFAULT_CAPTION_BOX),
+    });
+  });
+});
+
+describe('sampleCaptionCues', () => {
+  it('spreads the default phrase across the window (capped at 0.6s/word)', () => {
+    const cues = sampleCaptionCues({ start: 0, end: 6 });
+    expect(cues).toHaveLength(SAMPLE_CAPTION_PHRASE.length);
+    expect(cues[0]).toEqual({ index: 0, start: 0, end: 0.6, text: 'Your' });
+    // Evenly stepped at the 0.6s cap.
+    expect(cues[1].start).toBe(0.6);
+  });
+
+  it('compresses into a short window and honours a custom phrase + start offset', () => {
+    const cues = sampleCaptionCues({ start: 10, end: 10.5 }, ['a', 'b']);
+    expect(cues).toHaveLength(2);
+    expect(cues[0].start).toBe(10);
+    expect(cues[1].start).toBeCloseTo(10.25, 5);
+    expect(cues[1].end).toBeCloseTo(10.5, 5);
+  });
+
+  it('tolerates a degenerate (zero-length) window', () => {
+    const cues = sampleCaptionCues({ start: 5, end: 5 });
+    expect(cues[0].start).toBe(5);
+    expect(cues[cues.length - 1].end).toBeGreaterThan(5);
+  });
+});

--- a/app/renderer/src/lib/captionDesign.ts
+++ b/app/renderer/src/lib/captionDesign.ts
@@ -1,0 +1,68 @@
+// captionDesign.ts — the combined caption STYLE + POSITION the editor produces (P4 §4).
+//
+// A CaptionDesign bundles the chosen style template id with the normalised
+// caption box. It is what the caption editor (CaptionDesigner) emits, what the
+// Preferences area persists as a default, and what the export payload carries to
+// the sidecar (which converts the box to ASS margins/alignment and the style to
+// the caption engine). Pure helpers only — unit-tested in captionDesign.test.ts.
+
+import { type CaptionBox, DEFAULT_CAPTION_BOX, boxToWire, clampBox } from './captionPosition';
+import { CAPTION_STYLE_OPTIONS, DEFAULT_CAPTION_STYLE } from '../features/shortMakerLogic';
+import type { Cue } from './rpc';
+
+/** A caption style template + its on-frame position box. */
+export interface CaptionDesign {
+  /** A known caption style id (see CAPTION_STYLES). */
+  style: string;
+  /** The normalised caption region. */
+  box: CaptionBox;
+}
+
+/** The default design: the libass classic style in the default bottom band. */
+export const DEFAULT_CAPTION_DESIGN: CaptionDesign = {
+  style: DEFAULT_CAPTION_STYLE,
+  box: DEFAULT_CAPTION_BOX,
+};
+
+/** Validate a raw (persisted/untrusted) design into a clean CaptionDesign. */
+export function sanitizeCaptionDesign(
+  raw: Partial<CaptionDesign> | null | undefined,
+): CaptionDesign {
+  const r = raw ?? {};
+  const rawStyle = typeof r.style === 'string' ? r.style.trim() : '';
+  const style = CAPTION_STYLE_OPTIONS.includes(rawStyle) ? rawStyle : DEFAULT_CAPTION_STYLE;
+  return { style, box: clampBox(r.box ?? {}) };
+}
+
+/** The export-payload slice for a caption design (style id + wire-rounded box). */
+export interface CaptionDesignWire {
+  captionStyle: string;
+  captionPosition: CaptionBox;
+}
+
+/** Convert a design to the frozen export payload fields the sidecar reads. */
+export function captionDesignWire(design: CaptionDesign): CaptionDesignWire {
+  return { captionStyle: design.style, captionPosition: boxToWire(design.box) };
+}
+
+/** The placeholder phrase the editor animates when there is no real transcript. */
+export const SAMPLE_CAPTION_PHRASE = ['Your', 'captions', 'look', 'like', 'this'];
+
+/**
+ * Build word-level SAMPLE cues spread across a preview window so the caption
+ * editor can animate the chosen style live before a transcript exists. Pure;
+ * the words are evenly sliced (capped at 0.6s each) inside the window.
+ */
+export function sampleCaptionCues(
+  window: { start: number; end: number },
+  words: readonly string[] = SAMPLE_CAPTION_PHRASE,
+): Cue[] {
+  const span = Math.max(0.1, window.end - window.start);
+  const per = Math.min(0.6, span / Math.max(1, words.length));
+  return words.map((text, i) => ({
+    index: i,
+    start: window.start + i * per,
+    end: window.start + (i + 1) * per,
+    text,
+  }));
+}

--- a/app/renderer/src/lib/captionPosition.test.ts
+++ b/app/renderer/src/lib/captionPosition.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type CaptionBox,
+  DEFAULT_CAPTION_BOX,
+  MIN_BOX_H,
+  MIN_BOX_W,
+  RESIZE_HANDLES,
+  bandBox,
+  boxBand,
+  boxToCss,
+  boxToWire,
+  clampBox,
+  moveBox,
+  resizeBox,
+} from './captionPosition';
+
+describe('clampBox', () => {
+  it('passes a valid box through unchanged', () => {
+    const box: CaptionBox = { x: 0.2, y: 0.3, w: 0.5, h: 0.2 };
+    expect(clampBox(box)).toEqual(box);
+  });
+
+  it('clamps width/height into [min, 1]', () => {
+    expect(clampBox({ x: 0, y: 0, w: 0.01, h: 0.01 })).toEqual({
+      x: 0,
+      y: 0,
+      w: MIN_BOX_W,
+      h: MIN_BOX_H,
+    });
+    expect(clampBox({ x: 0, y: 0, w: 5, h: 5 })).toEqual({ x: 0, y: 0, w: 1, h: 1 });
+  });
+
+  it('clamps the top-left so the box stays inside the frame', () => {
+    // x too negative -> 0; y past the bottom -> 1-h.
+    expect(clampBox({ x: -1, y: 9, w: 0.4, h: 0.2 })).toEqual({ x: 0, y: 0.8, w: 0.4, h: 0.2 });
+    // x past the right edge -> 1-w.
+    expect(clampBox({ x: 9, y: 0, w: 0.4, h: 0.2 })).toEqual({ x: 0.6, y: 0, w: 0.4, h: 0.2 });
+  });
+
+  it('falls back to default fields for missing or non-finite values', () => {
+    expect(clampBox({})).toEqual(DEFAULT_CAPTION_BOX);
+    expect(clampBox({ x: NaN, y: Infinity, w: NaN, h: NaN })).toEqual(DEFAULT_CAPTION_BOX);
+    // A non-number field also falls back.
+    expect(clampBox({ w: 'wide' as unknown as number })).toEqual(DEFAULT_CAPTION_BOX);
+  });
+});
+
+describe('bandBox', () => {
+  it('seeds top/center/bottom bands centred horizontally', () => {
+    const { w, h } = DEFAULT_CAPTION_BOX;
+    const x = (1 - w) / 2;
+    expect(bandBox('top')).toEqual({ x, y: 0.06, w, h });
+    expect(bandBox('center')).toEqual({ x, y: (1 - h) / 2, w, h });
+    expect(bandBox('bottom')).toEqual({ x, y: 1 - h - 0.06, w, h });
+  });
+});
+
+describe('moveBox', () => {
+  it('translates by fractional deltas', () => {
+    expect(moveBox({ x: 0.2, y: 0.2, w: 0.4, h: 0.2 }, 0.1, -0.05)).toEqual({
+      x: 0.30000000000000004,
+      y: 0.15000000000000002,
+      w: 0.4,
+      h: 0.2,
+    });
+  });
+
+  it('clamps at the frame edge', () => {
+    expect(moveBox({ x: 0.5, y: 0.5, w: 0.4, h: 0.2 }, 1, 1)).toEqual({
+      x: 0.6,
+      y: 0.8,
+      w: 0.4,
+      h: 0.2,
+    });
+  });
+});
+
+describe('resizeBox', () => {
+  const base: CaptionBox = { x: 0.3, y: 0.3, w: 0.4, h: 0.4 };
+
+  it('grows the east edge and caps width at the minimum', () => {
+    expect(resizeBox(base, 'e', 0.1, 0)).toEqual({ ...base, w: 0.5 });
+    expect(resizeBox(base, 'e', -1, 0)).toEqual({ ...base, w: MIN_BOX_W });
+  });
+
+  it('grows the south edge and caps height at the minimum', () => {
+    expect(resizeBox(base, 's', 0.1, 0.1)).toEqual({ ...base, h: 0.5 });
+    expect(resizeBox(base, 's', 0, -1)).toEqual({ ...base, h: MIN_BOX_H });
+  });
+
+  const closeBox = (got: CaptionBox, want: CaptionBox): void => {
+    expect(got.x).toBeCloseTo(want.x, 10);
+    expect(got.y).toBeCloseTo(want.y, 10);
+    expect(got.w).toBeCloseTo(want.w, 10);
+    expect(got.h).toBeCloseTo(want.h, 10);
+  };
+
+  it('moves the west edge (negative dx grows leftward) and caps it', () => {
+    // dx negative -> x decreases, width grows.
+    closeBox(resizeBox(base, 'w', -0.1, 0), { ...base, x: 0.2, w: 0.5 });
+    // dx large positive -> x capped so width stays >= MIN.
+    const capped = resizeBox(base, 'w', 1, 0);
+    expect(capped.w).toBeCloseTo(MIN_BOX_W, 10);
+    expect(capped.x).toBeCloseTo(0.7 - MIN_BOX_W, 10);
+  });
+
+  it('moves the north edge and caps it', () => {
+    closeBox(resizeBox(base, 'n', 0, -0.1), { ...base, y: 0.2, h: 0.5 });
+    const capped = resizeBox(base, 'n', 0, 1);
+    expect(capped.h).toBeCloseTo(MIN_BOX_H, 10);
+    expect(capped.y).toBeCloseTo(0.7 - MIN_BOX_H, 10);
+  });
+
+  it('handles a corner (south-east grows both)', () => {
+    closeBox(resizeBox(base, 'se', 0.1, 0.1), { ...base, w: 0.5, h: 0.5 });
+  });
+
+  it('handles a corner (north-west moves origin and grows both)', () => {
+    closeBox(resizeBox(base, 'nw', -0.1, -0.1), { x: 0.2, y: 0.2, w: 0.5, h: 0.5 });
+  });
+
+  it('re-clamps a resize that overflows the frame', () => {
+    const big = resizeBox({ x: 0.8, y: 0.8, w: 0.15, h: 0.15 }, 'se', 0.5, 0.5);
+    expect(big.x + big.w).toBeLessThanOrEqual(1.0000001);
+    expect(big.y + big.h).toBeLessThanOrEqual(1.0000001);
+  });
+
+  it('exposes the eight handles in render order', () => {
+    expect(RESIZE_HANDLES).toEqual(['nw', 'n', 'ne', 'w', 'e', 'sw', 's', 'se']);
+  });
+});
+
+describe('boxToCss', () => {
+  it('formats percent placement', () => {
+    expect(boxToCss({ x: 0.1, y: 0.25, w: 0.8, h: 0.16 })).toEqual({
+      left: '10.0000%',
+      top: '25.0000%',
+      width: '80.0000%',
+      height: '16.0000%',
+    });
+  });
+});
+
+describe('boxToWire', () => {
+  it('rounds to 4 decimals after clamping', () => {
+    expect(boxToWire({ x: 0.123456, y: 0.654321, w: 0.5, h: 0.2 })).toEqual({
+      x: 0.1235,
+      y: 0.6543,
+      w: 0.5,
+      h: 0.2,
+    });
+  });
+});
+
+describe('boxBand', () => {
+  it('classifies by the box centre', () => {
+    expect(boxBand({ x: 0, y: 0, w: 1, h: 0.1 })).toBe('top');
+    expect(boxBand({ x: 0, y: 0.45, w: 1, h: 0.1 })).toBe('center');
+    expect(boxBand({ x: 0, y: 0.9, w: 1, h: 0.1 })).toBe('bottom');
+  });
+});

--- a/app/renderer/src/lib/captionPosition.ts
+++ b/app/renderer/src/lib/captionPosition.ts
@@ -1,0 +1,137 @@
+// captionPosition.ts — pure geometry for the caption POSITION editor (P4 §4).
+//
+// The caption editor lets the user drag/resize a caption box over a real video
+// frame so the on-export caption lands exactly where they place it. The box is
+// stored NORMALISED (fractions of the frame, 0..1) so it is resolution- and
+// aspect-independent — the same box applies to the 1080x1920 export and to the
+// live preview at any size.
+//
+// Everything here is pure (no React, no DOM): the component (CaptionBox.tsx)
+// converts pointer pixels to fractional deltas and calls these helpers; the
+// sidecar receives the normalised box and converts it to ASS margins/alignment.
+// Exhaustively unit-tested in captionPosition.test.ts.
+
+/** A normalised caption region: top-left (x,y) + size (w,h), all fractions 0..1. */
+export interface CaptionBox {
+  /** Left edge as a fraction of frame width (0 = left, 1 = right). */
+  x: number;
+  /** Top edge as a fraction of frame height (0 = top, 1 = bottom). */
+  y: number;
+  /** Width as a fraction of frame width. */
+  w: number;
+  /** Height as a fraction of frame height. */
+  h: number;
+}
+
+/** Minimum box size (fraction) so a caption region never collapses to nothing. */
+export const MIN_BOX_W = 0.1;
+export const MIN_BOX_H = 0.05;
+
+/** The eight resize handles + the body (drag-to-move). */
+export type ResizeHandle = 'n' | 's' | 'e' | 'w' | 'ne' | 'nw' | 'se' | 'sw';
+export const RESIZE_HANDLES: readonly ResizeHandle[] = ['nw', 'n', 'ne', 'w', 'e', 'sw', 's', 'se'];
+
+/** The three vertical position bands a style template can seed the box from. */
+export type CaptionBand = 'top' | 'center' | 'bottom';
+
+/** Clamp a number into [lo, hi] (callers only ever pass lo <= hi). */
+function clamp(n: number, lo: number, hi: number): number {
+  if (n < lo) return lo;
+  if (n > hi) return hi;
+  return n;
+}
+
+/**
+ * Normalise any box into a valid one: size clamped to [min, 1], then the
+ * top-left clamped so the whole box stays inside the [0,1] frame. NaN/missing
+ * fields fall back to the default box's value for that field (never throws).
+ */
+export function clampBox(box: Partial<CaptionBox>): CaptionBox {
+  const w = clamp(numOr(box.w, DEFAULT_CAPTION_BOX.w), MIN_BOX_W, 1);
+  const h = clamp(numOr(box.h, DEFAULT_CAPTION_BOX.h), MIN_BOX_H, 1);
+  const x = clamp(numOr(box.x, DEFAULT_CAPTION_BOX.x), 0, 1 - w);
+  const y = clamp(numOr(box.y, DEFAULT_CAPTION_BOX.y), 0, 1 - h);
+  return { x, y, w, h };
+}
+
+/** A finite number, or `fallback` for NaN/Infinity/non-number. */
+function numOr(v: unknown, fallback: number): number {
+  return typeof v === 'number' && Number.isFinite(v) ? v : fallback;
+}
+
+/** Default caption box: a wide bottom-centred band (the short-form norm). */
+export const DEFAULT_CAPTION_BOX: CaptionBox = { x: 0.1, y: 0.76, w: 0.8, h: 0.16 };
+
+/** Seed a box for a vertical band, preserving the default width/height. */
+export function bandBox(band: CaptionBand): CaptionBox {
+  const { w, h } = DEFAULT_CAPTION_BOX;
+  const x = (1 - w) / 2;
+  if (band === 'top') return { x, y: 0.06, w, h };
+  if (band === 'center') return { x, y: (1 - h) / 2, w, h };
+  return { x, y: 1 - h - 0.06, w, h };
+}
+
+/** Move the box by fractional deltas, clamped inside the frame. */
+export function moveBox(box: CaptionBox, dx: number, dy: number): CaptionBox {
+  return clampBox({ ...box, x: box.x + dx, y: box.y + dy });
+}
+
+/**
+ * Resize the box by dragging `handle` by fractional deltas. Each edge the
+ * handle controls moves; the opposite edge is pinned. Minimum size is enforced
+ * by capping the moving edge before re-clamping to the frame.
+ */
+export function resizeBox(
+  box: CaptionBox,
+  handle: ResizeHandle,
+  dx: number,
+  dy: number,
+): CaptionBox {
+  let { x, y, w, h } = box;
+  if (handle.includes('e')) {
+    w = Math.max(MIN_BOX_W, w + dx);
+  }
+  if (handle.includes('s')) {
+    h = Math.max(MIN_BOX_H, h + dy);
+  }
+  if (handle.includes('w')) {
+    const right = x + w;
+    x = Math.min(x + dx, right - MIN_BOX_W);
+    w = right - x;
+  }
+  if (handle.includes('n')) {
+    const bottom = y + h;
+    y = Math.min(y + dy, bottom - MIN_BOX_H);
+    h = bottom - y;
+  }
+  return clampBox({ x, y, w, h });
+}
+
+/** CSS placement (percent strings) for absolutely positioning the box. */
+export interface BoxCss {
+  left: string;
+  top: string;
+  width: string;
+  height: string;
+}
+
+/** Convert a normalised box to CSS percent placement. */
+export function boxToCss(box: CaptionBox): BoxCss {
+  const pct = (n: number): string => `${(n * 100).toFixed(4)}%`;
+  return { left: pct(box.x), top: pct(box.y), width: pct(box.w), height: pct(box.h) };
+}
+
+/** Round a box to a stable wire precision (4 decimals) for the export payload. */
+export function boxToWire(box: CaptionBox): CaptionBox {
+  const r = (n: number): number => Math.round(n * 1e4) / 1e4;
+  const c = clampBox(box);
+  return { x: r(c.x), y: r(c.y), w: r(c.w), h: r(c.h) };
+}
+
+/** The vertical band a box's CENTRE falls into (top < 1/3 <= center < 2/3 <= bottom). */
+export function boxBand(box: CaptionBox): CaptionBand {
+  const cy = box.y + box.h / 2;
+  if (cy < 1 / 3) return 'top';
+  if (cy < 2 / 3) return 'center';
+  return 'bottom';
+}

--- a/app/renderer/src/lib/captionPreferences.test.ts
+++ b/app/renderer/src/lib/captionPreferences.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_LANGUAGE,
+  DEFAULT_PREFERENCES,
+  PREFERENCE_KEYS,
+  coerceLanguage,
+  preferencesPatch,
+  readPreferences,
+} from './captionPreferences';
+import { DEFAULT_CAPTION_DESIGN } from './captionDesign';
+
+describe('coerceLanguage', () => {
+  it('accepts a known code', () => {
+    expect(coerceLanguage('es')).toBe('es');
+  });
+  it('falls back for unknown / non-string', () => {
+    expect(coerceLanguage('zz')).toBe(DEFAULT_LANGUAGE);
+    expect(coerceLanguage(5)).toBe(DEFAULT_LANGUAGE);
+  });
+});
+
+describe('readPreferences', () => {
+  it('returns defaults for a non-object', () => {
+    expect(readPreferences(null)).toEqual(DEFAULT_PREFERENCES);
+    expect(readPreferences('x')).toEqual(DEFAULT_PREFERENCES);
+  });
+
+  it('reads each persisted field', () => {
+    const prefs = readPreferences({
+      [PREFERENCE_KEYS.style]: 'karaoke',
+      [PREFERENCE_KEYS.box]: { x: 0.1, y: 0.2, w: 0.5, h: 0.2 },
+      [PREFERENCE_KEYS.subtitleMode]: 'sidecar',
+      [PREFERENCE_KEYS.language]: 'pt',
+    });
+    expect(prefs).toEqual({
+      design: { style: 'karaoke', box: { x: 0.1, y: 0.2, w: 0.5, h: 0.2 } },
+      subtitleMode: 'sidecar',
+      language: 'pt',
+    });
+  });
+
+  it('validates/falls back per field for partial data', () => {
+    const prefs = readPreferences({ [PREFERENCE_KEYS.style]: 'bogus' });
+    expect(prefs.design).toEqual(DEFAULT_CAPTION_DESIGN);
+    expect(prefs.subtitleMode).toBe('burn');
+    expect(prefs.language).toBe(DEFAULT_LANGUAGE);
+  });
+});
+
+describe('preferencesPatch', () => {
+  it('round-trips through readPreferences', () => {
+    const prefs = {
+      design: { style: 'neon', box: { x: 0.2, y: 0.7, w: 0.6, h: 0.15 } },
+      subtitleMode: 'softmux' as const,
+      language: 'fr',
+    };
+    expect(readPreferences(preferencesPatch(prefs))).toEqual(prefs);
+  });
+});

--- a/app/renderer/src/lib/captionPreferences.ts
+++ b/app/renderer/src/lib/captionPreferences.ts
@@ -1,0 +1,74 @@
+// captionPreferences.ts — persisted caption + output DEFAULTS (P4 §4 Preferences).
+//
+// The Preferences/Settings area lets a user set the defaults every new short
+// starts from: the caption style + on-frame position, the subtitle delivery
+// mode, and the default language. They are stored in the free-form settings
+// store (C12: settings.get/set, like the brand kit) under four FROZEN keys, so
+// the Make Shorts flow + the Output Tray seed from one place instead of every
+// surface re-choosing. Pure read/write helpers only — unit-tested.
+
+import { type CaptionDesign, DEFAULT_CAPTION_DESIGN, sanitizeCaptionDesign } from './captionDesign';
+import { type SubtitleMode, DEFAULT_OUTPUT_OPTIONS, coerceSubtitleMode } from './outputOptions';
+import { LANGUAGES } from './languages';
+
+/** The default language id when none is persisted (most common creator lang). */
+export const DEFAULT_LANGUAGE = 'en';
+
+/** The persisted caption + output defaults. */
+export interface CaptionPreferences {
+  /** Default caption style + position. */
+  design: CaptionDesign;
+  /** Default subtitle delivery mode. */
+  subtitleMode: SubtitleMode;
+  /** Default language code (an ISO code from lib/languages). */
+  language: string;
+}
+
+/** The out-of-box defaults (used before anything is persisted). */
+export const DEFAULT_PREFERENCES: CaptionPreferences = {
+  design: DEFAULT_CAPTION_DESIGN,
+  subtitleMode: DEFAULT_OUTPUT_OPTIONS.subtitleMode,
+  language: DEFAULT_LANGUAGE,
+};
+
+/** The four FROZEN settings-store keys these preferences live under. */
+export const PREFERENCE_KEYS = {
+  style: 'defaultCaptionStyle',
+  box: 'defaultCaptionBox',
+  subtitleMode: 'defaultSubtitleMode',
+  language: 'defaultLanguage',
+} as const;
+
+/** A known language code, or the default (dropdown-only — never a free-typed id). */
+export function coerceLanguage(raw: unknown): string {
+  const v = typeof raw === 'string' ? raw.trim() : '';
+  return LANGUAGES.some((l) => l.code === v) ? v : DEFAULT_LANGUAGE;
+}
+
+/**
+ * Read preferences out of a raw `settings.get` result, tolerating absent keys
+ * (the keys may not be in DEFAULT_SETTINGS yet). A non-object input yields the
+ * out-of-box defaults; each field is independently validated.
+ */
+export function readPreferences(raw: unknown): CaptionPreferences {
+  if (!raw || typeof raw !== 'object') return DEFAULT_PREFERENCES;
+  const r = raw as Record<string, unknown>;
+  return {
+    design: sanitizeCaptionDesign({
+      style: r[PREFERENCE_KEYS.style] as string | undefined,
+      box: r[PREFERENCE_KEYS.box] as CaptionDesign['box'] | undefined,
+    }),
+    subtitleMode: coerceSubtitleMode(r[PREFERENCE_KEYS.subtitleMode]),
+    language: coerceLanguage(r[PREFERENCE_KEYS.language]),
+  };
+}
+
+/** The `settings.set` patch for the preferences (only the four FROZEN keys). */
+export function preferencesPatch(prefs: CaptionPreferences): Record<string, unknown> {
+  return {
+    [PREFERENCE_KEYS.style]: prefs.design.style,
+    [PREFERENCE_KEYS.box]: prefs.design.box,
+    [PREFERENCE_KEYS.subtitleMode]: prefs.subtitleMode,
+    [PREFERENCE_KEYS.language]: prefs.language,
+  };
+}

--- a/app/renderer/src/lib/outputOptions.test.ts
+++ b/app/renderer/src/lib/outputOptions.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_OUTPUT_OPTIONS,
+  type OutputOptions,
+  SUBTITLE_MODES,
+  SUBTITLE_MODE_META,
+  coerceSubtitleMode,
+  describeOutputs,
+  embedsSubtitles,
+  hasOutput,
+  outputArtifacts,
+  resolveBurn,
+  sanitizeOutputOptions,
+  writesSubtitleFile,
+} from './outputOptions';
+
+const opts = (over: Partial<OutputOptions> = {}): OutputOptions => ({
+  ...DEFAULT_OUTPUT_OPTIONS,
+  ...over,
+});
+
+describe('subtitle mode metadata', () => {
+  it('has label + help for every mode', () => {
+    for (const mode of SUBTITLE_MODES) {
+      expect(SUBTITLE_MODE_META[mode].label).toBeTruthy();
+      expect(SUBTITLE_MODE_META[mode].help).toBeTruthy();
+    }
+  });
+});
+
+describe('resolveBurn / embedsSubtitles', () => {
+  it('burns only the burn mode', () => {
+    expect(resolveBurn('burn')).toBe(true);
+    expect(resolveBurn('softmux')).toBe(false);
+    expect(resolveBurn('sidecar')).toBe(false);
+    expect(resolveBurn('none')).toBe(false);
+  });
+
+  it('embeds for burn + soft track only', () => {
+    expect(embedsSubtitles('burn')).toBe(true);
+    expect(embedsSubtitles('softmux')).toBe(true);
+    expect(embedsSubtitles('sidecar')).toBe(false);
+    expect(embedsSubtitles('none')).toBe(false);
+  });
+});
+
+describe('writesSubtitleFile', () => {
+  it('writes a file for sidecar delivery', () => {
+    expect(writesSubtitleFile(opts({ subtitleMode: 'sidecar', saveSrt: false }))).toBe(true);
+  });
+  it('writes a file when SRT save is requested', () => {
+    expect(writesSubtitleFile(opts({ subtitleMode: 'burn', saveSrt: true }))).toBe(true);
+  });
+  it('does not write a file for burn/softmux without an SRT save', () => {
+    expect(writesSubtitleFile(opts({ subtitleMode: 'burn', saveSrt: false }))).toBe(false);
+    expect(writesSubtitleFile(opts({ subtitleMode: 'softmux', saveSrt: false }))).toBe(false);
+  });
+});
+
+describe('coerceSubtitleMode', () => {
+  it('accepts a known mode (case-insensitive, trimmed)', () => {
+    expect(coerceSubtitleMode('  SoftMux ')).toBe('softmux');
+  });
+  it('falls back to the default for unknown/non-string', () => {
+    expect(coerceSubtitleMode('nonsense')).toBe('burn');
+    expect(coerceSubtitleMode(42)).toBe('burn');
+  });
+});
+
+describe('sanitizeOutputOptions', () => {
+  it('validates a partial object', () => {
+    expect(sanitizeOutputOptions({ subtitleMode: 'sidecar', saveClip: true })).toEqual({
+      subtitleMode: 'sidecar',
+      saveClip: true,
+      saveShort: true,
+      saveSrt: false,
+    });
+  });
+  it('falls back to defaults for null + non-boolean fields', () => {
+    expect(sanitizeOutputOptions(null)).toEqual(DEFAULT_OUTPUT_OPTIONS);
+    expect(sanitizeOutputOptions({ saveShort: 'yes' as unknown as boolean })).toEqual(
+      DEFAULT_OUTPUT_OPTIONS,
+    );
+  });
+  it('defaults undefined input', () => {
+    expect(sanitizeOutputOptions(undefined)).toEqual(DEFAULT_OUTPUT_OPTIONS);
+  });
+});
+
+describe('outputArtifacts / hasOutput', () => {
+  it('lists artifacts in stable order', () => {
+    expect(outputArtifacts(opts({ saveClip: true, saveShort: true, saveSrt: true }))).toEqual([
+      'clip',
+      'short',
+      'srt',
+    ]);
+  });
+  it('includes srt when delivery is sidecar even without saveSrt', () => {
+    expect(outputArtifacts(opts({ saveShort: false, subtitleMode: 'sidecar' }))).toEqual(['srt']);
+  });
+  it('hasOutput is false when nothing is selected', () => {
+    expect(hasOutput(opts({ saveShort: false, saveClip: false, saveSrt: false }))).toBe(false);
+    expect(hasOutput(DEFAULT_OUTPUT_OPTIONS)).toBe(true);
+  });
+});
+
+describe('describeOutputs', () => {
+  it('summarises the selection', () => {
+    expect(describeOutputs(opts({ saveClip: true, saveShort: true }))).toBe(
+      'Save cut, short (captions: burn in).',
+    );
+  });
+  it('reports nothing selected', () => {
+    expect(describeOutputs(opts({ saveShort: false }))).toBe('Nothing selected to save.');
+  });
+});

--- a/app/renderer/src/lib/outputOptions.ts
+++ b/app/renderer/src/lib/outputOptions.ts
@@ -1,0 +1,121 @@
+// outputOptions.ts — pure model for the Output Tray's delivery options (P4 §h).
+//
+// Consolidates the "how do I get my subtitles + which files do I keep" choices
+// the Output Tray exposes after any primary action (Make Shorts / Edit /
+// Director). Kept pure (no React) so the permutations are exhaustively unit
+// tested and the same resolver feeds the export payload + the human summary.
+//
+// Subtitle DELIVERY is a single mode (you can't both burn AND soft-mux the same
+// pass); the three SAVE intents are independent booleans, so every combination
+// of {clip, short, srt} is expressible. The sidecar mirrors `resolveBurn` /
+// `writesSubtitleFile` server-side when it runs the export.
+
+/** How subtitles are delivered with the exported video. */
+export type SubtitleMode = 'burn' | 'softmux' | 'sidecar' | 'none';
+
+/** Delivery modes in display order. */
+export const SUBTITLE_MODES: readonly SubtitleMode[] = ['burn', 'softmux', 'sidecar', 'none'];
+
+/** Friendly label + one-line help for each delivery mode (UI copy). */
+export const SUBTITLE_MODE_META: Record<SubtitleMode, { label: string; help: string }> = {
+  burn: { label: 'Burn in', help: 'Captions are baked into the video pixels (always visible).' },
+  softmux: {
+    label: 'Soft track',
+    help: 'Captions are a selectable subtitle track inside the video file.',
+  },
+  sidecar: {
+    label: 'Separate file',
+    help: 'Captions are written as a separate subtitle file next to the video.',
+  },
+  none: { label: 'No captions', help: 'Export the video with no captions at all.' },
+};
+
+/** The Output Tray's delivery + save selection. */
+export interface OutputOptions {
+  /** How subtitles ride the exported video. */
+  subtitleMode: SubtitleMode;
+  /** Keep the edited/source clip (the cut). */
+  saveClip: boolean;
+  /** Keep the produced short. */
+  saveShort: boolean;
+  /** Write the .srt subtitle file separately. */
+  saveSrt: boolean;
+}
+
+/** Quality-ON default (G-4): burn captions, keep the short. */
+export const DEFAULT_OUTPUT_OPTIONS: OutputOptions = {
+  subtitleMode: 'burn',
+  saveClip: false,
+  saveShort: true,
+  saveSrt: false,
+};
+
+/** True when subtitles are hard-burned into the pixels. */
+export function resolveBurn(mode: SubtitleMode): boolean {
+  return mode === 'burn';
+}
+
+/** True when subtitles appear IN the exported video (burned or soft track). */
+export function embedsSubtitles(mode: SubtitleMode): boolean {
+  return mode === 'burn' || mode === 'softmux';
+}
+
+/**
+ * True when a standalone subtitle FILE must be produced: explicitly as the
+ * sidecar delivery, OR because the user asked to save the SRT separately. (Burn
+ * + soft-mux still need an intermediate subtitle build, but only this set keeps
+ * the file as a deliverable.)
+ */
+export function writesSubtitleFile(options: OutputOptions): boolean {
+  return options.subtitleMode === 'sidecar' || options.saveSrt;
+}
+
+/** A known subtitle mode, or the default for anything else. */
+export function coerceSubtitleMode(raw: unknown): SubtitleMode {
+  const v = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  return (SUBTITLE_MODES as readonly string[]).includes(v)
+    ? (v as SubtitleMode)
+    : DEFAULT_OUTPUT_OPTIONS.subtitleMode;
+}
+
+/** A real boolean, or `fallback` (for persisted/untrusted values). */
+function boolOr(v: unknown, fallback: boolean): boolean {
+  return typeof v === 'boolean' ? v : fallback;
+}
+
+/** Validate raw (persisted/untrusted) options into a clean OutputOptions. */
+export function sanitizeOutputOptions(
+  raw: Partial<OutputOptions> | null | undefined,
+): OutputOptions {
+  const r = raw ?? {};
+  return {
+    subtitleMode: coerceSubtitleMode(r.subtitleMode),
+    saveClip: boolOr(r.saveClip, DEFAULT_OUTPUT_OPTIONS.saveClip),
+    saveShort: boolOr(r.saveShort, DEFAULT_OUTPUT_OPTIONS.saveShort),
+    saveSrt: boolOr(r.saveSrt, DEFAULT_OUTPUT_OPTIONS.saveSrt),
+  };
+}
+
+/** The set of artifacts a given selection produces (stable order). */
+export function outputArtifacts(options: OutputOptions): string[] {
+  const out: string[] = [];
+  if (options.saveClip) out.push('clip');
+  if (options.saveShort) out.push('short');
+  if (writesSubtitleFile(options)) out.push('srt');
+  return out;
+}
+
+/** True when at least one deliverable will be produced (gates the Save action). */
+export function hasOutput(options: OutputOptions): boolean {
+  return outputArtifacts(options).length > 0;
+}
+
+/** A short human summary of the selection (UI acknowledgement + a11y). */
+export function describeOutputs(options: OutputOptions): string {
+  const artifacts = outputArtifacts(options);
+  if (artifacts.length === 0) return 'Nothing selected to save.';
+  const names: Record<string, string> = { clip: 'cut', short: 'short', srt: 'SRT' };
+  const list = artifacts.map((a) => names[a]).join(', ');
+  const sub = SUBTITLE_MODE_META[options.subtitleMode].label.toLowerCase();
+  return `Save ${list} (captions: ${sub}).`;
+}

--- a/app/renderer/src/views/MakeShorts.test.tsx
+++ b/app/renderer/src/views/MakeShorts.test.tsx
@@ -8,6 +8,7 @@ import type { Candidate, ShortReexportHint, Video } from '../lib/rpc';
 
 const libraryListMock = vi.fn();
 const exportMock = vi.fn();
+const settingsGetMock = vi.fn();
 let hasApiValue = true;
 
 vi.mock('../lib/rpc', () => ({
@@ -15,7 +16,26 @@ vi.mock('../lib/rpc', () => ({
   client: {
     library: { list: (...a: unknown[]) => libraryListMock(...a) },
     shortmaker: { export: (...a: unknown[]) => exportMock(...a) },
+    settings: { get: (...a: unknown[]) => settingsGetMock(...a) },
   },
+}));
+
+vi.mock('../components/CaptionDesigner', () => ({
+  CaptionDesigner: ({
+    design,
+    onChange,
+    videoId,
+  }: {
+    design: { style: string };
+    onChange: (d: { style: string }) => void;
+    videoId?: string;
+  }) => (
+    <div data-testid="caption-designer" data-style={design.style} data-video-id={videoId}>
+      <button type="button" onClick={() => onChange({ ...design, style: 'karaoke' })}>
+        designer-pick-karaoke
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock('./Shorts', () => ({
@@ -76,7 +96,13 @@ const MANUAL_CANDS: Candidate[] = [
 
 vi.mock('../components/OutputTray', () => {
   // Self-contained (vi.mock is hoisted — no top-level refs allowed).
-  const seed = { caption: true, translate: false, reframe: true, burnSubs: true, language: 'en' };
+  const seed = {
+    caption: true,
+    translate: false,
+    reframe: true,
+    subtitleMode: 'burn',
+    language: 'en',
+  };
   return {
     DEFAULT_OUTPUT_TRAY: seed,
     OutputTray: ({
@@ -126,6 +152,8 @@ beforeEach(() => {
   libraryListMock.mockResolvedValue({ videos: [makeVideo()] });
   exportMock.mockReset();
   exportMock.mockResolvedValue({ clips: [{ path: '/out/1.mp4' }] });
+  settingsGetMock.mockReset();
+  settingsGetMock.mockResolvedValue({});
   container = document.createElement('div');
   document.body.appendChild(container);
   root = createRoot(container);
@@ -240,9 +268,65 @@ describe('<MakeShorts />', () => {
     const [vid, ids, opts] = exportMock.mock.calls[0];
     expect(vid).toBe('v1');
     expect(ids).toEqual(['1@10']);
-    expect(opts).toMatchObject({ candidates: MANUAL_CANDS });
+    // P4 §4: the caption design + subtitle delivery ride the export payload.
+    expect(opts).toMatchObject({
+      candidates: MANUAL_CANDS,
+      captionStyle: 'libass',
+      subtitleMode: 'burn',
+    });
+    expect(opts.captionPosition).toMatchObject({ w: expect.any(Number), h: expect.any(Number) });
     expect(container.querySelector('.make-shorts__note')?.textContent).toContain('Exported 1 clip');
     expect(container.querySelector('[data-testid="output-tray"]')).toBeTruthy();
+  });
+
+  it('seeds the caption design + subtitle delivery from persisted preferences', async () => {
+    settingsGetMock.mockResolvedValue({
+      defaultCaptionStyle: 'neon',
+      defaultSubtitleMode: 'sidecar',
+      defaultLanguage: 'pt',
+    });
+    await mount();
+    await selectVideo('v1');
+    // The designer reflects the persisted style.
+    expect(
+      container.querySelector('[data-testid="caption-designer"]')?.getAttribute('data-style'),
+    ).toBe('neon');
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'manual-submit',
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    const [, , opts] = exportMock.mock.calls[0];
+    expect(opts).toMatchObject({ captionStyle: 'neon', subtitleMode: 'sidecar' });
+  });
+
+  it('swallows a settings.get rejection (keeps built-in defaults)', async () => {
+    settingsGetMock.mockRejectedValue(new Error('settings down'));
+    await mount();
+    await selectVideo('v1');
+    // Built-in default style survives.
+    expect(
+      container.querySelector('[data-testid="caption-designer"]')?.getAttribute('data-style'),
+    ).toBe('libass');
+  });
+
+  it('updates the caption design from the editor', async () => {
+    await mount();
+    await selectVideo('v1');
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'designer-pick-karaoke',
+        ) as HTMLButtonElement
+      ).click();
+    });
+    expect(
+      container.querySelector('[data-testid="caption-designer"]')?.getAttribute('data-style'),
+    ).toBe('karaoke');
   });
 
   it('surfaces a manual-export error and shows no tray', async () => {
@@ -338,6 +422,25 @@ describe('<MakeShorts />', () => {
     act(() => root.unmount());
     await act(async () => {
       resolveList({ videos: [makeVideo()] });
+      await Promise.resolve();
+    });
+    root = createRoot(container);
+  });
+
+  it('ignores a late settings.get result after unmount (cancelled guard)', async () => {
+    let resolveSettings: (v: Record<string, unknown>) => void = () => {};
+    settingsGetMock.mockReturnValue(
+      new Promise((res) => {
+        resolveSettings = res;
+      }),
+    );
+    await act(async () => {
+      root.render(<MakeShorts />);
+    });
+    await flush();
+    act(() => root.unmount());
+    await act(async () => {
+      resolveSettings({ defaultCaptionStyle: 'neon' });
       await Promise.resolve();
     });
     root = createRoot(container);

--- a/app/renderer/src/views/MakeShorts.tsx
+++ b/app/renderer/src/views/MakeShorts.tsx
@@ -19,10 +19,21 @@ import { Repurpose } from './Repurpose';
 import { ShortMaker } from '../features/ShortMaker';
 import { ManualInterval } from '../features/ManualInterval';
 import { OutputTray, DEFAULT_OUTPUT_TRAY, type OutputTrayState } from '../components/OutputTray';
+import { CaptionDesigner } from '../components/CaptionDesigner';
 import { buildExportParams } from '../features/shortMakerPresets';
 import { candidateId, sanitizeControls } from '../features/shortMakerLogic';
+import {
+  type CaptionDesign,
+  DEFAULT_CAPTION_DESIGN,
+  captionDesignWire,
+  sampleCaptionCues,
+} from '../lib/captionDesign';
+import { readPreferences } from '../lib/captionPreferences';
 import { client, hasApi, type Candidate, type ShortReexportHint, type Video } from '../lib/rpc';
 import './makeShorts.css';
+
+/** Seconds of the source the caption editor previews (style/position rehearsal). */
+const CAPTION_PREVIEW_SEC = 6;
 
 const SECTIONS: TabDef[] = [
   { id: 'make', label: 'Make' },
@@ -50,6 +61,9 @@ export function MakeShorts({ resumeId }: MakeShortsProps): React.ReactElement {
   const [manualError, setManualError] = useState<string | null>(null);
   const [tray, setTray] = useState<OutputTrayState>(DEFAULT_OUTPUT_TRAY);
   const [trayOpen, setTrayOpen] = useState(false);
+  // P4 §4: the caption design (style + on-frame position) for the manual export,
+  // seeded from the persisted Preferences (Settings → Caption defaults).
+  const [design, setDesign] = useState<CaptionDesign>(DEFAULT_CAPTION_DESIGN);
 
   useEffect(() => {
     if (!hasApi()) return;
@@ -61,6 +75,29 @@ export function MakeShorts({ resumeId }: MakeShortsProps): React.ReactElement {
       })
       .catch(() => {
         // Best-effort: the picker simply stays empty if the list fails.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // P4 §4: seed the caption design + output defaults from the persisted
+  // Preferences so a new short starts from the user's chosen style/position/
+  // delivery. Best-effort: a missing/failed settings read keeps the built-in
+  // defaults (never blocks the front door).
+  useEffect(() => {
+    if (!hasApi()) return;
+    let cancelled = false;
+    void client.settings
+      .get()
+      .then((raw) => {
+        if (cancelled) return;
+        const prefs = readPreferences(raw);
+        setDesign(prefs.design);
+        setTray((t) => ({ ...t, subtitleMode: prefs.subtitleMode, language: prefs.language }));
+      })
+      .catch(() => {
+        // Best-effort: keep the built-in defaults if preferences can't be read.
       });
     return () => {
       cancelled = true;
@@ -91,7 +128,14 @@ export function MakeShorts({ resumeId }: MakeShortsProps): React.ReactElement {
       setTrayOpen(false);
       setManualBusy(true);
       try {
-        const params = buildExportParams(selectedId, candidates, sanitizeControls({}), '');
+        const wire = captionDesignWire(design);
+        // The design's style flows via controls.captionStyle; the position +
+        // subtitle delivery flow via the export output options (P4 §4).
+        const controls = sanitizeControls({ captionStyle: wire.captionStyle });
+        const params = buildExportParams(selectedId, candidates, controls, '', {
+          captionPosition: wire.captionPosition,
+          subtitleMode: tray.subtitleMode,
+        });
         await client.shortmaker.export(selectedId, candidates.map(candidateId), params);
         setManualNote(`Exported ${candidates.length} clip(s) from your ranges.`);
         setTrayOpen(true);
@@ -101,7 +145,7 @@ export function MakeShorts({ resumeId }: MakeShortsProps): React.ReactElement {
         setManualBusy(false);
       }
     },
-    [selectedId],
+    [selectedId, design, tray.subtitleMode],
   );
 
   return (
@@ -133,6 +177,21 @@ export function MakeShorts({ resumeId }: MakeShortsProps): React.ReactElement {
                 <section className="make-shorts__ai">
                   <h2 className="make-shorts__heading">AI moment-pick</h2>
                   <ShortMaker videoId={selectedId} />
+                </section>
+
+                <section className="make-shorts__captions">
+                  <h2 className="make-shorts__heading">Caption &amp; style</h2>
+                  <p className="make-shorts__sub">
+                    Drag the caption box to position it, pick a style — previewed live on your
+                    video.
+                  </p>
+                  <CaptionDesigner
+                    videoId={selectedId}
+                    window={{ start: 0, end: CAPTION_PREVIEW_SEC }}
+                    cues={sampleCaptionCues({ start: 0, end: CAPTION_PREVIEW_SEC })}
+                    design={design}
+                    onChange={setDesign}
+                  />
                 </section>
 
                 <section className="make-shorts__manual">

--- a/app/renderer/src/views/Settings.test.tsx
+++ b/app/renderer/src/views/Settings.test.tsx
@@ -38,6 +38,9 @@ vi.mock('../components/PathsPanel', () => ({
 vi.mock('../components/SetupStatusPanel', () => ({
   SetupStatusPanel: () => <div data-testid="setup" />,
 }));
+vi.mock('../components/CaptionPreferences', () => ({
+  CaptionPreferences: () => <div data-testid="preferences" />,
+}));
 
 import { Settings, SETTINGS_SECTIONS } from './Settings';
 
@@ -84,6 +87,7 @@ describe('Settings sub-nav', () => {
       'setup',
       'providers',
       'storage',
+      'preferences',
       'health',
     ]);
     expect(SETTINGS_SECTIONS.map((s) => s.label)).toEqual([
@@ -91,8 +95,19 @@ describe('Settings sub-nav', () => {
       'Setup',
       'Providers & Keys',
       'Storage',
+      'Caption defaults',
       'System Health',
     ]);
+  });
+
+  it('opens the Caption defaults (Preferences) section via the sub-tab', async () => {
+    await mount();
+    await act(async () => {
+      subtab('Caption defaults').click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="preferences"]')).not.toBeNull();
+    expect(subtab('Caption defaults').classList.contains('tab--active')).toBe(true);
   });
 
   it('opens the Setup section (self-diagnostic) via the sub-tab', async () => {

--- a/app/renderer/src/views/Settings.tsx
+++ b/app/renderer/src/views/Settings.tsx
@@ -20,6 +20,7 @@ import { SystemHealth } from '../features/SystemHealth';
 import { ProvidersKeys } from '../features/ProvidersKeys';
 import { PathsPanel, type PathsBridge } from '../components/PathsPanel';
 import { SetupStatusPanel } from '../components/SetupStatusPanel';
+import { CaptionPreferences } from '../components/CaptionPreferences';
 import { client } from '../lib/rpc';
 import { resolveWindowApi } from '../features/shortMakerLogic';
 import './settings.css';
@@ -93,6 +94,13 @@ export const SETTINGS_SECTIONS: SettingsSection[] = [
     // `client.paths`; the data-root flow + open-in-folder via the window.api
     // bridge (fail-soft per control when the preload is absent).
     render: () => <PathsPanel rpc={client.paths} bridge={pathsBridge()} />,
+  },
+  {
+    id: 'preferences',
+    label: 'Caption defaults',
+    // P4 §4: the Preferences area — caption style/position, subtitle delivery,
+    // and language defaults every new short seeds from (persisted to settings).
+    render: () => <CaptionPreferences />,
   },
   {
     id: 'health',

--- a/sidecar/media_studio/features/caption.py
+++ b/sidecar/media_studio/features/caption.py
@@ -29,6 +29,7 @@ injectable so tests exercise argv construction with no real ffmpeg present.
 from __future__ import annotations
 
 import contextlib
+import math
 import os
 import tempfile
 from collections.abc import Callable, Mapping, Sequence
@@ -198,6 +199,57 @@ def render_cue_text(cue: CueLike) -> str:
 # --------------------------------------------------------------------------- #
 # ASS document generation (pure function — the heart of the unit)
 # --------------------------------------------------------------------------- #
+def normalize_caption_box(raw: Any) -> dict[str, float] | None:
+    """Validate a renderer caption box (``{x,y,w,h}`` fractions 0..1) or None.
+
+    The renderer's caption position editor (P4 §4) sends a NORMALISED box; this
+    coerces + clamps it into a usable box, returning ``None`` for anything that
+    is not a finite-numbered ``{x,y,w,h}`` so the caller keeps the default
+    bottom-centred placement (never a silent crash on malformed input).
+    """
+    if not isinstance(raw, dict):
+        return None
+    try:
+        x = float(raw["x"])
+        y = float(raw["y"])
+        w = float(raw["w"])
+        h = float(raw["h"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not all(math.isfinite(v) for v in (x, y, w, h)):
+        return None
+    w = min(max(w, 0.0), 1.0)
+    h = min(max(h, 0.0), 1.0)
+    x = min(max(x, 0.0), 1.0)
+    y = min(max(y, 0.0), 1.0)
+    return {"x": x, "y": y, "w": w, "h": h}
+
+
+def caption_position_fields(box: dict[str, float], play_x: int, play_y: int) -> tuple[int, int, int, int]:
+    """ASS ``(Alignment, MarginL, MarginR, MarginV)`` for a normalised box.
+
+    The box centre's vertical band picks the anchor (top=8 / middle=5 /
+    bottom=2, all horizontally centred); margins place the box edge in pixels.
+    For a TOP-anchored line MarginV measures from the top edge, for a BOTTOM line
+    from the bottom edge, and a MIDDLE line ignores MarginV (libass centres it).
+    """
+    y = box["y"]
+    h = box["h"]
+    cy = y + h / 2.0
+    if cy < 1.0 / 3.0:
+        alignment = 8
+        margin_v = int(round(y * play_y))
+    elif cy < 2.0 / 3.0:
+        alignment = 5
+        margin_v = 0
+    else:
+        alignment = 2
+        margin_v = int(round((1.0 - (y + h)) * play_y))
+    margin_l = int(round(box["x"] * play_x))
+    margin_r = int(round((1.0 - (box["x"] + box["w"])) * play_x))
+    return alignment, max(0, margin_l), max(0, margin_r), max(0, margin_v)
+
+
 def build_ass(
     cues: Sequence[CueLike],
     width: int = 1080,
@@ -205,6 +257,7 @@ def build_ass(
     source_start: float = 0.0,
     hook_title: str | None = None,
     total_sec: float = 0.0,
+    position: Any = None,
 ) -> str:
     """Build a complete ASS subtitle document for ``cues``.
 
@@ -226,7 +279,16 @@ def build_ass(
     # A readable default style scaled to the canvas height. Bottom-centred,
     # white fill with a black outline + drop shadow (typical short-form caption).
     font_size = max(12, int(round(play_y * 0.045)))
-    margin_v = max(10, int(round(play_y * 0.06)))
+    default_margin_v = max(10, int(round(play_y * 0.06)))
+
+    # P4 §4: honour the renderer's normalised caption POSITION box when present
+    # (alignment + margins from the box); otherwise keep the bottom-centred
+    # default. Malformed boxes fall back to the default (no silent crash).
+    box = normalize_caption_box(position)
+    if box is not None:
+        alignment, margin_l, margin_r, margin_v = caption_position_fields(box, play_x, play_y)
+    else:
+        alignment, margin_l, margin_r, margin_v = 2, 40, 40, default_margin_v
 
     styles = [
         (
@@ -235,7 +297,7 @@ def build_ass(
             "&H00FFFFFF,&H000000FF,&H00000000,&H64000000,"
             "-1,0,0,0,"
             "100,100,0,0,1,3,1,"
-            f"2,40,40,{margin_v},1"
+            f"{alignment},{margin_l},{margin_r},{margin_v},1"
         ),
     ]
 
@@ -434,6 +496,7 @@ class CaptionEngine:
         source_start: float = 0.0,
         hook_title: str | None = None,
         total_sec: float = 0.0,
+        position: Any = None,
     ) -> str:
         """Generate the ASS document (delegates to module-level :func:`build_ass`)."""
         return build_ass(
@@ -443,6 +506,7 @@ class CaptionEngine:
             source_start=source_start,
             hook_title=hook_title,
             total_sec=total_sec,
+            position=position,
         )
 
     def render(
@@ -458,6 +522,7 @@ class CaptionEngine:
         should_cancel: Callable[[], bool] | None = None,
         total_sec: float = 0.0,
         hook_title: str | None = None,
+        position: Any = None,
     ) -> str:
         """Render ``cues`` onto ``clip_path`` -> ``out_path`` and return ``out_path``.
 
@@ -481,6 +546,7 @@ class CaptionEngine:
             source_start=source_start,
             hook_title=hook_title,
             total_sec=total_sec,
+            position=position,
         )
 
         # Write the ASS to a temp sidecar file. We pass its path as an argv

--- a/sidecar/media_studio/features/shortmaker.py
+++ b/sidecar/media_studio/features/shortmaker.py
@@ -328,6 +328,30 @@ def _lazy_brand_overlay(in_path, out_path, logo_path, *, settings=None) -> str:
     return out_path
 
 
+# P4 §4: subtitle DELIVERY mode (renderer Output Tray). Burn = hardcode into
+# pixels; softmux = embed a selectable soft subtitle track; sidecar = deliver the
+# subtitles as a SEPARATE file (no captions embedded in the short); none = no
+# subtitles at all. The renderer also exposes "Save SRT separately" (subtitles.
+# export), so the sidecar/none modes still let the user keep an SRT.
+_SUBTITLE_MODES = ("burn", "softmux", "sidecar", "none")
+
+
+def resolve_subtitle_mode(settings) -> str:
+    """The validated ``subtitleMode`` (defaults to ``burn`` — quality-ON, G-4)."""
+    raw = str((settings or {}).get("subtitleMode") or "").strip().lower()
+    return raw if raw in _SUBTITLE_MODES else "burn"
+
+
+def caption_embedded(settings) -> bool:
+    """True when captions are written INTO the exported video (burn or soft track)."""
+    return resolve_subtitle_mode(settings) in ("burn", "softmux")
+
+
+def resolve_caption_burn(settings) -> bool:
+    """True when captions are hard-burned into the pixels (``subtitleMode=burn``)."""
+    return resolve_subtitle_mode(settings) == "burn"
+
+
 def _lazy_caption(
     clip_path,
     cues,
@@ -347,12 +371,18 @@ def _lazy_caption(
       - "none"                                       -> skip captioning entirely
       - anything else / unset                        -> libass (the default)
 
+    P4 §4 subtitle DELIVERY (settings["subtitleMode"]): captions are only written
+    INTO the video for burn / softmux; for sidecar / none the stage is skipped
+    (the clip passes through bare and the subtitles, if any, are delivered as a
+    separate file via subtitles.export). ``settings["captionPosition"]`` (a
+    normalised box) positions the libass default caption when present.
+
     P3-A: ``hook_title`` (the candidate's hook headline, or None to skip) is
     threaded into BOTH engines so the overlay rides whichever caption engine the
     style selects.
     """
     style = str((settings or {}).get("captionStyle") or "").strip().lower()
-    if style == "none":
+    if style == "none" or not caption_embedded(settings):
         return clip_path  # pass-through: the export stage encodes the bare clip
 
     if style:
@@ -384,6 +414,8 @@ def _lazy_caption(
         height=height,
         source_start=source_start,
         hook_title=hook_title,
+        # P4 §4: the libass default engine honours the caption position box.
+        position=(settings or {}).get("captionPosition"),
     )
 
 
@@ -1001,13 +1033,17 @@ def _export_one(
     if (settings or {}).get("hookTitle", True):
         hook_text = str(candidate.get("hook", "") or "").strip()
         hook_title = hook_text or None
+    # P4 §4 subtitle DELIVERY: burn only when subtitleMode is "burn"; for the
+    # soft-track / sidecar / none modes the caption stage soft-muxes or skips (the
+    # stage RETURNS the path to encode — the bare clip when it skips), so capture
+    # it instead of assuming the captioned path always exists.
     captioned_path = str(out_dir / f"{stem}.captioned.mp4")
-    stages.render_caption(
+    caption_out = stages.render_caption(
         caption_clip,
         caption_cues,
         captioned_path,
         source_start=caption_source_start,
-        burn=True,
+        burn=resolve_caption_burn(settings),
         width=OUT_WIDTH,
         height=OUT_HEIGHT,
         settings=settings,
@@ -1020,11 +1056,11 @@ def _export_one(
     # drained ffmpeg.run seam (C16). The final {stem}.mp4 path is unchanged.
     from . import brandkit as _brandkit  # lazy: keep shortmaker import-light
 
-    export_input = captioned_path
+    export_input = caption_out
     if _brandkit.has_brand_logo(settings):
         branded_path = str(out_dir / f"{stem}.branded.mp4")
         stages.brand_overlay(
-            captioned_path,
+            caption_out,
             branded_path,
             _brandkit.brand_logo_path(settings),
             settings=settings,
@@ -1260,10 +1296,17 @@ class ShortMaker:
             raise _invalid_params("videoId (str) is required")
         settings = dict(self.settings_provider())
         # T4b: optional per-export string overrides (renderer ShortMaker controls).
-        for key in ("reframeEngine", "captionStyle"):
+        # P4 §4: subtitleMode is the same kind of optional per-export string
+        # override (burn / softmux / sidecar / none — Output Tray delivery).
+        for key in ("reframeEngine", "captionStyle", "subtitleMode"):
             value = params.get(key)
             if isinstance(value, str) and value:
                 settings[key] = value
+        # P4 §4: the caption POSITION box (normalised {x,y,w,h}); only a dict is
+        # accepted so a malformed value can never poison the libass layout.
+        caption_position = params.get("captionPosition")
+        if isinstance(caption_position, dict):
+            settings["captionPosition"] = caption_position
         # P3/P4: optional per-export BOOLEAN toggles (frozen mini-contract):
         #   hookTitle (default true)  -> render the candidate's hook as a top
         #                                title in the CAPTION stage (P3-A);

--- a/sidecar/tests/test_caption_position.py
+++ b/sidecar/tests/test_caption_position.py
@@ -1,0 +1,139 @@
+"""P4 §4 — caption POSITION box -> ASS alignment + margins (caption.py).
+
+Heavy-ML-free: ffmpeg is mocked at the seam (binary resolution monkeypatched,
+runner injected), so no real ffmpeg is spawned.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import ffmpeg
+from media_studio.features import caption
+from media_studio.features.caption import CaptionEngine, build_ass
+
+
+def cue(index: int, start: float, end: float, text: str) -> dict[str, Any]:
+    return {"index": index, "start": start, "end": end, "text": text}
+
+
+@pytest.fixture()
+def fake_ffmpeg(monkeypatch, tmp_path: Path):
+    fake = tmp_path / "ffmpeg"
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(ffmpeg, "ffmpeg_path", lambda settings=None: str(fake))
+    return str(fake)
+
+
+def _default_style_line(doc: str) -> list[str]:
+    line = next(ln for ln in doc.splitlines() if ln.startswith("Style: Default,"))
+    return line.split(",")
+
+
+# --------------------------------------------------------------------------- #
+# normalize_caption_box
+# --------------------------------------------------------------------------- #
+def test_normalize_caption_box_clamps_into_unit_range():
+    assert caption.normalize_caption_box({"x": -0.5, "y": 2.0, "w": 5.0, "h": -1.0}) == {
+        "x": 0.0,
+        "y": 1.0,
+        "w": 1.0,
+        "h": 0.0,
+    }
+
+
+def test_normalize_caption_box_passes_valid_box():
+    assert caption.normalize_caption_box({"x": 0.1, "y": 0.2, "w": 0.5, "h": 0.2}) == {
+        "x": 0.1,
+        "y": 0.2,
+        "w": 0.5,
+        "h": 0.2,
+    }
+
+
+def test_normalize_caption_box_rejects_bad_input():
+    assert caption.normalize_caption_box(None) is None
+    assert caption.normalize_caption_box([1, 2]) is None
+    assert caption.normalize_caption_box({"x": 0.1}) is None
+    assert caption.normalize_caption_box({"x": "wide", "y": 0, "w": 0.5, "h": 0.2}) is None
+    assert caption.normalize_caption_box({"x": float("nan"), "y": 0, "w": 0.5, "h": 0.2}) is None
+
+
+# --------------------------------------------------------------------------- #
+# caption_position_fields
+# --------------------------------------------------------------------------- #
+def test_caption_position_fields_bottom_band():
+    align, ml, mr, mv = caption.caption_position_fields({"x": 0.1, "y": 0.8, "w": 0.8, "h": 0.15}, 1000, 2000)
+    assert align == 2
+    assert (ml, mr) == (100, 100)
+    assert mv == int(round((1.0 - 0.95) * 2000))
+
+
+def test_caption_position_fields_top_band():
+    align, _ml, _mr, mv = caption.caption_position_fields({"x": 0.0, "y": 0.02, "w": 1.0, "h": 0.1}, 1000, 2000)
+    assert align == 8
+    assert mv == int(round(0.02 * 2000))
+
+
+def test_caption_position_fields_middle_band():
+    align, _ml, _mr, mv = caption.caption_position_fields({"x": 0.0, "y": 0.45, "w": 1.0, "h": 0.1}, 1000, 2000)
+    assert align == 5
+    assert mv == 0
+
+
+# --------------------------------------------------------------------------- #
+# build_ass + CaptionEngine threading
+# --------------------------------------------------------------------------- #
+def test_build_ass_honours_position_box_top():
+    doc = build_ass(
+        [cue(1, 0.0, 1.0, "hi")],
+        width=1080,
+        height=1920,
+        position={"x": 0.0, "y": 0.05, "w": 1.0, "h": 0.1},
+    )
+    assert _default_style_line(doc)[-5] == "8"
+
+
+def test_build_ass_default_position_is_bottom_centre():
+    doc = build_ass([cue(1, 0.0, 1.0, "hi")], width=1080, height=1920)
+    fields = _default_style_line(doc)
+    assert fields[-5] == "2"
+    assert (fields[-4], fields[-3]) == ("40", "40")
+
+
+def test_build_ass_ignores_malformed_position():
+    doc = build_ass([cue(1, 0.0, 1.0, "hi")], position={"x": 0.1})  # missing keys
+    assert _default_style_line(doc)[-5] == "2"  # falls back to the default
+
+
+def test_engine_build_ass_threads_position():
+    doc = CaptionEngine().build_ass([cue(1, 0.0, 1.0, "hi")], position={"x": 0.0, "y": 0.05, "w": 1.0, "h": 0.1})
+    assert _default_style_line(doc)[-5] == "8"
+
+
+def test_render_threads_position_into_ass(fake_ffmpeg, monkeypatch):
+    written: dict[str, str] = {}
+    captured: dict[str, str] = {}
+    real_mkstemp = caption.tempfile.mkstemp
+
+    def spy(*a, **k):
+        fd, path = real_mkstemp(*a, **k)
+        written["path"] = path
+        return fd, path
+
+    monkeypatch.setattr(caption.tempfile, "mkstemp", spy)
+
+    def runner(argv, total_sec=0.0, on_progress=None, should_cancel=None):
+        with open(written["path"], encoding="utf-8") as fh:
+            captured["ass"] = fh.read()
+        return 0
+
+    CaptionEngine(runner=runner).render(
+        "/in.mp4",
+        [cue(1, 0.0, 1.0, "body")],
+        "/out.mp4",
+        position={"x": 0.0, "y": 0.05, "w": 1.0, "h": 0.1},
+    )
+    assert _default_style_line(captured["ass"])[-5] == "8"

--- a/sidecar/tests/test_shortmaker.py
+++ b/sidecar/tests/test_shortmaker.py
@@ -203,6 +203,7 @@ class RecordingStages:
                 "width": width,
                 "height": height,
                 "hook_title": hook_title,
+                "settings": settings,
             }
         )
         return out_path

--- a/sidecar/tests/test_shortmaker_export_delivery.py
+++ b/sidecar/tests/test_shortmaker_export_delivery.py
@@ -1,0 +1,98 @@
+"""P4 §4 — subtitle DELIVERY + caption position through run_export + the export
+handler. Reuses the shared harness from test_shortmaker (RecordingStages, the
+registry/transcript fixtures, loader_for, _rpc_ctx)."""
+
+from __future__ import annotations
+
+from media_studio.features import shortmaker as sm
+
+# `registry` is a conftest fixture (auto-available — no import needed).
+from .test_shortmaker import (  # type: ignore[attr-defined]
+    RecordingStages,
+    _rpc_ctx,
+    loader_for,
+    make_ctx,
+    transcript,  # noqa: F401  (pytest fixture, used by name)
+)
+
+_CAND = {
+    "rank": 1,
+    "start": 0.0,
+    "end": 25.0,
+    "durationSec": 25.0,
+    "hook": "h",
+    "why": "w",
+    "score": 9,
+    "sourceStart": 0.0,
+}
+
+
+def test_run_export_softmux_sets_burn_false(transcript, tmp_path):  # noqa: F811
+    rec = RecordingStages([])
+    sm.run_export(
+        make_ctx(),
+        video_id="v1",
+        candidates=[dict(_CAND)],
+        load_context=loader_for(str(tmp_path / "src.mp4"), transcript),
+        out_dir=str(tmp_path / "out"),
+        stages=rec.as_stages(),
+        settings={"subtitleMode": "softmux"},
+    )
+    assert rec.caption_kwargs[0]["burn"] is False
+
+
+def test_run_export_burn_mode_burns(transcript, tmp_path):  # noqa: F811
+    rec = RecordingStages([])
+    sm.run_export(
+        make_ctx(),
+        video_id="v1",
+        candidates=[dict(_CAND)],
+        load_context=loader_for(str(tmp_path / "src.mp4"), transcript),
+        out_dir=str(tmp_path / "out"),
+        stages=rec.as_stages(),
+        settings={"subtitleMode": "burn"},
+    )
+    assert rec.caption_kwargs[0]["burn"] is True
+
+
+def _maker(tmp_path, transcript, rec):  # noqa: F811
+    return sm.ShortMaker(
+        load_context=loader_for(str(tmp_path / "talk.mp4"), transcript),
+        out_dir_for=lambda vid: str(tmp_path / "out"),
+        stages=rec.as_stages(),
+    )
+
+
+def test_export_handler_threads_subtitle_mode_and_position(registry, transcript, tmp_path):  # noqa: F811
+    rec = RecordingStages([])
+    maker = _maker(tmp_path, transcript, rec)
+    box = {"x": 0.1, "y": 0.8, "w": 0.8, "h": 0.15}
+    out = maker.export(
+        {
+            "videoId": "v1",
+            "candidates": [dict(_CAND)],
+            "subtitleMode": "sidecar",
+            "captionPosition": box,
+        },
+        _rpc_ctx(registry),
+    )
+    registry.get(out["jobId"]).wait(timeout=5)
+    cap = rec.caption_kwargs[0]
+    assert cap["settings"]["subtitleMode"] == "sidecar"
+    assert cap["settings"]["captionPosition"] == box
+    assert cap["burn"] is False  # sidecar delivery never burns
+
+
+def test_export_handler_ignores_non_dict_caption_position(registry, transcript, tmp_path):  # noqa: F811
+    rec = RecordingStages([])
+    maker = _maker(tmp_path, transcript, rec)
+    out = maker.export(
+        {
+            "videoId": "v1",
+            "candidates": [dict(_CAND)],
+            "captionPosition": "not-a-dict",
+        },
+        _rpc_ctx(registry),
+    )
+    registry.get(out["jobId"]).wait(timeout=5)
+    assert "captionPosition" not in rec.caption_kwargs[0]["settings"]

--- a/sidecar/tests/test_shortmaker_subtitle_mode.py
+++ b/sidecar/tests/test_shortmaker_subtitle_mode.py
@@ -1,0 +1,102 @@
+"""P4 §4 — subtitle DELIVERY mode + caption position routing (shortmaker.py).
+
+Self-contained: exercises the pure resolvers + ``_lazy_caption`` with both
+caption engines faked (no ffmpeg, no heavy-ML imports).
+"""
+
+from __future__ import annotations
+
+import pytest
+from media_studio.features import shortmaker as sm
+
+
+# --------------------------------------------------------------------------- #
+# pure resolvers
+# --------------------------------------------------------------------------- #
+def test_resolve_subtitle_mode_defaults_to_burn():
+    assert sm.resolve_subtitle_mode({}) == "burn"
+    assert sm.resolve_subtitle_mode(None) == "burn"
+    assert sm.resolve_subtitle_mode({"subtitleMode": "bogus"}) == "burn"
+
+
+@pytest.mark.parametrize("mode", ["burn", "softmux", "sidecar", "none"])
+def test_resolve_subtitle_mode_validates_case_insensitively(mode):
+    assert sm.resolve_subtitle_mode({"subtitleMode": f"  {mode.upper()} "}) == mode
+
+
+def test_caption_embedded():
+    assert sm.caption_embedded({"subtitleMode": "burn"}) is True
+    assert sm.caption_embedded({"subtitleMode": "softmux"}) is True
+    assert sm.caption_embedded({"subtitleMode": "sidecar"}) is False
+    assert sm.caption_embedded({"subtitleMode": "none"}) is False
+
+
+def test_resolve_caption_burn():
+    assert sm.resolve_caption_burn({"subtitleMode": "burn"}) is True
+    assert sm.resolve_caption_burn({"subtitleMode": "softmux"}) is False
+    assert sm.resolve_caption_burn({}) is True  # default burn
+
+
+# --------------------------------------------------------------------------- #
+# _lazy_caption delivery routing
+# --------------------------------------------------------------------------- #
+def _route(monkeypatch, settings):
+    fired: dict = {}
+
+    class FakeLibass:
+        def __init__(self, s):
+            fired["engine"] = "libass"
+
+        def render(self, clip, cues, out, **kw):
+            fired["kw"] = kw
+            return out
+
+    class FakeRemotion:
+        def __init__(self, s):
+            fired["engine"] = "remotion"
+
+        def render(self, clip, cues, out, **kw):
+            fired["kw"] = kw
+            return out
+
+    import media_studio.features.caption as cap
+    import media_studio.features.caption_remotion as rem
+
+    monkeypatch.setattr(cap, "CaptionEngine", FakeLibass)
+    monkeypatch.setattr(rem, "RemotionCaptionEngine", FakeRemotion)
+    out = sm._lazy_caption(
+        "clip.mp4",
+        [],
+        "out.mp4",
+        source_start=0.0,
+        burn=True,
+        width=1080,
+        height=1920,
+        settings=settings,
+    )
+    return fired, out
+
+
+def test_sidecar_mode_skips_embedding(monkeypatch):
+    fired, out = _route(monkeypatch, {"captionStyle": "libass", "subtitleMode": "sidecar"})
+    assert "engine" not in fired  # nothing embedded in the video
+    assert out == "clip.mp4"
+
+
+def test_none_mode_skips_embedding(monkeypatch):
+    fired, out = _route(monkeypatch, {"captionStyle": "bold", "subtitleMode": "none"})
+    assert "engine" not in fired
+    assert out == "clip.mp4"
+
+
+def test_softmux_mode_still_renders(monkeypatch):
+    fired, out = _route(monkeypatch, {"captionStyle": "libass", "subtitleMode": "softmux"})
+    assert fired["engine"] == "libass"
+    assert out == "out.mp4"
+
+
+def test_caption_position_threaded_to_libass(monkeypatch):
+    box = {"x": 0.0, "y": 0.05, "w": 1.0, "h": 0.1}
+    fired, _out = _route(monkeypatch, {"captionStyle": "libass", "subtitleMode": "burn", "captionPosition": box})
+    assert fired["engine"] == "libass"
+    assert fired["kw"]["position"] == box


### PR DESCRIPTION
## WU Phase 4 — Caption editor + output (renderer, on top of the new IA)

Implements docs/V1-GRILL-DECISIONS §f Phase 4 + §h Output Tray: the caption **position editor**, **style templates**, **output options**, and a **Preferences** area. Per CapCut/Submagic/Descript best practice. All existing functionality preserved.

### Position editor (drag/resize/preview)
- `lib/captionPosition.ts` — pure normalised box math (move/resize/clamp, band presets, CSS + wire).
- `components/CaptionBox.tsx` — draggable + 8-handle resizable region over a frame.
- `components/CaptionDesigner.tsx` — **live preview on a real video frame** (Player + box + word-highlighted sample) producing a `CaptionDesign`; Top/Center/Bottom quick bands.

### Style templates (previewable)
- `components/CaptionStylePicker.tsx` — swatch grid; each style rendered with its real palette/font/box/outline and previewed live on the video before processing.

### Output options (burn / srt / combos)
- `lib/outputOptions.ts` + `OutputTray` — subtitle delivery is a real choice (**burn-in / soft track / separate file / none**) + save cut/short/SRT in any combination.
- Sidecar now **honours** the delivery mode: `burn` is derived from `subtitleMode` (was hard-coded `True`); `sidecar`/`none` skip embedding.

### Preferences
- `lib/captionPreferences.ts` + `components/CaptionPreferences.tsx` + Settings -> **Caption defaults** — persists default style/position/delivery/language; Make Shorts seeds from it.

### Sidecar
- `caption.build_ass(position=...)` — normalised box -> ASS alignment + margins (validated, bottom-centred default fallback).
- `shortmaker` — `subtitleMode` resolvers + `captionPosition` accepted by the export handler and threaded to the caption stage.

## Test plan
- Renderer gate: `cd app && npx vitest run --coverage` -> **100%** stmts/branches/funcs/lines (1843 tests).
- Sidecar gate: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` -> **100%** (4269 tests).
- TDD throughout (failing test first); ruff/biome/oxlint clean; gitleaks clean on the diff.
