### PR TITLE
feat: v1.5 Director rail destination (on DirectorPanel + EditorContext)

### DIFF
--- a/app/renderer/src/App.test.tsx
+++ b/app/renderer/src/App.test.tsx
@@ -96,9 +96,10 @@ vi.mock('./views/MakeShorts', () => ({
   ),
 }));
 
-// Stub the lazy AI Director panel (it owns its own tests). The marker echoes the
-// threaded video id + exposes the empty-state CTA so App's WU-E1 wiring is testable.
-vi.mock('./panels/DirectorPanel', () => ({
+// Stub the lazy Director rail destination (it owns its own tests). The marker
+// echoes the threaded video id + exposes the empty-state CTA so App's WU-E1 wiring
+// is testable (the view forwards both straight to the composed DirectorPanel).
+vi.mock('./views/Director', () => ({
   default: ({ video, onChooseVideo }: { video: Video | null; onChooseVideo?: () => void }) => (
     <div data-testid="director" data-video-id={video?.id ?? ''}>
       <button type="button" onClick={onChooseVideo}>

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -38,8 +38,9 @@ import {
   RepurposeIcon,
   SettingsIcon,
 } from './components/navIcons';
-// AI Director panel (lazy: it pulls the storyboard/diff + cost-banner surface).
-const DirectorPanel = lazy(() => import('./panels/DirectorPanel'));
+// Director rail destination (lazy: it pulls the DirectorPanel storyboard/diff +
+// cost-banner surface, the shared editor stage, and the per-phase hand-off).
+const Director = lazy(() => import('./views/Director'));
 import {
   client,
   hasApi,
@@ -450,10 +451,12 @@ function AppShell(): React.ReactElement {
       case 'director':
         return (
           <Suspense fallback={<div className="panel panel--loading">Loading…</div>}>
-            {/* WU-E1: thread the app-selected video so the Director plans against
+            {/* v1.5 §4: the first-class Director rail destination — built on the
+                shipped DirectorPanel + the shared EditorContext + the per-phase
+                hand-off. WU-E1: thread the app-selected video so it plans against
                 video.id (never the goal text); the empty-state CTA routes to the
                 Library to pick one. */}
-            <DirectorPanel video={editVideo} onChooseVideo={backToLibrary} />
+            <Director video={editVideo} onChooseVideo={backToLibrary} />
           </Suspense>
         );
       case 'settings':

--- a/app/renderer/src/features/director/DirectorHandoff.test.tsx
+++ b/app/renderer/src/features/director/DirectorHandoff.test.tsx
@@ -1,0 +1,93 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { EditorSeed } from '../../lib/editorState';
+import { TRUST_REVERSIBLE, TRUST_TEXT_EGRESS } from '../../lib/directorHandoff';
+import { EditorProvider } from '../EditorContext';
+import { DirectorHandoff } from './DirectorHandoff';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const WINDOW = { start: 0, end: 10 };
+const CUE = (index: number) => ({ index, start: index, end: index + 1, text: `w${index}` });
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+function render(over: Partial<EditorSeed> = {}): void {
+  const seed: EditorSeed = {
+    video: { videoId: 'v1', window: WINDOW, durationSec: 10 },
+    ...over,
+  };
+  act(() => {
+    root.render(
+      <EditorProvider seed={seed}>
+        <DirectorHandoff />
+      </EditorProvider>,
+    );
+  });
+}
+
+describe('DirectorHandoff', () => {
+  it('titles the surface and restates the reversible trust line verbatim', () => {
+    render();
+    expect(q('.director-handoff__title')?.textContent).toBe('Where your edit lands');
+    expect(q('.director-handoff__lede')?.textContent).toBe(TRUST_REVERSIBLE);
+  });
+
+  it('renders the three per-phase routes in order with their destinations', () => {
+    render();
+    const routes = Array.from(container.querySelectorAll('.director-handoff__route'));
+    expect(routes.map((r) => r.getAttribute('data-phase'))).toEqual(['edit', 'caption', 'reframe']);
+    expect(
+      Array.from(container.querySelectorAll('.director-handoff__dest')).map((d) => d.textContent),
+    ).toEqual(['Edit', 'Caption', 'Reframe']);
+    // Every route carries a plain-language change label + a blurb.
+    expect(q('[data-phase="edit"] .director-handoff__change')?.textContent).toBe('Cuts & pacing');
+    expect(
+      q('[data-phase="reframe"] .director-handoff__blurb')?.textContent?.length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('reflects a fully-seeded editor state as ready landing zones', () => {
+    render({ cues: [CUE(1), CUE(2)], cropPlan: { engine: 'x' } });
+    expect(q('[data-phase="edit"]')?.getAttribute('data-ready')).toBe('yes');
+    expect(q('[data-phase="caption"]')?.getAttribute('data-ready')).toBe('yes');
+    expect(q('[data-phase="reframe"]')?.getAttribute('data-ready')).toBe('yes');
+    expect(q('[data-testid="zone-caption"]')?.textContent).toBe(
+      'Transcript ready — 2 words to re-time.',
+    );
+  });
+
+  it('reflects a bare editor state as pending caption + reframe zones', () => {
+    render();
+    expect(q('[data-phase="edit"]')?.getAttribute('data-ready')).toBe('yes');
+    expect(q('[data-phase="caption"]')?.getAttribute('data-ready')).toBe('no');
+    expect(q('[data-phase="reframe"]')?.getAttribute('data-ready')).toBe('no');
+    expect(q('[data-testid="zone-caption"]')?.textContent).toBe(
+      'No transcript yet — the Director reads the speech first.',
+    );
+    expect(q('[data-testid="zone-reframe"]')?.textContent).toBe(
+      'No crop plan yet — framing starts from center.',
+    );
+  });
+
+  it('surfaces the verbatim text-egress privacy beat', () => {
+    render();
+    expect(q('.director-handoff__egress')?.textContent).toBe(TRUST_TEXT_EGRESS);
+  });
+});

--- a/app/renderer/src/features/director/DirectorHandoff.tsx
+++ b/app/renderer/src/features/director/DirectorHandoff.tsx
@@ -1,0 +1,51 @@
+// DirectorHandoff.tsx — the "where your edit lands" review surface (§4 Director).
+//
+// The Director does NOT silently apply: its proposed edit decomposes into
+// REVIEWABLE per-phase diffs (cuts -> Edit, keyframes -> Caption, crop -> Reframe).
+// This panel makes that promise legible — the routing contract plus each phase's
+// LIVE landing-zone status read from the shared editor state (`useEditor`) — and
+// restates the brand's reversible-edit + text-egress trust microcopy VERBATIM in
+// the AA-safe quiet step (never #50555F). A thin context consumer: it owns no
+// editor state, only reads it.
+
+import React from 'react';
+import { useEditor } from '../EditorContext';
+import { TRUST_REVERSIBLE, TRUST_TEXT_EGRESS, handoffRows } from '../../lib/directorHandoff';
+import './directorHandoff.css';
+
+export function DirectorHandoff(): React.ReactElement {
+  const { state } = useEditor();
+  const rows = handoffRows(state);
+
+  return (
+    <aside className="director-handoff" aria-label="Where your edit lands">
+      <h3 className="director-handoff__title">Where your edit lands</h3>
+      <p className="director-handoff__lede">{TRUST_REVERSIBLE}</p>
+      <ol className="director-handoff__routes">
+        {rows.map((row) => (
+          <li
+            key={row.phase}
+            className="director-handoff__route"
+            data-phase={row.phase}
+            data-ready={row.ready ? 'yes' : 'no'}
+          >
+            <div className="director-handoff__route-head">
+              <span className="director-handoff__change">{row.change}</span>
+              <span className="director-handoff__arrow" aria-hidden="true">
+                →
+              </span>
+              <span className="director-handoff__dest">{row.destination}</span>
+            </div>
+            <p className="director-handoff__blurb">{row.blurb}</p>
+            <p className="director-handoff__status" data-testid={`zone-${row.phase}`}>
+              {row.status}
+            </p>
+          </li>
+        ))}
+      </ol>
+      <p className="director-handoff__egress">{TRUST_TEXT_EGRESS}</p>
+    </aside>
+  );
+}
+
+export default DirectorHandoff;

--- a/app/renderer/src/features/director/directorHandoff.css
+++ b/app/renderer/src/features/director/directorHandoff.css
@@ -1,0 +1,133 @@
+/* directorHandoff.css — the "where your edit lands" review surface. Tokens only.
+ *
+ * One-accent discipline: amber stays on the DirectorPanel's approve action; here
+ * the only colour is the semantic READY signal (status green) vs a quiet pending
+ * step — never a decorative second hue. Trust copy renders in the AA-safe quiet
+ * steps (--text-secondary / --text-faint), never the rejected #50555F. */
+
+.director-handoff {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-6);
+  background: var(--atmos-toplight), var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+  min-width: 0;
+}
+
+.director-handoff__title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  color: var(--text-primary);
+}
+
+/* The signature reversible-edit promise — an AA-safe quiet step, never #50555F. */
+.director-handoff__lede {
+  margin: 0;
+  max-width: 46ch;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}
+
+.director-handoff__routes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+/* Each route is a low-density card with a status-tinted leading edge. */
+.director-handoff__route {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  background: var(--surface-bg);
+  border-radius: var(--radius-sm);
+  border-inline-start: 2px solid var(--edge);
+}
+
+.director-handoff__route[data-ready="yes"] {
+  border-inline-start-color: var(--status-success);
+}
+
+.director-handoff__route-head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.director-handoff__change {
+  font-size: var(--type-body-size);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.director-handoff__arrow {
+  color: var(--text-faint);
+}
+
+/* The destination phase, as a quiet tracked-caps tag (the label voice). */
+.director-handoff__dest {
+  padding: var(--control-pad-mini);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  background: var(--surface-hover);
+  border-radius: var(--radius-xs);
+}
+
+.director-handoff__blurb {
+  margin: 0;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-faint);
+}
+
+/* The live landing-zone status: a green dot + green text when ready, a quiet
+ * muted step when the baseline is not yet present. Colour is redundant with the
+ * text ("ready" / "no … yet"), so the signal never rides on hue alone. */
+.director-handoff__status {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  margin: 0;
+  font-size: var(--type-caption-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-faint);
+}
+
+.director-handoff__status::before {
+  content: "";
+  flex: 0 0 auto;
+  width: var(--size-dot-sm);
+  height: var(--size-dot-sm);
+  border-radius: var(--radius-pill);
+  background: var(--text-faint);
+  transform: translateY(-1px);
+}
+
+.director-handoff__route[data-ready="yes"] .director-handoff__status {
+  color: var(--status-success);
+}
+
+.director-handoff__route[data-ready="yes"] .director-handoff__status::before {
+  background: var(--status-success);
+}
+
+/* The verbatim per-data-type egress beat — the quietest readable AA-safe step. */
+.director-handoff__egress {
+  margin: 0;
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--edge);
+  font-size: var(--type-caption-size);
+  color: var(--text-faint);
+}

--- a/app/renderer/src/lib/directorHandoff.test.ts
+++ b/app/renderer/src/lib/directorHandoff.test.ts
@@ -1,0 +1,179 @@
+// directorHandoff.test.ts — the pure per-phase hand-off model (v1.5 Director).
+
+import { describe, expect, it } from 'vitest';
+import type { DirectorOpKind } from './directorTypes';
+import { egressWarning } from './directorTypes';
+import type { CropPlan } from './editorState';
+import { type EditorState, initialEditorState } from './editorState';
+import {
+  HANDOFF_ROUTES,
+  type HandoffPhase,
+  TRUST_REVERSIBLE,
+  TRUST_TEXT_EGRESS,
+  handoffRows,
+  landingZones,
+  phaseForOpKind,
+} from './directorHandoff';
+
+const WINDOW = { start: 0, end: 10 };
+
+function stateWith(over: { cues?: EditorState['cues']; cropPlan?: CropPlan | null }): EditorState {
+  return initialEditorState({
+    video: { videoId: 'v1', window: WINDOW, durationSec: 10 },
+    cues: over.cues,
+    cropPlan: over.cropPlan,
+  });
+}
+
+const CUE = (index: number) => ({ index, start: index, end: index + 1, text: `w${index}` });
+
+describe('phaseForOpKind', () => {
+  it('routes cut/pacing kinds to the Edit phase', () => {
+    const editKinds: DirectorOpKind[] = [
+      'trim',
+      'cut',
+      'join',
+      'removeSilence',
+      'removeFillers',
+      'reorder',
+      'retime',
+    ];
+    for (const kind of editKinds) {
+      expect(phaseForOpKind(kind)).toBe('edit');
+    }
+  });
+
+  it('routes caption/text kinds to the Caption phase', () => {
+    const captionKinds: DirectorOpKind[] = [
+      'caption',
+      'translateCaption',
+      'overlayText',
+      'lowerThird',
+    ];
+    for (const kind of captionKinds) {
+      expect(phaseForOpKind(kind)).toBe('caption');
+    }
+  });
+
+  it('routes crop/framing kinds to the Reframe phase', () => {
+    const reframeKinds: DirectorOpKind[] = ['reframe', 'zoomPan', 'stitchPanorama', 'regenScroll'];
+    for (const kind of reframeKinds) {
+      expect(phaseForOpKind(kind)).toBe('reframe');
+    }
+  });
+
+  it('leaves terminal/analysis kinds unrouted (not a reviewable phase diff)', () => {
+    expect(phaseForOpKind('export')).toBeNull();
+    expect(phaseForOpKind('ocrExtractList')).toBeNull();
+  });
+});
+
+describe('HANDOFF_ROUTES', () => {
+  it('names exactly the three review phases in the directed order', () => {
+    expect(HANDOFF_ROUTES.map((r) => r.phase)).toEqual(['edit', 'caption', 'reframe']);
+    expect(HANDOFF_ROUTES.map((r) => r.destination)).toEqual(['Edit', 'Caption', 'Reframe']);
+  });
+
+  it('describes each route in plain language (no op jargon, no model codenames)', () => {
+    for (const route of HANDOFF_ROUTES) {
+      expect(route.change.length).toBeGreaterThan(0);
+      expect(route.blurb.length).toBeGreaterThan(0);
+      // No engineer op-kind identifiers leak into the copy.
+      expect(route.change).not.toMatch(/removeSilence|zoomPan|ocrExtractList/);
+    }
+  });
+});
+
+describe('landingZones', () => {
+  it('marks Edit ready always (there is always a source timeline)', () => {
+    const zones = landingZones(stateWith({}));
+    const edit = zones.find((z) => z.phase === 'edit')!;
+    expect(edit.ready).toBe(true);
+    expect(edit.status).toContain('Timeline ready');
+  });
+
+  it('gates Caption on a transcript and reports the (plural) word count', () => {
+    const zones = landingZones(stateWith({ cues: [CUE(1), CUE(2)] }));
+    const caption = zones.find((z) => z.phase === 'caption')!;
+    expect(caption.ready).toBe(true);
+    expect(caption.status).toBe('Transcript ready — 2 words to re-time.');
+  });
+
+  it('uses the singular for a one-word transcript', () => {
+    const zones = landingZones(stateWith({ cues: [CUE(1)] }));
+    expect(zones.find((z) => z.phase === 'caption')!.status).toBe(
+      'Transcript ready — 1 word to re-time.',
+    );
+  });
+
+  it('reports Caption not-ready with no transcript', () => {
+    const caption = landingZones(stateWith({ cues: [] })).find((z) => z.phase === 'caption')!;
+    expect(caption.ready).toBe(false);
+    expect(caption.status).toBe('No transcript yet — the Director reads the speech first.');
+  });
+
+  it('gates Reframe on a crop plan', () => {
+    const withCrop = landingZones(stateWith({ cropPlan: { engine: 'x' } })).find(
+      (z) => z.phase === 'reframe',
+    )!;
+    expect(withCrop.ready).toBe(true);
+    expect(withCrop.status).toBe('Crop plan in place — framing nudges land on it.');
+
+    const noCrop = landingZones(stateWith({ cropPlan: null })).find((z) => z.phase === 'reframe')!;
+    expect(noCrop.ready).toBe(false);
+    expect(noCrop.status).toBe('No crop plan yet — framing starts from center.');
+  });
+
+  it('returns exactly one zone per review phase', () => {
+    const phases = landingZones(stateWith({})).map((z) => z.phase);
+    expect([...phases].sort()).toEqual(['caption', 'edit', 'reframe']);
+  });
+});
+
+describe('handoffRows', () => {
+  it('merges each route with its live landing zone, aligned by phase', () => {
+    const rows = handoffRows(stateWith({ cues: [CUE(1)], cropPlan: { engine: 'x' } }));
+    expect(rows.map((r) => r.phase)).toEqual(['edit', 'caption', 'reframe']);
+    // Row carries BOTH the route copy and the live zone status.
+    const caption = rows.find((r) => r.phase === 'caption')!;
+    expect(caption.destination).toBe('Caption');
+    expect(caption.ready).toBe(true);
+    expect(caption.status).toBe('Transcript ready — 1 word to re-time.');
+  });
+
+  it('keeps the route order and the zone order aligned', () => {
+    const rows = handoffRows(stateWith({}));
+    const zones = landingZones(stateWith({}));
+    rows.forEach((row, i) => {
+      expect(row.phase).toBe(zones[i].phase);
+    });
+  });
+});
+
+describe('trust microcopy (verbatim, single-sourced)', () => {
+  it('pins the reviewable/reversible signature line', () => {
+    expect(TRUST_REVERSIBLE).toBe(
+      'The Director plans a reviewable, reversible edit — nothing is applied until you confirm.',
+    );
+  });
+
+  it('pins the text-egress beat and keeps it identical to the cost-banner warning', () => {
+    expect(TRUST_TEXT_EGRESS).toBe('Text will leave your machine.');
+    // The same verbatim string directorTypes surfaces for a text-egressing op.
+    expect(
+      egressWarning({
+        function: 'editPlan',
+        route: 'cloud',
+        costEst: 0,
+        willEgress: true,
+        cacheHit: false,
+        cacheKey: 'k',
+      }),
+    ).toBe(TRUST_TEXT_EGRESS);
+  });
+
+  it('exposes the phase union type through a usable value', () => {
+    const phase: HandoffPhase = 'edit';
+    expect(HANDOFF_ROUTES.some((r) => r.phase === phase)).toBe(true);
+  });
+});

--- a/app/renderer/src/lib/directorHandoff.ts
+++ b/app/renderer/src/lib/directorHandoff.ts
@@ -1,0 +1,167 @@
+// directorHandoff.ts — the PURE per-phase hand-off model for the Director screen.
+//
+// The redesign directive (§4 "Director"): the Director's output must land as
+// REVIEWABLE per-phase diffs — cuts -> Edit, keyframes -> Caption, crop -> Reframe —
+// and NOTHING is applied until the user confirms. This module is that hand-off's
+// PURE core: the op-kind -> phase routing map, the ordered routing contract the
+// screen shows while planning, and the LIVE "landing zone" status derived from the
+// shared editor state (does this video already hold a transcript / crop plan the
+// diffs land against). No React, no DOM — so it is exhaustively unit-testable and
+// the screen stays a thin render shell (mirrors directorTypes' pure-helper split).
+
+import type { DirectorOpKind } from './directorTypes';
+import { type EditorState, transcriptReady } from './editorState';
+
+/** The three phases a Director edit decomposes into (each its own review surface). */
+export type HandoffPhase = 'edit' | 'caption' | 'reframe';
+
+/**
+ * Which review phase each Director op-kind's diff lands in. The three the
+ * direction names (cuts -> Edit, caption timing -> Caption, crop -> Reframe) plus
+ * their siblings. Terminal/analysis kinds (an export render, an on-screen-text
+ * read) are NOT reviewable phase diffs and map to null. Total over DirectorOpKind
+ * (the Record type enforces it), so `phaseForOpKind` needs no fallback branch.
+ */
+const PHASE_BY_OP_KIND: Readonly<Record<DirectorOpKind, HandoffPhase | null>> = {
+  trim: 'edit',
+  cut: 'edit',
+  join: 'edit',
+  removeSilence: 'edit',
+  removeFillers: 'edit',
+  reorder: 'edit',
+  retime: 'edit',
+  reframe: 'reframe',
+  zoomPan: 'reframe',
+  stitchPanorama: 'reframe',
+  regenScroll: 'reframe',
+  caption: 'caption',
+  translateCaption: 'caption',
+  overlayText: 'caption',
+  lowerThird: 'caption',
+  export: null,
+  ocrExtractList: null,
+};
+
+/** The review phase an op-kind's diff lands in, or null when it is not a phase diff. */
+export function phaseForOpKind(kind: DirectorOpKind): HandoffPhase | null {
+  return PHASE_BY_OP_KIND[kind];
+}
+
+/** One row of the per-phase hand-off contract shown on the Director screen. */
+export interface HandoffRoute {
+  phase: HandoffPhase;
+  /** What KIND of change routes here, in plain language (never op-kind jargon). */
+  change: string;
+  /** The destination phase name as it appears in the app rail. */
+  destination: string;
+  /** One quiet line describing the reviewable diff that lands there. */
+  blurb: string;
+}
+
+/**
+ * The ordered hand-off contract: the three review phases a Director edit lands in,
+ * in the order the direction names them (cuts -> Edit, keyframes -> Caption,
+ * crop -> Reframe). Rendered as the "where your edit lands" legend so the review-
+ * per-phase promise is legible while the user plans.
+ */
+export const HANDOFF_ROUTES: readonly HandoffRoute[] = [
+  {
+    phase: 'edit',
+    change: 'Cuts & pacing',
+    destination: 'Edit',
+    blurb: 'Trims, cuts and reordering arrive as reviewable timeline edits.',
+  },
+  {
+    phase: 'caption',
+    change: 'Caption timing',
+    destination: 'Caption',
+    blurb: 'Caption cues and on-screen text arrive as reviewable word timing.',
+  },
+  {
+    phase: 'reframe',
+    change: 'Crop & framing',
+    destination: 'Reframe',
+    blurb: 'Reframing and zoom nudges arrive as a reviewable crop plan.',
+  },
+];
+
+/** The live status of one review phase's landing zone (what diffs land against). */
+export interface LandingZone {
+  phase: HandoffPhase;
+  /** True when the target already holds the baseline content the diffs build on. */
+  ready: boolean;
+  /** A short, jargon-free status line (single-sourced here for the screen + tests). */
+  status: string;
+}
+
+/**
+ * Derive each phase's landing-zone status from the shared editor state — the
+ * baseline a Director diff would land against. Edit is always ready (there is
+ * always a source timeline); Caption is ready once a transcript exists (its cues
+ * are the word timing the Director re-times); Reframe is ready once a crop plan
+ * exists (else framing starts from center). Pure + total: one entry per phase, in
+ * the same order as {@link HANDOFF_ROUTES}.
+ */
+export function landingZones(state: EditorState): LandingZone[] {
+  const transcript = transcriptReady(state);
+  const wordCount = state.cues.length;
+  const hasCrop = state.cropPlan !== null;
+  return [
+    {
+      phase: 'edit',
+      ready: true,
+      status: 'Timeline ready — cuts land as reviewable edits.',
+    },
+    {
+      phase: 'caption',
+      ready: transcript,
+      status: transcript
+        ? `Transcript ready — ${wordCount} ${wordCount === 1 ? 'word' : 'words'} to re-time.`
+        : 'No transcript yet — the Director reads the speech first.',
+    },
+    {
+      phase: 'reframe',
+      ready: hasCrop,
+      status: hasCrop
+        ? 'Crop plan in place — framing nudges land on it.'
+        : 'No crop plan yet — framing starts from center.',
+    },
+  ];
+}
+
+/** A hand-off route merged with its live landing-zone status (what the screen renders). */
+export interface HandoffRow extends HandoffRoute {
+  ready: boolean;
+  status: string;
+}
+
+/**
+ * Merge each {@link HANDOFF_ROUTES} row with its {@link landingZones} status,
+ * aligned by position (both lists are the three phases in the same order). The
+ * screen maps these directly, so the review contract + the live baseline render as
+ * one row per phase.
+ */
+export function handoffRows(state: EditorState): HandoffRow[] {
+  const zones = landingZones(state);
+  return HANDOFF_ROUTES.map((route, i) => ({
+    ...route,
+    ready: zones[i].ready,
+    status: zones[i].status,
+  }));
+}
+
+/**
+ * The brand's signature trust line, kept VERBATIM (§4 "Director" voice) — rendered
+ * in the AA-safe quiet step on the screen, never the rejected #50555F. Single-
+ * sourced here so the wording can never silently drift (matches DirectorPanel's
+ * own intro).
+ */
+export const TRUST_REVERSIBLE =
+  'The Director plans a reviewable, reversible edit — nothing is applied until you confirm.';
+
+/**
+ * The verbatim per-data-type egress beat — identical to the string directorTypes'
+ * `egressWarning` surfaces for a text-egressing op, so the privacy voice reads the
+ * same everywhere the Director speaks it.
+ */
+export const TRUST_TEXT_EGRESS = 'Text will leave your machine.';

--- a/app/renderer/src/styles/tokens.conformance.test.ts
+++ b/app/renderer/src/styles/tokens.conformance.test.ts
@@ -240,6 +240,70 @@ describe('dark-editorial surface ladder recalibration (WU-2a)', () => {
   });
 });
 
+// --- PR #290: red-text AA guard — error-alert text on the soft-error wash --------
+//
+// The error-alert TEXT (e.g. .director-view__error) sits on the translucent
+// --status-error-soft wash. The saturated base --status-error (#e5484d),
+// composited over that wash on the LIFTED elevation planes, drops to ~3.2-4.2:1 —
+// a real WCAG 1.4.3 (AA) fail for body-size text. The fix is a dedicated red-TEXT
+// token (--status-error-text, a lighter tint) mirroring the --status-abundance-text
+// "lighter tint for AA on the wash" precedent. This guard re-derives the sRGB
+// composite + WCAG contrast INDEPENDENTLY and pins that the red-text token clears
+// 4.5:1 on EVERY elevation plane — and that it is genuinely lighter than (and the
+// base red genuinely fails on) that wash — so alert text can never silently decay
+// back to the sub-AA saturated red.
+
+/** Parse an `rgba(r, g, b, a)` token into [r, g, b, a]. Throws if not an rgba(). */
+function toRgba(
+  tokens: Map<string, string>,
+  name: string,
+): readonly [number, number, number, number] {
+  const raw = tokens.get(name);
+  if (raw === undefined) throw new Error(`missing token ${name}`);
+  const m = /^rgba\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*,\s*([\d.]+)\s*\)$/.exec(raw);
+  if (m === null) throw new Error(`token ${name} is not an rgba(): ${raw}`);
+  return [Number(m[1]), Number(m[2]), Number(m[3]), Number.parseFloat(m[4])];
+}
+
+/** Alpha-composite a translucent wash over an opaque plane in sRGB 0-255 — how the
+ * browser blends a background-color alpha over its backdrop (source-over). */
+function over(wash: readonly [number, number, number, number], plane: Rgb): Rgb {
+  const [wr, wg, wb, a] = wash;
+  const [pr, pg, pb] = plane;
+  return [a * wr + (1 - a) * pr, a * wg + (1 - a) * pg, a * wb + (1 - a) * pb];
+}
+
+describe('red-text token clears AA on the soft-error wash (PR #290)', () => {
+  it('defines --status-error-text as a lighter tint than --status-error', () => {
+    const tokens = readTokens();
+    // toRgb throws unless the token is a plain #rrggbb; the text token is a
+    // genuinely lighter red (the fix direction — it lifts the saturated base up to
+    // an AA-legible tint on the wash), never a copy of the base value.
+    expect(relLum(toRgb(tokens, '--status-error-text'))).toBeGreaterThan(
+      relLum(toRgb(tokens, '--status-error')),
+    );
+  });
+
+  it('holds --status-error-text at AA (>=4.5:1) on the wash over every elevation plane', () => {
+    const tokens = readTokens();
+    const text = toRgb(tokens, '--status-error-text');
+    const wash = toRgba(tokens, '--status-error-soft');
+    for (const plane of ELEVATION_PLANES) {
+      expect(contrast(text, over(wash, toRgb(tokens, plane)))).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it('proves the base --status-error FAILS AA on that wash (why the token exists)', () => {
+    // Documents the exact regression the token fixes: the base red on the wash
+    // drops below AA on the lifted planes (here --surface-raised, ~3.75:1), so a
+    // component MUST route alert text through --status-error-text, not --status-error.
+    const tokens = readTokens();
+    const base = toRgb(tokens, '--status-error');
+    const wash = toRgba(tokens, '--status-error-soft');
+    expect(contrast(base, over(wash, toRgb(tokens, '--surface-raised')))).toBeLessThan(4.5);
+  });
+});
+
 // --- WU-D1: TYPE / WEIGHT / CONTROL token-scale completeness guard ---------------
 //
 // The design review found the type layer incomplete: NO font-weight tokens (raw

--- a/app/renderer/src/styles/tokens.css
+++ b/app/renderer/src/styles/tokens.css
@@ -70,6 +70,14 @@
   --status-success-soft: rgba(70, 196, 131, 0.12);
   --status-error: #e5484d;
   --status-error-soft: rgba(229, 72, 77, 0.1);
+  /* error TEXT on the soft wash — a lighter red tint (the "lighter tint for AA on
+   * the wash" precedent set by --status-abundance-text). The saturated base
+   * --status-error (#e5484d), composited over --status-error-soft, drops to
+   * ~3.2-4.2:1 on the lifted elevation planes — a real WCAG 1.4.3 (AA) fail for
+   * body-size alert text; this tint clears >=4.5:1 on every elevation plane.
+   * Consume for ERROR-ALERT TEXT over the soft wash; pinned by the tokens.conformance
+   * red-text guard. */
+  --status-error-text: #ff6b6b;
   --status-warn: #e7c14b; /* yellow-leaning, distinct from the orange-leaning accent */
   --status-warn-soft: rgba(231, 193, 75, 0.1);
 

--- a/app/renderer/src/views/Director.test.tsx
+++ b/app/renderer/src/views/Director.test.tsx
@@ -1,0 +1,165 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Video } from '../lib/rpc';
+import { Director } from './Director';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const cuesMock = vi.fn();
+let hasApiReturn = true;
+
+vi.mock('../lib/rpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/rpc')>();
+  return {
+    ...actual,
+    hasApi: () => hasApiReturn,
+    client: {
+      ...actual.client,
+      captions: { cues: (...args: unknown[]) => cuesMock(...args) },
+    },
+  };
+});
+
+// The DirectorPanel owns its own comprehensive tests; stub it so the view test
+// exercises ONLY the screen (shell + EditorContext seeding + cue load + hand-off).
+// The marker echoes the threaded video id + exposes the empty-state CTA.
+vi.mock('../panels/DirectorPanel', () => ({
+  DirectorPanel: ({
+    video,
+    onChooseVideo,
+  }: {
+    video: Video | null;
+    onChooseVideo?: () => void;
+  }) => (
+    <div data-testid="director-panel" data-video-id={video?.id ?? ''}>
+      <button type="button" onClick={onChooseVideo}>
+        choose-video
+      </button>
+    </div>
+  ),
+}));
+
+const VIDEO: Video = {
+  id: 'v1',
+  path: '/clips/x.mp4',
+  title: 'My Clip',
+  addedAt: '2026-01-01',
+  durationSec: 20,
+  hasTranscript: false,
+};
+const CUES = [
+  { index: 1, start: 2, end: 3, text: 'Hello' },
+  { index: 2, start: 6, end: 7, text: 'world' },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+const onChooseVideo = vi.fn();
+
+beforeEach(() => {
+  cuesMock.mockReset();
+  onChooseVideo.mockReset();
+  hasApiReturn = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function render(video: Video | null): void {
+  act(() => {
+    root.render(<Director video={video} onChooseVideo={onChooseVideo} />);
+  });
+}
+
+describe('Director view', () => {
+  it('renders the editorial shell with the serif hero + the DirectorPanel', () => {
+    render(null);
+    expect(q('.director-view__title')?.textContent).toBe('Direct the edit');
+    expect(q('[data-testid="director-panel"]')).not.toBeNull();
+  });
+
+  it('shows the DirectorPanel empty state (no hand-off) when no video is open', () => {
+    render(null);
+    // No video -> the DirectorPanel carries its own "No video open" CTA; the
+    // per-phase hand-off (which needs editor state) is not mounted.
+    expect(q('[data-testid="director-panel"]')?.getAttribute('data-video-id')).toBe('');
+    expect(q('.director-handoff')).toBeNull();
+    expect(cuesMock).not.toHaveBeenCalled();
+  });
+
+  it('routes back to the Library from the shell back control', () => {
+    render(null);
+    act(() => q<HTMLButtonElement>('.director-view__back')?.click());
+    expect(onChooseVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it('threads the DirectorPanel CTA back to the Library', () => {
+    render(null);
+    act(() => q<HTMLButtonElement>('[data-testid="director-panel"] button')?.click());
+    expect(onChooseVideo).toHaveBeenCalledTimes(1);
+  });
+
+  it('seeds the editor, loads cues via the typed client, and shows the hand-off', async () => {
+    cuesMock.mockResolvedValue({ cues: CUES });
+    render(VIDEO);
+    await flush();
+    expect(cuesMock).toHaveBeenCalledWith('v1');
+    expect(q('[data-testid="director-panel"]')?.getAttribute('data-video-id')).toBe('v1');
+    expect(q('.director-handoff')).not.toBeNull();
+    // The loaded transcript makes the Caption landing zone read as ready.
+    expect(q('[data-phase="caption"]')?.getAttribute('data-ready')).toBe('yes');
+    expect(q('.director-view__error')).toBeNull();
+  });
+
+  it('handles an empty cues payload as a pending Caption zone', async () => {
+    cuesMock.mockResolvedValue({});
+    render(VIDEO);
+    await flush();
+    expect(q('[data-phase="caption"]')?.getAttribute('data-ready')).toBe('no');
+    expect(q('.director-view__error')).toBeNull();
+  });
+
+  it('surfaces a cue-load failure as an alert', async () => {
+    cuesMock.mockRejectedValue(new Error('load boom'));
+    render(VIDEO);
+    await flush();
+    expect(q('.director-view__error')?.textContent).toBe('load boom');
+    expect(q('.director-view__error')?.getAttribute('role')).toBe('alert');
+  });
+
+  it('stringifies a non-Error rejection', async () => {
+    cuesMock.mockRejectedValue('weird failure');
+    render(VIDEO);
+    await flush();
+    expect(q('.director-view__error')?.textContent).toBe('weird failure');
+  });
+
+  it('no-ops the cue RPC when the preload bridge is unavailable', async () => {
+    hasApiReturn = false;
+    render(VIDEO);
+    await flush();
+    expect(cuesMock).not.toHaveBeenCalled();
+    // The hand-off still renders; its Caption zone is simply pending.
+    expect(q('.director-handoff')).not.toBeNull();
+    expect(q('[data-phase="caption"]')?.getAttribute('data-ready')).toBe('no');
+  });
+});

--- a/app/renderer/src/views/Director.tsx
+++ b/app/renderer/src/views/Director.tsx
@@ -1,0 +1,127 @@
+// Director.tsx — the DIRECTOR phase view (v1.5, §4 "Director").
+//
+// The first-class rail destination for prompt-driven AI editing, built ON the
+// shipped DirectorPanel (COMPOSED, not rewritten) inside the ONE consciously
+// low-density, editorial-spacious screen — the strongest home for the serif
+// display voice, left-anchored and composed so no form is stranded in dead space.
+//
+// It seeds the shared EditorContext from the open video and reads that video's
+// word-level cues via the typed #282 client (so the hand-off's Caption landing
+// zone reflects whether a transcript already exists), then composes the
+// DirectorPanel (planning / reviewable storyboard / cost-egress banner / apply
+// gate / one-shot undo) beside the DirectorHandoff — the surface that makes the
+// "output lands as REVIEWABLE per-phase diffs, nothing applied until you confirm"
+// promise legible (cuts -> Edit, keyframes -> Caption, crop -> Reframe). The
+// provider remounts per video (`key`) so a video switch re-seeds cleanly. With no
+// video open, the DirectorPanel's own "No video open" empty state carries the CTA.
+
+import React, { useEffect, useState } from 'react';
+import { type Cue, type Video, client, hasApi } from '../lib/rpc';
+import type { EditorSeed } from '../lib/editorState';
+import { EditorProvider, useEditor } from '../features/EditorContext';
+import { DirectorPanel } from '../panels/DirectorPanel';
+import { DirectorHandoff } from '../features/director/DirectorHandoff';
+import './director.css';
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** Read the cue list off a captions.cues response (defensive against a malformed body). */
+function cuesOf(res: { cues?: Cue[] }): Cue[] {
+  return res.cues ?? [];
+}
+
+export interface DirectorProps {
+  video: Video | null;
+  /** Route to the Library — the shell back control AND the DirectorPanel empty CTA. */
+  onChooseVideo: () => void;
+}
+
+/** The editorial screen chrome: the serif hero + a back control + a low lede. */
+function DirectorFrame({
+  onChooseVideo,
+  children,
+}: {
+  onChooseVideo: () => void;
+  children: React.ReactNode;
+}): React.ReactElement {
+  return (
+    <section className="director-view" aria-label="Director">
+      <header className="director-view__head">
+        <button type="button" className="director-view__back" onClick={onChooseVideo}>
+          ← Library
+        </button>
+        <h1 className="director-view__title">Direct the edit</h1>
+        <p className="director-view__lede">
+          One prompt in. A reviewable plan out — phase by phase.
+        </p>
+      </header>
+      {children}
+    </section>
+  );
+}
+
+/** Inner workspace: seeds the editor, loads cues, composes the panel + hand-off. */
+function DirectorWorkspace({
+  video,
+  onChooseVideo,
+}: {
+  video: Video;
+  onChooseVideo: () => void;
+}): React.ReactElement {
+  const { dispatch } = useEditor();
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!hasApi()) return;
+    void client.captions
+      .cues(video.id)
+      .then((res) => dispatch({ type: 'setCues', cues: cuesOf(res) }))
+      .catch((err) => setError(errText(err)));
+  }, [video.id, dispatch]);
+
+  return (
+    <DirectorFrame onChooseVideo={onChooseVideo}>
+      {error && (
+        <p className="director-view__error" role="alert">
+          {error}
+        </p>
+      )}
+      <div className="director-view__body">
+        <div className="director-view__main">
+          <DirectorPanel video={video} onChooseVideo={onChooseVideo} />
+        </div>
+        <DirectorHandoff />
+      </div>
+    </DirectorFrame>
+  );
+}
+
+export function Director({ video, onChooseVideo }: DirectorProps): React.ReactElement {
+  if (!video) {
+    return (
+      <DirectorFrame onChooseVideo={onChooseVideo}>
+        <div className="director-view__body director-view__body--empty">
+          <DirectorPanel video={null} onChooseVideo={onChooseVideo} />
+        </div>
+      </DirectorFrame>
+    );
+  }
+
+  const seed: EditorSeed = {
+    video: {
+      videoId: video.id,
+      window: { start: 0, end: video.durationSec },
+      durationSec: video.durationSec,
+    },
+  };
+
+  return (
+    <EditorProvider key={video.id} seed={seed}>
+      <DirectorWorkspace video={video} onChooseVideo={onChooseVideo} />
+    </EditorProvider>
+  );
+}
+
+export default Director;

--- a/app/renderer/src/views/director.css
+++ b/app/renderer/src/views/director.css
@@ -67,7 +67,10 @@
   margin: 0;
   padding: var(--space-3) var(--space-4);
   font-size: var(--type-body-size);
-  color: var(--status-error);
+  /* AA-safe red TEXT on the soft wash: the saturated --status-error drops to
+   * ~3.2-4.2:1 composited over --status-error-soft on the lifted planes (WCAG
+   * 1.4.3 fail); --status-error-text is the lighter tint that clears >=4.5:1. */
+  color: var(--status-error-text);
   background: var(--status-error-soft);
   border-radius: var(--radius-sm);
 }

--- a/app/renderer/src/views/director.css
+++ b/app/renderer/src/views/director.css
@@ -1,0 +1,112 @@
+/* director.css — the Director phase view layout (v1.5, §4).
+ *
+ * The ONE consciously LOW-density, editorial-spacious screen: the upper spacing
+ * rungs (space-6/7), the strongest home for the serif DISPLAY voice (a real scale
+ * jump from 13px body to the 30px editorial display), left-anchored and composed
+ * (planning panel + hand-off side by side) so no form is stranded in dead space.
+ * Tokens only. */
+
+.director-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-6);
+  padding: var(--space-7);
+  min-height: 0;
+}
+
+/* Left-anchored editorial hero — generous vertical rhythm, not a centered block. */
+.director-view__head {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-4);
+}
+
+.director-view__back {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.director-view__back:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.director-view__back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* The serif display voice with a real scale jump — the editorial moment. */
+.director-view__title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-display-size);
+  font-weight: var(--type-display-weight);
+  letter-spacing: var(--type-display-tracking);
+  line-height: var(--type-display-leading);
+  color: var(--text-primary);
+}
+
+.director-view__lede {
+  margin: 0;
+  max-width: 52ch;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}
+
+.director-view__error {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--type-body-size);
+  color: var(--status-error);
+  background: var(--status-error-soft);
+  border-radius: var(--radius-sm);
+}
+
+/* Composed, left-anchored: the planning panel (main) beside the per-phase hand-off
+ * (aside). Reflows to a single vertical column at narrow widths so the panel is
+ * never trapped in a cramped aside and nothing overflows horizontally. */
+.director-view__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(300px, 400px);
+  gap: var(--space-6);
+  align-items: start;
+}
+
+.director-view__main {
+  min-width: 0;
+}
+
+/* The no-video state is just the DirectorPanel's own empty state — cap its measure
+ * so it never stretches across an ultrawide window. */
+.director-view__body--empty {
+  display: block;
+  max-width: 640px;
+}
+
+@media (max-width: 1024px) {
+  .director-view__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* prefers-reduced-motion: neutralize all motion under the screen (the DoD honours
+ * it for any streaming/thinking animation the composed panel may run). */
+@media (prefers-reduced-motion: reduce) {
+  .director-view *,
+  .director-view *::before,
+  .director-view *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
## Summary

Builds the **Director** screen per the redesign direction (§4 "Director") as a **first-class rail destination built on the shipped `DirectorPanel`** — not folded into the phase stepper. The existing `director` route (which rendered the bare panel) now renders an editorial `views/Director.tsx` screen that **composes** `DirectorPanel` (unchanged) with the shared `EditorContext` and a new **per-phase hand-off** surface.

This is the ONE consciously **low-density, editorial-spacious** screen: the serif display voice with a real scale jump (`--font-editorial` at `--type-display`), left-anchored and **composed** (planning panel beside the hand-off) so no form is stranded in dead space.

## What it does

- **Consumes the shared `EditorContext`** — seeds the provider from the open video (remounts per `video.id`) and loads that video's word-level cues via the typed `client.captions.cues` (mirrors the Caption pilot), so the hand-off's Caption landing zone reflects whether a transcript already exists.
- **Composes `DirectorPanel` wholesale** — empty "No video open" + CTA, busy "Working…" + `aria-live="polite"`, error `role="alert"`, the reviewable collapsible storyboard with keyboard-complete per-op enable/disable/reorder, the per-data-type cost/egress banner, the Apply gate echoing the budget cacheKey, one-shot Undo, and "Adjust & re-plan". These are **not** re-implemented — the panel is rendered as-is.
- **Designs the per-phase hand-off** (`lib/directorHandoff.ts` + `features/director/DirectorHandoff.tsx`) — the Director does **not** silently apply. Its output decomposes into REVIEWABLE per-phase diffs: **cuts → Edit, keyframes → Caption, crop → Reframe**. The surface renders the op-kind→phase routing contract plus each phase's **live landing-zone status** read from the shared editor state, and restates the reversible-edit + text-egress **trust microcopy VERBATIM** in the AA-safe quiet step (`--text-secondary`/`--text-faint`, never `#50555F`).

## Definition of Done

| Gate | Status |
|---|---|
| Contrast — no readable text below 4.5:1; conformance ladder green | ✅ trust copy in `--text-secondary`/`--text-faint`; `tokens.conformance.test.ts` (25 tests) passes; new CSS uses **only** defined tokens (WU-D7 green) |
| Keyboard — native/role-complete controls, visible `--focus-ring` | ✅ back control + composed panel are keyboard-complete; focus ring on the shell control |
| State completeness — empty/loading/busy/terminal | ✅ inherited wholesale from `DirectorPanel`; cue-load failure surfaces as `role="alert"` |
| Motion — `prefers-reduced-motion` neutralizes motion | ✅ scoped reduced-motion block over the screen |
| Responsive — no horizontal overflow; reflows at narrow widths | ✅ 2-col grid → single vertical column at ≤1024px; panel never trapped in a 320px aside |
| One-accent discipline — amber only; status green/amber/red | ✅ amber stays on the panel's approve action; ready = status green, no decorative hue |
| Voice — no jargon/model codenames; trust copy verbatim | ✅ plain-language routing labels (test asserts no op-kind leaks); `TRUST_REVERSIBLE` + `TRUST_TEXT_EGRESS` pinned verbatim |
| Immutable; small files (<800 lines) | ✅ pure reducers/selectors return new objects; largest new file ~180 lines |

**Deferred (out of scope for this WU):** the live plan-ops → editorState staging bridge (wiring an *applied* Director plan's ops into the Edit/Caption/Reframe inspectors as concrete diffs) depends on the Wave-0 applied-plan RPC surface; this WU delivers the hand-off **contract + live landing zones + review-per-phase guarantee** without modifying the shipped `DirectorPanel`.

## Constraints honored

- **TDD** — tests written first for each unit (pure lib → surface → view).
- **No new** `/* v8 ignore */`, `istanbul ignore`, or `.skip` (the only `v8 ignore` in the director tree is pre-existing in `directorTypes.ts`).
- **`App.tsx` change is minimal + additive** — the existing `director` route swaps its render target to the new view; `video` + `onChooseVideo` are threaded unchanged, lazy-loaded. `DirectorPanel` is untouched (all its hardening kept).

## Gate results (actual)

- `npm run typecheck` (tsc --noEmit): **clean**
- `npm run test:coverage` (vitest gate:3): **193 files / 3348 tests passed**, coverage **100% lines / 100% branches / 100% functions / 100% statements** (All files). New files: `features/director` 100/100/100/100, `views/Director.tsx` 100/100/100/100, `lib/directorHandoff.ts` 100.
- `tokens.conformance.test.ts`: **25 tests passed**
- oxlint `--deny-warnings`, biome (format), gitleaks (pre-commit): **Passed**

## Test plan

- `lib/directorHandoff.test.ts` (17) — op-kind→phase routing (incl. unrouted terminal/analysis kinds), the ordered routing contract, live landing zones (singular/plural word counts, transcript + crop-plan gating), verbatim trust constants (text-egress cross-checked against `directorTypes.egressWarning`).
- `features/director/DirectorHandoff.test.tsx` (5) — routes render in order, verbatim trust lede + egress beat, ready vs pending zones reflect the seeded editor state.
- `views/Director.test.tsx` (9) — serif shell, no-video empty state (no hand-off), cue load → ready Caption zone, empty-payload/failure/non-Error/bridge-absent branches, back + panel CTA both route to the Library.
- `App.test.tsx` — existing Director routing tests pass against the swapped render target.

https://claude.ai/code/session_01M7yMAVChqv4LXKjEPaV8Dq
