### PR TITLE
fix(v1-adv): redact cloudApiKey over RPC + stop silent caption erasure

### DIFF
--- a/sidecar/media_studio/features/silencetrim.py
+++ b/sidecar/media_studio/features/silencetrim.py
@@ -272,14 +272,21 @@ def trim_clip(
     run = run or ffmpeg.run
     duration = duration or ffmpeg.ffprobe_duration
 
+    # ADV-FIX (caption erasure): a passthrough that returns ``[]`` made the
+    # caller's :func:`fillers.remap_cues` collapse EVERY caption cue to length 0
+    # (``remap_time`` over an empty keep-list returns 0.0 for all times) — every
+    # caption was then dropped, silently. The identity keep ``[(0.0, inf)]`` maps
+    # any cue time ``t`` back to ``t`` (cues pass through UNCHANGED), so a clip we
+    # could not / need not trim keeps its captions intact.
+    identity_keeps: list[Span] = [(0.0, float("inf"))]
     try:
         total = float(duration(in_path, settings))
     except Exception:  # noqa: BLE001 - a probe failure means we can't trim safely
         log.warning("duration probe failed for %s; skipping silence-trim", in_path)
         _notify(on_notice, "duration probe failed")
-        return in_path, 0.0, []
+        return in_path, 0.0, identity_keeps
     if total <= 0.0:
-        return in_path, 0.0, []
+        return in_path, 0.0, identity_keeps
 
     silences = detect_silence_spans(
         in_path,

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -18,7 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from .models import budget as _budget
-from .models.secrets import redact_keys
+from .models.secrets import redact, redact_keys
 from .util import get_logger
 
 log = get_logger("media_studio.settings")
@@ -166,18 +166,22 @@ class SettingsStore:
     def get(self) -> dict[str, Any]:
         """Return the REDACTED §2 settings object (defaults backfilled).
 
-        This is the RPC-facing view: ``settings.providers[].apiKeys`` are
-        redacted to last-4 via :func:`secrets.redact_keys` so NO full key ever
+        This is the RPC-facing view: ``settings.providers[].apiKeys`` AND the
+        legacy single-cloud ``cloudApiKey`` are redacted to last-4 via
+        :func:`secrets.redact` / :func:`secrets.redact_keys` so NO full key ever
         crosses the RPC boundary (PLAN §WU-keys security invariant). The
-        provider/translator FACTORY path must call :meth:`get_raw` instead — see
-        its docstring. ``cloudApiKey`` (the legacy single-cloud key) stays as-is:
-        it is not part of the pool and the §0 contract names it directly; the
-        Hub's redaction is scoped to the new ``providers`` pool only.
+        provider/translator FACTORY path must call :meth:`get_raw` instead — it is
+        the ONLY accessor that returns the live ``cloudApiKey`` (and pool keys),
+        and it is never registered over RPC. An empty/absent ``cloudApiKey`` is
+        left as-is so the UI does not imply a key exists when none is set.
         """
         merged = self.get_raw()
         providers = merged.get("providers")
         if isinstance(providers, list):
             merged["providers"] = redact_keys(providers)
+        cloud_key = merged.get("cloudApiKey")
+        if isinstance(cloud_key, str) and cloud_key:
+            merged["cloudApiKey"] = redact(cloud_key)
         return merged
 
     def get_raw(self) -> dict[str, Any]:

--- a/sidecar/tests/test_settings_store.py
+++ b/sidecar/tests/test_settings_store.py
@@ -70,10 +70,23 @@ def test_set_is_a_partial_merge(store: SettingsStore) -> None:
 
 def test_set_persists_cloud_api_key_but_not_in_a_project(store: SettingsStore, tmp_path: Path) -> None:
     # The key lives ONLY in the per-user config file, never a project folder (§0).
-    store.set({"cloudApiKey": "sk-secret"})
-    assert store.get()["cloudApiKey"] == "sk-secret"
+    # SECURITY (adv-fix): the RPC-facing get() MUST NOT echo the full cloud key —
+    # it is redacted to last-4 exactly like providers[].apiKeys. Only get_raw()
+    # (the factory path, never registered over RPC) and the on-disk store keep the
+    # live key. set() returns the redacted view too (no echo of a full key).
+    redacted = store.set({"cloudApiKey": "sk-secret-1234"})
+    assert redacted["cloudApiKey"] == "…1234"
+    assert store.get()["cloudApiKey"] == "…1234"
+    assert store.get_raw()["cloudApiKey"] == "sk-secret-1234"
     raw = json.loads((tmp_path / "settings.json").read_text(encoding="utf-8"))
-    assert raw["cloudApiKey"] == "sk-secret"
+    assert raw["cloudApiKey"] == "sk-secret-1234"
+
+
+def test_get_does_not_redact_empty_cloud_api_key(store: SettingsStore) -> None:
+    # An empty/absent cloud key must render as-is ("") — never "…" — so the UI
+    # does not imply a key exists when none is set (the redact branch is skipped).
+    store.set({"cloudApiKey": ""})
+    assert store.get()["cloudApiKey"] == ""
 
 
 def test_set_rejects_non_dict(store: SettingsStore) -> None:

--- a/sidecar/tests/test_silencetrim.py
+++ b/sidecar/tests/test_silencetrim.py
@@ -232,7 +232,11 @@ class TestTrimClip:
             duration=boom_duration,
         )
         assert path == "/in.mp4" and removed == 0.0
-        assert keeps == []  # no timeline -> nothing to remap
+        # ADV-FIX (caption-erasure): a passthrough must return IDENTITY keeps so
+        # the caller's remap_cues maps caption cues through UNCHANGED. Returning
+        # [] made remap_time collapse EVERY cue to 0 -> all captions silently
+        # erased. An open-ended keep (0 .. inf) is the identity transform.
+        assert keeps == [(0.0, float("inf"))]
 
     def test_trim_duration_probe_failure_surfaces_notice(self, settings, tmp_path):
         # WU-3: a probe failure currently passes through silently — it must now
@@ -250,7 +254,8 @@ class TestTrimClip:
             duration=boom_duration,
             on_notice=notices.append,
         )
-        assert path == "/in.mp4" and removed == 0.0 and keeps == []
+        assert path == "/in.mp4" and removed == 0.0
+        assert keeps == [(0.0, float("inf"))]  # identity remap (cues survive)
         assert len(notices) == 1
         assert notices[0]["type"] == stm.SILENCE_TRIM_UNAVAILABLE_NOTICE
         assert "duration" in notices[0]["reason"].lower()
@@ -285,7 +290,37 @@ class TestTrimClip:
             duration=lambda p, s=None: 0.0,
         )
         assert path == "/in.mp4" and removed == 0.0
-        assert keeps == []
+        # ADV-FIX: a non-positive probed duration is also a passthrough; return
+        # identity keeps so cues are never silently erased on remap.
+        assert keeps == [(0.0, float("inf"))]
+
+    def test_trim_passthrough_keeps_remap_cues_through_unchanged(self, settings, tmp_path):
+        # ADV-FIX regression (caption erasure): the identity keeps a passthrough
+        # returns MUST leave caption cues intact when fed to fillers.remap_cues
+        # (the exact shortmaker.py wiring). With the old empty-keeps bug every cue
+        # collapsed to length 0 and was dropped -> all captions silently erased.
+        from media_studio.features import fillers as _fillers
+
+        def boom_duration(p, s=None):
+            raise OSError("ffprobe died")
+
+        _path, _removed, keeps = stm.trim_clip(
+            "/in.mp4",
+            str(tmp_path / "out.mp4"),
+            settings=settings,
+            detect_run=detect_with(SILENCE_STDERR),
+            run=RecordingRun(),
+            duration=boom_duration,
+        )
+        cues = [
+            {"start": 0.0, "end": 1.5, "text": "hello"},
+            {"start": 2.0, "end": 4.0, "text": "world"},
+        ]
+        remapped = _fillers.remap_cues(cues, keeps)
+        assert [(c["start"], c["end"], c["text"]) for c in remapped] == [
+            (0.0, 1.5, "hello"),
+            (2.0, 4.0, "world"),
+        ]
 
     def test_trim_ffmpeg_failure_raises(self, settings, tmp_path):
         with pytest.raises(stm.SilenceTrimError, match="silence-trim re-cut"):


### PR DESCRIPTION
## Summary
Fixes the **CRITICAL** + **HIGH** findings from the V1 adversarial reviews. Both coverage gates remain at 100%.

### SECURITY [CRITICAL] — `cloudApiKey` leaked unredacted over the IPC bridge
`SettingsStore.get()` (the only settings accessor that crosses RPC) redacted `providers[].apiKeys` but passed the legacy single-cloud `cloudApiKey` through in full, so the live key reached the renderer. Now `cloudApiKey` is redacted to last-4 via `secrets.redact()` exactly like the pool keys. The live key is only ever returned by `get_raw()` (the provider/translator factory path, never registered over RPC) and persisted on disk. Empty/absent keys are left as-is so the UI never implies a key exists when none is set.

### CODE [HIGH] — silent caption erasure on silence-trim passthrough
When `trim_clip()` could not trim (duration probe raised, or a non-positive probed duration) it returned an **empty** keeps list. The caller feeds keeps to `fillers.remap_cues()`; `remap_time()` over an empty keep-list maps **every** cue time to `0.0`, so every caption collapsed to zero length and was dropped — captions silently erased. `trim_clip()` now returns the identity keep `[(0.0, inf)]` on both passthrough paths, mapping every cue time t to itself so captions pass through unchanged.

## Completeness review
The COMPLETENESS audit ran against an older `main` (`7b36772`, Phase 1 / #239). Its flagged gaps — manual-interval shorts (h, E3), the Output Tray keystone, the first-class join/concat op (h, E2), the 5-section IA, and the caption editor (P4) — were **already integrated** on the current `main` by #240–#243 (verified). No additional gap work was required.

## Test plan
- [x] TDD: failing tests written first (settings redaction + raw/disk split; silencetrim identity keeps + an end-to-end `remap_cues` cue-survival regression), then implementation.
- [x] Sidecar gate: `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → 100% (4271 passed).
- [x] Renderer gate: `vitest run --coverage` → 100% stmts/branches/funcs/lines (1843 passed).
- [x] pre-commit (ruff lint + format, gitleaks) clean.
