### PR TITLE
fix(jobs): sidecar crash -> terminal job event (v1.5 Wave-0 P0)

### DIFF
--- a/app/main/ipc.test.ts
+++ b/app/main/ipc.test.ts
@@ -4,9 +4,11 @@
 // are stripped from providers.upsert before they reach the sidecar, provider-calling
 // methods gain _injectedKeys, non-provider methods pass through, the secure.status
 // channel is served only with a bridge, and the disposer removes every handler.
+import { EventEmitter } from 'node:events';
 import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import type { BrowserWindow } from 'electron';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -20,7 +22,13 @@ vi.mock('electron', () => ({
 
 import { KEYSTORE_FILENAME, loadDecryptedKeys, type SafeStorageLike } from './keystore';
 import { INJECTED_KEYS_FIELD, KeyBridge } from './keyBridge';
-import { RPC_CHANNEL, SECURE_STATUS_CHANNEL, SIDECAR_RESTART_CHANNEL, registerIpc } from './ipc';
+import {
+  RPC_CHANNEL,
+  SECURE_STATUS_CHANNEL,
+  SIDECAR_RESTART_CHANNEL,
+  SIDECAR_STATUS_CHANNEL,
+  registerIpc,
+} from './ipc';
 import type { Sidecar } from './sidecar';
 
 function makeSafeStorage(available = true): SafeStorageLike {
@@ -153,5 +161,52 @@ describe('registerIpc — key guard wiring', () => {
     dispose();
     const removed = mocks.removeHandler.mock.calls.map(([ch]) => ch as string);
     expect(removed).not.toContain(SECURE_STATUS_CHANNEL);
+  });
+});
+
+// v1.5 crash fix: the sidecar `exit` event is bridged to a renderer-visible
+// non-running lifecycle push, so the renderer's useJob fails its active job
+// instead of spinning forever. Uses a real EventEmitter as the sidecar so
+// on('exit')/off('exit') actually wire, and a fake window to capture the fan-out.
+describe('registerIpc — sidecar exit bridge', () => {
+  /** An EventEmitter posing as a Sidecar (only request/restart are touched here). */
+  function makeEmitterSidecar(): Sidecar & EventEmitter {
+    const sc = new EventEmitter() as Sidecar & EventEmitter;
+    Object.assign(sc, {
+      request: vi.fn(async () => ({ ok: true })),
+      restart: vi.fn(async () => ({ ok: true })),
+    });
+    return sc;
+  }
+
+  /** A live fake window recording `webContents.send`. */
+  function fakeWindow(): { win: BrowserWindow; send: ReturnType<typeof vi.fn> } {
+    const send = vi.fn();
+    const win = {
+      isDestroyed: () => false,
+      webContents: { isDestroyed: () => false, send },
+    } as unknown as BrowserWindow;
+    return { win, send };
+  }
+
+  it('broadcasts a non-running sidecar.status when the sidecar process exits', () => {
+    const sc = makeEmitterSidecar();
+    const { win, send } = fakeWindow();
+    registerIpc(sc, () => [win]);
+
+    sc.emit('exit', 1);
+
+    expect(send).toHaveBeenCalledWith(SIDECAR_STATUS_CHANNEL, 'restarting');
+  });
+
+  it('the disposer detaches the exit bridge (no broadcast after dispose)', () => {
+    const sc = makeEmitterSidecar();
+    const { win, send } = fakeWindow();
+    const dispose = registerIpc(sc, () => [win]);
+    dispose();
+
+    sc.emit('exit', 1);
+
+    expect(send).not.toHaveBeenCalled();
   });
 });

--- a/app/main/ipc.ts
+++ b/app/main/ipc.ts
@@ -104,10 +104,20 @@ export function registerIpc(
   const onProgress = (p: ProgressNotification): void => broadcast(PROGRESS_CHANNEL, p);
   const onDone = (d: DoneNotification): void => broadcast(DONE_CHANNEL, d);
   const onStatus = (state: SidecarState): void => broadcast(SIDECAR_STATUS_CHANNEL, state);
+  // v1.5 crash fix: a sidecar CRASH emits 'exit' but the renderer tracks jobs
+  // only via job.progress/job.done — a crash would strand its long-job panels
+  // spinning forever (the proxy path already guards this in sidecar.ts
+  // buildProxyJob). Relay the process exit as a NON-running lifecycle push so the
+  // renderer's useJob fails its active job at once. 'restarting' is the imminent
+  // next state (the supervisor auto-restarts); if it ultimately gives up, its own
+  // 'down' push follows and wins. A clean stop() never emits 'exit' (its per-child
+  // guard drops it), so this fires only on genuine crashes.
+  const onExit = (): void => broadcast(SIDECAR_STATUS_CHANNEL, 'restarting' satisfies SidecarState);
 
   sidecar.on('progress', onProgress);
   sidecar.on('done', onDone);
   sidecar.on('status', onStatus);
+  sidecar.on('exit', onExit);
 
   return (): void => {
     ipcMain.removeHandler(RPC_CHANNEL);
@@ -118,5 +128,6 @@ export function registerIpc(
     sidecar.off('progress', onProgress);
     sidecar.off('done', onDone);
     sidecar.off('status', onStatus);
+    sidecar.off('exit', onExit);
   };
 }

--- a/app/renderer/src/components/useJob.test.tsx
+++ b/app/renderer/src/components/useJob.test.tsx
@@ -31,9 +31,12 @@ import { ToastProvider } from './toast/ToastProvider';
 import { ToastHost } from './toast/ToastHost';
 
 // The job.done relay is read straight off the window.api bridge (the frozen
-// §1 surface + the preload's onJobDone) — install a capturing fake.
+// §1 surface + the preload's onJobDone) — install a capturing fake. The
+// v1.5 crash fix ALSO reads the preload's onSidecarStatus off the same bridge.
 type DoneCb = (e: { jobId: string; result?: unknown }) => void;
+type StatusCb = (status: 'running' | 'restarting' | 'down') => void;
 let doneCb: DoneCb | null = null;
+let statusCb: StatusCb | null = null;
 
 function installBridge(): void {
   (window as unknown as { api?: unknown }).api = {
@@ -41,6 +44,12 @@ function installBridge(): void {
       doneCb = cb;
       return () => {
         doneCb = null;
+      };
+    },
+    onSidecarStatus: (cb: StatusCb) => {
+      statusCb = cb;
+      return () => {
+        statusCb = null;
       };
     },
   };
@@ -74,6 +83,7 @@ beforeEach(() => {
   rpcMock.mockReset();
   progressCb = null;
   doneCb = null;
+  statusCb = null;
   api = null;
   installBridge();
   container = document.createElement('div');
@@ -87,6 +97,7 @@ afterEach(() => {
   registerJobRetry(null);
   delete (window as unknown as { api?: unknown }).api;
   doneCb = null;
+  statusCb = null;
 });
 
 async function flush(): Promise<void> {
@@ -496,6 +507,101 @@ describe('useJob × job.done error surface (P2 U3)', () => {
     expect(toastEl).not.toBeNull();
     expect(toastEl!.textContent).toContain('Short-maker failed: sidecar down');
     expect(document.body.querySelector('.toast__action')).toBeNull();
+  });
+});
+
+describe('useJob × sidecar-status interruption (v1.5 crash fix)', () => {
+  it('fails the active job when the sidecar goes non-running (restarting)', async () => {
+    const onError = vi.fn();
+    rpcMock.mockResolvedValueOnce({ jobId: 'jc1' });
+    await renderWithToasts({ onError });
+    await act(async () => {
+      await api!.start('shortmaker.select', { videoId: 'v1' });
+    });
+    expect(api!.state.running).toBe(true);
+
+    // A sidecar crash surfaces as a non-running lifecycle push; the stranded
+    // job fails instead of spinning forever (its job.done can never arrive).
+    await act(async () => {
+      statusCb!('restarting');
+    });
+
+    expect(api!.state.running).toBe(false);
+    expect(api!.state.error).toBe('Sidecar stopped — the job was interrupted');
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobId: 'jc1',
+        method: 'shortmaker.select',
+        feature: 'shortmaker',
+        label: 'Short-maker',
+        message: 'Sidecar stopped — the job was interrupted',
+        type: 'JobInterrupted',
+      }),
+    );
+    const toastEl = document.body.querySelector('.toast--error');
+    expect(toastEl).not.toBeNull();
+    expect(toastEl!.textContent).toContain('Short-maker failed: Sidecar stopped');
+  });
+
+  it('also fails the active job when the sidecar gives up (down)', async () => {
+    rpcMock.mockResolvedValueOnce({ jobId: 'jc2' });
+    await renderWithToasts();
+    await act(async () => {
+      await api!.start('convert.start', { videoId: 'v1' });
+    });
+    await act(async () => {
+      statusCb!('down');
+    });
+    expect(api!.state.running).toBe(false);
+    expect(api!.state.error).toBe('Sidecar stopped — the job was interrupted');
+  });
+
+  it('leaves the active job untouched on a running status', async () => {
+    rpcMock.mockResolvedValueOnce({ jobId: 'jc3' });
+    await renderWithToasts();
+    await act(async () => {
+      await api!.start('convert.start', { videoId: 'v1' });
+    });
+    await act(async () => {
+      statusCb!('running');
+    });
+    expect(api!.state.running).toBe(true);
+    expect(api!.state.error).toBeNull();
+    expect(bodyToasts()).toHaveLength(0);
+  });
+
+  it('ignores a non-running status when no job is active', async () => {
+    const onError = vi.fn();
+    await renderWithToasts({ onError });
+    // No start() -> activeJobId is null -> the status push is a no-op.
+    await act(async () => {
+      statusCb!('down');
+    });
+    expect(api!.state.running).toBe(false);
+    expect(api!.state.error).toBeNull();
+    expect(onError).not.toHaveBeenCalled();
+    expect(bodyToasts()).toHaveLength(0);
+  });
+
+  it('fails safe (no crash) when the whole window.api bridge is absent', async () => {
+    // Both onJobDone and onSidecarStatus bridges take their no-op path when
+    // window.api is undefined at mount (covers the `!api` guard); the hook
+    // still starts + tracks jobs via the mocked ./api onProgress.
+    delete (window as unknown as { api?: unknown }).api;
+    rpcMock.mockResolvedValueOnce({ jobId: 'no-bridge-2' });
+    await act(async () => {
+      root.render(React.createElement(Harness));
+    });
+    await act(async () => {
+      await api!.start('convert.start', { videoId: 'v1' });
+    });
+    await flush();
+    expect(api!.state.jobId).toBe('no-bridge-2');
+    expect(api!.state.running).toBe(true);
+    await act(async () => {
+      progressCb!({ jobId: 'no-bridge-2', pct: 55, message: 'go' });
+    });
+    expect(api!.state.pct).toBe(55);
   });
 });
 

--- a/app/renderer/src/components/useJob.ts
+++ b/app/renderer/src/components/useJob.ts
@@ -68,6 +68,27 @@ function onJobDoneBridge(cb: (event: JobDoneEvent) => void): () => void {
   return api.onJobDone(cb);
 }
 
+// ---- sidecar-status plumbing (v1.5 crash fix) -------------------------------
+
+/** Self-healing supervisor lifecycle states (mirrors preload's SidecarStatus). */
+export type SidecarStatus = 'running' | 'restarting' | 'down';
+
+// CONTRACT-NOTE: like onJobDone, the preload exposes `onSidecarStatus` (the
+// `sidecar.status` relay) but components/api.ts doesn't re-export it, so read it
+// structurally off the frozen §1 bridge — graceful no-op when absent (tests/early
+// boot), so existing useJob behavior is unchanged in that case.
+function onSidecarStatusBridge(cb: (status: SidecarStatus) => void): () => void {
+  const api = (
+    globalThis as {
+      window?: {
+        api?: { onSidecarStatus?: (cb: (status: SidecarStatus) => void) => () => void };
+      };
+    }
+  ).window?.api;
+  if (!api || typeof api.onSidecarStatus !== 'function') return () => undefined;
+  return api.onSidecarStatus(cb);
+}
+
 /**
  * Pull the A3 error payload out of a job.done `result`, if present.
  * (Verified against the sidecar: a failed job emits
@@ -251,6 +272,24 @@ export function useJob(options?: UseJobOptions) {
       }
       activeJobId.current = null;
       setState((prev) => ({ ...prev, running: false, pct: 100 }));
+    });
+    return unsubscribe;
+  }, [surfaceError]);
+
+  useEffect(() => {
+    // v1.5 crash fix: a sidecar crash/restart is surfaced to the renderer as a
+    // NON-running lifecycle status ('restarting' | 'down'; ipc.ts also relays the
+    // raw process 'exit' onto this channel). The dead process can never emit the
+    // active job's terminal job.done, so fail the job instead of leaving the panel
+    // spinning forever — mirroring sidecar.ts buildProxyJob's exit->reject. A
+    // 'running' push (initial spawn / recovery) is not a failure, and with no
+    // active job there is nothing to fail.
+    const unsubscribe = onSidecarStatusBridge((status) => {
+      if (status === 'running' || !activeJobId.current) return;
+      surfaceError({
+        message: 'Sidecar stopped — the job was interrupted',
+        type: 'JobInterrupted',
+      });
     });
     return unsubscribe;
   }, [surfaceError]);

--- a/sidecar/media_studio/jobs.py
+++ b/sidecar/media_studio/jobs.py
@@ -490,6 +490,10 @@ class JobRegistry:
             return
         shell_handler = handler if handler is not None else self._rehydrated_noop
         max_seen = 0
+        # Jobs rehydrated INTERRUPTED (were mid-flight at the last exit); each needs a
+        # synthetic terminal job.done AFTER the loop (emit is I/O — kept outside the
+        # registry lock, mirroring _set_status's mutate-under-lock / write-outside).
+        interrupted_ids: list[str] = []
         # Load in ascending numeric-id (creation) order so list_info's reversed()
         # ordering + 100-item cap stay correct after a restart (job-10 IS newer than
         # job-2), regardless of the store's own load_all ordering.
@@ -511,12 +515,30 @@ class JobRegistry:
                     # the load is now id-ascending); INTERRUPTED jobs are non-terminal
                     # and are never auto-evicted.
                     self._terminal_order.append(job_id)
+                else:
+                    # Every non-terminal rehydrated job is INTERRUPTED (pending/
+                    # running/queued/unknown all degrade to it) — collect it for a
+                    # synthetic terminal job.done below. (``job`` is always present
+                    # here: _rehydrate_one just registered ``job_id``.)
+                    interrupted_ids.append(job_id)
         # New ids must not collide with rehydrated ones; and a restart with more
         # terminal records than the retention cap prunes down to the newest N (from
         # both the registry and the store).
         with self._lock:
             self._counter = max(self._counter, max_seen)
             self._prune_terminal_history()
+        # A mid-flight job whose process died leaves any client still holding its
+        # {jobId} (a renderer long-job panel spinning on job.progress after a
+        # sidecar crash+restart) waiting on job.done FOREVER. Emit a synthetic
+        # TERMINAL job.done carrying a JobInterrupted error — the same "a stalled
+        # job MUST notify" invariant that _finish_error/_finish_cancelled enforce.
+        # The status stays INTERRUPTED (resumable via job.retry); this only settles
+        # the waiter. Emitted id-ascending, outside the lock (the sink writes stdout).
+        for job_id in interrupted_ids:
+            self._emit_done(
+                job_id,
+                {"error": {"message": "job interrupted by restart", "type": "JobInterrupted"}},
+            )
 
     def _rehydrate_one(self, record: Any, shell_handler: JobHandler) -> str | None:
         """Rebuild ONE persisted record into a registered Job shell (F3b helper).

--- a/sidecar/tests/test_jobs_persistence.py
+++ b/sidecar/tests/test_jobs_persistence.py
@@ -14,6 +14,7 @@ Heavy-ML-free: handlers are plain callables; the store is the WU-5
 from __future__ import annotations
 
 import threading
+from typing import Any
 
 import pytest
 from media_studio.job_store import InMemoryJobStore
@@ -217,6 +218,64 @@ def test_rehydrate_writes_back_interrupted_status(emit_sinks):
     reg.rehydrate()
     rec = next(r for r in store.load_all() if r["jobId"] == "job-1")
     assert rec["status"] == "interrupted"
+
+
+def _done_emits(collected) -> list[tuple[str, Any]]:
+    """Filter the recording sink down to ``(job_id, result)`` for done emits."""
+    return [payload for (kind, payload) in collected if kind == "done"]
+
+
+def test_rehydrate_emits_terminal_job_done_for_interrupted(collected, emit_sinks):
+    # A job left mid-flight (running/pending/queued) when the process exited is
+    # rehydrated INTERRUPTED — and MUST also emit a terminal job.done carrying a
+    # JobInterrupted error, or a renderer still holding its {jobId} (a long-job
+    # panel spinning on job.progress after a sidecar crash+restart) waits on
+    # job.done forever. Terminal records emit nothing.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "running", "method": "a.x", "params": {}})
+    store.write({"jobId": "job-2", "status": "pending", "method": "b.y", "params": {}})
+    store.write({"jobId": "job-3", "status": "done", "method": "c.z", "params": {}})
+    store.write({"jobId": "job-4", "status": "error", "method": "d.w", "params": {}})
+    store.write({"jobId": "job-5", "status": "cancelled", "method": "e.v", "params": {}})
+
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+
+    emits = _done_emits(collected)
+    # Exactly the two non-terminal jobs notified (id-ascending order), each with
+    # the frozen A3 error shape {error:{message,type}} and type "JobInterrupted".
+    assert [job_id for (job_id, _result) in emits] == ["job-1", "job-2"]
+    for _job_id, result in emits:
+        assert result == {"error": {"message": "job interrupted by restart", "type": "JobInterrupted"}}
+    # The status re-mark is unchanged: still INTERRUPTED (resumable via job.retry),
+    # NOT flipped to a terminal ERROR by the notification.
+    assert reg.get("job-1").status is JobStatus.INTERRUPTED
+    assert reg.get("job-2").status is JobStatus.INTERRUPTED
+
+
+def test_rehydrate_emits_nothing_when_all_terminal(collected, emit_sinks):
+    # No mid-flight jobs -> no synthetic job.done notifications at all.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "done", "method": "a.x", "params": {}})
+    store.write({"jobId": "job-2", "status": "cancelled", "method": "b.y", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    assert _done_emits(collected) == []
+
+
+def test_rehydrate_emits_job_done_for_unknown_status(collected, emit_sinks):
+    # An out-of-vocabulary status degrades to INTERRUPTED (F3b) and is notified
+    # too, so a client tracking such a job never hangs either.
+    store = InMemoryJobStore()
+    store.write({"jobId": "job-1", "status": "garbage", "method": "a.x", "params": {}})
+    ep, ed = emit_sinks
+    reg = JobRegistry(ep, ed, store=store)
+    reg.rehydrate()
+    assert _done_emits(collected) == [
+        ("job-1", {"error": {"message": "job interrupted by restart", "type": "JobInterrupted"}})
+    ]
 
 
 def test_rehydrate_terminal_not_rewritten(emit_sinks):


### PR DESCRIPTION
## Problem (v1.5 audit, Wave-0 P0)

A sidecar crash left the flagship long-job panel **spinning forever with no error** while the header job pill dropped to 0. Three seams each let a stranded job hang:

- `sidecar/media_studio/jobs.py` rehydrate-on-restart never emitted a terminal `job.done` for jobs left RUNNING (they became `INTERRUPTED` silently).
- `app/main/ipc.ts` never bridged the sidecar `exit` event to a per-job failure.
- `app/renderer/.../useJob.ts` never failed when `sidecar.status` went non-running.

The proxy path already does this correctly (`app/main/sidecar.ts` `buildProxyJob`, exit -> reject); this PR mirrors that pattern for the general job system.

## Fix (defense-in-depth, TDD)

**(a) `jobs.py` — `rehydrate`** collects every job rehydrated `INTERRUPTED` (pending/running/queued/unknown all degrade to it) and emits a synthetic **terminal** `job.done {error:{message, type:"JobInterrupted"}}` (outside the registry lock, id-ascending). A client still awaiting its `{jobId}` after a crash+restart now settles instead of hanging on `job.done` forever. Status stays `INTERRUPTED` (still resumable via `job.retry`) — this only unblocks the waiter, honoring the existing `_finish_error`/`_finish_cancelled` "a stalled job MUST notify" invariant.

**(b) `app/main/ipc.ts` — `registerIpc`** subscribes to the sidecar `exit` event and relays it to renderers as a non-running `sidecar.status` push (`'restarting'`; the supervisor's own `'down'` follows if it gives up). A clean `stop()` never emits `exit` (its per-child guard drops it), so this fires only on genuine crashes. The disposer detaches the new listener.

**(c) `app/renderer/.../useJob.ts`** subscribes to `onSidecarStatus` (read structurally off the frozen `window.api` bridge, mirroring the existing `onJobDone` read) and fails the active job on any non-running status via the existing `surfaceError` path. No active job / a `running` push are no-ops.

## Tests (written first)

- **pytest** `test_jobs_persistence.py`: rehydrate emits the terminal `job.done{JobInterrupted}` for running/pending/unknown, and nothing when all records are terminal; status stays `INTERRUPTED`.
- **vitest** `ipc.test.ts`: the `exit` event broadcasts a non-running `sidecar.status`; the disposer detaches it.
- **vitest** `useJob.test.tsx`: non-running status (`restarting`/`down`) fails the active job with a `JobInterrupted` toast + `onError`; `running` and no-active-job are no-ops; absent bridge is a safe no-op.

## Local validation

- `npx tsc --noEmit` — clean.
- `npx vitest run --coverage` — **170 files pass, renderer 100%** (statements/branches/functions/lines).
- Sidecar jobs suite (`test_jobs*.py` + `test_rpc.py`) — **139 pass**; new rehydrate lines covered.
- `ruff check` + `ruff format --check`, `oxlint --deny-warnings`, `biome format` — all clean on the changed files.
- Deferred to CI `quality` gate: full-suite pytest `--cov-fail-under=100` (heavy ML deps) + basedpyright + gitleaks/osv/charter.

Scope: 3 source + 3 test files only; nothing else touched. **Do not merge** — opened for CI validation + review.