### PR TITLE
chore(deps): ignore unfixable local-AV torch CVEs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  # torch / torchvision / torchaudio are GPU-validated, CUDA-wheel-pinned runtime
+  # assets (declared in sidecar/pyproject.toml, deliberately NOT in the scanned
+  # requirements.lock.txt) and must be bumped together only after manual GPU
+  # re-validation (A6 lesson 5) -- never via an unattended Dependabot PR. The open
+  # torch advisories (CVE-2025-2148/2149/2953/2998/2999/3000/3001/3730) are all
+  # LOCAL attack-vector (AV:L), low/medium, several with no fixed version, and are
+  # not reachable in a local desktop app processing the user's own media. Triaged
+  # + alerts dismissed 2026-06-29; reopen if the threat model changes.
+  - dependency-name: torch
+  - dependency-name: torchvision
+  - dependency-name: torchaudio
   labels:
   - dependencies
   - type:chore


### PR DESCRIPTION
Splits the **wanted** half out of #248 (now closed). #248 bundled two unrelated changes; this PR carries **only** the Dependabot torch-ignore. The SonarCloud revive from #248 was intentionally **dropped** — reviving Sonar contradicts the documented June lean-gate decision to retire it ("drop Sonar, replaced by local opengrep"; `reports/PR-PURGE-CHECKLIST.md`).

## What this does
Adds `torch` / `torchvision` / `torchaudio` to the `pip` (`/sidecar`) ignore list in `.github/dependabot.yml` (+11 lines, config-only) so the 9 already-dismissed torch advisories stop regenerating.

## Why (triage already done in #248)
- All 9 alerts are `torch` CVEs (CVE-2025-2148 / -2149 / -2953 / -2998 / -2999 / -3000 / -3001 / -3730), all **LOCAL attack-vector (AV:L)**, low/medium.
- `torch` is a GPU-validated, CUDA-wheel-pinned runtime dep declared in `sidecar/pyproject.toml` (deliberately **not** in the scanned `requirements.lock.txt`); it is bumped only after manual GPU re-validation, never via an unattended Dependabot PR.
- Several advisories have no fixed version at any release; none are reachable in a local desktop app processing the user's own media. The repo's osv-scanner gate already reports 0 actionable.
- The 9 existing alerts were dismissed as `tolerable_risk` on 2026-06-29 (reversible — reopen if the threat model changes).

**Base:** `feat/v1.1.0`. Config-only; no app behaviour changes; the cherry-picked commit is byte-identical to the dependabot change that was in #248.

https://claude.ai/code/session_013zoWpevAed9fXHFdz372cC
