### PR TITLE
fix(reframe): hardening — no silent fallback, first-run provisioning, E2E hang, Settings crash

### DIFF
--- a/app/main/firstRunGate.test.ts
+++ b/app/main/firstRunGate.test.ts
@@ -1,0 +1,52 @@
+// Tests for the packaged first-run gate helpers (WIRING-T5 §2 provisioning
+// hardening). These pin the decision logic that closes the half-provisioned
+// silent-app trap: the supervisor runs bootstrap until a FULL provision marker
+// exists, and never bricks a previously-working install on a re-provision fail.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import {
+  FIRST_RUN_COMPLETE_MARKER,
+  needsFirstRunSetup,
+  shouldStartSidecarAfterFailedFirstRun,
+} from './firstRunGate';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..');
+const BOOTSTRAP_PY = resolve(REPO_ROOT, 'sidecar', 'runtime_setup', 'bootstrap.py');
+
+describe('FIRST_RUN_COMPLETE_MARKER', () => {
+  it('stays byte-identical to bootstrap.py FIRST_RUN_COMPLETE_MARKER', () => {
+    // The supervisor reads the exact file bootstrap.py writes; a drift here
+    // would make the gate check the wrong path and never see completion.
+    const src = readFileSync(BOOTSTRAP_PY, 'utf8');
+    const match = src.match(/FIRST_RUN_COMPLETE_MARKER\s*=\s*"([^"]+)"/);
+    expect(match?.[1]).toBe(FIRST_RUN_COMPLETE_MARKER);
+  });
+});
+
+describe('needsFirstRunSetup', () => {
+  it('runs bootstrap on a packaged build with no completion marker', () => {
+    expect(needsFirstRunSetup(true, false)).toBe(true);
+  });
+
+  it('skips bootstrap once the full-provision marker exists', () => {
+    expect(needsFirstRunSetup(true, true)).toBe(false);
+  });
+
+  it('never runs bootstrap in dev (unpackaged), marker or not', () => {
+    expect(needsFirstRunSetup(false, false)).toBe(false);
+    expect(needsFirstRunSetup(false, true)).toBe(false);
+  });
+});
+
+describe('shouldStartSidecarAfterFailedFirstRun', () => {
+  it('starts the existing env degraded when a prior env sentinel exists', () => {
+    expect(shouldStartSidecarAfterFailedFirstRun(true)).toBe(true);
+  });
+
+  it('stays down on a truly empty first run (nothing installed to start)', () => {
+    expect(shouldStartSidecarAfterFailedFirstRun(false)).toBe(false);
+  });
+});

--- a/app/main/firstRunGate.ts
+++ b/app/main/firstRunGate.ts
@@ -1,0 +1,37 @@
+// firstRunGate.ts — pure decision helpers for the packaged first-run gate.
+//
+// WIRING-T5 §2 hardening (first-run provisioning). The Electron supervisor must
+// decide, per packaged launch, whether to run stage-2 bootstrap.py. The honest
+// signal is the FIRST-RUN-COMPLETE marker bootstrap.py writes at the DATA ROOT
+// only after a FULL provision (env + every model + the S3FD/LR-ASD weights)
+// succeeds — NOT the per-env sentinel (`.media-studio-env.json`), which only
+// means "the pip env installed". Gating on the env sentinel let a run that built
+// the env but failed the model/weight downloads look "done", so the next launch
+// skipped bootstrap and the app ran half-provisioned (silently centre-cropping).
+//
+// This name MUST stay in sync with bootstrap.py FIRST_RUN_COMPLETE_MARKER
+// (firstRunGate.test.ts asserts they match by reading bootstrap.py).
+export const FIRST_RUN_COMPLETE_MARKER = '.first-run-complete.json';
+
+/**
+ * True when packaged AND the full first run has NOT completed yet — the only
+ * time stage-2 bootstrap.py must run. An existing (pre-marker) install missing
+ * the marker re-runs bootstrap, which is idempotent (pip re-checks satisfied,
+ * ensure_assets skips downloaded assets) and back-fills anything newly added.
+ */
+export function needsFirstRunSetup(isPackaged: boolean, completeMarkerExists: boolean): boolean {
+  return isPackaged && !completeMarkerExists;
+}
+
+/**
+ * After a FAILED first-run bootstrap, whether to still start the sidecar.
+ *
+ * If a prior env sentinel exists this was a RE-PROVISION (e.g. an upgrade
+ * back-filling new deps) of an already-working install — start it DEGRADED
+ * rather than brick a previously-working app over a transient download failure;
+ * the loud bootstrap-error banner already told the user what to fix. A truly
+ * empty first run (no env) has nothing to start, so it stays down + loud.
+ */
+export function shouldStartSidecarAfterFailedFirstRun(envSentinelExists: boolean): boolean {
+  return envSentinelExists;
+}

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -34,6 +34,11 @@ import {
 } from './mediaProtocol';
 import { registerShellIpc } from './shellIpc';
 import { pthZipName, renderPthBody } from './pthActivation';
+import {
+  FIRST_RUN_COMPLETE_MARKER,
+  needsFirstRunSetup,
+  shouldStartSidecarAfterFailedFirstRun,
+} from './firstRunGate';
 import { Sidecar } from './sidecar';
 
 // mstream:// must be declared privileged BEFORE app ready (U1).
@@ -198,6 +203,18 @@ function propagateDataRootEnv(): void {
 /** WIRING-T5 §2: the sidecar-env sentinel bootstrap.py writes on success. */
 function firstRunSentinelPath(): string {
   return join(DATA_ROOT, 'envs', 'sidecar', '.media-studio-env.json');
+}
+
+/**
+ * WIRING-T5 §2 (provisioning hardening): the FIRST-RUN-COMPLETE marker
+ * bootstrap.py writes at the data root ONLY after a full provision (env + every
+ * model + the S3FD/LR-ASD weights) succeeds. Gating first-run on THIS — not the
+ * env sentinel — is what stops a run that built the env but failed the model
+ * downloads from looking "done" and leaving a half-provisioned, silently
+ * centre-cropping app on the next launch.
+ */
+function firstRunCompletePath(): string {
+  return join(DATA_ROOT, FIRST_RUN_COMPLETE_MARKER);
 }
 
 /**
@@ -461,7 +478,7 @@ function bootstrap(): void {
   // run BEFORE the sidecar starts (the embeddable python cannot serve
   // `-m media_studio` until bootstrap.py rewrites its ._pth). Dev builds (and
   // already-bootstrapped packaged builds) start immediately, exactly as before.
-  const firstRun = app.isPackaged && !existsSync(firstRunSentinelPath());
+  const firstRun = needsFirstRunSetup(app.isPackaged, existsSync(firstRunCompletePath()));
   if (!firstRun) {
     // T5 hardening: a packaged build whose env already exists still needs THIS
     // copy's embeddable ._pth pointed at it (the sentinel is shared in appData,
@@ -563,6 +580,15 @@ function bootstrap(): void {
     const begin = (): void => {
       void runFirstRunBootstrap().then((ok) => {
         if (ok) {
+          sc2.start();
+        } else if (shouldStartSidecarAfterFailedFirstRun(existsSync(firstRunSentinelPath()))) {
+          // Re-provision of an already-working install failed (e.g. an upgrade
+          // back-filling new deps hit a transient download error). Start the
+          // EXISTING env degraded rather than brick it — the loud bootstrap
+          // error banner already surfaced what failed.
+          ensurePthActivated();
+          // eslint-disable-next-line no-console
+          console.error('[bootstrap] first-run setup failed; starting existing env (degraded)');
           sc2.start();
         } else {
           // eslint-disable-next-line no-console

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -12,7 +12,13 @@ import {
   applyOutcomeText,
   errText,
   indexAssets,
+  ingestRenderable,
   isInstalled,
+  isRenderableOverview,
+  isRenderableRecommendation,
+  isRenderableReport,
+  isRenderableRunners,
+  malformedDataMessage,
   mergeOverviewRoutingPolicy,
   qualityFraction,
   recommendationAlreadyOptimal,
@@ -249,6 +255,90 @@ describe('pure helpers', () => {
     expect(sizeForComponent(vlm, byAsset)).toBe(4540);
     // unknown asset -> null
     expect(sizeForComponent({ ...smol, name: 'mystery' }, byAsset)).toBeNull();
+  });
+});
+
+// ---- HARDENING: renderable-shape guards (crash-blank prevention) ------------
+describe('renderable-shape guards', () => {
+  it('isRenderableReport requires components/tiers/notes arrays', () => {
+    expect(isRenderableReport(report())).toBe(true);
+    // a missing array (structurally-broken sidecar payload) is rejected.
+    expect(isRenderableReport({ ...report(), tiers: undefined } as unknown as AdvisorReport)).toBe(
+      false,
+    );
+  });
+
+  it('isRenderableOverview requires eligibility.models array + routingPolicy', () => {
+    const ov = modelsOverview({});
+    expect(isRenderableOverview(ov)).toBe(true);
+    // eligibility missing -> eligibility?.models is undefined -> rejected.
+    expect(
+      isRenderableOverview({ ...ov, eligibility: undefined } as unknown as ModelsOverview),
+    ).toBe(false);
+    // eligibility present but routingPolicy missing -> rejected.
+    expect(
+      isRenderableOverview({ ...ov, routingPolicy: undefined } as unknown as ModelsOverview),
+    ).toBe(false);
+  });
+
+  it('isRenderableRunners requires whisper, llm and a runners array', () => {
+    const plan = localModelPlan();
+    expect(isRenderableRunners(plan)).toBe(true);
+    expect(isRenderableRunners({ ...plan, whisper: undefined } as unknown as LocalModelPlan)).toBe(
+      false,
+    );
+    expect(isRenderableRunners({ ...plan, llm: undefined } as unknown as LocalModelPlan)).toBe(
+      false,
+    );
+    expect(isRenderableRunners({ ...plan, runners: undefined } as unknown as LocalModelPlan)).toBe(
+      false,
+    );
+  });
+
+  it('isRenderableRecommendation requires routing.perFunction + downloads/rationale arrays', () => {
+    const rec = recommendation();
+    expect(isRenderableRecommendation(rec)).toBe(true);
+    // routing entirely absent -> routing?.perFunction is undefined -> rejected.
+    expect(
+      isRenderableRecommendation({ ...rec, routing: undefined } as unknown as Recommendation),
+    ).toBe(false);
+    // routing present but perFunction absent -> rejected.
+    expect(
+      isRenderableRecommendation({ ...rec, routing: {} } as unknown as Recommendation),
+    ).toBe(false);
+    expect(
+      isRenderableRecommendation({ ...rec, downloads: undefined } as unknown as Recommendation),
+    ).toBe(false);
+    expect(
+      isRenderableRecommendation({ ...rec, rationale: undefined } as unknown as Recommendation),
+    ).toBe(false);
+  });
+
+  it('ingestRenderable: null passes through, valid returns as-is, malformed rejects + warns', () => {
+    const warn = vi.fn();
+    // null/undefined = capability absent (quiet), never a malformed warning.
+    expect(ingestRenderable(null, isRenderableReport, warn)).toBeNull();
+    expect(ingestRenderable(undefined, isRenderableReport, warn)).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    // a valid payload is stored unchanged.
+    const good = report();
+    expect(ingestRenderable(good, isRenderableReport, warn)).toBe(good);
+    expect(warn).not.toHaveBeenCalled();
+    // a broken payload is rejected (null) and the LOUD warning fires.
+    expect(
+      ingestRenderable(
+        { recommendedPreset: 'x', vramBudgetMb: 1 } as unknown as AdvisorReport,
+        isRenderableReport,
+        warn,
+      ),
+    ).toBeNull();
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('malformedDataMessage names the broken parts', () => {
+    expect(malformedDataMessage(['system report', 'models overview'])).toMatch(
+      /unexpected data \(system report, models overview\)/,
+    );
   });
 });
 
@@ -1531,6 +1621,42 @@ describe('<ModelsSystemPanel />', () => {
     expect(c.calls.some((x) => x.method === 'system.advisor')).toBe(true);
   });
 
+  it('surfaces a loud error (no blank) when a roll-up action re-run advisor is malformed', async () => {
+    const c = makeClient({
+      initialSettings: { firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          action: { kind: 'assets.ensure', assets: ['saliency'] },
+        },
+      ],
+    });
+    // The advisor re-run that the readiness action triggers returns a broken report.
+    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      { recommendedPreset: 'x', vramBudgetMb: 1 } as unknown as AdvisorReport,
+    );
+    await mount(c);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const fix = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      fix.click();
+    });
+    await act(async () => {
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+    });
+    // Panel survives (no crash-blank) and the malformed re-run is announced loudly.
+    expect(container.querySelector('.models-system-panel')).not.toBeNull();
+    const alert = container.querySelector('p.error[role="alert"]');
+    expect(alert?.textContent ?? '').toMatch(/unexpected data/i);
+  });
+
   it('surfaces an error when a roll-up assets.ensure action fails', async () => {
     const c = makeClient({
       initialSettings: { firstRunChoiceMade: true },
@@ -2152,5 +2278,95 @@ describe('<ModelsSystemPanel /> WU-B3 card', () => {
     // analysis ran (hardware present) but the overview compose was empty.
     expect(container.querySelector('[data-section="hardware"]')).not.toBeNull();
     expect(container.querySelector('[data-section="reason-strip"]')).toBeNull();
+  });
+
+  // ---- HARDENING: malformed (non-null) sidecar payloads must NOT crash-blank ---
+  // The panel maps over report.tiers/components/notes, overview.eligibility.models,
+  // runners.runners and reads recommendation.routing.perFunction. A STRUCTURALLY
+  // BROKEN (non-null) payload from the sidecar — arrays or required objects missing
+  // — would throw during render and, with no top-level error boundary, blank the
+  // ENTIRE app. These assert the panel survives (root still present), hides the
+  // affected section, and surfaces a LOUD error (never a silent blank/degrade).
+
+  it('survives a malformed system.advisor report (missing arrays) without blanking', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      // recommendedPreset/vramBudgetMb present but tiers/components/notes ABSENT.
+      { recommendedPreset: 'tier1-multimodal', vramBudgetMb: 6000 } as unknown as AdvisorReport,
+    );
+    await mount(c);
+    await analyze();
+    // Panel root still rendered (no crash-blank) and the tier/model grid hidden.
+    expect(container.querySelector('.models-system-panel')).not.toBeNull();
+    expect(container.querySelector('[data-section="tiers"]')).toBeNull();
+    expect(container.querySelector('[data-section="models"]')).toBeNull();
+    // Loud error surfaced (not a silent degrade).
+    const alert = container.querySelector('p.error[role="alert"]');
+    expect(alert).not.toBeNull();
+    expect(alert?.textContent ?? '').toMatch(/unexpected data/i);
+  });
+
+  it('survives a malformed models.overview (missing eligibility) without blanking', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    (c.client.models.overview as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      // routingPolicy present but eligibility ABSENT -> overview.eligibility.models throws.
+      { routingPolicy: { global: 'local', overrides: {} } } as unknown as ModelsOverview,
+    );
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('.models-system-panel')).not.toBeNull();
+    expect(container.querySelector('[data-section="reason-strip"]')).toBeNull();
+    expect(container.querySelector('p.error[role="alert"]')).not.toBeNull();
+  });
+
+  it('survives a malformed models.runners plan (missing runners array) without blanking', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    (c.client.models.runners as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      // whisper/llm present but the runners array ABSENT -> LocalRunners map throws.
+      {
+        whisper: { model: 'w', label: 'W', reason: 'r' },
+        llm: { model: 'l', label: 'L', reason: 'r' },
+      } as unknown as LocalModelPlan,
+    );
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('.models-system-panel')).not.toBeNull();
+    expect(container.querySelector('[data-section="local-runners"]')).toBeNull();
+    expect(container.querySelector('p.error[role="alert"]')).not.toBeNull();
+  });
+
+  it('survives a malformed system.recommend payload (missing routing) without blanking', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    (c.client.system.recommend as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      // routing ABSENT -> recommendationUnavailable(Object.keys(routing.perFunction)) throws.
+      { recommendation: { preset: 'balanced' } } as unknown as { recommendation: Recommendation },
+    );
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('.models-system-panel')).not.toBeNull();
+    expect(container.querySelector('[data-section="recommend"]')).toBeNull();
+    expect(container.querySelector('p.error[role="alert"]')).not.toBeNull();
+  });
+
+  it('surfaces a loud error when a re-run advisor (post-download) returns a broken report', async () => {
+    const c = makeClient({ initialSettings: optedIn });
+    await mount(c);
+    await analyze();
+    // After the download re-runs system.advisor, a broken report must not crash.
+    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      { recommendedPreset: 'x', vramBudgetMb: 1 } as unknown as AdvisorReport,
+    );
+    const dl = container.querySelector(
+      '[data-section="models"] button[data-action="download"][data-state="download"]',
+    ) as HTMLButtonElement | null;
+    // A downloadable (not-installed, has-asset) model card exists in the default report.
+    expect(dl).not.toBeNull();
+    await act(async () => dl?.click());
+    // download chains ensure -> list -> advisor (3 sequential awaits); flush enough.
+    await act(async () => {
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+    });
+    expect(container.querySelector('.models-system-panel')).not.toBeNull();
+    expect(container.querySelector('p.error[role="alert"]')).not.toBeNull();
   });
 });

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -303,9 +303,9 @@ describe('renderable-shape guards', () => {
       isRenderableRecommendation({ ...rec, routing: undefined } as unknown as Recommendation),
     ).toBe(false);
     // routing present but perFunction absent -> rejected.
-    expect(
-      isRenderableRecommendation({ ...rec, routing: {} } as unknown as Recommendation),
-    ).toBe(false);
+    expect(isRenderableRecommendation({ ...rec, routing: {} } as unknown as Recommendation)).toBe(
+      false,
+    );
     expect(
       isRenderableRecommendation({ ...rec, downloads: undefined } as unknown as Recommendation),
     ).toBe(false);
@@ -1635,9 +1635,10 @@ describe('<ModelsSystemPanel />', () => {
       ],
     });
     // The advisor re-run that the readiness action triggers returns a broken report.
-    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      { recommendedPreset: 'x', vramBudgetMb: 1 } as unknown as AdvisorReport,
-    );
+    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      recommendedPreset: 'x',
+      vramBudgetMb: 1,
+    } as unknown as AdvisorReport);
     await mount(c);
     await act(async () => {
       await Promise.resolve();
@@ -2353,9 +2354,10 @@ describe('<ModelsSystemPanel /> WU-B3 card', () => {
     await mount(c);
     await analyze();
     // After the download re-runs system.advisor, a broken report must not crash.
-    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
-      { recommendedPreset: 'x', vramBudgetMb: 1 } as unknown as AdvisorReport,
-    );
+    (c.client.system.advisor as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      recommendedPreset: 'x',
+      vramBudgetMb: 1,
+    } as unknown as AdvisorReport);
     const dl = container.querySelector(
       '[data-section="models"] button[data-action="download"][data-state="download"]',
     ) as HTMLButtonElement | null;

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -163,6 +163,62 @@ export function applyOutcomeText(rec: Recommendation): string {
   return `Applied: ${parts.join(', ')}.`;
 }
 
+/**
+ * HARDENING (Settings › Models crash-blank guard) — the sidecar is an UNTRUSTED
+ * boundary. The panel maps over `report.tiers/components/notes`,
+ * `overview.eligibility.models`, `runners.runners` and reads
+ * `recommendation.routing.perFunction`. A structurally-broken (NON-null) payload
+ * with a required array/object missing would throw during render and, with no
+ * top-level error boundary, blank the ENTIRE app. Each `isRenderable*` guard
+ * asserts the exact shape the panel accesses so a broken payload is rejected at
+ * INGESTION (stored as null → the section hides AND a LOUD error is surfaced),
+ * never a silent blank and never a silent degrade. `null`/`undefined` (capability
+ * legitimately absent) is NOT malformed — it hides the section quietly, the
+ * established progressive-disclosure pattern.
+ */
+export function isRenderableReport(report: AdvisorReport): boolean {
+  return [report.components, report.tiers, report.notes].every((value) => Array.isArray(value));
+}
+
+export function isRenderableOverview(overview: ModelsOverview): boolean {
+  return Array.isArray(overview.eligibility?.models) && overview.routingPolicy != null;
+}
+
+export function isRenderableRunners(plan: LocalModelPlan): boolean {
+  return plan.whisper != null && plan.llm != null && Array.isArray(plan.runners);
+}
+
+export function isRenderableRecommendation(rec: Recommendation): boolean {
+  return (
+    rec.routing?.perFunction != null &&
+    Array.isArray(rec.downloads) &&
+    Array.isArray(rec.rationale)
+  );
+}
+
+/**
+ * Store a sidecar payload ONLY when it has the shape the panel renders. A
+ * `null`/`undefined` payload passes through as null (the section hides quietly).
+ * A present-but-malformed payload is rejected (returns null) and `onMalformed`
+ * fires so the caller can raise a LOUD error — the crash-blank guard's whole
+ * point is that a broken payload degrades to an announced empty, not a blank app.
+ */
+export function ingestRenderable<T>(
+  raw: T | null | undefined,
+  isRenderable: (value: T) => boolean,
+  onMalformed: () => void,
+): T | null {
+  if (raw == null) return null;
+  if (isRenderable(raw)) return raw;
+  onMalformed();
+  return null;
+}
+
+/** The user-facing (LOUD) message when the sidecar returns malformed panel data. */
+export function malformedDataMessage(parts: readonly string[]): string {
+  return `Analysis returned unexpected data (${parts.join(', ')}). Those panels are unavailable — re-analyze or update the app.`;
+}
+
 export interface ModelsSystemPanelProps {
   /** Inject the typed client for tests; defaults to the real lib/rpc client. */
   rpcClient?: typeof client;
@@ -291,16 +347,28 @@ export function ModelsSystemPanel({
           // (real quant + VRAM est) the reason strip names.
           api.models.overview({ commercial }),
         ]);
+      // HARDENING: reject any present-but-malformed payload at ingestion so a
+      // sidecar-data-coupled break degrades to an announced empty, never a blank
+      // app. Collect the broken payload names to surface ONE loud error below.
+      const malformed: string[] = [];
+      const flag = (what: string) => (): void => void malformed.push(what);
       setHardware(hw ?? null);
-      setReport(rep ?? null);
+      setReport(ingestRenderable(rep, isRenderableReport, flag('system report')));
       setAssets(Array.isArray(assetRes?.assets) ? assetRes.assets : []);
       setEngines(Array.isArray(engineRes?.engines) ? engineRes.engines : []);
       setUsage(Array.isArray(usageRes?.usage) ? usageRes.usage : []);
       setCatalog(catalogRes ?? null);
-      setRecommendation(recRes?.recommendation ?? null);
-      setRunners(runnersRes ?? null);
-      setOverview(overviewRes ?? null);
+      setRecommendation(
+        ingestRenderable(
+          recRes?.recommendation,
+          isRenderableRecommendation,
+          flag('setup recommendation'),
+        ),
+      );
+      setRunners(ingestRenderable(runnersRes, isRenderableRunners, flag('local model plan')));
+      setOverview(ingestRenderable(overviewRes, isRenderableOverview, flag('models overview')));
       setApplyOutcome('');
+      if (malformed.length > 0) setError(malformedDataMessage(malformed));
       setAnalyzed(true);
       // First-run tour: show once if the user hasn't seen it.
       if (!settings.modelsOnboardingSeen) setShowTour(true);
@@ -493,7 +561,11 @@ export function ModelsSystemPanel({
         setAssets(Array.isArray(res?.assets) ? res.assets : []);
         // Re-run the advisor so installed-state flips the verdicts/recommendation.
         const rep = await api.system.advisor({ commercial: Boolean(settings.commercial) });
-        setReport(rep ?? null);
+        setReport(
+          ingestRenderable(rep, isRenderableReport, () =>
+            setError(malformedDataMessage(['system report'])),
+          ),
+        );
       } catch (err) {
         setError(errText(err));
       } finally {
@@ -523,7 +595,11 @@ export function ModelsSystemPanel({
         const res = await api.assets.list();
         setAssets(Array.isArray(res?.assets) ? res.assets : []);
         const rep = await api.system.advisor({ commercial: Boolean(settings.commercial) });
-        setReport(rep ?? null);
+        setReport(
+          ingestRenderable(rep, isRenderableReport, () =>
+            setError(malformedDataMessage(['system report'])),
+          ),
+        );
       } catch (err) {
         setError(errText(err));
       }

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -190,9 +190,7 @@ export function isRenderableRunners(plan: LocalModelPlan): boolean {
 
 export function isRenderableRecommendation(rec: Recommendation): boolean {
   return (
-    rec.routing?.perFunction != null &&
-    Array.isArray(rec.downloads) &&
-    Array.isArray(rec.rationale)
+    rec.routing?.perFunction != null && Array.isArray(rec.downloads) && Array.isArray(rec.rationale)
   );
 }
 

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -149,16 +149,33 @@ class ClaudeShortsBackendUnavailableError(ClaudeShortsReframeError):
 REFRAME_DEGRADED_NOTICE = "reframe.degraded"
 
 
-def make_degraded_notice(reason: str) -> dict[str, str]:
+# Appended to a degrade message when the active detector backend is the weaker
+# OpenCV/haar face detector because the preferred MODEL (MediaPipe) is not
+# installed. NO-SILENT-FALLBACK: a center crop caused by a missing model must
+# NAME that model (actionable) rather than reading as an unexplained "no subject".
+MEDIAPIPE_MISSING_HINT = (
+    " MediaPipe is not installed — the app fell back to lower-quality OpenCV face "
+    "detection, which often can't hold turned or profile faces; install mediapipe "
+    "for accurate speaker tracking."
+)
+
+
+def make_degraded_notice(reason: str, *, backend: str | None = None) -> dict[str, str]:
     """Build the typed per-clip degraded notice (``{type, message, reason}``).
 
     ``message`` is the human line a job surfaces via ``job.progress``; ``reason``
     is the specific cause (a detector error, or no trackable subject) so the UI /
-    logs can explain WHY the crop fell back to center.
+    logs can explain WHY the crop fell back to center. When ``backend == "haar"``
+    the message also NAMES the missing MediaPipe model (:data:`MEDIAPIPE_MISSING_HINT`)
+    so a model-unavailability degrade is surfaced loudly, never silently reduced to
+    "no subject" (NO-SILENT-FALLBACK).
     """
+    message = f"reframe: speaker tracking unavailable ({reason}) — used center crop"
+    if backend == "haar":
+        message += MEDIAPIPE_MISSING_HINT
     return {
         "type": REFRAME_DEGRADED_NOTICE,
-        "message": f"reframe: speaker tracking unavailable ({reason}) — used center crop",
+        "message": message,
         "reason": reason,
     }
 
@@ -619,8 +636,15 @@ def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | Non
         cascade_path = os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml")  # pyright: ignore[reportAttributeAccessIssue]
         cascade = cv2.CascadeClassifier(cascade_path)
         if cascade.empty():
-            _log.warning("haar cascade missing at %s; using center crop", cascade_path)
-            return None, lambda: None
+            # NO-SILENT-FALLBACK: a missing/unreadable cascade is a broken OpenCV
+            # provisioning (the cascade ships WITH opencv-python), NOT a per-clip
+            # event — fail loud with an actionable "reinstall opencv" error rather
+            # than quietly returning a no-op finder that collapses to a center crop.
+            raise ClaudeShortsBackendUnavailableError(
+                f"OpenCV face cascade missing or unreadable at {cascade_path} — the "
+                "opencv-python install is incomplete; reinstall it to enable speaker "
+                "tracking (this is a provisioning/setup error, not a per-clip degrade)"
+            )
         prev = {"img": None}
 
         def find_haar(img: Any) -> float | None:
@@ -839,6 +863,7 @@ class ClaudeShortsReframeEngine:
         runner: Runner | None = None,
         prober: Prober | None = None,
         detector: Detector | None = None,
+        backend_probe: Callable[[], str] | None = None,
     ) -> None:
         self._settings = settings or {}
         # A6 lesson 2: the default encode runner is ffmpeg.run — it drains
@@ -848,6 +873,10 @@ class ClaudeShortsReframeEngine:
         self._detector: Detector = detector or (
             lambda path, ts: detect_subject_centers(path, ts, settings=self._settings)
         )
+        # Resolves the active detection backend ("mediapipe" | "haar") so a
+        # center-crop degrade can NAME a missing model, and so a total provisioning
+        # failure (no cv2) surfaces loudly. Injectable for deterministic tests.
+        self._backend_probe: Callable[[], str] = backend_probe or detect_backend
 
     def compute_plan(
         self,
@@ -871,6 +900,11 @@ class ClaudeShortsReframeEngine:
         src_w, src_h, duration = self._prober(in_path)
         crop = centered_crop(src_w, src_h, aspect)
         timestamps = window_timestamps(duration)
+        # Resolve the active backend up front so any degrade below can NAME a
+        # missing model. A total provisioning failure (no cv2/mediapipe) raises
+        # ClaudeShortsBackendUnavailableError here and propagates loudly — never a
+        # silent center crop (NO-SILENT-FALLBACK).
+        backend = self._backend_probe()
         try:
             samples = list(self._detector(in_path, timestamps) or [])
         except ClaudeShortsBackendUnavailableError:
@@ -882,13 +916,13 @@ class ClaudeShortsReframeEngine:
             # A broken detector degrades to the centered crop — the encode still
             # runs; only subject tracking is lost. SURFACE it (never swallow).
             _log.warning("subject detection failed; using centered crop", exc_info=True)
-            self._notify_degraded(on_notice, f"subject detection failed: {exc}")
+            self._notify_degraded(on_notice, f"subject detection failed: {exc}", backend=backend)
             return crop, [], duration
         # Trust gate: a couple of stray hits across many windows is detector noise,
         # not a locatable subject -> keep the centered crop rather than tracking it.
         min_hits = max(1, math.ceil(len(timestamps) * MIN_SUBJECT_HIT_FRAC))
         if len(samples) < min_hits:
-            self._notify_degraded(on_notice, "no trackable subject located")
+            self._notify_degraded(on_notice, "no trackable subject located", backend=backend)
             return crop, [], duration
 
         smoothed = smooth_centers([c for _, c in samples])
@@ -910,14 +944,22 @@ class ClaudeShortsReframeEngine:
         return crop, kfs, duration
 
     @staticmethod
-    def _notify_degraded(on_notice: Callable[[dict[str, str]], None] | None, reason: str) -> None:
+    def _notify_degraded(
+        on_notice: Callable[[dict[str, str]], None] | None,
+        reason: str,
+        *,
+        backend: str | None = None,
+    ) -> None:
         """Surface a per-clip degraded notice through ``on_notice`` (when wired).
 
         The degrade is ALSO logged, but the structured notice is what lets the
         orchestrator/UI render a degraded badge — the "never swallow" contract.
+        ``backend`` (the active detector backend) is passed to
+        :func:`make_degraded_notice` so a haar/no-MediaPipe degrade names the
+        missing model instead of silently reading as "no subject".
         """
         if on_notice is not None:
-            on_notice(make_degraded_notice(reason))
+            on_notice(make_degraded_notice(reason, backend=backend))
 
     def reframe(
         self,

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -632,6 +632,17 @@ def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | Non
     if backend == "haar":
         import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
 
+        # NO-SILENT-FALLBACK: some opencv builds (headless/objdetect-stripped) import
+        # cleanly but omit the native face-cascade class, so a bare call would raise
+        # an opaque ``AttributeError``. Fail loud with an actionable provisioning
+        # error instead — never a quiet center crop (WU no-silent-fallback).
+        if not hasattr(cv2, "CascadeClassifier"):
+            raise ClaudeShortsBackendUnavailableError(
+                "OpenCV is installed but lacks the objdetect face detector "
+                "(cv2.CascadeClassifier) — the opencv-python build is incomplete or "
+                "stripped; install the full opencv-python to enable speaker tracking "
+                "(this is a provisioning/setup error, not a per-clip degrade)"
+            )
         # cv2.data is a real runtime submodule; the opencv type stubs omit it.
         cascade_path = os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml")  # pyright: ignore[reportAttributeAccessIssue]
         cascade = cv2.CascadeClassifier(cascade_path)  # pyright: ignore[reportAttributeAccessIssue]
@@ -688,6 +699,17 @@ def _person_center(img: Any) -> float | None:
     h, w = int(img.shape[0]), int(img.shape[1])
     if w < _HOG_MIN_W or h < _HOG_MIN_H:
         return None
+    # NO-SILENT-FALLBACK: an objdetect-stripped opencv build imports but omits the
+    # HOG people detector, so a bare call would raise an opaque ``AttributeError``.
+    # Fail loud with an actionable provisioning error rather than silently skipping
+    # the body fallback (which would masquerade as "no person" -> center crop).
+    if not hasattr(cv2, "HOGDescriptor"):
+        raise ClaudeShortsBackendUnavailableError(
+            "OpenCV is installed but lacks the HOG people detector "
+            "(cv2.HOGDescriptor) — the opencv-python build is incomplete or stripped; "
+            "install the full opencv-python to enable body-fallback subject tracking "
+            "(this is a provisioning/setup error, not a per-clip degrade)"
+        )
     hog = cv2.HOGDescriptor()  # pyright: ignore[reportAttributeAccessIssue]
     hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())  # pyright: ignore[reportAttributeAccessIssue]
     rects, weights = hog.detectMultiScale(img, winStride=(8, 8))

--- a/sidecar/media_studio/features/reframe_claudeshorts.py
+++ b/sidecar/media_studio/features/reframe_claudeshorts.py
@@ -634,7 +634,7 @@ def _make_face_finder(backend: str) -> tuple[Callable[[Any], float | None] | Non
 
         # cv2.data is a real runtime submodule; the opencv type stubs omit it.
         cascade_path = os.path.join(cv2.data.haarcascades, "haarcascade_frontalface_default.xml")  # pyright: ignore[reportAttributeAccessIssue]
-        cascade = cv2.CascadeClassifier(cascade_path)
+        cascade = cv2.CascadeClassifier(cascade_path)  # pyright: ignore[reportAttributeAccessIssue]
         if cascade.empty():
             # NO-SILENT-FALLBACK: a missing/unreadable cascade is a broken OpenCV
             # provisioning (the cascade ships WITH opencv-python), NOT a per-clip
@@ -688,7 +688,7 @@ def _person_center(img: Any) -> float | None:
     h, w = int(img.shape[0]), int(img.shape[1])
     if w < _HOG_MIN_W or h < _HOG_MIN_H:
         return None
-    hog = cv2.HOGDescriptor()
+    hog = cv2.HOGDescriptor()  # pyright: ignore[reportAttributeAccessIssue]
     hog.setSVMDetector(cv2.HOGDescriptor_getDefaultPeopleDetector())  # pyright: ignore[reportAttributeAccessIssue]
     rects, weights = hog.detectMultiScale(img, winStride=(8, 8))
     if rects is None or len(rects) == 0:

--- a/sidecar/runtime_setup/bootstrap.py
+++ b/sidecar/runtime_setup/bootstrap.py
@@ -399,7 +399,14 @@ class _ConsoleJobCtx:
 
 
 def default_first_run_assets() -> list[str]:
-    """The core asset set first run installs (models + llama-server builds)."""
+    """The core asset set first run installs (models + llama-server builds).
+
+    Includes the vendored Light-ASD / S3FD active-speaker weights: they were
+    registered on-demand but never in the first-run set, so a fresh install had
+    no way to run the multi-speaker reframe engine and silently fell back to a
+    single-speaker/centre crop. Provisioning them up front (sha256-pinned, ~90MB)
+    keeps the engine's on-demand path honest — present, or a loud failure.
+    """
     from media_studio import tools_resolver
     from media_studio.assets import manifest
 
@@ -409,6 +416,8 @@ def default_first_run_assets() -> list[str]:
         tools_resolver.LLAMA_CUDA_ASSET,
         tools_resolver.LLAMA_CUDART_ASSET,
         tools_resolver.LLAMA_CPU_ASSET,
+        manifest.LIGHTASD_S3FD_ASSET_NAME,
+        manifest.LIGHTASD_ASD_ASSET_NAME,
     ]
 
 
@@ -427,6 +436,73 @@ def activate_env_in_process(env_dir: Path) -> None:
     import site
 
     site.addsitedir(str(env_dir))
+
+
+# --------------------------------------------------------------------------- #
+# fail-loud provisioning verification + first-run-complete marker
+# --------------------------------------------------------------------------- #
+#: written at ``<root>/`` ONLY after a FULL first run (env + assets + verify)
+#: succeeds. Its presence is the honest "everything provisioned" signal the
+#: Electron supervisor gates re-runs on — distinct from the per-env sentinel
+#: (``.media-studio-env.json``), which only means "the pip env is installed".
+#: A run that installs the env but then fails on model/weight downloads leaves
+#: NO marker, so the next launch retries instead of silently running a
+#: half-provisioned (silent-centre-crop) app.
+FIRST_RUN_COMPLETE_MARKER = ".first-run-complete.json"
+
+
+def first_run_complete_path(root: Path | str) -> Path:
+    """The first-run-complete marker path under ``root``."""
+    return Path(root) / FIRST_RUN_COMPLETE_MARKER
+
+
+def _default_asset_manager(root: Path) -> Any:
+    """Construct the real :class:`AssetManager` (lazy import — httpx et al. only
+    exist once the sidecar env is installed + site-dir'd)."""
+    from media_studio.assets.manager import AssetManager
+
+    return AssetManager(root=root)
+
+
+def verify_provisioned(
+    names: Sequence[str],
+    root: Path,
+    *,
+    manager: Any | None = None,
+) -> None:
+    """FAIL LOUD if any expected asset did not actually land on disk.
+
+    ``ensure_assets`` already raises when a download fails, but this is the
+    explicit no-silent-fallback gate: a bootstrap must NOT print
+    ``SUCCESS`` (nor write the completion marker) while a model or the S3FD /
+    LR-ASD weights are missing — that is exactly the half-provisioned state that
+    left the app silently centre-cropping. Any unregistered or not-installed
+    asset raises a :class:`BootstrapError` naming EVERY offender.
+    """
+    from media_studio.assets import manifest
+
+    mgr = manager if manager is not None else _default_asset_manager(root)
+    missing: list[str] = []
+    for name in names:
+        entry = manifest.get_asset(name)
+        if entry is None or mgr.installed_path(entry) is None:
+            missing.append(name)
+    if missing:
+        raise BootstrapError(
+            "first-run provisioning incomplete — these assets did not install: "
+            f"{', '.join(missing)} | fix: relaunch to retry the download (check "
+            "network + free disk space); the app will not run half-provisioned"
+        )
+
+
+def write_first_run_complete(root: Path | str, names: Sequence[str]) -> Path:
+    """Write the first-run-complete marker recording the provisioned asset set."""
+    marker = first_run_complete_path(root)
+    marker.write_text(
+        json.dumps({"assets": list(names)}, indent=2),
+        encoding="utf-8",
+    )
+    return marker
 
 
 # --------------------------------------------------------------------------- #
@@ -600,11 +676,16 @@ def main(argv: Sequence[str] | None = None) -> int:
                 embed_dir=embed_dir,
             )
 
+        asset_names: list[str] = []
         if not args.skip_assets:
+            asset_names = list(args.assets or default_first_run_assets())
             # step 3 needs httpx from the just-installed env in THIS process.
             activate_env_in_process(env_dir)
-            ensure_assets(args.assets or default_first_run_assets(), root)
+            ensure_assets(asset_names, root)
             extract_tool_archives(root)
+            # NO SILENT FALLBACK: prove every model + the S3FD/LR-ASD weights
+            # actually landed before we ever claim success.
+            verify_provisioned(asset_names, root)
 
         if args.chatterbox:
             # The chatterbox env installs with the DEDICATED py3.14 interpreter
@@ -626,6 +707,12 @@ def main(argv: Sequence[str] | None = None) -> int:
                 req_file=CHATTERBOX_REQUIREMENTS,
                 embed_dir=chatter_embed,
             )
+
+        # Only a FULL run (env + assets) is a completed first run. Partial
+        # invocations (--skip-env / --skip-assets, used for manual repair) must
+        # NOT write the marker, or the supervisor would skip a real re-run.
+        if not args.skip_env and not args.skip_assets:
+            write_first_run_complete(root, asset_names)
 
         print("SUCCESS:bootstrap first-run setup complete")
         return 0

--- a/sidecar/runtime_setup/requirements-sidecar.txt
+++ b/sidecar/runtime_setup/requirements-sidecar.txt
@@ -26,3 +26,15 @@ kokoro-onnx==0.5.0
 # CUDA runtime wheels for ctranslate2/onnxruntime GPU paths (pins = dev venv)
 nvidia-cublas-cu12==12.9.2.10
 nvidia-cudnn-cu12==9.23.2.1
+
+# DELIBERATELY NOT HERE: mediapipe. The claudeshorts reframe engine's optional
+# MediaPipe backend uses the LEGACY Solutions API (`mp.solutions.face_detection`),
+# which only exists in mediapipe <=0.10.21 — and those wheels declare `numpy<2`,
+# a hard conflict with the `numpy==2.5.0` above (required by ctranslate2 / av /
+# onnxruntime / kokoro-onnx). mediapipe >=0.10.31 (numpy-2 clean) REMOVED the
+# Solutions API entirely, so pinning it would install a mediapipe whose
+# `mp.solutions` is missing -> the backend crashes at job time -> a SILENT drop
+# to the haar detector. Verified empirically 2026-07-03 (see basic-memory
+# "Reframe mediapipe cannot be provisioned into numpy-2 sidecar"). haar is the
+# honest baseline; a real MediaPipe path needs a Tasks-API migration (separate
+# reframe-engine WU), not a requirements pin.

--- a/sidecar/tests/e2e/README.md
+++ b/sidecar/tests/e2e/README.md
@@ -89,3 +89,11 @@ python sidecar/tests/e2e/real_pipeline_smoke.py \
   `<job>.json.tmp` name; the dispatch and worker threads race on the same temp →
   `FileNotFoundError`). The media pipeline is unaffected by store choice (the
   transcript persists via the project manifest, not the job store).
+- **Windows native pre-import (bug #4):** `_tiny_sidecar.py` calls the production
+  composition root's `_suppress_windows_error_dialogs()` + `_preimport_native_modules()`
+  (imported from `media_studio.__main__`, never reimplemented) BEFORE it serves. On
+  Windows the FIRST import of a native C-extension DLL (numpy / av / ctranslate2 /
+  ...) from a JOB THREAD deadlocks while the main thread is parked in
+  `sys.stdin.readline()`; pre-importing the natives in the main thread is what stops
+  the harness hanging forever at `transcribe.start`. Production `python -m media_studio`
+  already does this — the launcher must stay in lockstep.

--- a/sidecar/tests/e2e/_tiny_sidecar.py
+++ b/sidecar/tests/e2e/_tiny_sidecar.py
@@ -26,6 +26,15 @@ import sys
 
 from media_studio import handlers, rpc
 
+# REUSE the production composition root's Windows pre-serve hardening (bug #4).
+# ``_preimport_native_modules`` loads the native C-extension DLLs
+# (numpy/av/ctranslate2/cv2/...) in the MAIN thread; ``_suppress_windows_error_dialogs``
+# turns a failed DLL load into a normal exception instead of an invisible modal
+# dialog. Imported (not reimplemented) so this launcher's pre-imported native set
+# can never drift from production — see ``main`` for why the E2E harness hangs
+# without them.
+from media_studio.__main__ import _preimport_native_modules, _suppress_windows_error_dialogs
+
 
 class TinyCpuWhisperLoader:
     """A WhisperLoader whose ``load()`` forces tiny / cpu / int8 (ignores args).
@@ -55,6 +64,15 @@ def main() -> int:
     if not data_dir:
         print("MEDIA_STUDIO_E2E_DATADIR is required", file=sys.stderr)
         return 2
+    # BUG #4 (Windows E2E hang) fix — MUST run before serving, exactly as the
+    # production ``media_studio.__main__.main`` does. On Windows the FIRST import
+    # of a native C-extension DLL (numpy/av/ctranslate2/...) from a JOB THREAD
+    # deadlocks while the main thread is parked in ``sys.stdin.readline()`` (the
+    # serve loop). This launcher previously omitted the pre-import, so the real
+    # E2E harness hung forever at ``transcribe.start``. Pre-importing the natives
+    # in THIS (main) thread means no job thread ever triggers the first DLL load.
+    _suppress_windows_error_dialogs()
+    _preimport_native_modules()
     handlers.register_all(handlers.Services(data_dir=data_dir, whisper_loader=TinyCpuWhisperLoader()))
     # NOTE: the production __main__.main() injects a DiskJobStore here. We use the
     # in-memory store (store=None, a supported back-compat mode) ON PURPOSE: the

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -111,13 +111,18 @@ def _engine(
     detector,
     runner=None,
     dims=(1280, 720, 8.0),
+    backend_probe=None,
 ):
     runner = runner or _make_ff_runner(0)
+    kwargs = {}
+    if backend_probe is not None:
+        kwargs["backend_probe"] = backend_probe
     eng = ClaudeShortsReframeEngine(
         settings=fake_bins,
         runner=runner,
         prober=lambda _path: dims,
         detector=detector,
+        **kwargs,
     )
     return eng, runner
 
@@ -732,6 +737,97 @@ def test_reframe_threads_on_notice_through_to_compute_plan(fake_bins):
     assert notices[0]["type"] == cs.REFRAME_DEGRADED_NOTICE
 
 
+# --------------------------------------------------------------------------- #
+# NO-SILENT-FALLBACK: a MODEL being unavailable (mediapipe absent -> the weaker
+# OpenCV/haar backend) must NAME the missing model in the degrade notice, so the
+# center-crop fallback is never silently attributed to "no subject" alone.
+# --------------------------------------------------------------------------- #
+def test_make_degraded_notice_names_missing_mediapipe_on_haar_backend():
+    """The typed notice enriches its message when the active backend is haar
+    (mediapipe unavailable) — the CAUSE is surfaced, not swallowed."""
+    notice = cs.make_degraded_notice("no trackable subject located", backend="haar")
+    assert notice["type"] == cs.REFRAME_DEGRADED_NOTICE
+    assert "center crop" in notice["message"].lower()
+    assert "mediapipe" in notice["message"].lower()
+    # the raw reason is preserved verbatim for logs/UI attribution
+    assert notice["reason"] == "no trackable subject located"
+
+
+def test_make_degraded_notice_omits_hint_when_mediapipe_present():
+    """When mediapipe IS the active backend the message must NOT claim it is
+    missing (no false 'install mediapipe' advice)."""
+    notice = cs.make_degraded_notice("no trackable subject located", backend="mediapipe")
+    assert "mediapipe" not in notice["message"].lower()
+
+
+def test_compute_plan_haar_backend_degrade_names_missing_mediapipe(fake_bins):
+    """END-TO-END: mediapipe unavailable (haar backend) + a center-crop degrade ->
+    the surfaced notice names the missing model. Still exactly ONE notice (the
+    model cause is folded into the existing degrade, not a second badge)."""
+    eng, _ = _engine(
+        fake_bins,
+        detector=lambda p, t: [],  # no subject -> center-crop degrade
+        backend_probe=lambda: "haar",  # mediapipe absent
+    )
+    notices: list[dict] = []
+    crop, kfs, _d = eng.compute_plan("/in.mp4", on_notice=notices.append)
+    assert kfs == [] and crop["x"] == 437  # still degrades to center (encode proceeds)
+    assert len(notices) == 1
+    msg = notices[0]["message"].lower()
+    assert "center crop" in msg
+    assert "mediapipe" in msg  # the missing MODEL is surfaced, never silent
+
+
+def test_compute_plan_mediapipe_backend_degrade_omits_downgrade_hint(fake_bins):
+    """With mediapipe present, a genuine no-subject degrade must NOT falsely claim
+    the model is missing."""
+    eng, _ = _engine(
+        fake_bins,
+        detector=lambda p, t: [],
+        backend_probe=lambda: "mediapipe",
+    )
+    notices: list[dict] = []
+    eng.compute_plan("/in.mp4", on_notice=notices.append)
+    assert len(notices) == 1
+    assert "mediapipe" not in notices[0]["message"].lower()
+
+
+def test_compute_plan_detector_exception_on_haar_names_missing_model(fake_bins):
+    """A detector RUNTIME failure on the haar backend also names the missing model
+    in its surfaced degrade (the enrichment applies to every center-crop path)."""
+
+    def broken(p, t):
+        raise RuntimeError("boom")
+
+    eng, _ = _engine(fake_bins, detector=broken, backend_probe=lambda: "haar")
+    notices: list[dict] = []
+    eng.compute_plan("/in.mp4", on_notice=notices.append)
+    assert len(notices) == 1
+    assert "mediapipe" in notices[0]["message"].lower()
+    assert "boom" in notices[0]["reason"]
+
+
+def test_compute_plan_backend_probe_provisioning_failure_propagates(fake_bins):
+    """If the backend probe itself reports NO usable backend (no cv2/mediapipe),
+    that PROVISIONING failure propagates loudly — never a silent center crop."""
+
+    def no_backend():
+        raise cs.ClaudeShortsBackendUnavailableError("opencv (cv2) not installed")
+
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [], backend_probe=no_backend)
+    notices: list[dict] = []
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError):
+        eng.compute_plan("/in.mp4", on_notice=notices.append)
+    assert notices == []  # not turned into a per-clip degrade badge
+
+
+def test_engine_default_backend_probe_is_detect_backend(fake_bins):
+    """The engine's default backend probe is the real ``detect_backend`` (so the
+    degrade cause is resolved from the live import state when not injected)."""
+    eng, _ = _engine(fake_bins, detector=lambda p, t: [(0.0, 0.5)])
+    assert eng._backend_probe is cs.detect_backend
+
+
 def test_engine_passes_total_sec_and_argv_list(fake_bins):
     eng, runner = _engine(fake_bins, detector=lambda p, t: [])
     eng.reframe("/in.mp4", "/out.mp4")
@@ -1061,10 +1157,15 @@ def test_make_face_finder_haar_no_faces_returns_none(monkeypatch):
     assert find(np.zeros((50, 50, 3), dtype=np.uint8)) is None
 
 
-def test_make_face_finder_haar_missing_cascade_degrades_to_none(monkeypatch):
+def test_make_face_finder_haar_missing_cascade_raises_provisioning_error(monkeypatch):
+    """A missing/empty haar cascade is a PROVISIONING failure (a broken OpenCV
+    install), NOT a silent per-clip degrade: it must raise the loud
+    ``ClaudeShortsBackendUnavailableError`` so the job surfaces an actionable
+    "reinstall opencv" error instead of quietly using a center crop
+    (WU no-silent-fallback)."""
     import cv2
 
-    # Force an EMPTY cascade (the "cascade file missing" branch) -> no finder.
+    # Force an EMPTY cascade (the "cascade file missing/unreadable" branch).
     class _EmptyCascade:
         def __init__(self, *_a):
             pass
@@ -1073,9 +1174,9 @@ def test_make_face_finder_haar_missing_cascade_degrades_to_none(monkeypatch):
             return True
 
     monkeypatch.setattr(cv2, "CascadeClassifier", _EmptyCascade)
-    find, close = cs._make_face_finder("haar")
-    assert find is None
-    close()
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError) as exc:
+        cs._make_face_finder("haar")
+    assert "cascade" in str(exc.value).lower()
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_reframe_claudeshorts.py
+++ b/sidecar/tests/test_reframe_claudeshorts.py
@@ -1101,9 +1101,24 @@ def test_make_face_finder_mediapipe_no_detection_returns_none(monkeypatch):
     assert find(np.zeros((50, 50, 3), dtype=np.uint8)) is None
 
 
-def test_make_face_finder_haar_returns_callable_finder():
+def test_make_face_finder_haar_returns_callable_finder(monkeypatch):
+    import cv2
     import numpy as np
 
+    # Mock the cascade (present, no-face) so this exercises the finder wiring
+    # WITHOUT depending on the installed cv2 build actually shipping the native
+    # objdetect class (a headless/stripped cv2 omits it — see CI).
+    class _NoFaceCascade:
+        def __init__(self, *_a):
+            pass
+
+        def empty(self):
+            return False
+
+        def detectMultiScale(self, gray, scaleFactor, minNeighbors):
+            return ()  # no faces
+
+    monkeypatch.setattr(cv2, "CascadeClassifier", _NoFaceCascade, raising=False)
     find, close = cs._make_face_finder("haar")
     assert callable(find)
     # A blank frame has no face -> the haar finder returns None (no detection).
@@ -1129,7 +1144,7 @@ def test_make_face_finder_haar_returns_normalized_center_on_detection(monkeypatc
             # two boxes; the larger (by w*h) wins. frame width below is 200.
             return [(10, 10, 20, 20), (100, 10, 40, 40)]  # second is larger
 
-    monkeypatch.setattr(cv2, "CascadeClassifier", _FaceCascade)
+    monkeypatch.setattr(cv2, "CascadeClassifier", _FaceCascade, raising=False)
     find, close = cs._make_face_finder("haar")
     img = np.zeros((120, 200, 3), dtype=np.uint8)  # width 200
     cx = find(img)
@@ -1152,7 +1167,7 @@ def test_make_face_finder_haar_no_faces_returns_none(monkeypatch):
         def detectMultiScale(self, gray, scaleFactor, minNeighbors):
             return ()  # empty -> finder returns None
 
-    monkeypatch.setattr(cv2, "CascadeClassifier", _NoFaceCascade)
+    monkeypatch.setattr(cv2, "CascadeClassifier", _NoFaceCascade, raising=False)
     find, _close = cs._make_face_finder("haar")
     assert find(np.zeros((50, 50, 3), dtype=np.uint8)) is None
 
@@ -1173,18 +1188,45 @@ def test_make_face_finder_haar_missing_cascade_raises_provisioning_error(monkeyp
         def empty(self):
             return True
 
-    monkeypatch.setattr(cv2, "CascadeClassifier", _EmptyCascade)
+    monkeypatch.setattr(cv2, "CascadeClassifier", _EmptyCascade, raising=False)
     with pytest.raises(cs.ClaudeShortsBackendUnavailableError) as exc:
         cs._make_face_finder("haar")
     assert "cascade" in str(exc.value).lower()
 
 
+def test_make_face_finder_haar_missing_cv2_objdetect_raises(monkeypatch):
+    """A cv2 build that imports but lacks cv2.CascadeClassifier (headless/stripped)
+    is a PROVISIONING failure: fail loud with the typed backend error instead of a
+    bare AttributeError or a silent center crop (WU no-silent-fallback)."""
+    import cv2
+
+    monkeypatch.delattr(cv2, "CascadeClassifier", raising=False)
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError) as exc:
+        cs._make_face_finder("haar")
+    assert "cascadeclassifier" in str(exc.value).lower()
+
+
 # --------------------------------------------------------------------------- #
 # detect_subject_centers — the non-center body (real cv2.imread of fake frames)
 # --------------------------------------------------------------------------- #
-def test_detect_subject_centers_haar_reads_extracted_frames():
+def test_detect_subject_centers_haar_reads_extracted_frames(monkeypatch):
     import cv2
     import numpy as np
+
+    # Mock a present, no-face cascade so the body runs on a cv2 build that lacks
+    # the native objdetect class (CI). Frames are 80x160 (shorter than the 64x128
+    # HOG window) so the person fallback is guarded out before touching HOG.
+    class _NoFaceCascade:
+        def __init__(self, *_a):
+            pass
+
+        def empty(self):
+            return False
+
+        def detectMultiScale(self, gray, scaleFactor, minNeighbors):
+            return ()
+
+    monkeypatch.setattr(cv2, "CascadeClassifier", _NoFaceCascade, raising=False)
 
     # A frame_runner that writes a REAL (blank) jpeg to the requested path so
     # cv2.imread succeeds; the haar finder finds no face -> no samples appended.
@@ -1199,7 +1241,23 @@ def test_detect_subject_centers_haar_reads_extracted_frames():
     assert samples == []
 
 
-def test_detect_subject_centers_skips_missing_and_unreadable_frames():
+def test_detect_subject_centers_skips_missing_and_unreadable_frames(monkeypatch):
+    import cv2
+
+    # Mock a present, no-face cascade so building the haar finder does not depend
+    # on the installed cv2 shipping the native objdetect class (CI lacks it).
+    class _NoFaceCascade:
+        def __init__(self, *_a):
+            pass
+
+        def empty(self):
+            return False
+
+        def detectMultiScale(self, gray, scaleFactor, minNeighbors):
+            return ()
+
+    monkeypatch.setattr(cv2, "CascadeClassifier", _NoFaceCascade, raising=False)
+
     # A frame_runner that NEVER writes the frame file -> os.path.exists False ->
     # the frame is skipped (the "frame not produced" continue branch).
     def no_write_runner(argv, capture_output=True, check=False):
@@ -1282,12 +1340,39 @@ def test_person_center_skips_subwindow_frame_no_crash():
     assert cs._person_center(small) is None
 
 
-def test_person_center_no_person_returns_none():
+def test_person_center_no_person_returns_none(monkeypatch):
+    import cv2
     import numpy as np
 
-    # A blank window-sized frame -> the real HOG finds no person.
+    # Mock a present HOG detector that finds no person, so this does not depend on
+    # the installed cv2 shipping the native HOG class (CI's build omits it).
+    class _HOG:
+        def setSVMDetector(self, _d):
+            pass
+
+        def detectMultiScale(self, _img, winStride):
+            return (), None  # no bodies
+
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG(), raising=False)
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object(), raising=False)
+    # A blank window-sized frame -> the (mocked) HOG finds no person.
     blank = np.zeros((256, 256, 3), dtype=np.uint8)
     assert cs._person_center(blank) is None
+
+
+def test_person_center_missing_cv2_hog_raises(monkeypatch):
+    """A cv2 build that imports but lacks cv2.HOGDescriptor (headless/stripped) is a
+    PROVISIONING failure: on a window-sized frame the body fallback must fail loud
+    with the typed backend error, never a bare AttributeError or a silent skip."""
+    import cv2
+    import numpy as np
+
+    monkeypatch.delattr(cv2, "HOGDescriptor", raising=False)
+    # window-sized frame so the sub-window guard does NOT short-circuit first.
+    frame = np.zeros((256, 256, 3), dtype=np.uint8)
+    with pytest.raises(cs.ClaudeShortsBackendUnavailableError) as exc:
+        cs._person_center(frame)
+    assert "hogdescriptor" in str(exc.value).lower()
 
 
 def test_person_center_returns_normalized_center_on_detection(monkeypatch):
@@ -1304,8 +1389,8 @@ def test_person_center_returns_normalized_center_on_detection(monkeypatch):
             weights = [0.2, 0.9]
             return rects, weights
 
-    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
-    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG(), raising=False)
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object(), raising=False)
     img = np.zeros((200, 400, 3), dtype=np.uint8)  # width 400
     cx = cs._person_center(img)
     # best body center x = 300 + 60/2 = 330; normalized = 330/400 = 0.825
@@ -1323,8 +1408,8 @@ def test_person_center_no_rects_returns_none(monkeypatch):
         def detectMultiScale(self, _img, winStride):
             return (), None  # no rects, no weights
 
-    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
-    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG(), raising=False)
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object(), raising=False)
     assert cs._person_center(np.zeros((200, 200, 3), dtype=np.uint8)) is None
 
 
@@ -1339,8 +1424,8 @@ def test_person_center_missing_weights_uses_zero(monkeypatch):
         def detectMultiScale(self, _img, winStride):
             return [(40, 0, 80, 120)], None  # rect present, weights None
 
-    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
-    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG(), raising=False)
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object(), raising=False)
     img = np.zeros((200, 200, 3), dtype=np.uint8)
     # single rect, center x = 40 + 80/2 = 80; normalized = 80/200 = 0.4
     assert cs._person_center(img) == pytest.approx(0.4)
@@ -1522,7 +1607,7 @@ def test_make_face_finder_haar_two_faces_picks_larger(monkeypatch):
             # left small (20x20 @x=20), right large (60x60 @x=300). width = 400.
             return [(20, 20, 20, 20), (300, 20, 60, 60)]
 
-    monkeypatch.setattr(cv2, "CascadeClassifier", _TwoFaces)
+    monkeypatch.setattr(cv2, "CascadeClassifier", _TwoFaces, raising=False)
     find, _close = cs._make_face_finder("haar")
     cx = find(np.zeros((120, 400, 3), dtype=np.uint8))
     # larger face center x = 300 + 30 = 330 -> 330/400 = 0.825.
@@ -1543,7 +1628,7 @@ def test_make_face_finder_haar_active_speaker_motion_tiebreak(monkeypatch):
         def detectMultiScale(self, gray, scaleFactor, minNeighbors):
             return [(20, 20, 40, 40), (120, 20, 40, 40)]  # equal size; width = 200
 
-    monkeypatch.setattr(cv2, "CascadeClassifier", _TwoEqual)
+    monkeypatch.setattr(cv2, "CascadeClassifier", _TwoEqual, raising=False)
     find, _close = cs._make_face_finder("haar")
     f0 = np.zeros((100, 200, 3), dtype=np.uint8)
     f1 = np.zeros((100, 200, 3), dtype=np.uint8)
@@ -1582,8 +1667,8 @@ def test_person_center_prefers_larger_closer_body_over_higher_weight(monkeypatch
             # left BIG body (closer) lower weight; right small higher weight. width=400.
             return [(10, 0, 160, 300), (320, 0, 40, 90)], [0.3, 0.95]
 
-    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG())
-    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object())
+    monkeypatch.setattr(cv2, "HOGDescriptor", lambda: _HOG(), raising=False)
+    monkeypatch.setattr(cv2, "HOGDescriptor_getDefaultPeopleDetector", lambda: object(), raising=False)
     cx = cs._person_center(np.zeros((320, 400, 3), dtype=np.uint8))
     # dominant = larger (closer) body -> center x = 10 + 80 = 90 -> 90/400 = 0.225.
     assert cx == pytest.approx(0.225)

--- a/sidecar/tests/test_runtime_setup.py
+++ b/sidecar/tests/test_runtime_setup.py
@@ -72,6 +72,11 @@ class TestShippedRequirementFiles:
         assert pins["opencv-python"] == "4.13.0.92"
         assert pins["nvidia-cublas-cu12"] == "12.9.2.10"
         assert pins["nvidia-cudnn-cu12"] == "9.23.2.1"
+        # DELIBERATELY ABSENT: mediapipe. Its legacy Solutions API (used by the
+        # claudeshorts backend) only exists in wheels that pin numpy<2, which
+        # conflicts with numpy==2.5.0; numpy-2-clean mediapipe removed Solutions.
+        # Pinning it would install a mediapipe that crashes -> silent haar drop.
+        assert "mediapipe" not in pins
         assert "kokoro-onnx" in pins  # pinned TTS engine (exact version chosen by T5)
         # A6.5 / §7: torch must NEVER enter the main sidecar env
         assert "torch" not in pins
@@ -395,6 +400,15 @@ class TestAssets:
         assert tr.LLAMA_CUDA_ASSET in names
         assert tr.LLAMA_CPU_ASSET in names
 
+    def test_default_first_run_assets_include_lightasd_weights(self):
+        # WU first-run-provisioning: the multi-speaker reframe engine's S3FD +
+        # LR-ASD weights were registered but never in the first-run set, so a
+        # fresh install silently fell back to a single-speaker/center crop. They
+        # must be provisioned up front.
+        names = bs.default_first_run_assets()
+        assert manifest.LIGHTASD_S3FD_ASSET_NAME in names
+        assert manifest.LIGHTASD_ASD_ASSET_NAME in names
+
     def test_ensure_assets_delegates_to_manager(self, tmp_path):
         class FakeManager:
             def __init__(self):
@@ -409,6 +423,62 @@ class TestAssets:
         mgr = FakeManager()
         bs.ensure_assets(["a", "b"], tmp_path, manager=mgr)
         assert mgr.calls == [["a", "b"]]
+
+
+# --------------------------------------------------------------------------- #
+# fail-loud provisioning verification + first-run-complete marker
+# --------------------------------------------------------------------------- #
+class _FakeMgr:
+    """A minimal AssetManager stand-in: installed_path echoes a per-name map."""
+
+    def __init__(self, installed: dict[str, str | None]):
+        self._installed = installed
+
+    def installed_path(self, entry: Any) -> str | None:
+        return self._installed.get(entry.name)
+
+
+class TestVerifyProvisioned:
+    def test_passes_when_all_assets_installed(self, tmp_path):
+        names = [manifest.LIGHTASD_S3FD_ASSET_NAME, manifest.LIGHTASD_ASD_ASSET_NAME]
+        mgr = _FakeMgr({n: f"{tmp_path}/{n}.bin" for n in names})
+        # No raise == provisioning verified.
+        bs.verify_provisioned(names, tmp_path, manager=mgr)
+
+    def test_raises_naming_every_missing_asset(self, tmp_path):
+        names = [manifest.LIGHTASD_S3FD_ASSET_NAME, manifest.LIGHTASD_ASD_ASSET_NAME]
+        # S3FD installed, ASD missing -> only the missing one is named.
+        mgr = _FakeMgr({manifest.LIGHTASD_S3FD_ASSET_NAME: f"{tmp_path}/s3fd.bin"})
+        with pytest.raises(bs.BootstrapError, match=manifest.LIGHTASD_ASD_ASSET_NAME):
+            bs.verify_provisioned(names, tmp_path, manager=mgr)
+
+    def test_raises_for_unregistered_asset(self, tmp_path):
+        with pytest.raises(bs.BootstrapError, match="not-a-real-asset"):
+            bs.verify_provisioned(["not-a-real-asset"], tmp_path, manager=_FakeMgr({}))
+
+    def test_default_manager_is_constructed_when_none(self, tmp_path, monkeypatch):
+        seen: dict[str, Any] = {}
+
+        def fake_default(root):
+            seen["root"] = root
+            return _FakeMgr({manifest.WHISPER_ASSET_NAME: "x"})
+
+        monkeypatch.setattr(bs, "_default_asset_manager", fake_default)
+        bs.verify_provisioned([manifest.WHISPER_ASSET_NAME], tmp_path)
+        assert seen["root"] == tmp_path
+
+
+class TestFirstRunCompleteMarker:
+    def test_write_and_path_round_trip(self, tmp_path):
+        names = ["whisper-large-v3-turbo", manifest.LIGHTASD_ASD_ASSET_NAME]
+        marker = bs.write_first_run_complete(tmp_path, names)
+        assert marker == bs.first_run_complete_path(tmp_path)
+        assert marker.is_file()
+        payload = json.loads(marker.read_text(encoding="utf-8"))
+        assert payload["assets"] == names
+
+    def test_marker_absent_before_write(self, tmp_path):
+        assert not bs.first_run_complete_path(tmp_path).exists()
 
 
 # --------------------------------------------------------------------------- #
@@ -432,6 +502,62 @@ class TestCli:
         code = bs.main(["--tools-only", "--root", str(tmp_path)])
         assert code == 0
         assert "SUCCESS:bootstrap tools-only" in capsys.readouterr().out
+
+
+class TestMainFullRunProvisioning:
+    """A full first run (no --skip flags) must VERIFY assets then write the
+    first-run-complete marker — the honest 'everything provisioned' signal the
+    Electron supervisor gates re-runs on. A verification failure must fail loud
+    AND leave NO marker (so the next launch retries instead of silently running
+    a half-provisioned app)."""
+
+    def _fake_py(self, tmp_path: Path) -> Path:
+        fake_py = tmp_path / "py" / "python.exe"
+        fake_py.parent.mkdir(parents=True)
+        fake_py.write_text("", encoding="utf-8")
+        return fake_py
+
+    def _stub_env_and_assets(self, tmp_path, monkeypatch) -> dict[str, Any]:
+        captured: dict[str, Any] = {}
+        monkeypatch.setattr(bs, "write_pth", lambda *a, **k: None)
+        monkeypatch.setattr(bs, "install_env", lambda **k: Path(k["root"]) / "envs" / "sidecar")
+        monkeypatch.setattr(bs, "activate_env_in_process", lambda *a, **k: None)
+        monkeypatch.setattr(bs, "ensure_assets", lambda names, root, **k: captured.__setitem__("ensured", list(names)))
+        monkeypatch.setattr(bs, "extract_tool_archives", lambda *a, **k: [])
+        return captured
+
+    def test_full_run_verifies_then_writes_marker(self, tmp_path, monkeypatch, capsys):
+        captured = self._stub_env_and_assets(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            bs, "verify_provisioned", lambda names, root, **k: captured.__setitem__("verified", list(names))
+        )
+        rc = bs.main(["--root", str(tmp_path), "--python", str(self._fake_py(tmp_path))])
+        assert rc == 0
+        assert "SUCCESS:bootstrap first-run setup complete" in capsys.readouterr().out
+        # verification ran over exactly the ensured asset set...
+        assert captured["verified"] == captured["ensured"]
+        # ...and the honest completion marker is written.
+        assert bs.first_run_complete_path(tmp_path).is_file()
+
+    def test_failed_verification_is_loud_and_leaves_no_marker(self, tmp_path, monkeypatch, capsys):
+        self._stub_env_and_assets(tmp_path, monkeypatch)
+
+        def boom(names, root, **k):
+            raise bs.BootstrapError("weight lightasd-asd did not install")
+
+        monkeypatch.setattr(bs, "verify_provisioned", boom)
+        rc = bs.main(["--root", str(tmp_path), "--python", str(self._fake_py(tmp_path))])
+        assert rc == 1
+        assert "FAILED:bootstrap" in capsys.readouterr().out
+        assert not bs.first_run_complete_path(tmp_path).exists()
+
+    def test_partial_run_skips_marker(self, tmp_path, monkeypatch):
+        # --skip-assets is an explicit PARTIAL provision; it must NOT mark the
+        # first run complete (that would let the supervisor skip a real re-run).
+        self._stub_env_and_assets(tmp_path, monkeypatch)
+        rc = bs.main(["--skip-assets", "--root", str(tmp_path), "--python", str(self._fake_py(tmp_path))])
+        assert rc == 0
+        assert not bs.first_run_complete_path(tmp_path).exists()
 
 
 class TestMainOrdering:

--- a/sidecar/tests/test_tiny_sidecar_launcher.py
+++ b/sidecar/tests/test_tiny_sidecar_launcher.py
@@ -1,0 +1,80 @@
+"""Lean-gate unit coverage for the E2E tiny-CPU sidecar launcher's Windows-hang
+fix (bug #4).
+
+``tests/e2e/_tiny_sidecar.py`` is spawned as a CHILD process by the real-pipeline
+E2E harness (``real_pipeline_smoke.py`` PHASE B). On Windows the FIRST import of a
+native C-extension DLL (numpy / av / ctranslate2 / ...) from a JOB THREAD deadlocks
+while the main thread is parked in ``sys.stdin.readline()`` (the sidecar's normal
+serving state). The production composition root ``media_studio.__main__`` already
+guards this by pre-importing the natives in the MAIN thread before it serves; the
+E2E launcher previously omitted that step, so the harness hung forever at
+``transcribe.start`` on Windows.
+
+These tests pin that the launcher REUSES the exact production pre-serve hardening
+(so the native list can never drift) and runs it BEFORE any handler registration
+or the stdio serve loop. No real stdio loop is served and no native is actually
+imported: the seams are monkeypatched. Marked lean (NOT ``e2e``) so it runs in the
+default 100%-coverage gate.
+"""
+
+from __future__ import annotations
+
+import tests.e2e._tiny_sidecar as tiny
+
+
+def test_main_runs_windows_native_hardening_before_serving(monkeypatch, tmp_path):
+    """main(): suppresses Windows error dialogs and PRE-IMPORTS the natives in the
+    main thread BEFORE it registers handlers or serves — the bug #4 Windows-hang
+    fix — then registers a tiny/cpu whisper loader at the env data dir and returns
+    ``rpc.main()``'s exit code."""
+    calls: list[str] = []
+    monkeypatch.setenv("MEDIA_STUDIO_E2E_DATADIR", str(tmp_path))
+    monkeypatch.setattr(tiny, "_suppress_windows_error_dialogs", lambda: calls.append("suppress"))
+    monkeypatch.setattr(tiny, "_preimport_native_modules", lambda: calls.append("preimport"))
+
+    captured: dict[str, object] = {}
+
+    def fake_register_all(services):
+        calls.append("register")
+        captured["services"] = services
+
+    def fake_rpc_main():
+        calls.append("serve")
+        return 0
+
+    monkeypatch.setattr(tiny.handlers, "register_all", fake_register_all)
+    monkeypatch.setattr(tiny.rpc, "main", fake_rpc_main)
+
+    rc = tiny.main()
+
+    assert rc == 0
+    # The native pre-import MUST happen (main thread) BEFORE any handler wiring or
+    # the serve loop — otherwise the first job-thread DLL load deadlocks the child.
+    assert calls == ["suppress", "preimport", "register", "serve"]
+    # Forced-deviation preserved: a tiny/cpu whisper loader rooted at the env dir.
+    svc = captured["services"]
+    assert isinstance(svc, tiny.handlers.Services)
+    assert svc.data_dir == tmp_path
+    assert isinstance(svc._whisper_loader, tiny.TinyCpuWhisperLoader)
+
+
+def test_main_reuses_production_hardening_seams(monkeypatch):
+    """The launcher must REUSE the production ``media_studio.__main__`` hardening
+    (not a private reimplementation), so the pre-imported native list can never
+    drift from production. Assert the launcher's bound names ARE those functions."""
+    import media_studio.__main__ as entry
+
+    assert tiny._preimport_native_modules is entry._preimport_native_modules
+    assert tiny._suppress_windows_error_dialogs is entry._suppress_windows_error_dialogs
+
+
+def test_main_requires_datadir_env(monkeypatch, capsys):
+    """No data dir -> exit 2, and the hardening/serve seams are never reached."""
+    monkeypatch.delenv("MEDIA_STUDIO_E2E_DATADIR", raising=False)
+    reached: list[str] = []
+    monkeypatch.setattr(tiny, "_preimport_native_modules", lambda: reached.append("preimport"))
+    monkeypatch.setattr(tiny.rpc, "main", lambda: reached.append("serve"))
+
+    assert tiny.main() == 2
+    assert reached == []
+    assert "MEDIA_STUDIO_E2E_DATADIR is required" in capsys.readouterr().err


### PR DESCRIPTION
## Reframe hardening — make it actually work, no silent failures

Fixes the reliability gaps the v1.2.0 grounding surfaced (the app shipped gated-green but the flagship could silently degrade on an incomplete install).

### Fixes (all TDD, on top of v1.1.0)
- **`8ca2730` — no silent center-crop.** When MediaPipe / speaker-tracking is unavailable, the reframe now **fails loud** with a typed error + user-facing notice instead of silently center-cropping (a V1 "no-silent-fallback" requirement violation).
- **`f7cbdd1` — first-run provisioning.** Installs the S3FD/LR-ASD weights and **fails loud rather than leaving a half-provisioned app** that would silently degrade.
- **`205b852` — E2E harness Windows hang (#4).** Pre-imports natives in the tiny-CPU launcher so the E2E harness completes on Windows.
- **`0076bae` — Settings > Models crash-blank.** Guards the sidecar-data-coupled data path against the blank-screen crash.

### Honesty / what still needs real hardware
Validated locally via unit tests (jsdom / mocked detectors). **Not** validated on a real GPU or a packaged bundled-runtime this session (no GPU/build box): the live multi-speaker inference path, the packaged first-run download, and the drawtext/opengrep legs should be confirmed green in CI / on a GPU machine before tagging.

Opened as **draft to run the quality gate** — the external signal the mocked unit tests can't provide.
