### PR TITLE
fix(reframe): declare+pin speechbrain, fail loud on missing diarizer

### DIFF
--- a/sidecar/media_studio/features/diarize_backend.py
+++ b/sidecar/media_studio/features/diarize_backend.py
@@ -61,6 +61,59 @@ MIN_WINDOW_SEC = 0.5
 SUBWINDOW_CLUSTER_THRESHOLD = 0.45
 
 
+class DiarizeBackendUnavailableError(RuntimeError):
+    """SpeechBrain (the diarizer's VAD + ECAPA backend) is not importable.
+
+    A SETUP/PROVISIONING failure, NOT a per-clip event: without ``speechbrain``
+    the diarizer cannot run VAD or embed speakers at all, so the multi-speaker
+    reframe's diarize stage (and ``diarize.start``) cannot run. It is raised as an
+    EXPLICIT, typed, actionable signal — never a raw :class:`ModuleNotFoundError`
+    bubbling out of a job thread, and never a silent fallback — so the job
+    surfaces an install/provision message (v1.2.0 NO-SILENT-FALLBACK, mirroring
+    ``reframe_claudeshorts.ClaudeShortsBackendUnavailableError``).
+    """
+
+
+def _import_speechbrain() -> tuple[type[Any], type[Any]]:
+    """Import the SpeechBrain inference API ``(VAD, EncoderClassifier)`` — or fail loud.
+
+    Wraps the two ``speechbrain.inference`` imports in a typed guard: a missing
+    (or broken) ``speechbrain`` raises :class:`DiarizeBackendUnavailableError`
+    with an actionable "install speechbrain / provision the diarizer" message,
+    rather than a raw :class:`ModuleNotFoundError` propagating from a job thread.
+    Kept a module-level seam (not inside the ``# pragma: no cover`` class body) so
+    the fail-loud contract is unit-covered without the heavy native stack. The
+    ``speechbrain.inference`` API requires speechbrain >= 1.0.0.
+    """
+    try:
+        from speechbrain.inference.classifiers import EncoderClassifier  # noqa: PLC0415
+        from speechbrain.inference.VAD import VAD  # noqa: PLC0415
+    except ImportError as exc:
+        raise DiarizeBackendUnavailableError(
+            "speaker diarization requires SpeechBrain (the VAD + ECAPA backend), "
+            "but importing 'speechbrain' failed; install speechbrain "
+            '(pip install "media-studio-sidecar[reframe-gpu]") or provision the '
+            "diarizer env to enable multi-speaker reframe / diarization"
+        ) from exc
+    return VAD, EncoderClassifier
+
+
+def _fetch_safe_audio_path(audio_path: str) -> str:
+    """Return ``audio_path`` in a form SpeechBrain's ``fetch`` handles on any OS.
+
+    ``VAD.get_speech_segments`` funnels the audio path through SpeechBrain's
+    ``split_path`` + ``fetch`` (HF-fetch machinery keyed on a POSIX ``source/name``
+    split). A Windows absolute path (``C:\\dir\\a.wav``) contains no ``/``, so
+    ``split_path`` cannot separate the directory from the filename — ``fetch`` then
+    treats the whole thing as a bare name and PREPENDS the CWD, yielding a doubled
+    path (``…\\cwd\\C:\\dir\\a.wav``) that libsndfile/soundfile cannot open. Forward-
+    slashing the path (a no-op on POSIX, whose separators are already ``/``) lets
+    ``split_path`` find the final component so ``fetch`` resolves the real file. This
+    is what makes the diarize stage runnable on native Windows, not only Linux/WSL.
+    """
+    return str(audio_path).replace("\\", "/")
+
+
 class SpeechBrainDiarizer:  # pragma: no cover - requires the heavy native stack
     """VAD + ECAPA pipeline over the pretrained SpeechBrain models.
 
@@ -86,13 +139,13 @@ class SpeechBrainDiarizer:  # pragma: no cover - requires the heavy native stack
     def _ensure_models(self) -> None:
         if self._vad is not None and self._encoder is not None:
             return
-        from speechbrain.inference.classifiers import EncoderClassifier  # noqa: PLC0415
-        from speechbrain.inference.VAD import VAD  # noqa: PLC0415
-
+        # Fail loud (typed) when speechbrain is missing — never a raw
+        # ModuleNotFoundError out of the job thread (v1.2.0 NO-SILENT-FALLBACK).
+        vad_cls, encoder_cls = _import_speechbrain()
         device = self._device()
         run_opts = {"device": device}
-        self._vad = VAD.from_hparams(source="speechbrain/vad-crdnn-libriparty", run_opts=run_opts)
-        self._encoder = EncoderClassifier.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb", run_opts=run_opts)
+        self._vad = vad_cls.from_hparams(source="speechbrain/vad-crdnn-libriparty", run_opts=run_opts)
+        self._encoder = encoder_cls.from_hparams(source="speechbrain/spkrec-ecapa-voxceleb", run_opts=run_opts)
         log.info("speechbrain diarizer ready on %s", device)
 
     @staticmethod
@@ -141,8 +194,10 @@ class SpeechBrainDiarizer:  # pragma: no cover - requires the heavy native stack
         if on_progress is not None:
             on_progress(5.0, "running VAD")
 
-        # VAD -> a tensor of [start, end] (seconds) speech boundaries.
-        boundaries = self._vad.get_speech_segments(audio_path)
+        # VAD -> a tensor of [start, end] (seconds) speech boundaries. Feed the
+        # path forward-slashed so SpeechBrain's split_path/fetch resolves it on
+        # Windows too (see _fetch_safe_audio_path), not only POSIX/WSL.
+        boundaries = self._vad.get_speech_segments(_fetch_safe_audio_path(audio_path))
         waveform, sr = torchaudio.load(audio_path)
         if sr != TARGET_SR:
             waveform = torchaudio.functional.resample(waveform, sr, TARGET_SR)
@@ -180,5 +235,6 @@ __all__ = [
     "SUBWINDOW_CLUSTER_THRESHOLD",
     "TARGET_SR",
     "WINDOW_SEC",
+    "DiarizeBackendUnavailableError",
     "SpeechBrainDiarizer",
 ]

--- a/sidecar/pyproject.toml
+++ b/sidecar/pyproject.toml
@@ -38,11 +38,12 @@ dev = [
   "hypothesis>=6.0",   # property/fuzz tests (deterministic CI profile in conftest)
 ]
 # R1 multi-speaker reframe GPU tier (the vendored S3FD + LR-ASD active-speaker
-# stack in media_studio/features/_lightasd/). These are NOT installed by build agents and
-# NOT in the CI gate env (the unit tests are heavy-ML-free); a human installs them
-# on the GPU host. PINNED to the GPU-validated versions (A6 lesson 5). ⚠ torch /
-# torchvision / torchaudio must be installed from the CUDA wheel index to get the
-# +cuXXX builds, e.g.:
+# stack in media_studio/features/_lightasd/ PLUS the SpeechBrain diarize stage —
+# reframe_multispeaker_backend._stage_diarize -> diarize_backend.SpeechBrainDiarizer).
+# These are NOT installed by build agents and NOT in the CI gate env (the unit tests
+# are heavy-ML-free); a human installs them on the GPU host. PINNED to the
+# GPU-validated versions (A6 lesson 5). ⚠ torch / torchvision / torchaudio must be
+# installed from the CUDA wheel index to get the +cuXXX builds, e.g.:
 #   pip install "media-studio-sidecar[reframe-gpu]" \
 #     --extra-index-url https://download.pytorch.org/whl/cu124
 reframe-gpu = [
@@ -52,6 +53,21 @@ reframe-gpu = [
   "opencv-python-headless==4.13.0.92",  # frame I/O + face-crop ops (headless: no GUI libs)
   "python_speech_features==0.6",  # MFCC features for the ASD audio frontend
   "scipy==1.18.0",                # face-track interpolation + median filter + wav read
+  # DIARIZE stage (VAD + ECAPA-TDNN) — the speaker turns the director fuses with
+  # visual ASD. Uses the ``speechbrain.inference`` API (requires >= 1.0.0). PINNED
+  # to 1.0.3 (GPU-validated on the RTX 4050): loads ``speechbrain/vad-crdnn-libriparty``
+  # + ``spkrec-ecapa-voxceleb`` cleanly. 1.1.0 is DELIBERATELY AVOIDED — its
+  # ``speechbrain.integrations.k2_fsa`` LAZY module makes ``VAD.from_hparams`` fail
+  # with ``pydoc.ErrorDuringImport`` (hyperpyyaml's ``pydoc.locate`` re-imports
+  # ``lobes.models.CRDNN`` -> touches the k2 LazyModule -> ``import k2`` (no Windows
+  # wheels) blows up). speechbrain missing at runtime fails LOUD (typed
+  # ``DiarizeBackendUnavailableError``), never a silent ModuleNotFoundError.
+  "speechbrain==1.0.3",
+  # speechbrain 1.0.x calls ``hf_hub_download(use_auth_token=...)``, an argument
+  # REMOVED in huggingface_hub 1.0. Cap below 1.0 so the diarize models actually
+  # fetch/load (validated at 0.36.2, the newest 0.x). huggingface_hub is otherwise a
+  # transitive dep (faster-whisper) that resolves to 1.x and would break the VAD load.
+  "huggingface-hub>=0.30,<1.0",
 ]
 
 [project.scripts]

--- a/sidecar/tests/test_diarize.py
+++ b/sidecar/tests/test_diarize.py
@@ -518,6 +518,90 @@ def test_diarize_backend_module_imports_light():
 
     assert db.TARGET_SR == 16000
     assert "SpeechBrainDiarizer" in db.__all__
+    assert "DiarizeBackendUnavailableError" in db.__all__
     # Construction is cheap (no models loaded until detect_and_embed).
     inst = db.SpeechBrainDiarizer({"device": "cpu"})
     assert inst is not None
+
+
+# --------------------------------------------------------------------------- #
+# diarize_backend: FAIL LOUD (typed) when speechbrain is unavailable
+# (v1.2.0 NO-SILENT-FALLBACK — a raw ModuleNotFoundError must NOT escape).
+# --------------------------------------------------------------------------- #
+def test_import_speechbrain_raises_typed_error_when_missing(monkeypatch):
+    # The speechbrain-ABSENT path: a sentinel ``None`` in sys.modules for the two
+    # leaf modules makes the guarded import raise ImportError, which the guard
+    # converts into a TYPED, actionable DiarizeBackendUnavailableError — never a
+    # raw ModuleNotFoundError. Poisoning sys.modules exercises the except branch
+    # DETERMINISTICALLY regardless of whether real speechbrain is installed here.
+    import sys
+
+    from media_studio.features import diarize_backend as db
+
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.classifiers", None)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.VAD", None)
+    with pytest.raises(db.DiarizeBackendUnavailableError) as excinfo:
+        db._import_speechbrain()
+    # Actionable message NAMES speechbrain and the fix; chained from the ImportError.
+    msg = str(excinfo.value).lower()
+    assert "speechbrain" in msg
+    assert "install" in msg or "provision" in msg
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+def test_import_speechbrain_returns_api_when_present(monkeypatch):
+    # The speechbrain-PRESENT path: inject fake ``speechbrain.inference`` modules so
+    # the success branch is covered with no native stack. The guard must return the
+    # (VAD, EncoderClassifier) classes it imported, in that order.
+    import sys
+    import types as _types
+
+    from media_studio.features import diarize_backend as db
+
+    class _FakeVAD: ...
+
+    class _FakeEncoder: ...
+
+    sb = _types.ModuleType("speechbrain")
+    inference = _types.ModuleType("speechbrain.inference")
+    vad_mod = _types.ModuleType("speechbrain.inference.VAD")
+    cls_mod = _types.ModuleType("speechbrain.inference.classifiers")
+    vad_mod.VAD = _FakeVAD
+    cls_mod.EncoderClassifier = _FakeEncoder
+    sb.inference = inference
+    inference.VAD = vad_mod
+    inference.classifiers = cls_mod
+    monkeypatch.setitem(sys.modules, "speechbrain", sb)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference", inference)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.VAD", vad_mod)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.classifiers", cls_mod)
+
+    vad_cls, encoder_cls = db._import_speechbrain()
+    assert vad_cls is _FakeVAD
+    assert encoder_cls is _FakeEncoder
+
+
+def test_ensure_models_fails_loud_when_speechbrain_missing(monkeypatch):
+    # The multi-speaker diarize path enters through SpeechBrainDiarizer._ensure_models
+    # (SpeechBrainDiarizer.detect_and_embed -> _ensure_models); with speechbrain
+    # unavailable it must surface the SAME typed error, not a raw ModuleNotFoundError.
+    import sys
+
+    from media_studio.features import diarize_backend as db
+
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.classifiers", None)
+    monkeypatch.setitem(sys.modules, "speechbrain.inference.VAD", None)
+    inst = db.SpeechBrainDiarizer({"device": "cpu"})
+    with pytest.raises(db.DiarizeBackendUnavailableError):
+        inst._ensure_models()
+
+
+def test_fetch_safe_audio_path_forward_slashes_windows_paths():
+    # SpeechBrain's VAD.get_speech_segments routes the path through split_path/fetch,
+    # which mangles a Windows backslash absolute path (prepends CWD). Forward-slashing
+    # is the fix; it is a no-op on already-POSIX paths.
+    from media_studio.features import diarize_backend as db
+
+    assert db._fetch_safe_audio_path(r"C:\dir\sub\a.wav") == "C:/dir/sub/a.wav"
+    assert db._fetch_safe_audio_path("/tmp/x.wav") == "/tmp/x.wav"
+    assert db._fetch_safe_audio_path("relative/name.wav") == "relative/name.wav"


### PR DESCRIPTION
## What & why

The multi-speaker reframe's **diarize stage** (`reframe_multispeaker_backend._stage_diarize` → `diarize_backend.SpeechBrainDiarizer`) depends on **speechbrain**, but:

1. speechbrain was **undeclared** anywhere (neither the base deps nor the `reframe-gpu` extra), and
2. it was imported **raw** in `_ensure_models()` — a missing speechbrain surfaced as a bare `ModuleNotFoundError` out of a job thread, violating the v1.2.0 **no-silent-fallback** contract.

This gates the v1.2.0 release (multispeaker must be airtight). Fixed on this branch, TDD + lean gate.

## Changes

**1. Fail loud (typed, TDD-first)** — `diarize_backend.py`
- New typed `DiarizeBackendUnavailableError` (mirrors `reframe_claudeshorts.ClaudeShortsBackendUnavailableError`) with an actionable *"install speechbrain / provision the diarizer"* message.
- The guarded import lives in a covered module-level seam `_import_speechbrain()` (the `SpeechBrainDiarizer` class body stays `# pragma: no cover`), so the fail-loud contract is unit-tested without the heavy native stack. `_ensure_models()` now raises the typed error instead of a raw `ModuleNotFoundError`.

**2. Declare + pin** — `pyproject.toml` `reframe-gpu` extra
- `speechbrain==1.0.3` + `huggingface-hub>=0.30,<1.0` (validated at hub 0.36.2).
- **1.1.0 is deliberately avoided**: its `speechbrain.integrations.k2_fsa` lazy module makes `VAD.from_hparams` raise `pydoc.ErrorDuringImport` — hyperpyyaml's `pydoc.locate` re-imports `lobes.models.CRDNN`, which touches the k2 `LazyModule`, whose `import k2` blows up (k2 has no Windows wheels). Empirically reproduced on this box.
- **1.0.x needs hub < 1.0**: it calls `hf_hub_download(use_auth_token=...)`, an argument removed in huggingface_hub 1.0 (transitively resolves to 1.x otherwise, breaking the VAD load).

**3. Windows path fix** — `diarize_backend.py`
- Forward-slash the audio path before `VAD.get_speech_segments` (`_fetch_safe_audio_path`, covered). SpeechBrain's `split_path`/`fetch` mangles a Windows absolute path (`C:\dir\a.wav` has no `/`, so `fetch` prepends CWD → the doubled path `…\cwd\C:\dir\a.wav` → libsndfile can't open it). This is what made the diarize stage runnable on **native Windows**, not only Linux/WSL — required to verify end-to-end on this box.

## Verification (RTX 4050, torch 2.6.0+cu124, speechbrain 1.0.3, hub 0.36.2)

- **VAD-load fix confirmed:** `VAD.from_hparams("speechbrain/vad-crdnn-libriparty")` fails on 1.1.0 (`pydoc.ErrorDuringImport` via k2_fsa) and **loads cleanly on 1.0.3**. `SpeechBrainDiarizer._ensure_models()` loads **both** VAD + ECAPA on `cuda:0`.
- **Full multispeaker GPU e2e** on `e2e_artifacts/sample.mp4`:
  `get_engine("reframe_multispeaker", …).reframe(in, out)` → `REFRAME_OK` in 16.3 s, GPU peak 191 MB.
  `ffprobe` output: **codec `h264`, `1080x1920`, duration 8.01 s** → `VERIFY_1080x1920_H264 True`.
  (The sample is a synthetic clip with 0 detectable faces, so the engine cold-starts to a single-speaker crop — still a valid render exercising shots + diarize + visual + encode.)

## Local gate

- **Touched tests:** `pytest tests/test_diarize.py tests/test_phase8_backend_surfaces.py` → **61 passed**, `--cov=media_studio.features.diarize_backend --cov-branch` = **100%**.
- **Full sidecar suite:** `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **coverage 100.00%**. The only failures are 4 pre-existing `test_director_render_integration::test_drawtext_*` cases (Windows ffmpeg drawtext/font, unrelated to this change — verified identical on `origin/main` in the same env).
- **ruff** check + format: clean. **basedpyright**: 0 errors (only the expected `reportMissingImports` *warnings* for the heavy speechbrain/torchaudio deps, unchanged from baseline).

https://claude.ai/code/session_01TTkqbh6EUgNAAqsePAmHz9
