### PR TITLE
docs: V1.1 feature spec - tiered subtitles, model management, media lineage

### DIFF
--- a/docs/V1.1-FEATURES.md
+++ b/docs/V1.1-FEATURES.md
@@ -23,6 +23,59 @@ Tray** opt-in (§h KEYSTONE), the **Edit** Transcript&Captions home (§h.3), or 
 
 ---
 
+## Lane 0 — Foundation Hardening (lands FIRST)
+
+The v1.0.0 **E2E** ("Has-headaches — NOT smooth"), the **pre-build gate** (GO_WITH_CHANGES), and the
+**main ultrareview** (SOLID_WITH_FIXES) reunite into one register: the failure/cancel paths violate the
+V1 "no silent fallbacks — fail LOUD + clear" contract, and the worst offenders live in **shared seams
+every feature lane inherits**. So Lane 0 hardens the foundation BEFORE the S/M/L feature lanes. Full
+reunited register (severity, file:line, source) is in the GATE + ULTRAREVIEW appendix at the end.
+Each F-WU is TDD-first and inherits the 100% line+branch gate + the metaswarm 4-phase flow.
+
+- **F1 — Silent error-masking (HIGH; E2E F1, broadened).** *Who/wants/so-that:* a creator whose job
+  errors WANTS a clear error + Retry SO THAT they don't fiddle prompts on a job that actually failed.
+  Renderer: the SHARED `app/renderer/src/features/_api.ts:151-164` `waitForJobDone` (+ `shortMakerLogic.ts`
+  copies + Transcribe/Convert/Subtitles/Tracks) only extracts success fields and returns null on the
+  `{error}` `job.done` payload → a failed job renders as empty success ("No candidates proposed",
+  "Exported 0 clips"); Transcribe/Convert freeze on 'running' forever (no error branch, no finally).
+  Sidecar: `features/select.py:362-377,636-639` `extract_clips()` returns `[]` on LLM parse-failure
+  (≠ genuine empty). *Acceptance:* bake `{error}` detection into the shared `waitForJobDone` (reuse the
+  existing `extractJobError`, ignore `JobCancelled`, **delete the 5 duplicated `doneErrorMessage` copies**,
+  add a terminal `finally`); raise a typed `SelectionParseError` in `select.py`; distinct error state +
+  Retry; the "No candidates proposed" copy is reserved for a confirmed zero-result.
+- **F2 — Indefinite hang / dead-end (HIGH; E2E F2, broadened).** The shared `_api.ts waitForJobDone`
+  has NO timeout (9 panels); ShortMaker select/batch pass none; `cancel()` never resolves the pending
+  wait nor resets phase, and cancelled jobs emit no `job.done` → Cancel wedges the UI forever; the
+  helper leaks the `onJobDone` subscription. *Acceptance:* timeout + `clearTimeout` + `off()` + reject
+  in the shared helper (sane default for all 9 callers) + AbortSignal so cancel/unmount tears down;
+  `cancel()` sets phase idle regardless of `job.done`. There is ALWAYS a visible escape to idle.
+- **F3 — Windows RAM probe (MEDIUM; E2E F3).** `system_advisor.py:619-638` `_ram_from_os` is POSIX-only
+  → None on Windows. *Acceptance:* a `_ram_from_windows()` (ctypes `GlobalMemoryStatusEx`) behind the
+  EXISTING `RamProbe`/`HardwareProbe` seam (Linux CI covers both branches, no `# pragma`); pin psutil;
+  device card + reason strip render null RAM gracefully ("RAM: unknown", never "undefined MB").
+- **F3b — Sidecar reliability guards (MEDIUM, from ultrareview):** `jobs.py:385-397` `rehydrate()` gets a
+  per-record try/except (else one bad record crashes ALL resumption); a per-job wall-clock watchdog
+  (`jobs.py` worker pool) force-ERRORs a wedged handler so the 2-slot pool can't starve; `transcribe.py`
+  GPU→CPU fallback surfaces a `job.progress` notice ("GPU unavailable — running on CPU, slower");
+  `ctc_align.py` checks the ffmpeg returncode + emits a notice when alignment is skipped (else karaoke
+  timing silently degrades); `handlers.py` gets a `_require_number` validator (clean INVALID_PARAMS).
+- **F3c — Security hardening (MEDIUM, from ultrareview):** require `sha256` (+ HF commit revision) for
+  every `installer='download'` asset incl. the executed `get-pip.py` (`assets/manifest.py`/`manager.py`);
+  Electron defense-in-depth (`app/main/main.ts`): `will-navigate` allowlist, `openExternal` https-only,
+  deny-by-default permission handlers, CSP via `onHeadersReceived`, realpath/symlink containment.
+- **F4 — Modal a11y + onboarding (MEDIUM; E2E F4).** Bounded to the EXACT E2E Lane D findings: a shared
+  `useFocusTrap` (focus-in/Escape/restore) for `ModelsOnboarding`/`FirstRunChooser`; `aria-keyshortcuts`
+  + visible legend for `CandidateReview`; Escape/focus + `aria-controls` for the Jobs slide-over; the
+  enumerated onboarding items become explicit acceptance criteria (no onboarding redesign).
+- **F4b — Quality cleanup (MEDIUM/LOW):** split the god-modules `handlers.py` (4104L) + `rpc.ts` (1555L)
+  early (every lane touches them), then others opportunistically; remove the 2 renderer `console.warn`;
+  add the missing public type annotations; settings_store preserves the RAW key on a redacted round-trip.
+- **F5 — E2E re-run = release gate.** Update the a11y/visual E2E specs to the SHIPPED Make Shorts/Edit/
+  Director/Settings IA (they still drive removed Create/Repurpose/Workspace tabs — `a11y.a11y.spec.ts:62,74,95`),
+  re-baseline snapshots, and cover the T2 disclosure + models.overview + lineage view. F5 must pass before the PR.
+
+---
+
 ## Lane 1 — Tiered Subtitle Customization
 
 ### 1.0 What exists today (the substrate this bolts onto)
@@ -468,6 +521,18 @@ new surface / cross-cutting risk → deferred. Every WU is TDD-first and must ho
 lines+branches gate (sidecar + renderer) — noted per WU. "Gate" column = needs the
 **design-review-gate** (5-agent) before build.
 
+### Lane 0 — Foundation Hardening (sequenced FIRST, before the feature lanes)
+| WU | Label | Scope | Depends | Gate? |
+|----|-------|-------|---------|-------|
+| **F1** | V1.1 | Shared `_api.ts waitForJobDone` detects `{error}` (reuse `extractJobError`, ignore JobCancelled, terminal `finally`) + delete 5 dup `doneErrorMessage`; typed `SelectionParseError` in `select.py`; distinct error state + Retry; reserve "no candidates" for true empty | — | No (HIGH fix) |
+| **F2** | V1.1 | Timeout + AbortSignal + `off()`/reject in the shared `waitForJobDone` (9 panels) + ShortMaker select/batch; `cancel()` resets phase idle regardless of `job.done` | — | No (HIGH fix) |
+| **F3** | V1.1 | `_ram_from_windows()` (ctypes GlobalMemoryStatusEx) behind the existing RamProbe seam (no pragma) + pin psutil + null-RAM UX | — | No |
+| **F3b** | V1.1 | Sidecar guards: `rehydrate()` per-record try/except; worker-pool per-job watchdog→force-ERROR; transcribe CPU-fallback notice; ctc_align ffmpeg-returncode check + skip-notice; `_require_number` validator | — | No |
+| **F3c** | V1.1 | Security: `sha256`+HF-revision required for `installer='download'` (incl. executed get-pip.py); Electron will-navigate allowlist + openExternal https-only + deny-by-default perms + CSP via headers + realpath containment | — | No |
+| **F4** | V1.1 | a11y: shared `useFocusTrap` (focus/Escape/restore) for ModelsOnboarding/FirstRunChooser + `aria-keyshortcuts`/legend for CandidateReview + Jobs slide-over Escape/focus/`aria-controls`; enumerated onboarding items as criteria | — | No |
+| **F4b** | V1.1 | Quality: split `handlers.py`(4104L)+`rpc.ts`(1555L) early; remove 2 renderer `console.warn`; add missing public type annotations; settings_store preserves RAW key on redacted round-trip | — | No |
+| **F5** | V1.1 | Re-run E2E = release gate; update a11y/visual specs to the shipped Make Shorts/Edit/Director/Settings IA + re-baseline; cover T2/overview/lineage | F1-F4b, all S/M/L | No |
+
 ### Lane 1 — Subtitles
 | WU | Label | Scope | Depends | Gate? |
 |----|-------|-------|---------|-------|
@@ -547,20 +612,31 @@ incremental/additive and proceed under the standard plan-review-gate + TDD.
 
 ---
 
-## OPEN QUESTIONS FOR USER
-1. **V1.1 scope cut line:** ship all three lanes' V1.1 WUs in one iteration, or sequence one lane
-   per release (recommended: L1 + Lane-1 first, since subtitles is the most-requested per §e)?
-2. **SQLite migration (L1):** OK to replace `library.json` with SQLite (keeping it as backup), or
-   keep JSON and add a *sidecar* provenance DB to avoid touching the source index at all (lower risk,
-   slight duplication)?
-3. **Curated font list (S2):** bundle a fixed font allowlist for `CaptionOverride.fontFamily`, or
-   detect system fonts (portability/licensing risk on burn-in)?
-4. **Routing default for "auto" (M3):** when cloud is configured, should `global` ever auto-promote
-   to `auto`, or stay `local` until the user explicitly flips it (recommended: stay local)?
-5. **C2PA (L7):** is content-provenance manifest emit a wanted V2 direction (signing keys, identity),
-   or out of scope entirely?
-6. **Execution method for the build:** metaswarm orchestrated / subagent-driven / parallel session
-   (per CLAUDE.md, you choose) — and confirm the design-review gate runs on S5/M3/M6/M7/L1/L7.
+## DECISIONS (RESOLVED 2026-06-28 — do not re-litigate)
+1. **Scope/release:** ONE **v1.1.0** ships Lane 0 (foundation hardening) + all three lanes' V1.1 WUs together. No interim v1.0.1 patch.
+2. **SQLite migration (L1):** REPLACE `library.json` with SQLite behind the `Library` façade; keep `library.json` as backup; `PRAGMA user_version` + single transaction + WAL.
+3. **Curated font list (S2):** bundle a fixed curated allowlist (`CURATED_CAPTION_FONTS`); no system-font detection.
+4. **Routing default (M3):** `global` defaults to `local` and never auto-promotes; user flips it explicitly.
+5. **C2PA (L7):** deferred to V2 (needs a signing identity).
+6. **Execution:** metaswarm orchestrated (4-phase per WU). In-scope design-gated WUs = **M3 + L1** (S5/M6/M7/L7 are V2, out of this build).
+
+## GATE + ULTRAREVIEW — REQUIRED CHANGES (2026-06-28)
+Reunites the v1.0.0 **E2E**, the **pre-build gate** (GO_WITH_CHANGES, 5 genuine reviews), and the **main
+ultrareview** (SOLID_WITH_FIXES; 0 CRITICAL / 3 HIGH / 10 MEDIUM / 5 LOW). HIGH/MEDIUM foundation items
+are Lane 0 (above). The refinements below apply to the named S/M/L feature WUs.
+
+**Apply to the feature WUs:**
+- **S2/S4:** the `#RRGGBB`→`&H00BBGGRR&` BGR+inverted-alpha conversion is asserted by exact-string tests; the per-language CPS default (17 / 20-EN / 13-children), the 10–30 `maxCps` clamp, and `maxLines`→`max_cpl` are NET-NEW branches (table-driven tests incl. clamp edges). **S3:** T2 colours are swatch grid + native `<input type=color>` presets — no hex text field on the primary path. (Karaoke word-timing benefits from the Lane 0 F3b ctc_align fix.)
+- **M1:** split into **M1a** (thin `models.overview` compose) + **M1b** (metadata eligibility: Ollama native `/api/show` POST + `/api/tags` GET at ROOT not `/v1`, VRAM fit formula, **dedup by digest**) via a GET-capable injectable transport. **M2:** null-RAM device-card + reason copy (ties to F3). **M1/M3:** add the requested model **sort** (by VRAM-fit/size/name) + **point** (manual runner base URL/port) affordances in the Advanced disclosure. **M4:** key-pool RPC carries only `redact()`'d last-4; scrub the `/api/v1/key` probe error body; cooldown-not-delete. Runner probes stay key-free (key only to the canonical provider host).
+- **M3 (gated):** single `RoutingPolicy{global, overrides}` with resolution rule `resolve_route(fn) = overrides[fn] ?? { mode: global }` (header toggle = global; Advanced = per-function overrides). The round-1 "dual routing store" concern was reviewed against source and **RETIRED as unverified**.
+- **L1 (gated):** the façade preserves the FULL public surface (`add/list/remove/get/set_has_transcript/set_thumbnail` + `_normalize`) with a shape regression test; migration tests run against a REAL temp-file DB (WAL + `user_version>=1` idempotency + partial/corrupt JSON + transaction rollback); **parameterized (`?`) SQL only** + an injection round-trip test; `content_hash` is a nullable/unpopulated column (no BLAKE3 dep in L1).
+- **L2:** `Depends = L1, M3` (lineage records the resolved RoutingPolicy from M3; build M1-M3 before L2, else add a back-fill WU + placeholder-agent test). Run `params_json`/`agent` through `redact_keys` before write (no secret at rest) + a no-key-in-rows/RPC test.
+- **L5:** ships **hash-verified re-pointing** (explicit user ask): whole-file **BLAKE3** verify on relink. `(size,mtime)` alone is not content verification. Piece-hash recheck stays V2 (L6).
+
+**Reconciliations (deeper review wins):**
+- The gate's "F1 must scrub SECRETS = BLOCKER" → **DOWNGRADED to LOW (path-only)**: the ultrareview's adversarial-verify proved keys are already scrubbed at the `ProviderError` site; only absolute-path disclosure remains (low on a single-user local app). Optional shared path-redactor; a generic wire error + server-side log.
+
+Full reunited register (every finding, file:line, source): basic-memory note `reframe-v1.1.0-reunited-defect-register`.
 
 ---
 

--- a/docs/V1.1-FEATURES.md
+++ b/docs/V1.1-FEATURES.md
@@ -1,0 +1,450 @@
+# Reframe V1.1 — Feature Specification (Tiered Subtitles · Model Management · Media Lineage)
+
+> **Status:** DESIGN ONLY — buildable, gate-ready. No implementation in this PR.
+> **Date:** 2026-06-28 · **Branch:** `docs/v1.1-feature-spec`
+> **Baseline:** merged `main` (#236) + the converged V1 design in
+> [`V1-GRILL-DECISIONS.md`](V1-GRILL-DECISIONS.md) (esp. §e/§f/§g/§h) and the
+> capability boundary in [`ROADMAP.md`](ROADMAP.md).
+> **Architecture (unchanged):** Electron renderer (`app/renderer/src`, React) ⇄
+> Python sidecar (`sidecar/media_studio`) over stdio JSON-RPC.
+> **Hard gate (unchanged):** [`.coverage-thresholds.json`](../.coverage-thresholds.json) =
+> 100% lines+branches, sidecar (pytest `--cov-fail-under=100 --cov-branch`) **and**
+> renderer (vitest 100% lines/branches/functions/statements). Every WU below
+> inherits this. The three-way caption mirror conformance test
+> (`lib/captionTemplates.conformance.test.ts`) is also a hard invariant.
+
+This spec converges three design lanes into ONE iteration. Each lane **extends, does
+not rebuild**, existing modules. The governing V1 principle holds throughout
+(V1-GRILL §e/§h): **novice-first, near-zero config, smart defaults ON, power behind a
+single contextual disclosure.** Nothing in V1.1 is allowed to put a knob on the novice
+front door (Make Shorts single-screen, §h.2) — every new control lives in the **Output
+Tray** opt-in (§h KEYSTONE), the **Edit** Transcript&Captions home (§h.3), or **Settings**
+(§h.5).
+
+---
+
+## Lane 1 — Tiered Subtitle Customization
+
+### 1.0 What exists today (the substrate this bolts onto)
+- **Sidecar render:** `caption.py` `build_ass()` (ASS doc, hook-title, `normalize_caption_box`
+  → `caption_position_fields` = alignment + L/R/V margins), `build_burn_argv` / `build_softmux_argv`;
+  `subtitles.py` `to_ass`/`to_srt`/`to_vtt`, `Cue`/`SubtitleTrack`, `generate_polished`, `translate`,
+  `stack_bilingual`.
+- **Timing/quality gate:** `caption_polish.py` `polish_cues()` — `enforce_cps_cpl`, `enforce_min_gap`,
+  `wrap_two_lines`, `apply_emphasis_spans`, `mask_profanity` (CPS/CPL constants already present).
+- **Word timing:** `ctc_align.py` `align_words()` → `WordSpan`, `merge_word_times_into_transcript`
+  (drives karaoke).
+- **Emphasis:** `emphasis.py` `find_emphasis_spans`, `annotate`, `default_emphasis_for_style`.
+- **Renderer mirror:** `lib/captionTemplates.ts` (`CaptionTemplateVisual`,
+  `REMOTION_CAPTION_TEMPLATES`, `CLEAN_CAPTION_STYLES`, `defaultEmphasisForStyle`);
+  catalog `features/shortMakerLogic.ts` `CAPTION_STYLES` (libass + 14 remotion families + none),
+  `DEFAULT_CAPTION_STYLE='libass'`; wire `lib/captionDesign.ts` (`CaptionDesign{style,box}`,
+  `CaptionDesignWire{captionStyle,captionPosition}`, `sanitizeCaptionDesign`, `sampleCaptionCues`).
+- **Live preview:** `CaptionDesigner` / `CaptionBox` / `CaptionStylePicker` (drag/resize box,
+  animate style on `sampleCaptionCues`).
+
+**The gap:** a "caption style" today is a *whole-template atomic pick* (`style: string`). The user
+cannot adjust *within* a template (font, size, color, outline, position-band, casing, max
+lines/CPS) without a developer adding a new template id to the three-way mirror. There is no
+notion of a saved *user* style, and the timing/readability knobs (`caption_polish` CPS/CPL) are
+sidecar-internal constants, never surfaced.
+
+### 1.1 Converged model — three tiers of customization (progressive disclosure)
+Tiering follows progressive-disclosure best practice (NN/g): the 80% novice sees one choice; the
+20% who want more reveal the next tier without leaving the screen.
+
+| Tier | Who | Surface | What they touch |
+|------|-----|---------|-----------------|
+| **T1 Preset** (default) | novice | Output Tray "Caption?" → style row | Pick 1 of the existing `CAPTION_STYLES` + drag the box. **Zero new fields.** This is exactly today's flow. |
+| **T2 Tune** | prosumer | "Customize…" disclosure under the style row (Edit › Transcript&Captions, and Output Tray) | A bounded **`CaptionOverride`** patch on top of the chosen template: font family (from a curated list), size scale, text/active/spoken colors, outline on/off, box on/off, UPPERCASE on/off, position band, max lines, reading-speed cap. |
+| **T3 Saved style** | power | Settings › Storage&Branding (lives with Brand Kit) | Save a `{style + override}` as a **named user caption style** that then appears in the T1 row across projects; export/import as JSON. |
+
+**Key insight that keeps the three-way mirror intact:** templates stay a *frozen, mirrored* base
+layer; **`CaptionOverride` is a separate, additive patch** applied at render time. The conformance
+test (`captionTemplates.conformance.test.ts`) keeps guarding the base `CAPTION_STYLES` ↔ `TEMPLATES`
+↔ sidecar `STYLES` relation unchanged; overrides are validated independently and never widen the
+template id set.
+
+### 1.2 Schema (frozen field names — additive to `CaptionDesign`)
+
+Renderer (`lib/captionOverride.ts`, new):
+```ts
+export interface CaptionOverride {
+  fontFamily?: string;       // must be in CURATED_CAPTION_FONTS (allowlist); else dropped
+  sizeScale?: number;        // 0.6..1.8 multiplier on the template/auto size; clamp
+  textColor?: string;        // #RRGGBB (validated); falls back to template
+  activeColor?: string;      // karaoke active word
+  spokenColor?: string;      // karaoke already-spoken
+  outline?: boolean;
+  box?: boolean;             // solid caption card
+  uppercase?: boolean;
+  positionBand?: 'top' | 'center' | 'bottom';  // coarse band; fine offset stays in CaptionBox
+  maxLines?: 1 | 2;          // wrap target (Netflix: keep to 1 line unless >42 CPL)
+  maxCps?: number;           // 10..30 reading-speed cap; default per §1.5
+}
+
+// CaptionDesign GAINS one optional field (back-compat: absent => today's behaviour)
+export interface CaptionDesign {
+  style: string;
+  box: CaptionBox;
+  override?: CaptionOverride;   // NEW (V1.1)
+}
+// Wire GAINS one optional field; sidecar reads it, ignores when absent.
+export interface CaptionDesignWire {
+  captionStyle: string;
+  captionPosition: CaptionBox;
+  captionOverride?: CaptionOverride;   // NEW
+}
+```
+
+Sidecar (`caption.py`): a pure `apply_override(base_visual, override) -> ResolvedCaptionStyle`
+helper that merges the validated override onto the resolved template visual *before* `build_ass`
+emits `Style:` lines, and feeds `maxLines`/`maxCps` into `caption_polish.polish_cues` (which already
+enforces CPS/CPL). Validation mirrors `sanitizeCaptionDesign`: unknown font → drop; bad hex → drop;
+out-of-range number → clamp. **No silent crash** (V1-GRILL D-reliability invariant): a malformed
+override degrades field-by-field to the template default, and the resolved style is echoed back to
+the UI so the preview shows exactly what will burn.
+
+Saved user style (T3) persists in settings under `captionStyles: NamedCaptionStyle[]`:
+```ts
+interface NamedCaptionStyle { id: string; name: string; base: string; override: CaptionOverride; }
+```
+
+### 1.3 Algorithm — render path (additive, single new merge step)
+1. UI emits `CaptionDesign{style, box, override?}` → `captionDesignWire()` → export payload.
+2. Sidecar resolves the base visual for `captionStyle` (existing path).
+3. **NEW:** `apply_override()` validates+merges `captionOverride` → `ResolvedCaptionStyle`
+   (font/size/colors/outline/box/uppercase).
+4. `polish_cues()` runs with `max_cpl` derived from `maxLines` and `max_cps` from `maxCps`
+   (existing function, now parameterized from the override instead of module constants).
+5. `build_ass()` emits `Style:`/`Dialogue:` using the resolved style + `caption_position_fields`
+   from `box`+`positionBand`. Karaoke (`\k` tags via `ctc_align` word spans) and emphasis spans are
+   unchanged; colors now come from the resolved style.
+6. Burn (`build_burn_argv`) / softmux / sidecar-SRT outputs are unchanged (Output Tray decides
+   which — V1-GRILL §h KEYSTONE).
+
+### 1.4 UI (novice-first; lives in existing homes, no new tab)
+- **T1 (default, Output Tray "Caption?"):** the existing style row + draggable box on the live
+  video preview. One tap = done. *No change for the novice.*
+- **T2 "Customize…" disclosure:** revealed under the style row in Edit › Transcript&Captions and in
+  the Output Tray's caption step. ~7 controls, all dropdowns/toggles/sliders (V1-GRILL §e "mostly
+  dropdowns, almost no typing"): Font ▾, Size slider, Color swatches (text/active/spoken), Outline
+  ◻, Card ◻, UPPERCASE ◻, Position band ▾, Max lines ▾, Reading speed slider. **Live preview updates
+  on every change** via `sampleCaptionCues` (reuses `CaptionDesigner`).
+- **T3 "Save this style…":** writes a `NamedCaptionStyle`; it appears in the T1 row with a "★ My
+  styles" group. Managed (rename/delete/export/import) in Settings › Storage&Branding next to Brand
+  Kit (V1-GRILL §h.5).
+
+### 1.5 Novice-first defaults
+- Default design unchanged: `DEFAULT_CAPTION_STYLE='libass'`, `DEFAULT_CAPTION_BOX`, **no override**.
+- T2 is collapsed by default; the novice never sees it unless they tap "Customize…".
+- **Reading-speed default = 20 CPS** for English / **17 CPS** for other languages, **max 42 CPL**,
+  prefer 1 line — Netflix Timed Text reading-speed norms, which `caption_polish` already models.[^netflix]
+- Color/emphasis defaults inherit from the template (so "Bold" still looks like Bold). Overrides are
+  *deltas*, never a blank slate.
+
+### 1.6 How it extends V1
+- Extends V1-GRILL §e "Caption/output richness" (style templates + position editor + live preview)
+  by adding the *within-template* tuning the user asked be designed "per CapCut/Submagic/Descript
+  norms" — without breaking the frozen three-way mirror.
+- Slots into the §h IA exactly: T1/T2 in the Output Tray + Edit › Transcript&Captions, T3 in
+  Settings. Zero new top-level surface. Honors §e "language is a dropdown" (override does not touch
+  language).
+
+---
+
+## Lane 2 — Model Management (local / cloud / mixed)
+
+### 2.0 What exists today
+- **Advisor:** `features/system_advisor.py` — `advise()` → `AdvisorReport{components, tiers,
+  recommended_preset, hardware}`, `TierSpec` (tier0-numeric / tier1-multimodal / tier2-vlm),
+  per-component/per-tier `Verdict` with loud reason strings. RPC `system.advisor` / `system.probe`
+  / `system.recommend` / `system.selfTest`.
+- **Model reco:** `models/model_recommend.py` — `recommend_whisper`, `recommend_llm`,
+  `recommend_local_models()` → `LocalModelPlan`, `runner_advice()` → `RunnerAdvice` (per detected
+  runner), `_pull_hint`.
+- **Local runner detect:** `models/local_detect.py` — `detect_local_servers()` probes **Ollama**
+  (`:11434/v1`) and **LM Studio** (`:1234/v1`) → `PoolEntry`. RPC `models.runners`.
+- **Catalog:** `models/catalog.py` — `CatalogEntry`, `PrivacyTier`, `CostClass`, `top_pick_for_task`,
+  `filter_by_capability`. RPC `providers.catalog`.
+- **Cloud + keys:** `models/provider.py` (`CloudProvider`, OpenAI-compatible, key header-only,
+  scrubbed), `models/secrets.py` (`redact`, `scrub_error_body`, `redact_keys`), spend/usage
+  (`spend_ledger.py`, `openrouter_usage.py`, `usage.py`, `budget.py`, `consent.py`). RPC
+  `providers.*` (list/upsert/remove/testKey/usage/spend/openrouterUsage/setConsent/firstRun…).
+
+**The gap:** the pieces exist but are not *unified into one decision surface*. There is no single
+"what will actually run, where, and why" view; no first-class **routing policy** (local-only /
+cloud-only / **mixed** per function); the OpenRouter key *pool* exists in data but lacks a
+rotation+per-key-usage UX; and the advisor's loud reason strings are not yet wired into a novice
+"using model X because device Y" line (V1-GRILL G-9, the cited near-zero-cost trust win).
+
+### 2.1 Converged model — one Routing Policy over three execution modes
+A single **`RoutingPolicy`** is the seam that unifies all of the above. It answers, per AI function
+(asr, moment-select/LLM, caption-polish, translate, director), **where** the work runs:
+
+```ts
+type ExecutionMode = 'local' | 'cloud' | 'auto';   // 'auto' = mixed/poly-processing
+interface FunctionRoute { fn: AiFunction; mode: ExecutionMode; localModel?: string; cloudModel?: string; }
+interface RoutingPolicy {
+  global: ExecutionMode;                 // header toggle (V1-GRILL §h E6)
+  overrides: Record<AiFunction, FunctionRoute>;  // Settings/Advanced per-function override
+}
+```
+- **local** → use a detected runner (Ollama/LM Studio) or bundled local model; never egresses.
+- **cloud** → use a provider key (OpenRouter pool); shows egress + cost.
+- **auto (mixed)** → the existing `AiJob.degradeChain` logic, made first-class: prefer the
+  device-appropriate path, **fall back loudly** to local (terminates local per G-10), surfacing
+  "degraded: fell back to local". This is the poly-processing seam V1-GRILL §h E6 calls for.
+
+**Default = `global: 'local'`, no overrides** (V1-GRILL G-10 local-only default; zero egress
+surprises). Cloud is opt-in and always shows a `willEgress` badge (G-12).
+
+### 2.2 Schema (additive; reuses existing dataclasses)
+- Sidecar surfaces a **unified "Models & System" report** = `advise()` (already produced) +
+  `detect_local_servers()` + `runner_advice()` + provider/key state + `RoutingPolicy`, merged into
+  one RPC response so the UI renders one screen. New thin RPC **`models.overview`** (read) and
+  **`models.setRoutingPolicy`** (write) — composed from existing functions, no new model logic.
+- **OpenRouter key pool** (extends `PoolEntry`/`secrets`): `KeyPoolEntry{id, providerId,
+  redactedKey, unit?, usage: {spent, limit?, lastUsedAt, status}}`. Rotation = round-robin over
+  healthy keys; a key that returns 402/429 is marked `cooldown` (not deleted), surfaced per-key.
+  Reuses `redact()`/`redact_keys()` so RPC never carries a raw key; reuses `openrouter_usage.py` for
+  per-key consumption.
+
+### 2.3 Algorithm — model selection (extend, don't rebuild)
+1. On first run / Settings open: `system.probe` → hardware; `advise()` → `recommended_preset` +
+   loud reasons; `detect_local_servers()` → runners; `recommend_local_models()` → suggested
+   whisper+LLM pulls; provider/key state loaded.
+2. **NEW (thin):** compose into `models.overview` = `{hardware, tiers, recommendedPreset,
+   runners[], localPlan, providers[], keyPool[], routingPolicy}`.
+3. UI shows the **one-line reason** (G-9): "Transcribing with `whisper large-v3-turbo` (GPU 8GB) ·
+   moments by `qwen2.5:7b` via Ollama (local)." Reasons come verbatim from the advisor's existing
+   strings (V1-GRILL Better-Ideas: reuse loud strings; near-zero build cost).
+4. Routing resolution per job: `resolve_route(fn, policy, overview)` → concrete `{mode, model,
+   runner|provider}`; on cloud failure in `auto`, degrade to local and emit a loud per-job notice.
+5. Key rotation: `next_key(pool)` picks the next healthy key; updates per-key usage from the
+   response headers (existing `_headers` surfacing in `provider.py`).
+
+### 2.4 UI (Settings › Models&System + Providers&Keys; header toggle)
+- **Header global toggle** Local ▾ / Cloud / Auto (V1-GRILL §h E6) — one control, visible on the
+  novice surface; default Local.
+- **Settings › Models&System:** the `models.overview` screen — device card (RAM/VRAM/GPU/disk),
+  recommended preset with loud reasons, detected runners with one-click "Pull recommended model"
+  (uses `_pull_hint`; advise-and-link, do not hand-provision per V1-GRILL §e), and a per-function
+  routing table (Advanced disclosure).
+- **Settings › Providers&Keys:** OpenRouter **key pool** list — each row: redacted key, status
+  (active/cooldown), per-key usage/limit, test/remove. Add-key form (validated, `providers.testKey`).
+- **Egress/cost badges** (G-12) wherever a cloud route is selected, plus the "degraded → local"
+  notice (reuse the reliability per-clip badge pattern).
+
+### 2.5 Novice-first defaults
+- Local-only, auto-picked models, nothing to configure (G-8/G-10). The novice only ever sees the
+  one-line "using X because Y" reason — never a model picker.
+- Cloud requires an explicit key paste + an explicit egress acknowledgement.
+- "Auto/mixed" is opt-in and clearly labelled as "uses cloud when available, falls back to local."
+
+### 2.6 How it extends V1
+- Directly implements V1-GRILL §f Phase 2 (extend `system_advisor` → device-ranked recommend in UI;
+  Ollama/LM Studio detect+pull; OpenRouter key-pool + per-key usage; ETA/device strip) and §h.5
+  Settings + E6 (global toggle + per-function override = poly-processing) **without** adding cloud
+  ASR (G-11 stays V2) or auto-installing runners (advise-only per §e).
+
+---
+
+## Lane 3 — Media Lineage / Provenance Library
+
+### 3.0 What exists today
+- **Library:** `library.py` `Library` = a JSON index (`library.json`,
+  `{version, videos:[{id,path,title,addedAt,durationSec,hasTranscript}]}`), add/list/remove
+  **by path** (never copies source bytes). `Project` = versioned manifest referencing source by path
+  with `consolidate`/`find_missing_sources`. RPC `library.*`, `project.*`, `readiness.summary`.
+- **Jobs:** `job_store.py` (`DiskJobStore`), `jobs.py` (`Job`, `JobRegistry`, `JobStatus`) record
+  what ran. Data root: `app/main/dataRoot.ts` (one relocatable root, `chooseDataRoot`).
+
+**The gap:** the library knows *sources* but not *derivations* — there is no record that "short_07"
+came from "podcast.mp4" via shortmaker.select with preset P, model M, at time T. No "where did this
+file come from / what did I make from this" graph; no re-open/regenerate-from-source; the flat JSON
+index doesn't scale to derived-asset rows or queries.
+
+### 3.1 Converged model — a provenance DAG, modeled on W3C PROV
+Adopt the W3C PROV triad (**Entity / Activity / Agent** + **Derivation/Usage/Generation**
+relations)[^prov] as the conceptual model, stored in **SQLite** (replacing `library.json` as the index;
+sources are still referenced by path, never copied):
+
+- **Entity** = a media asset row (source video, produced short, exported SRT, reframed clip,
+  consolidated project asset). Fields: `id, kind, path, role(source|derived|export), title,
+  addedAt, durationSec, hash?, hasTranscript`.
+- **Activity** = a job that produced entities (maps 1:1 to `jobs.py` `Job`): `id, op
+  (shortmaker.select|reframe|subtitles.generate|export|…), startedAt, endedAt, status, params
+  (preset, route/model, captionDesign, etc.)`.
+- **Agent** = the software config responsible: app version + the resolved `RoutingPolicy`/model +
+  preset (so "what made this" is answerable and reproducible).
+- **Relations:** `derived_from(entity→entity)`, `generated_by(entity→activity)`,
+  `used(activity→entity)`, `associated_with(activity→agent)`.
+
+This is a *local, telemetry-free* provenance graph — the same shape used for media Content
+Credentials (C2PA), kept internal for V1.1 with a clean seam to **optionally** emit a C2PA manifest
+later (see V2 below).[^c2pa]
+
+### 3.2 Schema (SQLite — replaces `library.json`, migrates on first open)
+```sql
+CREATE TABLE entity (
+  id TEXT PRIMARY KEY, kind TEXT, path TEXT, role TEXT,        -- source|derived|export
+  title TEXT, added_at TEXT, duration_sec REAL, content_hash TEXT, has_transcript INTEGER);
+CREATE TABLE activity (
+  id TEXT PRIMARY KEY, op TEXT, started_at TEXT, ended_at TEXT,
+  status TEXT, params_json TEXT, agent_id TEXT);
+CREATE TABLE agent (
+  id TEXT PRIMARY KEY, app_version TEXT, route_json TEXT, preset TEXT);
+CREATE TABLE edge (
+  src TEXT, dst TEXT, rel TEXT);                               -- derived_from|generated_by|used|associated_with
+CREATE INDEX ix_edge_src ON edge(src); CREATE INDEX ix_edge_dst ON edge(dst);
+```
+- **Migration:** on first open, if `library.json` exists and the DB does not, import each video as a
+  `role='source'` entity (one-way, idempotent; keep `library.json` as a backup). `Library`'s public
+  methods (`add/list/remove`) keep their signatures (façade over SQLite) so existing handlers and
+  the renderer are untouched — this is the back-compat keystone.
+- Stored under the existing `dataRoot` (no new root). `content_hash` is optional/lazy (cheap stat +
+  size first; full hash only when dedup is requested) — see content-hash-cache best practice.
+
+### 3.3 Algorithm — recording lineage (one write at job completion)
+1. Every primary action already runs through `jobs.py`. **NEW:** on `Job` success, write one
+   `activity` row + its `agent` + `entity` rows for outputs + `edge` rows
+   (`generated_by`, `derived_from` source, `used` inputs, `associated_with` agent). This is a single
+   transactional append in a `record_lineage(job, inputs, outputs, agent)` helper — jobs that don't
+   opt in simply don't call it (no behavior change).
+2. **Query:** `lineage_of(entity_id)` → ancestors (where it came from) + descendants (what was made
+   from it), via recursive `edge` walk.
+3. **Re-open / regenerate:** because params+agent are stored, "regenerate this short" replays the
+   activity against the (still-by-path) source — surfacing missing sources via the existing
+   `find_missing_sources` pattern (loud, no silent skip).
+
+### 3.4 UI (Library section — extends, no new tab)
+- **Library section (§h.1)** gains a **Lineage view** toggle: list ⇄ graph. Each asset shows a
+  "Made from ▸" / "Used to make ▸" expander (the PROV ancestors/descendants).
+- **Asset detail drawer:** provenance card — "Created `2026-…` by Reframe v… · shortmaker.select ·
+  preset Punchy · moments by qwen2.5:7b (local) · captions Bold." Buttons: **Reveal source**,
+  **Regenerate**, **Open project**.
+- **Provenance badge** on produced shorts in the Make Shorts gallery (links back to source).
+
+### 3.5 Novice-first defaults
+- Lineage is **recorded automatically and silently** (no setup); the novice never configures it.
+- The default Library view is unchanged (flat list); the graph/lineage view is an opt-in toggle.
+- "Regenerate" and "Reveal source" are one-click, no jargon ("provenance"/"PROV" never shown in
+  novice copy — it's "Made from" / "History").
+
+### 3.6 How it extends V1
+- Extends V1-GRILL §h.1 (Library = "sources & readiness") and the §h KEYSTONE Output Tray (every
+  Save action becomes a recorded derivation) and §g (the unified Save/output step) — turning the
+  flat index into a queryable derivation graph **without** changing the by-path source contract or
+  adding a tab.
+
+---
+
+## WU BUILD PLAN
+
+Labels: **V1.1** = incremental, low-risk, additive (back-compat, fits the gate). **V2** = heavier /
+new surface / cross-cutting risk → deferred. Every WU is TDD-first and must hold the 100%
+lines+branches gate (sidecar + renderer) — noted per WU. "Gate" column = needs the
+**design-review-gate** (5-agent) before build.
+
+### Lane 1 — Subtitles
+| WU | Label | Scope | Depends | Gate? |
+|----|-------|-------|---------|-------|
+| **S1** | V1.1 | `CaptionOverride` type + `captionOverride.ts` validators (font allowlist, hex, clamps) + extend `CaptionDesign`/`Wire` (optional field, back-compat) | — | No |
+| **S2** | V1.1 | Sidecar `apply_override()` + parameterize `polish_cues` CPS/CPL from override; echo resolved style back | S1 | No |
+| **S3** | V1.1 | T2 "Customize…" disclosure UI + live preview wiring (reuse CaptionDesigner) | S1 | No |
+| **S4** | V1.1 | Novice defaults (Netflix CPS/CPL) + per-language reading-speed default | S2 | No |
+| **S5** | V2 | T3 named user styles (persist/list/export/import) + "★ My styles" group + Settings management | S1-S4 | **Yes** (new persisted artifact + Settings surface) |
+
+### Lane 2 — Models
+| WU | Label | Scope | Depends | Gate? |
+|----|-------|-------|---------|-------|
+| **M1** | V1.1 | `models.overview` thin compose RPC (advise + detect + runner_advice + providers + policy) | — | No |
+| **M2** | V1.1 | One-line "using X because Y" reason strip (reuse advisor strings) + device card | M1 | No |
+| **M3** | V1.1 | `RoutingPolicy` type + `models.setRoutingPolicy` + header global toggle (local default) | M1 | **Yes** (cross-cutting routing seam) |
+| **M4** | V1.1 | OpenRouter key-pool UI (rotation, per-key usage/cooldown, redacted) over existing secrets/usage | M1 | No |
+| **M5** | V1.1 | Per-function routing override table (Settings/Advanced) + `resolve_route` + loud degrade-to-local notice | M3 | No |
+| **M6** | V2 | Cloud ASR provider (new seam — G-11 defers) | M3,M5 | **Yes** |
+| **M7** | V2 | Auto-install/provision runners (G-11/§e advise-only today) | M1 | **Yes** |
+
+### Lane 3 — Lineage
+| WU | Label | Scope | Depends | Gate? |
+|----|-------|-------|---------|-------|
+| **L1** | V1.1 | SQLite schema + `Library` façade (same public methods) + `library.json`→DB migration (idempotent, backup kept) | — | **Yes** (storage migration = data-safety risk) |
+| **L2** | V1.1 | `record_lineage()` on `Job` success (activity+agent+entity+edges; opt-in per op) | L1 | No |
+| **L3** | V1.1 | `lineage_of()` query (ancestors/descendants) + `library.lineage` RPC | L1,L2 | No |
+| **L4** | V1.1 | Library Lineage view toggle + asset detail provenance card | L3 | No |
+| **L5** | V1.1 | Reveal source + Regenerate-from-source (reuse find_missing_sources for loud-missing) | L2,L3 | No |
+| **L6** | V2 | Content-hash dedup across library (lazy full-hash) | L1 | No |
+| **L7** | V2 | Optional C2PA Content-Credentials manifest emit on export | L2 | **Yes** (external standard + signing) |
+
+### Dependencies & sequencing (cross-lane)
+- **Lanes are independent** and can be built in parallel by separate owners (no shared files beyond
+  `captionDesign.ts` for L4's gallery badge — owner = renderer, scoped adds only).
+- **Within-lane order:** S1→S2→S3→S4 (S5 V2 last); M1→M2/M4 then M3→M5 (M6/M7 V2);
+  L1→L2→L3→L4/L5 (L6/L7 V2).
+- **Recommended build order for V1.1:** **L1 first** (it's the only data migration and gates the
+  rest of Lane 3) → then S1-S4 and M1-M5 in parallel → L2-L5. M3 (routing seam) should land before
+  M5 and before any future cloud work.
+- **Cross-lane touchpoint:** M3's `RoutingPolicy.agent` is the same `agent` recorded by L2 (model +
+  preset provenance) — build M1-M3 before L2 so lineage records the real route, else L2 records a
+  placeholder agent and is back-filled.
+
+### Risks
+1. **Three-way caption mirror drift (S1/S2).** *Mitigation:* override is a *separate additive patch*;
+   conformance test is untouched; add override-merge unit tests, not new template ids.
+2. **SQLite migration data loss (L1).** *Highest risk.* *Mitigation:* one-way idempotent import,
+   keep `library.json` as backup, façade preserves signatures, dedicated migration tests
+   (empty/partial/corrupt/already-migrated). **Design-review gate required.**
+3. **Routing seam regressions (M3).** A wrong route silently using cloud = egress surprise (violates
+   G-10/G-12). *Mitigation:* default local; explicit egress ack; loud degrade notice; route
+   resolution unit-tested per mode. **Gate required.**
+4. **Key-pool secret leakage (M4).** *Mitigation:* reuse `redact`/`scrub_error_body`/`redact_keys`;
+   assert no raw key crosses RPC in tests; cooldown not delete.
+5. **100% coverage on new branches (all).** Validation/clamp/migration branches are branch-heavy.
+   *Mitigation:* table-driven tests for every clamp/fallback/degrade branch; keep new modules small
+   & pure (V1-GRILL/coding-style: many small files).
+6. **Scope creep into V2 (M6/M7/L7/S5).** *Mitigation:* explicitly labelled V2; do not start until
+   V1.1 lands.
+
+### TDD / coverage impact
+- **New pure modules** (`captionOverride.ts`, `apply_override`, `resolve_route`, `record_lineage`,
+  `lineage_of`, key-pool rotation, migration) are pure/seam-injected → unit-testable to 100% without
+  ffmpeg/network (follow existing injection pattern, e.g. `library.py` `probe_duration`).
+- **Mutation targets** (non-blocking nightly): add `apply_override`/`resolve_route`/migration to the
+  pure-logic mutation scope alongside `caption`/`subtitles`/`spend_ledger`.
+- **No relaxation** of `.coverage-thresholds.json` is permitted; if a branch is genuinely
+  host-dependent, isolate it behind an injected seam rather than `# pragma: no cover`.
+
+### Which WUs need the design-review gate (5-agent)
+**S5, M3, M6, M7, L1, L7.** (New persisted artifacts, the cross-cutting routing seam, the data
+migration, cloud-ASR/provisioning surfaces, and the external-standard C2PA emit.) All other WUs are
+incremental/additive and proceed under the standard plan-review-gate + TDD.
+
+---
+
+## OPEN QUESTIONS FOR USER
+1. **V1.1 scope cut line:** ship all three lanes' V1.1 WUs in one iteration, or sequence one lane
+   per release (recommended: L1 + Lane-1 first, since subtitles is the most-requested per §e)?
+2. **SQLite migration (L1):** OK to replace `library.json` with SQLite (keeping it as backup), or
+   keep JSON and add a *sidecar* provenance DB to avoid touching the source index at all (lower risk,
+   slight duplication)?
+3. **Curated font list (S2):** bundle a fixed font allowlist for `CaptionOverride.fontFamily`, or
+   detect system fonts (portability/licensing risk on burn-in)?
+4. **Routing default for "auto" (M3):** when cloud is configured, should `global` ever auto-promote
+   to `auto`, or stay `local` until the user explicitly flips it (recommended: stay local)?
+5. **C2PA (L7):** is content-provenance manifest emit a wanted V2 direction (signing keys, identity),
+   or out of scope entirely?
+6. **Execution method for the build:** metaswarm orchestrated / subagent-driven / parallel session
+   (per CLAUDE.md, you choose) — and confirm the design-review gate runs on S5/M3/M6/M7/L1/L7.
+
+---
+
+### Sources
+[^netflix]: Netflix Timed Text Style Guide — reading speed (20 CPS adult / 17 CPS children EN; 42 CPL; prefer 1 line). <https://partnerhelp.netflixstudios.com/hc/en-us/articles/215758617-Timed-Text-Style-Guide-General-Requirements>, <https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines>
+[^c2pa]: C2PA Content Credentials Technical Specification 2.2 (2025-05) / v2.3 draft (2025-12) — Content Provenance manifests. <https://spec.c2pa.org/specifications/specifications/2.2/specs/_attachments/C2PA_Specification.pdf>
+[^prov]: W3C PROV-DM / PROV-O — Entity / Activity / Agent + Derivation/Usage/Generation provenance model. <https://www.w3.org/TR/prov-dm/>
+
+Progressive disclosure (tiered customization) follows Nielsen Norman Group's progressive-disclosure
+guidance; CPS/CPL timing aligns with the BBC and Netflix subtitle reading-speed norms already
+modeled in `caption_polish.py`.

--- a/docs/V1.1-FEATURES.md
+++ b/docs/V1.1-FEATURES.md
@@ -53,6 +53,17 @@ sidecar-internal constants, never surfaced.
 Tiering follows progressive-disclosure best practice (NN/g): the 80% novice sees one choice; the
 20% who want more reveal the next tier without leaving the screen.
 
+**Competitor landscape (what the `T2` knob set must cover to match expectations).** CapCut's
+auto-caption surface exposes ~8 *caption types* (standard, aesthetic, highlight, word-by-word/karaoke,
+minimal, dynamic-animated, dual-language, uppercase-impact) plus named *preset families* (Glow,
+Trending, Word, Frame, Aesthetic, Monoline…) over a small set of underlying knobs: font, size,
+colour (text + highlight/active), outline/stroke, background card, casing, position, and
+per-word reveal.[^capcut] Submagic/Descript expose the same primitive set behind named presets. The
+takeaway that shaped `CaptionOverride` below: every competitor "style" decomposes to **~8 primitive
+controls layered on a base template** — exactly the additive-patch model here. We deliberately do NOT
+add a free-form animation editor (that stays a template/V2 concern); T2 covers the primitives, T3
+saves a named combination (our equivalent of a CapCut "preset family").
+
 | Tier | Who | Surface | What they touch |
 |------|-----|---------|-----------------|
 | **T1 Preset** (default) | novice | Output Tray "Caption?" → style row | Pick 1 of the existing `CAPTION_STYLES` + drag the box. **Zero new fields.** This is exactly today's flow. |
@@ -105,6 +116,31 @@ out-of-range number → clamp. **No silent crash** (V1-GRILL D-reliability invar
 override degrades field-by-field to the template default, and the resolved style is echoed back to
 the UI so the preview shows exactly what will burn.
 
+**`CaptionOverride` → ASS/libass mapping (the concrete render contract).** Each override field maps
+to a specific ASS `Style:`-field or inline override tag that `build_ass` emits; libass renders them.
+This pins the schema to the format so the implementer has no ambiguity:[^asstags]
+
+| Override field | ASS Style field | Inline override tag | Notes |
+|----------------|-----------------|---------------------|-------|
+| `fontFamily` | `Fontname` | `\fn<name>` | name must exist in the burn-in fontconfig set (S2 allowlist) |
+| `sizeScale` | `Fontsize` (× base) | `\fs<px>` | multiply resolved base size; clamp 0.6–1.8 |
+| `textColor` | `PrimaryColour` | `\1c&H…&` | **BGR, not RGB** (see below) |
+| `activeColor` (karaoke) | `SecondaryColour`/`\1c` swap under `\k` | `\1c&H…&` | colour the syllable currently lit by `\k` |
+| `spokenColor` (karaoke) | resolved as the pre-`\k` primary | `\1c&H…&` | already-spoken words |
+| `outline` | `BorderStyle=1` + `Outline`/`OutlineColour` | `\bord<w>` + `\3c&H…&` | off ⇒ `\bord0` |
+| `box` (solid card) | `BorderStyle=3` + `BackColour` | `\4c&H…&` | opaque-box border style; mutually exclusive with pure outline |
+| `uppercase` | — (text transform) | — | upcase cue text pre-emit; not an ASS tag |
+| `positionBand` | `Alignment` (numpad `\an`) | `\an{7..9 / 4..6 / 1..3}` | top/center/bottom band; fine offset stays in `caption_position_fields` margins |
+| `maxLines` | — | `\q1`/`\q2` wrap style | drives `wrap_two_lines` / `polish_cues`, not a colour |
+| `maxCps` | — | — | feeds `polish_cues` reading-speed gate only |
+
+**⚠ Load-bearing format detail:** ASS colours are **`&HAABBGGRR`** — alpha + **blue-green-red,
+reverse of CSS `#RRGGBB`** — and `AA` is *inverted* alpha (`00` = opaque, `FF` = transparent).[^asstags][^assbgr]
+`apply_override` MUST convert the UI's `#RRGGBB` hex into `&H00BBGGRR&` (swap byte order, default
+alpha `00`). Getting this wrong silently renders the wrong colour with no crash — so the override-merge
+unit tests assert the exact `&H…` string per input hex (e.g. `#FF0000` → `&H000000FF&`), and the
+resolved style echoed to the UI is the *post-conversion* value used for preview parity.
+
 Saved user style (T3) persists in settings under `captionStyles: NamedCaptionStyle[]`:
 ```ts
 interface NamedCaptionStyle { id: string; name: string; base: string; override: CaptionOverride; }
@@ -135,11 +171,24 @@ interface NamedCaptionStyle { id: string; name: string; base: string; override: 
   styles" group. Managed (rename/delete/export/import) in Settings › Storage&Branding next to Brand
   Kit (V1-GRILL §h.5).
 
-### 1.5 Novice-first defaults
+### 1.5 Novice-first defaults & readability numbers (reconciled with `caption_polish.py`)
 - Default design unchanged: `DEFAULT_CAPTION_STYLE='libass'`, `DEFAULT_CAPTION_BOX`, **no override**.
 - T2 is collapsed by default; the novice never sees it unless they tap "Customize…".
-- **Reading-speed default = 20 CPS** for English / **17 CPS** for other languages, **max 42 CPL**,
-  prefer 1 line — Netflix Timed Text reading-speed norms, which `caption_polish` already models.[^netflix]
+- **Reading-speed (CPS) — the numbers `caption_polish.py` ships today and the override clamps to:**
+  - `MAX_CPS = 17` — the conservative **cross-language** Netflix adult value; this is the module
+    default the override starts from.[^netflix]
+  - `MAX_CPS_CHILDREN = 13` — Netflix children's reading speed.[^netflix]
+  - **English adult may relax to 20 CPS** (Netflix English template). `maxCps` is the field that lets
+    a user move within the **10–30** clamp; default stays 17 unless the project language is English
+    (then 20) — keeps a single safe default while honouring the per-language norm.
+- **Line layout:** `MAX_CPL = 42` characters/line (Netflix Latin-script limit), `MAX_LINES = 2`,
+  **prefer 1 line** unless the cue exceeds 42 CPL — these are existing `caption_polish` constants the
+  `maxLines` override toggles between 1 and 2.[^netflix]
+- **Minimum gap:** `MIN_GAP_FRAMES = 2` at `DEFAULT_FPS = 30` (≈67 ms) between consecutive cues —
+  existing constant; not user-exposed.
+- **Vertical safe area (9:16 Shorts/Reels/TikTok):** keep captions clear of the bottom ~15–20% (UI
+  chrome / progress bar) and top ~10%; the `positionBand='bottom'` default already sits above this
+  via `caption_position_fields` margins — documented here so the band defaults are not "lowest pixel".
 - Color/emphasis defaults inherit from the template (so "Bold" still looks like Bold). Overrides are
   *deltas*, never a blank slate.
 
@@ -209,6 +258,39 @@ surprises). Cloud is opt-in and always shows a `willEgress` badge (G-12).
   healthy keys; a key that returns 402/429 is marked `cooldown` (not deleted), surfaced per-key.
   Reuses `redact()`/`redact_keys()` so RPC never carries a raw key; reuses `openrouter_usage.py` for
   per-key consumption.
+  - **Per-key state comes from the real OpenRouter endpoint:** `GET https://openrouter.ai/api/v1/key`
+    (auth: the key itself) returns `{label, usage, limit, limit_remaining, is_free_tier, rate_limit}`
+    — exactly the `{spent, limit, status}` the pool needs, no scraping.[^orkey] Cost/credit totals
+    (account-wide) are `GET /api/v1/credits` (management key).[^orcredits] Cooldown triggers: a `402`
+    (insufficient credits) or `429` (rate-limited) response, plus the free-tier rule **< 10 credits ⇒
+    capped at 50 `:free` requests/day** — surfaced per key so the user sees *why* a key parked.[^orkey]
+    The `X-RateLimit-*` response headers refresh `usage` opportunistically on every real call (existing
+    `_headers` surfacing in `provider.py`), so the pool stays current without a polling loop.
+- **Model eligibility — from real runner metadata, with the hardcoded ladder as fallback.** Today
+  `model_recommend.py` picks from two **hardcoded ladders** (`WHISPER_LADDER`, `LLM_LADDER` of
+  `ModelTier(model,label,min_vram_mb,min_ram_mb)`; `_fits()` = `vram_mb >= min_vram_mb` when a GPU is
+  present, else `ram_mb >= min_ram_mb`). The ladders are *guesses* at each model's resident cost. V1.1
+  refines this **without rebuilding it**: when a runner is detected, read the model's *actual* metadata
+  and compute fit from it; keep the ladder only as the no-runner / unknown-model floor.
+  - **Ollama metadata** (no new dep — same `:11434` we already probe): `POST /api/show {model}` returns
+    `details{parameter_size, quantization_level, family/families}`, a `model_info{…}` map (incl.
+    `general.parameter_count`, the context length, `…block_count`), and a **`capabilities`** array
+    (`completion` / `vision` / `tools` / `embedding` / `thinking`).[^ollamashow] `GET /api/tags` lists
+    installed models with a `size` (bytes on disk) and a `digest`.[^ollamatags] LM Studio exposes the
+    analogous fields over its REST/OpenAI-compatible API.
+  - **Capabilities gate the function** (don't offer an `embedding`-only model for moment-selection;
+    require `tools` only where the director needs them) — replaces the implicit "any LLM" assumption.
+  - **VRAM estimate (the fit formula).** From parameter count + quant, a model's resident VRAM is
+    **`VRAM_GB ≈ params_B × bytes_per_param × (1 + overhead) + kv_cache`**, where `bytes_per_param =
+    quant_bits / 8` (FP16 = 2 B/param, Q8 ≈ 1, Q4 ≈ 0.5) and `overhead ≈ 0.15–0.20`. The field rule of
+    thumb this encodes: **≈2 GB per 1 B params at FP16, ≈0.5 GB/B at INT4, plus 15–20%**, then add the
+    KV cache (grows with context length × layers).[^vram][^vramcalc] This lets the advisor say "qwen2.5
+    7B-Q4 ≈ 4.0 GB + cache — fits your 8 GB GPU" from the model's *real* quant, not a static guess; the
+    `min_vram_mb` ladder rungs are reinterpreted as the fallback when metadata is absent.
+  - **Dedup the picker** (`DEDUP_PATTERN`): `/api/tags` routinely lists the *same* blob under several
+    tags (`qwen2.5:7b`, `qwen2.5:7b-instruct-q4_K_M`, a user retag) — all sharing one **`digest`**.
+    Collapse rows by `digest` first, then prefer the most specific tag; this stops the recommendation
+    list and routing dropdowns from showing 3–4 aliases of one download.
 
 ### 2.3 Algorithm — model selection (extend, don't rebuild)
 1. On first run / Settings open: `system.probe` → hardware; `advise()` → `recommended_preset` +
@@ -241,6 +323,15 @@ surprises). Cloud is opt-in and always shows a `willEgress` badge (G-12).
   one-line "using X because Y" reason — never a model picker.
 - Cloud requires an explicit key paste + an explicit egress acknowledgement.
 - "Auto/mixed" is opt-in and clearly labelled as "uses cloud when available, falls back to local."
+- **Low-GPU shortlist (the floor the ladder + VRAM formula resolve to on ≤4 GB VRAM / iGPU / CPU).**
+  These are the models the advisor should recommend and the "Pull recommended" button should target on
+  weak hardware, all comfortably inside ~4 GB at Q4 by the formula above:
+  - **ASR (faster-whisper):** `small` (≈0.6 GB) → `base` (CPU floor, 0 GB GPU) — matches the existing
+    `WHISPER_LADDER` floor rungs.
+  - **LLM (Ollama Q4):** `qwen2.5:3b` (≈3 GB) → `llama3.2:3b` → `gemma2:2b` → `qwen2.5:1.5b` →
+    `llama3.2:1b` / `qwen2.5:0.5b` (CPU backstop). `phi3.5` (3.8B) is the quality pick if ~4 GB is free.
+  - The ladder's guaranteed-floor rung (`min_vram_mb=0`, `min_ram_mb=0`) stays the last resort so a
+    pick *always* exists on an unknown/headless device (existing invariant, unchanged).
 
 ### 2.6 How it extends V1
 - Directly implements V1-GRILL §f Phase 2 (extend `system_advisor` → device-ranked recommend in UI;
@@ -281,9 +372,14 @@ sources are still referenced by path, never copied):
 - **Relations:** `derived_from(entity→entity)`, `generated_by(entity→activity)`,
   `used(activity→entity)`, `associated_with(activity→agent)`.
 
-This is a *local, telemetry-free* provenance graph — the same shape used for media Content
-Credentials (C2PA), kept internal for V1.1 with a clean seam to **optionally** emit a C2PA manifest
-later (see V2 below).[^c2pa]
+This is a *local, telemetry-free* provenance graph — the same Entity/Activity/Agent shape used for
+media Content Credentials (C2PA). **C2PA verdict: keep the model internal for V1.1, defer manifest
+emit to V2 (L7).** Reasons: C2PA manifest emit/verify needs a *signing identity* (certificate / trust
+list) and embeds its *own* hard-binding asset hash + claim signature — that is signing-key and
+identity scope, not a local index feature, and a half-implemented (unsigned) manifest is worse than
+none. Our internal `content_hash` is therefore deliberately **independent** of any future C2PA
+hard-binding hash; the W3C-PROV graph maps cleanly onto a C2PA manifest when L7 lands, so nothing here
+forecloses it.[^c2pa]
 
 ### 3.2 Schema (SQLite — replaces `library.json`, migrates on first open)
 ```sql
@@ -299,12 +395,37 @@ CREATE TABLE edge (
   src TEXT, dst TEXT, rel TEXT);                               -- derived_from|generated_by|used|associated_with
 CREATE INDEX ix_edge_src ON edge(src); CREATE INDEX ix_edge_dst ON edge(dst);
 ```
-- **Migration:** on first open, if `library.json` exists and the DB does not, import each video as a
-  `role='source'` entity (one-way, idempotent; keep `library.json` as a backup). `Library`'s public
-  methods (`add/list/remove`) keep their signatures (façade over SQLite) so existing handlers and
-  the renderer are untouched — this is the back-compat keystone.
-- Stored under the existing `dataRoot` (no new root). `content_hash` is optional/lazy (cheap stat +
-  size first; full hash only when dedup is requested) — see content-hash-cache best practice.
+- **Migration (hardened to SQLite practice):** on first open, if `library.json` exists and the DB
+  does not, import each video as a `role='source'` entity. Schema version is tracked with
+  **`PRAGMA user_version`** (the canonical lightweight SQLite migration mechanism — an integer stamped
+  in the DB header, not a metadata table), the import runs **inside a single transaction** (all-or-
+  nothing; a crash mid-migrate leaves the old `library.json` authoritative), and the DB opens in
+  **WAL journal mode** for safe concurrent reader/writer access from the sidecar.[^sqlitemig][^sqlitepragma]
+  One-way + idempotent (re-running is a no-op once `user_version >= 1`); `library.json` is kept as a
+  backup. `Library`'s public methods (`add/list/remove`) keep their signatures (façade over SQLite) so
+  existing handlers and the renderer are untouched — this is the back-compat keystone.
+- Stored under the existing `dataRoot` (no new root).
+
+**Hashing strategy (`content_hash`) — chosen: lazy BLAKE3, size+mtime fast-path first.**
+`content_hash` stays **optional/lazy**: the cheap **`(size, mtime)` stat is the first-line identity
+check** (covers "did this source change / is this the same file" for free), and a **full content hash
+is computed only when dedup is explicitly requested** (L6) — content-hash-cache best practice.[^chcache]
+When a full hash *is* needed, use **BLAKE3**: it is **much faster than SHA-256/SHA-1/MD5 on large
+inputs** (the official benchmark shows ~10–14× over SHA-256 on long inputs single-threaded, and it is
+SIMD- and **multithread-parallel by design** — ideal for multi-GB video files).[^blake3]
+- **Documented caveat (do not over-claim the speedup):** the advantage is **input-size- and
+  platform-dependent**. On *small* inputs and on **arm64/Apple-Silicon**, where SHA-256 has hardware
+  (SHA-NI / crypto-extension) acceleration and BLAKE3's NEON SIMD is only 128-bit, BLAKE3 can match or
+  *lose* to SHA-256.[^blake3nuance] Media assets here are large, so BLAKE3 wins in the common case, but
+  the column stores a **self-describing, algorithm-prefixed digest** (e.g. `blake3:…`) so the choice is
+  not baked in and a future SHA-256/C2PA path can coexist without a migration.
+- **Verification model — BitTorrent "recheck" (informs L6, not V1.1 core):** to verify a large by-path
+  source still matches *and localise what changed*, the proven model is **fixed-size piece hashing**:
+  split the file into pieces, store a per-piece hash list (a Merkle-style set), and "recheck" by
+  re-hashing pieces — exactly how BitTorrent clients verify/repair downloads, allowing **incremental,
+  partial re-verification** instead of re-hashing the whole file.[^bittorrent] V1.1 ships only the
+  whole-file BLAKE3 + `(size,mtime)` fast path; **piece-level recheck is the documented design for L6**
+  (dedup/integrity) where regenerate-from-source needs to know a multi-GB source is still intact.
 
 ### 3.3 Algorithm — recording lineage (one write at job completion)
 1. Every primary action already runs through `jobs.py`. **NEW:** on `Job` success, write one
@@ -351,7 +472,7 @@ lines+branches gate (sidecar + renderer) — noted per WU. "Gate" column = needs
 | WU | Label | Scope | Depends | Gate? |
 |----|-------|-------|---------|-------|
 | **S1** | V1.1 | `CaptionOverride` type + `captionOverride.ts` validators (font allowlist, hex, clamps) + extend `CaptionDesign`/`Wire` (optional field, back-compat) | — | No |
-| **S2** | V1.1 | Sidecar `apply_override()` + parameterize `polish_cues` CPS/CPL from override; echo resolved style back | S1 | No |
+| **S2** | V1.1 | Sidecar `apply_override()` → ASS Style/override-tag mapping (§1.2) incl. **`#RRGGBB`→`&H00BBGGRR&` BGR conversion** (unit-test exact strings); parameterize `polish_cues` CPS/CPL from override (CPS 17 default / 20 EN / 13 children); echo resolved style back | S1 | No |
 | **S3** | V1.1 | T2 "Customize…" disclosure UI + live preview wiring (reuse CaptionDesigner) | S1 | No |
 | **S4** | V1.1 | Novice defaults (Netflix CPS/CPL) + per-language reading-speed default | S2 | No |
 | **S5** | V2 | T3 named user styles (persist/list/export/import) + "★ My styles" group + Settings management | S1-S4 | **Yes** (new persisted artifact + Settings surface) |
@@ -359,10 +480,10 @@ lines+branches gate (sidecar + renderer) — noted per WU. "Gate" column = needs
 ### Lane 2 — Models
 | WU | Label | Scope | Depends | Gate? |
 |----|-------|-------|---------|-------|
-| **M1** | V1.1 | `models.overview` thin compose RPC (advise + detect + runner_advice + providers + policy) | — | No |
-| **M2** | V1.1 | One-line "using X because Y" reason strip (reuse advisor strings) + device card | M1 | No |
+| **M1** | V1.1 | `models.overview` thin compose RPC (advise + detect + runner_advice + providers + policy) + **metadata-driven eligibility**: read Ollama `/api/show` (`capabilities`, `parameter_size`, `quantization_level`) & `/api/tags` (`digest`), compute fit via the VRAM formula (§2.2), **dedup by `digest`**; static ladder = fallback | — | No |
+| **M2** | V1.1 | One-line "using X because Y" reason strip (reuse advisor strings) + device card; reason now names the **real quant + VRAM estimate** ("7B-Q4 ≈ 4 GB, fits 8 GB GPU") | M1 | No |
 | **M3** | V1.1 | `RoutingPolicy` type + `models.setRoutingPolicy` + header global toggle (local default) | M1 | **Yes** (cross-cutting routing seam) |
-| **M4** | V1.1 | OpenRouter key-pool UI (rotation, per-key usage/cooldown, redacted) over existing secrets/usage | M1 | No |
+| **M4** | V1.1 | OpenRouter key-pool UI (rotation, per-key usage/cooldown, redacted) over existing secrets/usage; per-key state from **`GET /api/v1/key`** (`usage`/`limit`/`is_free_tier`); cooldown on 402/429 + <10-credit free cap | M1 | No |
 | **M5** | V1.1 | Per-function routing override table (Settings/Advanced) + `resolve_route` + loud degrade-to-local notice | M3 | No |
 | **M6** | V2 | Cloud ASR provider (new seam — G-11 defers) | M3,M5 | **Yes** |
 | **M7** | V2 | Auto-install/provision runners (G-11/§e advise-only today) | M1 | **Yes** |
@@ -370,12 +491,12 @@ lines+branches gate (sidecar + renderer) — noted per WU. "Gate" column = needs
 ### Lane 3 — Lineage
 | WU | Label | Scope | Depends | Gate? |
 |----|-------|-------|---------|-------|
-| **L1** | V1.1 | SQLite schema + `Library` façade (same public methods) + `library.json`→DB migration (idempotent, backup kept) | — | **Yes** (storage migration = data-safety risk) |
+| **L1** | V1.1 | SQLite schema + `Library` façade (same public methods) + `library.json`→DB migration (idempotent, backup kept) using **`PRAGMA user_version`** versioning, **single transaction**, **WAL mode** (§3.2) | — | **Yes** (storage migration = data-safety risk) |
 | **L2** | V1.1 | `record_lineage()` on `Job` success (activity+agent+entity+edges; opt-in per op) | L1 | No |
 | **L3** | V1.1 | `lineage_of()` query (ancestors/descendants) + `library.lineage` RPC | L1,L2 | No |
 | **L4** | V1.1 | Library Lineage view toggle + asset detail provenance card | L3 | No |
 | **L5** | V1.1 | Reveal source + Regenerate-from-source (reuse find_missing_sources for loud-missing) | L2,L3 | No |
-| **L6** | V2 | Content-hash dedup across library (lazy full-hash) | L1 | No |
+| **L6** | V2 | Content-hash dedup across library — **lazy BLAKE3** (algorithm-prefixed digest), `(size,mtime)` fast-path first; optional **BitTorrent-style piece-hash recheck** for incremental integrity verify of multi-GB sources (§3.2) | L1 | No |
 | **L7** | V2 | Optional C2PA Content-Credentials manifest emit on export | L2 | **Yes** (external standard + signing) |
 
 ### Dependencies & sequencing (cross-lane)
@@ -393,6 +514,9 @@ lines+branches gate (sidecar + renderer) — noted per WU. "Gate" column = needs
 ### Risks
 1. **Three-way caption mirror drift (S1/S2).** *Mitigation:* override is a *separate additive patch*;
    conformance test is untouched; add override-merge unit tests, not new template ids.
+   *New (from research):* the **ASS BGR colour order + inverted alpha** (`&HAABBGGRR`, §1.2) is a
+   silent-wrong-colour trap (no crash) — `apply_override` must convert `#RRGGBB`→`&H00BBGGRR&`, and S2
+   tests assert the exact `&H…` string per input hex so a byte-order regression fails loudly.
 2. **SQLite migration data loss (L1).** *Highest risk.* *Mitigation:* one-way idempotent import,
    keep `library.json` as backup, façade preserves signatures, dedicated migration tests
    (empty/partial/corrupt/already-migrated). **Design-review gate required.**
@@ -444,6 +568,53 @@ incremental/additive and proceed under the standard plan-review-gate + TDD.
 [^netflix]: Netflix Timed Text Style Guide — reading speed (20 CPS adult / 17 CPS children EN; 42 CPL; prefer 1 line). <https://partnerhelp.netflixstudios.com/hc/en-us/articles/215758617-Timed-Text-Style-Guide-General-Requirements>, <https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines>
 [^c2pa]: C2PA Content Credentials Technical Specification 2.2 (2025-05) / v2.3 draft (2025-12) — Content Provenance manifests. <https://spec.c2pa.org/specifications/specifications/2.2/specs/_attachments/C2PA_Specification.pdf>
 [^prov]: W3C PROV-DM / PROV-O — Entity / Activity / Agent + Derivation/Usage/Generation provenance model. <https://www.w3.org/TR/prov-dm/>
+[^capcut]: CapCut caption types / preset families + caption templates (competitor knob-set reference). <https://www.capcut.com/resource/caption-template>
+[^asstags]: ASS override tags (`\fn \fs \1c \3c \4c \bord \shad \an \k \kf \q`) + Style fields. Aegisub — ASS Override Tags & Editing Styles. <https://aegisub.org/docs/latest/ass_tags/>, <https://aegisub.org/docs/latest/styles/>; SubStation Alpha format reference <https://fileformats.fandom.com/wiki/SubStation_Alpha>
+[^assbgr]: ASS colour is `&HAABBGGRR` (alpha + **BGR**, reverse of RGB; alpha inverted, `00`=opaque). <https://www.reddit.com/r/aegisub/comments/17xoii3/cant_decipher_color_codes_for_ass_files/>
+[^ollamashow]: Ollama `POST /api/show` — `details` (parameter_size, quantization_level, families), `model_info`, and `capabilities`. <https://docs.ollama.com/api/show>
+[^ollamatags]: Ollama `GET /api/tags` — installed models with `size` + `digest` (dedup key). <https://docs.ollama.com/api/tags>
+[^vram]: VRAM rule of thumb — ≈2 GB/B params at FP16, ≈0.5 GB/B at INT4, +15–20% overhead, plus KV cache. <https://www.spheron.network/blog/gpu-memory-requirements-llm/>
+[^vramcalc]: LLM VRAM & performance calculator (quant + KV-cache breakdown). <https://apxml.com/tools/vram-calculator>
+[^orkey]: OpenRouter `GET /api/v1/key` (usage/limit/is_free_tier/rate_limit) + rate-limit rules (<10 credits ⇒ 50 :free req/day; 402/429). <https://openrouter.ai/docs/api/reference/limits>
+[^orcredits]: OpenRouter `GET /api/v1/credits` — total purchased/used credits (management key). <https://openrouter.ai/docs/api/api-reference/credits/get-credits>
+[^blake3]: BLAKE3 — cryptographic hash much faster than MD5/SHA-1/SHA-2/SHA-3/BLAKE2 on large inputs; SIMD + multithread-parallel by design (official benchmark ~10–14× over SHA-256 on long inputs). <https://github.com/BLAKE3-team/BLAKE3>
+[^blake3nuance]: BLAKE3 advantage is size/platform-dependent — on small inputs and arm64/Apple-Silicon (hardware SHA-256, 128-bit NEON) it can match or lose to SHA-256. <https://arxiv.org/html/2407.08284v1>, <https://kerkour.com/fast-secure-hash-function-sha256-sha512-sha3-blake3>
+[^sqlitemig]: SQLite migration via `PRAGMA user_version` + ordered scripts in a transaction. <https://coddy.tech/docs/sqlite/migrations>
+[^sqlitepragma]: SQLite `PRAGMA` reference (`user_version`, `journal_mode=WAL`, `data_version`). <https://sqlite.org/pragma.html>
+[^chcache]: Content-hash cache pattern — cheap `(size,mtime)` stat first, full content hash only on demand; path-independent, auto-invalidating. (ECC `content-hash-cache-pattern` skill.)
+[^bittorrent]: BitTorrent piece-hashing / "recheck" — fixed-size pieces with per-piece hashes enable incremental partial integrity re-verification. BEP-3 / BitTorrent v2. <https://www.bittorrent.org/beps/bep_0003.html>
+
+---
+
+## References
+
+All externally-cited sources, grouped by area. (V1 baseline citations — Netflix, NN/g progressive
+disclosure, W3C PROV, C2PA — are retained in footnotes above.)
+
+**Lane 1 — Subtitles (styling, ASS format, readability)**
+- ASS override tags & Style fields — Aegisub: <https://aegisub.org/docs/latest/ass_tags/> · <https://aegisub.org/docs/latest/styles/>
+- SubStation Alpha (ASS) format reference: <https://fileformats.fandom.com/wiki/SubStation_Alpha>
+- ASS colour `&HAABBGGRR` (BGR + inverted alpha): <https://www.reddit.com/r/aegisub/comments/17xoii3/cant_decipher_color_codes_for_ass_files/>
+- Netflix Timed Text Style Guide (CPS/CPL/timing): <https://partnerhelp.netflixstudios.com/hc/en-us/articles/215758617-Timed-Text-Style-Guide-General-Requirements> · <https://partnerhelp.netflixstudios.com/hc/en-us/articles/360051554394-Timed-Text-Style-Guide-Subtitle-Timing-Guidelines>
+- CapCut caption types / templates (competitor knob set): <https://www.capcut.com/resource/caption-template>
+- Progressive disclosure — Nielsen Norman Group: <https://www.nngroup.com/articles/progressive-disclosure/>
+
+**Lane 2 — Models (runner metadata, VRAM, providers)**
+- Ollama `POST /api/show` (capabilities, parameter_size, quantization_level): <https://docs.ollama.com/api/show>
+- Ollama `GET /api/tags` (size, digest for dedup): <https://docs.ollama.com/api/tags>
+- VRAM rule of thumb (FP16 / INT4 / overhead + KV cache): <https://www.spheron.network/blog/gpu-memory-requirements-llm/>
+- VRAM & performance calculator: <https://apxml.com/tools/vram-calculator>
+- OpenRouter API rate limits / `GET /api/v1/key`: <https://openrouter.ai/docs/api/reference/limits>
+- OpenRouter `GET /api/v1/credits`: <https://openrouter.ai/docs/api/api-reference/credits/get-credits>
+
+**Lane 3 — Lineage (hashing, provenance, storage)**
+- W3C PROV-DM / PROV-O: <https://www.w3.org/TR/prov-dm/>
+- BLAKE3 (official impl + benchmark): <https://github.com/BLAKE3-team/BLAKE3>
+- BLAKE3 platform/size caveat: <https://arxiv.org/html/2407.08284v1> · <https://kerkour.com/fast-secure-hash-function-sha256-sha512-sha3-blake3>
+- BitTorrent piece-hashing / recheck (BEP-3): <https://www.bittorrent.org/beps/bep_0003.html>
+- SQLite `PRAGMA` (user_version / WAL): <https://sqlite.org/pragma.html>
+- SQLite migration practice (user_version + transactions): <https://coddy.tech/docs/sqlite/migrations>
+- C2PA Content Credentials spec 2.2: <https://spec.c2pa.org/specifications/specifications/2.2/specs/_attachments/C2PA_Specification.pdf>
 
 Progressive disclosure (tiered customization) follows Nielsen Norman Group's progressive-disclosure
 guidance; CPS/CPL timing aligns with the BBC and Netflix subtitle reading-speed norms already


### PR DESCRIPTION
**DESIGN ONLY — no feature implementation.** Adds `docs/V1.1-FEATURES.md`.

Converges the three V1.1 design lanes into one buildable, gate-ready spec, building on `docs/V1-GRILL-DECISIONS.md` (converged V1, sections e/f/g/h) and `docs/ROADMAP.md` (V2 cut-list).

## Contents
1. **Tiered subtitle customization** — `CaptionOverride` patch (additive to `CaptionDesign`), three tiers (Preset / Tune / Saved), render-path merge `apply_override()`, novice defaults (Netflix CPS/CPL). Keeps the three-way caption mirror frozen.
2. **Model management (local/cloud/mixed)** — one `RoutingPolicy` over local/cloud/auto, `models.overview` thin compose RPC, OpenRouter key-pool + per-key usage, loud "using X because Y" reasons. Extends `system_advisor` + `local_detect` + `provider`/`secrets`; local-only default.
3. **Media lineage/provenance** — W3C PROV Entity/Activity/Agent graph in SQLite (replaces `library.json` via facade + idempotent migration), `record_lineage()` on job success, lineage view + regenerate-from-source. Clean seam to optional C2PA later.

## WU build plan
Per-lane WUs labelled **V1.1** (incremental/low-risk) vs **V2** (heavier), with dependencies, sequencing, risks, TDD/coverage impact (100% gate held), and which need the 5-agent design-review gate (S5, M3, M6, M7, L1, L7).

Open questions for the user are at the end of the doc (scope cut line, SQLite-vs-sidecar-DB, font allowlist, auto-routing default, C2PA, execution method).

Cross-ref: V1-GRILL-DECISIONS.md, ROADMAP.md, .coverage-thresholds.json.
