### PR TITLE
fix(renderer): contain P0 readiness roll-up crash + a11y hardening

### DIFF
--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -371,13 +371,20 @@ function AppShell(): React.ReactElement {
 
         <TopTabBar tabs={tabs} active={activeTab} onSelect={selectTab} />
 
-        <main
-          className="app__main"
-          role="tabpanel"
-          id={topTabPanelId(activeTab)}
-          aria-labelledby={topTabId(activeTab)}
-        >
-          {renderRoute()}
+        {/* The shell's single MAIN landmark (fixes axe `landmark-one-main`). The
+            ARIA `tabpanel` role lives on the inner wrapper so it does NOT override
+            the <main> landmark role (a <main role="tabpanel"> is reported by axe
+            as both `landmark-one-main` and `aria-allowed-role`). The tab↔panel
+            wiring (id / aria-labelledby) rides the wrapper. */}
+        <main className="app__main">
+          <div
+            className="app__panel"
+            role="tabpanel"
+            id={topTabPanelId(activeTab)}
+            aria-labelledby={topTabId(activeTab)}
+          >
+            {renderRoute()}
+          </div>
         </main>
       </div>
       <JobQueue open={jobsOpen} onClose={() => setJobsOpen(false)} />

--- a/app/renderer/src/components/ErrorBoundary.test.tsx
+++ b/app/renderer/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,94 @@
+// ErrorBoundary.test.tsx — contains a child render throw to an inline fallback
+// instead of letting it unmount the whole tree (the Library roll-up guard).
+//
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { ErrorBoundary } from './ErrorBoundary';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+let consoleError: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  // React logs caught render errors to console.error; silence it for clean output.
+  consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  consoleError.mockRestore();
+});
+
+function Boom({ message }: { message: string }): never {
+  throw new Error(message);
+}
+
+describe('<ErrorBoundary />', () => {
+  it('renders its children when nothing throws', async () => {
+    await act(async () => {
+      root.render(
+        <ErrorBoundary>
+          <p className="ok">all good</p>
+        </ErrorBoundary>,
+      );
+    });
+    expect(container.querySelector('.ok')?.textContent).toBe('all good');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('contains a child render throw to the default inline alert', async () => {
+    await act(async () => {
+      root.render(
+        <ErrorBoundary label="Panel failed">
+          <Boom message="kaboom" />
+        </ErrorBoundary>,
+      );
+    });
+    const alert = container.querySelector('[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent).toContain('kaboom');
+    expect(alert?.getAttribute('aria-label')).toBe('Panel failed');
+  });
+
+  it('renders a custom fallback and reports via onError', async () => {
+    const onError = vi.fn();
+    await act(async () => {
+      root.render(
+        <ErrorBoundary fallback={(err) => <span className="fb">caught: {err.message}</span>} onError={onError}>
+          <Boom message="nope" />
+        </ErrorBoundary>,
+      );
+    });
+    expect(container.querySelector('.fb')?.textContent).toBe('caught: nope');
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('coerces a non-Error throw into an Error message', async () => {
+    function ThrowString(): never {
+      // Throw via an `unknown`-typed binding (not a literal) so the non-Error
+      // coercion branch is exercised without tripping throw-literal lints.
+      const notAnError: unknown = 'plain string failure';
+      throw notAnError;
+    }
+    await act(async () => {
+      root.render(
+        <ErrorBoundary>
+          <ThrowString />
+        </ErrorBoundary>,
+      );
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain string failure');
+  });
+});

--- a/app/renderer/src/components/ErrorBoundary.tsx
+++ b/app/renderer/src/components/ErrorBoundary.tsx
@@ -1,0 +1,54 @@
+// ErrorBoundary.tsx — a small, reusable render-error containment boundary.
+//
+// React unmounts the ENTIRE tree from the nearest root when a render/lifecycle
+// throw is uncaught, blanking the whole app. Wrapping a fragile subtree in this
+// boundary contains the failure to an inline alert so the rest of the shell
+// keeps working (DESIGN: a panel failure must never be app-fatal). It is a thin
+// class component (the only React API able to catch render errors) with no
+// dependencies, so any panel can adopt it.
+import React from 'react';
+
+export interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  /** Inline fallback. Receives the caught error; defaults to a quiet alert. */
+  fallback?: (error: Error) => React.ReactNode;
+  /** Optional side-effect sink for logging/telemetry (never rethrows). */
+  onError?: (error: Error, info: React.ErrorInfo) => void;
+  /** Accessible label for the default fallback region. */
+  label?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: unknown): ErrorBoundaryState {
+    return { error: error instanceof Error ? error : new Error(String(error)) };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo): void {
+    this.props.onError?.(error, info);
+  }
+
+  render(): React.ReactNode {
+    const { error } = this.state;
+    if (error) {
+      if (this.props.fallback) return this.props.fallback(error);
+      return (
+        <p
+          className="error-boundary__fallback jobqueue__error"
+          role="alert"
+          aria-label={this.props.label}
+        >
+          {error.message}
+        </p>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/app/renderer/src/components/ReadinessRollup.tsx
+++ b/app/renderer/src/components/ReadinessRollup.tsx
@@ -44,7 +44,14 @@ export function ReadinessRollup({
     let alive = true;
     setError('');
     setItems(null);
-    Promise.resolve(api.readiness.summary())
+    // Defer the bridge call into a microtask so a SYNCHRONOUS throw from
+    // `api.readiness.summary()` (e.g. the preload `window.api` bridge is not
+    // present — it throws synchronously, see lib/rpc/client.ts `bridge()`) is
+    // routed to `.catch` instead of escaping the effect and unmounting the whole
+    // React tree. `Promise.resolve(api.readiness.summary())` would evaluate the
+    // call EAGERLY as an argument, before Promise.resolve can wrap it (P0 crash).
+    Promise.resolve()
+      .then(() => api.readiness.summary())
       .then((res) => {
         if (alive) setItems(Array.isArray(res?.items) ? res.items : []);
       })

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -73,7 +73,7 @@ body,
   align-items: center;
   gap: var(--space-5);
   padding: 0 var(--space-5);
-  height: 46px;
+  height: 48px;
   flex: none;
   background: var(--surface-raised);
   box-shadow: var(--shadow-raise);
@@ -127,7 +127,14 @@ body,
 .quality-toggle__btn {
   appearance: none;
   border: none;
-  padding: 5px 14px;
+  /* >=44px tap target (a11y / layout_lint tap-target gate): center the label in
+     a 44px box rather than relying on text-height + thin padding. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 5px 16px;
   background: var(--surface-deep);
   color: var(--text-muted);
   font-family: inherit;
@@ -176,7 +183,15 @@ body,
 .routing-toggle__btn {
   appearance: none;
   border: none;
-  padding: 5px 14px;
+  /* >=44px tap target (a11y / layout_lint tap-target gate). NOTE: the audit
+     brief named `.routing-toggle__egress`, but that is a non-interactive hint
+     <span> the gate never measures — the gate-relevant control is this button. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 5px 16px;
   background: var(--surface-deep);
   color: var(--text-muted);
   font-family: inherit;
@@ -216,7 +231,9 @@ body,
   font-weight: 600;
   text-transform: uppercase;
   letter-spacing: 0.04em;
-  color: var(--warn, #c9772a);
+  /* Was `var(--warn, …)` — `--warn` is undeclared, so it silently fell back to a
+     one-off hex. Use the canonical semantic warn token (same as `.sm-nudged`). */
+  color: var(--status-warn);
 }
 
 /* .app__jobs-toggle lives in jobqueue.css; both consume the same tokens. */
@@ -229,6 +246,19 @@ body,
 }
 
 .app__main > * {
+  flex: 1;
+  min-height: 0;
+}
+
+/* The tab-panel wrapper inside <main> (carries role="tabpanel"). It must pass the
+   flex fill through to the single route child so layout is identical to when the
+   route rendered as a direct child of .app__main. */
+.app__panel {
+  display: flex;
+  flex-direction: column;
+}
+
+.app__panel > * {
   flex: 1;
   min-height: 0;
 }
@@ -1109,7 +1139,14 @@ button {
 }
 
 .sm-row-actions button {
-  padding: 3px 8px;
+  /* >=44px tap target (a11y / layout_lint tap-target gate): short mono labels
+     (e.g. "Undo") otherwise fall below 44px in both axes. */
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 44px;
+  min-width: 44px;
+  padding: 3px 12px;
   font-size: var(--type-caption-size);
   font-family: var(--font-mono);
   background: transparent;

--- a/app/renderer/src/components/topTabBar.css
+++ b/app/renderer/src/components/topTabBar.css
@@ -20,7 +20,11 @@
   position: relative;
   display: inline-flex;
   align-items: center;
+  justify-content: center;
   gap: var(--space-3);
+  /* >=44px tap target (a11y / layout_lint tap-target gate). */
+  min-height: 44px;
+  min-width: 44px;
   padding: 10px 14px;
   border: none;
   background: transparent;

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { rpc, type Video } from '../components/api';
 import { useVideoThumbnail, type VideoThumbnailRpc } from '../components/useVideoThumbnail';
 import { ReadinessRollup } from '../components/ReadinessRollup';
+import { ErrorBoundary } from '../components/ErrorBoundary';
 import { LineagePanel, type LineageAsset } from '../features/LineagePanel';
 import { lineageActions } from '../features/lineageActionsClient';
 import type { LineageResult, ReadinessAction } from '../lib/rpc';
@@ -391,7 +392,11 @@ export function Library({
         </div>
       </header>
 
-      <ReadinessRollup title="What works right now" onAction={onReadinessAction} />
+      {/* Contain any future render throw from the roll-up to an inline alert so
+          a readiness-panel failure can never blank the whole Library view. */}
+      <ErrorBoundary label="Readiness roll-up failed to render">
+        <ReadinessRollup title="What works right now" onAction={onReadinessAction} />
+      </ErrorBoundary>
 
       {dragOver ? (
         <div className="library__drophint" aria-hidden="true">


### PR DESCRIPTION
## P0 crash fix: Library readiness roll-up could blank the whole app

### The bug (P0)
`renderer/src/components/ReadinessRollup.tsx` called:

```ts
Promise.resolve(api.readiness.summary())
```

`api.readiness.summary()` is evaluated **eagerly as an argument**, *before* `Promise.resolve` can wrap it. When the preload `window.api` bridge is absent, `bridge()` (`lib/rpc/client.ts`) throws **synchronously**, so the throw escaped the `useEffect`, propagated to the React root, and **unmounted the entire tree** — the app went blank.

### The fix
Defer the bridge call into a microtask so a synchronous throw is routed to `.catch` instead of escaping:

```ts
Promise.resolve()
  .then(() => api.readiness.summary())
  .then(/* ... */)
  .catch(/* ... */)
```

Plus defense-in-depth: a new reusable `<ErrorBoundary>` wraps the roll-up in `views/Library.tsx`, so any *future* render throw is contained to an inline alert rather than being app-fatal.

### Accessibility / layout (from the UI audit)
- **landmark-one-main**: `role="tabpanel"` moved off `<main>` onto an inner `.app__panel` wrapper, preserving the single MAIN landmark (the old `<main role="tabpanel">` was flagged as both `landmark-one-main` and `aria-allowed-role`).
- **tap-targets**: >=44px min-height/width on the quality/routing toggles, top-tab buttons, and `sm-row-actions` buttons.
- **token fix**: undeclared `var(--warn, #c9772a)` fallback replaced with the canonical `--status-warn` token.

### Verification
- Re-audit after the fix: **app renders**; axe violations **7 -> 3**.
- `npm test` (vitest): **131 files / 2235 tests pass** (includes the 4 new `ErrorBoundary` tests).
- `tsc --noEmit`: clean.

Files: `App.tsx`, `ReadinessRollup.tsx`, `shell.css`, `topTabBar.css`, `Library.tsx`, plus new `ErrorBoundary.tsx` / `ErrorBoundary.test.tsx`.

https://claude.ai/code/session_013zoWpevAed9fXHFdz372cC
