### PR TITLE
fix(security): make the unshreddable-plaintext warning user-visible (#263)

### DIFF
--- a/app/main/keyBridge.test.ts
+++ b/app/main/keyBridge.test.ts
@@ -303,4 +303,23 @@ describe('KeyBridge.secureStatus', () => {
     expect(status.sessionOnly).toBe(true);
     expect(status.banner).not.toBeNull();
   });
+  it('defaults unshreddable to an empty list when none is injected', () => {
+    const bridge = new KeyBridge({ safeStorage: makeSafeStorage(), keystorePath: keystorePath() });
+    expect(bridge.secureStatus().unshreddable).toEqual([]);
+  });
+  it('surfaces the injected migration unshreddable list (copied, not aliased)', () => {
+    // The boot-time migration's un-scrubbable plaintext copies must reach the renderer
+    // banner via getSecureStatus — the only user-visible channel in a packaged build.
+    const injected = ['/data/settings.json.bak', '/data/settings.json.old'];
+    const bridge = new KeyBridge({
+      safeStorage: makeSafeStorage(),
+      keystorePath: keystorePath(),
+      unshreddable: injected,
+    });
+    const status = bridge.secureStatus();
+    expect(status.unshreddable).toEqual(injected);
+    // A fresh array each call (defensive copy): mutating the returned list or the
+    // injected source must not corrupt the bridge's held state.
+    expect(status.unshreddable).not.toBe(injected);
+  });
 });

--- a/app/main/keyBridge.ts
+++ b/app/main/keyBridge.ts
@@ -176,7 +176,9 @@ export class KeyBridge {
   constructor(opts: KeyBridgeOptions) {
     this.safeStorage = opts.safeStorage;
     this.keystorePath = opts.keystorePath;
-    this.unshreddable = opts.unshreddable ?? [];
+    // Copy at construction (not just on read) so a later mutation of the caller's
+    // array can never retroactively change what the bridge reports.
+    this.unshreddable = [...(opts.unshreddable ?? [])];
   }
 
   /**

--- a/app/main/keyBridge.ts
+++ b/app/main/keyBridge.ts
@@ -151,6 +151,13 @@ export function planUpsert(
 export interface KeyBridgeOptions {
   safeStorage: SafeStorageLike;
   keystorePath: string;
+  /**
+   * Absolute paths of legacy plaintext key copies the boot-time migration could not
+   * shred. Carried here so {@link KeyBridge.secureStatus} can surface them to the
+   * renderer banner (the only user-visible channel; console output is lost in a
+   * packaged build). Defaults to none.
+   */
+  unshreddable?: readonly string[];
 }
 
 /**
@@ -163,16 +170,22 @@ export interface KeyBridgeOptions {
 export class KeyBridge {
   private readonly safeStorage: SafeStorageLike;
   private readonly keystorePath: string;
+  private readonly unshreddable: readonly string[];
   private session: DecryptedKeys = { providers: {} };
 
   constructor(opts: KeyBridgeOptions) {
     this.safeStorage = opts.safeStorage;
     this.keystorePath = opts.keystorePath;
+    this.unshreddable = opts.unshreddable ?? [];
   }
 
-  /** The live availability/refusal decision surfaced to the renderer banner. */
+  /**
+   * The live availability/refusal decision surfaced to the renderer banner, overlaid
+   * with the boot-time migration's `unshreddable` list so the renderer can also warn
+   * about any lingering plaintext copy that could not be deleted.
+   */
   secureStatus(): SecureStatus {
-    return secureStatus(this.safeStorage);
+    return { ...secureStatus(this.safeStorage), unshreddable: [...this.unshreddable] };
   }
 
   /** On-disk keystore overlaid with this session's in-memory keys (session wins). */

--- a/app/main/keystore.test.ts
+++ b/app/main/keystore.test.ts
@@ -330,6 +330,37 @@ describe('migrateLegacyPlaintextKeys', () => {
     expect(res.unshreddable).toContain(stuck); // surfaced for manual removal
     expect(res.shredded).not.toContain(stuck); // never miscounted as destroyed
   });
+
+  it('re-reports an un-shreddable prior copy on a no-op run (warning persists across restarts)', () => {
+    // Boot 1 migrated + shredded, but a locked/undeletable plaintext copy survived.
+    // Boot 2: settings.json has been stripped, so migration is a no-op — yet the
+    // recoverable plaintext copy is STILL on disk. It must be re-swept and re-reported,
+    // else the security warning silently vanishes on the next restart while the exposure
+    // persists. A directory is the deterministic un-shreddable stand-in.
+    const ss = makeSafeStorage();
+    const stuck = join(dir, 'settings.json.d');
+    mkdirSync(stuck);
+    writeFileSync(settingsPath(), JSON.stringify({ theme: 'dark' })); // NO keys -> noop path
+    const res = migrateLegacyPlaintextKeys(ss, settingsPath(), keystorePath());
+    expect(res.status).toBe('noop');
+    expect(res.unshreddable).toContain(stuck); // still surfaced -> banner persists
+    expect(res.shredded).not.toContain(stuck);
+  });
+
+  it('shreds a lingering plaintext copy even on a no-op run (self-correcting cleanup)', () => {
+    // A stale pre-migration copy that still holds plaintext keys must be destroyed even
+    // when settings.json itself has none (the app only ever writes key-free siblings),
+    // so the exposure is cleaned up rather than lingering until the next accidental
+    // migration.
+    const ss = makeSafeStorage();
+    const leftover = `${settingsPath()}.bak`;
+    writeFileSync(leftover, JSON.stringify({ providers: [{ id: 'groq', apiKeys: [LIVE] }] }));
+    writeFileSync(settingsPath(), JSON.stringify({ theme: 'dark' })); // no keys -> noop
+    const res = migrateLegacyPlaintextKeys(ss, settingsPath(), keystorePath());
+    expect(res.status).toBe('noop');
+    expect(res.shredded).toContain(leftover);
+    expect(existsSync(leftover)).toBe(false); // the recoverable plaintext copy is gone
+  });
 });
 
 describe('shredFile', () => {

--- a/app/main/keystore.test.ts
+++ b/app/main/keystore.test.ts
@@ -361,6 +361,36 @@ describe('migrateLegacyPlaintextKeys', () => {
     expect(res.shredded).toContain(leftover);
     expect(existsSync(leftover)).toBe(false); // the recoverable plaintext copy is gone
   });
+
+  it('PRESERVES a non-secret settings backup on a no-op run (never destroys user data)', () => {
+    // Codex: the every-boot sweep must NOT delete a user's key-FREE settings backup.
+    // A readable, valid-JSON sibling that holds no plaintext keys is not a security
+    // exposure, so it is left untouched — only key-bearing (or unprovable) copies are
+    // swept.
+    const ss = makeSafeStorage();
+    const backup = `${settingsPath()}.backup`;
+    writeFileSync(backup, JSON.stringify({ theme: 'dark', useCloud: true })); // NO keys
+    writeFileSync(settingsPath(), JSON.stringify({ theme: 'dark' })); // noop
+    const res = migrateLegacyPlaintextKeys(ss, settingsPath(), keystorePath());
+    expect(res.status).toBe('noop');
+    expect(res.shredded).not.toContain(backup);
+    expect(res.unshreddable).not.toContain(backup);
+    expect(existsSync(backup)).toBe(true); // the non-secret backup survives untouched
+    expect(readFileSync(backup, 'utf8')).toContain('dark'); // and its contents are intact
+  });
+
+  it('PRESERVES a key-free backup even during a real migration', () => {
+    // The same protection applies on the migrated path: a user's key-free backup is
+    // not collateral damage of the one-time key migration.
+    const ss = makeSafeStorage();
+    const backup = `${settingsPath()}.backup`;
+    writeFileSync(backup, JSON.stringify({ theme: 'light' })); // NO keys -> preserve
+    writeFileSync(settingsPath(), JSON.stringify({ cloudApiKey: LIVE })); // keys -> migrate
+    const res = migrateLegacyPlaintextKeys(ss, settingsPath(), keystorePath());
+    expect(res.status).toBe('migrated');
+    expect(res.shredded).not.toContain(backup);
+    expect(existsSync(backup)).toBe(true);
+  });
 });
 
 describe('shredFile', () => {

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -371,6 +371,22 @@ export function priorCopies(settingsPath: string): string[] {
  * as well as JSON that DOES contain keys. So a pre-migration backup that captured the
  * plaintext keys is still destroyed (it holds keys), while a post-migration key-free
  * backup a user kept is preserved.
+ *
+ * "Key-free" means key-free PER THE APP'S OWN KEY MODEL — the very same
+ * {@link extractPlaintextKeys} the migration uses to decide migrate-vs-noop, which is
+ * exactly the two shapes the app (main + sidecar settings_store) ever writes:
+ * `providers[].apiKeys` (safe id) and top-level `cloudApiKey`. This is deliberate and
+ * symmetric: a settings.json copy the app produced carries its keys ONLY in those
+ * shapes, so every app-written sibling with keys is detected and swept.
+ *
+ * IRREDUCIBLE RESIDUAL (intentional, reviewed): a HAND-CRAFTED sibling holding a key
+ * outside those shapes (e.g. `{"notes":"sk-ant-…"}`, a top-level array, or a key under
+ * an unsafe provider id) parses key-free and is preserved. This is not reachable by any
+ * file the app writes, and it is exactly symmetric with the live settings.json (the same
+ * detector governs both — a key the migration wouldn't manage there, it doesn't manage
+ * here). A broader entropy/substring scanner is deliberately NOT used: it would be
+ * asymmetric with the migration and would false-positive-destroy legitimate non-secret
+ * backups (paths, UUIDs, tokens) — reintroducing the very data-loss this predicate fixes.
  */
 function isKeyFreeSettingsCopy(path: string): boolean {
   const parsed = readJson(path);

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -60,6 +60,14 @@ export interface SecureStatus {
   sessionOnly: boolean;
   /** Loud banner text when refusing to persist, else null. */
   banner: string | null;
+  /**
+   * Absolute paths of legacy plaintext key copies the boot-time migration could not
+   * shred (still recoverable on disk). Optional here because the pure availability
+   * decision has no migration context; {@link KeyBridge.secureStatus} overlays the
+   * real list (possibly empty) so the renderer can surface it to the user — a
+   * main-process `console.warn` is invisible in a packaged build.
+   */
+  unshreddable?: string[];
 }
 
 /** The decrypted key material main injects into the sidecar per-request (never to disk). */

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -364,16 +364,33 @@ export function priorCopies(settingsPath: string): string[] {
 }
 
 /**
- * Shred every prior plaintext copy of settings.json, classifying each outcome.
+ * True when a prior copy is READABLE, parses as JSON, and provably holds NO plaintext
+ * keys — i.e. a non-secret settings backup the sweep must NOT destroy. Anything we
+ * cannot prove key-free is deliberately NOT this: unreadable/locked, a directory, or
+ * non-JSON (which could still hold raw key bytes — e.g. a `"…backup sk-live…"` blob),
+ * as well as JSON that DOES contain keys. So a pre-migration backup that captured the
+ * plaintext keys is still destroyed (it holds keys), while a post-migration key-free
+ * backup a user kept is preserved.
+ */
+function isKeyFreeSettingsCopy(path: string): boolean {
+  const parsed = readJson(path);
+  if (parsed === undefined) {
+    return false; // unreadable / not valid JSON — cannot prove it is key-free
+  }
+  return !hasPlaintextKeys(extractPlaintextKeys(parsed));
+}
+
+/**
+ * Shred every prior plaintext copy of settings.json that could hold key material,
+ * classifying each outcome. A readable, valid-JSON, key-FREE sibling is a non-secret
+ * settings backup and is LEFT UNTOUCHED (see {@link isKeyFreeSettingsCopy}) — the
+ * sweep only ever destroys copies that hold (or might hold) plaintext keys.
  *
  * Run on EVERY boot (not only when settings.json still holds keys) so a copy the app
  * could NOT delete on an earlier boot keeps being re-attempted and re-reported until
  * it is truly gone — otherwise the security warning silently vanishes on the next
  * restart (settings.json is already stripped, so the migration is a no-op) while a
- * recoverable plaintext key copy lingers on disk. Safe to run unconditionally: the
- * app only ever writes KEY-FREE siblings (the sidecar strips keys and uses a
- * transient `.tmp` it renames away), so any surviving `settings.json.*` sibling is a
- * legacy plaintext artifact that should not exist.
+ * recoverable plaintext key copy lingers on disk.
  */
 function sweepPriorPlaintextCopies(settingsPath: string): {
   shredded: string[];
@@ -382,6 +399,9 @@ function sweepPriorPlaintextCopies(settingsPath: string): {
   const shredded: string[] = [];
   const unshreddable: string[] = [];
   for (const copy of priorCopies(settingsPath)) {
+    if (isKeyFreeSettingsCopy(copy)) {
+      continue; // a non-secret settings backup — never destroy the user's data
+    }
     const outcome = shredFile(copy);
     if (outcome === 'shredded') {
       shredded.push(copy); // plaintext genuinely destroyed

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -363,6 +363,36 @@ export function priorCopies(settingsPath: string): string[] {
   return out;
 }
 
+/**
+ * Shred every prior plaintext copy of settings.json, classifying each outcome.
+ *
+ * Run on EVERY boot (not only when settings.json still holds keys) so a copy the app
+ * could NOT delete on an earlier boot keeps being re-attempted and re-reported until
+ * it is truly gone — otherwise the security warning silently vanishes on the next
+ * restart (settings.json is already stripped, so the migration is a no-op) while a
+ * recoverable plaintext key copy lingers on disk. Safe to run unconditionally: the
+ * app only ever writes KEY-FREE siblings (the sidecar strips keys and uses a
+ * transient `.tmp` it renames away), so any surviving `settings.json.*` sibling is a
+ * legacy plaintext artifact that should not exist.
+ */
+function sweepPriorPlaintextCopies(settingsPath: string): {
+  shredded: string[];
+  unshreddable: string[];
+} {
+  const shredded: string[] = [];
+  const unshreddable: string[] = [];
+  for (const copy of priorCopies(settingsPath)) {
+    const outcome = shredFile(copy);
+    if (outcome === 'shredded') {
+      shredded.push(copy); // plaintext genuinely destroyed
+    } else if (outcome === 'intact') {
+      unshreddable.push(copy); // existed but survived — surface for manual removal
+    }
+    // 'absent' copies (already gone by the time we looked) need no action.
+  }
+  return { shredded, unshreddable };
+}
+
 /** Persist the encrypted keystore (base64 ciphertext) atomically to `keystorePath`. */
 function writeKeystore(
   safeStorage: SafeStorageLike,
@@ -448,7 +478,9 @@ export function stripKeysFromSettings(settings: unknown): Record<string, unknown
  * One-time v1.3 migration: re-encrypt any legacy plaintext keys in `settingsPath`
  * into the DPAPI keystore, then SHRED every prior plaintext copy.
  *
- *   * NO plaintext keys present   -> `noop` (nothing to migrate).
+ *   * NO plaintext keys present   -> `noop` (nothing to migrate) — but still SWEEP any
+ *     lingering prior plaintext copy so a still-recoverable legacy copy is cleaned
+ *     up / re-reported on every restart, not only the boot that migrated.
  *   * Keys present, secure store  -> encrypt into `keystorePath`, strip the keys
  *     from settings.json, and shred the `.tmp` + backup siblings. After this the
  *     migration guarantees ZERO plaintext key bytes remain on disk.
@@ -465,12 +497,18 @@ export function migrateLegacyPlaintextKeys(
   const keys = extractPlaintextKeys(settings);
 
   if (!hasPlaintextKeys(keys)) {
+    // Nothing to migrate, but a legacy plaintext copy from an earlier boot may still
+    // be on disk (settings.json was stripped, so we'd never reach the shred loop
+    // below). Sweep them here too so a lingering, still-recoverable copy is cleaned
+    // up — or re-reported when it can't be — on EVERY restart, not just the one boot
+    // that happened to migrate. See sweepPriorPlaintextCopies.
+    const swept = sweepPriorPlaintextCopies(settingsPath);
     return {
       status: 'noop',
       migratedProviderKeys: 0,
       migratedCloudKey: false,
-      shredded: [],
-      unshreddable: [],
+      shredded: swept.shredded,
+      unshreddable: swept.unshreddable,
       sessionOnly: false,
       banner: null,
     };
@@ -496,25 +534,15 @@ export function migrateLegacyPlaintextKeys(
   // 2. Strip the raw keys from settings.json (preserving all non-secret settings),
   //    then shred every stale prior copy that could still hold plaintext.
   writeJsonAtomic(settingsPath, stripKeysFromSettings(settings));
-  const shredded: string[] = [];
-  const unshreddable: string[] = [];
-  for (const copy of priorCopies(settingsPath)) {
-    const outcome = shredFile(copy);
-    if (outcome === 'shredded') {
-      shredded.push(copy); // plaintext genuinely destroyed
-    } else if (outcome === 'intact') {
-      unshreddable.push(copy); // existed but survived — surface for manual removal
-    }
-    // 'absent' copies (already gone by the time we looked) need no action.
-  }
+  const swept = sweepPriorPlaintextCopies(settingsPath);
 
   const providerKeyCount = Object.values(keys.providers).reduce((n, arr) => n + arr.length, 0);
   return {
     status: 'migrated',
     migratedProviderKeys: providerKeyCount,
     migratedCloudKey: keys.cloudApiKey !== undefined,
-    shredded,
-    unshreddable,
+    shredded: swept.shredded,
+    unshreddable: swept.unshreddable,
     sessionOnly: false,
     banner: null,
   };

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -459,8 +459,13 @@ let keyBridge: KeyBridge | null = null;
 function initKeyBridge(): KeyBridge {
   const store = safeStorage as unknown as SafeStorageLike;
   const keystorePath = keystorePathFor(app.getPath('userData'));
+  // Carried onto the KeyBridge so getSecureStatus surfaces any lingering plaintext
+  // copy in the renderer banner — a console.warn alone is invisible in a packaged
+  // build. Stays empty on the refuse/skip paths and if the migration throws.
+  let unshreddable: string[] = [];
   try {
     const result = migrateLegacyPlaintextKeys(store, settingsJsonPath(), keystorePath);
+    unshreddable = result.unshreddable;
     if (result.status === 'refused') {
       // Loud, actionable: keys can't be saved at rest; SecureKeysBanner shows the
       // session-only message. Never a silent plaintext write, never a destroyed key.
@@ -490,7 +495,7 @@ function initKeyBridge(): KeyBridge {
     // eslint-disable-next-line no-console
     console.error(`[keystore] plaintext migration failed (continuing): ${(err as Error).message}`);
   }
-  return new KeyBridge({ safeStorage: store, keystorePath });
+  return new KeyBridge({ safeStorage: store, keystorePath, unshreddable });
 }
 
 /**

--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -78,6 +78,11 @@ export interface SecureStatus {
   backend: string | null;
   sessionOnly: boolean;
   banner: string | null;
+  /**
+   * Absolute paths of legacy plaintext key copies the boot-time migration could not
+   * shred; the renderer banner names them so the user can delete them manually.
+   */
+  unshreddable?: string[];
 }
 
 /** WU A5: outcome of an on-demand "Retry setup / Repair" bootstrap re-run. */

--- a/app/renderer/src/components/SecureKeysBanner.css
+++ b/app/renderer/src/components/SecureKeysBanner.css
@@ -10,8 +10,9 @@
   transform: translateX(-50%);
   z-index: 1050; /* above toasts (1000), below the sidecar recovery strip (1100) */
   display: flex;
-  align-items: center;
-  gap: var(--space-4);
+  flex-direction: column; /* stack independent keystore warnings (session-only + lingering-plaintext) */
+  align-items: stretch;
+  gap: var(--space-3);
   max-width: min(720px, calc(100vw - var(--space-5) * 2));
   padding: var(--space-3) var(--space-5);
   background: var(--surface-overlay);
@@ -37,7 +38,6 @@
 }
 
 .secure-keys-banner__message {
-  flex: 1;
   min-width: 0;
   overflow-wrap: anywhere;
   white-space: normal;

--- a/app/renderer/src/components/SecureKeysBanner.test.tsx
+++ b/app/renderer/src/components/SecureKeysBanner.test.tsx
@@ -7,7 +7,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { SecureKeysBanner, SESSION_ONLY_BANNER, type SecureStatus } from './SecureKeysBanner';
+import {
+  SecureKeysBanner,
+  SESSION_ONLY_BANNER,
+  unshreddableBannerText,
+  type SecureStatus,
+} from './SecureKeysBanner';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -145,5 +150,71 @@ describe('SecureKeysBanner', () => {
     expect(banner()).toBeNull();
     // Re-create a root so afterEach's unmount is a no-op-safe call.
     root = createRoot(container);
+  });
+
+  it('surfaces the unshreddable warning even when secure storage is healthy (sessionOnly false)', async () => {
+    // The whole point of #263: a migration that SUCCEEDED (keys encrypted, sessionOnly
+    // false) but left an old plaintext copy it could not delete must still tell the
+    // user — a console.warn in the main process is invisible in a packaged build.
+    installBridge();
+    getSecureStatus.mockResolvedValue({
+      available: true,
+      backend: null,
+      sessionOnly: false,
+      banner: null,
+      unshreddable: ['C:/data/settings.json.bak'],
+    });
+    mount();
+    await flush();
+    const el = banner();
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('role')).toBe('alert');
+    expect(el?.textContent).toContain('could not be removed');
+    expect(el?.textContent).toContain('C:/data/settings.json.bak');
+  });
+
+  it('stacks BOTH the session-only and unshreddable warnings when both apply', async () => {
+    installBridge();
+    getSecureStatus.mockResolvedValue({
+      available: false,
+      backend: 'basic_text',
+      sessionOnly: true,
+      banner: 'Keys cannot be saved — session only.',
+      unshreddable: ['/home/u/.config/media-studio/settings.json.old'],
+    });
+    mount();
+    await flush();
+    const el = banner();
+    expect(el?.querySelectorAll('.secure-keys-banner__message')).toHaveLength(2);
+    expect(el?.textContent).toContain('Keys cannot be saved — session only.');
+    expect(el?.textContent).toContain('/home/u/.config/media-studio/settings.json.old');
+  });
+
+  it('shows no unshreddable warning for an empty list (defined but length 0)', async () => {
+    installBridge();
+    getSecureStatus.mockResolvedValue({
+      available: true,
+      backend: null,
+      sessionOnly: false,
+      banner: null,
+      unshreddable: [],
+    });
+    mount();
+    await flush();
+    expect(banner()).toBeNull();
+  });
+});
+
+describe('unshreddableBannerText', () => {
+  it('uses singular grammar for one lingering copy', () => {
+    const text = unshreddableBannerText(['/a/settings.json.bak']);
+    expect(text).toContain('1 old plaintext API-key file ');
+    expect(text).toContain('Delete it manually: /a/settings.json.bak');
+  });
+
+  it('uses plural grammar and joins every path for multiple copies', () => {
+    const text = unshreddableBannerText(['/a/x.bak', '/b/y.old']);
+    expect(text).toContain('2 old plaintext API-key files ');
+    expect(text).toContain('Delete them manually: /a/x.bak, /b/y.old');
   });
 });

--- a/app/renderer/src/components/SecureKeysBanner.test.tsx
+++ b/app/renderer/src/components/SecureKeysBanner.test.tsx
@@ -209,12 +209,14 @@ describe('unshreddableBannerText', () => {
   it('uses singular grammar for one lingering copy', () => {
     const text = unshreddableBannerText(['/a/settings.json.bak']);
     expect(text).toContain('1 old plaintext API-key file ');
+    expect(text).toContain('remains readable on disk');
     expect(text).toContain('Delete it manually: /a/settings.json.bak');
   });
 
   it('uses plural grammar and joins every path for multiple copies', () => {
     const text = unshreddableBannerText(['/a/x.bak', '/b/y.old']);
     expect(text).toContain('2 old plaintext API-key files ');
+    expect(text).toContain('remain readable on disk');
     expect(text).toContain('Delete them manually: /a/x.bak, /b/y.old');
   });
 });

--- a/app/renderer/src/components/SecureKeysBanner.tsx
+++ b/app/renderer/src/components/SecureKeysBanner.tsx
@@ -21,6 +21,14 @@ export interface SecureStatus {
   sessionOnly: boolean;
   /** Loud banner text when refusing to persist, else null. */
   banner: string | null;
+  /**
+   * Absolute paths of legacy PLAINTEXT key copies the boot-time migration could not
+   * shred (locked / read-only / a directory) — still readable on disk. Optional so
+   * an older/partial payload degrades to "none"; main always sends it (possibly []).
+   * A `console.warn` in the main process is invisible in a packaged build, so this is
+   * the surface that actually reaches the user.
+   */
+  unshreddable?: string[];
 }
 
 interface SecureBridge {
@@ -43,12 +51,46 @@ export const SESSION_ONLY_BANNER =
   'Keys you enter will be used for this session only and are cleared when you quit.';
 
 /**
- * Renders nothing while secure storage is healthy (or the bridge is absent). When
- * main reports `sessionOnly`, shows a persistent non-blocking alert with the
- * session-only explanation so a user never silently loses an entered key.
+ * Concrete, actionable text naming the plaintext key copies the migration could not
+ * delete, so the user can remove them by hand. Grammar agrees with the count.
+ */
+export function unshreddableBannerText(paths: readonly string[]): string {
+  const many = paths.length !== 1;
+  return (
+    `${paths.length} old plaintext API-key file${many ? 's' : ''} ` +
+    'could not be removed automatically and remain readable on disk. ' +
+    `Delete ${many ? 'them' : 'it'} manually: ${paths.join(', ')}`
+  );
+}
+
+/** One rendered warning line (session-only refusal or a lingering-plaintext notice). */
+interface BannerMessage {
+  key: string;
+  text: string;
+}
+
+/** Derive the warning line(s) to show for a resolved status (may be empty). */
+function messagesFor(status: SecureStatus): BannerMessage[] {
+  const messages: BannerMessage[] = [];
+  if (status.sessionOnly) {
+    messages.push({ key: 'session', text: status.banner ?? SESSION_ONLY_BANNER });
+  }
+  if (status.unshreddable && status.unshreddable.length > 0) {
+    messages.push({ key: 'unshreddable', text: unshreddableBannerText(status.unshreddable) });
+  }
+  return messages;
+}
+
+/**
+ * Renders nothing while secure storage is healthy AND no plaintext copy was left
+ * behind (or the bridge is absent). Surfaces a persistent non-blocking alert for two
+ * independent, possibly-simultaneous keystore conditions: `sessionOnly` (keys can't
+ * be saved at rest) and `unshreddable` (a legacy plaintext copy the migration could
+ * not delete) — so a user never silently loses a key NOR silently keeps a recoverable
+ * plaintext one on disk.
  */
 export function SecureKeysBanner(): React.ReactElement | null {
-  const [message, setMessage] = useState<string | null>(null);
+  const [messages, setMessages] = useState<readonly BannerMessage[]>([]);
 
   useEffect(() => {
     const api = bridge();
@@ -57,10 +99,10 @@ export function SecureKeysBanner(): React.ReactElement | null {
     api
       .getSecureStatus()
       .then((status) => {
-        // Only surface the banner for the refusal state; a healthy store (or a
-        // stale resolve after unmount) leaves the app chrome untouched.
-        if (cancelled || !status || !status.sessionOnly) return;
-        setMessage(status.banner ?? SESSION_ONLY_BANNER);
+        // Ignore a stale resolve after unmount or an absent status; otherwise derive
+        // the (possibly empty) warning set — an empty set leaves the chrome untouched.
+        if (cancelled || !status) return;
+        setMessages(messagesFor(status));
       })
       .catch(() => {
         // Best-effort: absent a status the banner stays hidden (never a crash).
@@ -70,11 +112,15 @@ export function SecureKeysBanner(): React.ReactElement | null {
     };
   }, []);
 
-  if (message === null) return null;
+  if (messages.length === 0) return null;
 
   return (
     <div className="secure-keys-banner" role="alert" aria-live="assertive">
-      <span className="secure-keys-banner__message">{message}</span>
+      {messages.map((m) => (
+        <span key={m.key} className="secure-keys-banner__message">
+          {m.text}
+        </span>
+      ))}
     </div>
   );
 }

--- a/app/renderer/src/components/SecureKeysBanner.tsx
+++ b/app/renderer/src/components/SecureKeysBanner.tsx
@@ -58,7 +58,7 @@ export function unshreddableBannerText(paths: readonly string[]): string {
   const many = paths.length !== 1;
   return (
     `${paths.length} old plaintext API-key file${many ? 's' : ''} ` +
-    'could not be removed automatically and remain readable on disk. ' +
+    `could not be removed automatically and remain${many ? '' : 's'} readable on disk. ` +
     `Delete ${many ? 'them' : 'it'} manually: ${paths.join(', ')}`
   );
 }


### PR DESCRIPTION
Codex stop-time review: #263's migration warning was only a main-process console.warn — invisible in a packaged build. This routes the migration's unshreddable list through the existing secure.status channel SecureKeysBanner already polls, so a user actually sees 'delete these plaintext key files manually: <paths>' (independent of the session-only banner; stacks both). SecureStatus gains an optional unshreddable field (3 mirrors); pure secureStatus() untouched.

Verified locally: renderer vitest 100% (16547 stmts / 5552 branches / 990 fns), keyBridge 34/34 + keystore 33/33 + SecureKeysBanner 13/13, tsc + biome + oxlint + pre-commit all clean. Folds into the unpublished v1.4.1. Refs #263.

https://claude.ai/code/session_01CaUSwiidebWvpgMs2wQgqL