### PR TITLE
fix(sidecar): route log/path sinks through pathsafe sanitizers (CodeQL, 6 alerts)

### DIFF
--- a/sidecar/media_studio/assets/manager.py
+++ b/sidecar/media_studio/assets/manager.py
@@ -904,8 +904,8 @@ class AssetManager:
             log.warning(
                 "hashed lock declared but not staged (F1 build-prep) for %s: %s — "
                 "falling back to the pinned (unhashed-transitive) inline install",
-                entry.name,
-                candidate,
+                clean_for_log(entry.name),
+                clean_for_log(candidate),
             )
             return None
         validate_hashed_lock(candidate.read_text(encoding="utf-8"))

--- a/sidecar/media_studio/features/saliency_backend.py
+++ b/sidecar/media_studio/features/saliency_backend.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..pathsafe import clean_for_log
 from ..util import get_logger
 from .saliency import ASSET_NAME
 
@@ -118,7 +119,7 @@ class ViNetSaliencyBackend:  # pragma: no cover - requires torch + the vendored 
         )
         model.eval().to(self._device)
         self._model = model
-        log.info("ViNet-S saliency ready on %s (%s)", self._device, weight_path)
+        log.info("ViNet-S saliency ready on %s (%s)", self._device, clean_for_log(weight_path))
 
     def infer(self, frames: np.ndarray) -> np.ndarray:
         """Return an ``NxHxW`` per-frame saliency stack for the ``NxHxWx3`` ``frames``.

--- a/sidecar/media_studio/features/scene_transnet_backend.py
+++ b/sidecar/media_studio/features/scene_transnet_backend.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..pathsafe import clean_for_log
 from ..util import get_logger
 from .scene_transnet import ASSET_NAME, CancelProbe, ProgressCb
 
@@ -88,7 +89,7 @@ class RealTransNetBackend:  # pragma: no cover - requires the heavy native stack
         )
         model.eval().to(device)
         self._model = model
-        log.info("transnetv2 ready on %s (%s)", device, weight_path)
+        log.info("transnetv2 ready on %s (%s)", device, clean_for_log(weight_path))
 
     def predict(
         self,

--- a/sidecar/media_studio/features/tts/voices.py
+++ b/sidecar/media_studio/features/tts/voices.py
@@ -83,7 +83,11 @@ class VoiceStore:
         *,
         duration_probe: DurationProber | None = None,
     ) -> None:
-        self.samples_dir = Path(samples_dir) if samples_dir is not None else default_voices_dir()
+        raw_dir = Path(samples_dir) if samples_dir is not None else default_voices_dir()
+        # Canonicalise the voices base through the ensure_within barrier so the
+        # mkdir sinks below operate on a realpath-normalised dir (CodeQL
+        # py/path-injection); files under it are then confined via ensure_within too.
+        self.samples_dir = Path(ensure_within(raw_dir))
         self.index_path = Path(ensure_within(self.samples_dir, _INDEX_FILENAME))
         self._probe = duration_probe or _default_probe
 

--- a/sidecar/media_studio/models/runner.py
+++ b/sidecar/media_studio/models/runner.py
@@ -335,7 +335,11 @@ class ModelRunner:
                     if requested is None or _same_model(self._server_model_path, requested):
                         return self._server_proc
                     # Different model requested: graceful stop, then relaunch.
-                    log.info("model switch: %s -> %s", self._server_model_path, requested)
+                    log.info(
+                        "model switch: %s -> %s",
+                        clean_for_log(self._server_model_path),
+                        clean_for_log(requested),
+                    )
                     self._stop_server_locked()
                 else:
                     # Stale handle (the server crashed/exited on its own).


### PR DESCRIPTION
Applies the codebase's own pathsafe sanitizers to the CodeQL sinks where confinement is genuinely correct, clearing **6 pre-existing main alerts**:

- **py/log-injection (4)** — wrap the user-derived value logged in a `log.*` call with `clean_for_log(...)`: models/runner.py (model-switch paths), assets/manager.py (unstaged-lock warning), features/saliency_backend.py + scene_transnet_backend.py (weight_path; device is a constant, left alone).
- **py/path-injection (2)** — features/tts/voices.py: canonicalize the voices base via `ensure_within(...)` (the sanctioned no-parts form, matching the existing index_path treatment) so the samples_dir mkdir sinks operate on a realpath-normalised dir.

The other 16 pre-existing alerts are genuine false positives handled by dismissal (list-form subprocess = not injectable; secret-stripped clear-text write; app-manifest / user-file-picker / generic-hash-util / Electron-decoupled-keystore paths where confining would break a real feature or be pure taint-laundering).

Gates: sidecar pytest 100% branch coverage (5793 passed); basedpyright 0 errors; ruff clean. No new CodeQL alerts introduced.

https://claude.ai/code/session_01AMvR2PHoEEGaxgaciH5nFh
