### PR TITLE
fix: v1.5 shell polish — red-text AA + card-tail demotion + microcopy

### DIFF
--- a/app/renderer/src/components/ReadinessBadge.test.tsx
+++ b/app/renderer/src/components/ReadinessBadge.test.tsx
@@ -76,7 +76,7 @@ describe('<ReadinessBadge /> — action button', () => {
       <ReadinessBadge status="needsDownload" capabilityLabel="Captions" action={action} />,
     );
     const button = container.querySelector('button') as HTMLButtonElement;
-    expect(button.getAttribute('aria-label')).toBe('Download Captions model');
+    expect(button.getAttribute('aria-label')).toBe('Download the Captions model');
     expect(button.tagName).toBe('BUTTON');
   });
 
@@ -93,7 +93,7 @@ describe('<ReadinessBadge /> — action button', () => {
       <ReadinessBadge status="needsConsent" capabilityLabel="Captions" action={action} />,
     );
     const button = container.querySelector('button') as HTMLButtonElement;
-    expect(button.getAttribute('aria-label')).toBe('Grant consent for openai');
+    expect(button.getAttribute('aria-label')).toBe('Grant consent for OpenAI');
   });
 
   it('renders NO button when there is no action (ready / blocked-no-fix)', async () => {

--- a/app/renderer/src/components/ReadinessRollup.test.tsx
+++ b/app/renderer/src/components/ReadinessRollup.test.tsx
@@ -112,7 +112,7 @@ describe('<ReadinessRollup /> — WU-14 wiring', () => {
 
     const buttons = container.querySelectorAll('button.readiness-badge__action');
     expect(buttons.length).toBe(1);
-    expect(buttons[0].getAttribute('aria-label')).toBe('Download Vision model');
+    expect(buttons[0].getAttribute('aria-label')).toBe('Download the Vision model');
   });
 
   it('shows the reused in-flight skeleton before the data resolves', async () => {

--- a/app/renderer/src/components/library-cards.css
+++ b/app/renderer/src/components/library-cards.css
@@ -177,7 +177,7 @@ li.library__item:focus-within .library__select,
    Transcript chip keeps the neutral base .library__chip look (from shell.css). */
 .library__badge.library__chip--failed {
   background: var(--status-error-soft);
-  color: var(--status-error);
+  color: var(--status-error-text);
 }
 
 .library__badge.library__chip--failed::before {
@@ -214,4 +214,54 @@ li.library__item:focus-within .library__select,
 .library__shorts-label:hover {
   background: var(--surface-hover);
   color: var(--text-primary);
+}
+
+/* ---- card provenance disclosure (demotes the source/storage plumbing) ----
+   A quiet per-card toggle that keeps the resting card content-first (poster +
+   title + shorts + compact status); the source path / on-disk / keep-a-copy tail
+   is revealed on demand, mirroring the capabilities chip. */
+.card-provenance {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.card-provenance__toggle {
+  appearance: none;
+  display: inline-flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  width: 100%;
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-faint);
+  font-family: var(--font-ui);
+  font-size: var(--type-caption-size);
+  font-weight: var(--weight-medium);
+  cursor: pointer;
+  transition:
+    color var(--dur-fast) var(--ease-out),
+    background var(--dur-fast) var(--ease-out);
+}
+
+.card-provenance__toggle:hover {
+  background: var(--surface-hover);
+  color: var(--text-secondary);
+}
+
+.card-provenance__toggle:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.card-provenance__caret {
+  color: var(--text-faint);
+  font-size: var(--type-chip-size);
+}
+
+.card-provenance__panel {
+  padding-top: var(--space-1);
 }

--- a/app/renderer/src/components/library-cards.css
+++ b/app/renderer/src/components/library-cards.css
@@ -233,6 +233,7 @@ li.library__item:focus-within .library__select,
   justify-content: space-between;
   gap: var(--space-2);
   width: 100%;
+  min-height: var(--size-target-min); /* WCAG 2.5.8 target size */
   padding: var(--space-1) var(--space-2);
   border: none;
   border-radius: var(--radius-sm);

--- a/app/renderer/src/components/library-shell.css
+++ b/app/renderer/src/components/library-shell.css
@@ -53,7 +53,7 @@
 
 .capabilities-chip__error {
   margin: 0;
-  color: var(--status-error);
+  color: var(--status-error-text);
   font-size: var(--type-caption-size);
 }
 
@@ -178,7 +178,7 @@
 }
 
 .library-toolbar__batch-remove:hover {
-  color: var(--status-error);
+  color: var(--status-error-text);
   border-color: var(--status-error);
 }
 

--- a/app/renderer/src/components/readinessBadge.css
+++ b/app/renderer/src/components/readinessBadge.css
@@ -31,7 +31,7 @@
 }
 
 .readiness-badge.is-unavailable {
-  color: var(--status-error);
+  color: var(--status-error-text);
   background: var(--status-error-soft);
 }
 

--- a/app/renderer/src/components/readinessMeta.test.ts
+++ b/app/renderer/src/components/readinessMeta.test.ts
@@ -8,6 +8,7 @@ import {
   READINESS_CLASS,
   READINESS_HINT,
   READINESS_LABEL,
+  providerDisplayName,
   readinessActionLabel,
   readinessClass,
   readinessHint,
@@ -75,24 +76,45 @@ describe('label maps are complete', () => {
 });
 
 describe('readinessActionLabel', () => {
-  it('names the verb + capability for assets.ensure', () => {
+  it('names the verb + capability for assets.ensure (article-led, reads mid-sentence)', () => {
     const action: ReadinessAction = { kind: 'assets.ensure', assets: ['siglip2-so400m'] };
-    expect(readinessActionLabel(action, 'Multimodal')).toBe('Download Multimodal model');
+    expect(readinessActionLabel(action, 'Multimodal')).toBe('Download the Multimodal model');
   });
   it('names the add-key action', () => {
     const action: ReadinessAction = { kind: 'openProviders', provider: 'gpt' };
     expect(readinessActionLabel(action, 'AI: select')).toBe('Add a provider key');
   });
-  it('names the provider for setConsent', () => {
+  it('display-names the provider for setConsent (never a raw lowercase slug)', () => {
     const action: ReadinessAction = { kind: 'setConsent', provider: 'gpt' };
-    expect(readinessActionLabel(action, 'AI: vision')).toBe('Grant consent for gpt');
+    expect(readinessActionLabel(action, 'AI: vision')).toBe('Grant consent for OpenAI');
   });
   it('falls back to a generic provider name when setConsent omits the provider', () => {
     const action = { kind: 'setConsent' } as ReadinessAction;
-    expect(readinessActionLabel(action, 'AI: vision')).toBe('Grant consent for provider');
+    expect(readinessActionLabel(action, 'AI: vision')).toBe('Grant consent for the provider');
   });
   it('falls back to the capability label for an unknown action kind (defensive)', () => {
     const action = { kind: 'mystery' } as unknown as ReadinessAction;
     expect(readinessActionLabel(action, 'Some capability')).toBe('Some capability');
+  });
+});
+
+describe('providerDisplayName', () => {
+  it('maps known provider slugs to their proper brand name (never lowercase)', () => {
+    expect(providerDisplayName('openai')).toBe('OpenAI');
+    expect(providerDisplayName('gpt')).toBe('OpenAI');
+    expect(providerDisplayName('claude')).toBe('Anthropic');
+    expect(providerDisplayName('groq')).toBe('Groq');
+    expect(providerDisplayName('local')).toBe('On-device');
+  });
+  it('is case-insensitive on the slug lookup', () => {
+    expect(providerDisplayName('OpenAI')).toBe('OpenAI');
+    expect(providerDisplayName('GROQ')).toBe('Groq');
+  });
+  it('title-cases an unknown slug so it never leaks bare lowercase', () => {
+    expect(providerDisplayName('my-proxy')).toBe('My Proxy');
+    expect(providerDisplayName('some_vendor')).toBe('Some Vendor');
+  });
+  it('drops empty segments from a delimiter-padded slug (defensive)', () => {
+    expect(providerDisplayName('-edge-')).toBe('Edge');
   });
 });

--- a/app/renderer/src/components/readinessMeta.ts
+++ b/app/renderer/src/components/readinessMeta.ts
@@ -49,16 +49,57 @@ export function readinessHint(status: ReadinessStatus): string {
 }
 
 /**
+ * Human display name for a raw provider id/slug (§8 Voice). A lowercase config
+ * slug ("openai", "gpt", "local") must NEVER leak into a user-visible string.
+ * Known providers map to their proper brand name; anything else is title-cased
+ * so an unusual slug still reads as words, never bare lowercase. In this app's
+ * routing a `gpt`/`openai` slug denotes OpenAI and `claude` denotes Anthropic,
+ * so each aliases to the brand a user recognises.
+ */
+export const PROVIDER_DISPLAY_NAMES: Readonly<Record<string, string>> = {
+  openai: 'OpenAI',
+  gpt: 'OpenAI',
+  anthropic: 'Anthropic',
+  claude: 'Anthropic',
+  google: 'Google',
+  gemini: 'Google',
+  'google-ai-studio': 'Google AI Studio',
+  groq: 'Groq',
+  cerebras: 'Cerebras',
+  sambanova: 'SambaNova',
+  mistral: 'Mistral',
+  openrouter: 'OpenRouter',
+  'github-models': 'GitHub Models',
+  local: 'On-device',
+};
+
+/** Map a raw provider id to a display name (known brand, else title-cased). */
+export function providerDisplayName(id: string): string {
+  const known = PROVIDER_DISPLAY_NAMES[id.toLowerCase()];
+  if (known) return known;
+  return id
+    .split(/[-_\s]+/)
+    .filter((word) => word.length > 0)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+/**
  * The capability-tied accessible name for a readiness fix action. Never
  * icon-only: the returned string names BOTH the verb and the capability/provider
  * so screen readers announce a self-describing control (WU-9 a11y requirement).
+ * The provider is display-named (never a raw slug) and the capability is
+ * article-led ("the <capability> model") so it reads naturally mid-sentence.
  * An unknown action kind falls back to the capability label (defensive).
  */
 export function readinessActionLabel(action: ReadinessAction, capabilityLabel: string): string {
   const builders: Record<ReadinessAction['kind'], () => string> = {
-    'assets.ensure': () => `Download ${capabilityLabel} model`,
+    'assets.ensure': () => `Download the ${capabilityLabel} model`,
     openProviders: () => 'Add a provider key',
-    setConsent: () => `Grant consent for ${action.provider ?? 'provider'}`,
+    setConsent: () =>
+      action.provider
+        ? `Grant consent for ${providerDisplayName(action.provider)}`
+        : 'Grant consent for the provider',
   };
   return (builders[action.kind] ?? (() => capabilityLabel))();
 }

--- a/app/renderer/src/features/keep-copy-control.css
+++ b/app/renderer/src/features/keep-copy-control.css
@@ -98,15 +98,18 @@
   cursor: default;
 }
 
-/* Keep = the primary opt-in: accent-outlined to signal the recommended action. */
+/* Keep = a secondary OPT-IN, not an approve/primary/progress action, so it stays
+   OFF the amber accent (one-accent discipline). Hierarchy comes from tone + a
+   stronger neutral edge, never hue. */
 .keep-copy__btn--keep {
-  color: var(--accent);
-  border-color: var(--accent-edge);
+  color: var(--text-primary);
+  border-color: var(--edge-strong);
 }
 
-/* Destructive confirm step leans on the error hue. */
+/* Destructive confirm step leans on the error hue (AA-safe text on the solid
+   red border). */
 .keep-copy__btn--danger {
-  color: var(--status-error);
+  color: var(--status-error-text);
   border-color: var(--status-error);
 }
 
@@ -121,7 +124,7 @@
 }
 
 .keep-copy__status--error {
-  color: var(--status-error);
+  color: var(--status-error-text);
 }
 
 .keep-copy__status--info {

--- a/app/renderer/src/features/library-provenance.css
+++ b/app/renderer/src/features/library-provenance.css
@@ -47,7 +47,7 @@
 }
 
 .library-provenance__badge--missing {
-  color: var(--status-error);
+  color: var(--status-error-text);
   background: var(--status-error-soft);
 }
 
@@ -108,7 +108,7 @@
 }
 
 .library-provenance__status--error {
-  color: var(--status-error);
+  color: var(--status-error-text);
 }
 
 .library-provenance__status--info {

--- a/app/renderer/src/styles/tokens.conformance.test.ts
+++ b/app/renderer/src/styles/tokens.conformance.test.ts
@@ -568,3 +568,68 @@ describe('v1.5 shell token evolution — locks the reconciled §5.A guardrails (
     expect(tokens.get('--ease-out') ?? '').toContain('cubic-bezier(');
   });
 });
+
+// --- v1.5 shell-polish: red status TEXT must clear AA (the DoD contrast floor) ---
+//
+// The visual audit found #e5484d (--status-error, the SOLID signal red) used as
+// TEXT — the FAILED chip, "Missing", "Unavailable" — sitting at ~4.1:1 on
+// --surface-raised, UNDER the 4.5:1 AA floor the DoD pins (green ~7.3:1 / amber
+// ~9.3:1 already clear it). The fix SPLITS the token: --status-error stays the
+// solid FILL/BORDER red (unchanged — zero fill regression), and a NEW
+// --status-error-text carries a lighter, AA-safe red for every red STRING. These
+// tests PIN that invariant (never weaken it): the text red clears AA on every
+// elevation plane, sits LIGHTER than the fill red, and the Library sheets route
+// their red text through the AA-safe token (no bare `color: var(--status-error)`).
+
+/** A bare `color: var(--status-error)` text leak — NOT border-color, NOT -soft/-text. */
+const RED_TEXT_LEAK = /[^-]color:\s*var\(--status-error\)/g;
+
+/** The Library sheets whose red TEXT was migrated to the AA-safe token. */
+const LIBRARY_RED_TEXT_SHEETS = [
+  resolve(HERE, '..', 'components', 'library-cards.css'),
+  resolve(HERE, '..', 'components', 'library-shell.css'),
+  resolve(HERE, '..', 'components', 'readinessBadge.css'),
+  resolve(HERE, '..', 'features', 'library-provenance.css'),
+  resolve(HERE, '..', 'features', 'keep-copy-control.css'),
+] as const;
+
+describe('red status text clears AA — the DoD contrast floor (v1.5 shell-polish)', () => {
+  it('defines an AA-safe red TEXT token, lighter than the unchanged solid fill red', () => {
+    const tokens = readTokens();
+    // The fill red is untouched (no regression to the FAILED-dot / progress fills);
+    // the text red is a distinct, lighter tone.
+    expect(tokens.get('--status-error')).toBe('#e5484d');
+    const fill = toRgb(tokens, '--status-error');
+    const text = toRgb(tokens, '--status-error-text');
+    expect(relLum(text)).toBeGreaterThan(relLum(fill));
+  });
+
+  it('holds red TEXT at AA (>=4.5:1) on every elevation plane', () => {
+    const tokens = readTokens();
+    const text = toRgb(tokens, '--status-error-text');
+    for (const plane of ELEVATION_PLANES) {
+      expect(contrast(text, toRgb(tokens, plane))).toBeGreaterThanOrEqual(4.5);
+    }
+  });
+
+  it('holds the green + amber status TEXT at AA on raised (the whole ladder passes)', () => {
+    const tokens = readTokens();
+    const raised = toRgb(tokens, '--surface-raised');
+    // Green (success) + amber (warn) are light enough to double as text already;
+    // pin them so the status-text ladder cannot silently drop below AA either.
+    expect(contrast(toRgb(tokens, '--status-success'), raised)).toBeGreaterThanOrEqual(4.5);
+    expect(contrast(toRgb(tokens, '--status-warn'), raised)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it('routes Library red TEXT through the AA-safe token (no bare status-error text)', () => {
+    for (const path of LIBRARY_RED_TEXT_SHEETS) {
+      const css = stripComments(readFileSync(path, 'utf8'));
+      expect(css.match(RED_TEXT_LEAK) ?? []).toEqual([]);
+    }
+    // …and the AA-safe token is actually consumed as text in the Library sheets.
+    const consumed = LIBRARY_RED_TEXT_SHEETS.some((p) =>
+      stripComments(readFileSync(p, 'utf8')).includes('var(--status-error-text)'),
+    );
+    expect(consumed).toBe(true);
+  });
+});

--- a/app/renderer/src/styles/tokens.css
+++ b/app/renderer/src/styles/tokens.css
@@ -68,8 +68,16 @@
   /* ---- status (semantic, never decorative) -------------------------------- */
   --status-success: #46c483;
   --status-success-soft: rgba(70, 196, 131, 0.12);
-  --status-error: #e5484d;
+  --status-error: #e5484d; /* the SOLID signal red: fills, borders, status dots */
   --status-error-soft: rgba(229, 72, 77, 0.1);
+  /* Red TEXT step: the solid #e5484d is only ~4.1:1 on --surface-raised (below the
+   * 4.5:1 AA floor the DoD pins), so red STRINGS — the FAILED chip, "Missing",
+   * "Unavailable" — read from this lighter tone instead (>=4.5:1 on every
+   * elevation plane). Mirrors --status-abundance-text: colour is never the sole
+   * signal (every red state also carries its text label). Green/amber are light
+   * enough to double as text already; only red needed the split. Pinned by the
+   * tokens.conformance red-text-AA guard so it can never decay back below AA. */
+  --status-error-text: #ff6b6b;
   --status-warn: #e7c14b; /* yellow-leaning, distinct from the orange-leaning accent */
   --status-warn-soft: rgba(231, 193, 75, 0.1);
 

--- a/app/renderer/src/styles/tokens.css
+++ b/app/renderer/src/styles/tokens.css
@@ -186,6 +186,7 @@
   --size-glyph-lg: 26px; /* thumbnail fallback glyph */
   --size-dot: 8px; /* brand tick + status/egress dots */
   --size-dot-sm: 5px; /* chip lead dot */
+  --size-target-min: 24px; /* WCAG 2.5.8 minimum interactive target (min-height) */
 
   /* Control padding (role shorthands): the compact control paddings sit off the
    * 4px rhythm ON PURPOSE (a dense editing UI — a segmented toggle is tighter

--- a/app/renderer/src/views/CardProvenanceDisclosure.test.tsx
+++ b/app/renderer/src/views/CardProvenanceDisclosure.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import { CardProvenanceDisclosure } from './CardProvenanceDisclosure';
+import type { ProvenanceHandlers } from '../features/LibraryProvenance';
+
+function handlers(): ProvenanceHandlers & { reveal: ReturnType<typeof vi.fn> } {
+  return {
+    reveal: vi.fn(async () => ({
+      id: 'v1',
+      sources: [
+        { id: 'v1', path: '/movies/talk.mp4', title: 'Talk', exists: true, relinkable: true },
+      ],
+      missing: [] as string[],
+    })),
+    pinHash: vi.fn(async () => ({})),
+    relink: vi.fn(async () => {}),
+    openInFolder: vi.fn(async () => true),
+    pickRelinkTarget: vi.fn(async () => null),
+  };
+}
+
+const video = { id: 'v1', path: '/movies/talk.mp4', title: 'Talk' };
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < 6; i += 1) await Promise.resolve();
+  });
+}
+
+async function render(h: ProvenanceHandlers): Promise<void> {
+  await act(async () => {
+    root.render(<CardProvenanceDisclosure video={video} handlers={h} />);
+  });
+  await flush();
+}
+
+function toggle(): HTMLButtonElement {
+  return container.querySelector('.card-provenance__toggle') as HTMLButtonElement;
+}
+
+async function click(el: HTMLElement): Promise<void> {
+  await act(async () => {
+    el.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  });
+  await flush();
+}
+
+describe('CardProvenanceDisclosure', () => {
+  it('renders a collapsed toggle at rest — the provenance tail is demoted', async () => {
+    const h = handlers();
+    await render(h);
+    const btn = toggle();
+    expect(btn).not.toBeNull();
+    expect(btn.getAttribute('aria-expanded')).toBe('false');
+    // The plumbing (path / on-disk / keep-a-copy) is NOT in the resting card…
+    expect(container.querySelector('.library-provenance')).toBeNull();
+    // …and it is not even fetched until the user asks for it (lazy).
+    expect(h.reveal).not.toHaveBeenCalled();
+    // The caret reads "collapsed".
+    expect(container.querySelector('.card-provenance__caret')?.textContent).toBe('▾');
+  });
+
+  it('reveals the provenance panel on toggle and wires aria-controls to it', async () => {
+    const h = handlers();
+    await render(h);
+    await click(toggle());
+
+    expect(toggle().getAttribute('aria-expanded')).toBe('true');
+    const panel = container.querySelector('.card-provenance__panel') as HTMLElement;
+    expect(panel).not.toBeNull();
+    expect(panel.querySelector('.library-provenance')).not.toBeNull();
+    expect(toggle().getAttribute('aria-controls')).toBe(panel.id);
+    expect(panel.id.length).toBeGreaterThan(0);
+    // Opening the disclosure is what triggers the source lookup.
+    expect((h as ReturnType<typeof handlers>).reveal).toHaveBeenCalledWith('v1');
+    expect(container.querySelector('.card-provenance__caret')?.textContent).toBe('▴');
+  });
+
+  it('collapses again on a second toggle', async () => {
+    const h = handlers();
+    await render(h);
+    await click(toggle());
+    expect(container.querySelector('.library-provenance')).not.toBeNull();
+    await click(toggle());
+    expect(toggle().getAttribute('aria-expanded')).toBe('false');
+    expect(container.querySelector('.library-provenance')).toBeNull();
+  });
+});

--- a/app/renderer/src/views/CardProvenanceDisclosure.test.tsx
+++ b/app/renderer/src/views/CardProvenanceDisclosure.test.tsx
@@ -102,4 +102,35 @@ describe('CardProvenanceDisclosure', () => {
     expect(toggle().getAttribute('aria-expanded')).toBe('false');
     expect(container.querySelector('.library-provenance')).toBeNull();
   });
+
+  it('wraps the disclosure in a plain <div> — no duplicate "region" landmark per card', async () => {
+    await render(handlers());
+    const wrapper = container.querySelector('.card-provenance') as HTMLElement;
+    expect(wrapper).not.toBeNull();
+    // A per-card <section aria-label> minted N identical "Source & storage" region
+    // landmarks across the Library; the toggle button already names the disclosure,
+    // so the wrapper is a plain <div> carrying no landmark role or label.
+    expect(wrapper.tagName).toBe('DIV');
+    expect(wrapper.getAttribute('aria-label')).toBeNull();
+    expect(container.querySelector('section')).toBeNull();
+    expect(container.querySelector('[role="region"]')).toBeNull();
+  });
+
+  it('keeps aria-controls a valid IDREF at rest — panel is present but hidden + empty', async () => {
+    await render(handlers());
+    const btn = toggle();
+    const controls = btn.getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+    // WAI-ARIA disclosure: the controlled panel is ALWAYS in the DOM (so the resting
+    // card's aria-controls never dangles) and merely toggles `hidden`.
+    const panel = document.getElementById(controls as string);
+    expect(panel).not.toBeNull();
+    expect(panel?.classList.contains('card-provenance__panel')).toBe(true);
+    expect(panel?.hasAttribute('hidden')).toBe(true);
+    // …while the heavy provenance body stays lazy — the hidden panel is empty at rest.
+    expect(panel?.querySelector('.library-provenance')).toBeNull();
+    // Opening un-hides the very same panel node (no dangling / swapped IDREF).
+    await click(btn);
+    expect(document.getElementById(controls as string)?.hasAttribute('hidden')).toBe(false);
+  });
 });

--- a/app/renderer/src/views/CardProvenanceDisclosure.tsx
+++ b/app/renderer/src/views/CardProvenanceDisclosure.tsx
@@ -1,0 +1,59 @@
+// CardProvenanceDisclosure.tsx — v1.5 shell-polish: demote the Library card's
+// source/storage "plumbing" behind a per-card disclosure (fixes the re-introduced
+// "Library foregrounds plumbing" P1). The resting card is poster + title + shorts
+// + compact status; the source path / on-disk state / Show-in-folder / Relink /
+// Keep-a-copy tail only appears when the user opens this disclosure.
+//
+// It mirrors the CapabilitiesChip disclosure pattern (a real toggle <button> with
+// aria-expanded + aria-controls + a caret) and, like it, is LAZY: <LibraryProvenance>
+// mounts only once opened, so a resting library of N cards fires zero reveal/pin
+// probes. The toggle is a SIBLING of the card's open-button (never nested), so no
+// nested-interactive control is introduced.
+import React, { useId, useState } from 'react';
+
+import {
+  LibraryProvenance,
+  type ProvenanceHandlers,
+  type ProvenanceVideo,
+} from '../features/LibraryProvenance';
+import '../components/library-cards.css';
+
+export interface CardProvenanceDisclosureProps {
+  /** The card's asset (id + by-path source + title). */
+  video: ProvenanceVideo;
+  /** The injected L5 provenance handlers passed straight to <LibraryProvenance>. */
+  handlers: ProvenanceHandlers;
+}
+
+export function CardProvenanceDisclosure({
+  video,
+  handlers,
+}: CardProvenanceDisclosureProps): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <section className="card-provenance" aria-label="Source & storage">
+      <button
+        type="button"
+        className="card-provenance__toggle"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span className="card-provenance__label">{'Source & storage'}</span>
+        <span className="card-provenance__caret" aria-hidden="true">
+          {open ? '▴' : '▾'}
+        </span>
+      </button>
+
+      {open ? (
+        <div id={panelId} className="card-provenance__panel">
+          <LibraryProvenance video={video} handlers={handlers} />
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+export default CardProvenanceDisclosure;

--- a/app/renderer/src/views/CardProvenanceDisclosure.tsx
+++ b/app/renderer/src/views/CardProvenanceDisclosure.tsx
@@ -5,10 +5,15 @@
 // Keep-a-copy tail only appears when the user opens this disclosure.
 //
 // It mirrors the CapabilitiesChip disclosure pattern (a real toggle <button> with
-// aria-expanded + aria-controls + a caret) and, like it, is LAZY: <LibraryProvenance>
-// mounts only once opened, so a resting library of N cards fires zero reveal/pin
-// probes. The toggle is a SIBLING of the card's open-button (never nested), so no
-// nested-interactive control is introduced.
+// aria-expanded + aria-controls + a caret) and, like it, is LAZY: the heavy
+// <LibraryProvenance> body mounts only once opened, so a resting library of N cards
+// fires zero reveal/pin probes. Per the WAI-ARIA disclosure pattern the controlled
+// panel element is ALWAYS rendered and merely toggles its `hidden` attribute, so a
+// resting card's aria-controls is never a dangling IDREF (the panel is present but
+// empty + hidden until opened). The wrapper is a plain <div>, NOT a <section> — a
+// per-card landmark would mint N identical "region"s across the Library; the toggle
+// button already names the disclosure. The toggle is a SIBLING of the card's
+// open-button (never nested), so no nested-interactive control is introduced.
 import React, { useId, useState } from 'react';
 
 import {
@@ -33,7 +38,7 @@ export function CardProvenanceDisclosure({
   const panelId = useId();
 
   return (
-    <section className="card-provenance" aria-label="Source & storage">
+    <div className="card-provenance">
       <button
         type="button"
         className="card-provenance__toggle"
@@ -47,12 +52,12 @@ export function CardProvenanceDisclosure({
         </span>
       </button>
 
-      {open ? (
-        <div id={panelId} className="card-provenance__panel">
-          <LibraryProvenance video={video} handlers={handlers} />
-        </div>
-      ) : null}
-    </section>
+      {/* Panel is ALWAYS rendered so aria-controls resolves at rest; `hidden`
+          collapses it and the heavy provenance body stays lazy until opened. */}
+      <div id={panelId} className="card-provenance__panel" hidden={!open}>
+        {open ? <LibraryProvenance video={video} handlers={handlers} /> : null}
+      </div>
+    </div>
   );
 }
 

--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -909,7 +909,7 @@ describe('Library source provenance (WU-1f)', () => {
     };
   }
 
-  it('renders a provenance row per card and drops the legacy compact path line', async () => {
+  it('demotes each card provenance behind a disclosure and drops the legacy path line', async () => {
     rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
     const handlers = provenanceHandlers();
     await act(async () => {
@@ -917,14 +917,25 @@ describe('Library source provenance (WU-1f)', () => {
     });
     await flush();
 
-    // The provenance row renders (with the clear full path) and calls reveal.
-    expect(container.querySelector('.library-provenance')).not.toBeNull();
+    // Resting card: the disclosure toggle is present, but the provenance plumbing
+    // is hidden (and not even fetched) — the card stays content-first.
+    expect(container.querySelector('.card-provenance__toggle')).not.toBeNull();
+    expect(container.querySelector('.library-provenance')).toBeNull();
+    expect(handlers.reveal).not.toHaveBeenCalled();
+    // The legacy tiny grey path line is gone regardless (provenance owns the path).
+    expect(container.querySelector('.library__item-path')).toBeNull();
+
+    // Opening the disclosure reveals the full source path and calls reveal.
+    await act(async () => {
+      (container.querySelector('.card-provenance__toggle') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    await flush();
     expect(container.querySelector('.library-provenance__path')?.textContent).toBe(
       '/movies/talk.mp4',
     );
     expect(handlers.reveal).toHaveBeenCalledWith('v1');
-    // The legacy tiny grey path line is replaced by the provenance row.
-    expect(container.querySelector('.library__item-path')).toBeNull();
   });
 });
 

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -184,16 +184,35 @@ describe('LibraryCard', () => {
     expect(onOpenShorts.mock.calls[0][0].id).toBe('v1');
   });
 
+  it('pluralizes the shorts label + aria for a single short (never "1 shorts")', async () => {
+    await renderCard({ shortsCount: 1 });
+    const label = container.querySelector('.library__shorts-label') as HTMLButtonElement;
+    expect(label.textContent).toBe('1 short');
+    expect(label.getAttribute('aria-label')).toBe('View 1 produced short for Talk');
+  });
+
   it('hides the shorts label when the video has none', async () => {
     await renderCard({ shortsCount: 0 });
     expect(container.querySelector('.library__shorts-label')).toBeNull();
   });
 
-  it('renders the provenance row and drops the legacy path line when provenance is wired', async () => {
+  it('demotes provenance behind a per-card disclosure and drops the legacy path line', async () => {
     const handlers = provenanceHandlers();
     await renderCard({ provenance: handlers });
-    expect(container.querySelector('.library-provenance')).not.toBeNull();
+    // Resting card: the disclosure toggle is present but the plumbing is hidden
+    // (and not even fetched) so the card stays poster + title + shorts + status.
+    expect(container.querySelector('.card-provenance__toggle')).not.toBeNull();
+    expect(container.querySelector('.library-provenance')).toBeNull();
     expect(container.querySelector('.library__item-path')).toBeNull();
+    expect(handlers.reveal).not.toHaveBeenCalled();
+    // Opening the disclosure reveals the provenance row and triggers the lookup.
+    await act(async () => {
+      (container.querySelector('.card-provenance__toggle') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    await flush();
+    expect(container.querySelector('.library-provenance')).not.toBeNull();
     expect(handlers.reveal).toHaveBeenCalledWith('v1');
   });
 

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -12,13 +12,16 @@ import React, { useState } from 'react';
 import { rpc } from '../components/api';
 import type { Video } from '../components/api';
 import { useVideoThumbnail, type VideoThumbnailRpc } from '../components/useVideoThumbnail';
-import { LibraryProvenance, type ProvenanceHandlers } from '../features/LibraryProvenance';
+import type { ProvenanceHandlers } from '../features/LibraryProvenance';
+import { CardProvenanceDisclosure } from './CardProvenanceDisclosure';
 import {
   type LibraryVideo,
   cardAriaLabel,
   cardBadges,
   formatAdded,
   formatDuration,
+  shortsCountLabel,
+  shortsOpenAriaLabel,
 } from './libraryModel';
 import '../components/library-cards.css';
 
@@ -136,7 +139,7 @@ export function LibraryCard({
       </button>
 
       {provenance ? (
-        <LibraryProvenance
+        <CardProvenanceDisclosure
           video={{ id: video.id, path: video.path, title: video.title }}
           handlers={provenance}
         />
@@ -147,10 +150,10 @@ export function LibraryCard({
           <button
             type="button"
             className="library__shorts-label"
-            aria-label={`View ${shortsCount} produced shorts for ${video.title}`}
+            aria-label={shortsOpenAriaLabel(shortsCount, video.title)}
             onClick={() => onOpenShorts(video)}
           >
-            {shortsCount} shorts
+            {shortsCountLabel(shortsCount)}
           </button>
         ) : null}
         <button

--- a/app/renderer/src/views/libraryModel.test.ts
+++ b/app/renderer/src/views/libraryModel.test.ts
@@ -14,6 +14,8 @@ import {
   cardBadges,
   cardAriaLabel,
   formatAdded,
+  shortsCountLabel,
+  shortsOpenAriaLabel,
 } from './libraryModel';
 
 function makeVideo(over: Partial<LibraryVideo> = {}): LibraryVideo {
@@ -183,6 +185,25 @@ describe('cardAriaLabel', () => {
   });
   it('omits an unknown duration from the name', () => {
     expect(cardAriaLabel(makeVideo({ durationSec: 0 }), false)).toBe('Open Talk, no transcript');
+  });
+});
+
+describe('shortsCountLabel', () => {
+  it('uses the singular noun for exactly one short', () => {
+    expect(shortsCountLabel(1)).toBe('1 short');
+  });
+  it('uses the plural noun for zero or many shorts', () => {
+    expect(shortsCountLabel(0)).toBe('0 shorts');
+    expect(shortsCountLabel(3)).toBe('3 shorts');
+  });
+});
+
+describe('shortsOpenAriaLabel', () => {
+  it('pluralizes the produced-shorts open name (singular)', () => {
+    expect(shortsOpenAriaLabel(1, 'Talk')).toBe('View 1 produced short for Talk');
+  });
+  it('pluralizes the produced-shorts open name (plural)', () => {
+    expect(shortsOpenAriaLabel(3, 'Talk')).toBe('View 3 produced shorts for Talk');
   });
 });
 

--- a/app/renderer/src/views/libraryModel.ts
+++ b/app/renderer/src/views/libraryModel.ts
@@ -130,3 +130,20 @@ export function formatAdded(iso: string): string {
   const m = /^(\d{4}-\d{2}-\d{2})/.exec(iso);
   return m ? m[1] : '';
 }
+
+/**
+ * The produced-shorts count label on a card ("1 short" / "N shorts") — correctly
+ * pluralized so a single short never reads the ungrammatical "1 shorts".
+ */
+export function shortsCountLabel(count: number): string {
+  return `${count} ${count === 1 ? 'short' : 'shorts'}`;
+}
+
+/**
+ * The card's produced-shorts open aria-label, pluralized to match the visible
+ * count ("View 1 produced short for <title>" / "View N produced shorts for …").
+ */
+export function shortsOpenAriaLabel(count: number, title: string): string {
+  const noun = count === 1 ? 'short' : 'shorts';
+  return `View ${count} produced ${noun} for ${title}`;
+}


### PR DESCRIPTION
## v1.5 shell polish — visual-audit fixes to the shipped shell

Library + tokens + label sources only (no Director/Export files touched). Composes the shipped components; keeps all hardening; App.tsx untouched (no new rail destination for a polish pass).

### 1. Red-text AA (a DoD contrast violation)
`--status-error` (`#e5484d`) used as **text** — the FAILED chip, "Missing", "Unavailable", relink-danger — sat at **~4.1:1** on `--surface-raised`, under the 4.5:1 AA floor the DoD pins (green ~7.3:1 / amber ~9.3:1 already clear it).

- Split the token: `--status-error` stays the **solid fill/border** red (unchanged → zero fill regression); new **`--status-error-text` `#ff6b6b`** carries every red string. It clears AA on **all four elevation planes** (worst = overlay **4.97:1**; raised **5.8:1**). Mirrors the existing `--status-abundance-text` fill-vs-text split.
- Repointed the Library red-text sheets (`library-cards`, `library-shell`, `readinessBadge`, `library-provenance`, `keep-copy-control`) from `color: var(--status-error)` → `var(--status-error-text)`; fills/borders/soft washes unchanged.
- `tokens.conformance.test.ts` now **pins** the red-text AA invariant (and pins green/amber as text on raised), plus a guard that forbids bare `color: var(--status-error)` in the Library sheets so it can't regress.

> Scope note: the AA-safe `--status-error-text` token is now the canonical red-text token. Non-Library sheets (shell/jobqueue/providers/Director/Export/settings) still reference `--status-error` for their red text and should migrate to `--status-error-text` in their own polish passes — out of scope for this Library-only PR (Director/Export explicitly off-limits).

### 2. Card-tail demotion (re-introduced "Library foregrounds plumbing" P1)
The card's lower half (source path / On-disk / Show-in-folder / Missing / "Linked (original only)" / keep-copy caution / "Keep a copy") is now behind a **per-card disclosure** (new `CardProvenanceDisclosure`, mirroring the `CapabilitiesChip` pattern — real toggle `button` with `aria-expanded` + `aria-controls` + caret). Resting card = **poster + title + shorts + compact status**. Bonus: the disclosure is **lazy** — `LibraryProvenance` mounts only when opened, so a resting library fires zero reveal/pin probes. Toggle stays a sibling of the open-button (no nested-interactive).

### 3. Microcopy (fixed at the source)
- **"1 shorts" → "1 short"** (`shortsCountLabel` / `shortsOpenAriaLabel`, visible label + aria).
- **"openai" leak** → `providerDisplayName` maps known providers to their brand ("OpenAI", "Anthropic", "On-device") and title-cases the rest; "Grant consent for openai" → "Grant consent for OpenAI".
- **"Download &lt;label&gt; model"** → **"Download the &lt;label&gt; model"** (reads naturally mid-sentence).

### 4. "Keep a copy" amber → neutral
A secondary opt-in is not approve/primary/progress, so the button drops the amber accent for a neutral tone + stronger edge (one-accent discipline).

---

### Gate results (actual)
- **vitest `--coverage` (gate:3):** 100% — statements 18309/18309, branches 6145/6145, functions 1096/1096, lines 18309/18309 (exit 0).
- **tokens.conformance.test.ts:** 29/29 (4 new red-text AA assertions).
- **tsc `--noEmit`:** clean.
- **oxlint `--deny-warnings` + biome (format) + gitleaks:** pass (`pre-commit run`).
- No new `/* v8 ignore */` / istanbul-ignore / `.skip`; immutable; files < 800 lines.

### DoD
Met: contrast (red text now >=4.5:1, conformance green) · keyboard (disclosure toggle is a native button w/ focus-ring + aria) · one-accent (amber removed from keep-copy) · voice (no lowercase provider slug / jargon in labels). Deferred (out of Library scope): migrating non-Library red text to `--status-error-text`.
