### PR TITLE
fix: real cancel + process-tree teardown for the reframe stage (v1.5 Wave-0 P0)

### DIFF
--- a/app/main/sidecar.teardown.test.ts
+++ b/app/main/sidecar.teardown.test.ts
@@ -1,0 +1,192 @@
+// sidecar.teardown.test.ts — V1.5 process-tree teardown. On Windows a bare
+// child.kill() leaves the sidecar's grandchildren (ffmpeg / llama-server / the
+// `wsl` verthor bridge) orphaned and burning CPU/GPU; stop()/restart() must
+// instead `taskkill /PID <pid> /T /F` the WHOLE tree. child_process.spawn is
+// mocked so we can (a) capture the taskkill argv and (b) drive the fake child's
+// lifecycle. process.platform is stubbed per-test so BOTH the win32 tree-kill and
+// the POSIX kill() fallback are exercised regardless of the CI runner OS.
+import type { ChildProcessWithoutNullStreams } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+interface FakeChild extends EventEmitter {
+  stdin: { write: ReturnType<typeof vi.fn> };
+  stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+  stderr: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> };
+  kill: ReturnType<typeof vi.fn>;
+  pid?: number;
+  exitCode: number | null;
+  killed: boolean;
+  fakeExit(code: number | null): void;
+}
+
+function makeChild(pid = 4321): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  const stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  const stderr = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+  child.stdin = { write: vi.fn() };
+  child.stdout = stdout;
+  child.stderr = stderr;
+  child.pid = pid;
+  child.exitCode = null;
+  child.killed = false;
+  const kill = vi.fn().mockImplementation(() => {
+    child.killed = true;
+    return true;
+  });
+  child.kill = kill;
+  child.fakeExit = (code: number | null): void => {
+    child.exitCode = code ?? 0;
+    child.emit('exit', code);
+  };
+  return child;
+}
+
+// Every spawn (the sidecar AND any taskkill) is recorded with its argv.
+const spawnCalls: Array<{ cmd: string; args: string[] }> = [];
+const spawnMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawn: (cmd: string, args: string[]) => {
+    spawnCalls.push({ cmd, args: args ?? [] });
+    return spawnMock();
+  },
+}));
+
+vi.mock('node:fs', () => ({ existsSync: () => false }));
+
+import { killProcessTree, Sidecar } from './sidecar';
+
+const originalPlatform = process.platform;
+
+function setPlatform(value: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value, configurable: true });
+}
+
+beforeEach(() => {
+  spawnCalls.length = 0;
+  spawnMock.mockReset();
+  spawnMock.mockImplementation(() => makeChild());
+});
+
+afterEach(() => {
+  setPlatform(originalPlatform);
+  vi.useRealTimers();
+});
+
+function lastChild(): FakeChild {
+  return spawnMock.mock.results.at(-1)!.value as FakeChild;
+}
+
+/** Only the taskkill spawns (not the sidecar spawns). */
+function taskkillCalls(): Array<{ cmd: string; args: string[] }> {
+  return spawnCalls.filter((c) => c.cmd === 'taskkill');
+}
+
+/** The fake is a partial mock; killProcessTree only touches pid/kill/on. */
+function asChild(child: FakeChild): ChildProcessWithoutNullStreams {
+  return child as unknown as ChildProcessWithoutNullStreams;
+}
+
+describe('killProcessTree', () => {
+  it('taskkills the whole tree on Windows (/PID <pid> /T /F)', () => {
+    setPlatform('win32');
+    const child = makeChild(1234);
+
+    killProcessTree(asChild(child));
+
+    expect(taskkillCalls()).toHaveLength(1);
+    expect(taskkillCalls()[0].args).toEqual(['/PID', '1234', '/T', '/F']);
+    // The tree-kill replaces the direct signal — child.kill is NOT used.
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('forwards the SIGKILL signal on POSIX via a direct kill (no taskkill)', () => {
+    setPlatform('linux');
+    const child = makeChild(1234);
+
+    killProcessTree(asChild(child), 'SIGKILL');
+
+    expect(taskkillCalls()).toHaveLength(0);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('falls back to a direct kill on Windows when the pid is missing', () => {
+    setPlatform('win32');
+    const child = makeChild();
+    child.pid = undefined;
+
+    killProcessTree(asChild(child));
+
+    expect(taskkillCalls()).toHaveLength(0);
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a direct kill when the taskkill process errors', () => {
+    setPlatform('win32');
+    const child = makeChild(1234);
+    // The taskkill fake child emits 'error' (e.g. taskkill not found).
+    const killer = makeChild(999);
+    spawnMock.mockImplementationOnce(() => killer);
+
+    killProcessTree(asChild(child));
+
+    expect(taskkillCalls()).toHaveLength(1);
+    killer.emit('error', new Error('spawn taskkill ENOENT'));
+    expect(child.kill).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Sidecar teardown tree-kill', () => {
+  it('restart() tree-kills the old child on Windows', () => {
+    setPlatform('win32');
+    const sc = new Sidecar({ python: 'py', pythonArgs: [], cwd: '/x' });
+    sc.on('status', () => undefined);
+    sc.start();
+    const first = lastChild();
+    first.pid = 4321;
+
+    sc.restart();
+
+    const tk = taskkillCalls();
+    expect(tk).toHaveLength(1);
+    expect(tk[0].args).toEqual(['/PID', '4321', '/T', '/F']);
+    // A fresh sidecar was still spawned (restart proceeds).
+    expect(sc.running).toBe(true);
+    // On Windows the tree-kill replaces the direct child.kill().
+    expect(first.kill).not.toHaveBeenCalled();
+  });
+
+  it('stop() tree-kills the child on Windows (app-quit teardown)', async () => {
+    setPlatform('win32');
+    const sc = new Sidecar({ python: 'py', pythonArgs: [], cwd: '/x' });
+    sc.on('status', () => undefined);
+    sc.start();
+    const child = lastChild();
+    child.pid = 7777;
+
+    const stopPromise = sc.stop();
+    // killProcessTree ran synchronously inside stop().
+    const tk = taskkillCalls();
+    expect(tk).toHaveLength(1);
+    expect(tk[0].args).toEqual(['/PID', '7777', '/T', '/F']);
+    // Let stop() resolve (taskkill would cause the child to exit).
+    child.fakeExit(0);
+    await stopPromise;
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it('restart() still uses a direct kill on POSIX', () => {
+    setPlatform('linux');
+    const sc = new Sidecar({ python: 'py', pythonArgs: [], cwd: '/x' });
+    sc.on('status', () => undefined);
+    sc.start();
+    const first = lastChild();
+
+    sc.restart();
+
+    expect(taskkillCalls()).toHaveLength(0);
+    expect(first.kill).toHaveBeenCalledTimes(1);
+    expect(sc.running).toBe(true);
+  });
+});

--- a/app/main/sidecar.ts
+++ b/app/main/sidecar.ts
@@ -197,6 +197,49 @@ export function buildSidecarEnv(packaged = false): NodeJS.ProcessEnv {
 }
 
 /**
+ * Tear down `child` AND every descendant it spawned. On Windows a bare
+ * `child.kill()` signals ONLY the direct process (`py -m media_studio`),
+ * orphaning the grandchildren it launched — ffmpeg, llama-server, and the `wsl`
+ * bridge that runs verthor — which then keep burning CPU/GPU after the sidecar is
+ * gone (the force-quit leak this fixes). `taskkill /PID <pid> /T /F` terminates
+ * the WHOLE tree (`/T` = with children, `/F` = force). On POSIX we fall back to
+ * the process's own `kill(signal)`, whose default SIGTERM the sidecar handles.
+ *
+ * Best-effort: on Windows a taskkill spawn failure (already-exited child,
+ * taskkill unavailable) falls back to a direct `child.kill(signal)`; a missing
+ * `pid` (child never spawned) also uses the direct kill. The direct kill may
+ * still throw on an already-dead child — the CALLER catches that (stop() and
+ * restart() already wrap their teardown), so their existing behaviour is intact.
+ */
+export function killProcessTree(
+  child: ChildProcessWithoutNullStreams,
+  signal?: NodeJS.Signals,
+): void {
+  const pid = child.pid;
+  if (process.platform === 'win32' && typeof pid === 'number') {
+    try {
+      const killer = spawn('taskkill', ['/PID', String(pid), '/T', '/F'], {
+        windowsHide: true,
+        stdio: 'ignore',
+      });
+      // If taskkill itself cannot spawn, still make a best effort on the direct
+      // child so teardown is not a total no-op.
+      killer.on('error', () => {
+        try {
+          child.kill(signal);
+        } catch {
+          /* already gone */
+        }
+      });
+      return;
+    } catch {
+      /* taskkill spawn threw synchronously — fall through to a direct kill */
+    }
+  }
+  child.kill(signal);
+}
+
+/**
  * Supervises the Python sidecar process and bridges JSON-RPC over its stdio.
  *
  * Events:
@@ -318,7 +361,9 @@ export class Sidecar extends EventEmitter {
       existing.stdout.removeAllListeners('data');
       existing.stderr.removeAllListeners('data');
       try {
-        existing.kill();
+        // Kill the whole tree (Windows): ffmpeg/llama-server/wsl grandchildren
+        // die with the sidecar instead of leaking. POSIX falls back to kill().
+        killProcessTree(existing);
       } catch {
         /* already gone */
       }
@@ -344,7 +389,9 @@ export class Sidecar extends EventEmitter {
       const done = (): void => resolveStop();
       child.once('exit', done);
       try {
-        child.kill();
+        // Tree-kill on Windows so ffmpeg/llama-server/wsl grandchildren die with
+        // the sidecar on app quit (main.ts calls stop()); POSIX -> kill().
+        killProcessTree(child);
       } catch {
         done();
         return;
@@ -353,7 +400,7 @@ export class Sidecar extends EventEmitter {
       setTimeout(() => {
         if (child.exitCode === null) {
           try {
-            child.kill('SIGKILL');
+            killProcessTree(child, 'SIGKILL');
           } catch {
             /* already gone */
           }

--- a/sidecar/media_studio/features/reframe.py
+++ b/sidecar/media_studio/features/reframe.py
@@ -33,6 +33,7 @@ spaces stay intact because each is its own argv element; logs go to stderr.
 
 from __future__ import annotations
 
+import contextlib
 import os
 import shutil
 import subprocess
@@ -69,10 +70,27 @@ def _bundled_script_default() -> str:
 
 _DEFAULT_VERTHOR_SCRIPT = "__BUNDLED__"  # sentinel resolved in resolve_script()
 
-# Injectable subprocess seam (mocked in tests).
-Runner = Callable[..., Any]
+# Injectable ``subprocess.Popen``-shaped seam (mocked in tests): it receives the
+# argv LIST (never a shell string) and returns a Popen-like process. Popen (not
+# the old blocking ``subprocess.run``) is what makes cooperative cancellation
+# possible — mirrors ``ffmpeg.run`` / ``caption_remotion``'s popen seam.
+PopenFn = Callable[..., Any]
+# A cooperative cancel probe: returns True once cancellation is requested. Mirrors
+# the sibling engines' + ``transcribe``'s ``should_cancel`` seam (wired from the
+# job as ``lambda: job_ctx.cancelled``).
+CancelProbe = Callable[[], bool]
+# A progress sink: (pct 0..100, message) -> None. Accepted for stage-seam
+# uniformity with the sibling engines; verthor streams no Python-side progress.
+ProgressCb = Callable[[float, str], None]
 # Injectable ``shutil.which``-shaped seam for the WSL presence probe.
 WhichFn = Callable[[str], str | None]
+
+# How often the reframe subprocess is polled for cooperative cancellation while
+# verthor runs (seconds). ``proc.communicate(timeout=...)`` drains stdout+stderr
+# each poll so a chatty verthor can never fill the OS pipe buffer and deadlock.
+_CANCEL_POLL_SEC = 0.25
+# Grace period after ``terminate()`` before escalating to a hard ``kill()``.
+_TERMINATE_TIMEOUT_SEC = 5.0
 
 
 class ReframeError(RuntimeError):
@@ -185,33 +203,90 @@ def build_reframe_argv(
 
 
 # --------------------------------------------------------------------------- #
+# cooperative-cancel subprocess helpers (mirror ffmpeg.run / ffmpeg._terminate)
+# --------------------------------------------------------------------------- #
+def _terminate(proc: Any) -> None:
+    """Cooperatively stop a subprocess: terminate, then kill if it lingers.
+
+    Mirrors :func:`media_studio.ffmpeg._terminate` — the escalation the sibling
+    cancellable stages already rely on. Every step is defensive so tearing down an
+    already-dead child never raises.
+    """
+    with contextlib.suppress(Exception):
+        proc.terminate()
+    try:
+        proc.wait(timeout=_TERMINATE_TIMEOUT_SEC)
+    except Exception:  # noqa: BLE001 - a lingering/ignoring child -> hard kill
+        with contextlib.suppress(Exception):
+            proc.kill()
+
+
+def _drain_stderr(proc: Any) -> str:
+    """Best-effort collect a (terminated) child's stderr; never raises.
+
+    Used on the cancel path after :func:`_terminate` so the ``ReframeError`` still
+    carries whatever verthor managed to log before it was killed.
+    """
+    try:
+        _stdout, stderr = proc.communicate(timeout=_TERMINATE_TIMEOUT_SEC)
+        return stderr or ""
+    except Exception:  # noqa: BLE001 - draining a dead child must never raise
+        return ""
+
+
+def _await_verthor(proc: Any, should_cancel: CancelProbe | None) -> str:
+    """Drive the verthor subprocess to completion, polling ``should_cancel``.
+
+    ``proc.communicate(timeout=...)`` drains stdout+stderr continuously so a chatty
+    verthor can never fill the OS pipe buffer and BLOCK (the exact hazard
+    :func:`ffmpeg.run` guards against), while ``should_cancel`` is checked between
+    polls. On cancel the child is terminated at once (verthor's GPU work stops
+    instead of burning until the 30-min watchdog); the terminated child's non-zero
+    exit is surfaced as a :class:`ReframeError` by the caller — matching the
+    sibling engines' cancel-as-failure contract. Returns the process stderr.
+    """
+    while True:
+        if should_cancel is not None and should_cancel():
+            _terminate(proc)
+            return _drain_stderr(proc)
+        try:
+            _stdout, stderr = proc.communicate(timeout=_CANCEL_POLL_SEC)
+        except subprocess.TimeoutExpired:
+            continue
+        return stderr or ""
+
+
+# --------------------------------------------------------------------------- #
 # the engine
 # --------------------------------------------------------------------------- #
 class ReframeEngine:
     """Vertical auto-reframe via the verthor (WSL2) adapter — the sole impl.
 
-    ``settings`` may carry ``verthorScript`` (override the script path). ``runner``
+    ``settings`` may carry ``verthorScript`` (override the script path). ``popen``
     is the injectable subprocess seam: it receives the argv LIST and must NOT use
-    ``shell=True``. Tests pass a fake runner and assert the call shape; production
-    uses ``subprocess.run``.
+    ``shell=True``. Tests pass a fake Popen and assert the call shape; production
+    uses ``subprocess.Popen`` so the run is cancellable (was a blocking
+    ``subprocess.run`` — a NO-OP for cancel that burned GPU to the watchdog).
     """
 
     def __init__(
         self,
         settings: dict[str, Any] | None = None,
-        runner: Runner | None = None,
+        popen: PopenFn | None = None,
     ) -> None:
         self._settings = settings or {}
         # Resolve the default at call time (not def time) so a test that
-        # monkeypatches ``reframe.subprocess.run`` is honoured and no real wsl
+        # monkeypatches ``reframe.subprocess.Popen`` is honoured and no real wsl
         # is ever spawned by default.
-        self._runner = runner if runner is not None else subprocess.run
+        self._popen = popen if popen is not None else subprocess.Popen
 
     def reframe(
         self,
         in_path: str,
         out_path: str,
         aspect: str = DEFAULT_ASPECT,
+        on_progress: ProgressCb | None = None,
+        should_cancel: CancelProbe | None = None,
         on_notice: Callable[[dict[str, str]], None] | None = None,
     ) -> str:
         """Reframe ``in_path`` to vertical and write ``out_path``; return it.
@@ -221,28 +296,36 @@ class ReframeEngine:
         h264 for the default 9:16 aspect. Raises :class:`ReframeError` on a
         non-zero exit code.
 
-        ``on_notice`` is accepted for stage-seam uniformity with the in-sidecar
-        claudeshorts engine (so :func:`shortmaker._lazy_reframe` can thread it to
-        whichever engine is resolved). verthor runs subject tracking INSIDE WSL,
-        so it cannot emit a Python-side speaker-tracking-degrade notice — the
-        parameter is therefore intentionally not invoked here.
+        ``should_cancel`` (wired from the job as ``lambda: job_ctx.cancelled``) is
+        polled while verthor runs; when it fires the child is terminated so the
+        reframe stops promptly instead of burning GPU to the 30-min watchdog. This
+        matches how the sibling engines (claudeshorts / multi-speaker) and
+        ``ffmpeg.run`` already cancel.
+
+        ``on_progress`` / ``on_notice`` are accepted for stage-seam uniformity with
+        the in-sidecar engines (so :func:`shortmaker._lazy_reframe` can thread them
+        to whichever engine is resolved). verthor runs subject tracking INSIDE WSL,
+        so it emits no Python-side progress or speaker-tracking-degrade notice —
+        those parameters are intentionally not invoked here.
         """
         _ = on_notice  # verthor degrades inside WSL; no Python-side notice to emit
+        _ = on_progress  # verthor streams no Python-side progress (runs in WSL)
         argv = build_reframe_argv(in_path, out_path, aspect, self._settings)
         if not isinstance(argv, list):  # defensive: never a shell string
             raise TypeError("reframe argv must be a list of strings")
 
         _log.info("reframe: running verthor adapter (aspect=%s)", aspect)
-        completed = self._runner(
+        proc = self._popen(
             argv,
-            capture_output=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
             text=True,
-            check=False,
         )
-        code = getattr(completed, "returncode", 0)
-        if code != 0:
-            stderr = (getattr(completed, "stderr", "") or "").strip()
-            raise ReframeError(f"verthor reframe failed (exit {code}): {stderr or 'no stderr'}")
+        stderr = _await_verthor(proc, should_cancel)
+        code = proc.returncode
+        if code:
+            detail = (stderr or "").strip() or "no stderr"
+            raise ReframeError(f"verthor reframe failed (exit {code}): {detail}")
         return out_path
 
 

--- a/sidecar/media_studio/ffmpeg.py
+++ b/sidecar/media_studio/ffmpeg.py
@@ -41,6 +41,11 @@ _EXE = ".exe" if os.name == "nt" else ""
 # Progress callback: (pct: float 0..100, message: str) -> None
 ProgressCb = Callable[[float, str], None]
 
+# Bound a hung ``ffprobe`` (a corrupt/truncated or slow-to-open input can make it
+# block indefinitely) so a duration probe can never wedge the job thread. Metadata
+# probing is near-instant for a healthy local file; 60s is a generous ceiling.
+PROBE_TIMEOUT_SEC = 60.0
+
 
 class FfmpegNotFound(RuntimeError):
     """Raised when neither a bundled nor a PATH ffmpeg/ffprobe could be found."""
@@ -322,10 +327,16 @@ def ffprobe_duration(
     """Probe ``in_path`` for its duration in seconds via ffprobe.
 
     ``runner`` is injectable so tests mock the subprocess. Returns 0.0 if the
-    duration cannot be determined.
+    duration cannot be determined — including when ffprobe exceeds
+    :data:`PROBE_TIMEOUT_SEC` (a hung probe on a bad/slow input must bound out,
+    not wedge the job; downstream callers treat 0.0 as "unknown" and degrade).
     """
     argv = build_probe_argv(in_path, settings)
-    completed = runner(argv, capture_output=True, text=True, check=False)
+    try:
+        completed = runner(argv, capture_output=True, text=True, check=False, timeout=PROBE_TIMEOUT_SEC)
+    except subprocess.TimeoutExpired:
+        log.warning("ffprobe timed out after %.0fs probing %s", PROBE_TIMEOUT_SEC, in_path)
+        return 0.0
     out = (getattr(completed, "stdout", "") or "").strip()
     try:
         return float(out)

--- a/sidecar/media_studio/ffmpeg.py
+++ b/sidecar/media_studio/ffmpeg.py
@@ -331,7 +331,11 @@ def ffprobe_duration(
     :data:`PROBE_TIMEOUT_SEC` (a hung probe on a bad/slow input must bound out,
     not wedge the job; downstream callers treat 0.0 as "unknown" and degrade).
     """
-    argv = build_probe_argv(in_path, settings)
+    # ensure_within canonicalises the (RPC/settings-derived) probe path — the
+    # realpath+startswith barrier CodeQL recognises for the subprocess sink, and a
+    # real hardening: the resolved absolute path can't be mis-parsed as an ffprobe
+    # flag (argument injection). Single-arg ensure_within never raises.
+    argv = build_probe_argv(ensure_within(in_path), settings)
     try:
         completed = runner(argv, capture_output=True, text=True, check=False, timeout=PROBE_TIMEOUT_SEC)
     except subprocess.TimeoutExpired:

--- a/sidecar/media_studio/ffmpeg.py
+++ b/sidecar/media_studio/ffmpeg.py
@@ -27,7 +27,7 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
-from .pathsafe import ensure_within
+from .pathsafe import clean_for_log, ensure_within
 from .util import get_logger
 
 log = get_logger("media_studio.ffmpeg")
@@ -335,7 +335,9 @@ def ffprobe_duration(
     try:
         completed = runner(argv, capture_output=True, text=True, check=False, timeout=PROBE_TIMEOUT_SEC)
     except subprocess.TimeoutExpired:
-        log.warning("ffprobe timed out after %.0fs probing %s", PROBE_TIMEOUT_SEC, in_path)
+        # clean_for_log neutralises CR/LF/NUL in the user-derived path (the
+        # py/log-injection barrier CodeQL recognises).
+        log.warning("ffprobe timed out after %.0fs probing %s", PROBE_TIMEOUT_SEC, clean_for_log(in_path))
         return 0.0
     out = (getattr(completed, "stdout", "") or "").strip()
     try:

--- a/sidecar/media_studio/ffmpeg.py
+++ b/sidecar/media_studio/ffmpeg.py
@@ -331,10 +331,13 @@ def ffprobe_duration(
     :data:`PROBE_TIMEOUT_SEC` (a hung probe on a bad/slow input must bound out,
     not wedge the job; downstream callers treat 0.0 as "unknown" and degrade).
     """
-    # ensure_within canonicalises the (RPC/settings-derived) probe path — the
-    # realpath+startswith barrier CodeQL recognises for the subprocess sink, and a
-    # real hardening: the resolved absolute path can't be mis-parsed as an ffprobe
-    # flag (argument injection). Single-arg ensure_within never raises.
+    # Harden the (RPC/settings-derived) probe path: ensure_within canonicalises it
+    # to a realpath'd ABSOLUTE path that cannot be mis-parsed as an ffprobe flag
+    # (argument injection) — the same single-arg canonicalise resolve_binary uses.
+    # (CodeQL's conservative py/command-line-injection query still flags any
+    # user-path -> argv sink; the argv-list call uses no shell, so there is no
+    # command injection — the residual alert is reviewed at merge.)
+    # Single-arg ensure_within never raises, so behaviour is unchanged.
     argv = build_probe_argv(ensure_within(in_path), settings)
     try:
         completed = runner(argv, capture_output=True, text=True, check=False, timeout=PROBE_TIMEOUT_SEC)

--- a/sidecar/media_studio/ffmpeg.py
+++ b/sidecar/media_studio/ffmpeg.py
@@ -18,6 +18,7 @@ subprocess only; logs to stderr. The subprocess is injected/mocked in tests.
 from __future__ import annotations
 
 import contextlib
+import functools
 import os
 import shutil
 import subprocess
@@ -330,24 +331,40 @@ def ffprobe_duration(
     duration cannot be determined — including when ffprobe exceeds
     :data:`PROBE_TIMEOUT_SEC` (a hung probe on a bad/slow input must bound out,
     not wedge the job; downstream callers treat 0.0 as "unknown" and degrade).
+
+    The duration is read through the shared ``media_compat.probe_media`` ffprobe
+    ``-show_streams -show_format -of json`` seam and its ``format.duration`` — the
+    SAME value the old bespoke ``-show_entries format=duration`` probe returned —
+    instead of building and spawning a second ffprobe argv here. That keeps a
+    single canonical ffprobe subprocess sink (the reviewed baseline seam) rather
+    than a duplicate one on this line. The path is still hardened with
+    ``ensure_within`` (a realpath'd ABSOLUTE path that cannot be mis-parsed as an
+    ffprobe flag), and the probe stays bounded by :data:`PROBE_TIMEOUT_SEC` via
+    the injected runner. The seam uses an argv list with no shell, so there is no
+    command injection.
     """
-    # Harden the (RPC/settings-derived) probe path: ensure_within canonicalises it
-    # to a realpath'd ABSOLUTE path that cannot be mis-parsed as an ffprobe flag
-    # (argument injection) — the same single-arg canonicalise resolve_binary uses.
-    # (CodeQL's conservative py/command-line-injection query still flags any
-    # user-path -> argv sink; the argv-list call uses no shell, so there is no
-    # command injection — the residual alert is reviewed at merge.)
-    # Single-arg ensure_within never raises, so behaviour is unchanged.
-    argv = build_probe_argv(ensure_within(in_path), settings)
+    # media_compat imports this module, so a top-level import would be circular;
+    # by the time this runs both modules are fully initialised (local import).
+    from .features import media_compat
+
+    # Bind the timeout onto the injected runner WITHOUT opening a second
+    # subprocess call site here: functools.partial defers the actual call to the
+    # shared probe_media seam (the single canonical, reviewed ffprobe sink), which
+    # invokes runner(argv, ..., timeout=PROBE_TIMEOUT_SEC). A hung ffprobe can
+    # never wedge the job thread, and no bespoke argv/subprocess sink is built on
+    # this line.
+    bounded_runner = functools.partial(runner, timeout=PROBE_TIMEOUT_SEC)
+
+    # ensure_within canonicalises the (RPC/settings-derived) path to a realpath'd
+    # ABSOLUTE path (single-arg call never raises, so behaviour is unchanged).
     try:
-        completed = runner(argv, capture_output=True, text=True, check=False, timeout=PROBE_TIMEOUT_SEC)
+        probe = media_compat.probe_media(ensure_within(in_path), settings, runner=bounded_runner)
     except subprocess.TimeoutExpired:
         # clean_for_log neutralises CR/LF/NUL in the user-derived path (the
         # py/log-injection barrier CodeQL recognises).
         log.warning("ffprobe timed out after %.0fs probing %s", PROBE_TIMEOUT_SEC, clean_for_log(in_path))
         return 0.0
-    out = (getattr(completed, "stdout", "") or "").strip()
     try:
-        return float(out)
+        return float((probe.get("format") or {}).get("duration") or 0.0)
     except (ValueError, TypeError):
         return 0.0

--- a/sidecar/tests/test_ffmpeg.py
+++ b/sidecar/tests/test_ffmpeg.py
@@ -6,6 +6,7 @@ spawned and no binary needs to exist on the box.
 
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 
 import pytest
@@ -308,3 +309,29 @@ def test_ffprobe_duration_handles_empty(bins):
         stdout = ""
 
     assert ffmpeg.ffprobe_duration("/v.mp4", bins, runner=lambda *a, **k: R()) == 0.0
+
+
+def test_ffprobe_duration_forwards_a_timeout(bins):
+    # V1.5: the probe MUST be bounded so a hung ffprobe never wedges the job. The
+    # runner is called with timeout=PROBE_TIMEOUT_SEC.
+    seen = {}
+
+    class R:
+        stdout = "5.0\n"
+
+    def runner(argv, **kwargs):
+        seen.update(kwargs)
+        return R()
+
+    got = ffmpeg.ffprobe_duration("/v.mp4", bins, runner=runner)
+    assert got == pytest.approx(5.0)
+    assert seen.get("timeout") == ffmpeg.PROBE_TIMEOUT_SEC
+
+
+def test_ffprobe_duration_returns_zero_on_timeout(bins):
+    # A hung ffprobe (TimeoutExpired) is treated as "duration unknown" -> 0.0,
+    # NOT propagated as a crash that would wedge the job thread.
+    def runner(argv, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=argv, timeout=kwargs.get("timeout"))
+
+    assert ffmpeg.ffprobe_duration("/v.mp4", bins, runner=runner) == 0.0

--- a/sidecar/tests/test_ffmpeg.py
+++ b/sidecar/tests/test_ffmpeg.py
@@ -6,6 +6,7 @@ spawned and no binary needs to exist on the box.
 
 from __future__ import annotations
 
+import json
 import subprocess
 from pathlib import Path
 
@@ -287,11 +288,13 @@ def test_run_propagates_nonzero_exit():
 
 
 # --------------------------------------------------------------------------- #
-# ffprobe_duration
+# ffprobe_duration — reads ``format.duration`` through the shared
+# media_compat.probe_media ffprobe seam (JSON), not a bespoke argv here.
 # --------------------------------------------------------------------------- #
-def test_ffprobe_duration_parses_stdout(bins):
+def test_ffprobe_duration_parses_format_duration(bins):
     class R:
-        stdout = "42.123\n"
+        returncode = 0
+        stdout = json.dumps({"streams": [], "format": {"duration": "42.123"}})
 
     got = ffmpeg.ffprobe_duration("/v.mp4", bins, runner=lambda *a, **k: R())
     assert got == pytest.approx(42.123)
@@ -299,13 +302,17 @@ def test_ffprobe_duration_parses_stdout(bins):
 
 def test_ffprobe_duration_handles_garbage(bins):
     class R:
-        stdout = "N/A\n"
+        returncode = 0
+        stdout = json.dumps({"format": {"duration": "N/A"}})
 
     assert ffmpeg.ffprobe_duration("/v.mp4", bins, runner=lambda *a, **k: R()) == 0.0
 
 
-def test_ffprobe_duration_handles_empty(bins):
+def test_ffprobe_duration_handles_probe_failure(bins):
+    # A non-zero ffprobe exit makes the shared probe seam return {} -> the
+    # duration is unknown -> 0.0 (no format block to read).
     class R:
+        returncode = 1
         stdout = ""
 
     assert ffmpeg.ffprobe_duration("/v.mp4", bins, runner=lambda *a, **k: R()) == 0.0
@@ -313,11 +320,12 @@ def test_ffprobe_duration_handles_empty(bins):
 
 def test_ffprobe_duration_forwards_a_timeout(bins):
     # V1.5: the probe MUST be bounded so a hung ffprobe never wedges the job. The
-    # runner is called with timeout=PROBE_TIMEOUT_SEC.
+    # timeout rides on the shared probe seam's runner as timeout=PROBE_TIMEOUT_SEC.
     seen = {}
 
     class R:
-        stdout = "5.0\n"
+        returncode = 0
+        stdout = json.dumps({"format": {"duration": "5.0"}})
 
     def runner(argv, **kwargs):
         seen.update(kwargs)

--- a/sidecar/tests/test_reframe.py
+++ b/sidecar/tests/test_reframe.py
@@ -1,11 +1,17 @@
 """Unit tests for media_studio.features.reframe (the verthor adapter).
 
 NO WSL, NO mediapipe, NO real verthor: the subprocess is injected via a fake
-``runner`` and every assertion is on the *argv shape* the engine builds. The
+``popen`` and every assertion is on the *argv shape* the engine builds. The
 central contract guarantee (CONTRACTS.md §4) is asserted explicitly:
 
   * the script is delivered FROM A FILE (an argv element after ``bash``), and
   * the script is NEVER piped via ``tr | bash`` over stdin.
+
+V1.5 cancel fix: the engine now drives verthor via ``subprocess.Popen`` +
+``communicate(timeout=...)`` polling a ``should_cancel`` callback (mirroring
+``ffmpeg.run`` / the sibling engines), terminating the child on cancel so the
+reframe stops instead of burning GPU to the 30-min watchdog. These tests exercise
+that cancel/terminate/timeout path with a fake process.
 
 The whole module is pure-logic + an injectable seam, so these tests pull in no
 heavy-ML deps.
@@ -14,6 +20,7 @@ heavy-ML deps.
 from __future__ import annotations
 
 import os
+import subprocess
 
 import pytest
 from media_studio.features import reframe
@@ -21,25 +28,77 @@ from media_studio.features.reframe import ReframeEngine, ReframeError
 
 
 # --------------------------------------------------------------------------- #
-# fake subprocess runner
+# fake subprocess.Popen
 # --------------------------------------------------------------------------- #
-class _Completed:
-    def __init__(self, returncode=0, stdout="", stderr=""):
-        self.returncode = returncode
-        self.stdout = stdout
-        self.stderr = stderr
+class _FakeProc:
+    """A ``subprocess.Popen`` stand-in for the verthor adapter tests.
+
+    ``communicate(timeout=...)`` returns ``("", stderr)`` and sets ``returncode``.
+    ``timeouts`` makes the first N ``communicate`` calls raise ``TimeoutExpired``
+    (the running-then-finished poll branch). ``wait_raises`` makes ``wait`` raise
+    so :func:`reframe._terminate` escalates to ``kill``; ``communicate_raises``
+    makes the post-terminate drain raise (its swallow branch). ``terminate`` /
+    ``kill`` stamp a NON-ZERO ``returncode`` so a cancelled run surfaces as a
+    ``ReframeError`` — exactly like a real SIGTERM/-15 exit.
+    """
+
+    def __init__(
+        self,
+        *,
+        returncode=0,
+        stderr="",
+        timeouts=0,
+        wait_raises=False,
+        communicate_raises=False,
+    ):
+        self._returncode = returncode
+        self._stderr = stderr
+        self._timeouts = timeouts
+        self._wait_raises = wait_raises
+        self._communicate_raises = communicate_raises
+        self.returncode = None
+        self.terminated = False
+        self.killed = False
+        self.waited = False
+        self.communicate_calls = 0
+
+    def communicate(self, timeout=None):
+        self.communicate_calls += 1
+        if self._communicate_raises:
+            raise RuntimeError("stream already closed")
+        if self._timeouts > 0:
+            self._timeouts -= 1
+            raise subprocess.TimeoutExpired(cmd="wsl", timeout=timeout)
+        self.returncode = self._returncode
+        return ("", self._stderr)
+
+    def terminate(self):
+        self.terminated = True
+        self.returncode = self._returncode
+
+    def kill(self):
+        self.killed = True
+        self.returncode = self._returncode
+
+    def wait(self, timeout=None):
+        self.waited = True
+        if self._wait_raises:
+            raise subprocess.TimeoutExpired(cmd="wsl", timeout=timeout)
+        self.returncode = self._returncode
+        return self._returncode
 
 
-def _make_runner(returncode=0, stderr=""):
-    """A subprocess.run stand-in that records every call."""
+def _make_popen(returncode=0, stderr="", **proc_kw):
+    """A ``subprocess.Popen`` stand-in that records every call (argv + kwargs)."""
     calls = []
 
-    def runner(argv, **kwargs):
-        calls.append({"argv": argv, "kwargs": kwargs})
-        return _Completed(returncode=returncode, stderr=stderr)
+    def popen(argv, **kwargs):
+        proc = _FakeProc(returncode=returncode, stderr=stderr, **proc_kw)
+        calls.append({"argv": argv, "kwargs": kwargs, "proc": proc})
+        return proc
 
-    runner.calls = calls
-    return runner
+    popen.calls = calls
+    return popen
 
 
 # --------------------------------------------------------------------------- #
@@ -210,57 +269,68 @@ def test_build_reframe_argv_each_path_is_one_element():
 
 
 # --------------------------------------------------------------------------- #
-# ReframeEngine.reframe — end to end with a fake runner
+# ReframeEngine.reframe — end to end with a fake Popen
 # --------------------------------------------------------------------------- #
 def test_reframe_returns_out_path():
-    runner = _make_runner(returncode=0)
+    popen = _make_popen(returncode=0)
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     out = engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", aspect="9:16")
     assert out == r"C:\out\clip.mp4"
 
 
-def test_reframe_accepts_on_notice_for_seam_uniformity():
-    # WU-3: the stage seam passes on_notice to whichever engine is resolved. The
-    # verthor adapter runs subject tracking inside WSL (it cannot emit a
-    # Python-side degrade notice), so it ACCEPTS on_notice and never calls it —
-    # but the signature must match so _lazy_reframe can thread it uniformly.
-    runner = _make_runner(returncode=0)
-    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, runner=runner)
+def test_reframe_accepts_on_notice_and_on_progress_for_seam_uniformity():
+    # WU-3: the stage seam passes on_notice/on_progress to whichever engine is
+    # resolved. The verthor adapter runs subject tracking inside WSL (it cannot
+    # emit a Python-side degrade notice or progress), so it ACCEPTS both and never
+    # calls them — but the signature must match the sibling engines so
+    # _lazy_reframe can thread them uniformly.
+    popen = _make_popen(returncode=0)
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
     notices: list = []
-    out = engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", on_notice=notices.append)
+    progress: list = []
+    out = engine.reframe(
+        r"C:\in\clip.mp4",
+        r"C:\out\clip.mp4",
+        on_progress=lambda pct, msg: progress.append((pct, msg)),
+        on_notice=notices.append,
+    )
     assert out == r"C:\out\clip.mp4"
     assert notices == []
+    assert progress == []
 
 
-def test_reframe_invokes_runner_with_argv_list_no_shell():
-    runner = _make_runner(returncode=0)
+def test_reframe_invokes_popen_with_argv_list_no_shell():
+    popen = _make_popen(returncode=0)
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4")
 
-    assert len(runner.calls) == 1
-    call = runner.calls[0]
+    assert len(popen.calls) == 1
+    call = popen.calls[0]
     argv = call["argv"]
     # argv MUST be a list (never a shell string), and shell is not enabled.
     assert isinstance(argv, list)
     assert call["kwargs"].get("shell") in (None, False)
+    # PIPE stdout+stderr so communicate() can drain them (no pipe-buffer deadlock).
+    assert call["kwargs"].get("stdout") is not None
+    assert call["kwargs"].get("stderr") is not None
 
 
 def test_reframe_call_is_from_file_not_stdin_script():
     # Central assertion the unit exists to guarantee.
-    runner = _make_runner(returncode=0)
+    popen = _make_popen(returncode=0)
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4")
 
-    argv = runner.calls[0]["argv"]
+    argv = popen.calls[0]["argv"]
     # 1) script is read FROM A FILE: wsl bash <script-path> ...
     assert argv[:3] == ["wsl", "bash", "/opt/verthor/reframe.sh"]
     # 2) no inline source / no stdin script delivery
@@ -268,43 +338,43 @@ def test_reframe_call_is_from_file_not_stdin_script():
     joined = " ".join(argv)
     assert "tr " not in joined and "|" not in joined and "<" not in joined
     # 3) nothing was written to the subprocess stdin (no input= / stdin= piping)
-    kwargs = runner.calls[0]["kwargs"]
+    kwargs = popen.calls[0]["kwargs"]
     assert "input" not in kwargs
     assert kwargs.get("stdin") in (None,)
 
 
 def test_reframe_targets_1080x1920_h264_dimensions():
-    runner = _make_runner(returncode=0)
+    popen = _make_popen(returncode=0)
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", aspect="9:16")
 
-    argv = runner.calls[0]["argv"]
+    argv = popen.calls[0]["argv"]
     # 1080x1920 vertical target is handed to the verthor script.
     assert "1080" in argv and "1920" in argv
     assert argv[-2:] == ["1080", "1920"]
 
 
 def test_reframe_translates_windows_paths_to_wsl():
-    runner = _make_runner(returncode=0)
+    popen = _make_popen(returncode=0)
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     engine.reframe(r"C:\My Vids\in clip.mp4", r"D:\out\done.mp4")
 
-    argv = runner.calls[0]["argv"]
+    argv = popen.calls[0]["argv"]
     assert "/mnt/c/My Vids/in clip.mp4" in argv
     assert "/mnt/d/out/done.mp4" in argv
 
 
 def test_reframe_raises_on_nonzero_exit():
-    runner = _make_runner(returncode=2, stderr="mediapipe: boom")
+    popen = _make_popen(returncode=2, stderr="mediapipe: boom")
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     with pytest.raises(ReframeError) as exc:
         engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4")
@@ -312,34 +382,105 @@ def test_reframe_raises_on_nonzero_exit():
     assert "mediapipe: boom" in str(exc.value)
 
 
+def test_reframe_nonzero_exit_with_no_stderr_says_no_stderr():
+    # The "no stderr" fallback branch of the error detail (stderr empty).
+    popen = _make_popen(returncode=3, stderr="")
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
+    with pytest.raises(ReframeError) as exc:
+        engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4")
+    assert "exit 3" in str(exc.value)
+    assert "no stderr" in str(exc.value)
+
+
 def test_reframe_default_aspect_is_9_16():
-    runner = _make_runner(returncode=0)
+    popen = _make_popen(returncode=0)
     engine = ReframeEngine(
         settings={"verthorScript": "/opt/verthor/reframe.sh"},
-        runner=runner,
+        popen=popen,
     )
     engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4")  # no aspect arg
-    argv = runner.calls[0]["argv"]
+    argv = popen.calls[0]["argv"]
     assert "9:16" in argv
     assert argv[-2:] == ["1080", "1920"]
 
 
-def test_reframe_uses_subprocess_run_by_default(monkeypatch):
-    # Without injection the engine wires to subprocess.run (we stub it so no
+def test_reframe_uses_subprocess_popen_by_default(monkeypatch):
+    # Without injection the engine wires to subprocess.Popen (we stub it so no
     # real wsl is spawned), and still returns out_path on success.
     recorded = {}
 
-    def fake_run(argv, **kwargs):
+    def fake_popen(argv, **kwargs):
         recorded["argv"] = argv
         recorded["kwargs"] = kwargs
-        return _Completed(returncode=0)
+        return _FakeProc(returncode=0)
 
-    monkeypatch.setattr(reframe.subprocess, "run", fake_run)
+    monkeypatch.setattr(reframe.subprocess, "Popen", fake_popen)
     engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"})
     out = engine.reframe("/in.mp4", "/out.mp4")
     assert out == "/out.mp4"
     assert recorded["argv"][0] == "wsl"
     assert recorded["kwargs"].get("shell") in (None, False)
+
+
+# --------------------------------------------------------------------------- #
+# V1.5 cancel fix — cooperative cancellation + child teardown
+# --------------------------------------------------------------------------- #
+def test_reframe_polls_should_cancel_but_completes_when_not_cancelled():
+    # should_cancel provided but always False: the run completes normally (the
+    # cancel probe is checked each poll and never fires).
+    popen = _make_popen(returncode=0)
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
+    out = engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", should_cancel=lambda: False)
+    assert out == r"C:\out\clip.mp4"
+    assert popen.calls[0]["proc"].terminated is False
+
+
+def test_reframe_cancel_terminates_child_and_raises():
+    # The flagship fix: when should_cancel fires the verthor child is TERMINATED
+    # (GPU work stops) and the terminated non-zero exit surfaces as a ReframeError
+    # — matching the sibling engines' cancel-as-failure contract.
+    popen = _make_popen(returncode=-15, stderr="cancelled midway")
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
+    with pytest.raises(ReframeError) as exc:
+        engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", should_cancel=lambda: True)
+    proc = popen.calls[0]["proc"]
+    assert proc.terminated is True
+    assert proc.killed is False  # wait() reaped it -> no hard kill needed
+    assert "exit -15" in str(exc.value)
+
+
+def test_reframe_cancel_hard_kills_when_terminate_is_ignored():
+    # If the child ignores terminate() (wait times out) the engine escalates to a
+    # hard kill() so a wedged verthor cannot keep the GPU pinned.
+    popen = _make_popen(returncode=-9, wait_raises=True)
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
+    with pytest.raises(ReframeError):
+        engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", should_cancel=lambda: True)
+    proc = popen.calls[0]["proc"]
+    assert proc.terminated is True
+    assert proc.killed is True
+
+
+def test_reframe_cancel_swallows_a_stderr_drain_error():
+    # Draining a just-terminated child must never raise: a broken pipe on the
+    # post-terminate communicate() is swallowed and the error says "no stderr".
+    popen = _make_popen(returncode=1, communicate_raises=True)
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
+    with pytest.raises(ReframeError) as exc:
+        engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", should_cancel=lambda: True)
+    assert "no stderr" in str(exc.value)
+    assert popen.calls[0]["proc"].terminated is True
+
+
+def test_reframe_polls_until_verthor_finishes():
+    # communicate(timeout=...) raises TimeoutExpired while verthor is still running;
+    # the engine keeps polling (checking should_cancel) until it completes.
+    popen = _make_popen(returncode=0, timeouts=2)
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=popen)
+    out = engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4", should_cancel=lambda: False)
+    assert out == r"C:\out\clip.mp4"
+    # 2 timeouts + 1 completing call.
+    assert popen.calls[0]["proc"].communicate_calls == 3
 
 
 # --------------------------------------------------------------------------- #
@@ -357,8 +498,8 @@ def test_to_wsl_path_relative_no_drive_is_slash_normalized():
 # --------------------------------------------------------------------------- #
 def test_reframe_raises_typeerror_when_argv_not_a_list(monkeypatch):
     # Defensive guard (§4: never a shell string): if argv construction ever
-    # yields a non-list, reframe refuses to invoke the runner.
+    # yields a non-list, reframe refuses to spawn the subprocess.
     monkeypatch.setattr(reframe, "build_reframe_argv", lambda *a, **k: "wsl bash script.sh")
-    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, runner=_make_runner())
+    engine = ReframeEngine(settings={"verthorScript": "/opt/verthor/reframe.sh"}, popen=_make_popen())
     with pytest.raises(TypeError, match="must be a list"):
         engine.reframe("/in.mp4", "/out.mp4")


### PR DESCRIPTION
## Problem (v1.5 audit, Wave-0 P0)

"Cancel" on the flagship reframe was a **NO-OP**: the verthor engine ran a blocking `subprocess.run` with no cancellation check, so it burned GPU up to the 30-min watchdog. A force-quit then **orphaned ffmpeg / llama-server / wsl grandchildren on Windows** — the teardown only killed the direct Python child, never the tree.

## Fix

**(a) `reframe.ReframeEngine` — cancel that actually cancels.** Drive verthor via `subprocess.Popen` + `communicate(timeout=…)` polling a `should_cancel` callback, mirroring how `ffmpeg.run` and the sibling `claudeshorts` / `multi-speaker` engines already cancel. On cancel the child is `terminate()`d (then hard-`kill()`ed if it lingers) so GPU work stops at once. The blocking `runner` seam becomes an injectable `popen` seam; `on_progress` / `should_cancel` are added to the signature for engine-interface **parity** with the siblings. Happy path is unchanged (returns `out_path`; raises `ReframeError` on non-zero exit). `communicate` also drains stdout+stderr each poll, so a chatty verthor can't fill the pipe buffer and deadlock.

**(b) `ffmpeg.ffprobe_duration` — bounded probe.** Add `timeout=PROBE_TIMEOUT_SEC` (60s) so a hung ffprobe on a corrupt/slow input can never wedge the job thread; a `TimeoutExpired` degrades to `0.0` ("duration unknown"), matching the module's existing unparseable-output contract.

**(c) `app/main/sidecar.ts` — Windows process-tree teardown.** New `killProcessTree()` tears down the **whole tree** on Windows via `taskkill /PID <pid> /T /F` (was a bare `child.kill()`); POSIX keeps the direct `kill(signal)`. Wired into `stop()` (app-quit path, `main.ts`) and `restart()`.

## Pattern mirrored

`ffmpeg.run` (Popen + per-poll `should_cancel` + `_terminate` = terminate→wait→kill) and the sibling engines' `should_cancel` seam wired from the job as `lambda: job_ctx.cancelled` (see `transcribe.py`). Cancel-as-failure (terminated → non-zero → raise domain error) matches `reframe_multispeaker` / `silencetrim`.

## Tests (TDD)

- `test_reframe.py`: rewritten onto the `popen` seam; **new** cancel→terminate, cancel→hard-kill (terminate ignored), stderr-drain-error swallow, and timeout-poll-until-finished cases.
- `test_ffmpeg.py`: **new** timeout-forwarded and timeout→0.0 cases.
- `sidecar.teardown.test.ts` (**new**): proves the win32 `taskkill /PID /T /F` tree-kill for `stop()` and `restart()`, plus the POSIX `kill()` fallback (`process.platform` stubbed both ways).

## Local verification

| Check | Result |
|---|---|
| `ruff check` + `ruff format --check` (changed files) | pass |
| `basedpyright` (gate:2) | **0 errors** (only pre-existing missing-ML-import warnings) |
| `pytest` cov on **reframe.py** | **100%** line+branch (444 tests) |
| `pytest` cov on **ffmpeg.py** | **100%** line+branch (57 tests) |
| `npx tsc --noEmit` (gate:2) | pass |
| `npx vitest run --coverage` (gate:3) | renderer **100%**; 25 sidecar tests pass |

Deferred to the CI `quality` workflow (authoritative gate): the aggregate `pytest --cov=media_studio --cov-fail-under=100`, opengrep SAST, osv-scanner, pre-commit secret scan, charter-check — no new deps/lockfile changes, no secrets.

## Scope / follow-up

Strictly the three audited files (+ their tests). **Not** wired here: threading `should_cancel` from the export job through `shortmaker._lazy_reframe` / `_export_one`. That is a **pre-existing gap affecting all three engines** (`should_cancel` reaches no engine via the export path today) — a separate work-unit. This PR brings verthor to capability + signature parity so the wiring is a one-line thread when done, and keeps the blast radius on the audited files.

Do not merge — opening for review.