### PR TITLE
chore(ci): ignore torch/torchvision/torchaudio in Dependabot (GPU-pinned)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,17 @@ updates:
   - dependency-name: '*'
     update-types:
     - version-update:semver-major
+  # torch / torchvision / torchaudio are GPU-validated, CUDA-wheel-pinned runtime
+  # assets (declared in sidecar/pyproject.toml, deliberately NOT in the scanned
+  # requirements.lock.txt) and must be bumped together only after manual GPU
+  # re-validation (A6 lesson 5) -- never via an unattended Dependabot PR. The open
+  # torch advisories (CVE-2025-2148/2149/2953/2998/2999/3000/3001/3730) are all
+  # LOCAL attack-vector (AV:L), low/medium, several with no fixed version, and are
+  # not reachable in a local desktop app processing the user's own media. Triaged
+  # + alerts dismissed 2026-06-29; reopen if the threat model changes.
+  - dependency-name: torch
+  - dependency-name: torchvision
+  - dependency-name: torchaudio
   labels:
   - dependencies
   - type:chore


### PR DESCRIPTION
Salvaged from the retired chore/dependabot-ignore-torch branch before pruning the stale-branch backlog. Adds an explicit torch/torchvision/torchaudio Dependabot ignore to the pip/sidecar ecosystem — main previously ignored only semver-major, so a minor torch bump (the live 2.6.0->2.13.0 PR) slipped through and would break the GPU-validated cu128 pin. Config-only.

https://claude.ai/code/session_01AMvR2PHoEEGaxgaciH5nFh