### PR TITLE
feat: wire the produced-shorts gallery live + de-jargon capability labels

### DIFF
--- a/app/renderer/src/App.test.tsx
+++ b/app/renderer/src/App.test.tsx
@@ -30,11 +30,24 @@ vi.mock('./lib/rpc', () => ({
   },
 }));
 
+// The Library marker exposes onOpen + the v1.5 §4 P0 produced-shorts seams App
+// wires (whether the `shorts` port is injected, and the edit-in-Studio callback).
 vi.mock('./views/Library', () => ({
-  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => (
-    <div data-testid="library">
+  Library: ({
+    onOpen,
+    shorts,
+    onEditShort,
+  }: {
+    onOpen: (v: Video) => void;
+    shorts?: unknown;
+    onEditShort?: (short: { videoId: string }) => void;
+  }) => (
+    <div data-testid="library" data-has-shorts={shorts ? 'yes' : 'no'}>
       <button type="button" onClick={() => onOpen(makeVideo())}>
         open-video
+      </button>
+      <button type="button" onClick={() => onEditShort?.({ videoId: 'v1' })}>
+        edit-short
       </button>
     </div>
   ),
@@ -349,6 +362,30 @@ describe('App top-level tabs', () => {
     expect(view).not.toBeNull();
     expect(view!.getAttribute('data-video-id')).toBe('v1');
     // No batch resume on this deep-link.
+    expect(view!.getAttribute('data-resume')).toBe('');
+    expect(tab('Make Shorts').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('v1.5 §4 P0: injects the produced-shorts port + routes edit-in-Studio to Make Shorts', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    // The dormant produced-shorts seam is now LIVE: the port is injected into the Library.
+    expect(
+      container.querySelector('[data-testid="library"]')!.getAttribute('data-has-shorts'),
+    ).toBe('yes');
+    // "Edit in Studio" for a produced short reopens Make Shorts pre-selected to its source video.
+    const editBtn = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-testid="library"] button'),
+    ).find((b) => b.textContent === 'edit-short');
+    await act(async () => {
+      editBtn!.click();
+    });
+    await flush();
+    const view = container.querySelector('[data-testid="makeshorts"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-video-id')).toBe('v1');
     expect(view!.getAttribute('data-resume')).toBe('');
     expect(tab('Make Shorts').getAttribute('aria-selected')).toBe('true');
   });

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -24,6 +24,7 @@ import { MakeShorts } from './views/MakeShorts';
 import { Settings } from './views/Settings';
 import { incompleteBatches, remainingCount } from './features/repurposeLogic';
 import { lineageActions } from './features/lineageActionsClient';
+import { libraryShortsClient } from './features/libraryShortsClient';
 import { useToast } from './components/toast/useToast';
 import { TopTabBar, topTabId, topTabPanelId, type TopTab } from './components/TopTabBar';
 import {
@@ -35,7 +36,15 @@ import {
 } from './components/navIcons';
 // AI Director panel (lazy: it pulls the storyboard/diff + cost-banner surface).
 const DirectorPanel = lazy(() => import('./panels/DirectorPanel'));
-import { client, hasApi, rpc, type ReadinessAction, type RoutingMode, type Video } from './lib/rpc';
+import {
+  client,
+  hasApi,
+  rpc,
+  type ReadinessAction,
+  type RoutingMode,
+  type ShortInfo,
+  type Video,
+} from './lib/rpc';
 import { RoutingToggle } from './components/RoutingToggle';
 import { actionSection } from './features/providersKeysLogic';
 import { ToastProvider } from './components/toast/ToastProvider';
@@ -332,6 +341,14 @@ function AppShell(): React.ReactElement {
     setRoute({ name: 'makeshorts', videoId });
   }, []);
 
+  // v1.5 §4 P0: "edit in Studio" for a produced short (fired from the Library's
+  // per-video gallery modal) reuses the SAME single-owner ShortMaker deep-link —
+  // it reopens the Make Shorts section with the short's source video pre-selected.
+  const editShort = useCallback(
+    (short: ShortInfo) => openMakeShortsForVideo(short.videoId),
+    [openMakeShortsForVideo],
+  );
+
   // WU-3a1: the Task Hub's "Director" job card routes to the top-level Director
   // section (the open video is already threaded from shell state).
   const openDirector = useCallback(() => {
@@ -429,11 +446,16 @@ function AppShell(): React.ReactElement {
         // WU-14: a readiness fix action routes to Settings → Models & System.
         // WU-1f: the L5 provenance handlers drive each card's source-file row
         // (path + on-disk/missing badge + reveal/relink) and the lazy hash back-fill.
+        // v1.5 §4 P0: the produced-shorts port (client.shorts + openInFolder bridge)
+        // powers each card's "N shorts" gallery; onEditShort reopens the short in
+        // the Make Shorts studio.
         return (
           <Library
             onOpen={openVideo}
             onReadinessAction={handleReadinessAction}
             provenance={lineageActions}
+            shorts={libraryShortsClient}
+            onEditShort={editShort}
           />
         );
     }

--- a/app/renderer/src/components/TierCard.tsx
+++ b/app/renderer/src/components/TierCard.tsx
@@ -1,7 +1,7 @@
 // TierCard.tsx — one selectable quality tier (Tier-0/1/2) in the tier picker.
 // Shows the tier label, its will-it-run verdict badge, the member-component
 // summary, and a radio to select it (writes settings.phase8Tier upstream). The
-// Tier-2 card carries the "heavy, opt-in, runs alone" + SmolVLM2-int8-broken
+// Tier-2 card carries the "heaviest, opt-in, runs on its own, needs more memory"
 // warning. Pure presentational: selection + apply are callbacks.
 import React from 'react';
 import type { TierStatus } from '../lib/rpc';
@@ -22,7 +22,7 @@ export interface TierCardProps {
 const TIER_BLURB: Record<number, string> = {
   0: 'Instant, silent-video OK, zero downloads. Runs on any machine.',
   1: 'Default. Adds visual + audio + transcript models (downloads on first use).',
-  2: 'Heavy video-LLM re-rank of the top clips. Opt-in; runs alone; SmolVLM2 int8 is broken — uses BF16.',
+  2: 'The heaviest option — an AI watches the top clips to re-rank them. Opt-in; runs on its own and needs more memory.',
 };
 
 export function TierCard({

--- a/app/renderer/src/components/advisorComponents.test.tsx
+++ b/app/renderer/src/components/advisorComponents.test.tsx
@@ -95,7 +95,10 @@ describe('<TierCard />', () => {
     expect(card.getAttribute('data-tier')).toBe('1');
     expect(card.querySelector('.tier-card__recommended')).not.toBeNull();
     expect(card.querySelector('.verdict-badge')?.textContent).toBe('Will run');
-    expect(card.querySelector('.tier-card__members')?.textContent).toContain('SigLIP-2');
+    // §8 Voice: the member summary reads the plain capability label (no codename).
+    const members = card.querySelector('.tier-card__members')?.textContent ?? '';
+    expect(members).toContain('Understand the visuals');
+    expect(members).not.toContain('SigLIP');
     // Not selected -> no aria-current, no Selected badge (selection clarity).
     expect(card.getAttribute('aria-current')).toBeNull();
     expect(card.querySelector('.tier-card__selected')).toBeNull();
@@ -151,7 +154,8 @@ describe('<ModelCard />', () => {
       />,
     );
     const card = container.querySelector('.model-card') as HTMLElement;
-    expect(card.querySelector('.model-card__name')?.textContent).toContain('SigLIP-2');
+    // §8 Voice: the card name is the plain capability label, not a model codename.
+    expect(card.querySelector('.model-card__name')?.textContent).toBe('Understand the visuals');
     expect(card.querySelector('.license-chip')?.textContent).toBe('Commercial OK');
     expect(card.querySelector('.model-card__size')?.textContent).toBe('4.4 GB');
     const costFill = card.querySelector('.mini-meter__fill.is-cost') as HTMLElement;

--- a/app/renderer/src/components/advisorMeta.test.ts
+++ b/app/renderer/src/components/advisorMeta.test.ts
@@ -93,9 +93,38 @@ describe('fillPct / fillZone', () => {
 });
 
 describe('prettyName', () => {
-  it('maps special component ids', () => {
-    expect(prettyName('vlm_backbone')).toContain('SigLIP-2');
-    expect(prettyName('smolvlm2')).toContain('SmolVLM2');
+  it('maps special component ids to a plain-language capability label', () => {
+    // §8 Voice: the label says what the capability DOES, in plain words.
+    expect(prettyName('vlm_backbone')).toBe('Understand the visuals');
+    expect(prettyName('smolvlm2')).toBe('Re-rank clips by watching them');
+    expect(prettyName('saliency')).toBe('Keep the subject in frame');
+    expect(prettyName('audio_saliency')).toBe('Find audio highlights');
+    expect(prettyName('pyannote')).toBe('Tell speakers apart');
+  });
+  it('never leaks a model codename into a user-facing label (§8 Voice DoD)', () => {
+    // Every mapped capability must read as plain language — no model codename.
+    const codename =
+      /SigLIP|SmolVLM|PANNs|DOVER|TransNetV2|ViNet|pyannote|Parakeet|HSEmotion|RapidOCR|UNISAL|S3FD|TalkNet/i;
+    const capabilities = [
+      'vlm_backbone',
+      'audio_saliency',
+      'scene_transnet',
+      'quality_gate',
+      'smolvlm2',
+      'ctc_aligner',
+      'pyannote',
+      'parakeet',
+      'saliency',
+      'aesthetic',
+      'emotion',
+      'ocr',
+      'motion',
+      'diversity',
+      'ranker',
+    ];
+    for (const id of capabilities) {
+      expect(prettyName(id)).not.toMatch(codename);
+    }
   });
   it('title-cases + de-snakes unknowns', () => {
     expect(prettyName('foo_bar')).toBe('Foo bar');

--- a/app/renderer/src/components/advisorMeta.ts
+++ b/app/renderer/src/components/advisorMeta.ts
@@ -88,24 +88,30 @@ export function fillZone(
   return used / total > TIGHT_FRACTION ? 'tight' : 'ok';
 }
 
-/** Pretty display name for a raw component id (e.g. "vlm_backbone" -> "VLM backbone"). */
+/**
+ * Pretty display name for a raw component id — a plain-language capability label
+ * that says what the model DOES for the user, never a model codename (§8 Voice).
+ * The internal ids and asset names keep their real names; only this human-facing
+ * label is de-jargoned. Falls back to a title-cased, de-snaked id (e.g.
+ * "foo_bar" -> "Foo bar").
+ */
 export function prettyName(name: string): string {
   const special: Record<string, string> = {
-    vlm_backbone: 'Vision backbone (SigLIP-2)',
-    audio_saliency: 'Audio peaks (PANNs)',
-    scene_transnet: 'Scene cuts (TransNetV2)',
-    quality_gate: 'Quality gate (DOVER)',
-    smolvlm2: 'Video-LLM re-rank (SmolVLM2)',
+    vlm_backbone: 'Understand the visuals',
+    audio_saliency: 'Find audio highlights',
+    scene_transnet: 'Find scene changes',
+    quality_gate: 'Check video quality',
+    smolvlm2: 'Re-rank clips by watching them',
     ctc_aligner: 'Karaoke word-timing',
-    pyannote: 'Speaker diarization (pyannote)',
-    parakeet: 'Parakeet ASR',
-    saliency: 'Saliency / crop-track (ViNet-S)',
-    aesthetic: 'Aesthetic scorer',
-    emotion: 'Emotion peaks (HSEmotion)',
-    ocr: 'On-screen text (RapidOCR)',
-    motion: 'Motion energy',
-    diversity: 'Near-duplicate removal',
-    ranker: 'Learned re-rank',
+    pyannote: 'Tell speakers apart',
+    parakeet: 'Fast speech-to-text',
+    saliency: 'Keep the subject in frame',
+    aesthetic: 'Rate visual appeal',
+    emotion: 'Spot emotional moments',
+    ocr: 'Read on-screen text',
+    motion: 'Detect on-screen motion',
+    diversity: 'Skip near-duplicates',
+    ranker: 'Smart clip ranking',
   };
   if (special[name]) return special[name];
   return name.charAt(0).toUpperCase() + name.slice(1).replace(/_/g, ' ');

--- a/app/renderer/src/features/libraryShortsClient.test.ts
+++ b/app/renderer/src/features/libraryShortsClient.test.ts
@@ -1,0 +1,80 @@
+// libraryShortsClient.test.ts — the produced-shorts port for the content-first
+// Library (v1.5 §4 P0). Covers each rpc forward (listAll incl. the null-list
+// fallback, remove) and the fail-soft openFolder bridge across present / missing
+// / no-window.api shapes.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const listMock = vi.fn();
+const deleteMock = vi.fn();
+
+vi.mock('../lib/rpc', () => ({
+  client: {
+    shorts: {
+      list: (...a: unknown[]) => listMock(...a),
+      delete: (...a: unknown[]) => deleteMock(...a),
+    },
+  },
+}));
+
+import { libraryShortsClient } from './libraryShortsClient';
+import type { ShortInfo } from '../lib/rpc';
+
+beforeEach(() => {
+  listMock.mockReset();
+  deleteMock.mockReset();
+});
+
+afterEach(() => {
+  delete (window as { api?: unknown }).api;
+});
+
+describe('libraryShortsClient.listAll', () => {
+  it('returns every produced short from shorts.list (all sources)', async () => {
+    const shorts = [
+      { id: 's1', videoId: 'v1', path: '/exports/a.mp4' },
+      { id: 's2', videoId: 'v1', path: '/exports/b.mp4' },
+    ] as unknown as ShortInfo[];
+    listMock.mockResolvedValue({ shorts });
+    expect(await libraryShortsClient.listAll()).toEqual(shorts);
+    // No videoId -> every source's clips (the whole produced-shorts index).
+    expect(listMock).toHaveBeenCalledWith();
+  });
+
+  it('degrades to an empty array when the payload carries no list', async () => {
+    listMock.mockResolvedValue({});
+    expect(await libraryShortsClient.listAll()).toEqual([]);
+  });
+});
+
+describe('libraryShortsClient.openFolder (fail-soft bridge)', () => {
+  it('reveals the clip via the preload bridge when present', async () => {
+    const openInFolder = vi.fn(async () => true);
+    (window as { api?: unknown }).api = { openInFolder };
+    await libraryShortsClient.openFolder('/exports/a.mp4');
+    expect(openInFolder).toHaveBeenCalledWith('/exports/a.mp4');
+  });
+
+  it('throws a clear error when the bridge lacks openInFolder', async () => {
+    (window as { api?: unknown }).api = {}; // present, but no openInFolder member
+    await expect(libraryShortsClient.openFolder('/exports/a.mp4')).rejects.toThrow(
+      'openInFolder bridge not wired',
+    );
+  });
+
+  it('throws when there is no window.api at all', async () => {
+    // no window.api installed by this test
+    await expect(libraryShortsClient.openFolder('/exports/a.mp4')).rejects.toThrow(
+      'Reveal in folder is unavailable',
+    );
+  });
+});
+
+describe('libraryShortsClient.remove', () => {
+  it('deletes the clip via shorts.delete', async () => {
+    deleteMock.mockResolvedValue({ ok: true });
+    await libraryShortsClient.remove('/exports/a.mp4');
+    expect(deleteMock).toHaveBeenCalledWith('/exports/a.mp4');
+  });
+});

--- a/app/renderer/src/features/libraryShortsClient.ts
+++ b/app/renderer/src/features/libraryShortsClient.ts
@@ -1,0 +1,50 @@
+// libraryShortsClient.ts — the rpc/bridge-backed produced-shorts port for the
+// content-first Library (v1.5 §4 P0).
+//
+// Mirrors lineageActionsClient: it reuses the SHIPPED shorts RPCs
+// (`client.shorts.list` / `client.shorts.delete`, lib/rpc/client.ts §2) and the
+// existing `openInFolder` preload bridge (CONTRACTS.md §1) — no new machinery —
+// so the Library's per-card "N shorts" count + gallery modal have a real backing.
+// The bridge is read STRUCTURALLY at call time; the Library owns the fail-soft
+// handling (a rejected listAll degrades to an empty index; a rejected openFolder/
+// remove surfaces a typed toast), matching the lane-independent seam pattern.
+
+import { client } from '../lib/rpc';
+import type { ShortInfo } from '../lib/rpc';
+import type { LibraryShortsApi } from '../views/Library';
+
+/** The single optional preload-bridge member this port uses (read structurally). */
+interface FolderBridge {
+  openInFolder?: (path: string) => Promise<boolean>;
+}
+
+function folderBridge(): FolderBridge | null {
+  const api = (globalThis as { window?: { api?: unknown } }).window?.api;
+  return api && typeof api === 'object' ? (api as FolderBridge) : null;
+}
+
+export const libraryShortsClient: LibraryShortsApi = {
+  // Every produced clip across all sources (omitted videoId = all); the Library
+  // groups them by `videoId` for the per-card count. A `null`/absent payload
+  // list degrades to an empty array so grouping never throws.
+  listAll: async (): Promise<ShortInfo[]> => {
+    const { shorts } = await client.shorts.list();
+    return shorts ?? [];
+  },
+  // Reveal a clip in the OS file explorer. A missing bridge is surfaced (the
+  // Library toasts the thrown message) rather than silently doing nothing.
+  openFolder: async (path: string): Promise<void> => {
+    const bridge = folderBridge();
+    if (!bridge?.openInFolder) {
+      throw new Error('Reveal in folder is unavailable (openInFolder bridge not wired).');
+    }
+    await bridge.openInFolder(path);
+  },
+  // Delete a produced clip file (path-traversal guarded sidecar-side); the
+  // Library confirms + updates its index from the resolved deletion.
+  remove: async (path: string): Promise<void> => {
+    await client.shorts.delete(path);
+  },
+};
+
+export default libraryShortsClient;


### PR DESCRIPTION
## Summary

Two focused v1.5 shell increments on top of #284 (content-first Library + left rail):

1. **Make the P0 produced-shorts gallery LIVE.** #284 shipped the content-first Library with a *dormant* produced-shorts seam — `Library` accepts an injected `shorts` port (`LibraryShortsApi`) + `onEditShort`, and `ShortsGalleryModal` reuses the shipped `<ProducedShorts>` gallery — but the component rendering `<Library>` (`App.tsx`) never supplied them, so each card's "N shorts -> gallery" never rendered. This wires the seam.
2. **De-jargon the model-readiness capability labels (§8 Voice).** The Settings model-readiness UI surfaced raw model codenames; every user-facing label now says what the capability *does*.

## Commits

### 1. `feat: wire the produced-shorts gallery live in the Library` (418f4a9)
- **`features/libraryShortsClient.ts`** (new): a module-level `LibraryShortsApi` adapter over the shipped `client.shorts` (`list`/`delete`) + the existing `openInFolder` preload bridge — read structurally, fail-soft. Mirrors the `lineageActionsClient` seam-adapter pattern.
- **`App.tsx`**: injects `shorts={libraryShortsClient}` (each Library card now loads its produced-shorts index and opens `ShortsGalleryModal`) and wires `onEditShort` to the existing single-owner ShortMaker deep-link `openMakeShortsForVideo(short.videoId)` — "edit in Studio" reopens Make Shorts pre-selected to the short's source video.
- **Tests**: new `libraryShortsClient.test.ts` (6) + extended `App.test.tsx` (now 30) cover the port injection + edit-in-Studio routing.

### 2. `feat: de-jargon the model-readiness capability labels (§8 Voice)` (ce3c8b4)
- **`advisorMeta.ts` `prettyName`**: plain-language capability labels, no model codename. Examples:
  - `Saliency / crop-track (ViNet-S)` -> **Keep the subject in frame**
  - `Audio peaks (PANNs)` -> **Find audio highlights**
  - `Quality gate (DOVER)` -> **Check video quality**
  - `Vision backbone (SigLIP-2)` -> **Understand the visuals**
  - `Video-LLM re-rank (SmolVLM2)` -> **Re-rank clips by watching them**
  - `Speaker diarization (pyannote)` -> **Tell speakers apart**
  - `On-screen text (RapidOCR)` -> **Read on-screen text**
  - `Emotion peaks (HSEmotion)` -> **Spot emotional moments**
  - `Scene cuts (TransNetV2)` -> **Find scene changes**
  - `Parakeet ASR` -> **Fast speech-to-text**
- **`TierCard.tsx`**: the Tier-2 blurb drops `SmolVLM2 int8 is broken — uses BF16` -> "an AI watches the top clips to re-rank them ... runs on its own and needs more memory".
- Internal ids / asset names (`COMPONENT_ASSET`, e.g. `vinet-s-saliency`, `panns-cnn14`, `dover-mobile-quality`) are unchanged.
- Tests assert the new labels + a guard that no model codename leaks into any `prettyName` output.

## Gate results (actual, this branch)
- **tsc** (`npm run typecheck`, app): PASS (exit 0).
- **vitest --coverage** (`npm run test:coverage`): **180 test files passed**, exit 0. Coverage **100%** — Statements 17711/17711, Branches 5987/5987, Functions 1061/1061, Lines 17711/17711. No thresholds weakened; no new `v8 ignore` / `istanbul ignore` / `.skip`.
- **tokens.conformance.test.ts**: PASS (25 tests).
- **pre-commit** (changed files): oxlint `--deny-warnings` **Passed**, biome (format) **Passed**, gitleaks **Passed**.

## Scope notes / follow-ups
- The `shorts` port is injected unconditionally (matching the always-on `provenance={lineageActions}` pattern); the Library already degrades fail-soft when no preload bridge is present, so no `hasApi()` gate is added.
- De-jargon scope was the renderer's **capability-label table** (`advisorMeta.prettyName`) + the TierCard blurb — the model-readiness "what each stage does" surface. Deliberately **out of scope** (call out if you want them included):
  - the ASR / diarization **engine-selector** options in `ModelsSystemPanel` (Whisper / pyannote / Parakeet) — there the model name *is* the user's explicit choice, not a jargon capability label;
  - advisor `reason` / `notes` text and asset download-row labels (e.g. "SmolVLM2 2.2B") — backend-provided data, not a renderer string table;
  - `ThirdPartyNotices` — the ViNet-S / TransNetV2 names there are the legally **required** CC-BY-NC-SA / license attributions.
- `render-cli` was not re-typechecked (no `render-cli` files changed; its workspace deps are not installed in this worktree). The app `tsc` covering renderer + main passed.

Draft for independent + owner review.
