### PR TITLE
fix(deps): green main — re-pair chatterbox torch + revert untested cuDNN bump (#259)

### DIFF
--- a/sidecar/runtime_setup/requirements-chatterbox.txt
+++ b/sidecar/runtime_setup/requirements-chatterbox.txt
@@ -21,5 +21,5 @@
 # LIST, so a bootstrap-built env only counts as the installed "chatterbox-env"
 # asset when the pin order matches. Keep both in sync.
 chatterbox-tts==0.1.7
-torch==2.12.1
+torch==2.11.0+cu128
 torchaudio==2.11.0+cu128

--- a/sidecar/runtime_setup/requirements-sidecar.txt
+++ b/sidecar/runtime_setup/requirements-sidecar.txt
@@ -25,7 +25,7 @@ kokoro-onnx==0.5.0
 
 # CUDA runtime wheels for ctranslate2/onnxruntime GPU paths (pins = dev venv)
 nvidia-cublas-cu12==12.9.2.10
-nvidia-cudnn-cu12==9.24.0.43
+nvidia-cudnn-cu12==9.23.2.1
 
 # DELIBERATELY NOT HERE: mediapipe. The claudeshorts reframe engine's optional
 # MediaPipe backend uses the LEGACY Solutions API (`mp.solutions.face_detection`),

--- a/sidecar/tests/test_runtime_setup.py
+++ b/sidecar/tests/test_runtime_setup.py
@@ -66,7 +66,7 @@ class TestShippedRequirementFiles:
         pins = dict(p.split("==", 1) for p in reqs.pins)
         # the T5 brief's KNOWN dev-venv versions
         assert pins["faster-whisper"] == "1.2.1"
-        assert pins["ctranslate2"] == "4.8.0"
+        assert pins["ctranslate2"] == "4.8.1"
         assert pins["scenedetect"] == "0.7"
         assert pins["httpx"] == "0.28.1"
         assert pins["opencv-python"] == "4.13.0.92"
@@ -88,6 +88,19 @@ class TestShippedRequirementFiles:
         # The new py3.14 trio (torch 2.11 cu128).
         assert pins["torch"] == "2.11.0+cu128"
         assert pins["torchaudio"] == "2.11.0+cu128"
+        # HARDENING (WU1, dependabot #259 regression class): torch/torchaudio must
+        # stay PAIRED (identical version) and BOTH must keep the +cu128 CUDA local
+        # tag. #259 bumped torch->2.12.1 (stripped +cu128) while leaving torchaudio
+        # at 2.11.0+cu128 — an incompatible pair that would install CPU torch for
+        # the GPU dub env. These invariants fail LOUDLY on any such desync/strip,
+        # independent of the exact pinned version above.
+        assert pins["torch"] == pins["torchaudio"], (
+            f"torch ({pins['torch']}) and torchaudio ({pins['torchaudio']}) must be the same version"
+        )
+        assert pins["torch"].endswith("+cu128"), f"torch must keep the +cu128 CUDA tag, got {pins['torch']}"
+        assert pins["torchaudio"].endswith("+cu128"), (
+            f"torchaudio must keep the +cu128 CUDA tag, got {pins['torchaudio']}"
+        )
         assert pins["chatterbox-tts"] == "0.1.7"
         assert reqs.options == ("--extra-index-url https://download.pytorch.org/whl/cu128",)
         # ORDER MATTERS: mirror the CHATTERBOX_REQUIREMENTS tuple order so a


### PR DESCRIPTION
## What
`origin/main` quality.yml is RED because dependabot **#259** (`dc4fa55`) bumped a sidecar pip group in a way the pin-lock test correctly rejected:

| Dep | #259 | This PR | Why |
|---|---|---|---|
| `torch` (chatterbox) | 2.11.0+cu128 → **2.12.1** | **revert to 2.11.0+cu128** | stripped the `+cu128` CUDA tag AND desynced from `torchaudio==2.11.0+cu128` → GPU dub env would install CPU/mismatched torch |
| `nvidia-cudnn-cu12` | 9.23.2.1 → **9.24.0.43** | **revert to 9.23.2.1** | untested CUDA-runtime bump; these wheels are deliberately pinned to the dev venv |
| `ctranslate2` | 4.8.0 → **4.8.1** | keep (patch) | benign |
| `huggingface_hub` | 1.21.0 → **1.22.0** | keep | not safety-locked |

## Hardening
`test_runtime_setup.py` now enforces the invariant that would have caught this at PR time: `torch`/`torchaudio` must stay **paired** (same version) and **both** keep `+cu128`. Proven to go RED on a desync mutant.

## Verify
`pytest sidecar/tests/test_runtime_setup.py` → 61 passed. This greens `main`; a follow-up reconciles it into `feat/reframe-v1.4`.