### PR TITLE
feat: v1.5 shell — token reconciliation + content-first Library + left rail

### DIFF
--- a/app/renderer/src/components/TopTabBar.test.tsx
+++ b/app/renderer/src/components/TopTabBar.test.tsx
@@ -64,6 +64,13 @@ describe('TopTabBar — rendering + ARIA', () => {
     expect(container.querySelectorAll('[data-testid="icon"]')).toHaveLength(3);
   });
 
+  it('marks the tablist vertical (role-complete left rail)', () => {
+    render('library', () => {});
+    expect(container.querySelector('[role="tablist"]')!.getAttribute('aria-orientation')).toBe(
+      'vertical',
+    );
+  });
+
   it('accepts a custom tablist label', () => {
     render('library', () => {});
     act(() => {
@@ -158,6 +165,38 @@ describe('TopTabBar — keyboard model', () => {
     const onSelect = vi.fn();
     render('library', onSelect);
     press(tab('Library'), 'ArrowLeft');
+    expect(onSelect).toHaveBeenCalledWith('repurpose');
+    expect(document.activeElement).toBe(tab('Repurpose'));
+  });
+
+  it('ArrowDown moves to the next tab (vertical rail) and focuses it', () => {
+    const onSelect = vi.fn();
+    render('library', onSelect);
+    press(tab('Library'), 'ArrowDown');
+    expect(onSelect).toHaveBeenCalledWith('create');
+    expect(document.activeElement).toBe(tab('Create'));
+  });
+
+  it('ArrowDown wraps from the last tab to the first', () => {
+    const onSelect = vi.fn();
+    render('repurpose', onSelect);
+    press(tab('Repurpose'), 'ArrowDown');
+    expect(onSelect).toHaveBeenCalledWith('library');
+    expect(document.activeElement).toBe(tab('Library'));
+  });
+
+  it('ArrowUp moves to the previous tab (vertical rail)', () => {
+    const onSelect = vi.fn();
+    render('create', onSelect);
+    press(tab('Create'), 'ArrowUp');
+    expect(onSelect).toHaveBeenCalledWith('library');
+    expect(document.activeElement).toBe(tab('Library'));
+  });
+
+  it('ArrowUp wraps from the first tab to the last', () => {
+    const onSelect = vi.fn();
+    render('library', onSelect);
+    press(tab('Library'), 'ArrowUp');
     expect(onSelect).toHaveBeenCalledWith('repurpose');
     expect(document.activeElement).toBe(tab('Repurpose'));
   });

--- a/app/renderer/src/components/TopTabBar.tsx
+++ b/app/renderer/src/components/TopTabBar.tsx
@@ -1,14 +1,20 @@
-// TopTabBar.tsx — the application's TOP-LEVEL tabbed navigation.
+// TopTabBar.tsx — the application's TOP-LEVEL navigation, presented as a vertical
+// LEFT RAIL (v1.5 pro-shell). Despite the historical name it renders a rail, not
+// a top strip; the swap is PRESENTATIONAL ONLY — the component API, ids, roles,
+// and routing contract are unchanged (App still derives `active` from the route).
 //
-// This is the primary surface switcher (Library · Create · Director · Repurpose ·
-// Settings). It is a full ARIA tablist (role=tablist/tab), distinct from the
-// lightweight `TabBar` used for in-view sub-tabs (Workspace/Repurpose/Settings):
+// This is the primary surface switcher (Library · Make Shorts · Edit · Director ·
+// Settings). It is a full ARIA tablist (role=tablist/tab) with
+// aria-orientation="vertical" (the role-complete rail), distinct from the
+// lightweight `TabBar` used for in-view sub-tabs:
 //   * roving tabindex — exactly ONE tab is in the tab order at a time; the rest
-//     are reached with the arrow keys (WAI-ARIA "tabs with manual activation"…
-//     here automatic: arrow moves selection AND focus, which suits a router),
-//   * ArrowLeft/ArrowRight wrap around the ends; Home/End jump to first/last,
+//     are reached with the arrow keys (arrow moves selection AND focus, which
+//     suits a router),
+//   * ArrowUp/ArrowDown are the primary axis for the vertical rail, with
+//     ArrowLeft/ArrowRight kept as equivalents; all four wrap around the ends;
+//     Home/End jump to first/last,
 //   * each tab is wired to its panel via id ↔ aria-controls / aria-labelledby,
-//   * the active tab is unmistakable: accent color + a 2px accent underline +
+//   * the active tab is unmistakable: accent color + a 2px accent EDGE BAR +
 //     aria-selected="true" (color is NOT the only signal),
 //   * icons are inline Lucide-style 24×24 SVGs (never emoji), decorative
 //     (aria-hidden) since the visible label carries the accessible name.
@@ -46,11 +52,11 @@ export function topTabPanelId(id: string): string {
 }
 
 /**
- * The top-level tab strip. Keyboard model (roving tabindex + arrow nav):
- *   ArrowRight → next tab (wraps to first past the end)
- *   ArrowLeft  → previous tab (wraps to last before the start)
- *   Home       → first tab
- *   End        → last tab
+ * The left navigation rail. Keyboard model (roving tabindex + arrow nav):
+ *   ArrowDown / ArrowRight → next tab (wraps to first past the end)
+ *   ArrowUp   / ArrowLeft  → previous tab (wraps to last before the start)
+ *   Home                   → first tab
+ *   End                    → last tab
  * Any other key is a no-op (native button click/Enter/Space still activate).
  */
 export function TopTabBar({
@@ -74,12 +80,13 @@ export function TopTabBar({
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, index: number): void => {
     const last = tabs.length - 1;
-    if (event.key === 'ArrowRight') {
+    // Vertical rail: Down/Up are the primary axis; Right/Left kept as equivalents.
+    if (event.key === 'ArrowDown' || event.key === 'ArrowRight') {
       event.preventDefault();
       move(index === last ? 0 : index + 1);
       return;
     }
-    if (event.key === 'ArrowLeft') {
+    if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
       event.preventDefault();
       move(index === 0 ? last : index - 1);
       return;
@@ -98,7 +105,7 @@ export function TopTabBar({
   };
 
   return (
-    <div className="toptabs" role="tablist" aria-label={label}>
+    <div className="toptabs" role="tablist" aria-orientation="vertical" aria-label={label}>
       {tabs.map((tab, index) => {
         const isActive = tab.id === active;
         return (

--- a/app/renderer/src/components/library-cards.css
+++ b/app/renderer/src/components/library-cards.css
@@ -7,7 +7,8 @@
 
 ul.library__list {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  /* v1.5 content-first grid — the validated responsive model. */
+  grid-template-columns: repeat(auto-fill, minmax(215px, 1fr));
   gap: var(--space-5);
   padding: var(--space-4) var(--space-6) var(--space-6);
   align-content: start;
@@ -19,6 +20,7 @@ ul.library__list {
    (keyboard/SR-native), so the card-lift visuals live on it; the <li> is a
    plain stretch container that also carries the raised surface tone. */
 li.library__item {
+  position: relative;
   flex-direction: column;
   align-items: stretch;
   justify-content: flex-start;
@@ -140,4 +142,76 @@ li.library__item:hover .library__thumb-img {
   font-weight: var(--type-caption-weight);
   font-variant-numeric: tabular-nums;
   line-height: var(--type-caption-leading);
+}
+
+/* ---- v1.5 card additions: multi-select, badges, shorts label, meta ---- */
+
+/* Multi-select checkbox: an overlay on the poster top-left. Quiet at rest, it
+   surfaces on hover/focus-within and stays lit while checked (it's the batch
+   scale affordance, not chrome on every card at all times). */
+.library__select {
+  position: absolute;
+  top: var(--space-3);
+  left: var(--space-3);
+  z-index: 2;
+  display: flex;
+  opacity: 0;
+  transition: opacity var(--dur-fast) var(--ease-out);
+}
+
+li.library__item:hover .library__select,
+li.library__item:focus-within .library__select,
+.library__select:has(.library__select-box:checked) {
+  opacity: 1;
+}
+
+.library__select-box {
+  width: var(--size-icon);
+  height: var(--size-icon);
+  margin: 0;
+  accent-color: var(--accent);
+  cursor: pointer;
+}
+
+/* The FAILED attention badge: the only place status red appears on a card; the
+   Transcript chip keeps the neutral base .library__chip look (from shell.css). */
+.library__badge.library__chip--failed {
+  background: var(--status-error-soft);
+  color: var(--status-error);
+}
+
+.library__badge.library__chip--failed::before {
+  background: var(--status-error);
+}
+
+/* Quiet "Added <date>" meta line — additive, never a duplicate of a badge. */
+.library__item-added {
+  color: var(--text-faint);
+  font-size: var(--type-caption-size);
+}
+
+/* "N shorts" label opens the produced-shorts gallery. Deliberately NEUTRAL (a
+   navigation affordance, not a status/progress signal) so amber stays reserved;
+   the count text itself is the done-signal. Seats to the leading edge; Remove
+   trails. */
+.library__shorts-label {
+  appearance: none;
+  margin-right: auto;
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pill);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: var(--type-caption-size);
+  font-weight: var(--weight-semibold);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.library__shorts-label:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
 }

--- a/app/renderer/src/components/library-shell.css
+++ b/app/renderer/src/components/library-shell.css
@@ -1,0 +1,288 @@
+/* library-shell.css — v1.5 Library chrome that sits OUTSIDE the card grid
+   (library-cards.css): the capabilities disclosure chip, the search/sort +
+   multi-select toolbar, and the produced-shorts glass modal. All values are
+   tokens (styles/tokens.css); depth comes from the surface ladder + elevation,
+   the ONE accent stays amber, status stays green/amber/red. */
+
+/* ---- capabilities disclosure chip ---------------------------------------- */
+
+.capabilities-chip {
+  margin: 0 var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.capabilities-chip__toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  align-self: flex-start;
+  max-width: 100%;
+  padding: var(--control-pad-mini);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pill);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  box-shadow: var(--elev-1);
+  font-family: var(--font-ui);
+  font-size: var(--type-caption-size);
+  font-weight: var(--weight-semibold);
+  letter-spacing: var(--type-caption-tracking);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.capabilities-chip__toggle:hover:not(:disabled) {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.capabilities-chip__toggle:disabled {
+  cursor: default;
+  color: var(--text-faint);
+}
+
+.capabilities-chip__caret {
+  color: var(--text-faint);
+  font-size: var(--type-chip-size);
+}
+
+.capabilities-chip__error {
+  margin: 0;
+  color: var(--status-error);
+  font-size: var(--type-caption-size);
+}
+
+.capabilities-chip__list {
+  list-style: none;
+  margin: 0;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+  box-shadow: var(--elev-2);
+}
+
+.capabilities-chip__row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+}
+
+.capabilities-chip__cap {
+  color: var(--text-secondary);
+  font-size: var(--type-body-size);
+}
+
+/* ---- search / sort + multi-select toolbar -------------------------------- */
+
+.library-toolbar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  flex-wrap: wrap;
+  padding: var(--space-4) var(--space-6) var(--space-2);
+}
+
+.library-toolbar__filters {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex: 1;
+  min-width: 0;
+}
+
+.library-toolbar__search {
+  flex: 1;
+  min-width: 0;
+  max-width: 360px;
+  padding: var(--control-pad-input);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--surface-deep);
+  color: var(--text-primary);
+  font-family: var(--font-ui);
+  font-size: var(--type-body-size);
+}
+
+.library-toolbar__search::placeholder {
+  color: var(--text-faint);
+}
+
+.library-toolbar__sort {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.library-toolbar__sort-label {
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+}
+
+.library-toolbar__sort-select {
+  padding: var(--control-pad-input);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: var(--type-control-size);
+  cursor: pointer;
+}
+
+/* Batch bar: a NEUTRAL raised strip (selection is an active mode, but amber stays
+   reserved for progress/approve); the destructive action goes red only on hover. */
+.library-toolbar__batch {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pill);
+  background: var(--surface-raised);
+  box-shadow: var(--elev-1);
+}
+
+.library-toolbar__batch-count {
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+  font-weight: var(--weight-semibold);
+}
+
+.library-toolbar__batch-remove,
+.library-toolbar__batch-clear {
+  appearance: none;
+  padding: var(--control-pad-mini);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background: var(--surface-bg);
+  color: var(--text-secondary);
+  font-family: var(--font-ui);
+  font-size: var(--type-control-size);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.library-toolbar__batch-remove:hover {
+  color: var(--status-error);
+  border-color: var(--status-error);
+}
+
+.library-toolbar__batch-clear:hover {
+  color: var(--text-primary);
+  border-color: var(--edge-strong);
+}
+
+/* ---- produced-shorts glass modal (Wave-2 glass layer) -------------------- */
+
+.shorts-modal__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-6);
+  background: var(--overlay-scrim);
+  animation: shorts-modal-fade var(--dur-base) var(--ease-out);
+}
+
+.shorts-modal {
+  width: 100%;
+  max-width: var(--overlay-width);
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-lg);
+  /* The glass layer: the raised plane at reduced opacity + a backdrop blur. */
+  background: var(--surface-glass);
+  backdrop-filter: blur(var(--glass-blur));
+  box-shadow: var(--shadow-overlay);
+  animation: shorts-modal-rise var(--dur-slow) var(--ease-out);
+}
+
+.shorts-modal__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-5);
+  border-bottom: 1px solid var(--edge);
+}
+
+.shorts-modal__title {
+  margin: 0;
+  /* The editorial serif finally earns its (evolved) token here. */
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.shorts-modal__close {
+  appearance: none;
+  width: var(--size-icon);
+  height: var(--size-icon);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: var(--type-card-title-size);
+  line-height: 1;
+  cursor: pointer;
+}
+
+.shorts-modal__close:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.shorts-modal__body {
+  padding: var(--space-5);
+  overflow-y: auto;
+}
+
+.shorts-modal__empty {
+  margin: 0;
+  color: var(--text-faint);
+  text-align: center;
+}
+
+@keyframes shorts-modal-fade {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes shorts-modal-rise {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -62,13 +62,24 @@ body,
 
 /* ---- app chrome -------------------------------------------------------------- */
 
+/* v1.5 pro-shell: a three-zone grid — the app bar spans the top; below it the
+   vertical nav RAIL (components/topTabBar.css .toptabs, `rail` area) sits left of
+   the stage (`main` area). Presentational only: App.tsx renders bar → rail → main
+   as before; grid-area placement, not source order, positions them, so no DOM or
+   routing change was needed to move the nav from a top strip to a left rail. */
 .app {
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-template-rows: auto 1fr;
+  grid-template-areas:
+    "bar bar"
+    "rail main";
   height: 100%;
+  min-height: 0;
 }
 
 .app__bar {
+  grid-area: bar;
   display: flex;
   align-items: center;
   gap: var(--space-5);
@@ -303,8 +314,11 @@ body,
 /* .app__jobs-toggle lives in jobqueue.css; both consume the same tokens. */
 
 .app__main {
-  flex: 1;
+  grid-area: main;
   min-height: 0;
+  /* min-width:0 lets the stage shrink instead of a wide child (a table, the
+     timeline) forcing horizontal overflow of the whole shell at narrow widths. */
+  min-width: 0;
   display: flex;
   flex-direction: column;
 }

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -526,15 +526,9 @@ button {
   line-height: var(--type-display-leading);
 }
 
-/* WU-D4 gutter unify: the "what works right now" roll-up ships from its shared
-   component with NO inset, so at rest its eyebrow + status line sit flush at x=0
-   — left of the title, the skeleton, and the card list (four ragged left edges).
-   Library-scope a --space-6 inset so those two lines land on the SAME left gutter
-   as the header title and the card column, reading the home view as one column.
-   Scoped to `.library >` so the identical roll-up on the model panel is untouched. */
-.library > .readiness-rollup {
-  padding: 0 var(--space-6);
-}
+/* v1.5: the always-open readiness roll-up became the CapabilitiesChip disclosure
+   (views/CapabilitiesChip.tsx + library-shell.css), which owns its own gutter — so
+   the former `.library > .readiness-rollup` inset rule is retired here. */
 
 .library__add {
   display: flex;

--- a/app/renderer/src/components/topTabBar.css
+++ b/app/renderer/src/components/topTabBar.css
@@ -1,34 +1,42 @@
-/* topTabBar.css — the application's top-level tab strip (components/TopTabBar.tsx).
-   Distinct from the in-view `.tabbar`/`.tab` sub-tabs: this is the chrome-level
-   surface switcher under the app bar. All values are tokens (styles/tokens.css);
-   the dark theme + global focus ring + reduced-motion rules come from shell.css.
-   The active tab is unmistakable: accent text + icon AND a 2px accent underline
-   (color is never the only signal). */
+/* topTabBar.css — the application's primary navigation, presented as a vertical
+   LEFT RAIL (v1.5 pro-shell). Despite the name it is a rail, not a top strip;
+   the swap is PRESENTATIONAL — the component keeps its ARIA tablist role, ids,
+   and routing contract (see components/TopTabBar.tsx). It is placed into the
+   `rail` grid area by the `.app` grid in shell.css.
+   All values are tokens (styles/tokens.css); the dark theme + global focus ring
+   + reduced-motion rules come from shell.css. The active item is unmistakable:
+   accent text + icon + wash AND a 2px accent EDGE BAR (color is never alone). */
 
 .toptabs {
+  grid-area: rail;
   display: flex;
-  align-items: stretch;
+  flex-direction: column;
   gap: var(--space-1);
-  padding: 0 var(--space-5);
+  padding: var(--space-4) var(--space-3);
+  width: 200px;
   flex: none;
-  background: var(--surface-raised);
-  box-shadow: inset 0 -1px 0 var(--edge);
+  overflow-y: auto;
+  /* Top-lit raised plane + a right hairline SEAM dividing rail from stage. */
+  background: var(--atmos-toplight), var(--surface-raised);
+  box-shadow: inset -1px 0 0 var(--edge);
 }
 
 .toptab {
   appearance: none;
   position: relative;
-  display: inline-flex;
+  display: flex;
   align-items: center;
   gap: var(--space-3);
+  width: 100%;
   padding: var(--control-pad-toptab);
   border: none;
-  border-radius: var(--radius-sm) var(--radius-sm) 0 0;
+  border-radius: var(--radius-sm);
   background: transparent;
   color: var(--text-muted);
   font-family: var(--font-ui);
   font-size: var(--type-control-size);
   font-weight: var(--weight-medium);
+  text-align: left;
   cursor: pointer;
   /* Color/background shift only — no layout-bound props, so no hover jump. */
   transition:
@@ -36,24 +44,29 @@
     background var(--dur-fast) var(--ease-out);
 }
 
-/* The active underline. A pseudo-element so it never affects layout (no shift
-   between active/inactive); animates the accent in. */
+/* The active EDGE BAR: a left accent bar (was a bottom underline on the old top
+   strip). A pseudo-element so it never affects layout (no shift between
+   active/inactive); it grows in from zero height when the tab becomes active. */
 .toptab::after {
   content: "";
   position: absolute;
-  left: 10px;
-  right: 10px;
-  bottom: 0;
-  height: 2px;
-  border-radius: 2px 2px 0 0;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 2px;
+  height: 0;
+  border-radius: 0 2px 2px 0;
   background: transparent;
-  transition: background var(--dur-base) var(--ease-out);
+  transition:
+    height var(--dur-base) var(--ease-out),
+    background var(--dur-base) var(--ease-out);
 }
 
 .toptab__icon {
   display: inline-flex;
   width: var(--size-icon);
   height: var(--size-icon);
+  flex: none;
 }
 
 /* 24×24 source SVGs scaled down to the 18px chrome slot. */
@@ -62,16 +75,23 @@
   height: 100%;
 }
 
+/* The label takes the remaining width and truncates rather than widening the
+   rail, so a long surface name can never force horizontal overflow. */
 .toptab__label {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   white-space: nowrap;
 }
 
-/* Pending-count badge (e.g. interrupted Repurpose batches): a quiet accent chip,
-   tabular so multi-digit counts don't jitter. */
+/* Pending-count badge (e.g. interrupted Make Shorts batches): a quiet accent
+   chip, tabular so multi-digit counts don't jitter. Seats to the trailing edge. */
 .toptab__badge {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  flex: none;
   min-width: var(--size-icon);
   height: var(--size-icon);
   padding: 0 var(--space-2);
@@ -89,13 +109,14 @@
 }
 
 .toptab:hover::after {
+  height: 40%;
   background: var(--edge-strong);
 }
 
-/* Active: accent text + icon + a gentle accent WASH seating it into the strip +
-   an accent underline. Softer than a stark text-flip — the wash reads as a
-   designed, integrated active state; the underline is a second (shape) signal so
-   it is never colour-alone. */
+/* Active: accent text + icon + a gentle accent WASH seating it into the rail +
+   the accent edge bar. Softer than a stark text-flip — the wash reads as a
+   designed, integrated active state; the bar is a second (shape) signal so it is
+   never colour-alone. */
 .toptab--active {
   color: var(--accent);
   background: var(--accent-soft);
@@ -108,5 +129,15 @@
 
 .toptab--active::after,
 .toptab--active:hover::after {
+  height: 60%;
   background: var(--accent);
+}
+
+/* Narrow windows: tighten the rail so the stage keeps room, labels still truncate
+   (never hidden — the visible label is the tab's accessible name). */
+@media (max-width: 720px) {
+  .toptabs {
+    width: 168px;
+    padding: var(--space-3) var(--space-2);
+  }
 }

--- a/app/renderer/src/styles/tokens.conformance.test.ts
+++ b/app/renderer/src/styles/tokens.conformance.test.ts
@@ -465,3 +465,106 @@ describe('no undefined custom-property references in renderer CSS (WU-D7)', () =
     expect(offenders).toEqual([]);
   });
 });
+
+// --- v1.5 pro-shell token evolution (Wave-2) -------------------------------------
+//
+// The v1.5 redesign consumes the SHIPPED tokens (never the prototype's literal
+// hex — §5.A) and evolves the layer DELIBERATELY (§5.B): real bundled type faces
+// leading the UI / editorial / mono families, and a glass / floating-surface
+// layer for the produced-shorts modal (and the Cmd-K palette when it ships,
+// §7.5). These are the LOCK on that evolution — additive to the guards above,
+// never a weakening of them. A font family that decays back to a bare generic
+// (`system-ui` / `Georgia` / `ui-monospace` leading), or a glass layer that
+// loses its translucency / blur, fails here.
+
+/** The FIRST family in a `font-family` list (before the first comma), trimmed. */
+function leadFamily(value: string): string {
+  return (value.split(',')[0] ?? '').trim().replace(/^["']|["']$/g, '');
+}
+
+/** The alpha channel of an `rgba(r,g,b,a)` value, or NaN when not an rgba(). */
+function rgbaAlpha(value: string): number {
+  const m = /rgba\(\s*[\d.]+\s*,\s*[\d.]+\s*,\s*[\d.]+\s*,\s*([\d.]+)\s*\)/.exec(value);
+  return m ? Number.parseFloat(m[1]) : Number.NaN;
+}
+
+describe('v1.5 shell token evolution — type faces (WU-1.5)', () => {
+  it('leads --font-ui with a bundled non-generic face (Inter / Geist), keeping a system fallback', () => {
+    const value = readTokens().get('--font-ui') ?? '';
+    // The lead is a real bundled UI face, NOT the generic system-ui the prototype
+    // superseded (§5.B). A system fallback stays LAST so it renders before the
+    // @font-face binaries are bundled (documented follow-up).
+    expect(['Inter', 'Geist']).toContain(leadFamily(value));
+    expect(value).toContain('system-ui');
+    expect(value.trimEnd()).toMatch(/sans-serif;?$/);
+  });
+
+  it('sets --font-editorial to Newsreader with a serif fallback (the pull-quote voice)', () => {
+    const value = readTokens().get('--font-editorial') ?? '';
+    // Newsreader supersedes the stale Georgia lead; a generic serif stays as the
+    // fallback so the editorial voice never collapses to sans.
+    expect(leadFamily(value)).toBe('Newsreader');
+    expect(value.trimEnd()).toMatch(/serif;?$/);
+  });
+
+  it('leads --font-mono with a bundled mono face, keeping a monospace fallback (timecode voice)', () => {
+    const value = readTokens().get('--font-mono') ?? '';
+    expect(leadFamily(value)).toBe('IBM Plex Mono');
+    expect(value.trimEnd()).toMatch(/monospace;?$/);
+  });
+});
+
+describe('v1.5 shell token evolution — glass / floating-surface layer (WU-1.5)', () => {
+  it('defines a translucent glass surface + a real backdrop-blur radius', () => {
+    const tokens = readTokens();
+    // The glass surface is the raised plane at REDUCED opacity so a backdrop-blur
+    // reads through it — a solid fill would defeat the layer.
+    const glass = tokens.get('--surface-glass') ?? '';
+    const alpha = rgbaAlpha(glass);
+    expect(alpha).toBeGreaterThan(0);
+    expect(alpha).toBeLessThan(1);
+    // A non-zero px blur radius (the layer is meaningless at 0).
+    const blur = tokens.get('--glass-blur') ?? '';
+    expect(blur).toMatch(/^\d+px$/);
+    expect(Number.parseInt(blur, 10)).toBeGreaterThan(0);
+  });
+
+  it('defines the centered-surface scrim + measure (modal now, Cmd-K palette later)', () => {
+    const tokens = readTokens();
+    // The scrim that dims the canvas behind a centered floating surface: a
+    // translucent dark wash (alpha < 1 so the app stays faintly visible behind).
+    const scrim = tokens.get('--overlay-scrim') ?? '';
+    const alpha = rgbaAlpha(scrim);
+    expect(alpha).toBeGreaterThan(0);
+    expect(alpha).toBeLessThan(1);
+    // A pixel max-measure so the floating surface never spans an ultrawide window.
+    expect(tokens.get('--overlay-width') ?? '').toMatch(/^\d+px$/);
+  });
+});
+
+describe('v1.5 shell token evolution — locks the reconciled §5.A guardrails (WU-1.5)', () => {
+  it('pins the ink-on-accent value the redesign must bind (never the prototype #1a1205)', () => {
+    expect(readTokens().get('--accent-ink')).toBe('#211404');
+  });
+
+  it('keeps --text-faint OFF the rejected sub-AA #50555F (the WCAG 1.4.3 regression)', () => {
+    // The prototype re-introduced #50555F (~2.4:1) on quiet text; the shipped faint
+    // step is a real AA tone. Guard the exact rejected value can never creep back.
+    const faint = (readTokens().get('--text-faint') ?? '').toLowerCase();
+    expect(faint).not.toBe('#50555f');
+  });
+
+  it('pins the motion ladder (fast < base < slow) + a real easing curve', () => {
+    const tokens = readTokens();
+    const ms = (name: string): number => Number.parseInt(tokens.get(name) ?? '', 10);
+    const fast = ms('--dur-fast');
+    const base = ms('--dur-base');
+    const slow = ms('--dur-slow');
+    expect(fast).toBe(120);
+    expect(base).toBe(180);
+    expect(slow).toBe(260);
+    expect(fast).toBeLessThan(base);
+    expect(base).toBeLessThan(slow);
+    expect(tokens.get('--ease-out') ?? '').toContain('cubic-bezier(');
+  });
+});

--- a/app/renderer/src/styles/tokens.css
+++ b/app/renderer/src/styles/tokens.css
@@ -86,11 +86,20 @@
   --status-abundance-soft: rgba(155, 108, 255, 0.08); /* gradient wash */
 
   /* ---- type ---------------------------------------------------------------
-   * Pairing: weighted system sans for UI, ui-monospace for timecode/numbers,
-   * a serif voice ONLY for editorial pull-quote moments (ShortMaker hooks). */
-  --font-ui: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-  --font-mono: ui-monospace, "Cascadia Mono", "SF Mono", Consolas, monospace;
-  --font-editorial: Georgia, "Iowan Old Style", "Times New Roman", serif;
+   * Pairing: a weighted sans for UI, a mono for timecode/numbers, a serif voice
+   * ONLY for editorial pull-quote moments (ShortMaker hooks, Director, caption
+   * previews).
+   *
+   * v1.5 (§5.B) — the ONE place the redesign evolves tokens FORWARD: each family
+   * now leads with a BUNDLED, non-generic face (Inter for UI, IBM Plex Mono for
+   * timecode, Newsreader for editorial), superseding the stale system-ui/Georgia
+   * leads. The actual @font-face binaries (self-hosted under the renderer assets;
+   * CSP allows `font-src 'self'`) are a bundling FOLLOW-UP — until they land the
+   * system fallbacks kept LAST render everything correctly offline, so no PR is
+   * blocked on font files. The tokens.conformance WU-1.5 guard pins the leads. */
+  --font-ui: Inter, Geist, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+  --font-mono: "IBM Plex Mono", ui-monospace, "Cascadia Mono", "SF Mono", Consolas, monospace;
+  --font-editorial: Newsreader, Georgia, "Iowan Old Style", "Times New Roman", serif;
 
   /* ---- font-weight ramp (WU-D1) -------------------------------------------
    * ONE ordered weight ladder so component CSS never hard-codes a raw numeric
@@ -231,6 +240,20 @@
    * variant uses a cool slate highlight to keep the locked blue-gray mood. */
   --atmos-toplight: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0) 62%);
   --atmos-well: linear-gradient(180deg, rgba(148, 163, 184, 0.06), rgba(0, 0, 0, 0.12));
+
+  /* ---- glass / floating-surface layer (Wave-2, §5.B) ------------------------
+   * Backdrop-blurred floating surfaces: the produced-shorts modal now, and the
+   * Cmd-K command palette when it ships (§7.5). --surface-glass is the RAISED
+   * plane at reduced opacity so a `backdrop-filter: blur(var(--glass-blur))`
+   * reads through it (a solid fill would defeat the blur); --overlay-scrim dims
+   * the canvas behind a centered surface; --overlay-width caps its measure so a
+   * floating panel never spans an ultrawide window. Cool cast is preserved (the
+   * glass is --surface-raised at alpha). Pinned by tokens.conformance (WU-1.5);
+   * the entrance motion is gated on prefers-reduced-motion AT THE CONSUMER. */
+  --glass-blur: 14px;
+  --surface-glass: rgba(27, 33, 46, 0.72);
+  --overlay-scrim: rgba(9, 11, 16, 0.62);
+  --overlay-width: 640px;
 
   /* ---- motion ---------------------------------------------------------------- */
   --dur-fast: 120ms; /* hovers, color shifts */

--- a/app/renderer/src/views/CapabilitiesChip.test.tsx
+++ b/app/renderer/src/views/CapabilitiesChip.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { CapabilitiesChip } from './CapabilitiesChip';
+import type { ReadinessItem } from '../lib/rpc';
+
+function items(): ReadinessItem[] {
+  return [
+    { capability: 'a', label: 'Transcribe speech', status: 'ready', blockedBy: '', action: null },
+    { capability: 'b', label: 'Follow the speaker', status: 'ready', blockedBy: '', action: null },
+    {
+      capability: 'c',
+      label: 'Translate captions',
+      status: 'needsKey',
+      blockedBy: 'no key',
+      action: { kind: 'openProviders' },
+    },
+  ];
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as { api?: unknown }).api;
+});
+
+async function flush(turns = 6): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < turns; i += 1) await Promise.resolve();
+  });
+}
+
+function toggle(): HTMLButtonElement {
+  return container.querySelector('.capabilities-chip__toggle') as HTMLButtonElement;
+}
+
+function stubClient(summary: () => Promise<{ items: ReadinessItem[] }>) {
+  return { readiness: { summary } };
+}
+
+describe('CapabilitiesChip', () => {
+  it('binds the noun + a ready/total count separate from the card count', async () => {
+    await act(async () => {
+      root.render(<CapabilitiesChip rpcClient={stubClient(async () => ({ items: items() }))} />);
+    });
+    await flush();
+    // 2 of 3 ready — the plumbing count, not the visible-card count.
+    expect(toggle().textContent).toContain('Capabilities: 2 of 3 installed');
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    expect(toggle().disabled).toBe(false);
+    // Collapsed by default — no rows yet.
+    expect(container.querySelector('.capabilities-chip__list')).toBeNull();
+  });
+
+  it('discloses the readiness rows on expand and forwards a fix action', async () => {
+    const onAction = vi.fn();
+    await act(async () => {
+      root.render(
+        <CapabilitiesChip
+          rpcClient={stubClient(async () => ({ items: items() }))}
+          onAction={onAction}
+        />,
+      );
+    });
+    await flush();
+
+    await act(async () => {
+      toggle().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    const rows = container.querySelectorAll('.capabilities-chip__row');
+    expect(rows.length).toBe(3);
+    expect(container.textContent).toContain('Follow the speaker');
+
+    const fix = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    await act(async () => {
+      fix.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onAction).toHaveBeenCalledWith({ kind: 'openProviders' });
+
+    // Collapses again.
+    await act(async () => {
+      toggle().dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(container.querySelector('.capabilities-chip__list')).toBeNull();
+  });
+
+  it('reports "none" and disables the toggle when no capabilities exist', async () => {
+    await act(async () => {
+      root.render(<CapabilitiesChip rpcClient={stubClient(async () => ({ items: [] }))} />);
+    });
+    await flush();
+    expect(toggle().textContent).toContain('Capabilities: none reported');
+    expect(toggle().disabled).toBe(true);
+  });
+
+  it('treats a summary without an items array as empty', async () => {
+    await act(async () => {
+      root.render(
+        <CapabilitiesChip rpcClient={stubClient(async () => ({}) as { items: ReadinessItem[] })} />,
+      );
+    });
+    await flush();
+    expect(toggle().textContent).toContain('none reported');
+  });
+
+  it('shows a checking… busy state while the summary is in flight', async () => {
+    let resolve: (v: { items: ReadinessItem[] }) => void = () => {};
+    await act(async () => {
+      root.render(
+        <CapabilitiesChip
+          rpcClient={stubClient(
+            () =>
+              new Promise((r) => {
+                resolve = r;
+              }),
+          )}
+        />,
+      );
+    });
+    // Pending: checking + aria-busy + disabled.
+    expect(toggle().textContent).toContain('Capabilities: checking…');
+    expect(toggle().getAttribute('aria-busy')).toBe('true');
+    expect(toggle().disabled).toBe(true);
+    await act(async () => {
+      resolve({ items: items() });
+    });
+    await flush();
+    expect(toggle().textContent).toContain('2 of 3 installed');
+  });
+
+  it('degrades to an inline alert when the summary rejects', async () => {
+    await act(async () => {
+      root.render(
+        <CapabilitiesChip
+          rpcClient={stubClient(async () => {
+            throw new Error('summary boom');
+          })}
+        />,
+      );
+    });
+    await flush();
+    expect(toggle().textContent).toContain('Capabilities: unavailable');
+    expect(container.querySelector('.capabilities-chip__error')?.textContent).toContain(
+      'summary boom',
+    );
+  });
+
+  it('catches a SYNCHRONOUS bridge throw (missing preload) without a blank screen', async () => {
+    await act(async () => {
+      root.render(
+        <CapabilitiesChip
+          rpcClient={stubClient(() => {
+            throw new Error('window.api bridge is not available');
+          })}
+        />,
+      );
+    });
+    await flush();
+    expect(container.querySelector('.capabilities-chip__error')?.textContent).toContain(
+      'bridge is not available',
+    );
+    expect(toggle().getAttribute('aria-busy')).toBe('false');
+  });
+
+  it('defaults to the real lib/rpc client when none is injected', async () => {
+    // No rpcClient -> the `?? client` default runs; stub window.api so the real
+    // client.readiness.summary() resolves through the bridge.
+    (window as { api?: unknown }).api = {
+      rpc: async (method: string) => (method === 'readiness.summary' ? { items: items() } : {}),
+    };
+    await act(async () => {
+      root.render(<CapabilitiesChip />);
+    });
+    await flush();
+    expect(toggle().textContent).toContain('2 of 3 installed');
+  });
+
+  it('stringifies a non-Error rejection', async () => {
+    await act(async () => {
+      root.render(
+        <CapabilitiesChip
+          rpcClient={stubClient(async () => {
+            throw 'plain failure';
+          })}
+        />,
+      );
+    });
+    await flush();
+    expect(container.querySelector('.capabilities-chip__error')?.textContent).toContain(
+      'plain failure',
+    );
+  });
+});

--- a/app/renderer/src/views/CapabilitiesChip.tsx
+++ b/app/renderer/src/views/CapabilitiesChip.tsx
@@ -1,0 +1,118 @@
+// CapabilitiesChip.tsx — the Library "Capabilities: N of M installed" disclosure
+// (v1.5 §4/§P5). It fixes the redesign's cryptic capabilities chip: it binds a
+// real NOUN + a real count (ready / total capabilities) that is SEPARATE from the
+// visible card count (a plumbing count must never collide with the video count),
+// and it discloses the detail on demand instead of an always-open section.
+//
+// It reuses the SHIPPED readiness primitives — `readiness.summary` (WU-8) for the
+// data and <ReadinessBadge/> (WU-9) for each row — so the status is announced by
+// TEXT + role, never hue alone, and the jargon rewrite lands at readinessMeta's
+// source (not here). One fetch (no double-load); the eager preload-bridge throw is
+// caught sync-safely, exactly as ReadinessRollup guards it.
+import React, { useEffect, useId, useState } from 'react';
+import { client, type ReadinessAction, type ReadinessItem } from '../lib/rpc';
+import { ReadinessBadge } from '../components/ReadinessBadge';
+import '../components/readinessBadge.css';
+import '../components/library-shell.css';
+
+/** Error text from an unknown thrown value (mirrors the sibling panels). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface CapabilitiesChipProps {
+  /** Inject the typed client for tests; defaults to the real lib/rpc client. */
+  rpcClient?: Pick<typeof client, 'readiness'>;
+  /** Fired when a row's fix action is clicked (parent owns the routing). */
+  onAction?: (action: ReadinessAction) => void;
+}
+
+export function CapabilitiesChip({
+  rpcClient,
+  onAction,
+}: CapabilitiesChipProps): React.ReactElement {
+  const api = rpcClient ?? client;
+  const [items, setItems] = useState<ReadinessItem[] | null>(null);
+  const [error, setError] = useState<string>('');
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  useEffect(() => {
+    let alive = true;
+    setError('');
+    setItems(null);
+    // The bridge access is EAGER — `api.readiness.summary()` reaches through the
+    // preload bridge, which throws SYNCHRONOUSLY when window.api is missing (before
+    // Promise.resolve can wrap it). Guard it sync-safely so a missing bridge
+    // degrades to an inline error here instead of a thrown-through blank screen.
+    try {
+      Promise.resolve(api.readiness.summary())
+        .then((res) => {
+          if (alive) setItems(Array.isArray(res?.items) ? res.items : []);
+        })
+        .catch((err: unknown) => {
+          if (alive) setError(errText(err));
+        });
+    } catch (err) {
+      setError(errText(err));
+    }
+    return () => {
+      alive = false;
+    };
+  }, [api]);
+
+  const ready = items ? items.filter((i) => i.status === 'ready').length : 0;
+  const total = items ? items.length : 0;
+  const label =
+    items === null
+      ? 'Capabilities: checking…'
+      : total === 0
+        ? 'Capabilities: none reported'
+        : `Capabilities: ${ready} of ${total} installed`;
+
+  return (
+    <section className="capabilities-chip" aria-label="Capabilities">
+      <button
+        type="button"
+        className="capabilities-chip__toggle"
+        aria-expanded={open}
+        aria-controls={panelId}
+        aria-busy={items === null && !error}
+        disabled={items === null || total === 0}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="capabilities-chip__text">
+          {error ? 'Capabilities: unavailable' : label}
+        </span>
+        <span className="capabilities-chip__caret" aria-hidden="true">
+          {open ? '▴' : '▾'}
+        </span>
+      </button>
+
+      {error ? (
+        <p className="capabilities-chip__error" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {open && items && total > 0 ? (
+        <ul id={panelId} className="capabilities-chip__list">
+          {items.map((item) => (
+            <li key={item.capability} className="capabilities-chip__row">
+              <span className="capabilities-chip__cap">{item.label}</span>
+              <ReadinessBadge
+                status={item.status}
+                capabilityLabel={item.label}
+                blockedBy={item.blockedBy || undefined}
+                action={item.action}
+                onAction={onAction}
+              />
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}
+
+export default CapabilitiesChip;

--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -26,10 +26,82 @@ vi.mock('../lib/rpc', async (importOriginal) => {
   };
 });
 
-import { Library } from './Library';
+// Isolate the shorts gallery: a lightweight ProducedShorts stub (the real one is
+// covered by its own suite + ShortsGalleryModal.test) exposes the per-clip
+// affordances so Library's shorts wiring (count label, modal, delete/index-update,
+// open-folder, edit-in-Studio) is exercised directly.
+vi.mock('../features/ProducedShorts', () => ({
+  ProducedShorts: ({
+    shorts,
+    onOpenFolder,
+    onReexport,
+    onDelete,
+  }: {
+    shorts: { id: string; path: string }[];
+    onOpenFolder: (p: string) => void;
+    onReexport?: (p: string) => void;
+    onDelete: (p: string) => void;
+  }) => (
+    <div data-testid="produced-shorts">
+      {shorts.map((s) => (
+        <div key={s.id}>
+          <button type="button" data-testid={`folder-${s.id}`} onClick={() => onOpenFolder(s.path)}>
+            folder
+          </button>
+          <button type="button" data-testid={`delete-${s.id}`} onClick={() => onDelete(s.path)}>
+            delete
+          </button>
+          {onReexport ? (
+            <button type="button" data-testid={`edit-${s.id}`} onClick={() => onReexport(s.path)}>
+              edit
+            </button>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import { Library, type LibraryShortsApi } from './Library';
 import type { Video } from '../components/api';
-import type { ReadinessItem } from '../lib/rpc';
+import type { ReadinessItem, ShortInfo } from '../lib/rpc';
 import { videoThumbnailSrc } from '../components/useVideoThumbnail';
+
+function makeShort(over: Partial<ShortInfo> = {}): ShortInfo {
+  return {
+    id: 'sh1',
+    path: '/out/sh1.mp4',
+    videoId: 'v1',
+    sourceTitle: 'Talk',
+    template: '',
+    viralityPct: null,
+    durationSec: 30,
+    width: 1080,
+    height: 1920,
+    createdAt: 1,
+    thumbnailPath: '',
+    hook: '',
+    ...over,
+  };
+}
+
+/** A produced-shorts port whose handlers are spies. */
+function shortsPort(over: Partial<LibraryShortsApi> = {}): LibraryShortsApi {
+  return {
+    listAll: vi.fn(async () => [makeShort({ id: 's1', path: '/out/s1.mp4', videoId: 'v1' })]),
+    openFolder: vi.fn(async () => {}),
+    remove: vi.fn(async () => {}),
+    ...over,
+  };
+}
+
+/** Set a controlled input's value so React's tracker fires onChange. */
+function typeInto(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')
+    ?.set as (v: string) => void;
+  setter.call(input, value);
+  input.dispatchEvent(new Event('input', { bubbles: true }));
+}
 
 function makeVideo(over: Partial<Video> = {}): Video {
   return {
@@ -525,7 +597,8 @@ describe('Library', () => {
 
     const open = container.querySelector('.library__item-open') as HTMLButtonElement;
     expect(open.tagName).toBe('BUTTON');
-    expect(open.getAttribute('aria-label')).toBe('Open Talk');
+    // v1.5: the open name is enriched with duration + status (title+status+duration).
+    expect(open.getAttribute('aria-label')).toBe('Open Talk, 10:05, no transcript');
     // The <li> is a plain list item (no button role / tabindex) so the <ul> only
     // contains list items and the open/remove buttons are SIBLINGS, not nested.
     const item = container.querySelector('li.library__item') as HTMLLIElement;
@@ -773,7 +846,7 @@ describe('Library lineage view (L4)', () => {
 
     // The card open affordance re-labels itself for the history action.
     const open = container.querySelector('.library__item-open') as HTMLButtonElement;
-    expect(open.getAttribute('aria-label')).toBe('Show history of Talk');
+    expect(open.getAttribute('aria-label')).toBe('Show history of Talk, 10:05, no transcript');
 
     rpcMock.mockResolvedValueOnce(EMPTY_LINEAGE);
     await click(open);
@@ -855,20 +928,20 @@ describe('Library source provenance (WU-1f)', () => {
   });
 });
 
-describe('Library readiness roll-up (WU-14)', () => {
-  it('renders the ReadinessRollup section on the library home', async () => {
+describe('Library capabilities chip (v1.5 §4)', () => {
+  it('renders the capabilities disclosure chip on the library home', async () => {
     rpcMock.mockResolvedValueOnce({ videos: [] });
     await renderLibrary();
-    expect(container.querySelector('.readiness-rollup')).not.toBeNull();
+    expect(container.querySelector('.capabilities-chip')).not.toBeNull();
     expect(readinessSummaryMock).toHaveBeenCalled();
   });
 
-  it('forwards a roll-up action to the onReadinessAction prop', async () => {
+  it('forwards a capability fix action to onReadinessAction after expanding the chip', async () => {
     readinessSummaryMock.mockResolvedValue({
       items: [
         {
           capability: 'tr',
-          label: 'Translation',
+          label: 'Translate captions',
           status: 'needsKey',
           blockedBy: 'no key',
           action: { kind: 'openProviders' },
@@ -882,12 +955,321 @@ describe('Library readiness roll-up (WU-14)', () => {
     });
     await flush();
 
+    // The chip is collapsed by default — expand it to reveal the fix action.
+    await act(async () => {
+      (container.querySelector('.capabilities-chip__toggle') as HTMLButtonElement).click();
+    });
     const btn = container.querySelector(
-      '.readiness-rollup button.readiness-badge__action',
+      '.capabilities-chip button.readiness-badge__action',
     ) as HTMLButtonElement;
     await act(async () => {
       btn.click();
     });
     expect(onReadinessAction).toHaveBeenCalledWith({ kind: 'openProviders' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// v1.5 §4: in-context search + sort, multi-select batch actions, produced-shorts
+// ---------------------------------------------------------------------------
+
+function selectBoxes(): NodeListOf<HTMLInputElement> {
+  return container.querySelectorAll<HTMLInputElement>('.library__select-box');
+}
+
+function fire(el: Element | null): void {
+  (el as HTMLElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+}
+
+describe('Library search + sort (v1.5 §4)', () => {
+  it('filters the grid by the search query, showing a filter-empty state on no match', async () => {
+    rpcMock.mockResolvedValueOnce({
+      videos: [makeVideo({ id: 'a', title: 'Keynote' }), makeVideo({ id: 'b', title: 'Bloopers' })],
+    });
+    await renderLibrary();
+    expect(container.querySelectorAll('li.library__item').length).toBe(2);
+
+    const search = container.querySelector('.library-toolbar__search') as HTMLInputElement;
+    await act(async () => {
+      typeInto(search, 'key');
+    });
+    await flush();
+    expect(container.querySelectorAll('li.library__item').length).toBe(1);
+    expect(container.textContent).toContain('Keynote');
+
+    await act(async () => {
+      typeInto(search, 'zzz');
+    });
+    await flush();
+    expect(container.querySelector('.library__empty--filtered')).not.toBeNull();
+    expect(container.textContent).toContain('No videos match');
+  });
+
+  it('sorts the grid by the chosen mode', async () => {
+    rpcMock.mockResolvedValueOnce({
+      videos: [makeVideo({ id: 'a', title: 'Bravo' }), makeVideo({ id: 'b', title: 'Alpha' })],
+    });
+    await renderLibrary();
+    const sort = container.querySelector('.library-toolbar__sort-select') as HTMLSelectElement;
+    await act(async () => {
+      sort.value = 'title';
+      sort.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+    const titles = [...container.querySelectorAll('.library__item-title')].map(
+      (e) => e.textContent,
+    );
+    expect(titles).toEqual(['Alpha', 'Bravo']);
+  });
+});
+
+describe('Library multi-select + batch actions (v1.5 §4)', () => {
+  it('selects cards and batch-removes them', async () => {
+    rpcMock.mockResolvedValueOnce({
+      videos: [makeVideo({ id: 'a', title: 'A' }), makeVideo({ id: 'b', title: 'B' })],
+    });
+    await renderLibrary();
+    await act(async () => {
+      fire(selectBoxes()[0]);
+      fire(selectBoxes()[1]);
+    });
+    await flush();
+    expect(container.querySelector('.library-toolbar__batch-count')?.textContent).toBe(
+      '2 selected',
+    );
+
+    rpcMock.mockResolvedValue({ ok: true });
+    await act(async () => {
+      fire(container.querySelector('.library-toolbar__batch-remove'));
+    });
+    await flush();
+    expect(rpcMock).toHaveBeenCalledWith('library.remove', { id: 'a' });
+    expect(rpcMock).toHaveBeenCalledWith('library.remove', { id: 'b' });
+    expect(container.querySelectorAll('li.library__item').length).toBe(0);
+  });
+
+  it('toggles a selection off again', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    await renderLibrary();
+    await act(async () => {
+      fire(selectBoxes()[0]);
+    });
+    await flush();
+    expect(container.querySelector('.library-toolbar__batch-count')?.textContent).toBe(
+      '1 selected',
+    );
+    await act(async () => {
+      fire(selectBoxes()[0]);
+    });
+    await flush();
+    expect(container.querySelector('.library-toolbar__batch')).toBeNull();
+  });
+
+  it('clears a selection via Clear', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    await renderLibrary();
+    await act(async () => {
+      fire(selectBoxes()[0]);
+    });
+    await flush();
+    await act(async () => {
+      fire(container.querySelector('.library-toolbar__batch-clear'));
+    });
+    await flush();
+    expect(container.querySelector('.library-toolbar__batch')).toBeNull();
+  });
+
+  it('prunes a removed video from the selection on single remove', async () => {
+    rpcMock.mockResolvedValueOnce({
+      videos: [makeVideo({ id: 'a', title: 'A' }), makeVideo({ id: 'b', title: 'B' })],
+    });
+    await renderLibrary();
+    await act(async () => {
+      fire(selectBoxes()[0]);
+    });
+    await flush();
+    expect(container.querySelector('.library-toolbar__batch-count')?.textContent).toBe(
+      '1 selected',
+    );
+    rpcMock.mockResolvedValueOnce({ ok: true });
+    await act(async () => {
+      fire(container.querySelectorAll('.library__remove-btn')[0]);
+    });
+    await flush();
+    expect(container.querySelector('.library-toolbar__batch')).toBeNull();
+  });
+
+  it('reports a singular batch-remove failure', async () => {
+    rpcMock.mockResolvedValueOnce({
+      videos: [makeVideo({ id: 'a', title: 'A' }), makeVideo({ id: 'b', title: 'B' })],
+    });
+    await renderLibrary();
+    await act(async () => {
+      fire(selectBoxes()[0]);
+      fire(selectBoxes()[1]);
+    });
+    await flush();
+    rpcMock.mockRejectedValueOnce(new Error('x')).mockResolvedValueOnce({ ok: true });
+    await act(async () => {
+      fire(container.querySelector('.library-toolbar__batch-remove'));
+    });
+    await flush();
+    expect(container.querySelector('.library__error')?.textContent).toContain(
+      'Could not remove 1 video',
+    );
+  });
+
+  it('pluralizes a multi-failure batch-remove', async () => {
+    rpcMock.mockResolvedValueOnce({
+      videos: [makeVideo({ id: 'a', title: 'A' }), makeVideo({ id: 'b', title: 'B' })],
+    });
+    await renderLibrary();
+    await act(async () => {
+      fire(selectBoxes()[0]);
+      fire(selectBoxes()[1]);
+    });
+    await flush();
+    rpcMock.mockRejectedValueOnce(new Error('x')).mockRejectedValueOnce(new Error('y'));
+    await act(async () => {
+      fire(container.querySelector('.library-toolbar__batch-remove'));
+    });
+    await flush();
+    expect(container.querySelector('.library__error')?.textContent).toContain(
+      'Could not remove 2 videos',
+    );
+  });
+});
+
+describe('Library produced-shorts gallery (v1.5 §4 P0)', () => {
+  async function renderWithShorts(
+    port: LibraryShortsApi,
+    onEditShort?: (s: ShortInfo) => void,
+  ): Promise<void> {
+    await act(async () => {
+      root.render(<Library onOpen={() => {}} shorts={port} onEditShort={onEditShort} />);
+    });
+    await flush();
+  }
+
+  it('shows no shorts label without the shorts port', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    await renderLibrary();
+    expect(container.querySelector('.library__shorts-label')).toBeNull();
+  });
+
+  it('degrades to no counts when the shorts index fails to load', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    const port = shortsPort({
+      listAll: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+    await renderWithShorts(port);
+    expect(container.querySelector('.library__shorts-label')).toBeNull();
+  });
+
+  it('shows the "N shorts" count and opens + closes the gallery modal', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    const port = shortsPort({
+      listAll: vi.fn(async () => [
+        makeShort({ id: 's1', videoId: 'v1' }),
+        makeShort({ id: 's2', videoId: 'v1' }),
+      ]),
+    });
+    await renderWithShorts(port);
+    expect(port.listAll).toHaveBeenCalled();
+    const label = container.querySelector('.library__shorts-label') as HTMLButtonElement;
+    expect(label.textContent).toBe('2 shorts');
+
+    await act(async () => {
+      fire(label);
+    });
+    await flush();
+    expect(container.querySelector('.shorts-modal')?.getAttribute('aria-label')).toBe(
+      'Produced shorts for Talk',
+    );
+
+    await act(async () => {
+      fire(container.querySelector('.shorts-modal__close'));
+    });
+    await flush();
+    expect(container.querySelector('.shorts-modal')).toBeNull();
+  });
+
+  it('opens a short in Studio via the gallery edit action', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    const short = makeShort({ id: 's1', videoId: 'v1', path: '/out/s1.mp4' });
+    const port = shortsPort({ listAll: vi.fn(async () => [short]) });
+    const onEditShort = vi.fn();
+    await renderWithShorts(port, onEditShort);
+    await act(async () => {
+      fire(container.querySelector('.library__shorts-label'));
+    });
+    await flush();
+    await act(async () => {
+      fire(container.querySelector('[data-testid="edit-s1"]'));
+    });
+    expect(onEditShort).toHaveBeenCalledWith(short);
+  });
+
+  it('reveals a clip folder + deletes clips (updating the index) from the gallery', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    const port = shortsPort({
+      listAll: vi.fn(async () => [
+        makeShort({ id: 's1', path: '/o/s1.mp4', videoId: 'v1' }),
+        makeShort({ id: 's2', path: '/o/s2.mp4', videoId: 'v1' }),
+      ]),
+    });
+    await renderWithShorts(port);
+    await act(async () => {
+      fire(container.querySelector('.library__shorts-label'));
+    });
+    await flush();
+
+    await act(async () => {
+      fire(container.querySelector('[data-testid="folder-s1"]'));
+    });
+    expect(port.openFolder).toHaveBeenCalledWith('/o/s1.mp4');
+
+    // Delete s1 -> the v1 group keeps s2 (kept.length > 0).
+    await act(async () => {
+      fire(container.querySelector('[data-testid="delete-s1"]'));
+    });
+    await flush();
+    expect(port.remove).toHaveBeenCalledWith('/o/s1.mp4');
+    // Delete s2 -> the group empties (kept.length === 0 -> dropped) -> modal empty.
+    await act(async () => {
+      fire(container.querySelector('[data-testid="delete-s2"]'));
+    });
+    await flush();
+    expect(container.querySelector('.shorts-modal__empty')).not.toBeNull();
+  });
+
+  it('surfaces a toast when a gallery action fails', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    const port = shortsPort({
+      listAll: vi.fn(async () => [makeShort({ id: 's1', path: '/o/s1.mp4', videoId: 'v1' })]),
+      openFolder: vi.fn(async () => {
+        throw new Error('reveal failed');
+      }),
+      remove: vi.fn(async () => {
+        throw new Error('delete failed');
+      }),
+    });
+    await renderWithShorts(port);
+    await act(async () => {
+      fire(container.querySelector('.library__shorts-label'));
+    });
+    await flush();
+    await act(async () => {
+      fire(container.querySelector('[data-testid="folder-s1"]'));
+    });
+    await flush();
+    expect(errorToasts().join(' ')).toContain('reveal failed');
+    await act(async () => {
+      fire(container.querySelector('[data-testid="delete-s1"]'));
+    });
+    await flush();
+    expect(errorToasts().join(' ')).toContain('delete failed');
   });
 });

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -1,11 +1,20 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { rpc, type Video } from '../components/api';
-import { useVideoThumbnail, type VideoThumbnailRpc } from '../components/useVideoThumbnail';
-import { ReadinessRollup } from '../components/ReadinessRollup';
+import { CapabilitiesChip } from './CapabilitiesChip';
+import { LibraryCard } from './LibraryCard';
+import { LibraryToolbar } from './LibraryToolbar';
+import { ShortsGalleryModal } from './ShortsGalleryModal';
 import { LineagePanel, type LineageAsset } from '../features/LineagePanel';
-import { LibraryProvenance, type ProvenanceHandlers } from '../features/LibraryProvenance';
+import type { ProvenanceHandlers } from '../features/LibraryProvenance';
 import { lineageActions } from '../features/lineageActionsClient';
-import type { LineageResult, ReadinessAction } from '../lib/rpc';
+import type { LineageResult, ReadinessAction, ShortInfo } from '../lib/rpc';
+import {
+  type LibrarySort,
+  type LibraryVideo,
+  filterVideos,
+  groupShortsByVideo,
+  sortVideos,
+} from './libraryModel';
 import '../components/library-cards.css';
 
 // ---- Toasts (P2 U2) ---------------------------------------------------------
@@ -28,6 +37,22 @@ interface LocalToast extends ToastMessage {
 
 /** How long a fallback toast stays on screen. */
 const TOAST_TTL_MS = 6000;
+
+/**
+ * The injected produced-shorts port (v1.5 §4 P0). When provided, Library loads
+ * ALL produced shorts once, groups them by source video for the per-card "N
+ * shorts" count, and the gallery modal reveals/deletes clips through it. Absent
+ * -> the shorts affordances simply don't render (lane-independent, like the
+ * `provenance`/`toast` seams; the App-side adapter is a documented follow-up).
+ */
+export interface LibraryShortsApi {
+  /** Load EVERY produced short (grouped client-side by source `videoId`). */
+  listAll: () => Promise<ShortInfo[]>;
+  /** Reveal a produced clip in the OS file explorer. */
+  openFolder: (path: string) => Promise<void>;
+  /** Delete a produced clip file (the adapter owns any confirm). */
+  remove: (path: string) => Promise<void>;
+}
 
 export interface LibraryProps {
   /** Called when the user opens a video into the Workspace. */
@@ -53,6 +78,13 @@ export interface LibraryProps {
    * legacy compact path line and no provenance row (the app wires the real one).
    */
   provenance?: ProvenanceHandlers;
+  /**
+   * v1.5 §4 P0: the produced-shorts port. When provided, each card shows a
+   * "N shorts" label opening the gallery modal for that video.
+   */
+  shorts?: LibraryShortsApi;
+  /** v1.5 §4: "edit in Studio" for a produced short (from the gallery modal). */
+  onEditShort?: (short: ShortInfo) => void;
 }
 
 interface ListResult {
@@ -111,29 +143,6 @@ function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
-function formatDuration(sec: number): string {
-  if (!Number.isFinite(sec) || sec <= 0) return '--:--';
-  const total = Math.round(sec);
-  const h = Math.floor(total / 3600);
-  const m = Math.floor((total % 3600) / 60);
-  const s = total % 60;
-  const mm = String(m).padStart(2, '0');
-  const ss = String(s).padStart(2, '0');
-  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
-}
-
-// ---- Poster-frame thumbnails (WU-4 wiring, WU-14) ---------------------------
-
-/**
- * `library.thumbnail({id})` adapter over the shared `rpc` bridge — the thin RPC
- * slice `useVideoThumbnail` needs. Stable across renders so the hook's effect
- * does not re-fire every card render.
- */
-const thumbnailRpc: VideoThumbnailRpc = {
-  thumbnail: (videoId: string) =>
-    rpc<{ thumbnailPath: string }>('library.thumbnail', { id: videoId }),
-};
-
 /**
  * `library.lineage({id})` loader over the shared `rpc` bridge — the injected
  * `loadLineage` the L4 `LineagePanel` drawer consumes. Module-level so it is
@@ -144,63 +153,40 @@ function loadLineage(id: string): Promise<LineageResult> {
 }
 
 /**
- * Library-card poster: consumes `useVideoThumbnail` (WU-4) to serve the source
- * video's `thumb:` poster as a real <img>, generating it on demand (idempotent
- * server-side). Inherits WU-4's graceful degradation: a missing / failed poster
- * (empty resolved URL, or an <img> load error) falls back to the ▶ glyph and
- * NEVER blocks the gallery. The duration badge always renders (mm:ss).
- */
-function VideoThumb({ video }: { video: Video }): React.ReactElement {
-  const posterUrl = useVideoThumbnail(thumbnailRpc, video.id, video.thumbnailPath ?? '');
-  const [imgFailed, setImgFailed] = useState(false);
-  const showImg = posterUrl !== '' && !imgFailed;
-
-  return (
-    <div className="library__thumb">
-      {showImg ? (
-        <img
-          className="library__thumb-img"
-          src={posterUrl}
-          alt=""
-          aria-hidden="true"
-          onError={() => setImgFailed(true)}
-        />
-      ) : (
-        <div className="library__thumb-fallback" aria-hidden="true">
-          ▶
-        </div>
-      )}
-      <span className="library__thumb-duration">{formatDuration(video.durationSec)}</span>
-    </div>
-  );
-}
-
-/**
- * Library.tsx — the video-manager home.
- * Lists videos (library.list), adds via the NATIVE picker (window.api.openVideos
- * -> dialog.openVideos ipc) or drag-drop onto the view (multi-add, per-file
- * typed error toasts, de-dupe by id), removes (library.remove), and opens a
- * video into the Workspace on click.
+ * Library.tsx — the content-first video-manager home (v1.5 §4 re-skin).
+ * Lists videos (library.list) in a poster grid, adds via the NATIVE picker or
+ * drag-drop (multi-add, per-file typed error toasts, de-dupe by id), removes
+ * (single + batch), searches/sorts in-context, opens a video into the Workspace,
+ * and — via the injected shorts port — opens each video's produced-shorts gallery.
  */
 export function Library({
   onOpen,
   toast: externalToast,
   onReadinessAction,
   provenance,
+  shorts,
+  onEditShort,
 }: LibraryProps): React.ReactElement {
-  const [videos, setVideos] = useState<Video[]>([]);
+  const [videos, setVideos] = useState<LibraryVideo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [adding, setAdding] = useState(false);
   const [dragOver, setDragOver] = useState(false);
-  // L4 Lineage view: an opt-in toggle (default OFF -> the flat list opens videos
+  // L4 Lineage view: an opt-in toggle (default OFF -> the flat grid opens videos
   // in the Workspace, §3.5). When ON, clicking an asset opens its provenance
   // drawer (lineageAsset) instead. Leaving the mode closes any open drawer.
   const [lineageView, setLineageView] = useState(false);
   const [lineageAsset, setLineageAsset] = useState<LineageAsset | null>(null);
   const [toasts, setToasts] = useState<LocalToast[]>([]);
-  const toastIdRef = useRef(0);
-  const toastTimersRef = useRef<ReturnType<typeof setTimeout>[]>([]);
+  const toastIdRef = React.useRef(0);
+  const toastTimersRef = React.useRef<ReturnType<typeof setTimeout>[]>([]);
+
+  // v1.5 scale + one-to-many state.
+  const [query, setQuery] = useState('');
+  const [sortMode, setSortMode] = useState<LibrarySort>('recent');
+  const [selected, setSelected] = useState<Set<string>>(() => new Set());
+  const [shortsByVideo, setShortsByVideo] = useState<Record<string, ShortInfo[]>>({});
+  const [shortsVideo, setShortsVideo] = useState<LibraryVideo | null>(null);
 
   // Clear any pending fallback-toast expiry timers on unmount.
   useEffect(() => {
@@ -247,6 +233,20 @@ export function Library({
   useEffect(() => {
     void refresh();
   }, [refresh]);
+
+  // Load the produced-shorts index once (best-effort) when the port is wired, so
+  // each card can show its "N shorts" count and open the gallery.
+  const loadShorts = useCallback(async (api: LibraryShortsApi) => {
+    try {
+      setShortsByVideo(groupShortsByVideo(await api.listAll()));
+    } catch {
+      setShortsByVideo({});
+    }
+  }, []);
+
+  useEffect(() => {
+    if (shorts) void loadShorts(shorts);
+  }, [shorts, loadShorts]);
 
   /**
    * Multi-add: one library.add per path, sequential so list order is stable.
@@ -345,7 +345,7 @@ export function Library({
 
   /** Click an asset: open its lineage drawer in Lineage view, else the Workspace. */
   const handleItemClick = useCallback(
-    (video: Video) => {
+    (video: LibraryVideo) => {
       if (lineageView) {
         setLineageAsset({ id: video.id, title: video.title });
       } else {
@@ -355,6 +355,16 @@ export function Library({
     [lineageView, onOpen],
   );
 
+  /** Prune an id from the selection (kept in sync when a video leaves the list). */
+  const unselect = useCallback((id: string) => {
+    setSelected((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  }, []);
+
   const handleRemove = useCallback(
     async (id: string, event: React.MouseEvent) => {
       event.stopPropagation();
@@ -362,6 +372,7 @@ export function Library({
       // Optimistic removal; restore on failure.
       const snapshot = videos;
       setVideos((prev) => prev.filter((v) => v.id !== id));
+      unselect(id);
       try {
         await rpc<{ ok: boolean }>('library.remove', { id });
       } catch (err) {
@@ -369,7 +380,83 @@ export function Library({
         setVideos(snapshot);
       }
     },
-    [videos],
+    [videos, unselect],
+  );
+
+  const toggleSelect = useCallback((id: string) => {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const clearSelection = useCallback(() => setSelected(new Set()), []);
+
+  /** Batch remove: one library.remove per selected id; failures are counted. */
+  const removeSelected = useCallback(async () => {
+    const ids = [...selected];
+    setSelected(new Set());
+    setError(null);
+    const failed: string[] = [];
+    for (const id of ids) {
+      try {
+        await rpc<{ ok: boolean }>('library.remove', { id });
+        setVideos((prev) => prev.filter((v) => v.id !== id));
+      } catch {
+        failed.push(id);
+      }
+    }
+    if (failed.length > 0) {
+      setError(`Could not remove ${failed.length} video${failed.length === 1 ? '' : 's'}.`);
+    }
+  }, [selected]);
+
+  // ---- Produced-shorts gallery (P0 one-to-many) -----------------------------
+
+  const shortsCountFor = useCallback(
+    (id: string): number => (shorts ? (shortsByVideo[id]?.length ?? 0) : 0),
+    [shorts, shortsByVideo],
+  );
+
+  const openShorts = useCallback((video: LibraryVideo) => setShortsVideo(video), []);
+  const closeShorts = useCallback(() => setShortsVideo(null), []);
+
+  const openShortFolder = useCallback(
+    async (api: LibraryShortsApi, path: string) => {
+      try {
+        await api.openFolder(path);
+      } catch (err) {
+        emitToast('error', errText(err));
+      }
+    },
+    [emitToast],
+  );
+
+  const deleteShort = useCallback(
+    async (api: LibraryShortsApi, path: string) => {
+      try {
+        await api.remove(path);
+        setShortsByVideo((prev) => {
+          const next: Record<string, ShortInfo[]> = {};
+          for (const [vid, list] of Object.entries(prev)) {
+            const kept = list.filter((s) => s.path !== path);
+            if (kept.length > 0) next[vid] = kept;
+          }
+          return next;
+        });
+      } catch (err) {
+        emitToast('error', errText(err));
+      }
+    },
+    [emitToast],
+  );
+
+  // The visible grid: in-context search + sort, layered over the raw list.
+  const visible = useMemo(
+    () => sortVideos(filterVideos(videos, query), sortMode, shortsCountFor),
+    [videos, query, sortMode, shortsCountFor],
   );
 
   return (
@@ -401,9 +488,20 @@ export function Library({
         </div>
       </header>
 
-      {/* design-review P2: the cryptic "What works right now" eyebrow relabelled
-          to read as device/model readiness on THIS machine. */}
-      <ReadinessRollup title="Ready on this computer" onAction={onReadinessAction} />
+      {/* design-review P2/§4: the model-readiness roll-up demoted to a compact
+          "Capabilities: N of M installed" disclosure chip (a plumbing count, kept
+          separate from the visible card count). */}
+      <CapabilitiesChip onAction={onReadinessAction} />
+
+      <LibraryToolbar
+        query={query}
+        onQueryChange={setQuery}
+        sort={sortMode}
+        onSortChange={setSortMode}
+        selectedCount={selected.size}
+        onRemoveSelected={() => void removeSelected()}
+        onClearSelection={clearSelection}
+      />
 
       {dragOver ? (
         <div className="library__drophint" aria-hidden="true">
@@ -440,7 +538,7 @@ export function Library({
       )}
 
       {loading ? (
-        // Skeleton-shimmer placeholders shaped like the real library rows —
+        // Skeleton-shimmer placeholders shaped like the real library cards —
         // never a bare "LOADING…". aria-busy + label carry the state to AT while
         // the ghost rows (aria-hidden) hold the layout so it doesn't jump.
         <div
@@ -472,61 +570,26 @@ export function Library({
             Click “Add videos” or drop video files anywhere here.
           </p>
         </div>
+      ) : visible.length === 0 ? (
+        <div className="library__empty library__empty--filtered">
+          <p className="library__empty-title">No matches</p>
+          <p className="library__empty-hint">No videos match “{query}”.</p>
+        </div>
       ) : (
         <ul className="library__list">
-          {videos.map((video) => (
-            // A11Y: the row is a plain <li> (so the <ul> only contains list
-            // items — fixes axe `list`/`only-listitems`). The OPEN affordance is
-            // a real <button> wrapping the thumb + title (natively keyboard- and
-            // screen-reader-operable), and Remove is its SIBLING button — not a
-            // focusable nested inside another control (fixes `nested-interactive`
-            // / `no-focusable-content`).
-            <li key={video.id} className="library__item">
-              <button
-                type="button"
-                className="library__item-open"
-                aria-label={lineageView ? `Show history of ${video.title}` : `Open ${video.title}`}
-                onClick={() => handleItemClick(video)}
-              >
-                <VideoThumb video={video} />
-                <div className="library__item-main">
-                  <span className="library__item-title">{video.title}</span>
-                  {/* WU-2d: quiet provenance chip row — reads what the card CARRIES,
-                      derived from real card data (transcript). Wiring further
-                      provenance signals is a later WU; no fabricated chips. */}
-                  {video.hasTranscript ? (
-                    <div className="library__chips">
-                      <span className="library__badge library__chip" title="Has transcript">
-                        Transcript
-                      </span>
-                    </div>
-                  ) : null}
-                  {/* WU-1f: the clear source path moves into <LibraryProvenance>;
-                      without the provenance handlers, keep the legacy compact line. */}
-                  {provenance ? null : (
-                    <span className="library__item-path" title={video.path}>
-                      {video.path}
-                    </span>
-                  )}
-                </div>
-              </button>
-              {provenance ? (
-                <LibraryProvenance
-                  video={{ id: video.id, path: video.path, title: video.title }}
-                  handlers={provenance}
-                />
-              ) : null}
-              <div className="library__item-meta">
-                <button
-                  type="button"
-                  className="library__remove-btn"
-                  aria-label={`Remove ${video.title}`}
-                  onClick={(e) => handleRemove(video.id, e)}
-                >
-                  Remove
-                </button>
-              </div>
-            </li>
+          {visible.map((video) => (
+            <LibraryCard
+              key={video.id}
+              video={video}
+              lineageView={lineageView}
+              selected={selected.has(video.id)}
+              onToggleSelect={toggleSelect}
+              onOpen={handleItemClick}
+              onRemove={handleRemove}
+              shortsCount={shortsCountFor(video.id)}
+              onOpenShorts={openShorts}
+              provenance={provenance}
+            />
           ))}
         </ul>
       )}
@@ -537,6 +600,17 @@ export function Library({
           loadLineage={loadLineage}
           onClose={closeLineage}
           actions={lineageActions}
+        />
+      ) : null}
+
+      {shorts && shortsVideo ? (
+        <ShortsGalleryModal
+          title={shortsVideo.title}
+          shorts={shortsByVideo[shortsVideo.id] ?? []}
+          onClose={closeShorts}
+          onOpenFolder={(path) => void openShortFolder(shorts, path)}
+          onDelete={(path) => void deleteShort(shorts, path)}
+          onEdit={onEditShort}
         />
       ) : null}
     </div>

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+const rpcMock = vi.fn();
+vi.mock('../components/api', () => ({
+  rpc: (...args: unknown[]) => rpcMock(...args),
+  onProgress: () => () => {},
+  hasApi: () => true,
+}));
+
+import { LibraryCard } from './LibraryCard';
+import type { LibraryVideo } from './libraryModel';
+import { videoThumbnailSrc } from '../components/useVideoThumbnail';
+
+function makeVideo(over: Partial<LibraryVideo> = {}): LibraryVideo {
+  return {
+    id: 'v1',
+    path: '/movies/talk.mp4',
+    title: 'Talk',
+    addedAt: '2026-06-11T00:00:00Z',
+    durationSec: 605,
+    hasTranscript: false,
+    thumbnailPath: '/data/thumbnails/v1.jpg',
+    ...over,
+  };
+}
+
+function provenanceHandlers() {
+  return {
+    reveal: vi.fn(async () => ({
+      id: 'v1',
+      sources: [
+        { id: 'v1', path: '/movies/talk.mp4', title: 'Talk', exists: true, relinkable: true },
+      ],
+      missing: [] as string[],
+    })),
+    pinHash: vi.fn(async () => ({})),
+    relink: vi.fn(async () => {}),
+    openInFolder: vi.fn(async () => true),
+    pickRelinkTarget: vi.fn(async () => null),
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 6; i += 1) await Promise.resolve();
+  });
+}
+
+interface Over {
+  video?: LibraryVideo;
+  lineageView?: boolean;
+  selected?: boolean;
+  onToggleSelect?: (id: string) => void;
+  onOpen?: (v: LibraryVideo) => void;
+  onRemove?: (id: string, e: React.MouseEvent) => void;
+  shortsCount?: number;
+  onOpenShorts?: (v: LibraryVideo) => void;
+  provenance?: ReturnType<typeof provenanceHandlers>;
+}
+
+async function renderCard(over: Over = {}): Promise<void> {
+  await act(async () => {
+    root.render(
+      <ul>
+        <LibraryCard
+          video={over.video ?? makeVideo()}
+          lineageView={over.lineageView ?? false}
+          selected={over.selected ?? false}
+          onToggleSelect={over.onToggleSelect ?? (() => {})}
+          onOpen={over.onOpen ?? (() => {})}
+          onRemove={over.onRemove ?? (() => {})}
+          shortsCount={over.shortsCount ?? 0}
+          onOpenShorts={over.onOpenShorts ?? (() => {})}
+          provenance={over.provenance}
+        />
+      </ul>,
+    );
+  });
+  await flush();
+}
+
+describe('LibraryCard', () => {
+  it('renders the poster, title, added date, and an enriched open aria-label', async () => {
+    await renderCard();
+    const open = container.querySelector('.library__item-open') as HTMLButtonElement;
+    expect(open.getAttribute('aria-label')).toBe('Open Talk, 10:05, no transcript');
+    expect(container.querySelector('.library__item-title')?.textContent).toBe('Talk');
+    expect(container.querySelector('.library__item-added')?.textContent).toBe('Added 2026-06-11');
+    const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/v1.jpg'));
+    expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
+  });
+
+  it('omits the added line when the timestamp is unparseable', async () => {
+    await renderCard({ video: makeVideo({ addedAt: 'nope' }) });
+    expect(container.querySelector('.library__item-added')).toBeNull();
+  });
+
+  it('shows the FAILED attention badge before the Transcript chip', async () => {
+    await renderCard({ video: makeVideo({ failed: true, hasTranscript: true }) });
+    const badges = [...container.querySelectorAll('.library__badge')].map((b) => b.textContent);
+    expect(badges).toEqual(['Failed', 'Transcript']);
+    expect(container.querySelector('.library__chip--failed')).not.toBeNull();
+    expect(container.querySelector('.library__chip--transcript')).not.toBeNull();
+  });
+
+  it('renders no chips for a plain video', async () => {
+    await renderCard();
+    expect(container.querySelector('.library__chips')).toBeNull();
+  });
+
+  it('opens the video on click', async () => {
+    const onOpen = vi.fn();
+    await renderCard({ onOpen });
+    act(() => {
+      (container.querySelector('.library__item-open') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    expect(onOpen).toHaveBeenCalledTimes(1);
+    expect(onOpen.mock.calls[0][0].id).toBe('v1');
+  });
+
+  it('re-labels the open action in lineage view', async () => {
+    await renderCard({ lineageView: true });
+    expect(
+      (container.querySelector('.library__item-open') as HTMLButtonElement).getAttribute(
+        'aria-label',
+      ),
+    ).toBe('Show history of Talk, 10:05, no transcript');
+  });
+
+  it('toggles selection via the checkbox', async () => {
+    const onToggleSelect = vi.fn();
+    await renderCard({ selected: true, onToggleSelect });
+    const box = container.querySelector('.library__select-box') as HTMLInputElement;
+    expect(box.checked).toBe(true);
+    act(() => {
+      box.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onToggleSelect).toHaveBeenCalledWith('v1');
+  });
+
+  it('removes the video via the Remove control', async () => {
+    const onRemove = vi.fn();
+    await renderCard({ onRemove });
+    act(() => {
+      (container.querySelector('.library__remove-btn') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    expect(onRemove).toHaveBeenCalledTimes(1);
+    expect(onRemove.mock.calls[0][0]).toBe('v1');
+  });
+
+  it('shows a "N shorts" label that opens the gallery when the video has shorts', async () => {
+    const onOpenShorts = vi.fn();
+    await renderCard({ shortsCount: 3, onOpenShorts });
+    const label = container.querySelector('.library__shorts-label') as HTMLButtonElement;
+    expect(label.textContent).toBe('3 shorts');
+    expect(label.getAttribute('aria-label')).toBe('View 3 produced shorts for Talk');
+    act(() => {
+      label.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onOpenShorts).toHaveBeenCalledTimes(1);
+    expect(onOpenShorts.mock.calls[0][0].id).toBe('v1');
+  });
+
+  it('hides the shorts label when the video has none', async () => {
+    await renderCard({ shortsCount: 0 });
+    expect(container.querySelector('.library__shorts-label')).toBeNull();
+  });
+
+  it('renders the provenance row and drops the legacy path line when provenance is wired', async () => {
+    const handlers = provenanceHandlers();
+    await renderCard({ provenance: handlers });
+    expect(container.querySelector('.library-provenance')).not.toBeNull();
+    expect(container.querySelector('.library__item-path')).toBeNull();
+    expect(handlers.reveal).toHaveBeenCalledWith('v1');
+  });
+
+  it('keeps the legacy path line when no provenance is wired', async () => {
+    await renderCard();
+    expect(container.querySelector('.library__item-path')?.textContent).toBe('/movies/talk.mp4');
+  });
+
+  it('falls back to the ▶ glyph when the poster <img> fails to load', async () => {
+    await renderCard();
+    const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    act(() => {
+      img.dispatchEvent(new Event('error'));
+    });
+    expect(container.querySelector('img.library__thumb-img')).toBeNull();
+    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
+  });
+
+  it('falls back to the glyph when on-demand poster generation yields nothing', async () => {
+    // thumbnailPath omitted entirely -> the `video.thumbnailPath ?? ''` fallback,
+    // then on-demand generation via library.thumbnail (which fails here).
+    rpcMock.mockRejectedValueOnce(new Error('no poster'));
+    await renderCard({ video: makeVideo({ thumbnailPath: undefined }) });
+    expect(rpcMock).toHaveBeenCalledWith('library.thumbnail', { id: 'v1' });
+    expect(container.querySelector('img.library__thumb-img')).toBeNull();
+    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
+  });
+});

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -1,0 +1,169 @@
+// LibraryCard.tsx — one content-first Library card (v1.5 §4). A re-skin of the
+// shipped card: a real focusable OPEN button (aria-label = title + duration +
+// status), a poster-frame thumb, additive meta (date + a FAILED attention badge +
+// the quiet Transcript chip), the multi-select checkbox, and the "N shorts" label
+// that opens the produced-shorts gallery (the P0 one-to-many affordance).
+//
+// A11Y: the open action and the select/remove/shorts controls are SIBLINGS, never
+// nested inside one another (no nested-interactive); resting depth is the surface
+// ladder + --elev-* (library-cards.css), not a border-everywhere box.
+import React, { useState } from 'react';
+
+import { rpc } from '../components/api';
+import type { Video } from '../components/api';
+import { useVideoThumbnail, type VideoThumbnailRpc } from '../components/useVideoThumbnail';
+import { LibraryProvenance, type ProvenanceHandlers } from '../features/LibraryProvenance';
+import {
+  type LibraryVideo,
+  cardAriaLabel,
+  cardBadges,
+  formatAdded,
+  formatDuration,
+} from './libraryModel';
+import '../components/library-cards.css';
+
+/**
+ * `library.thumbnail({id})` adapter over the shared `rpc` bridge — the thin RPC
+ * slice `useVideoThumbnail` needs. Stable across renders so the hook's effect does
+ * not re-fire every card render.
+ */
+const thumbnailRpc: VideoThumbnailRpc = {
+  thumbnail: (videoId: string) =>
+    rpc<{ thumbnailPath: string }>('library.thumbnail', { id: videoId }),
+};
+
+/**
+ * Library-card poster: serves the source video's `thumb:` poster as a real <img>,
+ * generating it on demand (idempotent server-side). A missing / failed poster
+ * (empty URL or an <img> load error) falls back to the ▶ glyph and NEVER blocks
+ * the gallery. The duration badge always renders (mm:ss).
+ */
+function VideoThumb({ video }: { video: Video }): React.ReactElement {
+  const posterUrl = useVideoThumbnail(thumbnailRpc, video.id, video.thumbnailPath ?? '');
+  const [imgFailed, setImgFailed] = useState(false);
+  const showImg = posterUrl !== '' && !imgFailed;
+
+  return (
+    <div className="library__thumb">
+      {showImg ? (
+        <img
+          className="library__thumb-img"
+          src={posterUrl}
+          alt=""
+          aria-hidden="true"
+          onError={() => setImgFailed(true)}
+        />
+      ) : (
+        <div className="library__thumb-fallback" aria-hidden="true">
+          ▶
+        </div>
+      )}
+      <span className="library__thumb-duration">{formatDuration(video.durationSec)}</span>
+    </div>
+  );
+}
+
+export interface LibraryCardProps {
+  video: LibraryVideo;
+  /** Lineage view re-labels the open action + diverts it to the history drawer. */
+  lineageView: boolean;
+  selected: boolean;
+  onToggleSelect: (id: string) => void;
+  onOpen: (video: LibraryVideo) => void;
+  onRemove: (id: string, event: React.MouseEvent) => void;
+  /** How many produced shorts this video has (the done-signal + gallery count). */
+  shortsCount: number;
+  onOpenShorts: (video: LibraryVideo) => void;
+  /** L5 provenance handlers; when present the card shows its source-file row. */
+  provenance?: ProvenanceHandlers;
+}
+
+export function LibraryCard({
+  video,
+  lineageView,
+  selected,
+  onToggleSelect,
+  onOpen,
+  onRemove,
+  shortsCount,
+  onOpenShorts,
+  provenance,
+}: LibraryCardProps): React.ReactElement {
+  const badges = cardBadges(video);
+  const added = formatAdded(video.addedAt);
+
+  return (
+    <li className="library__item">
+      <label className="library__select">
+        <input
+          type="checkbox"
+          className="library__select-box"
+          checked={selected}
+          aria-label={`Select ${video.title}`}
+          onChange={() => onToggleSelect(video.id)}
+        />
+      </label>
+
+      <button
+        type="button"
+        className="library__item-open"
+        aria-label={cardAriaLabel(video, lineageView)}
+        onClick={() => onOpen(video)}
+      >
+        <VideoThumb video={video} />
+        <div className="library__item-main">
+          <span className="library__item-title">{video.title}</span>
+          {badges.length > 0 ? (
+            <div className="library__chips">
+              {badges.map((badge) => (
+                <span
+                  key={badge.kind}
+                  className={`library__badge library__chip library__chip--${badge.kind}`}
+                  title={badge.label}
+                >
+                  {badge.label}
+                </span>
+              ))}
+            </div>
+          ) : null}
+          {provenance ? null : (
+            <span className="library__item-path" title={video.path}>
+              {video.path}
+            </span>
+          )}
+          {added ? <span className="library__item-added">Added {added}</span> : null}
+        </div>
+      </button>
+
+      {provenance ? (
+        <LibraryProvenance
+          video={{ id: video.id, path: video.path, title: video.title }}
+          handlers={provenance}
+        />
+      ) : null}
+
+      <div className="library__item-meta">
+        {shortsCount > 0 ? (
+          <button
+            type="button"
+            className="library__shorts-label"
+            aria-label={`View ${shortsCount} produced shorts for ${video.title}`}
+            onClick={() => onOpenShorts(video)}
+          >
+            {shortsCount} shorts
+          </button>
+        ) : null}
+        <button
+          type="button"
+          className="library__remove-btn"
+          aria-label={`Remove ${video.title}`}
+          onClick={(event) => onRemove(video.id, event)}
+        >
+          Remove
+        </button>
+      </div>
+    </li>
+  );
+}
+
+export default LibraryCard;

--- a/app/renderer/src/views/LibraryToolbar.test.tsx
+++ b/app/renderer/src/views/LibraryToolbar.test.tsx
@@ -1,0 +1,113 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { LibraryToolbar } from './LibraryToolbar';
+import type { LibrarySort } from './libraryModel';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+interface Over {
+  query?: string;
+  onQueryChange?: (q: string) => void;
+  sort?: LibrarySort;
+  onSortChange?: (s: LibrarySort) => void;
+  selectedCount?: number;
+  onRemoveSelected?: () => void;
+  onClearSelection?: () => void;
+}
+
+function renderToolbar(over: Over = {}): void {
+  act(() => {
+    root.render(
+      <LibraryToolbar
+        query={over.query ?? ''}
+        onQueryChange={over.onQueryChange ?? (() => {})}
+        sort={over.sort ?? 'recent'}
+        onSortChange={over.onSortChange ?? (() => {})}
+        selectedCount={over.selectedCount ?? 0}
+        onRemoveSelected={over.onRemoveSelected ?? (() => {})}
+        onClearSelection={over.onClearSelection ?? (() => {})}
+      />,
+    );
+  });
+}
+
+describe('LibraryToolbar', () => {
+  it('renders the search + sort controls with the current values', () => {
+    renderToolbar({ query: 'talk', sort: 'title' });
+    const search = container.querySelector('.library-toolbar__search') as HTMLInputElement;
+    const sort = container.querySelector('.library-toolbar__sort-select') as HTMLSelectElement;
+    expect(search.value).toBe('talk');
+    expect(sort.value).toBe('title');
+    // Every sort mode is offered.
+    expect(sort.querySelectorAll('option').length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('forwards search input changes', () => {
+    const onQueryChange = vi.fn();
+    renderToolbar({ onQueryChange });
+    const search = container.querySelector('.library-toolbar__search') as HTMLInputElement;
+    // Use the native value setter so React's _valueTracker sees the change and
+    // fires onChange on a controlled input (a direct `.value =` is swallowed).
+    const setValue = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')
+      ?.set as (v: string) => void;
+    act(() => {
+      setValue.call(search, 'keynote');
+      search.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(onQueryChange).toHaveBeenCalledWith('keynote');
+  });
+
+  it('forwards sort changes', () => {
+    const onSortChange = vi.fn();
+    renderToolbar({ onSortChange });
+    const sort = container.querySelector('.library-toolbar__sort-select') as HTMLSelectElement;
+    act(() => {
+      sort.value = 'duration';
+      sort.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    expect(onSortChange).toHaveBeenCalledWith('duration');
+  });
+
+  it('hides the batch bar when nothing is selected', () => {
+    renderToolbar({ selectedCount: 0 });
+    expect(container.querySelector('.library-toolbar__batch')).toBeNull();
+  });
+
+  it('shows the batch bar and forwards remove + clear when a selection exists', () => {
+    const onRemoveSelected = vi.fn();
+    const onClearSelection = vi.fn();
+    renderToolbar({ selectedCount: 3, onRemoveSelected, onClearSelection });
+    expect(container.querySelector('.library-toolbar__batch-count')?.textContent).toBe(
+      '3 selected',
+    );
+
+    act(() => {
+      (
+        container.querySelector('.library-toolbar__batch-remove') as HTMLButtonElement
+      ).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onRemoveSelected).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      (container.querySelector('.library-toolbar__batch-clear') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/renderer/src/views/LibraryToolbar.tsx
+++ b/app/renderer/src/views/LibraryToolbar.tsx
@@ -1,0 +1,80 @@
+// LibraryToolbar.tsx — the Library scale affordances (v1.5 §4): per-library
+// search + sort, and the multi-select batch bar. Purely presentational — the
+// parent (Library) owns the query/sort/selection state and the batch action; this
+// renders the controls and forwards intent. Cmd-K is global but must not replace
+// in-context filtering at hundreds of videos, which is what this provides.
+import React from 'react';
+
+import { type LibrarySort, LIBRARY_SORT_MODES, LIBRARY_SORT_LABELS } from './libraryModel';
+import '../components/library-shell.css';
+
+export interface LibraryToolbarProps {
+  query: string;
+  onQueryChange: (query: string) => void;
+  sort: LibrarySort;
+  onSortChange: (sort: LibrarySort) => void;
+  /** Number of currently-selected cards (0 hides the batch bar). */
+  selectedCount: number;
+  onRemoveSelected: () => void;
+  onClearSelection: () => void;
+}
+
+export function LibraryToolbar({
+  query,
+  onQueryChange,
+  sort,
+  onSortChange,
+  selectedCount,
+  onRemoveSelected,
+  onClearSelection,
+}: LibraryToolbarProps): React.ReactElement {
+  return (
+    <div className="library-toolbar">
+      <div className="library-toolbar__filters">
+        <input
+          type="search"
+          className="library-toolbar__search"
+          placeholder="Search videos"
+          aria-label="Search videos"
+          value={query}
+          onChange={(event) => onQueryChange(event.target.value)}
+        />
+        <label className="library-toolbar__sort">
+          <span className="library-toolbar__sort-label">Sort</span>
+          <select
+            className="library-toolbar__sort-select"
+            aria-label="Sort videos"
+            value={sort}
+            onChange={(event) => onSortChange(event.target.value as LibrarySort)}
+          >
+            {LIBRARY_SORT_MODES.map((mode) => (
+              <option key={mode} value={mode}>
+                {LIBRARY_SORT_LABELS[mode]}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {selectedCount > 0 ? (
+        <div className="library-toolbar__batch" role="group" aria-label="Batch actions">
+          <span className="library-toolbar__batch-count" aria-live="polite">
+            {selectedCount} selected
+          </span>
+          <button
+            type="button"
+            className="library-toolbar__batch-remove"
+            onClick={onRemoveSelected}
+          >
+            Remove selected
+          </button>
+          <button type="button" className="library-toolbar__batch-clear" onClick={onClearSelection}>
+            Clear
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default LibraryToolbar;

--- a/app/renderer/src/views/ShortsGalleryModal.test.tsx
+++ b/app/renderer/src/views/ShortsGalleryModal.test.tsx
@@ -1,0 +1,199 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { ShortInfo } from '../lib/rpc';
+
+// Isolate the modal from the (separately-covered) ProducedShorts gallery: a
+// lightweight stub renders exactly the per-clip affordances the modal wires, so
+// each modal handler (play toggle / open-folder / delete / edit-mapping) is
+// exercised directly. The REAL ProducedShorts is reused in production.
+vi.mock('../features/ProducedShorts', () => ({
+  ProducedShorts: ({
+    shorts,
+    playingShortPath,
+    onPlay,
+    onOpenFolder,
+    onReexport,
+    onDelete,
+  }: {
+    shorts: ShortInfo[];
+    playingShortPath: string;
+    onPlay: (p: string) => void;
+    onOpenFolder: (p: string) => void;
+    onReexport?: (p: string) => void;
+    onDelete: (p: string) => void;
+  }) => (
+    <div data-testid="produced-shorts" data-playing={playingShortPath}>
+      {shorts.map((s) => (
+        <div key={s.id}>
+          <button type="button" data-testid={`play-${s.id}`} onClick={() => onPlay(s.path)}>
+            play
+          </button>
+          <button type="button" data-testid={`folder-${s.id}`} onClick={() => onOpenFolder(s.path)}>
+            folder
+          </button>
+          <button type="button" data-testid={`delete-${s.id}`} onClick={() => onDelete(s.path)}>
+            delete
+          </button>
+          {onReexport ? (
+            <button type="button" data-testid={`edit-${s.id}`} onClick={() => onReexport(s.path)}>
+              edit
+            </button>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  ),
+}));
+
+import { ShortsGalleryModal } from './ShortsGalleryModal';
+
+function makeShort(over: Partial<ShortInfo> = {}): ShortInfo {
+  return {
+    id: 's1',
+    path: '/out/s1.mp4',
+    videoId: 'v1',
+    sourceTitle: 'Talk',
+    template: '',
+    viralityPct: 90,
+    durationSec: 30,
+    width: 1080,
+    height: 1920,
+    createdAt: 1,
+    thumbnailPath: '',
+    hook: '',
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+interface Handlers {
+  onClose?: () => void;
+  onOpenFolder?: (p: string) => void;
+  onDelete?: (p: string) => void;
+  onEdit?: (s: ShortInfo) => void;
+  shorts?: ShortInfo[];
+}
+
+function renderModal(h: Handlers = {}): void {
+  act(() => {
+    root.render(
+      <ShortsGalleryModal
+        title="Talk"
+        shorts={h.shorts ?? [makeShort()]}
+        onClose={h.onClose ?? (() => {})}
+        onOpenFolder={h.onOpenFolder ?? (() => {})}
+        onDelete={h.onDelete ?? (() => {})}
+        onEdit={h.onEdit}
+      />,
+    );
+  });
+}
+
+function dialog(): HTMLElement {
+  return container.querySelector('.shorts-modal') as HTMLElement;
+}
+
+function click(sel: string): void {
+  act(() => {
+    (container.querySelector(sel) as HTMLElement).dispatchEvent(
+      new MouseEvent('click', { bubbles: true }),
+    );
+  });
+}
+
+describe('ShortsGalleryModal', () => {
+  it('renders a labelled dialog reusing ProducedShorts, and focuses the close button', () => {
+    renderModal();
+    const d = dialog();
+    expect(d.getAttribute('role')).toBe('dialog');
+    expect(d.getAttribute('aria-modal')).toBe('true');
+    expect(d.getAttribute('aria-label')).toBe('Produced shorts for Talk');
+    expect(container.querySelector('.shorts-modal__title')?.textContent).toBe('Talk');
+    expect(container.querySelector('[data-testid="produced-shorts"]')).not.toBeNull();
+    // Focus lands on the close control on open.
+    expect(document.activeElement).toBe(container.querySelector('.shorts-modal__close'));
+  });
+
+  it('shows an empty message when the video has no shorts', () => {
+    renderModal({ shorts: [] });
+    expect(container.querySelector('.shorts-modal__empty')?.textContent).toContain('No shorts');
+    expect(container.querySelector('[data-testid="produced-shorts"]')).toBeNull();
+  });
+
+  it('closes on backdrop click but NOT on an inner (dialog) click', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    // Inner click is swallowed (stopPropagation) — does not close.
+    click('.shorts-modal__title');
+    expect(onClose).not.toHaveBeenCalled();
+    // Backdrop click closes.
+    click('.shorts-modal__backdrop');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes on the close button and on Escape, but ignores other keys', () => {
+    const onClose = vi.fn();
+    renderModal({ onClose });
+    click('.shorts-modal__close');
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      dialog().dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(1); // unchanged
+
+    act(() => {
+      dialog().dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    });
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it('toggles inline playback of a clip (play then stop)', () => {
+    renderModal();
+    const shorts = () => container.querySelector('[data-testid="produced-shorts"]');
+    expect(shorts()?.getAttribute('data-playing')).toBe('');
+    click('[data-testid="play-s1"]');
+    expect(shorts()?.getAttribute('data-playing')).toBe('/out/s1.mp4');
+    click('[data-testid="play-s1"]'); // same clip again -> stop
+    expect(shorts()?.getAttribute('data-playing')).toBe('');
+  });
+
+  it('forwards open-folder and delete actions', () => {
+    const onOpenFolder = vi.fn();
+    const onDelete = vi.fn();
+    renderModal({ onOpenFolder, onDelete });
+    click('[data-testid="folder-s1"]');
+    expect(onOpenFolder).toHaveBeenCalledWith('/out/s1.mp4');
+    click('[data-testid="delete-s1"]');
+    expect(onDelete).toHaveBeenCalledWith('/out/s1.mp4');
+  });
+
+  it('maps the re-export affordance to onEdit(short) when Studio editing is wired', () => {
+    const onEdit = vi.fn();
+    const short = makeShort({ id: 's7', path: '/out/s7.mp4', hook: 'Hook 7' });
+    renderModal({ shorts: [short], onEdit });
+    click('[data-testid="edit-s7"]');
+    expect(onEdit).toHaveBeenCalledWith(short);
+  });
+
+  it('renders no edit affordance when onEdit is absent', () => {
+    renderModal();
+    expect(container.querySelector('[data-testid="edit-s1"]')).toBeNull();
+  });
+});

--- a/app/renderer/src/views/ShortsGalleryModal.tsx
+++ b/app/renderer/src/views/ShortsGalleryModal.tsx
@@ -1,0 +1,113 @@
+// ShortsGalleryModal.tsx — the produced-shorts gallery/picker (v1.5 §4 P0).
+//
+// The one-to-many model: a Library card's "N shorts" label opens THIS modal for
+// that source video. It reuses the shipped <ProducedShorts/> gallery (poster,
+// virality, duration, sort, per-clip actions) on a glass floating surface, so the
+// one clip -> many shorts relationship finally has a real home. Each short is
+// editable in Studio via `onEdit` (wired to the re-export/open affordance).
+//
+// Presentational + controlled: the parent (Library) owns which video's gallery is
+// open and the shorts list; this owns only the inline-play state + the dialog
+// shell (backdrop-close, Escape, focus-on-open). Motion is neutralised by the
+// global prefers-reduced-motion rule in shell.css.
+import React, { useCallback, useMemo, useState } from 'react';
+
+import { ProducedShorts } from '../features/ProducedShorts';
+import type { ShortInfo } from '../lib/rpc';
+import '../components/library-shell.css';
+
+export interface ShortsGalleryModalProps {
+  /** Source video title (the dialog's accessible name + heading). */
+  title: string;
+  /** This video's produced shorts (already grouped by the parent). */
+  shorts: ShortInfo[];
+  onClose: () => void;
+  /** Reveal a clip in the OS file explorer. */
+  onOpenFolder: (path: string) => void;
+  /** Delete a produced clip (the parent confirms + removes the file). */
+  onDelete: (path: string) => void;
+  /** "Edit in Studio" — reopen the short for further editing. */
+  onEdit?: (short: ShortInfo) => void;
+}
+
+export function ShortsGalleryModal({
+  title,
+  shorts,
+  onClose,
+  onOpenFolder,
+  onDelete,
+  onEdit,
+}: ShortsGalleryModalProps): React.ReactElement {
+  const [playingShortPath, setPlayingShortPath] = useState('');
+
+  // Focus the close control on open (and release cleanly on unmount) via a
+  // callback ref — both the mount (node) and unmount (null) paths run.
+  const focusOnOpen = useCallback((node: HTMLButtonElement | null) => {
+    node?.focus();
+  }, []);
+
+  const play = useCallback((path: string) => {
+    setPlayingShortPath((cur) => (cur === path ? '' : path));
+  }, []);
+
+  // ProducedShorts' re-export action hands back a clip PATH; map it to the clip so
+  // "edit in Studio" gets the full ShortInfo. The path always resolves (it comes
+  // from the rendered list), so the lookup is total.
+  const byPath = useMemo(() => new Map(shorts.map((s) => [s.path, s])), [shorts]);
+  const onReexport = onEdit
+    ? (path: string): void => {
+        onEdit(byPath.get(path) as ShortInfo);
+      }
+    : undefined;
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (event.key === 'Escape') {
+      event.stopPropagation();
+      onClose();
+    }
+  };
+
+  return (
+    <div className="shorts-modal__backdrop" onClick={onClose}>
+      {/* The dialog stops backdrop-close on inner clicks; it is dismissed by the
+          close button or Escape, so it is not itself an interactive control. */}
+      <div
+        className="shorts-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={`Produced shorts for ${title}`}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={onKeyDown}
+      >
+        <header className="shorts-modal__head">
+          <h2 className="shorts-modal__title">{title}</h2>
+          <button
+            ref={focusOnOpen}
+            type="button"
+            className="shorts-modal__close"
+            aria-label="Close produced shorts"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </header>
+        <div className="shorts-modal__body">
+          {shorts.length === 0 ? (
+            <p className="shorts-modal__empty">No shorts for this video yet.</p>
+          ) : (
+            <ProducedShorts
+              shorts={shorts}
+              playingShortPath={playingShortPath}
+              onPlay={play}
+              onOpenFolder={onOpenFolder}
+              onReexport={onReexport}
+              onDelete={onDelete}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ShortsGalleryModal;

--- a/app/renderer/src/views/libraryModel.test.ts
+++ b/app/renderer/src/views/libraryModel.test.ts
@@ -1,0 +1,210 @@
+// libraryModel.test.ts — full-branch coverage of the pure Library view-model.
+import { describe, it, expect } from 'vitest';
+
+import type { Video } from '../components/api';
+import type { ShortInfo } from '../lib/rpc';
+import {
+  type LibraryVideo,
+  LIBRARY_SORT_MODES,
+  LIBRARY_SORT_LABELS,
+  groupShortsByVideo,
+  filterVideos,
+  sortVideos,
+  formatDuration,
+  cardBadges,
+  cardAriaLabel,
+  formatAdded,
+} from './libraryModel';
+
+function makeVideo(over: Partial<LibraryVideo> = {}): LibraryVideo {
+  return {
+    id: 'v1',
+    path: '/movies/talk.mp4',
+    title: 'Talk',
+    addedAt: '2026-06-11T00:00:00Z',
+    durationSec: 605,
+    hasTranscript: false,
+    ...over,
+  };
+}
+
+function makeShort(over: Partial<ShortInfo> = {}): ShortInfo {
+  return {
+    id: 's1',
+    path: '/out/s1.mp4',
+    videoId: 'v1',
+    sourceTitle: 'Talk',
+    template: '',
+    viralityPct: null,
+    durationSec: 30,
+    width: 1080,
+    height: 1920,
+    createdAt: 1,
+    thumbnailPath: '',
+    hook: '',
+    ...over,
+  };
+}
+
+describe('sort model constants', () => {
+  it('exposes every sort mode with a label', () => {
+    for (const mode of LIBRARY_SORT_MODES) {
+      expect(LIBRARY_SORT_LABELS[mode]).toBeTruthy();
+    }
+    expect(LIBRARY_SORT_MODES[0]).toBe('recent');
+  });
+});
+
+describe('groupShortsByVideo', () => {
+  it('groups shorts under their source video id and skips id-less shorts', () => {
+    const grouped = groupShortsByVideo([
+      makeShort({ id: 'a', videoId: 'v1' }),
+      makeShort({ id: 'b', videoId: 'v2' }),
+      makeShort({ id: 'c', videoId: 'v1' }),
+      makeShort({ id: 'd', videoId: '' }), // no source — dropped
+    ]);
+    expect(grouped['v1'].map((s) => s.id)).toEqual(['a', 'c']);
+    expect(grouped['v2'].map((s) => s.id)).toEqual(['b']);
+    expect(Object.keys(grouped)).toEqual(['v1', 'v2']);
+  });
+
+  it('returns an empty map for no shorts', () => {
+    expect(groupShortsByVideo([])).toEqual({});
+  });
+});
+
+describe('filterVideos', () => {
+  const list = [
+    makeVideo({ id: 'a', title: 'Keynote' }),
+    makeVideo({ id: 'b', title: 'Bloopers' }),
+  ];
+
+  it('returns a copy of all videos for an empty / whitespace query', () => {
+    const out = filterVideos(list, '   ');
+    expect(out.map((v) => v.id)).toEqual(['a', 'b']);
+    expect(out).not.toBe(list);
+  });
+
+  it('matches the title case-insensitively', () => {
+    expect(filterVideos(list, 'key').map((v) => v.id)).toEqual(['a']);
+  });
+
+  it('returns an empty list when nothing matches', () => {
+    expect(filterVideos(list, 'zzz')).toEqual([]);
+  });
+});
+
+describe('sortVideos', () => {
+  const count = (id: string): number => ({ a: 2, b: 5, c: 5 })[id] ?? 0;
+  const list = [
+    makeVideo({ id: 'a', title: 'Bravo', addedAt: '2026-01-02', durationSec: 100 }),
+    makeVideo({ id: 'b', title: 'Alpha', addedAt: '2026-01-03', durationSec: 100 }),
+    makeVideo({ id: 'c', title: 'Charlie', addedAt: '2026-01-01', durationSec: 300 }),
+  ];
+
+  it('sorts by title A–Z', () => {
+    expect(sortVideos(list, 'title', count).map((v) => v.id)).toEqual(['b', 'a', 'c']);
+  });
+
+  it('sorts by duration desc, tie → title', () => {
+    // c(300) leads; a & b tie at 100 → title (Alpha 'b' before Bravo 'a').
+    expect(sortVideos(list, 'duration', count).map((v) => v.id)).toEqual(['c', 'b', 'a']);
+  });
+
+  it('sorts by shorts count desc, tie → title', () => {
+    // b & c tie at 5 → title (Alpha 'b' before Charlie 'c'); a has 2.
+    expect(sortVideos(list, 'shorts', count).map((v) => v.id)).toEqual(['b', 'c', 'a']);
+  });
+
+  it('sorts by recency (addedAt desc), preserving input order on a tie (stable)', () => {
+    const list = [
+      makeVideo({ id: 'a', title: 'Bravo', addedAt: '2026-01-01' }),
+      makeVideo({ id: 'b', title: 'Alpha', addedAt: '2026-01-03' }),
+      makeVideo({ id: 'x', title: 'Yankee', addedAt: '2026-01-02' }),
+      makeVideo({ id: 'y', title: 'Xray', addedAt: '2026-01-02' }),
+    ];
+    // b(03) leads; the 01-02 tie keeps its INPUT order (x before y); a(01) last.
+    expect(sortVideos(list, 'recent', count).map((v) => v.id)).toEqual(['b', 'x', 'y', 'a']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [...list];
+    sortVideos(input, 'title', count);
+    expect(input.map((v) => v.id)).toEqual(['a', 'b', 'c']);
+  });
+});
+
+describe('formatDuration', () => {
+  it('formats mm:ss under an hour', () => {
+    expect(formatDuration(605)).toBe('10:05');
+  });
+  it('formats h:mm:ss past an hour', () => {
+    expect(formatDuration(3725)).toBe('1:02:05');
+  });
+  it('returns --:-- for zero / negative / non-finite', () => {
+    expect(formatDuration(0)).toBe('--:--');
+    expect(formatDuration(-5)).toBe('--:--');
+    expect(formatDuration(Number.NaN)).toBe('--:--');
+  });
+});
+
+describe('cardBadges', () => {
+  it('is empty for a plain video', () => {
+    expect(cardBadges(makeVideo())).toEqual([]);
+  });
+  it('shows only the Transcript chip when transcribed', () => {
+    expect(cardBadges(makeVideo({ hasTranscript: true }))).toEqual([
+      { kind: 'transcript', label: 'Transcript' },
+    ]);
+  });
+  it('shows only the Failed badge for a failed video', () => {
+    expect(cardBadges(makeVideo({ failed: true }))).toEqual([{ kind: 'failed', label: 'Failed' }]);
+  });
+  it('leads with Failed then Transcript when both apply', () => {
+    expect(cardBadges(makeVideo({ failed: true, hasTranscript: true })).map((b) => b.kind)).toEqual(
+      ['failed', 'transcript'],
+    );
+  });
+});
+
+describe('cardAriaLabel', () => {
+  it('names open + duration + transcript status', () => {
+    expect(cardAriaLabel(makeVideo({ hasTranscript: true }), false)).toBe(
+      'Open Talk, 10:05, transcript ready',
+    );
+  });
+  it('names the history verb + no-transcript status in lineage view', () => {
+    expect(cardAriaLabel(makeVideo(), true)).toBe('Show history of Talk, 10:05, no transcript');
+  });
+  it('names the failed status', () => {
+    expect(cardAriaLabel(makeVideo({ failed: true }), false)).toBe(
+      'Open Talk, 10:05, processing failed',
+    );
+  });
+  it('omits an unknown duration from the name', () => {
+    expect(cardAriaLabel(makeVideo({ durationSec: 0 }), false)).toBe('Open Talk, no transcript');
+  });
+});
+
+describe('formatAdded', () => {
+  it('extracts the date part of an ISO timestamp', () => {
+    expect(formatAdded('2026-06-11T00:00:00Z')).toBe('2026-06-11');
+  });
+  it('returns empty string for an unparseable value', () => {
+    expect(formatAdded('not-a-date')).toBe('');
+  });
+});
+
+// A Video (no `failed`) is assignable to LibraryVideo — the forward-compatible seam.
+it('accepts a plain Video as a LibraryVideo', () => {
+  const v: Video = {
+    id: 'z',
+    path: '/z.mp4',
+    title: 'Z',
+    addedAt: '2026-01-01T00:00:00Z',
+    durationSec: 10,
+    hasTranscript: false,
+  };
+  const lv: LibraryVideo = v;
+  expect(cardBadges(lv)).toEqual([]);
+});

--- a/app/renderer/src/views/libraryModel.ts
+++ b/app/renderer/src/views/libraryModel.ts
@@ -1,0 +1,132 @@
+// libraryModel.ts — pure, render-free helpers for the content-first Library
+// (v1.5). No React, no I/O: grouping produced shorts by source video, the
+// search/sort model, the card's additive badges + meta, and the a11y open-label.
+// Keeping the branchy logic here lets LibraryCard/Library stay thin render shells
+// and pins each rule once (coverage + no drift). Everything returns NEW data.
+
+import type { Video } from '../components/api';
+import type { ShortInfo } from '../lib/rpc';
+
+/**
+ * A library video enriched with an OPTIONAL, forward-compatible processing
+ * status. The frozen `library.list` payload carries no failure field yet, so
+ * `failed` is `undefined` in production until the sidecar surfaces it (PR
+ * follow-up: a `Video.status`/job-failure field). The FAILED badge and its
+ * derivation are covered here + in LibraryCard so wiring it later is a one-liner.
+ */
+export type LibraryVideo = Video & { failed?: boolean };
+
+/** How the library grid is ordered (the per-library sort control). */
+export type LibrarySort = 'recent' | 'title' | 'duration' | 'shorts';
+
+/** Sort modes in DISPLAY order (recent leads — the default home ordering). */
+export const LIBRARY_SORT_MODES: readonly LibrarySort[] = ['recent', 'title', 'duration', 'shorts'];
+
+/** Human labels for the sort control. */
+export const LIBRARY_SORT_LABELS: Record<LibrarySort, string> = {
+  recent: 'Recently added',
+  title: 'Title (A–Z)',
+  duration: 'Duration',
+  shorts: 'Most shorts',
+};
+
+/**
+ * Group produced shorts by their source `videoId` (the P0 one-to-many index).
+ * Shorts with no source id are skipped (they cannot attach to a card). Immutable.
+ */
+export function groupShortsByVideo(shorts: readonly ShortInfo[]): Record<string, ShortInfo[]> {
+  const out: Record<string, ShortInfo[]> = {};
+  for (const s of shorts) {
+    if (!s.videoId) continue;
+    (out[s.videoId] ??= []).push(s);
+  }
+  return out;
+}
+
+/** Case-insensitive title search (trimmed; empty query → all). Never mutates. */
+export function filterVideos(videos: readonly LibraryVideo[], query: string): LibraryVideo[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return [...videos];
+  return videos.filter((v) => v.title.toLowerCase().includes(q));
+}
+
+/**
+ * Sort a COPY of the list by the chosen mode; `shortsCount` supplies the 'shorts'
+ * ordering (the plumbing count is injected, not re-derived here). Deterministic:
+ * every mode falls back to title A–Z on a tie, so the order never flickers.
+ */
+export function sortVideos(
+  videos: readonly LibraryVideo[],
+  mode: LibrarySort,
+  shortsCount: (id: string) => number,
+): LibraryVideo[] {
+  const byTitle = (a: LibraryVideo, b: LibraryVideo): number => a.title.localeCompare(b.title);
+  const copy = [...videos];
+  if (mode === 'title') return copy.sort(byTitle);
+  if (mode === 'duration')
+    return copy.sort((a, b) => b.durationSec - a.durationSec || byTitle(a, b));
+  if (mode === 'shorts') {
+    return copy.sort((a, b) => shortsCount(b.id) - shortsCount(a.id) || byTitle(a, b));
+  }
+  // 'recent': newest addedAt first (ISO strings sort lexicographically). A STABLE
+  // sort (ES2019+) preserves the incoming order for equal timestamps, so freshly
+  // added videos (library.add prepends newest) keep their order rather than being
+  // re-shuffled by a title tie-break.
+  return copy.sort((a, b) => b.addedAt.localeCompare(a.addedAt));
+}
+
+/**
+ * mm:ss (or h:mm:ss past an hour) for a source-video duration; '--:--' for a
+ * non-finite / non-positive input. Behaviour identical to the prior in-Library
+ * helper the card thumbnail relies on.
+ */
+export function formatDuration(sec: number): string {
+  if (!Number.isFinite(sec) || sec <= 0) return '--:--';
+  const total = Math.round(sec);
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  const mm = String(m).padStart(2, '0');
+  const ss = String(s).padStart(2, '0');
+  return h > 0 ? `${h}:${mm}:${ss}` : `${mm}:${ss}`;
+}
+
+/** A card status badge — reserved for ATTENTION states (failed) + provenance. */
+export interface CardBadge {
+  kind: 'transcript' | 'failed';
+  label: string;
+}
+
+/**
+ * The card's badges, additive and ORDER-STABLE: the FAILED attention badge leads
+ * (when a video is in a failed state), then the quiet Transcript provenance chip.
+ * Never a duplicate of the meta line or the shorts count.
+ */
+export function cardBadges(video: LibraryVideo): CardBadge[] {
+  const badges: CardBadge[] = [];
+  if (video.failed) badges.push({ kind: 'failed', label: 'Failed' });
+  if (video.hasTranscript) badges.push({ kind: 'transcript', label: 'Transcript' });
+  return badges;
+}
+
+/**
+ * The open-affordance accessible name: title + duration + status — one
+ * self-describing name so the card is fully usable by screen readers (the P0
+ * a11y contract). Duration is omitted when unknown so the name never reads a
+ * bare '--:--'.
+ */
+export function cardAriaLabel(video: LibraryVideo, lineageView: boolean): string {
+  const parts = [lineageView ? `Show history of ${video.title}` : `Open ${video.title}`];
+  const dur = formatDuration(video.durationSec);
+  if (dur !== '--:--') parts.push(dur);
+  parts.push(
+    video.failed ? 'processing failed' : video.hasTranscript ? 'transcript ready' : 'no transcript',
+  );
+  return parts.join(', ');
+}
+
+/** The date part (YYYY-MM-DD) of an ISO `addedAt`; '' when unparseable. */
+export function formatAdded(iso: string): string {
+  const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso);
+  return m ? m[1] : '';
+}


### PR DESCRIPTION
## v1.5 pro-shell — first increment (§7.1 "safe-now")

Executes the §7.1 non-big-bang step of the validated redesign direction: **token
reconciliation + deliberate evolution**, the **left rail**, and the **content-first
Library**. Nothing here is a big-bang rewrite — the shell mounts against the shipped
`tokens.css`, App.tsx routing is untouched, and every new surface is behind an
existing seam. **Draft** for an independent reviewer + owner sign-off.

### What shipped (per commit)

**1. `feat(tokens)` — token reconciliation + deliberate evolution (§5)**
- §5.A is already conformant in the shipped `tokens.css` (faint `#a6aebd`, the cool
  surface ramp, `--accent-ink #211404`); this commit **locks** those guardrails in
  the conformance test (accent-ink pinned, faint pinned off the rejected sub-AA
  `#50555F`, the 120/180/260 motion ladder) so the redesign can never regress them.
- §5.B deliberate evolution: font families now **lead with bundled non-generic
  faces** — `--font-ui` → Inter, `--font-mono` → IBM Plex Mono, `--font-editorial`
  → Newsreader — superseding the stale `system-ui`/`Georgia` leads, with system
  fallbacks kept **last** so everything renders offline until the binaries land.
- Wave-2 **glass / floating-surface layer** (`--surface-glass`, `--glass-blur`,
  `--overlay-scrim`, `--overlay-width`), consumed by the produced-shorts modal now
  and reusable by the Cmd-K palette when it ships (§7.5).
- New conformance guards (`WU-1.5`) pin the font leads + glass layer; **additive —
  no existing guard weakened**.

**2. `feat(shell)` — TopTabBar → vertical left rail (presentational only)**
- `.app` becomes a CSS **grid** (bar spans top; rail left of the stage); the rail is
  placed by `grid-area`, not source order, so **App.tsx DOM + routing are unchanged**.
- `topTabBar.css` restyled as a vertical rail (left accent edge-bar for the active
  item, truncating labels → no horizontal overflow, narrow-width tightening); keeps
  the `WU-D1`-pinned `--size-icon` + `--control-pad-toptab` consumptions and routes
  all type through tokens.
- Role-complete rail: `aria-orientation="vertical"` + **ArrowUp/ArrowDown** as the
  primary axis (ArrowLeft/Right kept as equivalents); every item keyboard-operable
  with the global visible focus ring. Existing tablist semantics preserved.

**3. `feat(library)` — content-first re-skin (§4)**
- **P0 one-to-many**: an injected `shorts` port loads the produced-shorts index once,
  grouped by source video; each card shows a **"N shorts"** label that opens a **glass
  gallery modal reusing the shipped `ProducedShorts`** (reveal / delete / edit-in-Studio).
- **Scale**: per-library **search + sort** (Recently added / Title / Duration / Most
  shorts) and **multi-select + batch remove** (new `LibraryToolbar`).
- **Capabilities chip**: the always-open readiness roll-up becomes a
  **"Capabilities: N of M installed"** disclosure (`CapabilitiesChip`) — a plumbing
  count kept separate from the visible card count, reusing `readiness.summary` +
  `ReadinessBadge`.
- **Card**: real focusable open button (`aria-label` = title + duration + status),
  additive meta (Added date), a **FAILED** attention badge + quiet Transcript chip,
  resting depth via `--elev-*`; grid `auto-fill minmax(215px,1fr)`.
- **State matrix**: first-run empty, loading skeleton, async posters, **new
  filter-empty**. Decomposed into small covered units + a pure `libraryModel` view-model.

### Gate results (actual)

| Gate | Result |
|---|---|
| `tsc --noEmit` (app) | **pass** (exit 0) |
| `vitest run --coverage` (renderer gate:3) | **175 files, 3177 tests pass; All files 100% lines/branches/functions/statements** (exit 0 = thresholds met) |
| `tokens.conformance.test.ts` | **25/25 pass** (incl. WU-1.5 + WU-D7 CSS-var scan) |
| `oxlint` (`--deny-warnings`) | **pass** (pre-commit) |
| `biome format` | **pass** (pre-commit) |
| `gitleaks` | **pass** (no secrets) |

No new `/* v8 ignore */`, `istanbul ignore`, or `.skip`. No thresholds weakened.

### §8 Definition-of-Done — this increment's surfaces

| DoD item | Status |
|---|---|
| Contrast — conformance ladder green | **met** (§5.A locked; faint AA on every plane) |
| Keyboard — native/role-complete + visible focus ring | **met** for the rail, cards, toolbar, chip, and modal (Escape + focus-on-open). Timeline / caption-clip keyboard models belong to later screens. |
| State completeness (empty/loading/busy/terminal) | **met** for Library (empty/loading/filter-empty/error/toasts), the chip (loading/error), and the gallery (empty; per-clip busy/error via ProducedShorts). |
| Motion — `prefers-reduced-motion` neutralizes decorative motion | **met** (modal animation gated by the global shell rule) |
| Responsive — no horizontal overflow at narrow widths | **met** (rail labels truncate + narrow at ≤720px; `.app__main { min-width: 0 }`). The `BrowserWindow` min-width **declaration** is main-process → out of this renderer-only scope. |
| One-accent discipline (amber only; status R/Y/G) | **met** (shorts label + batch bar deliberately NEUTRAL; FAILED = status red; no decorative 2nd hue) |
| Voice — no jargon/codenames in user-visible strings | **partial** — my surfaces add none (the chip uses `readiness.summary` plain labels); the `advisorMeta.ts` codename rewrite is out of scope (see follow-ups). |
| IA integrity — shorts-finding flow wired | **met** for Library's part (the one-to-many gallery); the full §6 map is the design artifact. |

### Follow-ups (deliberately deferred, with reasons)

1. **`advisorMeta.ts` jargon rewrite** — out of this increment's 3-area scope. Those
   codename strings (`ViNet-S`, `PANNs`, `TransNetV2`, `DOVER`, `SmolVLM2`, `SigLIP-2`,
   `pyannote`, `Parakeet`, `HSEmotion`, `RapidOCR` in `prettyName`) are consumed by
   `ModelsSystemPanel` / `ModelCard` (Settings), **not** the Library. My capabilities
   chip renders `readiness.summary`'s already-plain labels. Rewriting `advisorMeta`
   is a focused Settings-panel change and should ship with that screen.
2. **Font binaries** — the family tokens now lead with Inter / IBM Plex Mono /
   Newsreader, but the self-hosted `@font-face` files are not bundled yet (renders on
   the system fallbacks until then). Follow-up: add subsetted `woff2` under the
   renderer assets + `@font-face` (CSP already allows `font-src 'self'`). Per the
   task, the PR is **not** blocked on font files.
3. **App-side wiring of the `shorts` port + `onEditShort`** — the shorts feature is
   fully built + 100%-covered behind an injected seam (matching the repo's
   lane-independent `provenance`/`toast` pattern), but `App.tsx` is out of the
   declared 3-file scope. Making it live is a ~5-line adapter: `client.shorts.list()`
   → group, `openInFolder`, `shorts.delete`, and routing edit → Studio.
4. **`ProducedShorts` reuse vs `useShortsGallery`** — reused `ProducedShorts` (the
   gallery); used a thin port instead of `useShortsGallery`, whose handlers are
   coupled to ShortMaker's re-export **navigation**. Same visual gallery, cleaner
   Library-context wiring.
5. **FAILED badge data** — the badge + its derivation are built and covered, but the
   frozen `Video` type carries no failure field, so it is forward-compatible (never
   populated in production until a sidecar `Video.status` lands).
6. **Cmd-K palette tokens** — added the generic glass/overlay tokens (a real consumer
   now: the modal) rather than speculative `--cmdk-*` tokens; Cmd-K itself is deferred
   per §7.5 and will reuse the overlay layer.
