### PR TITLE
feat(caption): v1.5 Caption pilot — inspector-over-shared-stage (EditorContext)

### DIFF
--- a/app/renderer/src/App.caption.test.tsx
+++ b/app/renderer/src/App.caption.test.tsx
@@ -1,0 +1,167 @@
+// App.caption.test.tsx — the v1.5 Caption rail destination routing.
+//
+// Verifies the new top-level "Caption" tab: selecting it routes into the Caption
+// phase for the currently-open video (threaded from shell state), empty-states
+// when none is open, and its back control returns to the Library. The Caption
+// view itself is stubbed (it owns its own tests) so this exercises ONLY App's
+// routing wiring.
+
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { Video } from './lib/rpc';
+
+const rpcMock = vi.fn();
+const libraryListMock = vi.fn();
+const batchListMock = vi.fn();
+const setRoutingPolicyMock = vi.fn();
+let hasApiReturn = true;
+
+vi.mock('./lib/rpc', () => ({
+  rpc: (...a: unknown[]) => rpcMock(...a),
+  hasApi: () => hasApiReturn,
+  client: {
+    library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    batch: { list: (...a: unknown[]) => batchListMock(...a) },
+    models: { setRoutingPolicy: (...a: unknown[]) => setRoutingPolicyMock(...a) },
+  },
+}));
+
+vi.mock('./views/Library', () => ({
+  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => (
+    <div data-testid="library">
+      <button type="button" onClick={() => onOpen(makeVideo())}>
+        open-video
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./views/Edit', () => ({ Edit: () => <div data-testid="edit" /> }));
+vi.mock('./views/MakeShorts', () => ({ MakeShorts: () => <div data-testid="makeshorts" /> }));
+vi.mock('./views/Settings', () => ({ Settings: () => <div data-testid="settings" /> }));
+vi.mock('./panels/DirectorPanel', () => ({ default: () => <div data-testid="director" /> }));
+vi.mock('./components/JobQueue', () => ({
+  JobQueue: () => <div />,
+  JOBQUEUE_PANEL_ID: 'jobqueue-panel',
+}));
+vi.mock('./components/SidecarBanner', () => ({ SidecarBanner: () => <div /> }));
+
+// The Caption view is stubbed: it echoes the threaded video id and exposes its
+// back control so App's route wiring is testable without the real view's RPC.
+vi.mock('./views/Caption', () => ({
+  Caption: ({ video, onBack }: { video: Video | null; onBack: () => void }) => (
+    <div data-testid="caption" data-video-id={video?.id ?? ''}>
+      <button type="button" onClick={onBack}>
+        caption-back
+      </button>
+    </div>
+  ),
+}));
+
+import { App } from './App';
+
+function makeVideo(over: Partial<Video> = {}): Video {
+  return {
+    id: 'v1',
+    path: '/movies/talk.mp4',
+    title: 'Talk',
+    addedAt: '2026-06-11T00:00:00Z',
+    durationSec: 600,
+    hasTranscript: false,
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({});
+  libraryListMock.mockReset();
+  batchListMock.mockReset();
+  batchListMock.mockResolvedValue({ batches: [] });
+  setRoutingPolicyMock.mockReset();
+  setRoutingPolicyMock.mockResolvedValue({ routingPolicy: { global: 'local', overrides: {} } });
+  hasApiReturn = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function tab(label: string): HTMLButtonElement {
+  const btns = Array.from(container.querySelectorAll<HTMLButtonElement>('.toptab'));
+  const found = btns.find((b) => b.querySelector('.toptab__label')?.textContent === label);
+  if (!found) throw new Error(`tab "${label}" not found`);
+  return found;
+}
+
+describe('App Caption rail destination', () => {
+  it('mounts the Caption phase with an empty video when opened directly', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="caption"]')).toBeNull();
+    await act(async () => {
+      tab('Caption').click();
+    });
+    await flush();
+    const view = container.querySelector('[data-testid="caption"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-video-id')).toBe('');
+    expect(tab('Caption').getAttribute('aria-selected')).toBe('true');
+    const panel = container.querySelector<HTMLElement>('[role="tabpanel"]')!;
+    expect(panel.id).toBe('toptabpanel-caption');
+  });
+
+  it('threads the open video into the Caption phase', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="library"] button')!.click();
+    });
+    await flush();
+    await act(async () => {
+      tab('Caption').click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="caption"]')!.getAttribute('data-video-id')).toBe(
+      'v1',
+    );
+  });
+
+  it('routes back to the Library from the Caption phase', async () => {
+    await act(async () => {
+      root.render(<App />);
+    });
+    await flush();
+    await act(async () => {
+      tab('Caption').click();
+    });
+    await flush();
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="caption"] button')!.click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(tab('Library').getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -1,6 +1,6 @@
 // App.tsx — the renderer shell + TOP-LEVEL TABBED NAVIGATION (V1 IA §h).
 //
-// The app is organised into the FIVE V1 sections (components/TopTabBar.tsx):
+// The app is organised into the top-level sections (components/TopTabBar.tsx):
 //   * Library    — the video library home; opening a video routes into the Edit
 //                  section for that video,
 //   * Make Shorts — the novice front door: AI moment-pick + manual intervals +
@@ -8,6 +8,8 @@
 //                   (views/MakeShorts.tsx; carries the interrupted-batch badge),
 //   * Edit       — the per-video manual surface (trim/cut/join/reframe/caption/
 //                  audio…) hosted in the Workspace (views/Edit.tsx),
+//   * Caption    — the v1.5 Caption phase pilot: inspector-over-shared-stage
+//                  caption design + keyboard clip timing for the open video,
 //   * Director   — the prompt-driven AI video-editing panel (lazy),
 //   * Settings   — Models & System / Providers & Keys / Storage / Health.
 //
@@ -20,6 +22,7 @@
 import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from 'react';
 import { Library } from './views/Library';
 import { Edit } from './views/Edit';
+import { Caption } from './views/Caption';
 import { MakeShorts } from './views/MakeShorts';
 import { Settings } from './views/Settings';
 import { incompleteBatches, remainingCount } from './features/repurposeLogic';
@@ -28,6 +31,7 @@ import { libraryShortsClient } from './features/libraryShortsClient';
 import { useToast } from './components/toast/useToast';
 import { TopTabBar, topTabId, topTabPanelId, type TopTab } from './components/TopTabBar';
 import {
+  CaptionIcon,
   CreateIcon,
   DirectorIcon,
   LibraryIcon,
@@ -71,8 +75,8 @@ registerJobRetry((jobId) => rpc<{ jobId: string }>('job.retry', { jobId }));
 
 type Quality = 'local' | 'cloud';
 
-/** The five V1 top-level tab ids (the surface switcher). */
-type TabId = 'library' | 'makeshorts' | 'edit' | 'director' | 'settings';
+/** The top-level tab ids (the surface switcher). */
+type TabId = 'library' | 'makeshorts' | 'edit' | 'caption' | 'director' | 'settings';
 
 type Route =
   // The Library home.
@@ -83,6 +87,9 @@ type Route =
   | { name: 'makeshorts'; resumeId?: string; videoId?: string }
   // Edit: the per-video manual surface (the open video lives in shell state).
   | { name: 'edit' }
+  // Caption: the v1.5 Caption phase pilot (inspector-over-shared-stage) for the
+  // open video; empty-states when none is open.
+  | { name: 'caption' }
   // Director: the prompt-driven AI video-editing panel.
   | { name: 'director' }
   // Settings: a sub-navigated area (Models & System / Providers & Keys / Health).
@@ -95,6 +102,8 @@ function routeTab(route: Route): TabId {
       return 'makeshorts';
     case 'edit':
       return 'edit';
+    case 'caption':
+      return 'caption';
     case 'director':
       return 'director';
     case 'settings':
@@ -382,6 +391,9 @@ function AppShell(): React.ReactElement {
         case 'edit':
           setRoute({ name: 'edit' });
           break;
+        case 'caption':
+          setRoute({ name: 'caption' });
+          break;
         case 'director':
           setRoute({ name: 'director' });
           break;
@@ -406,6 +418,7 @@ function AppShell(): React.ReactElement {
       { id: 'library', label: 'Library', icon: <LibraryIcon /> },
       { id: 'makeshorts', label: 'Make Shorts', icon: <CreateIcon />, badge: batchBadge },
       { id: 'edit', label: 'Edit', icon: <RepurposeIcon /> },
+      { id: 'caption', label: 'Caption', icon: <CaptionIcon /> },
       { id: 'director', label: 'Director', icon: <DirectorIcon /> },
       { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
     ],
@@ -430,6 +443,10 @@ function AppShell(): React.ReactElement {
             onDirector={openDirector}
           />
         );
+      case 'caption':
+        // v1.5 Caption pilot: the inspector-over-shared-stage phase for the open
+        // video (empty-states + routes back to the Library when none is open).
+        return <Caption video={editVideo} onBack={backToLibrary} />;
       case 'director':
         return (
           <Suspense fallback={<div className="panel panel--loading">Loading…</div>}>

--- a/app/renderer/src/components/navIcons.tsx
+++ b/app/renderer/src/components/navIcons.tsx
@@ -77,6 +77,16 @@ export function RepurposeIcon(): React.ReactElement {
   );
 }
 
+/** Caption — a captions card with text lines (Lucide "captions"). */
+export function CaptionIcon(): React.ReactElement {
+  return (
+    <Svg>
+      <rect width="18" height="14" x="3" y="5" rx="2" ry="2" />
+      <path d="M7 15h4M15 15h2M7 11h2M13 11h4" />
+    </Svg>
+  );
+}
+
 /** Settings — gear (Lucide "settings"). */
 export function SettingsIcon(): React.ReactElement {
   return (

--- a/app/renderer/src/features/EditorContext.test.tsx
+++ b/app/renderer/src/features/EditorContext.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorProvider, useEditor } from './EditorContext';
+import { DEFAULT_CAPTION_DESIGN } from '../lib/captionDesign';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const WINDOW = { start: 1, end: 5 };
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function q<T extends Element>(sel: string): T {
+  const el = container.querySelector<T>(sel);
+  if (!el) throw new Error(`missing ${sel}`);
+  return el;
+}
+
+/** A probe consumer that renders the current style + a button to change it. */
+function Probe(): React.ReactElement {
+  const { state, dispatch } = useEditor();
+  return (
+    <div>
+      <span data-testid="style">{state.design.style}</span>
+      <span data-testid="playhead">{state.playhead}</span>
+      <button type="button" onClick={() => dispatch({ type: 'setStyle', style: 'serif' })}>
+        style
+      </button>
+      <button type="button" onClick={() => dispatch({ type: 'setPlayhead', playhead: 3 })}>
+        seek
+      </button>
+    </div>
+  );
+}
+
+class Boundary extends React.Component<
+  { children: React.ReactNode; onError: (e: Error) => void },
+  { failed: boolean }
+> {
+  state = { failed: false };
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+  componentDidCatch(err: Error): void {
+    this.props.onError(err);
+  }
+  render(): React.ReactNode {
+    return this.state.failed ? null : this.props.children;
+  }
+}
+
+describe('EditorProvider + useEditor', () => {
+  it('seeds the shared state and exposes it to a consumer', () => {
+    act(() => {
+      root.render(
+        <EditorProvider seed={{ video: { videoId: 'v1', window: WINDOW } }}>
+          <Probe />
+        </EditorProvider>,
+      );
+    });
+    expect(q('[data-testid="style"]').textContent).toBe(DEFAULT_CAPTION_DESIGN.style);
+    expect(q('[data-testid="playhead"]').textContent).toBe('1');
+  });
+
+  it('dispatches reducer actions that update every consumer', () => {
+    act(() => {
+      root.render(
+        <EditorProvider seed={{ video: { videoId: 'v1', window: WINDOW } }}>
+          <Probe />
+        </EditorProvider>,
+      );
+    });
+    act(() => {
+      q<HTMLButtonElement>('button:nth-of-type(1)').click();
+      q<HTMLButtonElement>('button:nth-of-type(2)').click();
+    });
+    expect(q('[data-testid="style"]').textContent).toBe('serif');
+    expect(q('[data-testid="playhead"]').textContent).toBe('3');
+  });
+
+  it('throws when used outside an EditorProvider', () => {
+    let captured: Error | null = null;
+    act(() => {
+      root.render(
+        <Boundary onError={(e) => (captured = e)}>
+          <Probe />
+        </Boundary>,
+      );
+    });
+    expect(captured).not.toBeNull();
+    expect((captured as unknown as Error).message).toMatch(/within an EditorProvider/);
+  });
+});

--- a/app/renderer/src/features/EditorContext.tsx
+++ b/app/renderer/src/features/EditorContext.tsx
@@ -1,0 +1,51 @@
+// EditorContext.tsx — the React binding for the shared editor state (v1.5 pilot).
+//
+// Wraps the pure `editorState` reducer (lib/editorState.ts) in a Context so a
+// Stage, a Timeline, and an Inspector become THIN CONSUMERS that read + write ONE
+// state via `useEditor()`, instead of each owning its own layout + copy of the
+// video/cues/design. The Caption phase pilots the pattern; the other four
+// redesigned phases reuse this same provider.
+//
+// The provider is UNCONTROLLED: it seeds the reducer once (useReducer init). A
+// host that swaps the media should remount the provider (e.g. `key={videoId}`) so
+// the fresh seed takes — the pilot's Caption view does exactly that.
+
+import React, { createContext, useContext, useMemo, useReducer } from 'react';
+import {
+  type EditorAction,
+  type EditorSeed,
+  type EditorState,
+  editorReducer,
+  initialEditorState,
+} from '../lib/editorState';
+
+/** What `useEditor()` returns: the current state + the reducer dispatch. */
+export interface EditorContextValue {
+  state: EditorState;
+  dispatch: React.Dispatch<EditorAction>;
+}
+
+const EditorContext = createContext<EditorContextValue | null>(null);
+
+export interface EditorProviderProps {
+  seed: EditorSeed;
+  children: React.ReactNode;
+}
+
+/** Provide the shared editor state to the Stage / Timeline / Inspector tree. */
+export function EditorProvider({ seed, children }: EditorProviderProps): React.ReactElement {
+  const [state, dispatch] = useReducer(editorReducer, seed, initialEditorState);
+  const value = useMemo<EditorContextValue>(() => ({ state, dispatch }), [state]);
+  return <EditorContext.Provider value={value}>{children}</EditorContext.Provider>;
+}
+
+/** Read the shared editor state. Throws if used outside an `EditorProvider`. */
+export function useEditor(): EditorContextValue {
+  const ctx = useContext(EditorContext);
+  if (!ctx) {
+    throw new Error('useEditor must be used within an EditorProvider');
+  }
+  return ctx;
+}
+
+export default EditorProvider;

--- a/app/renderer/src/features/caption/CaptionClipLane.test.tsx
+++ b/app/renderer/src/features/caption/CaptionClipLane.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorProvider, useEditor } from '../EditorContext';
+import { CaptionClipLane } from './CaptionClipLane';
+import type { EditorSeed } from '../../lib/editorState';
+import type { Cue } from '../../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+const cue = (index: number, start: number, end: number, text: string): Cue => ({
+  index,
+  start,
+  end,
+  text,
+});
+const CUES: Cue[] = [cue(1, 2, 3, 'Alpha'), cue(2, 6, 7, 'Beta'), cue(3, 10, 11, 'Gamma')];
+const SEED: EditorSeed = { video: { videoId: 'v1', window: { start: 0, end: 20 } }, cues: CUES };
+
+function Probe(): React.ReactElement {
+  const { state } = useEditor();
+  return (
+    <div>
+      <span data-testid="playhead">{state.playhead}</span>
+      <span data-testid="sel">{String(state.selection)}</span>
+      <span data-testid="c0start">{state.cues[0]?.start}</span>
+      <span data-testid="c0end">{state.cues[0]?.end}</span>
+      <span data-testid="c1start">{state.cues[1]?.start}</span>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+const num = (testid: string): number => Number(q(`[data-testid="${testid}"]`)?.textContent);
+
+function render(seed: EditorSeed = SEED): void {
+  act(() => {
+    root.render(
+      <EditorProvider seed={seed}>
+        <CaptionClipLane />
+        <Probe />
+      </EditorProvider>,
+    );
+  });
+}
+
+function keyClip(pos: number, key: string, shiftKey = false): void {
+  const clip = q(`[data-clip="${pos}"]`);
+  if (!clip) throw new Error(`no clip ${pos}`);
+  act(() => {
+    clip.dispatchEvent(new KeyboardEvent('keydown', { key, shiftKey, bubbles: true }));
+  });
+}
+
+describe('CaptionClipLane', () => {
+  it('shows an empty prompt when there are no cues', () => {
+    render({ video: { videoId: 'v1', window: { start: 0, end: 20 } }, cues: [] });
+    expect(q('.caption-clip-lane__empty')).not.toBeNull();
+    expect(q('.caption-clip')).toBeNull();
+  });
+
+  it('renders one focusable clip per cue plus the playhead', () => {
+    render();
+    expect(container.querySelectorAll('.caption-clip')).toHaveLength(3);
+    expect(q('[data-testid="clip-playhead"]')).not.toBeNull();
+    expect(q('[data-clip="0"]')?.getAttribute('aria-label')).toBe('Caption 1: Alpha');
+  });
+
+  it('selects a clip on click', () => {
+    render();
+    act(() => q<HTMLButtonElement>('[data-clip="1"]')?.click());
+    expect(num('sel')).toBe(1);
+    expect(q('[data-clip="1"]')?.classList.contains('is-selected')).toBe(true);
+  });
+
+  it('seeks the playhead to the clip start on Enter', () => {
+    render();
+    keyClip(0, 'Enter');
+    expect(num('playhead')).toBe(2);
+    expect(num('sel')).toBe(0);
+  });
+
+  it('seeks on Space as well', () => {
+    render();
+    keyClip(1, ' ');
+    expect(num('playhead')).toBe(6);
+  });
+
+  it('moves a clip later with ArrowRight (neighbor-clamped)', () => {
+    render();
+    keyClip(0, 'ArrowRight');
+    expect(num('c0start')).toBeGreaterThan(2);
+    expect(num('c0end')).toBeGreaterThan(3);
+  });
+
+  it('moves a clip earlier with ArrowLeft', () => {
+    render();
+    keyClip(1, 'ArrowLeft');
+    expect(num('c1start')).toBeLessThan(6);
+  });
+
+  it('resizes the clip out-point with Shift+ArrowRight (start unchanged)', () => {
+    render();
+    keyClip(0, 'ArrowRight', true);
+    expect(num('c0end')).toBeGreaterThan(3);
+    expect(num('c0start')).toBe(2);
+  });
+
+  it('ignores non-arrow, non-seek keys', () => {
+    render();
+    keyClip(0, 'Home');
+    expect(num('c0start')).toBe(2);
+    expect(num('playhead')).toBe(0);
+  });
+});

--- a/app/renderer/src/features/caption/CaptionClipLane.tsx
+++ b/app/renderer/src/features/caption/CaptionClipLane.tsx
@@ -1,0 +1,102 @@
+// CaptionClipLane.tsx — the KEYBOARD-operable caption clip lane (v1.5 §4, item 6).
+//
+// The redesign's charter removes a locked WCAG-A barrier: the shipped Timeline
+// edits cues with mouse-only pointer drags (no key handlers). This lane is the
+// keyboard-first replacement for the CAPTION phase — a thin consumer of the shared
+// editor state that renders each cue as a focusable clip over the window's time
+// axis and edits it entirely from the keyboard:
+//   * Enter / Space  — seek the shared playhead to the clip start (and select it);
+//   * Arrow Left/Right — MOVE the whole clip earlier/later (neighbor-clamped);
+//   * Shift+Arrow      — RESIZE the clip's out-point (neighbor-clamped).
+// All cue math is the shipped, unit-tested `timelineOps` (retimeAt/dragEdge) — the
+// same neighbor-clamping the mouse Timeline uses, reused, not rewritten.
+
+import React from 'react';
+import { type Cue, MIN_CUE_SEC, dragEdge, retimeAt } from '../../lib/timelineOps';
+import { useEditor } from '../EditorContext';
+import './captionClipLane.css';
+
+/** One keyboard nudge = 0.1s (fine, predictable caption timing steps). */
+export const CLIP_NUDGE_SEC = 0.1;
+
+/** Clamp a percentage into [0, 100] for absolute positioning. */
+function pct(value: number): number {
+  return Math.min(Math.max(value, 0), 100);
+}
+
+export function CaptionClipLane(): React.ReactElement {
+  const { state, dispatch } = useEditor();
+  const { cues, video, playhead, selection } = state;
+  const { start: winStart, end: winEnd } = video.window;
+  const span = Math.max(winEnd - winStart, MIN_CUE_SEC);
+
+  if (cues.length === 0) {
+    return (
+      <div className="caption-clip-lane caption-clip-lane--empty" aria-label="Caption clips">
+        <p className="caption-clip-lane__empty">
+          No caption clips yet — generate captions to edit their timing here.
+        </p>
+      </div>
+    );
+  }
+
+  const onClipKeyDown =
+    (pos: number, cue: Cue) =>
+    (e: React.KeyboardEvent): void => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        dispatch({ type: 'selectCue', index: pos });
+        dispatch({ type: 'setPlayhead', playhead: cue.start });
+        return;
+      }
+      const dir = e.key === 'ArrowRight' ? 1 : e.key === 'ArrowLeft' ? -1 : 0;
+      if (dir === 0) return;
+      e.preventDefault();
+      const delta = dir * CLIP_NUDGE_SEC;
+      // Shift = resize the out-point; plain arrow = move the whole clip. Both are
+      // neighbor-clamped by the shipped timelineOps helpers.
+      const next = e.shiftKey
+        ? dragEdge(cues, pos, 'end', cue.end + delta)
+        : retimeAt(cues, pos, cue.start + delta, cue.end + delta);
+      dispatch({ type: 'setCues', cues: next });
+    };
+
+  return (
+    <div
+      className="caption-clip-lane"
+      role="group"
+      aria-label="Caption clips — arrow keys move a clip, Shift+arrow resizes, Enter seeks"
+    >
+      <div className="caption-clip-lane__track">
+        {cues.map((cue, pos) => {
+          const selected = pos === selection;
+          return (
+            <button
+              key={`${cue.index}-${pos}`}
+              type="button"
+              className={`caption-clip${selected ? ' is-selected' : ''}`}
+              data-clip={pos}
+              aria-pressed={selected}
+              aria-label={`Caption ${pos + 1}: ${cue.text}`}
+              style={{
+                left: `${pct(((cue.start - winStart) / span) * 100)}%`,
+                width: `${pct(((cue.end - cue.start) / span) * 100)}%`,
+              }}
+              onClick={() => dispatch({ type: 'selectCue', index: pos })}
+              onKeyDown={onClipKeyDown(pos, cue)}
+            >
+              <span className="caption-clip__text">{cue.text}</span>
+            </button>
+          );
+        })}
+        <div
+          className="caption-clip-lane__playhead"
+          data-testid="clip-playhead"
+          style={{ left: `${pct(((playhead - winStart) / span) * 100)}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default CaptionClipLane;

--- a/app/renderer/src/features/caption/CaptionDelivery.test.tsx
+++ b/app/renderer/src/features/caption/CaptionDelivery.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';

--- a/app/renderer/src/features/caption/CaptionDelivery.test.tsx
+++ b/app/renderer/src/features/caption/CaptionDelivery.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CaptionDelivery, type CaptionDeliveryMode } from './CaptionDelivery';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onChange = vi.fn();
+
+beforeEach(() => {
+  onChange.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+function render(value: CaptionDeliveryMode): void {
+  act(() => {
+    root.render(<CaptionDelivery value={value} onChange={onChange} />);
+  });
+}
+
+describe('CaptionDelivery', () => {
+  it('shows the reversible soft-track note by default (no alert)', () => {
+    render('soft');
+    const note = q('.caption-delivery__note');
+    expect(note?.textContent).toMatch(/toggle captions on or off/);
+    expect(note?.classList.contains('is-warning')).toBe(false);
+    expect(note?.getAttribute('role')).toBeNull();
+    expect(q('.caption-delivery__option.is-active')?.textContent).toBe('Soft track');
+  });
+
+  it('raises a guarded permanence alert for burn-in', () => {
+    render('hard');
+    const note = q('.caption-delivery__note');
+    expect(note?.textContent).toMatch(/permanent/);
+    expect(note?.classList.contains('is-warning')).toBe(true);
+    expect(note?.getAttribute('role')).toBe('alert');
+    const active = q('.caption-delivery__option.is-active');
+    expect(active?.textContent).toBe('Burn in');
+    expect(active?.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('emits the chosen mode', () => {
+    render('soft');
+    act(() => {
+      const buttons = container.querySelectorAll<HTMLButtonElement>('.caption-delivery__option');
+      buttons[1].click();
+    });
+    expect(onChange).toHaveBeenCalledWith('hard');
+  });
+});

--- a/app/renderer/src/features/caption/CaptionDelivery.tsx
+++ b/app/renderer/src/features/caption/CaptionDelivery.tsx
@@ -1,0 +1,66 @@
+// CaptionDelivery.tsx — the burn reversibility signal as a GUARDED choice (§4).
+//
+// Captions ship one of two ways, and the difference is irreversible-vs-reversible:
+//   * SOFT track  — muxed as a selectable subtitle stream: viewers can toggle it,
+//                   and you can restyle or remove it anytime (lossless, reversible).
+//   * BURN IN     — hardsub: the pixels are baked into the frames permanently.
+//
+// The redesign requires the reversibility be surfaced as a GUARDED choice, not a
+// silent toggle, so a permanent bake is never a surprise. Choosing "Burn in"
+// raises an assertive, amber-flagged permanence warning. Controlled + presentational.
+
+import React from 'react';
+import './captionDelivery.css';
+
+/** How the captions are delivered: a toggleable soft track or a permanent burn. */
+export type CaptionDeliveryMode = 'soft' | 'hard';
+
+const OPTIONS: readonly { id: CaptionDeliveryMode; label: string }[] = [
+  { id: 'soft', label: 'Soft track' },
+  { id: 'hard', label: 'Burn in' },
+];
+
+export interface CaptionDeliveryProps {
+  value: CaptionDeliveryMode;
+  onChange: (mode: CaptionDeliveryMode) => void;
+}
+
+export function CaptionDelivery({ value, onChange }: CaptionDeliveryProps): React.ReactElement {
+  const permanent = value === 'hard';
+  return (
+    <div className="caption-delivery" role="group" aria-label="Caption delivery">
+      <span className="caption-delivery__label">Delivery</span>
+      <div
+        className="caption-delivery__options"
+        role="radiogroup"
+        aria-label="Caption delivery mode"
+      >
+        {OPTIONS.map((option) => {
+          const selected = value === option.id;
+          return (
+            <button
+              key={option.id}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              className={`caption-delivery__option${selected ? ' is-active' : ''}`}
+              onClick={() => onChange(option.id)}
+            >
+              {option.label}
+            </button>
+          );
+        })}
+      </div>
+      <p
+        className={`caption-delivery__note${permanent ? ' is-warning' : ''}`}
+        role={permanent ? 'alert' : undefined}
+      >
+        {permanent
+          ? 'Burned-in captions are permanent — they cannot be turned off later. Re-export from source to change them.'
+          : 'A soft track — viewers can toggle captions on or off, and you can restyle or remove them anytime.'}
+      </p>
+    </div>
+  );
+}
+
+export default CaptionDelivery;

--- a/app/renderer/src/features/caption/CaptionGallery.test.tsx
+++ b/app/renderer/src/features/caption/CaptionGallery.test.tsx
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';

--- a/app/renderer/src/features/caption/CaptionGallery.test.tsx
+++ b/app/renderer/src/features/caption/CaptionGallery.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { CaptionGallery } from './CaptionGallery';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onChange = vi.fn();
+
+beforeEach(() => {
+  onChange.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+function render(value: string): void {
+  act(() => {
+    root.render(<CaptionGallery value={value} onChange={onChange} />);
+  });
+}
+function expand(): void {
+  act(() => {
+    q<HTMLButtonElement>('.caption-gallery__toggle')?.click();
+  });
+}
+
+describe('CaptionGallery', () => {
+  it('shows the active look name in the collapsed bar (no grid)', () => {
+    render('hormozi');
+    expect(q('.caption-gallery__current')?.textContent).toBe('Keyword highlight');
+    expect(q('.caption-gallery__toggle')?.textContent).toBe('Browse styles');
+    expect(q('.caption-gallery__grid')).toBeNull();
+  });
+
+  it('expands into a grouped grid of look-named swatches', () => {
+    render('hormozi');
+    expand();
+    expect(q('.caption-gallery__grid')).not.toBeNull();
+    expect(q('.caption-gallery__toggle')?.textContent).toBe('Done');
+    // grouped by family — the headline word-by-word section comes first
+    const titles = [...container.querySelectorAll('.caption-gallery__group-title')].map(
+      (t) => t.textContent,
+    );
+    expect(titles[0]).toBe('Word by word');
+    // look names, never brand/engine jargon
+    const names = [...container.querySelectorAll('.caption-gallery__name')].map(
+      (n) => n.textContent,
+    );
+    expect(names).toContain('Word-by-word pop');
+    expect(names).toContain('Editorial serif');
+    expect(names.join(' ')).not.toMatch(/hormozi|libass|opusclip/i);
+  });
+
+  it('marks the selected swatch active and previews the none style as Off', () => {
+    render('serif');
+    expand();
+    const serif = q<HTMLButtonElement>('[data-style="serif"]');
+    expect(serif?.classList.contains('is-active')).toBe(true);
+    expect(serif?.getAttribute('aria-checked')).toBe('true');
+    const none = q<HTMLButtonElement>('[data-style="none"]');
+    expect(none?.getAttribute('aria-checked')).toBe('false');
+    expect(none?.querySelector('.caption-gallery__off')?.textContent).toBe('Off');
+    // a non-none swatch renders a live styled sample, not the Off text
+    expect(q('[data-style="serif"] .caption-gallery__sample')?.textContent).toBe('Aa');
+  });
+
+  it('emits the chosen style id on selection', () => {
+    render('hormozi');
+    expand();
+    act(() => {
+      q<HTMLButtonElement>('[data-style="serif"]')?.click();
+    });
+    expect(onChange).toHaveBeenCalledWith('serif');
+  });
+
+  it('collapses again when Done is pressed', () => {
+    render('hormozi');
+    expand();
+    expand();
+    expect(q('.caption-gallery__grid')).toBeNull();
+  });
+});

--- a/app/renderer/src/features/caption/CaptionGallery.tsx
+++ b/app/renderer/src/features/caption/CaptionGallery.tsx
@@ -1,0 +1,107 @@
+// CaptionGallery.tsx — the template-preset gallery (v1.5 Caption pilot, §4).
+//
+// The redesign rejects the prototype's cramped 320px style column: Caption's
+// density needs a preset gallery that EXPANDS over the timeline. This is that
+// gallery — a browse affordance that opens a wide, grouped grid of live style
+// previews. Every style is named by its LOOK (captionStyleNames), grouped by its
+// layout/behaviour FAMILY, and previewed with the SAME `sampleStyle` the shipped
+// picker/overlay use (composition, not a rewrite).
+//
+// One-accent GUARD: this is the surface most likely to sprout a decorative second
+// hue. It does not. Styles are told apart by their family SECTIONS + their own
+// caption palettes (that is the caption's look, i.e. content — not app chrome);
+// the only app-chrome accent is the amber selection ring (`is-active`). No new
+// chrome hue is introduced.
+//
+// Controlled + presentational: the parent owns `value` and gets `onChange(id)`.
+
+import React, { useState } from 'react';
+import { sampleStyle } from '../../components/CaptionStylePicker';
+import { captionVisualFor, isNoCaption } from '../../lib/captionTemplates';
+import {
+  type LookStyleOption,
+  groupByFamily,
+  lookNamedCatalog,
+  styleLook,
+} from '../../lib/captionStyleNames';
+import './captionGallery.css';
+
+/** Sample text shown on each styled swatch. */
+const SAMPLE_TEXT = 'Aa';
+
+export interface CaptionGalleryProps {
+  /** The selected style id (parent-owned). */
+  value: string;
+  /** Called with the chosen style id. */
+  onChange: (id: string) => void;
+  /** Override the look catalog (defaults to the full look-named catalog). */
+  catalog?: readonly LookStyleOption[];
+}
+
+export function CaptionGallery({
+  value,
+  onChange,
+  catalog = lookNamedCatalog(),
+}: CaptionGalleryProps): React.ReactElement {
+  const [expanded, setExpanded] = useState(false);
+  const groups = groupByFamily(catalog);
+  const active = styleLook(value);
+
+  return (
+    <section className="caption-gallery" aria-label="Caption style gallery">
+      <div className="caption-gallery__bar">
+        <span className="caption-gallery__label">Style</span>
+        <span className="caption-gallery__current">{active.name}</span>
+        <button
+          type="button"
+          className="caption-gallery__toggle"
+          aria-expanded={expanded}
+          onClick={() => setExpanded((open) => !open)}
+        >
+          {expanded ? 'Done' : 'Browse styles'}
+        </button>
+      </div>
+
+      {expanded && (
+        <div className="caption-gallery__grid" role="radiogroup" aria-label="Caption styles">
+          {groups.map((group) => (
+            <section key={group.family} className="caption-gallery__group" aria-label={group.label}>
+              <h4 className="caption-gallery__group-title">{group.label}</h4>
+              <div className="caption-gallery__swatches">
+                {group.options.map((option) => {
+                  const selected = option.id === value;
+                  const visual = captionVisualFor(option.id);
+                  return (
+                    <button
+                      key={option.id}
+                      type="button"
+                      className={`caption-gallery__swatch${selected ? ' is-active' : ''}`}
+                      data-style={option.id}
+                      role="radio"
+                      aria-checked={selected}
+                      onClick={() => onChange(option.id)}
+                    >
+                      <span className="caption-gallery__preview">
+                        {isNoCaption(option.id) ? (
+                          <span className="caption-gallery__off">Off</span>
+                        ) : (
+                          <span className="caption-gallery__sample" style={sampleStyle(visual)}>
+                            {SAMPLE_TEXT}
+                          </span>
+                        )}
+                      </span>
+                      <span className="caption-gallery__name">{option.label}</span>
+                      <span className="caption-gallery__blurb">{option.blurb}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default CaptionGallery;

--- a/app/renderer/src/features/caption/CaptionInspector.test.tsx
+++ b/app/renderer/src/features/caption/CaptionInspector.test.tsx
@@ -1,0 +1,121 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorProvider, useEditor } from '../EditorContext';
+import { CaptionInspector } from './CaptionInspector';
+import type { EditorSeed } from '../../lib/editorState';
+import { DEFAULT_CAPTION_DESIGN } from '../../lib/captionDesign';
+import type { Cue } from '../../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onGenerate = vi.fn();
+
+const cue = (index: number, start: number, end: number, text: string): Cue => ({
+  index,
+  start,
+  end,
+  text,
+});
+const CUES: Cue[] = [cue(0, 2, 3, 'Hello'), cue(1, 3, 4, 'world')];
+
+function Probe(): React.ReactElement {
+  const { state } = useEditor();
+  return (
+    <div>
+      <span data-testid="style">{state.design.style}</span>
+      <span data-testid="has-override">{state.design.override ? 'yes' : 'no'}</span>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  onGenerate.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+function render(seed: EditorSeed, props: Parameters<typeof CaptionInspector>[0] = {}): void {
+  act(() => {
+    root.render(
+      <EditorProvider seed={seed}>
+        <CaptionInspector {...props} />
+        <Probe />
+      </EditorProvider>,
+    );
+  });
+}
+
+const READY: EditorSeed = {
+  video: { videoId: 'v1', window: { start: 0, end: 10 } },
+  cues: CUES,
+  design: { ...DEFAULT_CAPTION_DESIGN, style: 'hormozi' },
+};
+const EMPTY: EditorSeed = { video: { videoId: 'v1', window: { start: 0, end: 10 } }, cues: [] };
+
+describe('CaptionInspector transcript gate', () => {
+  it('shows the "generate captions first" state with no transcript', () => {
+    render(EMPTY, { onGenerate });
+    expect(q('.caption-inspector__empty-title')?.textContent).toBe('Generate captions first');
+    const btn = q<HTMLButtonElement>('.caption-inspector__generate');
+    expect(btn?.textContent).toBe('Generate captions');
+    expect(btn?.disabled).toBe(false);
+    expect(q('.caption-gallery')).toBeNull();
+    act(() => btn?.click());
+    expect(onGenerate).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the generate button while a request is in flight', () => {
+    render(EMPTY, { onGenerate, generating: true });
+    const btn = q<HTMLButtonElement>('.caption-inspector__generate');
+    expect(btn?.textContent).toBe('Generating…');
+    expect(btn?.disabled).toBe(true);
+  });
+});
+
+describe('CaptionInspector editing surface (transcript ready)', () => {
+  it('composes the gallery, customizer, and delivery choice', () => {
+    render(READY);
+    expect(q('.caption-gallery')).not.toBeNull();
+    expect(q('.caption-customizer')).not.toBeNull();
+    expect(q('.caption-delivery')).not.toBeNull();
+    expect(q('.caption-inspector__empty')).toBeNull();
+  });
+
+  it('dispatches a style change from the gallery into the shared state', () => {
+    render(READY);
+    act(() => q<HTMLButtonElement>('.caption-gallery__toggle')?.click()); // expand
+    act(() => q<HTMLButtonElement>('[data-style="serif"]')?.click());
+    expect(q('[data-testid="style"]')?.textContent).toBe('serif');
+  });
+
+  it('dispatches a customizer override into the shared state', () => {
+    render(READY);
+    expect(q('[data-testid="has-override"]')?.textContent).toBe('no');
+    act(() => q<HTMLButtonElement>('.caption-customizer__toggle')?.click()); // open disclosure
+    act(() => q<HTMLButtonElement>('.caption-customizer__swatch[data-color="#FFD700"]')?.click());
+    expect(q('[data-testid="has-override"]')?.textContent).toBe('yes');
+  });
+
+  it('drives the guarded burn/soft delivery choice locally', () => {
+    render(READY);
+    expect(q('.caption-delivery__note')?.classList.contains('is-warning')).toBe(false);
+    act(() => {
+      const opts = container.querySelectorAll<HTMLButtonElement>('.caption-delivery__option');
+      opts[1].click(); // Burn in
+    });
+    expect(q('.caption-delivery__note')?.classList.contains('is-warning')).toBe(true);
+  });
+});

--- a/app/renderer/src/features/caption/CaptionInspector.tsx
+++ b/app/renderer/src/features/caption/CaptionInspector.tsx
@@ -1,0 +1,80 @@
+// CaptionInspector.tsx — the Caption phase inspector (v1.5 pilot, §4/§7.2).
+//
+// The inspector-over-shared-stage proof: this panel is a THIN CONSUMER of the
+// shared editor state (`useEditor`) that COMPOSES the shipped, verified caption
+// controls — the look-named preset gallery, the CaptionCustomizer tuning
+// disclosure, and the guarded burn/soft delivery choice — and dispatches their
+// edits back into the ONE state the Stage renders. It owns no layout of the
+// stage/timeline and no copy of the design; it only reads + writes context.
+//
+// Transcript gate (§2 disagreement 7): caption styling has a TRUE data dependency
+// on a transcript, so with no cues the inspector shows a single, explicit
+// "generate captions first" state instead of a wall of dead controls — the one
+// place the Caption phase is legitimately disabled.
+
+import React, { useState } from 'react';
+import { CaptionCustomizer } from '../../components/CaptionCustomizer';
+import type { CaptionContentContext } from '../../lib/captionDefaults';
+import { transcriptReady } from '../../lib/editorState';
+import { useEditor } from '../EditorContext';
+import { CaptionGallery } from './CaptionGallery';
+import { CaptionDelivery, type CaptionDeliveryMode } from './CaptionDelivery';
+import './captionInspector.css';
+
+export interface CaptionInspectorProps {
+  /** Invoked when the user asks to generate captions (shown while no transcript). */
+  onGenerate?: () => void;
+  /** True while a generate request is in flight (disables the generate button). */
+  generating?: boolean;
+  /** Per-language reading-speed context threaded to the customizer. */
+  content?: CaptionContentContext;
+}
+
+export function CaptionInspector({
+  onGenerate,
+  generating = false,
+  content,
+}: CaptionInspectorProps): React.ReactElement {
+  const { state, dispatch } = useEditor();
+  const [delivery, setDelivery] = useState<CaptionDeliveryMode>('soft');
+
+  if (!transcriptReady(state)) {
+    return (
+      <aside className="caption-inspector" aria-label="Caption inspector">
+        <div className="caption-inspector__empty">
+          <h3 className="caption-inspector__empty-title">Generate captions first</h3>
+          <p className="caption-inspector__empty-blurb">
+            Caption styling needs a transcript. Generate captions to unlock the style gallery, text
+            tuning, and delivery options.
+          </p>
+          <button
+            type="button"
+            className="caption-inspector__generate"
+            disabled={generating}
+            onClick={onGenerate}
+          >
+            {generating ? 'Generating…' : 'Generate captions'}
+          </button>
+        </div>
+      </aside>
+    );
+  }
+
+  return (
+    <aside className="caption-inspector" aria-label="Caption inspector">
+      <CaptionGallery
+        value={state.design.style}
+        onChange={(style) => dispatch({ type: 'setStyle', style })}
+      />
+      <CaptionCustomizer
+        value={state.design.override}
+        onChange={(override) => dispatch({ type: 'setOverride', override })}
+        style={state.design.style}
+        content={content}
+      />
+      <CaptionDelivery value={delivery} onChange={setDelivery} />
+    </aside>
+  );
+}
+
+export default CaptionInspector;

--- a/app/renderer/src/features/caption/CaptionStage.test.tsx
+++ b/app/renderer/src/features/caption/CaptionStage.test.tsx
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorProvider, useEditor } from '../EditorContext';
+import { CaptionStage } from './CaptionStage';
+import type { EditorSeed } from '../../lib/editorState';
+import { DEFAULT_CAPTION_DESIGN } from '../../lib/captionDesign';
+import type { Cue } from '../../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+const cue = (index: number, start: number, end: number, text: string): Cue => ({
+  index,
+  start,
+  end,
+  text,
+});
+const PHRASE: Cue[] = [cue(0, 2, 3, 'Hello'), cue(1, 3, 4, 'there'), cue(2, 4, 5, 'world')];
+
+function setReducedMotion(reduce: boolean): void {
+  (window as unknown as { matchMedia: (q: string) => MediaQueryList }).matchMedia = ((q: string) =>
+    ({
+      matches: reduce,
+      media: q,
+      onchange: null,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    }) as unknown as MediaQueryList) as unknown as (q: string) => MediaQueryList;
+}
+
+function Probe(): React.ReactElement {
+  const { state } = useEditor();
+  return (
+    <div>
+      <span data-testid="playhead">{state.playhead}</span>
+      <span data-testid="box-y">{state.design.box.y}</span>
+    </div>
+  );
+}
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (window as unknown as { matchMedia?: unknown }).matchMedia;
+});
+
+function render(seed: EditorSeed): void {
+  act(() => {
+    root.render(
+      <EditorProvider seed={seed}>
+        <CaptionStage />
+        <Probe />
+      </EditorProvider>,
+    );
+  });
+}
+
+/** Advance the shared playhead by firing the Player's native `timeupdate`. */
+function seekTo(t: number): void {
+  const video = container.querySelector('video');
+  if (!video) throw new Error('no video');
+  Object.defineProperty(video, 'currentTime', { configurable: true, get: () => t });
+  act(() => {
+    video.dispatchEvent(new Event('timeupdate'));
+  });
+}
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+describe('CaptionStage', () => {
+  it('shows the "No captions" hint for the none style', () => {
+    setReducedMotion(false);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: [],
+      design: { ...DEFAULT_CAPTION_DESIGN, style: 'none' },
+    });
+    expect(q('.caption-stage__hint')?.textContent).toBe('No captions');
+    expect(q('.caption-stage__line')).toBeNull();
+  });
+
+  it('shows the pre-transcript preview hint before any word is active', () => {
+    setReducedMotion(false);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: PHRASE,
+      design: { ...DEFAULT_CAPTION_DESIGN, style: 'hormozi' },
+    });
+    // initial playhead = window.start = 0, before the first cue (starts at 2s)
+    expect(q('.caption-stage__hint')?.textContent).toBe('Caption preview');
+    expect(q('.caption-stage__line')).toBeNull();
+  });
+
+  it('renders the live word line with the karaoke pop armed (motion allowed)', () => {
+    setReducedMotion(false);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: PHRASE,
+      design: { ...DEFAULT_CAPTION_DESIGN, style: 'opusclip-karaoke' },
+    });
+    seekTo(3.5);
+    expect(q('[data-testid="playhead"]')?.textContent).toBe('3.5');
+    const words = container.querySelectorAll('.caption-stage__word');
+    expect(words).toHaveLength(3);
+    expect(container.querySelectorAll('.caption-stage__word.is-active')).toHaveLength(1);
+    expect(q('.caption-stage__sample')?.getAttribute('data-karaoke-pop')).toBe('true');
+  });
+
+  it('leaves the karaoke pop OFF under prefers-reduced-motion', () => {
+    setReducedMotion(true);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: PHRASE,
+      design: { ...DEFAULT_CAPTION_DESIGN, style: 'opusclip-karaoke' },
+    });
+    seekTo(3.5);
+    expect(q('.caption-stage__line')).not.toBeNull();
+    expect(q('.caption-stage__sample')?.hasAttribute('data-karaoke-pop')).toBe(false);
+  });
+
+  it('renders a non-karaoke style with no pop attribute', () => {
+    setReducedMotion(false);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: PHRASE,
+      design: { ...DEFAULT_CAPTION_DESIGN, style: 'hormozi' },
+    });
+    seekTo(3.5);
+    expect(container.querySelectorAll('.caption-stage__word')).toHaveLength(3);
+    expect(q('.caption-stage__sample')?.hasAttribute('data-karaoke-pop')).toBe(false);
+  });
+
+  it('moves the caption region from the keyboard (on-canvas, WCAG 2.1.1)', () => {
+    setReducedMotion(false);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: PHRASE,
+      design: { ...DEFAULT_CAPTION_DESIGN, style: 'hormozi' },
+    });
+    const box = q('[data-testid="caption-box"]');
+    if (!box) throw new Error('no caption box');
+    act(() => {
+      box.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }));
+    });
+    const y = Number(q('[data-testid="box-y"]')?.textContent);
+    expect(y).toBeGreaterThan(0.76);
+  });
+});

--- a/app/renderer/src/features/caption/CaptionStage.tsx
+++ b/app/renderer/src/features/caption/CaptionStage.tsx
@@ -1,0 +1,100 @@
+// CaptionStage.tsx — the SHARED editor stage (v1.5 Caption pilot).
+//
+// The one video surface every panel talks about. It reads the shared editor
+// state (`useEditor`) and renders the live caption exactly as it will export —
+// via the pure `captionOverridePreview` mirror (previewVisual/previewSizeScale/
+// captionSampleStyle) + the CaptionOverlay word math (activeLine/wordColor) — so
+// the Inspector's style/override edits and the Timeline's playhead all reflect
+// here immediately, without the Stage owning any of those controls. Direct
+// manipulation of the caption REGION lives here (the keyboard-operable
+// CaptionBox), while style/text controls live in the Inspector — the
+// inspector-over-shared-stage split the pilot proves.
+//
+// Motion: the karaoke word "pop" preview is gated behind prefers-reduced-motion
+// (via the shared `prefersReducedMotion` helper) with a STATIC fallback — the CSS
+// animation only arms when `data-karaoke-pop` is set.
+
+import React from 'react';
+import { Player } from '../../components/Player';
+import { CaptionBox } from '../../components/CaptionBox';
+import { activeLine, wordColor } from '../../components/CaptionOverlay';
+import { prefersReducedMotion } from '../../components/UsageBar';
+import { isNoCaption } from '../../lib/captionTemplates';
+import { isKaraokeStyle, karaokeActiveColor } from '../../lib/captionKaraokePreset';
+import {
+  captionSampleStyle,
+  previewSizeScale,
+  previewVisual,
+} from '../../lib/captionOverridePreview';
+import { useEditor } from '../EditorContext';
+import './captionStage.css';
+
+/** The shared caption stage: live preview + on-canvas caption-region editing. */
+export function CaptionStage(): React.ReactElement {
+  const { state, dispatch } = useEditor();
+  const { video, cues, design, playhead } = state;
+  const win = video.window;
+
+  const visual = previewVisual(design.style, design.override);
+  const scale = previewSizeScale(design.override);
+  const lineStyle = captionSampleStyle(visual, scale);
+  const none = isNoCaption(design.style);
+  const karaoke = isKaraokeStyle(design.style);
+  const words = none ? [] : activeLine(cues, win, playhead - win.start);
+  // The word "pop" animation arms only for the karaoke look AND when the user
+  // has NOT asked for reduced motion; otherwise the active word stays static.
+  const pop = karaoke && !prefersReducedMotion();
+
+  return (
+    <div className="caption-stage" aria-label="Caption stage">
+      <div className="caption-stage__frame">
+        <Player
+          videoId={video.videoId}
+          src={video.src}
+          window={win}
+          controls
+          onTimeUpdate={(t) => dispatch({ type: 'setPlayhead', playhead: t })}
+        />
+        <CaptionBox box={design.box} onChange={(box) => dispatch({ type: 'setBox', box })}>
+          <div
+            className="caption-stage__sample"
+            data-style={design.style}
+            data-karaoke-pop={pop || undefined}
+          >
+            {none ? (
+              <span className="caption-stage__hint">No captions</span>
+            ) : words.length > 0 ? (
+              <span className="caption-stage__line" style={lineStyle}>
+                {words.map((w, i) => (
+                  <span
+                    key={`${w.text}-${w.start}-${i}`}
+                    className={`caption-stage__word${w.active ? ' is-active' : ''}`}
+                    style={{
+                      color: wordColor(
+                        w,
+                        visual,
+                        karaoke ? karaokeActiveColor(w.index) : undefined,
+                      ),
+                      backgroundColor: w.active ? visual.activeBackground : 'transparent',
+                    }}
+                  >
+                    {w.text}
+                  </span>
+                ))}
+              </span>
+            ) : (
+              <span
+                className="caption-stage__hint"
+                style={{ fontFamily: visual.fontFamily, fontSize: `${scale}em` }}
+              >
+                Caption preview
+              </span>
+            )}
+          </div>
+        </CaptionBox>
+      </div>
+    </div>
+  );
+}
+
+export default CaptionStage;

--- a/app/renderer/src/features/caption/captionClipLane.css
+++ b/app/renderer/src/features/caption/captionClipLane.css
@@ -1,0 +1,87 @@
+/* captionClipLane.css — the keyboard-operable caption clip lane. Tokens only. */
+
+.caption-clip-lane {
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.caption-clip-lane--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.caption-clip-lane__empty {
+  margin: 0;
+  font-size: var(--type-body-size);
+  color: var(--text-faint);
+}
+
+/* A single lane (a media well) with absolutely-positioned clips over the axis. */
+.caption-clip-lane__track {
+  position: relative;
+  height: 44px;
+  border-radius: var(--radius-sm);
+  background: var(--atmos-well), var(--surface-deep);
+  overflow: hidden;
+}
+
+.caption-clip {
+  position: absolute;
+  top: var(--space-2);
+  bottom: var(--space-2);
+  min-width: 8px;
+  padding: 0 var(--space-2);
+  display: flex;
+  align-items: center;
+  font-size: var(--type-chip-size);
+  color: var(--text-secondary);
+  background: var(--surface-overlay);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  overflow: hidden;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.caption-clip:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.caption-clip:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* The selected clip gets the ONE amber accent (active/selected). */
+.caption-clip.is-selected {
+  color: var(--accent-ink);
+  background: var(--accent-soft);
+  border-color: var(--accent-edge);
+  box-shadow: var(--focus-glow);
+}
+
+.caption-clip.is-selected .caption-clip__text {
+  color: var(--text-primary);
+}
+
+.caption-clip__text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* The shared playhead, mirrored from the stage. */
+.caption-clip-lane__playhead {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: var(--accent);
+  pointer-events: none;
+}

--- a/app/renderer/src/features/caption/captionDelivery.css
+++ b/app/renderer/src/features/caption/captionDelivery.css
@@ -1,0 +1,70 @@
+/* captionDelivery.css — the guarded burn/soft reversibility choice. Tokens only. */
+
+.caption-delivery {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.caption-delivery__label {
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.caption-delivery__options {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: var(--space-1);
+  gap: var(--space-1);
+  background: var(--surface-deep);
+  border-radius: var(--radius-pill);
+}
+
+.caption-delivery__option {
+  padding: var(--control-pad-toggle);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-pill);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.caption-delivery__option:hover {
+  color: var(--text-primary);
+}
+
+.caption-delivery__option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* The selected mode gets the ONE amber accent (active state). */
+.caption-delivery__option.is-active {
+  color: var(--accent-ink);
+  background: var(--accent);
+  box-shadow: var(--accent-glow);
+}
+
+.caption-delivery__note {
+  margin: 0;
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+  color: var(--text-faint);
+}
+
+/* The permanence warning uses the semantic WARN status (never a new hue). */
+.caption-delivery__note.is-warning {
+  color: var(--status-warn);
+}

--- a/app/renderer/src/features/caption/captionGallery.css
+++ b/app/renderer/src/features/caption/captionGallery.css
@@ -1,0 +1,152 @@
+/* captionGallery.css — the expand-over-timeline preset gallery (v1.5). Tokens only. */
+
+.caption-gallery {
+  position: relative;
+}
+
+.caption-gallery__bar {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.caption-gallery__label {
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+/* The active style name in the editorial serif voice — the pull-quote moment the
+ * --font-editorial token exists for. */
+.caption-gallery__current {
+  flex: 1;
+  font-family: var(--font-editorial);
+  font-size: var(--type-hook-size);
+  color: var(--text-primary);
+}
+
+.caption-gallery__toggle {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-overlay);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.caption-gallery__toggle:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.caption-gallery__toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* The expanded gallery floats OVER the timeline below it (not a cramped column). */
+.caption-gallery__grid {
+  position: absolute;
+  top: calc(100% + var(--space-2));
+  left: 0;
+  right: 0;
+  z-index: 5;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  max-height: 60vh;
+  overflow-y: auto;
+  padding: var(--space-5);
+  background: var(--surface-overlay);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-3);
+}
+
+.caption-gallery__group-title {
+  margin: 0 0 var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.caption-gallery__swatches {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+  gap: var(--space-3);
+}
+
+.caption-gallery__swatch {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  text-align: left;
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+  cursor: pointer;
+  transition:
+    transform var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out);
+}
+
+.caption-gallery__swatch:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--elev-2);
+}
+
+.caption-gallery__swatch:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* The ONLY app-chrome accent in the gallery: the amber selection ring. */
+.caption-gallery__swatch.is-active {
+  border-color: var(--accent-edge);
+  box-shadow: var(--focus-glow);
+}
+
+.caption-gallery__preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 54px;
+  border-radius: var(--radius-sm);
+  background: var(--atmos-well), var(--surface-deep);
+}
+
+.caption-gallery__sample {
+  font-size: var(--type-rank-size);
+  font-weight: var(--weight-bold);
+}
+
+.caption-gallery__off {
+  font-size: var(--type-caption-size);
+  color: var(--text-faint);
+  text-transform: uppercase;
+  letter-spacing: var(--type-caption-tracking);
+}
+
+.caption-gallery__name {
+  font-size: var(--type-card-title-size);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.caption-gallery__blurb {
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+  color: var(--text-faint);
+}

--- a/app/renderer/src/features/caption/captionInspector.css
+++ b/app/renderer/src/features/caption/captionInspector.css
@@ -1,0 +1,64 @@
+/* captionInspector.css — the Caption phase inspector column. Tokens only. */
+
+.caption-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  min-width: 0;
+}
+
+/* The transcript gate: one clear editorial empty-state, not a wall of dead controls. */
+.caption-inspector__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.caption-inspector__empty-title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  color: var(--text-primary);
+}
+
+.caption-inspector__empty-blurb {
+  margin: 0;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+  max-width: 42ch;
+}
+
+/* The primary action gets the ONE amber accent (approve/primary). */
+.caption-inspector__generate {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-bold);
+  color: var(--accent-ink);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--accent-glow);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.caption-inspector__generate:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: var(--accent-glow-hover);
+}
+
+.caption-inspector__generate:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.caption-inspector__generate:disabled {
+  opacity: 0.55;
+  cursor: progress;
+}

--- a/app/renderer/src/features/caption/captionStage.css
+++ b/app/renderer/src/features/caption/captionStage.css
@@ -1,0 +1,94 @@
+/* captionStage.css — the shared caption stage (v1.5 pilot). Tokens only. */
+
+.caption-stage {
+  display: flex;
+  justify-content: center;
+  padding: var(--space-5);
+}
+
+/* A 9:16 media well: footage floats in near-black (media wells step DOWN the
+ * surface ladder), lit from the top so it does not read as a flat fill. */
+.caption-stage__frame {
+  position: relative;
+  aspect-ratio: 9 / 16;
+  height: min(72vh, 640px);
+  max-width: 100%;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--atmos-well), var(--surface-deep);
+  box-shadow: var(--elev-2);
+}
+
+.caption-stage__frame .player__video,
+.caption-stage__frame video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+/* The live caption sample rendered INSIDE the caption box. */
+.caption-stage__sample {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  text-align: center;
+  pointer-events: none;
+}
+
+.caption-stage__line {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0 0.28em;
+  justify-content: center;
+  align-items: baseline;
+  line-height: 1.15;
+  padding: 0.15em 0.35em;
+  border-radius: var(--radius-sm);
+  font-weight: var(--weight-bold);
+}
+
+.caption-stage__word {
+  display: inline-block;
+  border-radius: var(--radius-xs);
+  padding: 0 0.08em;
+}
+
+/* Karaoke "pop": the active word scales up briefly. ARMED ONLY when the sample
+ * carries data-karaoke-pop (the JS gate = karaoke look AND motion allowed). The
+ * prefers-reduced-motion media query is a second belt so the animation can never
+ * play for a reduced-motion user even if the attribute is present. */
+.caption-stage__sample[data-karaoke-pop] .caption-stage__word.is-active {
+  animation: caption-word-pop var(--dur-base) var(--ease-out);
+}
+
+@keyframes caption-word-pop {
+  0% {
+    transform: scale(1);
+  }
+  55% {
+    transform: scale(1.15);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .caption-stage__sample[data-karaoke-pop] .caption-stage__word.is-active {
+    animation: none;
+  }
+}
+
+/* The pre-transcript / no-caption hint, in the quiet editorial voice. */
+.caption-stage__hint {
+  font-family: var(--font-editorial);
+  font-size: var(--type-title-size);
+  color: var(--text-faint);
+  background: var(--surface-overlay);
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+}

--- a/app/renderer/src/lib/captionStyleNames.test.ts
+++ b/app/renderer/src/lib/captionStyleNames.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CAPTION_FAMILY_LABEL,
+  CAPTION_FAMILY_ORDER,
+  CAPTION_STYLE_LOOKS,
+  DEFAULT_STYLE_LOOK,
+  type LookStyleOption,
+  groupByFamily,
+  lookNamedCatalog,
+  styleLook,
+} from './captionStyleNames';
+import { ALL_CAPTION_STYLES } from '../features/shortMakerLogic';
+
+describe('styleLook', () => {
+  it('returns the look identity for a known style', () => {
+    expect(styleLook('opusclip-karaoke')).toEqual({
+      name: 'Word-by-word pop',
+      family: 'word-by-word',
+      blurb: 'Each word pops as it is spoken',
+    });
+  });
+
+  it('falls back for an unknown style id', () => {
+    expect(styleLook('totally-unknown')).toBe(DEFAULT_STYLE_LOOK);
+  });
+});
+
+describe('look-name discipline', () => {
+  it('gives every selectable catalog id an explicit look entry (no missing names)', () => {
+    for (const option of ALL_CAPTION_STYLES) {
+      expect(CAPTION_STYLE_LOOKS[option.id], `missing look for ${option.id}`).toBeDefined();
+    }
+  });
+
+  it('never surfaces a font/codec/model/brand name in any look name', () => {
+    const banned =
+      /libass|remotion|hormozi|mrbeast|tiktok|opusclip|montserrat|anton|bangers|georgia|inter/i;
+    for (const look of Object.values(CAPTION_STYLE_LOOKS)) {
+      expect(banned.test(look.name), `jargon leaked in "${look.name}"`).toBe(false);
+      expect(banned.test(look.blurb), `jargon leaked in "${look.blurb}"`).toBe(false);
+    }
+    expect(banned.test(DEFAULT_STYLE_LOOK.name)).toBe(false);
+  });
+
+  it('maps every family used to a heading in the display order', () => {
+    for (const look of Object.values(CAPTION_STYLE_LOOKS)) {
+      expect(CAPTION_FAMILY_ORDER).toContain(look.family);
+      expect(CAPTION_FAMILY_LABEL[look.family]).toBeTruthy();
+    }
+  });
+});
+
+describe('lookNamedCatalog', () => {
+  it('re-labels the full catalog by look, preserving id + engine', () => {
+    const catalog = lookNamedCatalog();
+    expect(catalog).toHaveLength(ALL_CAPTION_STYLES.length);
+    const karaoke = catalog.find((o) => o.id === 'opusclip-karaoke');
+    expect(karaoke).toMatchObject({
+      id: 'opusclip-karaoke',
+      label: 'Word-by-word pop',
+      family: 'word-by-word',
+      engine: 'libass',
+    });
+  });
+
+  it('re-labels a supplied base catalog', () => {
+    const catalog = lookNamedCatalog([
+      { id: 'serif', engine: 'remotion', label: 'Serif (editorial)' },
+    ]);
+    expect(catalog).toEqual([
+      {
+        id: 'serif',
+        label: 'Editorial serif',
+        family: 'editorial',
+        blurb: 'A quiet pull-quote voice',
+        engine: 'remotion',
+      },
+    ]);
+  });
+});
+
+describe('groupByFamily', () => {
+  it('produces ordered, non-empty family sections', () => {
+    const groups = groupByFamily(lookNamedCatalog());
+    // headline behaviours first
+    expect(groups[0].family).toBe('word-by-word');
+    expect(groups.map((g) => g.family)).toEqual(
+      CAPTION_FAMILY_ORDER.filter((f) => groups.some((g) => g.family === f)),
+    );
+    for (const group of groups) {
+      expect(group.options.length).toBeGreaterThan(0);
+      expect(group.label).toBe(CAPTION_FAMILY_LABEL[group.family]);
+    }
+  });
+
+  it('omits families with no options', () => {
+    const onlyEditorial: LookStyleOption[] = [
+      {
+        id: 'serif',
+        label: 'Editorial serif',
+        family: 'editorial',
+        blurb: 'x',
+        engine: 'remotion',
+      },
+    ];
+    const groups = groupByFamily(onlyEditorial);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].family).toBe('editorial');
+  });
+});

--- a/app/renderer/src/lib/captionStyleNames.ts
+++ b/app/renderer/src/lib/captionStyleNames.ts
@@ -1,0 +1,153 @@
+// captionStyleNames.ts — LOOK-based caption style naming for the Caption gallery.
+//
+// The redesign (§4 Caption) requires styles be named by their LOOK — "Word-by-word
+// pop", "Keyword highlight", "Editorial serif" — with a live preview each, and it
+// FORBIDS surfacing any font/codec/model/brand name in a user-visible string. The
+// shipped catalog (`features/shortMakerLogic.ts` ALL_CAPTION_STYLES) still carries
+// creator/tool brand labels ("Hormozi", "MrBeast", "TikTok", "OpusClip Karaoke")
+// and engine jargon ("libass"). This pure module re-maps every catalog id to a
+// jargon-free look name + a LAYOUT/BEHAVIOUR family, so the gallery differentiates
+// styles by TYPE (how the caption behaves/sits), never by inventing a new accent
+// hue — the guard the redesign calls out for exactly this surface.
+//
+// Everything here is PURE. The `captionStyleNames` conformance test asserts every
+// selectable catalog id has an explicit look entry so a name can never silently
+// go missing (the same drift defence the caption template mirror uses).
+
+import { type CaptionEngineKind } from './captionTemplates';
+import { ALL_CAPTION_STYLES, type CaptionStyleOption } from '../features/shortMakerLogic';
+
+/**
+ * The LAYOUT/BEHAVIOUR family a style belongs to. Used to GROUP the gallery so
+ * styles are told apart by how they behave/sit, never by a decorative second hue.
+ */
+export type CaptionStyleFamily =
+  | 'word-by-word'
+  | 'keyword'
+  | 'bold'
+  | 'clean'
+  | 'editorial'
+  | 'none';
+
+/** A style's jargon-free look identity. */
+export interface CaptionStyleLook {
+  /** Look-based display name (never a font/codec/model/brand name). */
+  name: string;
+  /** The layout/behaviour family used to group the gallery. */
+  family: CaptionStyleFamily;
+  /** A one-line plain-language description of the look. */
+  blurb: string;
+}
+
+/**
+ * Every selectable style id → its look identity. Keyed by the catalog ids in
+ * `ALL_CAPTION_STYLES`. Names describe the LOOK/behaviour only.
+ */
+export const CAPTION_STYLE_LOOKS: Record<string, CaptionStyleLook> = {
+  'opusclip-karaoke': {
+    name: 'Word-by-word pop',
+    family: 'word-by-word',
+    blurb: 'Each word pops as it is spoken',
+  },
+  karaoke: {
+    name: 'Karaoke fill',
+    family: 'word-by-word',
+    blurb: 'Words fill in as they are said',
+  },
+  bounce: { name: 'Bouncy words', family: 'word-by-word', blurb: 'Words spring in one at a time' },
+  hormozi: {
+    name: 'Keyword highlight',
+    family: 'keyword',
+    blurb: 'A boxed line with the key word emphasised',
+  },
+  mrbeast: { name: 'Top banner', family: 'keyword', blurb: 'A big emphasised line across the top' },
+  bold: { name: 'Bold caps', family: 'bold', blurb: 'Loud, all-caps lines' },
+  impact: { name: 'Heavy outline', family: 'bold', blurb: 'Thick outlined display type' },
+  neon: { name: 'Neon glow', family: 'bold', blurb: 'Glowing outlined type' },
+  gradient: { name: 'Sunset blend', family: 'bold', blurb: 'A warm multi-tone display look' },
+  pop: { name: 'Playful pop', family: 'bold', blurb: 'Rounded, colourful display type' },
+  fire: { name: 'Hot sweep', family: 'bold', blurb: 'A warm sweep across the line' },
+  libass: { name: 'Clean classic', family: 'clean', blurb: 'Simple, fast, readable captions' },
+  clean: { name: 'Minimal', family: 'clean', blurb: 'Quiet, unstyled lines' },
+  subtitle: {
+    name: 'Broadcast subtitle',
+    family: 'clean',
+    blurb: 'Boxed broadcast-style captions',
+  },
+  tiktok: { name: 'Caption card', family: 'clean', blurb: 'A solid card behind the line' },
+  serif: { name: 'Editorial serif', family: 'editorial', blurb: 'A quiet pull-quote voice' },
+  none: { name: 'No captions', family: 'none', blurb: 'Leave the video uncaptioned' },
+};
+
+/** Fallback look for an unknown id (never throws — the gallery stays populated). */
+export const DEFAULT_STYLE_LOOK: CaptionStyleLook = {
+  name: 'Custom style',
+  family: 'clean',
+  blurb: 'A custom caption look',
+};
+
+/** The look identity for a style id (falls back for unknown ids; never throws). */
+export function styleLook(id: string): CaptionStyleLook {
+  return CAPTION_STYLE_LOOKS[id] ?? DEFAULT_STYLE_LOOK;
+}
+
+/** The family display order for the gallery (headline behaviours first). */
+export const CAPTION_FAMILY_ORDER: readonly CaptionStyleFamily[] = [
+  'word-by-word',
+  'keyword',
+  'bold',
+  'clean',
+  'editorial',
+  'none',
+];
+
+/** The section heading shown for each family. */
+export const CAPTION_FAMILY_LABEL: Record<CaptionStyleFamily, string> = {
+  'word-by-word': 'Word by word',
+  keyword: 'Keyword emphasis',
+  bold: 'Bold display',
+  clean: 'Clean & minimal',
+  editorial: 'Editorial',
+  none: 'Off',
+};
+
+/** A catalog option re-labelled by its LOOK, carrying its family + blurb. */
+export interface LookStyleOption {
+  id: string;
+  label: string;
+  family: CaptionStyleFamily;
+  blurb: string;
+  engine: CaptionEngineKind;
+}
+
+/** Re-label a base catalog by look (defaults to the full selectable catalog). */
+export function lookNamedCatalog(
+  base: readonly CaptionStyleOption[] = ALL_CAPTION_STYLES,
+): LookStyleOption[] {
+  return base.map((option) => {
+    const look = styleLook(option.id);
+    return {
+      id: option.id,
+      label: look.name,
+      family: look.family,
+      blurb: look.blurb,
+      engine: option.engine,
+    };
+  });
+}
+
+/** A gallery section: one family with its populated look options. */
+export interface CaptionStyleGroup {
+  family: CaptionStyleFamily;
+  label: string;
+  options: LookStyleOption[];
+}
+
+/** Group look options into ordered, non-empty family sections for the gallery. */
+export function groupByFamily(options: readonly LookStyleOption[]): CaptionStyleGroup[] {
+  return CAPTION_FAMILY_ORDER.map((family) => ({
+    family,
+    label: CAPTION_FAMILY_LABEL[family],
+    options: options.filter((option) => option.family === family),
+  })).filter((group) => group.options.length > 0);
+}

--- a/app/renderer/src/lib/editorState.test.ts
+++ b/app/renderer/src/lib/editorState.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  type EditorAction,
+  type EditorState,
+  clampSelection,
+  editorReducer,
+  initialEditorState,
+  transcriptReady,
+} from './editorState';
+import { DEFAULT_CAPTION_DESIGN } from './captionDesign';
+import { bandBox } from './captionPosition';
+import type { Cue } from './rpc';
+
+const WINDOW = { start: 2, end: 8 };
+const cue = (index: number, start: number, end: number, text: string): Cue => ({
+  index,
+  start,
+  end,
+  text,
+});
+const CUES: Cue[] = [cue(0, 2, 3, 'Hello'), cue(1, 3, 4, 'there'), cue(2, 4, 5, 'world')];
+
+function base(overrides: Partial<EditorState> = {}): EditorState {
+  return {
+    video: { videoId: 'v1', window: WINDOW },
+    cues: CUES,
+    cropPlan: null,
+    design: DEFAULT_CAPTION_DESIGN,
+    playhead: 2,
+    selection: null,
+    ...overrides,
+  };
+}
+
+describe('initialEditorState', () => {
+  it('seeds playhead at the window in-point with empty defaults', () => {
+    const state = initialEditorState({ video: { videoId: 'v1', window: WINDOW } });
+    expect(state.playhead).toBe(2);
+    expect(state.cues).toEqual([]);
+    expect(state.cropPlan).toBeNull();
+    expect(state.design).toBe(DEFAULT_CAPTION_DESIGN);
+    expect(state.selection).toBeNull();
+  });
+
+  it('honours a full seed (cues, cropPlan, design)', () => {
+    const design = { ...DEFAULT_CAPTION_DESIGN, style: 'serif' };
+    const cropPlan = { engine: 'verthor', keyframes: [] };
+    const state = initialEditorState({
+      video: { src: 'file.mp4', window: WINDOW },
+      cues: CUES,
+      cropPlan,
+      design,
+    });
+    expect(state.cues).toBe(CUES);
+    expect(state.cropPlan).toBe(cropPlan);
+    expect(state.design).toBe(design);
+  });
+});
+
+describe('transcriptReady', () => {
+  it('is false with no cues and true with cues', () => {
+    expect(transcriptReady(base({ cues: [] }))).toBe(false);
+    expect(transcriptReady(base({ cues: CUES }))).toBe(true);
+  });
+});
+
+describe('clampSelection', () => {
+  it('maps a null request to null', () => {
+    expect(clampSelection(null, 3)).toBeNull();
+  });
+  it('rejects a non-integer index', () => {
+    expect(clampSelection(1.5, 3)).toBeNull();
+  });
+  it('rejects a negative index', () => {
+    expect(clampSelection(-1, 3)).toBeNull();
+  });
+  it('rejects an out-of-range index', () => {
+    expect(clampSelection(5, 3)).toBeNull();
+  });
+  it('keeps a valid index', () => {
+    expect(clampSelection(1, 3)).toBe(1);
+  });
+});
+
+describe('editorReducer', () => {
+  it('setPlayhead replaces the playhead immutably', () => {
+    const prev = base();
+    const next = editorReducer(prev, { type: 'setPlayhead', playhead: 5 });
+    expect(next.playhead).toBe(5);
+    expect(next).not.toBe(prev);
+    expect(prev.playhead).toBe(2);
+  });
+
+  it('setCues replaces cues and keeps a still-valid selection', () => {
+    const next = editorReducer(base({ selection: 1 }), { type: 'setCues', cues: CUES });
+    expect(next.cues).toBe(CUES);
+    expect(next.selection).toBe(1);
+  });
+
+  it('setCues drops a now-out-of-range selection', () => {
+    const next = editorReducer(base({ selection: 2 }), {
+      type: 'setCues',
+      cues: [cue(0, 2, 3, 'only')],
+    });
+    expect(next.selection).toBeNull();
+  });
+
+  it('setVideo swaps the media and reseats the playhead to the new in-point', () => {
+    const next = editorReducer(base(), {
+      type: 'setVideo',
+      video: { videoId: 'v2', window: { start: 10, end: 20 } },
+    });
+    expect(next.video.videoId).toBe('v2');
+    expect(next.playhead).toBe(10);
+  });
+
+  it('setDesign replaces the whole design', () => {
+    const design = { ...DEFAULT_CAPTION_DESIGN, style: 'hormozi' };
+    const next = editorReducer(base(), { type: 'setDesign', design });
+    expect(next.design).toBe(design);
+  });
+
+  it('setStyle updates only the style slice', () => {
+    const next = editorReducer(base(), { type: 'setStyle', style: 'serif' });
+    expect(next.design.style).toBe('serif');
+    expect(next.design.box).toEqual(DEFAULT_CAPTION_DESIGN.box);
+  });
+
+  it('setOverride updates only the override slice (incl. clearing to undefined)', () => {
+    const withOverride = editorReducer(base(), {
+      type: 'setOverride',
+      override: { uppercase: true },
+    });
+    expect(withOverride.design.override).toEqual({ uppercase: true });
+    const cleared = editorReducer(withOverride, { type: 'setOverride', override: undefined });
+    expect(cleared.design.override).toBeUndefined();
+  });
+
+  it('setBox updates only the box slice', () => {
+    const box = bandBox('top');
+    const next = editorReducer(base(), { type: 'setBox', box });
+    expect(next.design.box).toBe(box);
+    expect(next.design.style).toBe(DEFAULT_CAPTION_DESIGN.style);
+  });
+
+  it('selectCue clamps the requested index against the cue list', () => {
+    expect(editorReducer(base(), { type: 'selectCue', index: 1 }).selection).toBe(1);
+    expect(editorReducer(base(), { type: 'selectCue', index: 9 }).selection).toBeNull();
+    expect(editorReducer(base(), { type: 'selectCue', index: null }).selection).toBeNull();
+  });
+
+  it('setCropPlan carries the cross-phase crop plan', () => {
+    const cropPlan = { engine: 'reframe_multispeaker', keyframes: [{ t: 0 }] };
+    const next = editorReducer(base(), { type: 'setCropPlan', cropPlan });
+    expect(next.cropPlan).toBe(cropPlan);
+  });
+
+  it('is a no-op for an unknown action', () => {
+    const prev = base();
+    const next = editorReducer(prev, { type: 'bogus' } as unknown as EditorAction);
+    expect(next).toBe(prev);
+  });
+});

--- a/app/renderer/src/lib/editorState.ts
+++ b/app/renderer/src/lib/editorState.ts
@@ -1,0 +1,155 @@
+// editorState.ts — the shared EDITOR STATE primitive (v1.5 Caption pilot).
+//
+// The redesign's load-bearing pattern is "inspector-over-shared-stage": a single
+// editor state (the video + its cues + the crop plan + the caption design + the
+// playhead + the current selection) that a Stage, a Timeline, and an Inspector
+// all read and write, so those panels become THIN CONSUMERS instead of layout
+// owners. This module is that state's PURE core — the reducer, its actions, and a
+// couple of selectors — with NO React and NO DOM, so it is exhaustively unit
+// testable. The React binding (Provider + `useEditor`) lives in
+// `features/EditorContext.tsx`; the caption panels consume it.
+//
+// Reusability note: the Caption phase is the pilot, so `design` is a
+// `CaptionDesign` today. The OTHER four redesigned phases reuse THIS same state
+// container (that is the whole point of extracting it) — a Reframe phase edits
+// `cropPlan`, an Edit phase reads `cues`/`playhead`, etc. `cropPlan` is therefore
+// carried here as an opaque cross-phase value the Caption phase never mutates, so
+// the shared context is already reusable by that phase without a second store.
+//
+// Everything here is IMMUTABLE — every action returns a NEW state object.
+
+import type { Cue } from './rpc';
+import { type CaptionDesign, DEFAULT_CAPTION_DESIGN } from './captionDesign';
+import type { CaptionOverride } from './captionOverride';
+import type { CaptionBox } from './captionPosition';
+
+/** A source-absolute preview window (structurally a Player `PlayerWindow`). */
+export interface EditorWindow {
+  start: number;
+  end: number;
+}
+
+/**
+ * Opaque cross-phase crop plan. Owned/edited by the REFRAME phase; the Caption
+ * pilot only carries it (never mutates it) so the shared editor state is already
+ * reusable by that phase without introducing a second store. Kept intentionally
+ * loose — the Reframe phase will refine the shape when it adopts this container.
+ */
+export interface CropPlan {
+  readonly engine?: string;
+  readonly keyframes?: readonly unknown[];
+}
+
+/** The media the editor is working on. */
+export interface EditorVideo {
+  /** Library video id — played as `mstream://media/<id>`. */
+  videoId?: string;
+  /** Direct src override (wins over videoId). */
+  src?: string;
+  /** The source-absolute preview window the cues re-base against. */
+  window: EditorWindow;
+  /** The video duration (source seconds) when known. */
+  durationSec?: number;
+}
+
+/** The whole shared editor state a Stage / Timeline / Inspector read + write. */
+export interface EditorState {
+  video: EditorVideo;
+  /** Word-level caption cues (source-absolute seconds). */
+  cues: Cue[];
+  /** Cross-phase crop plan (Reframe-owned; carried, not edited, here). */
+  cropPlan: CropPlan | null;
+  /** The caption design (style + box + within-template override). */
+  design: CaptionDesign;
+  /** The playhead in source-absolute seconds. */
+  playhead: number;
+  /** The selected cue index, or null when nothing is selected. */
+  selection: number | null;
+}
+
+/** The minimum seed needed to build an initial editor state. */
+export interface EditorSeed {
+  video: EditorVideo;
+  cues?: Cue[];
+  cropPlan?: CropPlan | null;
+  design?: CaptionDesign;
+}
+
+/**
+ * Build the initial editor state from a seed. The playhead starts at the window
+ * in-point; nothing is selected; the caption design defaults to the shipped
+ * default when none is supplied.
+ */
+export function initialEditorState(seed: EditorSeed): EditorState {
+  return {
+    video: seed.video,
+    cues: seed.cues ?? [],
+    cropPlan: seed.cropPlan ?? null,
+    design: seed.design ?? DEFAULT_CAPTION_DESIGN,
+    playhead: seed.video.window.start,
+    selection: null,
+  };
+}
+
+/** Every mutation the shared editor state supports (discriminated union). */
+export type EditorAction =
+  | { type: 'setPlayhead'; playhead: number }
+  | { type: 'setCues'; cues: Cue[] }
+  | { type: 'setVideo'; video: EditorVideo }
+  | { type: 'setDesign'; design: CaptionDesign }
+  | { type: 'setStyle'; style: string }
+  | { type: 'setOverride'; override: CaptionOverride | undefined }
+  | { type: 'setBox'; box: CaptionBox }
+  | { type: 'selectCue'; index: number | null }
+  | { type: 'setCropPlan'; cropPlan: CropPlan | null };
+
+/** True once at least one caption cue exists — the transcript-present gate. */
+export function transcriptReady(state: EditorState): boolean {
+  return state.cues.length > 0;
+}
+
+/**
+ * Clamp a requested selection index to a valid cue index, else null. A null
+ * request, a non-integer, or an out-of-range index all resolve to "no selection"
+ * so a stale selection can never point past a shortened cue list.
+ */
+export function clampSelection(index: number | null, cueCount: number): number | null {
+  if (index === null) return null;
+  if (!Number.isInteger(index) || index < 0 || index >= cueCount) return null;
+  return index;
+}
+
+/**
+ * The pure editor reducer. Every case returns a NEW state object (immutable);
+ * caption sub-actions rebuild only the `design` slice. Re-basing the selection
+ * on `setCues` keeps it valid when the cue list shrinks. An unknown action is a
+ * no-op (returns the same state).
+ */
+export function editorReducer(state: EditorState, action: EditorAction): EditorState {
+  switch (action.type) {
+    case 'setPlayhead':
+      return { ...state, playhead: action.playhead };
+    case 'setCues':
+      return {
+        ...state,
+        cues: action.cues,
+        selection: clampSelection(state.selection, action.cues.length),
+      };
+    case 'setVideo':
+      return { ...state, video: action.video, playhead: action.video.window.start };
+    case 'setDesign':
+      return { ...state, design: action.design };
+    case 'setStyle':
+      return { ...state, design: { ...state.design, style: action.style } };
+    case 'setOverride':
+      return { ...state, design: { ...state.design, override: action.override } };
+    case 'setBox':
+      return { ...state, design: { ...state.design, box: action.box } };
+    case 'selectCue':
+      return { ...state, selection: clampSelection(action.index, state.cues.length) };
+    case 'setCropPlan':
+      return { ...state, cropPlan: action.cropPlan };
+    default:
+      return state;
+  }
+}

--- a/app/renderer/src/views/Caption.test.tsx
+++ b/app/renderer/src/views/Caption.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Caption } from './Caption';
+import type { Video } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const cuesMock = vi.fn();
+const generateMock = vi.fn();
+let hasApiReturn = true;
+
+vi.mock('../lib/rpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/rpc')>();
+  return {
+    ...actual,
+    hasApi: () => hasApiReturn,
+    client: {
+      ...actual.client,
+      captions: { cues: (...args: unknown[]) => cuesMock(...args) },
+      subtitles: {
+        ...actual.client.subtitles,
+        generate: (...args: unknown[]) => generateMock(...args),
+      },
+    },
+  };
+});
+
+const VIDEO: Video = {
+  id: 'v1',
+  path: '/clips/x.mp4',
+  title: 'My Clip',
+  addedAt: '2026-01-01',
+  durationSec: 20,
+  hasTranscript: false,
+};
+const CUES = [
+  { index: 1, start: 2, end: 3, text: 'Hello' },
+  { index: 2, start: 6, end: 7, text: 'world' },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+const onBack = vi.fn();
+
+beforeEach(() => {
+  cuesMock.mockReset();
+  generateMock.mockReset();
+  onBack.mockReset();
+  hasApiReturn = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function render(video: Video | null): void {
+  act(() => {
+    root.render(<Caption video={video} onBack={onBack} />);
+  });
+}
+
+describe('Caption view', () => {
+  it('shows a no-video empty state that routes back to the Library', () => {
+    render(null);
+    expect(q('.caption-view__empty-title')?.textContent).toBe('Open a video to caption');
+    act(() => q<HTMLButtonElement>('.caption-view__back')?.click());
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(cuesMock).not.toHaveBeenCalled();
+  });
+
+  it('loads existing cues via the typed client and shows the editing surface', async () => {
+    cuesMock.mockResolvedValue({ cues: CUES });
+    render(VIDEO);
+    await flush();
+    expect(cuesMock).toHaveBeenCalledWith('v1');
+    expect(q('.caption-view__title')?.textContent).toBe('My Clip');
+    expect(q('.caption-gallery')).not.toBeNull();
+    expect(q('.caption-clip-lane')).not.toBeNull();
+    expect(q('.caption-inspector__empty')).toBeNull();
+  });
+
+  it('gates on transcript, then generates + reloads cues on request', async () => {
+    cuesMock.mockResolvedValueOnce({}).mockResolvedValueOnce({ cues: CUES });
+    generateMock.mockResolvedValue({});
+    render(VIDEO);
+    await flush();
+    // no cues yet -> the inspector's generate gate
+    expect(q('.caption-inspector__empty')).not.toBeNull();
+    act(() => q<HTMLButtonElement>('.caption-inspector__generate')?.click());
+    await flush();
+    expect(generateMock).toHaveBeenCalledWith('v1');
+    expect(cuesMock).toHaveBeenCalledTimes(2);
+    expect(q('.caption-gallery')).not.toBeNull();
+  });
+
+  it('surfaces a cue-load failure', async () => {
+    cuesMock.mockRejectedValue(new Error('load boom'));
+    render(VIDEO);
+    await flush();
+    expect(q('.caption-view__error')?.textContent).toBe('load boom');
+  });
+
+  it('stringifies a non-Error rejection', async () => {
+    cuesMock.mockRejectedValue('weird failure');
+    render(VIDEO);
+    await flush();
+    expect(q('.caption-view__error')?.textContent).toBe('weird failure');
+  });
+
+  it('surfaces a generate failure', async () => {
+    cuesMock.mockResolvedValue({});
+    generateMock.mockRejectedValue(new Error('gen boom'));
+    render(VIDEO);
+    await flush();
+    act(() => q<HTMLButtonElement>('.caption-inspector__generate')?.click());
+    await flush();
+    expect(q('.caption-view__error')?.textContent).toBe('gen boom');
+  });
+
+  it('no-ops RPC when the bridge is unavailable', async () => {
+    hasApiReturn = false;
+    render(VIDEO);
+    await flush();
+    expect(cuesMock).not.toHaveBeenCalled();
+    expect(q('.caption-inspector__empty')).not.toBeNull();
+    act(() => q<HTMLButtonElement>('.caption-inspector__generate')?.click());
+    await flush();
+    expect(generateMock).not.toHaveBeenCalled();
+  });
+});

--- a/app/renderer/src/views/Caption.tsx
+++ b/app/renderer/src/views/Caption.tsx
@@ -1,0 +1,125 @@
+// Caption.tsx — the CAPTION phase view (v1.5 pilot, §7.2).
+//
+// The integration point that makes the pilot real in the shell: it seeds the
+// shared EditorContext from the open video, loads that video's word-level cues via
+// the TYPED #282 client (`client.captions.cues`, not the old stringly rpc), and
+// composes the shared Stage + keyboard clip lane + Inspector — each a thin consumer
+// of the one editor state. Generating captions (no transcript yet) runs
+// `client.subtitles.generate` then re-reads the cues, again through the typed
+// client. The provider remounts per video (`key`) so a video switch re-seeds cleanly.
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { type Cue, type Video, client, hasApi } from '../lib/rpc';
+import type { EditorSeed } from '../lib/editorState';
+import { EditorProvider, useEditor } from '../features/EditorContext';
+import { CaptionStage } from '../features/caption/CaptionStage';
+import { CaptionClipLane } from '../features/caption/CaptionClipLane';
+import { CaptionInspector } from '../features/caption/CaptionInspector';
+import './caption.css';
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Read the cue list off a captions.cues response (defensive against a malformed body). */
+function cuesOf(res: { cues?: Cue[] }): Cue[] {
+  return res.cues ?? [];
+}
+
+export interface CaptionProps {
+  video: Video | null;
+  onBack: () => void;
+}
+
+/** Inner workspace: a context consumer that loads/generates cues + composes panels. */
+function CaptionWorkspace({
+  video,
+  onBack,
+}: {
+  video: Video;
+  onBack: () => void;
+}): React.ReactElement {
+  const { dispatch } = useEditor();
+  const [error, setError] = useState<string | null>(null);
+  const [generating, setGenerating] = useState(false);
+
+  useEffect(() => {
+    if (!hasApi()) return;
+    void client.captions
+      .cues(video.id)
+      .then((res) => dispatch({ type: 'setCues', cues: cuesOf(res) }))
+      .catch((err) => setError(errText(err)));
+  }, [video.id, dispatch]);
+
+  const generate = useCallback(async () => {
+    if (!hasApi()) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      await client.subtitles.generate(video.id);
+      const res = await client.captions.cues(video.id);
+      dispatch({ type: 'setCues', cues: cuesOf(res) });
+    } catch (err) {
+      setError(errText(err));
+    } finally {
+      setGenerating(false);
+    }
+  }, [video.id, dispatch]);
+
+  return (
+    <section className="caption-view" aria-label="Caption editor">
+      <header className="caption-view__head">
+        <button type="button" className="caption-view__back" onClick={onBack}>
+          ← Library
+        </button>
+        <h2 className="caption-view__title">{video.title}</h2>
+      </header>
+      {error && (
+        <p className="caption-view__error" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="caption-view__body">
+        <div className="caption-view__stage">
+          <CaptionStage />
+          <CaptionClipLane />
+        </div>
+        <CaptionInspector onGenerate={() => void generate()} generating={generating} />
+      </div>
+    </section>
+  );
+}
+
+export function Caption({ video, onBack }: CaptionProps): React.ReactElement {
+  if (!video) {
+    return (
+      <section className="caption-view caption-view--empty" aria-label="Caption editor">
+        <div className="caption-view__empty">
+          <h2 className="caption-view__empty-title">Open a video to caption</h2>
+          <p className="caption-view__empty-blurb">
+            Pick a video from the Library to design and time its captions.
+          </p>
+          <button type="button" className="caption-view__back" onClick={onBack}>
+            ← Library
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const seed: EditorSeed = {
+    video: {
+      videoId: video.id,
+      window: { start: 0, end: video.durationSec },
+      durationSec: video.durationSec,
+    },
+  };
+
+  return (
+    <EditorProvider key={video.id} seed={seed}>
+      <CaptionWorkspace video={video} onBack={onBack} />
+    </EditorProvider>
+  );
+}
+
+export default Caption;

--- a/app/renderer/src/views/caption.css
+++ b/app/renderer/src/views/caption.css
@@ -1,0 +1,107 @@
+/* caption.css — the Caption phase view layout (v1.5 pilot). Tokens only. */
+
+.caption-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  min-height: 0;
+}
+
+.caption-view__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.caption-view__back {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.caption-view__back:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.caption-view__back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.caption-view__title {
+  margin: 0;
+  font-size: var(--type-title-size);
+  font-weight: var(--type-title-weight);
+  letter-spacing: var(--type-title-tracking);
+  color: var(--text-primary);
+}
+
+.caption-view__error {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--type-body-size);
+  color: var(--status-error);
+  background: var(--status-error-soft);
+  border-radius: var(--radius-sm);
+}
+
+/* Stage + timeline on the left; the inspector column on the right. Collapses to a
+ * single column on a narrow window so nothing overflows horizontally. */
+.caption-view__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 380px);
+  gap: var(--space-5);
+  align-items: start;
+}
+
+.caption-view__stage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .caption-view__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* No-video empty state. */
+.caption-view--empty {
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+
+.caption-view__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  text-align: center;
+  padding: var(--space-8);
+}
+
+.caption-view__empty-title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  color: var(--text-primary);
+}
+
+.caption-view__empty-blurb {
+  margin: 0;
+  max-width: 40ch;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## v1.5 Caption pilot — inspector-over-shared-stage

Pilots the redesign's load-bearing pattern (spec `reframe-redesign-direction.md` §4/§7.2/§8): a shared **EditorContext** that a Stage, a keyboard Timeline, and an Inspector all read/write, so panels become **thin consumers, not layout owners**. Built by **composing** the shipped, verified caption components + pure libs — none were rewritten. Based on current `main` (incl. #282/#283/#284/#286).

### What's delivered (all 100% covered)
- **`lib/editorState.ts`** — the reusable primitive: pure reducer over `{ video, cues, cropPlan, caption design, playhead, selection }`. `cropPlan` is carried opaquely so the other 4 phases reuse this container. Immutable throughout.
- **`features/EditorContext.tsx`** — `EditorProvider` + `useEditor()`.
- **`features/caption/CaptionStage.tsx`** — the shared stage. Live caption via the pure `captionOverridePreview` mirror (`previewVisual`/`previewSizeScale`/`captionSampleStyle`) + `CaptionOverlay` word math, driven by the shared playhead. On-canvas **keyboard-operable** caption-region editing (`CaptionBox`). Karaoke word "pop" gated behind `prefers-reduced-motion` with a static fallback.
- **`features/caption/CaptionGallery.tsx`** — template-preset gallery that **expands over the timeline**; styles named by **LOOK** and grouped by layout **family** (never a new hue — one amber selection ring only); live preview each (composes the shipped `sampleStyle`).
- **`lib/captionStyleNames.ts`** — re-maps every catalog id to a jargon-free look name ("Word-by-word pop", "Keyword highlight", "Editorial serif"); a test asserts no font/codec/model/brand name ever reaches a label.
- **`features/caption/CaptionInspector.tsx`** — composes the shipped `CaptionCustomizer` + the gallery + the delivery choice; shows a single **"generate captions first"** gate when there's no transcript (the one legitimate disabled state).
- **`features/caption/CaptionDelivery.tsx`** — burn reversibility as a **guarded choice** (soft = toggleable vs hardsub = permanent) with an assertive permanence warning.
- **`features/caption/CaptionClipLane.tsx`** — the **keyboard-first** cue timeline replacing the mouse-only Timeline WCAG-A barrier: focusable clips, arrow = move, Shift+arrow = resize, Enter/Space = seek; composes the shipped `timelineOps` neighbor-clamping.
- **`views/Caption.tsx`** — seeds the context from the open video and loads/generates cues via the **typed #282 client** (`client.captions.cues` / `client.subtitles.generate`), not the old stringly `getApi().rpc`.
- **`App.tsx`** — a first-class "Caption" rail destination (route + tab + `CaptionIcon`).

### Actual gate results (verified by command output)
- `vitest run --coverage`: **190 files / 3317 tests passed**, **100%** statements (18244/18244), branches (6126/6126), functions (1091/1091), lines (18244/18244). No new `/* v8 ignore */`, `istanbul ignore`, or `.skip`; thresholds unchanged.
- `tokens.conformance.test.ts`: **green** (25 tests).
- `tsc --noEmit` (app): clean · `tsc -p . --noEmit` (render-cli): clean (after installing its separate workspace deps — the initial failure was missing `@remotion/*`, untouched by this PR).
- `biome format`, `oxlint --config app/.oxlintrc.json --deny-warnings`, `pre-commit run` (oxlint/biome/gitleaks): all clean.

### Measured pattern cost (the pilot's point)
- The **reusable core is cheap**: `editorState` + `EditorContext` = 2 files, pure+thin, ~28 tests. Every other phase inherits it for free.
- The **per-phase cost is composition, not rewrite**: the Stage/Inspector reuse `Player`, `CaptionBox`, `CaptionOverlay`, `CaptionCustomizer`, `CaptionStylePicker`'s `sampleStyle`, and the pure caption libs — wiring, not new logic.
- The **expensive parts** were the net-new a11y surfaces (keyboard clip lane) and exhaustive 100%-branch tests for the async view — not the pattern itself.
- **100%-no-new-ignore is achievable but shapes the design**: unreachable defensive branches must be removed rather than ignored (e.g. dropped a `next !== cues` guard and an unmount-cancelled guard because they couldn't be exercised). Net: the context + thin-consumer split *reduces* per-panel complexity, which is the payoff across all 5 phases.

### §8 DoD — met vs deferred
Met: contrast/tokens conformance · keyboard operability (caption box + clip lane + phase tab) · state completeness (empty / gate / loading / error) · reduced-motion neutralization · responsive grid (no horizontal overflow; inspector collapses at ≤900px) · one-accent discipline (guarded gallery) · no jargon/model names in strings · typed-RPC refactor demonstrated.

Deferred (documented, not half-finished):
- **Full subtitle Tracks CRUD relocation into Caption** (item 4, `client.tracks.*`). The burn **reversibility signal** is delivered (CaptionDelivery); the list/rename/relabel/burn/strip panel is a follow-up (~1 component + ~10 exhaustive tests).
- **Full multi-lane video/audio transport timeline** — spec §7.4 explicitly "build LAST as its own WU". This PR ships the caption-clip lane (the a11y-critical piece), not the multi-lane transport.
- Self-hosted `@font-face` binaries (Inter/Newsreader) — tokens already lead with them; bundling is a separate follow-up per `tokens.css`.

### Follow-ups
1. `CaptionTracks` panel (typed `client.tracks.*`) inside the inspector.
2. Multi-lane transport timeline (own TDD WU).
3. Reach Caption from the Edit phase stepper (not only the rail).

https://claude.ai/code/session_01M7yMAVChqv4LXKjEPaV8Dq
