### PR TITLE
feat: authenticate the auto-updater (no paid cert) [v1.5 trust]

### DIFF
--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -10,7 +10,7 @@
 // server in development (ELECTRON_RENDERER_URL) and from the built bundle
 // (out/renderer/index.html) in production. Security baseline: contextIsolation
 // ON, nodeIntegration OFF, sandbox ON — the renderer only sees `window.api`.
-import { app, BrowserWindow, ipcMain, safeStorage, session, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, net, safeStorage, session, shell } from 'electron';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, writeFileSync, promises as fsp } from 'node:fs';
 import { extname, join, resolve as resolvePath, sep } from 'node:path';
@@ -82,6 +82,7 @@ import {
   type UpdateStatus,
   type UpdaterHandle,
 } from './updater';
+import { signatureAssetUrl, verifyDownloadedUpdate } from './updateVerify';
 
 // mstream:// must be declared privileged BEFORE app ready (U1).
 // NOTE: registerSchemesAsPrivileged may only be called ONCE per app — if
@@ -744,26 +745,57 @@ function broadcastUpdateStatus(status: UpdateStatus): void {
 }
 
 /**
- * WU-U: wire electron-updater to a GitHub-Releases feed and auto-check on launch.
+ * WU-U2: fetch the detached Ed25519 `.sig` for a downloaded update from its GitHub
+ * release asset over Electron's `net` (honours the app's proxy/TLS stack). The URL is
+ * a FIXED github.com release path with the version + filename percent-encoded in
+ * (signatureAssetUrl), so a hostile feed value can never redirect the host. A missing
+ * or unreachable `.sig` throws, so the verifier fails CLOSED (the update is rejected).
+ */
+async function fetchUpdateSignature(args: { version: string; fileName: string }): Promise<string> {
+  const response = await net.fetch(signatureAssetUrl(args.version, args.fileName), {
+    redirect: 'follow',
+  });
+  if (!response.ok) {
+    throw new Error(`signature asset HTTP ${response.status}`);
+  }
+  return (await response.text()).trim();
+}
+
+/**
+ * WU-U: wire electron-updater to a GitHub-Releases feed and auto-check on launch,
+ * gated by the WU-U2 authenticity check.
  *
  * PACKAGED-ONLY: electron-updater reads `app-update.yml` (emitted into the app by
  * electron-builder's github `publish` block), which exists only in a packaged
  * build; a dev run has no feed and `checkForUpdates()` would throw. The real
  * singleton is cast to {@link AutoUpdaterLike} (the same structural-cast seam used
  * for safeStorage) and injected into the testable {@link registerUpdater} state
- * machine. autoDownload stays OFF — the user confirms the download in the
- * UpdateBanner; quitAndInstall() then runs the NSIS in-place upgrade, which
- * PRESERVES userData (the DPAPI keystore secure-keys.json + settings + the data
- * root). The app is UNSIGNED (no CSC in electron-builder.yml), so Windows
- * SmartScreen may warn when the downloaded installer runs — expected; we
- * deliberately do not add signing. The launch check is deferred until the
- * renderer has loaded so it can observe the status stream, and it degrades
+ * machine, together with the {@link verifyDownloadedUpdate} binding: before an update
+ * is announced ready OR installed, its bytes are hashed, its detached `.sig` fetched,
+ * and an Ed25519 signature over `version‖sha512` verified against the embedded public
+ * key. autoDownload + autoInstallOnAppQuit stay OFF — the user confirms the download
+ * in the UpdateBanner and NOTHING installs outside the verify gate; quitAndInstall()
+ * then runs the NSIS in-place upgrade, which PRESERVES userData (the DPAPI keystore
+ * secure-keys.json + settings + the data root).
+ *
+ * The OS-level build stays UNSIGNED (no Authenticode CSC in electron-builder.yml —
+ * Windows SmartScreen may still warn when the installer first runs), but the update
+ * channel itself is now AUTHENTICATED at the app layer. The launch check is deferred
+ * until the renderer has loaded so it can observe the status stream, and it degrades
  * quietly (never crashes) when offline or when no release exists yet.
  */
 function wireAutoUpdater(win: BrowserWindow): UpdaterHandle {
   const handle = registerUpdater({
     autoUpdater: autoUpdater as unknown as AutoUpdaterLike,
     broadcast: broadcastUpdateStatus,
+    verifyUpdate: (candidate) =>
+      verifyDownloadedUpdate({
+        version: candidate.version,
+        currentVersion: app.getVersion(),
+        downloadedFile: candidate.downloadedFile,
+        readFile: (path) => fsp.readFile(path),
+        fetchSignature: fetchUpdateSignature,
+      }),
     // eslint-disable-next-line no-console
     log: (message) => console.error(message),
   });

--- a/app/main/updateVerify.test.ts
+++ b/app/main/updateVerify.test.ts
@@ -1,0 +1,294 @@
+// updateVerify.test.ts — WU-U2 authenticity verifier, exhaustive to 100% branch.
+//
+// Real Node crypto is used end-to-end: each round-trip generates an EPHEMERAL
+// Ed25519 keypair, signs the SAME `buildSignedMessage(version, sha512(bytes))` the
+// app verifies, and checks the pure verifier accepts/rejects. No private key ever
+// lives in the repo — the embedded PUBLIC keys are only asserted parseable + used
+// as the "wrong key" for rejection paths. Fixtures cover: valid, tampered file
+// (digest mismatch), wrong version, downgrade, missing/empty sig, malformed sig,
+// wrong key, rotation (next-key accepted), read-throws, and fetch-throws.
+import { generateKeyPairSync, sign as cryptoSign, createHash, type KeyObject } from 'node:crypto';
+import { describe, it, expect, vi } from 'vitest';
+
+import {
+  EMBEDDED_UPDATE_PUBLIC_KEYS,
+  UPDATE_MESSAGE_CONTEXT,
+  UPDATE_RELEASE_BASE_URL,
+  buildSignedMessage,
+  isNotDowngrade,
+  sha512Base64,
+  signatureAssetUrl,
+  verifyDownloadedUpdate,
+  verifyEd25519,
+  type VerifyDownloadedUpdateDeps,
+} from './updateVerify';
+
+/** An ephemeral Ed25519 keypair with its public key already exported to PEM SPKI. */
+function makeKeypair(): { privateKey: KeyObject; pubPem: string } {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  return { privateKey, pubPem: publicKey.export({ type: 'spki', format: 'pem' }).toString() };
+}
+
+/** Sign `version‖sha512(bytes)` with `privateKey`, returning the base64 signature. */
+function signUpdate(privateKey: KeyObject, version: string, bytes: Buffer): string {
+  const message = buildSignedMessage(version, sha512Base64(bytes));
+  return cryptoSign(null, Buffer.from(message, 'utf8'), privateKey).toString('base64');
+}
+
+const INSTALLER = 'C:\\cache\\media-studio-1.5.0-win-x64.exe';
+
+/** Assemble {@link VerifyDownloadedUpdateDeps} with sensible defaults per test. */
+function makeDeps(over: Partial<VerifyDownloadedUpdateDeps> = {}): VerifyDownloadedUpdateDeps {
+  return {
+    version: '1.5.0',
+    currentVersion: '1.4.1',
+    downloadedFile: INSTALLER,
+    readFile: async () => Buffer.from('installer-bytes'),
+    fetchSignature: async () => '',
+    ...over,
+  };
+}
+
+describe('sha512Base64', () => {
+  it('matches node crypto SHA-512 base64 of the same bytes', () => {
+    const bytes = Buffer.from('hello reframe');
+    const expected = createHash('sha512').update(bytes).digest('base64');
+    expect(sha512Base64(bytes)).toBe(expected);
+  });
+});
+
+describe('buildSignedMessage — PINNED wire format (build/sign-release.mjs MUST match)', () => {
+  it('is the domain-separated, newline-delimited version‖digest binding', () => {
+    expect(UPDATE_MESSAGE_CONTEXT).toBe('reframe:update:v1');
+    expect(buildSignedMessage('1.5.0', 'DIGEST==')).toBe('reframe:update:v1\n1.5.0\nDIGEST==');
+  });
+});
+
+describe('signatureAssetUrl', () => {
+  it('builds the release .sig URL under the default GitHub base', () => {
+    expect(signatureAssetUrl('1.5.0', 'media-studio-1.5.0-win-x64.exe')).toBe(
+      `${UPDATE_RELEASE_BASE_URL}/v1.5.0/media-studio-1.5.0-win-x64.exe.sig`,
+    );
+  });
+
+  it('honours an explicit base and percent-encodes hostile path segments', () => {
+    expect(signatureAssetUrl('1.0/../evil', 'a b/c.exe', 'https://example.test/dl')).toBe(
+      'https://example.test/dl/v1.0%2F..%2Fevil/a%20b%2Fc.exe.sig',
+    );
+  });
+});
+
+describe('EMBEDDED_UPDATE_PUBLIC_KEYS', () => {
+  it('are two distinct, parseable Ed25519 public keys (current + next)', () => {
+    expect(EMBEDDED_UPDATE_PUBLIC_KEYS).toHaveLength(2);
+    for (const pem of EMBEDDED_UPDATE_PUBLIC_KEYS) {
+      // A round-trip sign under an ephemeral key must NOT verify against an embedded
+      // key (proves each is a real, independent Ed25519 key, not the test's own).
+      const { privateKey } = makeKeypair();
+      const sig = signUpdate(privateKey, '1.5.0', Buffer.from('x'));
+      const message = buildSignedMessage('1.5.0', sha512Base64(Buffer.from('x')));
+      expect(verifyEd25519(message, sig, [pem])).toBe(false);
+    }
+    expect(EMBEDDED_UPDATE_PUBLIC_KEYS[0]).not.toBe(EMBEDDED_UPDATE_PUBLIC_KEYS[1]);
+  });
+});
+
+describe('verifyEd25519', () => {
+  it('accepts a signature from the (single) matching key', () => {
+    const { privateKey, pubPem } = makeKeypair();
+    const bytes = Buffer.from('a');
+    const message = buildSignedMessage('1.5.0', sha512Base64(bytes));
+    expect(verifyEd25519(message, signUpdate(privateKey, '1.5.0', bytes), [pubPem])).toBe(true);
+  });
+
+  it('accepts a signature from the SECOND (rotation) key in the list', () => {
+    const wrong = makeKeypair();
+    const right = makeKeypair();
+    const bytes = Buffer.from('a');
+    const message = buildSignedMessage('1.5.0', sha512Base64(bytes));
+    const sig = signUpdate(right.privateKey, '1.5.0', bytes);
+    expect(verifyEd25519(message, sig, [wrong.pubPem, right.pubPem])).toBe(true);
+  });
+
+  it('rejects a valid signature made by a key NOT in the list', () => {
+    const signer = makeKeypair();
+    const other = makeKeypair();
+    const bytes = Buffer.from('a');
+    const message = buildSignedMessage('1.5.0', sha512Base64(bytes));
+    const sig = signUpdate(signer.privateKey, '1.5.0', bytes);
+    expect(verifyEd25519(message, sig, [other.pubPem])).toBe(false);
+  });
+
+  it('rejects a malformed (wrong-length) signature without throwing', () => {
+    const { pubPem } = makeKeypair();
+    expect(verifyEd25519('msg', 'AA==', [pubPem])).toBe(false);
+  });
+
+  it('rejects when a candidate public key is not valid PEM without throwing', () => {
+    const { privateKey } = makeKeypair();
+    const bytes = Buffer.from('a');
+    const message = buildSignedMessage('1.5.0', sha512Base64(bytes));
+    const sig = signUpdate(privateKey, '1.5.0', bytes);
+    expect(
+      verifyEd25519(message, sig, ['-----BEGIN PUBLIC KEY-----\nnope\n-----END PUBLIC KEY-----']),
+    ).toBe(false);
+  });
+});
+
+describe('isNotDowngrade — the signed-downgrade-replay guard', () => {
+  it('accepts a strictly newer core version', () => {
+    expect(isNotDowngrade('1.5.0', '1.4.1')).toBe(true);
+    expect(isNotDowngrade('2.0.0', '1.9.9')).toBe(true);
+  });
+
+  it('rejects an older core version', () => {
+    expect(isNotDowngrade('1.4.0', '1.5.0')).toBe(false);
+    expect(isNotDowngrade('1.4.1', '1.4.2')).toBe(false);
+  });
+
+  it('rejects the SAME version (no strict increase)', () => {
+    expect(isNotDowngrade('1.5.0', '1.5.0')).toBe(false);
+  });
+
+  it('treats a final release as newer than its prerelease and vice-versa', () => {
+    expect(isNotDowngrade('1.5.0', '1.5.0-beta.1')).toBe(true);
+    expect(isNotDowngrade('1.5.0-beta.1', '1.5.0')).toBe(false);
+  });
+
+  it('orders two prereleases of the same core lexically', () => {
+    expect(isNotDowngrade('1.5.0-beta.2', '1.5.0-beta.1')).toBe(true);
+    expect(isNotDowngrade('1.5.0-alpha', '1.5.0-beta')).toBe(false);
+    expect(isNotDowngrade('1.5.0-rc.1', '1.5.0-rc.1')).toBe(false);
+  });
+
+  it('handles unequal-length cores and build metadata', () => {
+    expect(isNotDowngrade('1.5.1', '1.5')).toBe(true); // current has fewer parts
+    expect(isNotDowngrade('1.5', '1.5.1')).toBe(false); // candidate has fewer parts
+    expect(isNotDowngrade('1.5.0+build9', '1.5.0')).toBe(false); // build metadata is not precedence
+  });
+
+  it('treats a non-numeric core identifier as zero', () => {
+    expect(isNotDowngrade('abc', '1.0.0')).toBe(false); // parseInt('abc') -> NaN -> 0
+    expect(isNotDowngrade('1.0.0', 'abc')).toBe(true);
+  });
+});
+
+describe('verifyDownloadedUpdate — the download→install authenticity gate', () => {
+  it('accepts a correctly signed, newer update', async () => {
+    const { privateKey, pubPem } = makeKeypair();
+    const bytes = Buffer.from('the-real-installer');
+    const log = vi.fn();
+    const res = await verifyDownloadedUpdate(
+      makeDeps({
+        readFile: async () => bytes,
+        fetchSignature: async () => signUpdate(privateKey, '1.5.0', bytes),
+        publicKeys: [pubPem],
+        log,
+      }),
+    );
+    expect(res).toEqual({ ok: true });
+    expect(log).not.toHaveBeenCalled(); // success never logs a rejection
+  });
+
+  it('rejects a blank version', async () => {
+    const res = await verifyDownloadedUpdate(makeDeps({ version: '' }));
+    expect(res).toEqual({ ok: false, reason: 'missing update version or downloaded file' });
+  });
+
+  it('rejects a blank downloaded file', async () => {
+    const res = await verifyDownloadedUpdate(makeDeps({ downloadedFile: '' }));
+    expect(res).toEqual({ ok: false, reason: 'missing update version or downloaded file' });
+  });
+
+  it('rejects a downgrade and logs the reason', async () => {
+    const log = vi.fn();
+    const res = await verifyDownloadedUpdate(
+      makeDeps({ version: '1.4.0', currentVersion: '1.5.0', log }),
+    );
+    expect(res.ok).toBe(false);
+    expect(res).toMatchObject({ reason: expect.stringContaining('refusing downgrade') });
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('refusing downgrade'));
+  });
+
+  it('rejects when the downloaded file cannot be read', async () => {
+    const res = await verifyDownloadedUpdate(
+      makeDeps({
+        readFile: async () => {
+          throw new Error('EACCES');
+        },
+      }),
+    );
+    expect(res).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('cannot read downloaded update'),
+    });
+    expect(res).toMatchObject({ reason: expect.stringContaining('EACCES') });
+  });
+
+  it('rejects when the signature cannot be fetched (non-Error throw covered)', async () => {
+    const res = await verifyDownloadedUpdate(
+      makeDeps({
+        readFile: async () => Buffer.from('bytes'),
+        fetchSignature: async () => {
+          throw '404 Not Found';
+        },
+      }),
+    );
+    expect(res).toMatchObject({
+      ok: false,
+      reason: expect.stringContaining('cannot fetch update signature'),
+    });
+    expect(res).toMatchObject({ reason: expect.stringContaining('404 Not Found') });
+  });
+
+  it('rejects an empty signature (no .sig published)', async () => {
+    const res = await verifyDownloadedUpdate(
+      makeDeps({ readFile: async () => Buffer.from('bytes'), fetchSignature: async () => '' }),
+    );
+    expect(res).toEqual({ ok: false, reason: 'update signature is empty (no .sig published?)' });
+  });
+
+  it('rejects a TAMPERED file — signature valid but bytes swapped after signing', async () => {
+    const { privateKey, pubPem } = makeKeypair();
+    const original = Buffer.from('original-installer');
+    const tampered = Buffer.from('MALICIOUS-installer');
+    const res = await verifyDownloadedUpdate(
+      makeDeps({
+        readFile: async () => tampered, // what is on disk now
+        fetchSignature: async () => signUpdate(privateKey, '1.5.0', original), // signed the original
+        publicKeys: [pubPem],
+      }),
+    );
+    expect(res).toEqual({
+      ok: false,
+      reason: 'signature does not match the embedded update key',
+    });
+  });
+
+  it('rejects a WRONG-VERSION signature — proves the version binding', async () => {
+    const { privateKey, pubPem } = makeKeypair();
+    const bytes = Buffer.from('installer');
+    const res = await verifyDownloadedUpdate(
+      makeDeps({
+        version: '1.5.0',
+        readFile: async () => bytes,
+        fetchSignature: async () => signUpdate(privateKey, '9.9.9', bytes), // signed a different version
+        publicKeys: [pubPem],
+      }),
+    );
+    expect(res).toMatchObject({ ok: false, reason: expect.stringContaining('does not match') });
+  });
+
+  it('rejects a valid signature from a key that is NOT embedded (default keys, no log)', async () => {
+    const { privateKey } = makeKeypair();
+    const bytes = Buffer.from('installer');
+    // No publicKeys override -> falls back to EMBEDDED_UPDATE_PUBLIC_KEYS; no log -> default noop.
+    const res = await verifyDownloadedUpdate(
+      makeDeps({
+        readFile: async () => bytes,
+        fetchSignature: async () => signUpdate(privateKey, '1.5.0', bytes),
+      }),
+    );
+    expect(res).toMatchObject({ ok: false, reason: expect.stringContaining('does not match') });
+  });
+});

--- a/app/main/updateVerify.ts
+++ b/app/main/updateVerify.ts
@@ -1,0 +1,251 @@
+// updateVerify.ts — WU-U2: AUTHENTICITY gate for the in-place auto-update.
+//
+// THREAT MODEL: electron-updater already proves INTEGRITY (it checks the SHA-512
+// block-map in `latest.yml`), but NOT AUTHENTICITY — a party who controls the
+// update feed can serve their own `latest.yml` + installer and electron-updater
+// would happily install it. Reframe ships UNSIGNED (no Authenticode/EV cert), so
+// there is no OS-level publisher check either. This module closes that gap with a
+// FREE, offline, zero-runtime-dependency authenticity check:
+//
+//   * At release time a human/CI step signs `version‖sha512(installer)` with an
+//     OFFLINE Ed25519 private key and publishes the detached signature as a
+//     `<installer>.sig` release asset (see build/sign-release.mjs).
+//   * The shipping app embeds the matching Ed25519 PUBLIC key(s) below and, before
+//     it will apply a downloaded update, recomputes sha512(installer), fetches the
+//     `.sig`, rebuilds the signed message, and verifies it with Node's built-in
+//     `crypto` (Ed25519 `crypto.verify(null, …)`). A compromised feed cannot forge
+//     a valid signature over `version‖sha512` without the offline private key.
+//
+// The message binds BOTH the version AND the file digest, so it blocks tampering
+// (wrong digest) AND downgrade replay of an old-but-validly-signed release (the
+// {@link isNotDowngrade} guard). This module is a PURE verifier: it imports only
+// `node:crypto` + `node:path`, takes ALL I/O (file read, signature fetch) as
+// injected deps, and NEVER throws — every failure is a typed `{ ok:false, reason }`
+// so the caller can gate the install without a try/catch. That keeps it trivially
+// unit-testable to the mandatory 100% branch bar, the same injected-fake seam used
+// by keystore.ts / updater.ts.
+import { createHash, createPublicKey, verify as cryptoVerify } from 'node:crypto';
+import { basename } from 'node:path';
+
+/**
+ * Domain-separation prefix baked into every signed message. Prevents a signature
+ * produced for some OTHER Ed25519 protocol (that happened to sign the same bytes)
+ * from being replayed as a valid Reframe update signature. Bump the `v1` suffix if
+ * the signed-message format ever changes.
+ */
+export const UPDATE_MESSAGE_CONTEXT = 'reframe:update:v1';
+
+/**
+ * The Ed25519 PUBLIC keys (PEM SPKI) the app accepts an update signature from.
+ * Ordered `[current, next]`: BOTH are accepted so a release can be signed by a
+ * pre-provisioned rotation key WITHOUT a code change — sign the next release with
+ * `next`, ship it, then drop the retired `current` in a later build. The matching
+ * PRIVATE keys live OFFLINE (never in this repo); only the public halves are here,
+ * and a public key is safe to publish — that is the whole point of asymmetric
+ * signing.
+ *
+ * SECURITY NOTE (draft): these two keys were generated for this proof-of-concept
+ * PR. Before the first PRODUCTION signed release, regenerate a fresh keypair on an
+ * offline machine (`node build/sign-release.mjs --generate-keypair`) whose private
+ * half has NEVER touched a shared/agent environment, and replace the entries below.
+ */
+export const EMBEDDED_UPDATE_PUBLIC_KEYS: readonly string[] = [
+  // current
+  '-----BEGIN PUBLIC KEY-----\n' +
+    'MCowBQYDK2VwAyEAvxb7zIqSUpXa94lNtkp+pY4IhPK+Mm+qq3NJq9pKD0w=\n' +
+    '-----END PUBLIC KEY-----\n',
+  // next (rotation)
+  '-----BEGIN PUBLIC KEY-----\n' +
+    'MCowBQYDK2VwAyEANt9M1z7diybhHYnUBJx0P/x8AIDi65USJ+jXkmWF7qk=\n' +
+    '-----END PUBLIC KEY-----\n',
+];
+
+/** GitHub Releases asset base URL Reframe publishes installers + `.sig`s under. */
+export const UPDATE_RELEASE_BASE_URL = 'https://github.com/Prekzursil/Reframe/releases/download';
+
+/** Verifier outcome — a typed union so the caller gates the install without a try/catch. */
+export type UpdateVerifyResult = { ok: true } | { ok: false; reason: string };
+
+/** Wiring {@link verifyDownloadedUpdate} needs; ALL I/O is injected for testability. */
+export interface VerifyDownloadedUpdateDeps {
+  /** The candidate update's version (from electron-updater's `update-downloaded`). */
+  version: string;
+  /** The running app's version (`app.getVersion()`), for the downgrade guard. */
+  currentVersion: string;
+  /** Absolute local path electron-updater wrote the installer to. */
+  downloadedFile: string;
+  /** Read the downloaded installer's bytes (main binds `node:fs/promises` readFile). */
+  readFile: (path: string) => Promise<Buffer>;
+  /** Fetch the detached `.sig` (base64) for `{version, fileName}` (main binds the net GET). */
+  fetchSignature: (args: { version: string; fileName: string }) => Promise<string>;
+  /** Ed25519 keys to accept; defaults to {@link EMBEDDED_UPDATE_PUBLIC_KEYS}. */
+  publicKeys?: readonly string[];
+  /** Optional diagnostic logger (a rejection reason is invisible in a packaged build otherwise). */
+  log?: (message: string) => void;
+}
+
+/** SHA-512 of `bytes`, base64-encoded — the file digest half of the signed message. */
+export function sha512Base64(bytes: Buffer): string {
+  return createHash('sha512').update(bytes).digest('base64');
+}
+
+/**
+ * The exact bytes an update signature is computed over: a domain-separated,
+ * newline-delimited binding of the version to the file digest. Both the release
+ * signer (build/sign-release.mjs) and this verifier MUST build it identically —
+ * the exact format is pinned by updateVerify.test.ts so any drift fails the gate.
+ */
+export function buildSignedMessage(version: string, sha512Digest: string): string {
+  return `${UPDATE_MESSAGE_CONTEXT}\n${version}\n${sha512Digest}`;
+}
+
+/** The GitHub Releases URL of the `.sig` asset for `fileName` at `version`'s tag. */
+export function signatureAssetUrl(
+  version: string,
+  fileName: string,
+  base: string = UPDATE_RELEASE_BASE_URL,
+): string {
+  // encodeURIComponent both path segments so a hostile feed value cannot break out
+  // of the release path (no `..`/`/`/scheme injection) — the base host stays fixed.
+  return `${base}/v${encodeURIComponent(version)}/${encodeURIComponent(fileName)}.sig`;
+}
+
+/**
+ * True iff `signatureB64` is a valid Ed25519 signature of `message` under ANY of
+ * `publicKeys` (rotation: current OR next). NEVER throws — a malformed key or
+ * signature for one candidate is caught and the next is tried; an all-miss returns
+ * false. Ed25519 verifies the message DIRECTLY (no pre-hash), hence `verify(null, …)`.
+ */
+export function verifyEd25519(
+  message: string,
+  signatureB64: string,
+  publicKeys: readonly string[],
+): boolean {
+  const data = Buffer.from(message, 'utf8');
+  const signature = Buffer.from(signatureB64, 'base64');
+  for (const pem of publicKeys) {
+    try {
+      if (cryptoVerify(null, data, createPublicKey(pem), signature)) {
+        return true;
+      }
+    } catch {
+      // Malformed candidate key or signature length — reject this key, try the next.
+    }
+  }
+  return false;
+}
+
+/** Numeric `[major, minor, patch, …]` core of a version (before any `-pre`/`+build`). */
+function coreParts(version: string): number[] {
+  const core = version.split('+', 1)[0].split('-', 1)[0];
+  return core.split('.').map((part) => {
+    const n = Number.parseInt(part, 10);
+    return Number.isNaN(n) ? 0 : n;
+  });
+}
+
+/** The prerelease tag (after `-`, before `+`), or `''` for a final release. */
+function prereleaseTag(version: string): string {
+  const beforeBuild = version.split('+', 1)[0];
+  const dash = beforeBuild.indexOf('-');
+  return dash === -1 ? '' : beforeBuild.slice(dash + 1);
+}
+
+/** Semver-style compare: -1 if `a<b`, 0 if equal, 1 if `a>b` (release > its prerelease). */
+function compareSemver(a: string, b: string): number {
+  const ca = coreParts(a);
+  const cb = coreParts(b);
+  const len = Math.max(ca.length, cb.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (ca[i] ?? 0) - (cb[i] ?? 0);
+    if (diff !== 0) {
+      return diff < 0 ? -1 : 1;
+    }
+  }
+  const pa = prereleaseTag(a);
+  const pb = prereleaseTag(b);
+  if (pa === pb) {
+    return 0;
+  }
+  if (pa === '') {
+    return 1; // a is a final release, b is a prerelease -> a is newer
+  }
+  if (pb === '') {
+    return -1; // b is a final release, a is a prerelease -> b is newer
+  }
+  return pa < pb ? -1 : 1; // both prerelease -> lexical order
+}
+
+/**
+ * True iff `candidate` is STRICTLY newer than `current`. The downgrade guard: a
+ * compromised feed could replay an OLD release that WAS validly signed with the
+ * real key (so its signature verifies) to re-expose a since-patched vuln — the
+ * signature alone cannot stop that, only this version check can.
+ */
+export function isNotDowngrade(candidate: string, current: string): boolean {
+  return compareSemver(candidate, current) > 0;
+}
+
+/** Extract a human-readable message from an unknown thrown value. */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Build a rejection result, logging the reason (invisible in a packaged build otherwise). */
+function reject(reason: string, log: (message: string) => void): UpdateVerifyResult {
+  log(`[updateVerify] reject: ${reason}`);
+  return { ok: false, reason };
+}
+
+/**
+ * Verify a DOWNLOADED update's authenticity before it is allowed to install.
+ *
+ * Steps (each a fail-closed gate; never throws):
+ *   1. Shape guard — a blank version or file path is rejected outright.
+ *   2. Downgrade guard — {@link isNotDowngrade} blocks a signed-but-older replay.
+ *   3. Read the installer bytes + fetch its detached `.sig` (both injected I/O).
+ *   4. Recompute sha512, rebuild `version‖sha512`, and Ed25519-verify against the
+ *      embedded key(s). A mismatch (tampered file, forged/absent signature, wrong
+ *      key) is rejected.
+ *
+ * Returns `{ ok:true }` ONLY when every gate passes; otherwise `{ ok:false, reason }`.
+ */
+export async function verifyDownloadedUpdate(
+  deps: VerifyDownloadedUpdateDeps,
+): Promise<UpdateVerifyResult> {
+  const { version, currentVersion, downloadedFile } = deps;
+  const publicKeys = deps.publicKeys ?? EMBEDDED_UPDATE_PUBLIC_KEYS;
+  const log = deps.log ?? ((): void => {});
+
+  if (version === '' || downloadedFile === '') {
+    return reject('missing update version or downloaded file', log);
+  }
+  if (!isNotDowngrade(version, currentVersion)) {
+    return reject(`refusing downgrade (candidate ${version} <= current ${currentVersion})`, log);
+  }
+
+  const fileName = basename(downloadedFile);
+
+  let bytes: Buffer;
+  try {
+    bytes = await deps.readFile(downloadedFile);
+  } catch (err) {
+    return reject(`cannot read downloaded update: ${errText(err)}`, log);
+  }
+
+  let signatureB64: string;
+  try {
+    signatureB64 = await deps.fetchSignature({ version, fileName });
+  } catch (err) {
+    return reject(`cannot fetch update signature: ${errText(err)}`, log);
+  }
+  if (signatureB64 === '') {
+    return reject('update signature is empty (no .sig published?)', log);
+  }
+
+  const message = buildSignedMessage(version, sha512Base64(bytes));
+  if (!verifyEd25519(message, signatureB64, publicKeys)) {
+    return reject('signature does not match the embedded update key', log);
+  }
+  return { ok: true };
+}

--- a/app/main/updater.test.ts
+++ b/app/main/updater.test.ts
@@ -1,10 +1,12 @@
-// updater.test.ts — unit tests for the IN-PLACE AUTO-UPDATE state machine (WU-U).
+// updater.test.ts — unit tests for the AUTO-UPDATE state machine + AUTHENTICITY gate.
 //
-// Electron ipcMain is mocked; a fake `autoUpdater` (EventEmitter-like) is
-// injected so the whole event -> IPC mapping is exercised WITHOUT electron-updater
-// or a packaged app. Pins: autoDownload forced OFF, each autoUpdater event -> its
-// UpdateStatus broadcast, the check/download/quitAndInstall handlers (success +
-// graceful failure), and the disposer.
+// Electron ipcMain is mocked; a fake `autoUpdater` (EventEmitter-like) and a fake
+// verifier are injected so the whole event -> verify -> IPC mapping is exercised
+// WITHOUT electron-updater, node crypto, or a packaged app. Pins: autoDownload AND
+// autoInstallOnAppQuit forced OFF, each autoUpdater event -> its UpdateStatus
+// broadcast, the download-time verify gate (ready only on a passing signature), the
+// install gate (refused unless verified + a TOCTOU re-verify), the check/download/
+// quitAndInstall handlers (success + graceful failure), and the disposer.
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -23,9 +25,14 @@ import {
   registerUpdater,
   toPercent,
   type AutoUpdaterLike,
+  type DownloadedUpdate,
   type UpdateStatus,
   type UpdateActionResult,
 } from './updater';
+import type { UpdateVerifyResult } from './updateVerify';
+
+/** Flush pending microtasks/timers so an async verify continuation runs. */
+const tick = (): Promise<void> => new Promise((resolve) => setTimeout(resolve, 0));
 
 /** A capturing fake autoUpdater: records listeners so tests can emit events. */
 function makeAutoUpdater(over: Partial<AutoUpdaterLike> = {}): {
@@ -41,6 +48,7 @@ function makeAutoUpdater(over: Partial<AutoUpdaterLike> = {}): {
   const quitAndInstall = vi.fn();
   const autoUpdater: AutoUpdaterLike = {
     autoDownload: true,
+    autoInstallOnAppQuit: true,
     on(event: string, listener: (...args: never[]) => void) {
       listeners.set(event, listener as (arg: never) => void);
       return autoUpdater;
@@ -55,6 +63,34 @@ function makeAutoUpdater(over: Partial<AutoUpdaterLike> = {}): {
     if (fn) fn(arg as never);
   };
   return { autoUpdater, emit, checkForUpdates, downloadUpdate, quitAndInstall };
+}
+
+const okVerify = (): ReturnType<typeof vi.fn> =>
+  vi.fn(async (_c: DownloadedUpdate): Promise<UpdateVerifyResult> => ({ ok: true }));
+
+/** Wire registerUpdater with a fake autoUpdater + verifier; return the moving parts. */
+function setup(
+  opts: {
+    autoUpdater?: ReturnType<typeof makeAutoUpdater>;
+    verifyUpdate?: ReturnType<typeof vi.fn>;
+    log?: (message: string) => void;
+  } = {},
+): {
+  au: ReturnType<typeof makeAutoUpdater>;
+  broadcast: ReturnType<typeof vi.fn>;
+  verifyUpdate: ReturnType<typeof vi.fn>;
+  handle: ReturnType<typeof registerUpdater>;
+} {
+  const au = opts.autoUpdater ?? makeAutoUpdater();
+  const broadcast = vi.fn<(s: UpdateStatus) => void>();
+  const verifyUpdate = opts.verifyUpdate ?? okVerify();
+  const handle = registerUpdater({
+    autoUpdater: au.autoUpdater,
+    broadcast,
+    verifyUpdate,
+    log: opts.log,
+  });
+  return { au, broadcast, verifyUpdate, handle };
 }
 
 /** Find the ipcMain.handle callback registered for `channel`. */
@@ -85,91 +121,107 @@ describe('toPercent', () => {
 
 describe('registerUpdater — event -> IPC state machine', () => {
   it('forces autoDownload OFF (the user confirms the download)', () => {
-    const { autoUpdater } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    expect(autoUpdater.autoDownload).toBe(false);
+    const { au } = setup();
+    expect(au.autoUpdater.autoDownload).toBe(false);
+  });
+
+  it('forces autoInstallOnAppQuit OFF (no silent install-on-quit bypass)', () => {
+    const { au } = setup();
+    expect(au.autoUpdater.autoInstallOnAppQuit).toBe(false);
   });
 
   it('maps checking-for-update -> {state:checking}', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('checking-for-update');
+    const { au, broadcast } = setup();
+    au.emit('checking-for-update');
     expect(broadcast).toHaveBeenCalledWith({ state: 'checking' });
   });
 
   it('maps update-available -> {state:available, version}', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('update-available', { version: '1.4.0' });
+    const { au, broadcast } = setup();
+    au.emit('update-available', { version: '1.4.0' });
     expect(broadcast).toHaveBeenCalledWith({ state: 'available', version: '1.4.0' });
   });
 
   it('update-available with no version falls back to an empty string', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('update-available', {});
+    const { au, broadcast } = setup();
+    au.emit('update-available', {});
     expect(broadcast).toHaveBeenCalledWith({ state: 'available', version: '' });
   });
 
   it('maps update-not-available -> {state:none}', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('update-not-available', { version: '1.3.0' });
+    const { au, broadcast } = setup();
+    au.emit('update-not-available', { version: '1.3.0' });
     expect(broadcast).toHaveBeenCalledWith({ state: 'none' });
   });
 
   it('maps download-progress -> {state:progress, percent} (rounded/clamped)', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('download-progress', { percent: 37.4 });
+    const { au, broadcast } = setup();
+    au.emit('download-progress', { percent: 37.4 });
     expect(broadcast).toHaveBeenCalledWith({ state: 'progress', percent: 37 });
   });
 
-  it('maps update-downloaded -> {state:downloaded, version}', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('update-downloaded', { version: '1.4.0' });
-    expect(broadcast).toHaveBeenCalledWith({ state: 'downloaded', version: '1.4.0' });
-  });
-
-  it('update-downloaded with no version falls back to an empty string', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('update-downloaded', undefined);
-    expect(broadcast).toHaveBeenCalledWith({ state: 'downloaded', version: '' });
-  });
-
   it('maps error(Error) -> {state:error, message} and logs', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
     const log = vi.fn();
-    registerUpdater({ autoUpdater, broadcast, log });
-    emit('error', new Error('ENOTFOUND github.com'));
+    const { au, broadcast } = setup({ log });
+    au.emit('error', new Error('ENOTFOUND github.com'));
     expect(broadcast).toHaveBeenCalledWith({ state: 'error', message: 'ENOTFOUND github.com' });
     expect(log).toHaveBeenCalledWith(expect.stringContaining('ENOTFOUND github.com'));
   });
 
   it('error with a non-Error value falls back to a generic message', () => {
-    const { autoUpdater, emit } = makeAutoUpdater();
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
-    emit('error', undefined);
+    const { au, broadcast } = setup();
+    au.emit('error', undefined);
     expect(broadcast).toHaveBeenCalledWith({ state: 'error', message: 'update failed' });
+  });
+});
+
+describe('registerUpdater — download-time AUTHENTICITY gate', () => {
+  it('announces {state:downloaded} ONLY after the signature verifies', async () => {
+    const verifyUpdate = okVerify();
+    const { au, broadcast } = setup({ verifyUpdate });
+    au.emit('update-downloaded', {
+      version: '1.5.0',
+      downloadedFile: 'C:/cache/media-studio-1.5.0-win-x64.exe',
+    });
+    // Verification is async: nothing is announced synchronously.
+    expect(broadcast).not.toHaveBeenCalled();
+    await tick();
+    expect(verifyUpdate).toHaveBeenCalledWith({
+      version: '1.5.0',
+      downloadedFile: 'C:/cache/media-studio-1.5.0-win-x64.exe',
+    });
+    expect(broadcast).toHaveBeenCalledWith({ state: 'downloaded', version: '1.5.0' });
+  });
+
+  it('defaults a missing version/downloadedFile to empty strings for the verifier', async () => {
+    const verifyUpdate = okVerify();
+    const { au, broadcast } = setup({ verifyUpdate });
+    au.emit('update-downloaded', undefined);
+    await tick();
+    expect(verifyUpdate).toHaveBeenCalledWith({ version: '', downloadedFile: '' });
+    expect(broadcast).toHaveBeenCalledWith({ state: 'downloaded', version: '' });
+  });
+
+  it('a FAILED signature check broadcasts a rejection error, not {downloaded}', async () => {
+    const log = vi.fn();
+    const verifyUpdate = vi.fn(
+      async (): Promise<UpdateVerifyResult> => ({ ok: false, reason: 'bad signature' }),
+    );
+    const { au, broadcast } = setup({ verifyUpdate, log });
+    au.emit('update-downloaded', { version: '1.5.0', downloadedFile: 'C:/x.exe' });
+    await tick();
+    expect(broadcast).toHaveBeenCalledWith({
+      state: 'error',
+      message: 'Update rejected: bad signature',
+    });
+    expect(broadcast).not.toHaveBeenCalledWith(expect.objectContaining({ state: 'downloaded' }));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('bad signature'));
   });
 });
 
 describe('registerUpdater — renderer-facing ipc handlers', () => {
   it('registers exactly the check/download/quitAndInstall channels', () => {
-    const { autoUpdater } = makeAutoUpdater();
-    registerUpdater({ autoUpdater, broadcast: vi.fn() });
+    setup();
     const channels = mocks.handle.mock.calls.map((c) => c[0]);
     expect(channels).toEqual([
       UPDATE_CHECK_CHANNEL,
@@ -179,22 +231,20 @@ describe('registerUpdater — renderer-facing ipc handlers', () => {
   });
 
   it('the check handler triggers autoUpdater.checkForUpdates and resolves {ok:true}', async () => {
-    const { autoUpdater, checkForUpdates } = makeAutoUpdater();
-    registerUpdater({ autoUpdater, broadcast: vi.fn() });
+    const { au } = setup();
     const res = (await handlerFor(UPDATE_CHECK_CHANNEL)()) as UpdateActionResult;
-    expect(checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(au.checkForUpdates).toHaveBeenCalledTimes(1);
     expect(res).toEqual({ ok: true });
   });
 
   it('a failed check degrades quietly: {ok:false}, an error status, and a log', async () => {
-    const { autoUpdater } = makeAutoUpdater({
+    const au = makeAutoUpdater({
       checkForUpdates: vi.fn(async () => {
         throw new Error('offline');
       }),
     });
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
     const log = vi.fn();
-    registerUpdater({ autoUpdater, broadcast, log });
+    const { broadcast } = setup({ autoUpdater: au, log });
     const res = (await handlerFor(UPDATE_CHECK_CHANNEL)()) as UpdateActionResult;
     expect(res.ok).toBe(false);
     expect(res.reason).toBe('offline');
@@ -203,46 +253,103 @@ describe('registerUpdater — renderer-facing ipc handlers', () => {
   });
 
   it('the download handler triggers autoUpdater.downloadUpdate and resolves {ok:true}', async () => {
-    const { autoUpdater, downloadUpdate } = makeAutoUpdater();
-    registerUpdater({ autoUpdater, broadcast: vi.fn() });
+    const { au } = setup();
     const res = (await handlerFor(UPDATE_DOWNLOAD_CHANNEL)()) as UpdateActionResult;
-    expect(downloadUpdate).toHaveBeenCalledTimes(1);
+    expect(au.downloadUpdate).toHaveBeenCalledTimes(1);
     expect(res).toEqual({ ok: true });
   });
 
   it('a failed download reports {ok:false} + an error status (never throws)', async () => {
-    const { autoUpdater } = makeAutoUpdater({
+    const au = makeAutoUpdater({
       downloadUpdate: vi.fn(async () => {
         throw new Error('disk full');
       }),
     });
-    const broadcast = vi.fn<(s: UpdateStatus) => void>();
-    registerUpdater({ autoUpdater, broadcast });
+    const { broadcast } = setup({ autoUpdater: au });
     const res = (await handlerFor(UPDATE_DOWNLOAD_CHANNEL)()) as UpdateActionResult;
     expect(res).toEqual({ ok: false, reason: 'disk full' });
     expect(broadcast).toHaveBeenCalledWith({ state: 'error', message: 'disk full' });
   });
 
-  it('the install handler calls quitAndInstall (the NSIS in-place upgrade)', () => {
-    const { autoUpdater, quitAndInstall } = makeAutoUpdater();
-    registerUpdater({ autoUpdater, broadcast: vi.fn() });
-    const res = handlerFor(UPDATE_INSTALL_CHANNEL)() as UpdateActionResult;
-    expect(quitAndInstall).toHaveBeenCalledTimes(1);
-    expect(res).toEqual({ ok: true });
+  it('a non-Error string rejection is surfaced verbatim (errText string branch)', async () => {
+    const au = makeAutoUpdater({
+      downloadUpdate: vi.fn(async () => {
+        throw 'ECONNRESET peer';
+      }),
+    });
+    const { broadcast } = setup({ autoUpdater: au });
+    const res = (await handlerFor(UPDATE_DOWNLOAD_CHANNEL)()) as UpdateActionResult;
+    expect(res).toEqual({ ok: false, reason: 'ECONNRESET peer' });
+    expect(broadcast).toHaveBeenCalledWith({ state: 'error', message: 'ECONNRESET peer' });
   });
 
   it('the returned checkForUpdates helper is the same graceful path', async () => {
-    const { autoUpdater, checkForUpdates } = makeAutoUpdater();
-    const handle = registerUpdater({ autoUpdater, broadcast: vi.fn() });
+    const { au, handle } = setup();
     await expect(handle.checkForUpdates()).resolves.toEqual({ ok: true });
-    expect(checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(au.checkForUpdates).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('registerUpdater — install gate (verify + TOCTOU re-verify)', () => {
+  it('refuses to install when no update has been downloaded', async () => {
+    const { au, broadcast } = setup();
+    const res = (await handlerFor(UPDATE_INSTALL_CHANNEL)()) as UpdateActionResult;
+    expect(res).toEqual({ ok: false, reason: 'no update has been downloaded' });
+    expect(au.quitAndInstall).not.toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith({
+      state: 'error',
+      message: 'Update rejected: no update has been downloaded',
+    });
+  });
+
+  it('refuses to install a downloaded update whose signature FAILED', async () => {
+    const verifyUpdate = vi.fn(
+      async (): Promise<UpdateVerifyResult> => ({ ok: false, reason: 'forged' }),
+    );
+    const { au } = setup({ verifyUpdate });
+    au.emit('update-downloaded', { version: '1.5.0', downloadedFile: 'C:/x.exe' });
+    await tick();
+    const res = (await handlerFor(UPDATE_INSTALL_CHANNEL)()) as UpdateActionResult;
+    expect(res).toEqual({ ok: false, reason: 'update failed verification' });
+    expect(au.quitAndInstall).not.toHaveBeenCalled();
+  });
+
+  it('installs a verified update after a passing TOCTOU re-verify', async () => {
+    const verifyUpdate = okVerify();
+    const { au } = setup({ verifyUpdate });
+    au.emit('update-downloaded', {
+      version: '1.5.0',
+      downloadedFile: 'C:/cache/media-studio-1.5.0-win-x64.exe',
+    });
+    await tick();
+    const res = (await handlerFor(UPDATE_INSTALL_CHANNEL)()) as UpdateActionResult;
+    expect(res).toEqual({ ok: true });
+    expect(au.quitAndInstall).toHaveBeenCalledTimes(1);
+    // Verified once at download time, re-verified once at install time (TOCTOU).
+    expect(verifyUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  it('refuses install when the TOCTOU re-verify fails (file swapped after download)', async () => {
+    const verifyUpdate = vi
+      .fn<(c: DownloadedUpdate) => Promise<UpdateVerifyResult>>()
+      .mockResolvedValueOnce({ ok: true }) // passes at download time
+      .mockResolvedValueOnce({ ok: false, reason: 'digest changed' }); // fails at install time
+    const { au, broadcast } = setup({ verifyUpdate });
+    au.emit('update-downloaded', { version: '1.5.0', downloadedFile: 'C:/x.exe' });
+    await tick();
+    const res = (await handlerFor(UPDATE_INSTALL_CHANNEL)()) as UpdateActionResult;
+    expect(res).toEqual({ ok: false, reason: 're-verification failed: digest changed' });
+    expect(au.quitAndInstall).not.toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalledWith({
+      state: 'error',
+      message: 'Update rejected: re-verification failed: digest changed',
+    });
   });
 });
 
 describe('registerUpdater — teardown', () => {
   it('dispose removes all three handlers', () => {
-    const { autoUpdater } = makeAutoUpdater();
-    const handle = registerUpdater({ autoUpdater, broadcast: vi.fn() });
+    const { handle } = setup();
     handle.dispose();
     expect(mocks.removeHandler).toHaveBeenCalledWith(UPDATE_CHECK_CHANNEL);
     expect(mocks.removeHandler).toHaveBeenCalledWith(UPDATE_DOWNLOAD_CHANNEL);

--- a/app/main/updater.ts
+++ b/app/main/updater.ts
@@ -1,27 +1,34 @@
-// updater.ts — main-process IN-PLACE AUTO-UPDATE wiring (WU-U).
+// updater.ts — main-process IN-PLACE AUTO-UPDATE wiring (WU-U) + AUTHENTICITY gate (WU-U2).
 //
-// Reframe ships as an NSIS installer + portable zip and, until now, a new
-// version meant a manual uninstall/reinstall. This module wires
-// `electron-updater`'s `autoUpdater` to a GitHub-Releases feed so a running,
-// PACKAGED copy notices a newer release, lets the user confirm the download, and
-// then quitAndInstall()s the NSIS in-place upgrade — which PRESERVES userData
-// (the DPAPI keystore `secure-keys.json` + settings + the relocatable data root).
+// Reframe ships as an NSIS installer + portable zip; electron-updater lets a
+// running, PACKAGED copy notice a newer GitHub release, download it (user-confirmed),
+// and quitAndInstall() the NSIS in-place upgrade — which PRESERVES userData (the
+// DPAPI keystore `secure-keys.json` + settings + the relocatable data root).
+//
+// AUTHENTICITY (WU-U2): the app is UNSIGNED (no Authenticode/EV cert), and
+// electron-updater only proves INTEGRITY (the sha512 block-map in `latest.yml`) — NOT
+// authenticity. A party controlling the update feed could serve a malicious
+// `latest.yml` + installer and it would apply. This module closes that P0 by gating
+// BOTH the "downloaded -> ready" transition AND quitAndInstall() on an Ed25519
+// signature check ({@link ./updateVerify}): an update is applied ONLY when a detached
+// `.sig` over `version‖sha512(installer)` verifies against the embedded public key. A
+// compromised feed cannot forge that signature without the OFFLINE private key. The
+// install path RE-verifies immediately before quitAndInstall (closing the TOCTOU
+// window where the on-disk file could be swapped after the download-time check), and
+// `autoInstallOnAppQuit` is forced OFF so electron-updater cannot silently install a
+// downloaded update on quit WITHOUT crossing this gate.
 //
 // DECISIONS (user-chosen): GitHub feed + auto-check-on-launch, `autoDownload` OFF
 // (the user confirms in the renderer's UpdateBanner before any bytes download).
 //
-// UNSIGNED BUILD: the app has no code-signing certificate (electron-builder ships
-// with CSC off — see electron-builder.yml). electron-updater therefore skips
-// publisher-signature verification, and Windows SmartScreen may warn when the
-// downloaded installer runs. That is expected; we deliberately do NOT add signing.
-//
-// TESTABILITY: the real `autoUpdater` (an electron-updater singleton that reads
-// `app-update.yml`, only present in a packaged build) is INJECTED, mirroring the
-// injected-deps shape of `repairSetupIpc.ts`/`dataFolderIpc.ts`. main.ts casts
-// the real singleton to {@link AutoUpdaterLike} and provides the broadcast; tests
-// pass a fake so the whole event -> IPC state machine is exercised without
-// electron-updater or a packaged app. `ipcMain` is mocked in tests.
+// TESTABILITY: the real `autoUpdater` singleton and the verifier are INJECTED,
+// mirroring keystore.ts / repairSetupIpc.ts. main.ts casts the real singleton to
+// {@link AutoUpdaterLike}, binds the verifier to updateVerify.verifyDownloadedUpdate,
+// and provides the broadcast; tests pass fakes so the whole event -> verify -> IPC
+// state machine is exercised without electron-updater or a packaged app. `ipcMain`
+// is mocked in tests.
 import { ipcMain } from 'electron';
+import type { UpdateVerifyResult } from './updateVerify';
 
 /** main -> renderer: the current update lifecycle status (fan-out per window). */
 export const UPDATE_STATUS_CHANNEL = 'update.status';
@@ -36,7 +43,9 @@ export const UPDATE_INSTALL_CHANNEL = 'update.quitAndInstall';
  * The update lifecycle, as a discriminated union pushed on {@link
  * UPDATE_STATUS_CHANNEL}. Each `autoUpdater` event maps to exactly one variant so
  * the renderer's UpdateBanner can render `checking`/`available`/`progress`/
- * `downloaded`/`error`/`none` without any main-process knowledge.
+ * `downloaded`/`error`/`none` without any main-process knowledge. A FAILED
+ * authenticity check reuses the `error` variant (message `Update rejected: …`) — the
+ * renderer surface stays unchanged.
  */
 export type UpdateStatus =
   | { state: 'checking' }
@@ -46,14 +55,22 @@ export type UpdateStatus =
   | { state: 'downloaded'; version: string }
   | { state: 'error'; message: string };
 
-/** Subset of electron-updater's `UpdateInfo` this module reads. */
+/** Subset of electron-updater's `UpdateInfo`/`UpdateDownloadedEvent` this module reads. */
 export interface UpdateInfoLike {
   version?: string;
+  /** Present on `update-downloaded` (`UpdateDownloadedEvent`): the local installer path. */
+  downloadedFile?: string;
 }
 
 /** Subset of electron-updater's `ProgressInfo` this module reads. */
 export interface ProgressInfoLike {
   percent?: number;
+}
+
+/** A downloaded update awaiting (or having passed) the authenticity gate. */
+export interface DownloadedUpdate {
+  version: string;
+  downloadedFile: string;
 }
 
 /**
@@ -65,24 +82,37 @@ export interface ProgressInfoLike {
 export interface AutoUpdaterLike {
   /** OFF: the user confirms the download in the renderer before it starts. */
   autoDownload: boolean;
+  /**
+   * OFF: electron-updater's default is TRUE, which auto-installs a downloaded update
+   * on app quit via its own quit handler — WITHOUT crossing this module's IPC/verify
+   * gate. Forcing it false closes that silent auto-install-on-quit bypass.
+   */
+  autoInstallOnAppQuit: boolean;
   on(event: string, listener: (...args: never[]) => void): unknown;
   checkForUpdates(): Promise<unknown>;
   downloadUpdate(): Promise<unknown>;
   quitAndInstall(): void;
 }
 
-/** Outcome of a renderer-triggered check/download (never throws to the caller). */
+/** Outcome of a renderer-triggered check/download/install (never throws to the caller). */
 export interface UpdateActionResult {
   ok: boolean;
   reason?: string;
 }
 
-/** Wiring main.ts injects (keeps this module free of Electron window/IO). */
+/** Wiring main.ts injects (keeps this module free of Electron window/IO/crypto). */
 export interface UpdaterDeps {
   /** The electron-updater singleton (cast) — injected for testability. */
   autoUpdater: AutoUpdaterLike;
   /** Fan-out a status to every live renderer (main.ts owns the window set). */
   broadcast: (status: UpdateStatus) => void;
+  /**
+   * Verify a downloaded update's AUTHENTICITY (Ed25519 signature over
+   * `version‖sha512`). main.ts binds this to updateVerify.verifyDownloadedUpdate with
+   * the file-read + signature-fetch transport + the running app version. Injected so
+   * tests exercise the gate with a fake and this module stays crypto/Electron-free.
+   */
+  verifyUpdate: (candidate: DownloadedUpdate) => Promise<UpdateVerifyResult>;
   /** Optional main-process logger for the diagnostic breadcrumb. Default: no-op. */
   log?: (message: string) => void;
 }
@@ -116,17 +146,45 @@ export function toPercent(percent: number | undefined): number {
  * Wire `autoUpdater`'s events to {@link UPDATE_STATUS_CHANNEL} broadcasts and
  * register the three renderer-facing ipc handlers (check/download/quitAndInstall).
  *
- * Every event maps to one {@link UpdateStatus} variant; every action is wrapped so
- * a rejection becomes a loud-but-safe `{ ok:false }` + an `error` status rather
- * than an unhandled rejection. `autoDownload` is forced OFF so nothing downloads
- * until the user confirms.
+ * Every event maps to one {@link UpdateStatus} variant; every action is wrapped so a
+ * rejection becomes a loud-but-safe `{ ok:false }` + an `error` status rather than an
+ * unhandled rejection. `autoDownload` is forced OFF so nothing downloads until the
+ * user confirms; `autoInstallOnAppQuit` is forced OFF so nothing installs without
+ * crossing the authenticity gate. A downloaded update is only announced as `ready`
+ * once its Ed25519 signature verifies, and quitAndInstall is refused (and re-verified)
+ * unless that check passed.
  */
 export function registerUpdater(deps: UpdaterDeps): UpdaterHandle {
-  const { autoUpdater, broadcast } = deps;
+  const { autoUpdater, broadcast, verifyUpdate } = deps;
   const log = deps.log ?? ((): void => {});
 
-  // The user confirms the download in the UpdateBanner (autoDownload OFF).
+  // The user confirms the download in the UpdateBanner (autoDownload OFF); nothing
+  // auto-installs on quit outside the verify gate (autoInstallOnAppQuit OFF).
   autoUpdater.autoDownload = false;
+  autoUpdater.autoInstallOnAppQuit = false;
+
+  // Authenticity latch: a downloaded update is only installable once its signature
+  // verifies. `pending` is the last downloaded candidate (null until one arrives);
+  // `verified` gates the install and is reset on every fresh download.
+  let pending: DownloadedUpdate | null = null;
+  let verified = false;
+
+  const rejectUpdate = (reason: string): void => {
+    log(`[updater] update rejected: ${reason}`);
+    broadcast({ state: 'error', message: `Update rejected: ${reason}` });
+  };
+
+  /** Verify a freshly downloaded update; announce `ready` only on success. */
+  const verifyForDownload = async (candidate: DownloadedUpdate): Promise<void> => {
+    const result = await verifyUpdate(candidate);
+    if (result.ok) {
+      verified = true;
+      broadcast({ state: 'downloaded', version: candidate.version });
+    } else {
+      verified = false;
+      rejectUpdate(result.reason);
+    }
+  };
 
   autoUpdater.on('checking-for-update', () => broadcast({ state: 'checking' }));
   autoUpdater.on('update-available', (info: UpdateInfoLike) =>
@@ -136,9 +194,17 @@ export function registerUpdater(deps: UpdaterDeps): UpdaterHandle {
   autoUpdater.on('download-progress', (progress: ProgressInfoLike) =>
     broadcast({ state: 'progress', percent: toPercent(progress?.percent) }),
   );
-  autoUpdater.on('update-downloaded', (info: UpdateInfoLike) =>
-    broadcast({ state: 'downloaded', version: info?.version ?? '' }),
-  );
+  autoUpdater.on('update-downloaded', (info: UpdateInfoLike) => {
+    // AUTHENTICITY GATE: do NOT announce `downloaded`/ready until the signature
+    // verifies. Latch a fresh unverified candidate, then verify asynchronously.
+    const candidate: DownloadedUpdate = {
+      version: info?.version ?? '',
+      downloadedFile: info?.downloadedFile ?? '',
+    };
+    pending = candidate;
+    verified = false;
+    void verifyForDownload(candidate);
+  });
   autoUpdater.on('error', (err: Error) => {
     const message = errText(err);
     log(`[updater] error: ${message}`);
@@ -171,14 +237,34 @@ export function registerUpdater(deps: UpdaterDeps): UpdaterHandle {
     }
   };
 
-  ipcMain.handle(UPDATE_CHECK_CHANNEL, () => checkForUpdates());
-  ipcMain.handle(UPDATE_DOWNLOAD_CHANNEL, () => downloadUpdate());
-  ipcMain.handle(UPDATE_INSTALL_CHANNEL, (): UpdateActionResult => {
-    // quitAndInstall runs the NSIS in-place upgrade (preserves userData). It quits
-    // the app, so this resolves optimistically for the caller's fire-and-forget.
+  const refuseInstall = (reason: string): UpdateActionResult => {
+    rejectUpdate(reason);
+    return { ok: false, reason };
+  };
+
+  const quitAndInstall = async (): Promise<UpdateActionResult> => {
+    if (pending === null) {
+      return refuseInstall('no update has been downloaded');
+    }
+    if (!verified) {
+      return refuseInstall('update failed verification');
+    }
+    // TOCTOU: re-verify the on-disk installer immediately before install — its bytes
+    // could have been swapped between the download-time check and now.
+    const recheck = await verifyUpdate(pending);
+    if (!recheck.ok) {
+      verified = false;
+      return refuseInstall(`re-verification failed: ${recheck.reason}`);
+    }
+    // quitAndInstall runs the NSIS in-place upgrade (preserves userData) and quits the
+    // app, so this resolves optimistically for the caller's fire-and-forget.
     autoUpdater.quitAndInstall();
     return { ok: true };
-  });
+  };
+
+  ipcMain.handle(UPDATE_CHECK_CHANNEL, () => checkForUpdates());
+  ipcMain.handle(UPDATE_DOWNLOAD_CHANNEL, () => downloadUpdate());
+  ipcMain.handle(UPDATE_INSTALL_CHANNEL, () => quitAndInstall());
 
   const dispose = (): void => {
     ipcMain.removeHandler(UPDATE_CHECK_CHANNEL);

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -39,7 +39,17 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary'],
-      include: ['renderer/src/**/*.{ts,tsx}'],
+      // The renderer is fully gated. WU-U2 also promotes the P0 auto-update
+      // AUTHENTICITY verifier + its wiring into the 100% bar: `main/**` otherwise
+      // runs its tests but is NOT threshold-gated, and these two files are
+      // security-critical and fully unit-testable via injected fakes, so they must
+      // never silently regress below full branch coverage. The rest of `main/**`
+      // (BrowserWindow/IPC bootstrap that needs a real runtime) stays ungated.
+      include: [
+        'renderer/src/**/*.{ts,tsx}',
+        'main/updateVerify.ts',
+        'main/updater.ts',
+      ],
       exclude: [
         '**/*.test.{ts,tsx}',
         '**/*.d.ts',

--- a/build/sign-release.mjs
+++ b/build/sign-release.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+// build/sign-release.mjs — WU-U2 RELEASE-TIME signer for the auto-updater.
+//
+// NOT shipped in the app. Run AFTER `electron-builder` and BEFORE publishing, so the
+// detached `.sig` is uploaded alongside each installer:
+//
+//   node build/sign-release.mjs            # sign every dist/*-win-x64.exe
+//   node build/sign-release.mjs --generate-keypair   # make an offline keypair
+//
+// For each installer it computes sha512, builds the SAME `version‖sha512` message the
+// shipping app verifies (app/main/updateVerify.ts), Ed25519-signs it with the OFFLINE
+// private key from $REFRAME_UPDATE_PRIVATE_KEY, and writes `dist/<installer>.sig`
+// (base64). The private key is validated-present and NEVER printed/logged/committed.
+//
+// ANTI-DRIFT: the three constants/functions below (UPDATE_MESSAGE_CONTEXT,
+// buildSignedMessage, sha512Base64) MUST byte-match app/main/updateVerify.ts. That
+// exact wire format is PINNED by app/main/updateVerify.test.ts
+// ("buildSignedMessage — PINNED wire format"): if it changes there, that test fails
+// and this file must be updated in lockstep. The app can't import this .ts at
+// release time (no build step here), so the format is duplicated — and pinned.
+import { createHash, createPrivateKey, generateKeyPairSync, sign as edSign } from 'node:crypto';
+import { existsSync, readFileSync, readdirSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// --- PINNED wire format (keep identical to app/main/updateVerify.ts) ---------------
+const UPDATE_MESSAGE_CONTEXT = 'reframe:update:v1';
+
+/** SHA-512 of `bytes`, base64-encoded. */
+function sha512Base64(bytes) {
+  return createHash('sha512').update(bytes).digest('base64');
+}
+
+/** The exact bytes an update signature is computed over. */
+function buildSignedMessage(version, sha512Digest) {
+  return `${UPDATE_MESSAGE_CONTEXT}\n${version}\n${sha512Digest}`;
+}
+// -----------------------------------------------------------------------------------
+
+const PRIVATE_KEY_ENV = 'REFRAME_UPDATE_PRIVATE_KEY';
+const PASSPHRASE_ENV = 'REFRAME_UPDATE_PRIVATE_KEY_PASSPHRASE';
+const INSTALLER_SUFFIX = '-win-x64.exe';
+
+const buildDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(buildDir, '..');
+
+/** Print usage and exit. */
+function usage(code) {
+  process.stdout.write(
+    [
+      'Usage:',
+      '  node build/sign-release.mjs [--dist <dir>]   Sign every <dist>/*-win-x64.exe',
+      '  node build/sign-release.mjs --generate-keypair',
+      '',
+      `Signing reads the PEM private key from $${PRIVATE_KEY_ENV}`,
+      `(optionally decrypted with $${PASSPHRASE_ENV}).`,
+      '',
+    ].join('\n'),
+  );
+  process.exit(code);
+}
+
+/** Generate an offline Ed25519 keypair; print the halves for the human to place. */
+function generateKeypair() {
+  const { publicKey, privateKey } = generateKeyPairSync('ed25519');
+  const pub = publicKey.export({ type: 'spki', format: 'pem' }).toString().trim();
+  const priv = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString().trim();
+  process.stdout.write(
+    [
+      '# Generated an Ed25519 update-signing keypair. RUN THIS ON AN OFFLINE MACHINE.',
+      '#',
+      '# 1. PUBLIC key -> embed in app/main/updateVerify.ts EMBEDDED_UPDATE_PUBLIC_KEYS:',
+      pub,
+      '#',
+      `# 2. PRIVATE key -> store securely (e.g. a secrets manager) and export as`,
+      `#    $${PRIVATE_KEY_ENV} at release time. NEVER commit it or paste it anywhere shared.`,
+      priv,
+      '',
+    ].join('\n'),
+  );
+}
+
+/** Load the offline private key from the environment; fail loud if absent/invalid. */
+function loadPrivateKey() {
+  const pem = process.env[PRIVATE_KEY_ENV];
+  if (!pem) {
+    process.stderr.write(
+      `[sign-release] FAILED: $${PRIVATE_KEY_ENV} is not set. Export the offline Ed25519 ` +
+        'PEM private key before signing (see --generate-keypair).\n',
+    );
+    process.exit(1);
+  }
+  const passphrase = process.env[PASSPHRASE_ENV];
+  try {
+    return createPrivateKey(passphrase ? { key: pem, passphrase } : pem);
+  } catch (err) {
+    process.stderr.write(`[sign-release] FAILED: could not load the private key: ${err.message}\n`);
+    process.exit(1);
+    return undefined; // unreachable — exit above
+  }
+}
+
+/** Sign every installer in `distDir`, writing a sibling `.sig`. */
+function signInstallers(distDir) {
+  if (!existsSync(distDir)) {
+    process.stderr.write(`[sign-release] FAILED: dist dir not found: ${distDir}\n`);
+    process.exit(1);
+  }
+  const version = JSON.parse(readFileSync(join(repoRoot, 'app', 'package.json'), 'utf8')).version;
+  const installers = readdirSync(distDir).filter((name) => name.endsWith(INSTALLER_SUFFIX));
+  if (installers.length === 0) {
+    process.stderr.write(
+      `[sign-release] FAILED: no *${INSTALLER_SUFFIX} found in ${distDir} — run electron-builder first.\n`,
+    );
+    process.exit(1);
+  }
+  const privateKey = loadPrivateKey();
+  for (const name of installers) {
+    if (!name.includes(version)) {
+      process.stderr.write(
+        `[sign-release] WARNING: ${name} does not contain package version ${version}; ` +
+          'the app verifies against the FEED version — make sure they match.\n',
+      );
+    }
+    const installerPath = join(distDir, name);
+    const digest = sha512Base64(readFileSync(installerPath));
+    const message = buildSignedMessage(version, digest);
+    const signature = edSign(null, Buffer.from(message, 'utf8'), privateKey).toString('base64');
+    const sigPath = `${installerPath}.sig`;
+    writeFileSync(sigPath, `${signature}\n`, 'utf8');
+    process.stdout.write(`[sign-release] signed ${name} -> ${name}.sig (v${version})\n`);
+  }
+  process.stdout.write(
+    `[sign-release] OK: signed ${installers.length} installer(s). Upload the .sig assets ` +
+      'alongside the installers (gh release upload <tag> dist/*.sig).\n',
+  );
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.includes('--help') || args.includes('-h')) {
+    usage(0);
+  }
+  if (args.includes('--generate-keypair')) {
+    generateKeypair();
+    return;
+  }
+  const distFlag = args.indexOf('--dist');
+  const distDir = distFlag !== -1 && args[distFlag + 1] ? args[distFlag + 1] : join(repoRoot, 'dist');
+  signInstallers(distDir);
+}
+
+main();

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -11,7 +11,12 @@
 #   2. cd app && npm run build               # electron-vite -> app/out
 #   3. cd app/render-cli && npm run bundle   # T4a: writes render-cli/out/remotion-bundle
 #   4. cd app && npx electron-builder --config ../electron-builder.yml --win
+#   4b. node build/sign-release.mjs          # WU-U2: Ed25519-sign each dist/*-win-x64.exe over
+#                                            #   version‖sha512 (needs $REFRAME_UPDATE_PRIVATE_KEY)
+#                                            #   -> dist/<installer>.sig (the app verifies this)
 #   5. build/make-portable.ps1               # optional: zip + slim/size assertions
+#   6. publish: electron-builder --publish always, THEN gh release upload v<version> dist/*.sig
+#      so the signatures ship alongside the installer + latest.yml on the release.
 #
 # Paths below are relative to the PROJECT dir (app/), because the build runs
 # from app/ with `--config ../electron-builder.yml`.
@@ -23,9 +28,14 @@ productName: Reframe
 # manifest electron-updater polls) and the NSIS `.blockmap` (enables delta
 # downloads — only changed blocks are fetched) alongside the installer, and (b)
 # bundle `app-update.yml` INTO the app so a running copy knows where to check.
-# Signing stays OFF (no CSC): this is an unsigned build, so Windows SmartScreen
-# may warn when the downloaded installer runs. Publishing is a human/CI step
-# (`electron-builder --publish` with a GH_TOKEN); the build itself never auto-uploads.
+# OS CODE-SIGNING stays OFF (no CSC): this is an unsigned build, so Windows
+# SmartScreen may warn when the downloaded installer runs. AUTHENTICITY is instead
+# enforced at the APP layer (WU-U2): build/sign-release.mjs Ed25519-signs each
+# installer over `version‖sha512` and the `<installer>.sig` asset is verified against
+# the embedded public key before an update is applied (app/main/updateVerify.ts) — so
+# a compromised feed cannot ship a forged installer. Publishing is a human/CI step
+# (`electron-builder --publish` with a GH_TOKEN, then `gh release upload` for the
+# .sig assets); the build itself never auto-uploads.
 publish:
   provider: github
   owner: Prekzursil


### PR DESCRIPTION
## Summary

Closes the audit **P0**: the in-place auto-updater proved **integrity** (electron-updater checks the SHA-512 block-map in `latest.yml`) but **not authenticity** — a party controlling the update feed could serve a malicious `latest.yml` + installer and it would apply. The app is unsigned (no Authenticode/EV cert), so there was no OS-level publisher check either.

This adds a **free, offline, zero-runtime-dependency** authenticity gate: **Ed25519 detached signatures** over `version‖sha512(installer)`, signed at release time with an **offline** private key and verified fully offline inside the shipping app against an **embedded public key** — using Node's built-in `crypto` only (no `@noble`/Sigstore/TUF, no new lockfile/CVE surface). A compromised feed cannot forge a valid signature without the offline private key.

Chosen approach = **Option 1** from the trust plan (the minisign / Doyensec-SafeUpdater design). It is the only option needing **no certificate and no CI-build migration**, fitting Reframe's current manual, human-run local release. GitHub build-provenance attestations (Option 2) remain the right *later* hardening once/if the build moves into Actions — layered on top, not replacing this.

## What it does

- **Gates the `downloaded → ready` transition.** A downloaded update is only announced `ready` once its `.sig` verifies; a failed check broadcasts `Update rejected: …` (reuses the existing `error` status — no renderer change).
- **Gates `quitAndInstall()` with a TOCTOU re-verify.** Install is refused unless verified, and the on-disk installer is **re-verified immediately before install** (closing the window where the file could be swapped after the download-time check).
- **Forces `autoInstallOnAppQuit = false`.** electron-updater's default (`true`) auto-installs a downloaded update on app quit via its own quit handler — *without* crossing this gate. This closes that confirmed silent-install-on-quit bypass. (`autoDownload` stays OFF as before.)
- **Binds `version‖sha512(file)`**, so the signature blocks **tampering** (wrong digest) **and** a **downgrade replay** of an old-but-validly-signed release (`isNotDowngrade` strict-newer guard — the signature alone can't stop a genuine old release being replayed to re-expose a patched vuln).
- **Fails closed.** The verifier is a pure function that never throws — every failure (missing/empty/forged `.sig`, unreadable file, wrong key, downgrade) is a typed `{ ok:false, reason }`.

## Files

| File | Change |
|---|---|
| `app/main/updateVerify.ts` | **NEW** — pure verifier (only `node:crypto` + `node:path`, all I/O injected): `EMBEDDED_UPDATE_PUBLIC_KEYS`, `buildSignedMessage`, `sha512Base64`, `verifyEd25519`, `isNotDowngrade`, `signatureAssetUrl`, `verifyDownloadedUpdate`. |
| `app/main/updateVerify.test.ts` | **NEW** — 27 tests, real Ed25519 round-trips with ephemeral keys (no private key in repo). |
| `app/main/updater.ts` | Inject `verifyUpdate`; add `autoInstallOnAppQuit` (forced false) + `downloadedFile`; gate download/install; TOCTOU re-verify. |
| `app/main/updater.test.ts` | +25 tests: verify-gated download, install gate, TOCTOU re-verify, `autoInstallOnAppQuit` off, errText string branch. |
| `app/main/main.ts` | Bind `verifyDownloadedUpdate` (`fsp.readFile` + a `net.fetch` `.sig` transport to a fixed github.com release path); `app.getVersion()` for the downgrade check. |
| `app/vitest.config.ts` | Promote `main/updateVerify.ts` + `main/updater.ts` into the **100% branch** coverage gate. |
| `build/sign-release.mjs` | **NEW** — release-time signer: `REFRAME_UPDATE_PRIVATE_KEY` (offline) → sign each `dist/*-win-x64.exe` → `dist/<installer>.sig`. `--generate-keypair` helper. |
| `electron-builder.yml` | Docs only: add build step 4b (sign) + reconcile the "signing off" narrative (OS Authenticode still off; app-layer Ed25519 authenticity now on). No packaging-field change. |

## Release flow (human/CI step — no new workflow)

There is no release workflow today (only quality/mutation/e2e), so signing stays a documented release step:

```
npx electron-builder --config ../electron-builder.yml --win     # build
node build/sign-release.mjs                                      # sign -> dist/*.sig
electron-builder --publish always                               # installer + latest.yml
gh release upload v<version> dist/*.sig                          # ship signatures
```

## ⚠️ Key management (read before merging / first signed release)

`EMBEDDED_UPDATE_PUBLIC_KEYS` currently holds **two real, valid Ed25519 public keys generated for this PoC**. A public key is safe to publish — but their private halves briefly existed in an automated session, so **before your first production signed release**, regenerate a keypair on an **offline** machine (`node build/sign-release.mjs --generate-keypair`) whose private half has never touched a shared environment, and replace the embedded entries. The placeholder private keys were delivered to you **out-of-band** (not in this repo/PR) purely so the signed path can be exercised — do **not** use them in production.

## Testing (run locally in an isolated clone)

- `npx tsc --noEmit` → **pass**
- `npm run test:coverage` (full gate:3) → **pass**, **100%** lines/branches/functions/statements (17247/17247 stmts, 5825/5825 branches); `updateVerify.ts` + `updater.ts` both 100%.
- 3151 tests pass (52 new/updated in the two updater suites).
- `pre-commit run --all-files` (gate:1 + gate:5: ruff, oxlint `--deny-warnings`, biome, gitleaks) → **all Passed**.
- **Not run locally** (heavy env — CI verifies): opengrep SAST (gate:4), osv-scanner (gate:6 — **unaffected: zero new runtime dependencies**), basedpyright + pytest (Python sidecar untouched).

## Deferred (out of scope, by design)

- **Electron 39 → 43 upgrade** — intentionally a separate PR (orthogonal; a combined PR couldn't distinguish an auto-update break caused by the major bump from one caused by the new gate). Ship authenticity first; the Electron-bump release then exercises the signed path.
- **GitHub build-provenance attestations (Option 2)** — layer on top once/if the installer build moves into Actions (`actions/attest-build-provenance`).
- A dedicated `{ state: 'rejected' }` `UpdateStatus` variant (verify failure reuses `error` to keep the renderer surface untouched).

Draft: opened for review of the security design + key-management decision before the keys are finalized.
