### PR TITLE
ci(sonar): revive SonarCloud on current tree + triage the 9 torch Dependabot alerts

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  # torch / torchvision / torchaudio are GPU-validated, CUDA-wheel-pinned runtime
+  # assets (declared in sidecar/pyproject.toml, deliberately NOT in the scanned
+  # requirements.lock.txt) and must be bumped together only after manual GPU
+  # re-validation (A6 lesson 5) -- never via an unattended Dependabot PR. The open
+  # torch advisories (CVE-2025-2148/2149/2953/2998/2999/3000/3001/3730) are all
+  # LOCAL attack-vector (AV:L), low/medium, several with no fixed version, and are
+  # not reachable in a local desktop app processing the user's own media. Triaged
+  # + alerts dismissed 2026-06-29; reopen if the threat model changes.
+  - dependency-name: torch
+  - dependency-name: torchvision
+  - dependency-name: torchaudio
   labels:
   - dependencies
   - type:chore

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -1,0 +1,43 @@
+name: sonarcloud
+
+# Re-points the EXISTING SonarCloud project (Prekzursil_Reframe) at the current
+# tree. SonarCloud last scanned on 2026-03-30 (commit a252ab70) against the
+# retired SaaS monorepo and then stopped when that CI was removed in the lean-gate
+# migration. Config lives in sonar-project.properties at the repo root.
+#
+# NOTE: this is intentionally a NON-blocking, informational scan — it is NOT added
+# to branch protection, so it never gates a PR. It runs on main + PRs into main,
+# and can be kicked manually via the Actions tab (workflow_dispatch).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: sonarcloud-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  sonarcloud:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          # Full history so SonarCloud can attribute issues to the right commits
+          # and compute the new-code period correctly.
+          fetch-depth: 0
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        env:
+          # Repo secret (present since 2026-03-03). If analysis fails with an auth
+          # error, regenerate the token at sonarcloud.io and update SONAR_TOKEN.
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,25 @@
+# SonarCloud analysis configuration.
+#
+# WHY THIS FILE EXISTS: SonarCloud last analysed this repo on 2026-03-30 (commit
+# a252ab70 "Adopt managed CodeQL and security baseline"), against the now-retired
+# apps/web | apps/api | services/worker SaaS monorepo. That layout no longer
+# exists, so the ~329 issues still shown in the SonarCloud project are all stale
+# (they point at deleted paths). No Sonar analysis has run since. This file +
+# .github/workflows/sonarcloud.yml re-point the EXISTING SonarCloud project
+# (Prekzursil_Reframe, org prekzursil) at the CURRENT tree: the Electron app
+# under app/ and the Python sidecar under sidecar/.
+sonar.projectKey=Prekzursil_Reframe
+sonar.organization=prekzursil
+
+# Product code roots (current structure).
+sonar.sources=app/main,app/renderer/src,app/render-cli/src,sidecar/media_studio
+
+# Test code (kept out of the "new code" quality numbers but still analysed).
+sonar.tests=app/e2e,sidecar/tests
+sonar.test.inclusions=**/*.test.ts,**/*.test.tsx,**/*.spec.ts,**/*.spec.tsx
+
+# Never analyse build output, vendored code, fixtures, or dependencies.
+sonar.exclusions=**/node_modules/**,app/out/**,app/dist/**,app/render-cli/build/**,build/**,dist/**,installers/**,vendor/**,e2e_artifacts/**,spike/**,testdata/**,**/__pycache__/**,**/*.min.js
+
+sonar.python.version=3.12
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Security/CI follow-up to #247 (the UI-audit P0 fix). Two items surfaced during the audit. **Base: `feat/v1.1.0`.** Neither file runs on this PR (the sonar workflow only triggers on `main`), so this PR adds config without touching app behaviour.

---

## 1. Revive SonarCloud — "last scanned Mar 30, please check this tool is still running"

### Root cause
- SonarCloud's last analysis was **2026-03-30** (commit `a252ab70` *"Adopt managed CodeQL and security baseline"*) on `refs/heads/main`. Nothing since.
- It targeted the **retired** `apps/web` / `apps/api` / `services/worker` SaaS monorepo. The project `Prekzursil_Reframe` still holds **~329 issues**, but every one points at a **deleted path** (`apps/web/src/App.tsx`, …) — stale, not current findings.
- SonarCloud CI was removed in the lean-gate migration (PR #202 / `reports/PR-PURGE-CHECKLIST.md`), so no `sonar-project.properties` or sonar workflow exists in the tree. The "1 error / Unnamed API-upload" on the Security tab is that final March SARIF upload from `a252ab70`.

### Fix (this PR)
- New root **`sonar-project.properties`** pointing the existing project at the current tree (`app/` Electron + `sidecar/` Python), with sane exclusions.
- New **non-blocking** **`.github/workflows/sonarcloud.yml`** (`push:main` / `pull_request:main` / `workflow_dispatch`), actions SHA-pinned to match repo convention. **Not** wired into branch protection — it never gates a PR.
- **`SONAR_TOKEN` secret is already present** (set 2026-03-03) — no new secret needed. *If* it was since revoked, the first run fails with an auth error → regenerate at sonarcloud.io and update `SONAR_TOKEN`.

### Activation
The workflow triggers on `main`, **not** on PRs into `feat/v1.1.0`, so it does not run on this PR. SonarCloud re-scans current code the moment this lands on `main` (push trigger), or immediately via **Actions → sonarcloud → Run workflow** once it's on the default branch.

> **⚠️ Decision flag (please read before merging):** reviving SonarCloud **contradicts your own documented June decision to retire it** (`reports/PR-PURGE-CHECKLIST.md` §1 #3 + §3 recommend dropping the SonarCloud required check and uninstalling the `sonarqubecloud` app, "replaced by local opengrep"). If that retirement still stands, the *opposite* fix clears the stale-tool warning: **fully decommission** Sonar (uninstall the GitHub App + close the SonarCloud project). This PR does the **revive** path because that's what was requested — merge it to bring Sonar back, or close it and decommission instead. Your call.

---

## 2. The 9 Dependabot alerts (the "9" on the Security tab) — triaged + cleared

All 9 (GitHub's "3 moderate, 6 low") are **`torch`** CVEs:

| # | Sev | CVE | Source pin | Range | Fixed in |
|---|-----|-----|-----------|-------|----------|
| 262 | low | CVE-2025-3000 | chatterbox `torch==2.11.0` | ≤2.12.0 | — none |
| 255 | low | CVE-2025-3001 | pyproject `torch==2.6.0` | <2.10.0 | 2.10.0 |
| 254 | low | CVE-2025-3000 | pyproject `torch==2.6.0` | ≤2.12.0 | — none |
| 253 | med | CVE-2025-2999 | pyproject `torch==2.6.0` | <2.9.1 | 2.9.1 |
| 252 | low | CVE-2025-2149 | pyproject `torch==2.6.0` | ≤2.6.0 | — none |
| 251 | med | CVE-2025-2998 | pyproject `torch==2.6.0` | ≤2.6.0 | — none |
| 250 | low | CVE-2025-2148 | pyproject `torch==2.6.0` | ≤2.6.0 | — none |
| 249 | med | CVE-2025-3730 | pyproject `torch==2.6.0` | ≤2.7.1 | 2.8.0 |
| 248 | low | CVE-2025-2953 | pyproject `torch==2.6.0` | <2.7.1rc1 | 2.7.1rc1 |

> Dependabot tags the 8 pyproject ones with manifest `sidecar/requirements.lock.txt`, but **torch is not in that lockfile** — it's a GPU-only dep declared in `sidecar/pyproject.toml`.

### Verdict — 0 legitimate code fixes; all 9 non-applicable → dismissed
- Every advisory is **local attack-vector (AV:L)**, low/medium (max CVSS 5.3). For a desktop app running torch locally on the user's own machine + own media, none is reachable by an untrusted/remote attacker (several are disputed vuldb CVEs: `torch.jit.script`, `torch.load`, pad/pack memory).
- **5 of 9 have no fixed version at any release** — un-upgradable.
- The 4 patchable ones need torch `2.6.0 → ≥2.10.0`, but `sidecar/pyproject.toml` GPU-pins torch ("A6 lesson 5 — GPU-validated") and forbids casual bumps; that's an untestable-in-CI ML change, not a Dependabot merge.
- The repo's own **osv-scanner** gate already reports **0 actionable** for the same reason.

### Actions
- **Dismissed all 9 alerts** as `tolerable_risk` with the reasoning above (reversible — reopen anytime). Security-tab count: **9 → 0**.
- **`.github/dependabot.yml`**: added `torch`/`torchvision`/`torchaudio` to the `pip /sidecar` ignore list + dated comment, so these non-applicable advisories stop regenerating. A future torch bump stays a deliberate, GPU-revalidated manual step.

https://claude.ai/code/session_013zoWpevAed9fXHFdz372cC
