### PR TITLE
feat(security): surface plaintext copies the keystore migration could not shred (#263)

### DIFF
--- a/app/main/keystore.test.ts
+++ b/app/main/keystore.test.ts
@@ -309,29 +309,52 @@ describe('migrateLegacyPlaintextKeys', () => {
     const res = migrateLegacyPlaintextKeys(ss, settingsPath(), keystorePath());
     expect(res.status).toBe('migrated');
   });
+
+  it('surfaces a prior copy that could NOT be shredded in `unshreddable` (not `shredded`)', () => {
+    // A sibling whose basename starts with the settings basename is a prior-copy
+    // candidate priorCopies yields; when that candidate is itself un-scrubbable
+    // (both shredFile arms fail), the migration must list it in `unshreddable[]` so
+    // a lingering, still-recoverable plaintext copy is surfaced for manual removal —
+    // never dropped, and never miscounted as `shredded`. A directory whose name
+    // matches the prior-copy pattern is the deterministic cross-platform instance
+    // (openSync r+ -> EISDIR and unlink -> EISDIR/EPERM), standing in for a locked /
+    // read-only file that behaves identically.
+    const ss = makeSafeStorage();
+    const stuck = join(dir, 'settings.json.d'); // matches base prefix -> a prior copy
+    mkdirSync(stuck);
+    writeFileSync(settingsPath(), JSON.stringify({ cloudApiKey: LIVE }));
+
+    const res = migrateLegacyPlaintextKeys(ss, settingsPath(), keystorePath());
+
+    expect(res.status).toBe('migrated');
+    expect(res.unshreddable).toContain(stuck); // surfaced for manual removal
+    expect(res.shredded).not.toContain(stuck); // never miscounted as destroyed
+  });
 });
 
 describe('shredFile', () => {
-  it('is a no-op (false) for a missing file', () => {
-    expect(shredFile(join(dir, 'nope.json'))).toBe(false);
+  it("reports 'absent' for a missing file", () => {
+    // ENOENT -> nothing to shred and nothing for the user to clean up.
+    expect(shredFile(join(dir, 'nope.json'))).toBe('absent');
   });
-  it('truncates + removes a real plaintext file and reports it shredded (true)', () => {
+  it("truncates + removes a real plaintext file and reports it 'shredded'", () => {
     const f = join(dir, 'plain.json');
     writeFileSync(f, '{"cloudApiKey":"sk-live-should-be-scrubbed"}');
-    expect(shredFile(f)).toBe(true);
+    expect(shredFile(f)).toBe('shredded');
     expect(existsSync(f)).toBe(false); // the plaintext copy is genuinely gone
   });
-  it('returns false for a path that exists but cannot be scrubbed — never falsely reports an intact plaintext copy as shredded', () => {
+  it("reports 'intact' for a path that exists but cannot be scrubbed — never falsely reports a surviving plaintext copy as shredded", () => {
     // SECURITY (Codex stop-time review): a target that EXISTS but where BOTH the
     // truncate and the unlink fail — a locked / read-only / unwritable plaintext
     // copy, or a directory — is still fully recoverable on disk, so shredFile must
     // NOT report it handled (the migration would wrongly list it in `shredded[]`).
-    // "Existed" is not "shredded". A directory is the deterministic cross-platform
-    // instance of that class: openSync(dir,'r+') -> EISDIR and unlinkSync(dir) ->
-    // EISDIR/EPERM, so both arms fail exactly as they would for a locked file.
+    // "Existed" is not "shredded"; it is 'intact', and the caller surfaces it in
+    // `unshreddable[]` for manual removal. A directory is the deterministic
+    // cross-platform instance of that class: openSync(dir,'r+') -> EISDIR and
+    // unlinkSync(dir) -> EISDIR/EPERM, so both arms fail exactly as for a locked file.
     const asDir = join(dir, 'a-directory');
     mkdirSync(asDir);
-    expect(shredFile(asDir)).toBe(false); // NOT falsely reported as shredded
+    expect(shredFile(asDir)).toBe('intact'); // NOT falsely reported as shredded
     expect(existsSync(asDir)).toBe(true); // the intact copy is still on disk
   });
 });

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -79,6 +79,15 @@ export interface MigrationResult {
   migratedCloudKey: boolean;
   /** Absolute paths whose plaintext key material was shredded. */
   shredded: string[];
+  /**
+   * Absolute paths of plaintext key copies that EXISTED but could NOT be shredded
+   * (locked / read-only / unwritable / a directory — both the truncate and the
+   * unlink failed). These are still fully recoverable on disk, so the user should
+   * remove them manually; the caller surfaces them in a loud warning rather than
+   * letting a lingering plaintext copy stay silent. An `absent` copy never lands
+   * here (nothing to remove).
+   */
+  unshreddable: string[];
   /** True when the refuse path left keys session-only (secure storage unavailable). */
   sessionOnly: boolean;
   /** Loud banner text on the refuse path, else null. */
@@ -241,25 +250,45 @@ function writeJsonAtomic(path: string, data: unknown): void {
 }
 
 /**
+ * The three distinguishable end-states of a {@link shredFile} attempt. A plain
+ * boolean conflated `absent` with `intact`, so the migration could not tell a
+ * copy that was safely gone from one that survived, recoverable, on disk. The
+ * caller keys off this to warn ONLY about a lingering plaintext copy.
+ *   - `'shredded'` — the plaintext at that path is genuinely gone (truncated OR
+ *                    removed).
+ *   - `'absent'`   — nothing was there to shred (ENOENT); no action needed.
+ *   - `'intact'`   — the target EXISTED but could NOT be scrubbed (both arms
+ *                    failed); a still-recoverable copy the user must remove.
+ */
+export type ShredOutcome = 'shredded' | 'absent' | 'intact';
+
+/**
  * Truncate a file's bytes to zero then delete it, so a plaintext copy cannot be
  * recovered from the freed inode by a casual read.
  *
- * SECURITY CONTRACT (returns whether the plaintext was actually made unrecoverable):
- *   - `true`  ONLY when the bytes were truncated OR the file was removed — i.e. the
- *             plaintext at that path is genuinely gone. The caller (migration) lists
- *             these in `shredded[]` as "plaintext key material destroyed".
- *   - `false` when the target is absent (nothing to shred) OR still fully intact on
- *             disk — a LOCKED / read-only / unwritable file, or a directory, where
- *             BOTH the truncate and the unlink failed. Reporting such a file as
- *             shredded would let the caller wrongly believe a recoverable plaintext
- *             copy is gone. "Existed" is NOT "shredded".
+ * SECURITY CONTRACT (returns the outcome so the caller learns the state WITHOUT a
+ * separate `existsSync` probe — see the TOCTOU note below):
+ *   - `'shredded'` ONLY when the bytes were truncated OR the file was removed — i.e.
+ *             the plaintext at that path is genuinely gone. The caller (migration)
+ *             lists these in `shredded[]` as "plaintext key material destroyed".
+ *   - `'absent'`   when the target does not exist (ENOENT) — nothing to shred, and
+ *             nothing for the user to clean up.
+ *   - `'intact'`   when the target EXISTED but is still fully on disk — a LOCKED /
+ *             read-only / unwritable file, or a directory, where BOTH the truncate
+ *             and the unlink failed. Reporting such a file as shredded would let the
+ *             caller wrongly believe a recoverable plaintext copy is gone; instead
+ *             the migration lists it in `unshreddable[]` so it is surfaced for manual
+ *             removal. "Existed" is NOT "shredded".
  *
- * TOCTOU-free (CodeQL js/file-system-race): NO `existsSync`-then-write window. We
+ * TOCTOU-free (CodeQL js/file-system-race): NO `existsSync`-then-write window, and
+ * the caller needs NO `existsSync`-AFTER-shred to distinguish absent from intact
+ * (that separate probe would re-introduce the very race we removed, plus a
+ * js/path-injection sink) — the 3-state return carries that fact out directly. We
  * open with the `r+` flag — a single atomic syscall that REQUIRES the file to exist
- * and never creates it — so a truly-absent file fails `ENOENT` (returning false)
+ * and never creates it — so a truly-absent file fails `ENOENT` (returning `'absent'`)
  * instead of being silently created by a later write.
  */
-export function shredFile(path: string): boolean {
+export function shredFile(path: string): ShredOutcome {
   const safe = safeFilePath(path);
   let scrubbed = false;
   let fd: number | undefined;
@@ -267,7 +296,7 @@ export function shredFile(path: string): boolean {
     fd = openSync(safe, 'r+');
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
-      return false; // truly absent — nothing to shred
+      return 'absent'; // truly absent — nothing to shred
     }
     /* EISDIR/EACCES/EBUSY/…: exists but can't be opened r+; try the unlink below */
   }
@@ -292,8 +321,8 @@ export function shredFile(path: string): boolean {
     /* unlink failed; `scrubbed` reflects whether the truncate succeeded */
   }
   // Only report a real shred: a locked/unwritable/intact file (both arms failed)
-  // returns false so the caller never lists a still-recoverable copy as destroyed.
-  return scrubbed;
+  // returns 'intact' so the caller never lists a still-recoverable copy as destroyed.
+  return scrubbed ? 'shredded' : 'intact';
 }
 
 /**
@@ -433,6 +462,7 @@ export function migrateLegacyPlaintextKeys(
       migratedProviderKeys: 0,
       migratedCloudKey: false,
       shredded: [],
+      unshreddable: [],
       sessionOnly: false,
       banner: null,
     };
@@ -446,6 +476,7 @@ export function migrateLegacyPlaintextKeys(
       migratedProviderKeys: 0,
       migratedCloudKey: false,
       shredded: [],
+      unshreddable: [],
       sessionOnly: true,
       banner: status.banner,
     };
@@ -458,10 +489,15 @@ export function migrateLegacyPlaintextKeys(
   //    then shred every stale prior copy that could still hold plaintext.
   writeJsonAtomic(settingsPath, stripKeysFromSettings(settings));
   const shredded: string[] = [];
+  const unshreddable: string[] = [];
   for (const copy of priorCopies(settingsPath)) {
-    if (shredFile(copy)) {
-      shredded.push(copy);
+    const outcome = shredFile(copy);
+    if (outcome === 'shredded') {
+      shredded.push(copy); // plaintext genuinely destroyed
+    } else if (outcome === 'intact') {
+      unshreddable.push(copy); // existed but survived — surface for manual removal
     }
+    // 'absent' copies (already gone by the time we looked) need no action.
   }
 
   const providerKeyCount = Object.values(keys.providers).reduce((n, arr) => n + arr.length, 0);
@@ -470,6 +506,7 @@ export function migrateLegacyPlaintextKeys(
     migratedProviderKeys: providerKeyCount,
     migratedCloudKey: keys.cloudApiKey !== undefined,
     shredded,
+    unshreddable,
     sessionOnly: false,
     banner: null,
   };

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -475,6 +475,17 @@ function initKeyBridge(): KeyBridge {
           `${result.migratedCloudKey ? ' + cloud key' : ''}; shredded ${result.shredded.length} stale copy(ies)`,
       );
     }
+    if (result.unshreddable.length > 0) {
+      // Loud, actionable: a legacy plaintext copy EXISTED but could not be scrubbed
+      // (locked / read-only / unwritable / a directory) — it is still recoverable on
+      // disk, so name each path and tell the user to remove it manually. Never silent.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[keystore] WARNING: ${result.unshreddable.length} legacy plaintext key copy(ies) ` +
+          'could NOT be shredded and remain recoverable on disk — remove them manually: ' +
+          result.unshreddable.join(', '),
+      );
+    }
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(`[keystore] plaintext migration failed (continuing): ${(err as Error).message}`);


### PR DESCRIPTION
Closes #263. shredFile returns a 3-state ShredOutcome so migrateLegacyPlaintextKeys can collect an unshreddable[] (locked/unwritable intact copies) WITHOUT a TOCTOU existsSync; main.ts loud-warns naming each un-removable plaintext copy. Folds into the unpublished v1.4.1. keystore 33/33, vitest 100%, tsc+biome clean.

https://claude.ai/code/session_01CaUSwiidebWvpgMs2wQgqL