### PR TITLE
feat: v1.5 Export (guarded commit) + Deliver split

### DIFF
--- a/app/renderer/src/App.export.test.tsx
+++ b/app/renderer/src/App.export.test.tsx
@@ -1,0 +1,232 @@
+// App.export.test.tsx — the v1.5 §4 Export + Deliver rail routing.
+//
+// Verifies the new top-level "Export" (Phase-5 guarded commit for the open video)
+// and "Deliver" (batch / cross-video publish) tabs, that finishing an Export links
+// INTO Deliver (the Export/Deliver split), the open video is threaded into both,
+// and their back controls return to the Library. The views themselves are stubbed
+// (they own their tests) so this exercises ONLY App's routing wiring.
+
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { Video } from './lib/rpc';
+
+const rpcMock = vi.fn();
+const libraryListMock = vi.fn();
+const batchListMock = vi.fn();
+const setRoutingPolicyMock = vi.fn();
+let hasApiReturn = true;
+
+vi.mock('./lib/rpc', () => ({
+  rpc: (...a: unknown[]) => rpcMock(...a),
+  hasApi: () => hasApiReturn,
+  client: {
+    library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    batch: { list: (...a: unknown[]) => batchListMock(...a) },
+    models: { setRoutingPolicy: (...a: unknown[]) => setRoutingPolicyMock(...a) },
+  },
+}));
+
+vi.mock('./views/Library', () => ({
+  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => (
+    <div data-testid="library">
+      <button type="button" onClick={() => onOpen(makeVideo())}>
+        open-video
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./views/Edit', () => ({ Edit: () => <div data-testid="edit" /> }));
+vi.mock('./views/Caption', () => ({ Caption: () => <div data-testid="caption" /> }));
+vi.mock('./views/MakeShorts', () => ({ MakeShorts: () => <div data-testid="makeshorts" /> }));
+vi.mock('./views/Settings', () => ({ Settings: () => <div data-testid="settings" /> }));
+vi.mock('./panels/DirectorPanel', () => ({ default: () => <div data-testid="director" /> }));
+vi.mock('./components/JobQueue', () => ({
+  JobQueue: () => <div />,
+  JOBQUEUE_PANEL_ID: 'jobqueue-panel',
+}));
+vi.mock('./components/SidecarBanner', () => ({ SidecarBanner: () => <div /> }));
+
+// The Export stub echoes the threaded video id and exposes its back + "continue to
+// Deliver" controls so App's route wiring (incl. the Export→Deliver link) is testable.
+vi.mock('./views/Export', () => ({
+  Export: ({
+    video,
+    onBack,
+    onDeliver,
+  }: {
+    video: Video | null;
+    onBack: () => void;
+    onDeliver: () => void;
+  }) => (
+    <div data-testid="export" data-video-id={video?.id ?? ''}>
+      <button type="button" onClick={onBack}>
+        export-back
+      </button>
+      <button type="button" onClick={onDeliver}>
+        export-deliver
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./views/Deliver', () => ({
+  Deliver: ({ video, onBack }: { video: Video | null; onBack: () => void }) => (
+    <div data-testid="deliver" data-video-id={video?.id ?? ''}>
+      <button type="button" onClick={onBack}>
+        deliver-back
+      </button>
+    </div>
+  ),
+}));
+
+import { App } from './App';
+
+function makeVideo(over: Partial<Video> = {}): Video {
+  return {
+    id: 'v1',
+    path: '/movies/talk.mp4',
+    title: 'Talk',
+    addedAt: '2026-06-11T00:00:00Z',
+    durationSec: 600,
+    hasTranscript: false,
+    ...over,
+  };
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({});
+  libraryListMock.mockReset();
+  batchListMock.mockReset();
+  batchListMock.mockResolvedValue({ batches: [] });
+  setRoutingPolicyMock.mockReset();
+  setRoutingPolicyMock.mockResolvedValue({ routingPolicy: { global: 'local', overrides: {} } });
+  hasApiReturn = true;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+async function mount(): Promise<void> {
+  await act(async () => {
+    root.render(<App />);
+  });
+  await flush();
+}
+
+function tab(label: string): HTMLButtonElement {
+  const btns = Array.from(container.querySelectorAll<HTMLButtonElement>('.toptab'));
+  const found = btns.find((b) => b.querySelector('.toptab__label')?.textContent === label);
+  if (!found) throw new Error(`tab "${label}" not found`);
+  return found;
+}
+
+async function clickTab(label: string): Promise<void> {
+  await act(async () => {
+    tab(label).click();
+  });
+  await flush();
+}
+
+async function openVideo(): Promise<void> {
+  await act(async () => {
+    container.querySelector<HTMLButtonElement>('[data-testid="library"] button')!.click();
+  });
+  await flush();
+}
+
+describe('App Export rail destination', () => {
+  it('mounts the Export phase with an empty video when opened directly', async () => {
+    await mount();
+    expect(container.querySelector('[data-testid="export"]')).toBeNull();
+    await clickTab('Export');
+    const view = container.querySelector('[data-testid="export"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-video-id')).toBe('');
+    expect(tab('Export').getAttribute('aria-selected')).toBe('true');
+    expect(container.querySelector<HTMLElement>('[role="tabpanel"]')!.id).toBe(
+      'toptabpanel-export',
+    );
+  });
+
+  it('threads the open video into the Export phase', async () => {
+    await mount();
+    await openVideo();
+    await clickTab('Export');
+    expect(container.querySelector('[data-testid="export"]')!.getAttribute('data-video-id')).toBe(
+      'v1',
+    );
+  });
+
+  it('routes back to the Library from the Export phase', async () => {
+    await mount();
+    await clickTab('Export');
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="export"] button')!.click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(tab('Library').getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('links a finished Export INTO the Deliver rail (with the video threaded)', async () => {
+    await mount();
+    await openVideo();
+    await clickTab('Export');
+    // "Continue to Deliver" from the finished export.
+    const deliverBtn = Array.from(
+      container.querySelectorAll<HTMLButtonElement>('[data-testid="export"] button'),
+    ).find((b) => b.textContent === 'export-deliver')!;
+    await act(async () => {
+      deliverBtn.click();
+    });
+    await flush();
+    const deliver = container.querySelector('[data-testid="deliver"]');
+    expect(deliver).not.toBeNull();
+    expect(deliver!.getAttribute('data-video-id')).toBe('v1');
+    expect(tab('Deliver').getAttribute('aria-selected')).toBe('true');
+  });
+});
+
+describe('App Deliver rail destination', () => {
+  it('mounts the Deliver rail directly from its tab', async () => {
+    await mount();
+    await clickTab('Deliver');
+    const view = container.querySelector('[data-testid="deliver"]');
+    expect(view).not.toBeNull();
+    expect(view!.getAttribute('data-video-id')).toBe('');
+    expect(tab('Deliver').getAttribute('aria-selected')).toBe('true');
+    expect(container.querySelector<HTMLElement>('[role="tabpanel"]')!.id).toBe(
+      'toptabpanel-deliver',
+    );
+  });
+
+  it('routes back to the Library from the Deliver rail', async () => {
+    await mount();
+    await clickTab('Deliver');
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="deliver"] button')!.click();
+    });
+    await flush();
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(tab('Library').getAttribute('aria-selected')).toBe('true');
+  });
+});

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -23,6 +23,8 @@ import React, { Suspense, lazy, useCallback, useEffect, useMemo, useState } from
 import { Library } from './views/Library';
 import { Edit } from './views/Edit';
 import { Caption } from './views/Caption';
+import { Export } from './views/Export';
+import { Deliver } from './views/Deliver';
 import { MakeShorts } from './views/MakeShorts';
 import { Settings } from './views/Settings';
 import { incompleteBatches, remainingCount } from './features/repurposeLogic';
@@ -33,7 +35,9 @@ import { TopTabBar, topTabId, topTabPanelId, type TopTab } from './components/To
 import {
   CaptionIcon,
   CreateIcon,
+  DeliverIcon,
   DirectorIcon,
+  ExportIcon,
   LibraryIcon,
   RepurposeIcon,
   SettingsIcon,
@@ -76,7 +80,15 @@ registerJobRetry((jobId) => rpc<{ jobId: string }>('job.retry', { jobId }));
 type Quality = 'local' | 'cloud';
 
 /** The top-level tab ids (the surface switcher). */
-type TabId = 'library' | 'makeshorts' | 'edit' | 'caption' | 'director' | 'settings';
+type TabId =
+  | 'library'
+  | 'makeshorts'
+  | 'edit'
+  | 'caption'
+  | 'export'
+  | 'deliver'
+  | 'director'
+  | 'settings';
 
 type Route =
   // The Library home.
@@ -90,6 +102,10 @@ type Route =
   // Caption: the v1.5 Caption phase pilot (inspector-over-shared-stage) for the
   // open video; empty-states when none is open.
   | { name: 'caption' }
+  // Export: the v1.5 Phase-5 guarded-commit render/finish for the open video.
+  | { name: 'export' }
+  // Deliver: the batch / cross-video publish rail (Export/Deliver split, §4).
+  | { name: 'deliver' }
   // Director: the prompt-driven AI video-editing panel.
   | { name: 'director' }
   // Settings: a sub-navigated area (Models & System / Providers & Keys / Health).
@@ -104,6 +120,10 @@ function routeTab(route: Route): TabId {
       return 'edit';
     case 'caption':
       return 'caption';
+    case 'export':
+      return 'export';
+    case 'deliver':
+      return 'deliver';
     case 'director':
       return 'director';
     case 'settings':
@@ -364,6 +384,12 @@ function AppShell(): React.ReactElement {
     setRoute({ name: 'director' });
   }, []);
 
+  // v1.5 §4: the Deliver rail (batch / cross-video publish) — finishing a Phase-5
+  // Export links INTO here.
+  const openDeliver = useCallback(() => {
+    setRoute({ name: 'deliver' });
+  }, []);
+
   // Open Settings, optionally pre-selecting a sub-section (e.g. a readiness fix
   // jumps straight to Models & System).
   const openSettings = useCallback((section?: string) => {
@@ -394,6 +420,12 @@ function AppShell(): React.ReactElement {
         case 'caption':
           setRoute({ name: 'caption' });
           break;
+        case 'export':
+          setRoute({ name: 'export' });
+          break;
+        case 'deliver':
+          setRoute({ name: 'deliver' });
+          break;
         case 'director':
           setRoute({ name: 'director' });
           break;
@@ -419,6 +451,8 @@ function AppShell(): React.ReactElement {
       { id: 'makeshorts', label: 'Make Shorts', icon: <CreateIcon />, badge: batchBadge },
       { id: 'edit', label: 'Edit', icon: <RepurposeIcon /> },
       { id: 'caption', label: 'Caption', icon: <CaptionIcon /> },
+      { id: 'export', label: 'Export', icon: <ExportIcon /> },
+      { id: 'deliver', label: 'Deliver', icon: <DeliverIcon /> },
       { id: 'director', label: 'Director', icon: <DirectorIcon /> },
       { id: 'settings', label: 'Settings', icon: <SettingsIcon /> },
     ],
@@ -447,6 +481,14 @@ function AppShell(): React.ReactElement {
         // v1.5 Caption pilot: the inspector-over-shared-stage phase for the open
         // video (empty-states + routes back to the Library when none is open).
         return <Caption video={editVideo} onBack={backToLibrary} />;
+      case 'export':
+        // v1.5 Phase-5 Export: the guarded-commit render/finish for the open video;
+        // finishing links INTO the Deliver rail (the Export/Deliver split, §4).
+        return <Export video={editVideo} onBack={backToLibrary} onDeliver={openDeliver} />;
+      case 'deliver':
+        // v1.5 Deliver rail: batch / cross-video publish + platform presets + pro
+        // handoff (the open video drives the EDL/CSV handoff).
+        return <Deliver video={editVideo} onBack={backToLibrary} />;
       case 'director':
         return (
           <Suspense fallback={<div className="panel panel--loading">Loading…</div>}>

--- a/app/renderer/src/components/navIcons.tsx
+++ b/app/renderer/src/components/navIcons.tsx
@@ -87,6 +87,27 @@ export function CaptionIcon(): React.ReactElement {
   );
 }
 
+/** Export — render out to a file (Lucide "upload"-style arrow up over a line). */
+export function ExportIcon(): React.ReactElement {
+  return (
+    <Svg>
+      <path d="m18 9-6-6-6 6" />
+      <path d="M12 3v14" />
+      <path d="M5 21h14" />
+    </Svg>
+  );
+}
+
+/** Deliver — publish / send out (Lucide "send" paper plane). */
+export function DeliverIcon(): React.ReactElement {
+  return (
+    <Svg>
+      <path d="M22 2 11 13" />
+      <path d="M22 2 15 22l-4-9-9-4Z" />
+    </Svg>
+  );
+}
+
 /** Settings — gear (Lucide "settings"). */
 export function SettingsIcon(): React.ReactElement {
   return (

--- a/app/renderer/src/features/export/ExportInspector.test.tsx
+++ b/app/renderer/src/features/export/ExportInspector.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorProvider } from '../EditorContext';
+import type { EditorSeed } from '../../lib/editorState';
+import { EXPORT_CONFIRM_BLURB, EXPORT_PRIVACY_NOTE, ExportInspector } from './ExportInspector';
+import { exportConvertOptions, presetById } from './exportModel';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onCommit = vi.fn();
+
+beforeEach(() => {
+  onCommit.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+function render(seed: EditorSeed): void {
+  act(() => {
+    root.render(
+      <EditorProvider seed={seed}>
+        <ExportInspector onCommit={onCommit} />
+      </EditorProvider>,
+    );
+  });
+}
+
+const SEED: EditorSeed = { video: { videoId: 'v1', window: { start: 0, end: 40 } } };
+
+describe('ExportInspector', () => {
+  it('shows the pre-flight summary + the restated privacy beat, and defaults to a fitting destination', () => {
+    render(SEED);
+    // 40s clip: the first destination (TikTok, 9:16) fits and is the default.
+    expect(q('.export-inspector__preflight-title')?.textContent).toBe('Ready to export to TikTok');
+    const values = Array.from(container.querySelectorAll('.export-inspector__cell-value')).map(
+      (el) => el.textContent,
+    );
+    expect(values).toEqual(['1', '9:16', '0:40', '~0:20', '$0.00']);
+    expect(q('.export-inspector__privacy')?.textContent).toBe(EXPORT_PRIVACY_NOTE);
+    // The primary CTA is present and NOT yet a confirm.
+    expect(q('.export-inspector__primary')?.textContent).toBe('Export to TikTok');
+    expect(q('.export-inspector__confirm')).toBeNull();
+  });
+
+  it('re-summarizes when a different destination is chosen', () => {
+    render(SEED);
+    act(() => q<HTMLButtonElement>('[data-preset="square"]')?.click());
+    expect(q('.export-inspector__preflight-title')?.textContent).toBe(
+      'Ready to export to Square post',
+    );
+    const aspect = container.querySelectorAll('.export-inspector__cell-value')[1]?.textContent;
+    expect(aspect).toBe('1:1');
+    expect(q('.export-inspector__primary')?.textContent).toBe('Export to Square post');
+  });
+
+  it('guards the commit behind an explicit confirm gate', () => {
+    render(SEED);
+    // Step 1: the primary opens the confirm gate — it does NOT commit yet.
+    act(() => q<HTMLButtonElement>('.export-inspector__primary')?.click());
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(q('.export-inspector__confirm-title')?.textContent).toBe('Export to TikTok?');
+    expect(q('.export-inspector__confirm-blurb')?.textContent).toBe(EXPORT_CONFIRM_BLURB);
+    // The matrix is locked while confirming.
+    expect(q<HTMLButtonElement>('[data-preset="square"]')?.disabled).toBe(true);
+    // Step 2: "Export now" fires the commit with the chosen preset + render profile.
+    act(() => q<HTMLButtonElement>('.export-inspector__confirm-approve')?.click());
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    expect(onCommit).toHaveBeenCalledWith(presetById('tiktok'), exportConvertOptions());
+    // The gate closes after committing.
+    expect(q('.export-inspector__confirm')).toBeNull();
+  });
+
+  it('lets the user back out of the confirm gate without committing', () => {
+    render(SEED);
+    act(() => q<HTMLButtonElement>('.export-inspector__primary')?.click());
+    act(() => q<HTMLButtonElement>('.export-inspector__confirm-cancel')?.click());
+    expect(onCommit).not.toHaveBeenCalled();
+    // Back to the primary CTA, matrix re-enabled.
+    expect(q('.export-inspector__primary')).not.toBeNull();
+    expect(q<HTMLButtonElement>('[data-preset="square"]')?.disabled).toBe(false);
+  });
+});

--- a/app/renderer/src/features/export/ExportInspector.test.tsx
+++ b/app/renderer/src/features/export/ExportInspector.test.tsx
@@ -48,22 +48,53 @@ describe('ExportInspector', () => {
     const values = Array.from(container.querySelectorAll('.export-inspector__cell-value')).map(
       (el) => el.textContent,
     );
-    expect(values).toEqual(['1', '9:16', '0:40', '~0:20', '$0.00']);
+    // Honest pre-flight: the second cell states the FRAMING the export actually writes
+    // (the current framing) — never a per-destination aspect the export cannot produce.
+    expect(values).toEqual(['1', 'Original framing', '0:40', '~0:20', '$0.00']);
     expect(q('.export-inspector__privacy')?.textContent).toBe(EXPORT_PRIVACY_NOTE);
     // The primary CTA is present and NOT yet a confirm.
     expect(q('.export-inspector__primary')?.textContent).toBe('Export to TikTok');
     expect(q('.export-inspector__confirm')).toBeNull();
   });
 
-  it('re-summarizes when a different destination is chosen', () => {
+  it('re-summarizes the destination title/CTA but keeps framing destination-independent', () => {
     render(SEED);
+    const framingCell = (): string | null | undefined =>
+      container.querySelectorAll('.export-inspector__cell-value')[1]?.textContent;
+    expect(framingCell()).toBe('Original framing');
     act(() => q<HTMLButtonElement>('[data-preset="square"]')?.click());
     expect(q('.export-inspector__preflight-title')?.textContent).toBe(
       'Ready to export to Square post',
     );
-    const aspect = container.querySelectorAll('.export-inspector__cell-value')[1]?.textContent;
-    expect(aspect).toBe('1:1');
     expect(q('.export-inspector__primary')?.textContent).toBe('Export to Square post');
+    // Honest: switching destination re-summarizes the title + CTA but NEVER the framing —
+    // Export does not re-crop, so the output framing is identical for every destination.
+    expect(framingCell()).toBe('Original framing');
+  });
+
+  it('states the REFRAMED framing in the pre-flight when the clip carries a crop plan', () => {
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 40 } },
+      cropPlan: { engine: 'verthor' },
+    });
+    const framingCell = container.querySelectorAll('.export-inspector__cell-value')[1]?.textContent;
+    expect(framingCell).toBe('Reframed');
+  });
+
+  it('opens an announced alertdialog and moves focus to its primary action (WCAG 2.4.3)', () => {
+    render(SEED);
+    act(() => q<HTMLButtonElement>('.export-inspector__primary')?.click());
+    const dialog = q('.export-inspector__confirm');
+    // The confirm gate is an announced alertdialog, labelled + described by its own copy.
+    expect(dialog?.getAttribute('role')).toBe('alertdialog');
+    const titleId = q('.export-inspector__confirm-title')?.id;
+    const blurbId = q('.export-inspector__confirm-blurb')?.id;
+    expect(titleId).toBeTruthy();
+    expect(blurbId).toBeTruthy();
+    expect(dialog?.getAttribute('aria-labelledby')).toBe(titleId);
+    expect(dialog?.getAttribute('aria-describedby')).toBe(blurbId);
+    // Focus lands on the primary action, so it never drops to <body> when the gate opens.
+    expect(document.activeElement).toBe(q('.export-inspector__confirm-approve'));
   });
 
   it('guards the commit behind an explicit confirm gate', () => {

--- a/app/renderer/src/features/export/ExportInspector.tsx
+++ b/app/renderer/src/features/export/ExportInspector.tsx
@@ -1,0 +1,121 @@
+// ExportInspector.tsx — the Export phase inspector as a GUARDED COMMIT (v1.5 §4).
+//
+// Export is the ONE irreversible, spend/file-writing action, so this inspector
+// guards it: a per-platform destination matrix, a pre-flight SUMMARY (clips /
+// aspect / duration / est. time / est. spend), a restated privacy beat, and ONE
+// amber approve action — ranked ABOVE the secondary matrix by scale + elevation,
+// never an equal-weight tile. The approve is a TWO-STEP guarded commit: the primary
+// button opens an explicit confirm gate; only "Export now" fires `onCommit`.
+//
+// A THIN CONSUMER of the shared editor state (`useEditor`): it reads the video/
+// cues/cropPlan to build the pre-flight and never owns the stage or a copy of them.
+
+import React, { useState } from 'react';
+import type { ConvertOptions } from '../../lib/rpc';
+import { useEditor } from '../EditorContext';
+import {
+  type PlatformPreset,
+  buildPreflight,
+  exportConvertOptions,
+  firstAvailablePresetId,
+  presetById,
+  windowDurationSec,
+} from './exportModel';
+import { PresetMatrix } from './PresetMatrix';
+import './export.css';
+
+/** The local-first privacy beat — the same promise the Studio inspector makes. */
+export const EXPORT_PRIVACY_NOTE = 'Everything runs on your computer — nothing is uploaded.';
+
+/** The guarded-commit confirm copy: Export IS the bake, and it stays local. */
+export const EXPORT_CONFIRM_BLURB =
+  'This is the final render — everything you set is baked into the file. It is written to your ' +
+  'computer; nothing is uploaded.';
+
+export interface ExportInspectorProps {
+  /** Fired only after the explicit confirm — starts the guarded render. */
+  onCommit: (preset: PlatformPreset, options: ConvertOptions) => void;
+}
+
+export function ExportInspector({ onCommit }: ExportInspectorProps): React.ReactElement {
+  const { state } = useEditor();
+  const durationSec = windowDurationSec(state);
+  const [selected, setSelected] = useState<string>(() => firstAvailablePresetId(durationSec));
+  const [confirming, setConfirming] = useState(false);
+
+  const preset = presetById(selected);
+  const preflight = buildPreflight(state, preset);
+
+  const commit = (): void => {
+    setConfirming(false);
+    onCommit(preset, exportConvertOptions());
+  };
+
+  return (
+    <aside className="export-inspector" aria-label="Export">
+      <PresetMatrix
+        value={selected}
+        onChange={setSelected}
+        durationSec={durationSec}
+        disabled={confirming}
+      />
+
+      <section className="export-inspector__preflight" aria-label="Pre-flight summary">
+        <h3 className="export-inspector__preflight-title">Ready to export to {preset.name}</h3>
+        <div className="export-inspector__preflight-grid">
+          <div className="export-inspector__cell">
+            <span className="export-inspector__cell-label">Clips</span>
+            <span className="export-inspector__cell-value">{preflight.clipCount}</span>
+          </div>
+          <div className="export-inspector__cell">
+            <span className="export-inspector__cell-label">Aspect</span>
+            <span className="export-inspector__cell-value">{preflight.aspect}</span>
+          </div>
+          <div className="export-inspector__cell">
+            <span className="export-inspector__cell-label">Length</span>
+            <span className="export-inspector__cell-value">{preflight.durationLabel}</span>
+          </div>
+          <div className="export-inspector__cell">
+            <span className="export-inspector__cell-label">Est. time</span>
+            <span className="export-inspector__cell-value">{preflight.estRenderLabel}</span>
+          </div>
+          <div className="export-inspector__cell">
+            <span className="export-inspector__cell-label">Est. cost</span>
+            <span className="export-inspector__cell-value">{preflight.estSpendLabel}</span>
+          </div>
+        </div>
+      </section>
+
+      <p className="export-inspector__privacy">{EXPORT_PRIVACY_NOTE}</p>
+
+      {confirming ? (
+        <div className="export-inspector__confirm" role="group" aria-label="Confirm export">
+          <h3 className="export-inspector__confirm-title">Export to {preset.name}?</h3>
+          <p className="export-inspector__confirm-blurb">{EXPORT_CONFIRM_BLURB}</p>
+          <div className="export-inspector__confirm-actions">
+            <button type="button" className="export-inspector__confirm-approve" onClick={commit}>
+              Export now
+            </button>
+            <button
+              type="button"
+              className="export-inspector__confirm-cancel"
+              onClick={() => setConfirming(false)}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          className="export-inspector__primary"
+          onClick={() => setConfirming(true)}
+        >
+          Export to {preset.name}
+        </button>
+      )}
+    </aside>
+  );
+}
+
+export default ExportInspector;

--- a/app/renderer/src/features/export/ExportInspector.tsx
+++ b/app/renderer/src/features/export/ExportInspector.tsx
@@ -2,7 +2,7 @@
 //
 // Export is the ONE irreversible, spend/file-writing action, so this inspector
 // guards it: a per-platform destination matrix, a pre-flight SUMMARY (clips /
-// aspect / duration / est. time / est. spend), a restated privacy beat, and ONE
+// framing / duration / est. time / est. spend), a restated privacy beat, and ONE
 // amber approve action — ranked ABOVE the secondary matrix by scale + elevation,
 // never an equal-weight tile. The approve is a TWO-STEP guarded commit: the primary
 // button opens an explicit confirm gate; only "Export now" fires `onCommit`.
@@ -10,7 +10,7 @@
 // A THIN CONSUMER of the shared editor state (`useEditor`): it reads the video/
 // cues/cropPlan to build the pre-flight and never owns the stage or a copy of them.
 
-import React, { useState } from 'react';
+import React, { useEffect, useId, useRef, useState } from 'react';
 import type { ConvertOptions } from '../../lib/rpc';
 import { useEditor } from '../EditorContext';
 import {
@@ -18,6 +18,7 @@ import {
   buildPreflight,
   exportConvertOptions,
   firstAvailablePresetId,
+  framingSummary,
   presetById,
   windowDurationSec,
 } from './exportModel';
@@ -25,12 +26,12 @@ import { PresetMatrix } from './PresetMatrix';
 import './export.css';
 
 /** The local-first privacy beat — the same promise the Studio inspector makes. */
-export const EXPORT_PRIVACY_NOTE = 'Everything runs on your computer — nothing is uploaded.';
+export const EXPORT_PRIVACY_NOTE = 'Everything runs on your machine — nothing is uploaded.';
 
 /** The guarded-commit confirm copy: Export IS the bake, and it stays local. */
 export const EXPORT_CONFIRM_BLURB =
   'This is the final render — everything you set is baked into the file. It is written to your ' +
-  'computer; nothing is uploaded.';
+  'machine; nothing is uploaded.';
 
 export interface ExportInspectorProps {
   /** Fired only after the explicit confirm — starts the guarded render. */
@@ -42,9 +43,20 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
   const durationSec = windowDurationSec(state);
   const [selected, setSelected] = useState<string>(() => firstAvailablePresetId(durationSec));
   const [confirming, setConfirming] = useState(false);
+  const approveRef = useRef<HTMLButtonElement>(null);
+  const confirmTitleId = useId();
+  const confirmBlurbId = useId();
 
   const preset = presetById(selected);
   const preflight = buildPreflight(state, preset);
+  const framing = framingSummary(state);
+
+  // WCAG 2.4.3: activating the primary unmounts it and mounts the confirm gate, so
+  // move focus into the alertdialog's primary action — otherwise focus drops to
+  // <body> and the gate goes unannounced. `?.` no-ops on mount/close (ref detached).
+  useEffect(() => {
+    approveRef.current?.focus();
+  }, [confirming]);
 
   const commit = (): void => {
     setConfirming(false);
@@ -68,8 +80,8 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
             <span className="export-inspector__cell-value">{preflight.clipCount}</span>
           </div>
           <div className="export-inspector__cell">
-            <span className="export-inspector__cell-label">Aspect</span>
-            <span className="export-inspector__cell-value">{preflight.aspect}</span>
+            <span className="export-inspector__cell-label">Framing</span>
+            <span className="export-inspector__cell-value">{framing}</span>
           </div>
           <div className="export-inspector__cell">
             <span className="export-inspector__cell-label">Length</span>
@@ -89,11 +101,25 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
       <p className="export-inspector__privacy">{EXPORT_PRIVACY_NOTE}</p>
 
       {confirming ? (
-        <div className="export-inspector__confirm" role="group" aria-label="Confirm export">
-          <h3 className="export-inspector__confirm-title">Export to {preset.name}?</h3>
-          <p className="export-inspector__confirm-blurb">{EXPORT_CONFIRM_BLURB}</p>
+        <div
+          className="export-inspector__confirm"
+          role="alertdialog"
+          aria-labelledby={confirmTitleId}
+          aria-describedby={confirmBlurbId}
+        >
+          <h3 id={confirmTitleId} className="export-inspector__confirm-title">
+            Export to {preset.name}?
+          </h3>
+          <p id={confirmBlurbId} className="export-inspector__confirm-blurb">
+            {EXPORT_CONFIRM_BLURB}
+          </p>
           <div className="export-inspector__confirm-actions">
-            <button type="button" className="export-inspector__confirm-approve" onClick={commit}>
+            <button
+              ref={approveRef}
+              type="button"
+              className="export-inspector__confirm-approve"
+              onClick={commit}
+            >
               Export now
             </button>
             <button

--- a/app/renderer/src/features/export/ExportProgress.test.tsx
+++ b/app/renderer/src/features/export/ExportProgress.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ExportProgress } from './ExportProgress';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onCancel = vi.fn();
+
+beforeEach(() => {
+  onCancel.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+describe('ExportProgress', () => {
+  it('renders determinate progress with a rounded percent and a polite message', () => {
+    act(() => {
+      root.render(
+        <ExportProgress
+          destination="TikTok"
+          pct={42.7}
+          message="Rendering frames…"
+          onCancel={onCancel}
+        />,
+      );
+    });
+    expect(q('.export-progress__title')?.textContent).toBe('Exporting to TikTok');
+    expect(q('.export-progress__pct')?.textContent).toBe('43%');
+    const bar = q<HTMLProgressElement>('progress.export-progress__track');
+    expect(bar?.max).toBe(100);
+    expect(bar?.value).toBeCloseTo(42.7);
+    const status = q('.export-progress__message');
+    expect(status?.getAttribute('aria-live')).toBe('polite');
+    expect(status?.textContent).toBe('Rendering frames…');
+  });
+
+  it('exposes a real cancel control', () => {
+    act(() => {
+      root.render(<ExportProgress destination="Reels" pct={10} message="" onCancel={onCancel} />);
+    });
+    act(() => q<HTMLButtonElement>('.export-progress__cancel')?.click());
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/renderer/src/features/export/ExportProgress.tsx
+++ b/app/renderer/src/features/export/ExportProgress.tsx
@@ -1,0 +1,51 @@
+// ExportProgress.tsx — determinate export progress + a REAL cancel (v1.5 §4).
+//
+// The Wave-0 real-cancel needs its UI home here: a DETERMINATE bar (never the
+// forever-spinning optimistic pill the redesign rejects), the percent in amber
+// tabular-nums mono, a polite aria-live status line, and a live Cancel that maps to
+// `job.cancel`. Controlled + presentational: the parent (the Export view) owns the
+// progress stream + the cancel handler.
+
+import React from 'react';
+import './export.css';
+
+export interface ExportProgressProps {
+  /** The destination being rendered (e.g. "TikTok"). */
+  destination: string;
+  /** Determinate progress 0-100. */
+  pct: number;
+  /** The current step message (announced politely). */
+  message: string;
+  /** Cancel the in-flight render (maps to job.cancel). */
+  onCancel: () => void;
+}
+
+export function ExportProgress({
+  destination,
+  pct,
+  message,
+  onCancel,
+}: ExportProgressProps): React.ReactElement {
+  return (
+    <section className="export-progress" aria-label="Exporting">
+      <div className="export-progress__head">
+        <h3 className="export-progress__title">Exporting to {destination}</h3>
+        <span className="export-progress__pct">{Math.round(pct)}%</span>
+      </div>
+      <progress
+        className="export-progress__track"
+        max={100}
+        value={pct}
+        aria-label="Export progress"
+      />
+      <p className="export-progress__message" role="status" aria-live="polite">
+        {message}
+      </p>
+      <button type="button" className="export-progress__cancel" onClick={onCancel}>
+        Cancel export
+      </button>
+    </section>
+  );
+}
+
+export default ExportProgress;

--- a/app/renderer/src/features/export/ExportResult.test.tsx
+++ b/app/renderer/src/features/export/ExportResult.test.tsx
@@ -51,6 +51,13 @@ describe('ExportResult', () => {
     render({ outcome: 'done', paths: ['/out/a.mp4', '/out/b.mp4'], onReveal });
     expect(q('.export-result')?.className).toContain('is-done');
     expect(q('.export-result__title')?.textContent).toBe('Exported to TikTok');
+    // The completion is announced (role=status) and HONEST about framing: Export saved
+    // the CURRENT framing locally — it never claims a per-destination aspect output.
+    const blurb = q('.export-result__blurb');
+    expect(blurb?.getAttribute('role')).toBe('status');
+    expect(blurb?.textContent).toBe(
+      'Saved to your machine at its current framing — nothing was uploaded.',
+    );
     expect(all('.export-result__output').length).toBe(2);
     // Reveal each written file in the OS explorer.
     act(() => q<HTMLButtonElement>('.export-result__reveal')?.click());
@@ -79,11 +86,14 @@ describe('ExportResult', () => {
     expect(onExportAgain).toHaveBeenCalledTimes(1);
   });
 
-  it('CANCEL states plainly that no file was written', () => {
+  it('CANCEL states plainly that no file was written and announces via role=status', () => {
     render({ outcome: 'cancelled' });
     expect(q('.export-result')?.className).toContain('is-cancelled');
     expect(q('.export-result__title')?.textContent).toBe('Export cancelled');
-    expect(q('.export-result__blurb')?.textContent).toBe('No file was written.');
+    const blurb = q('.export-result__blurb');
+    expect(blurb?.textContent).toBe('No file was written.');
+    // The terminal cancel reaches SR users through a polite live region (not just visually).
+    expect(blurb?.getAttribute('role')).toBe('status');
     expect(q('.export-result__error')).toBeNull();
   });
 });

--- a/app/renderer/src/features/export/ExportResult.test.tsx
+++ b/app/renderer/src/features/export/ExportResult.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { ExportResult, type ExportResultProps } from './ExportResult';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onReveal = vi.fn();
+const onDeliver = vi.fn();
+const onExportAgain = vi.fn();
+
+beforeEach(() => {
+  onReveal.mockReset();
+  onDeliver.mockReset();
+  onExportAgain.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+const all = (sel: string): Element[] => Array.from(container.querySelectorAll(sel));
+
+function render(props: Partial<ExportResultProps> & Pick<ExportResultProps, 'outcome'>): void {
+  act(() => {
+    root.render(
+      <ExportResult
+        outcome={props.outcome}
+        destination={props.destination ?? 'TikTok'}
+        paths={props.paths ?? []}
+        error={props.error}
+        onReveal={props.onReveal}
+        onDeliver={props.onDeliver ?? onDeliver}
+        onExportAgain={props.onExportAgain ?? onExportAgain}
+      />,
+    );
+  });
+}
+
+describe('ExportResult', () => {
+  it('SUCCESS wires output locations to a reveal and links into Deliver', () => {
+    render({ outcome: 'done', paths: ['/out/a.mp4', '/out/b.mp4'], onReveal });
+    expect(q('.export-result')?.className).toContain('is-done');
+    expect(q('.export-result__title')?.textContent).toBe('Exported to TikTok');
+    expect(all('.export-result__output').length).toBe(2);
+    // Reveal each written file in the OS explorer.
+    act(() => q<HTMLButtonElement>('.export-result__reveal')?.click());
+    expect(onReveal).toHaveBeenCalledWith('/out/a.mp4');
+    // Continue into Deliver + export another.
+    act(() => q<HTMLButtonElement>('.export-result__deliver')?.click());
+    expect(onDeliver).toHaveBeenCalledTimes(1);
+    act(() => q<HTMLButtonElement>('.export-result__again')?.click());
+    expect(onExportAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it('SUCCESS without a reveal bridge omits the reveal button', () => {
+    render({ outcome: 'done', paths: ['/out/a.mp4'] });
+    expect(q('.export-result__reveal')).toBeNull();
+    expect(q('.export-result__path')?.textContent).toBe('/out/a.mp4');
+  });
+
+  it('FAILURE surfaces the error in an assertive alert with a retry', () => {
+    render({ outcome: 'failed', error: 'ffmpeg exploded' });
+    expect(q('.export-result')?.className).toContain('is-failed');
+    expect(q('.export-result__title')?.textContent).toBe('Export failed');
+    const alert = q('.export-result__error');
+    expect(alert?.getAttribute('role')).toBe('alert');
+    expect(alert?.textContent).toBe('ffmpeg exploded');
+    act(() => q<HTMLButtonElement>('.export-result__again')?.click());
+    expect(onExportAgain).toHaveBeenCalledTimes(1);
+  });
+
+  it('CANCEL states plainly that no file was written', () => {
+    render({ outcome: 'cancelled' });
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+    expect(q('.export-result__title')?.textContent).toBe('Export cancelled');
+    expect(q('.export-result__blurb')?.textContent).toBe('No file was written.');
+    expect(q('.export-result__error')).toBeNull();
+  });
+});

--- a/app/renderer/src/features/export/ExportResult.tsx
+++ b/app/renderer/src/features/export/ExportResult.tsx
@@ -3,9 +3,10 @@
 // Every async surface needs a terminal SUCCESS and a terminal FAILURE/cancel (§8
 // DoD). SUCCESS wires to the real output location (a "Show in folder" reveal, the
 // OutputTray role) and links INTO Deliver (finishing Phase-5 → batch publish).
-// FAILURE surfaces the error in an assertive alert with a recovery action; CANCEL
-// states clearly that no file was written. Status is text + a green/amber/red edge,
-// never hue alone. Controlled + presentational.
+// FAILURE surfaces the error in an assertive alert with a recovery action; SUCCESS
+// and CANCEL announce their terminal outcome through a polite `role="status"` live
+// region so completion reaches SR users too. Status is text + a green/amber/red
+// edge, never hue alone. Controlled + presentational.
 
 import React from 'react';
 import './export.css';
@@ -42,7 +43,9 @@ export function ExportResult({
     return (
       <section className="export-result is-done" aria-label="Export result">
         <h3 className="export-result__title">Exported to {destination}</h3>
-        <p className="export-result__blurb">Saved to your computer — nothing was uploaded.</p>
+        <p className="export-result__blurb" role="status">
+          Saved to your machine at its current framing — nothing was uploaded.
+        </p>
         <ul className="export-result__outputs">
           {paths.map((path) => (
             <li key={path} className="export-result__output">
@@ -80,7 +83,9 @@ export function ExportResult({
           {error}
         </p>
       ) : (
-        <p className="export-result__blurb">No file was written.</p>
+        <p className="export-result__blurb" role="status">
+          No file was written.
+        </p>
       )}
       <div className="export-result__actions">
         <button type="button" className="export-result__again" onClick={onExportAgain}>

--- a/app/renderer/src/features/export/ExportResult.tsx
+++ b/app/renderer/src/features/export/ExportResult.tsx
@@ -1,0 +1,94 @@
+// ExportResult.tsx — the TERMINAL export states (v1.5 §4).
+//
+// Every async surface needs a terminal SUCCESS and a terminal FAILURE/cancel (§8
+// DoD). SUCCESS wires to the real output location (a "Show in folder" reveal, the
+// OutputTray role) and links INTO Deliver (finishing Phase-5 → batch publish).
+// FAILURE surfaces the error in an assertive alert with a recovery action; CANCEL
+// states clearly that no file was written. Status is text + a green/amber/red edge,
+// never hue alone. Controlled + presentational.
+
+import React from 'react';
+import './export.css';
+
+/** The terminal outcome of a guarded export. */
+export type ExportOutcome = 'done' | 'failed' | 'cancelled';
+
+export interface ExportResultProps {
+  outcome: ExportOutcome;
+  /** The destination that was rendered (e.g. "TikTok"). */
+  destination: string;
+  /** The written output file paths (SUCCESS only). */
+  paths: readonly string[];
+  /** The failure message (FAILURE only). */
+  error?: string;
+  /** Reveal a written file in the OS file explorer (omit when unsupported). */
+  onReveal?: (path: string) => void;
+  /** Continue into the Deliver (batch/cross-video) surface. */
+  onDeliver: () => void;
+  /** Start another export of this clip (recovery / repeat). */
+  onExportAgain: () => void;
+}
+
+export function ExportResult({
+  outcome,
+  destination,
+  paths,
+  error,
+  onReveal,
+  onDeliver,
+  onExportAgain,
+}: ExportResultProps): React.ReactElement {
+  if (outcome === 'done') {
+    return (
+      <section className="export-result is-done" aria-label="Export result">
+        <h3 className="export-result__title">Exported to {destination}</h3>
+        <p className="export-result__blurb">Saved to your computer — nothing was uploaded.</p>
+        <ul className="export-result__outputs">
+          {paths.map((path) => (
+            <li key={path} className="export-result__output">
+              <span className="export-result__path">{path}</span>
+              {onReveal ? (
+                <button
+                  type="button"
+                  className="export-result__reveal"
+                  onClick={() => onReveal(path)}
+                >
+                  Show in folder
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+        <div className="export-result__actions">
+          <button type="button" className="export-result__deliver" onClick={onDeliver}>
+            Continue to Deliver
+          </button>
+          <button type="button" className="export-result__again" onClick={onExportAgain}>
+            Export another
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const failed = outcome === 'failed';
+  return (
+    <section className={`export-result is-${outcome}`} aria-label="Export result">
+      <h3 className="export-result__title">{failed ? 'Export failed' : 'Export cancelled'}</h3>
+      {failed ? (
+        <p className="export-result__error" role="alert">
+          {error}
+        </p>
+      ) : (
+        <p className="export-result__blurb">No file was written.</p>
+      )}
+      <div className="export-result__actions">
+        <button type="button" className="export-result__again" onClick={onExportAgain}>
+          Try again
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export default ExportResult;

--- a/app/renderer/src/features/export/ExportStage.test.tsx
+++ b/app/renderer/src/features/export/ExportStage.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { EditorProvider } from '../EditorContext';
+import type { EditorSeed } from '../../lib/editorState';
+import { ExportStage } from './ExportStage';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+function render(seed: EditorSeed): void {
+  act(() => {
+    root.render(
+      <EditorProvider seed={seed}>
+        <ExportStage />
+      </EditorProvider>,
+    );
+  });
+}
+
+const labelValue = (label: string): string | undefined => {
+  const items = Array.from(container.querySelectorAll('.export-stage__item'));
+  const item = items.find((el) => el.querySelector('.export-stage__label')?.textContent === label);
+  return item?.querySelector('.export-stage__value')?.textContent ?? undefined;
+};
+
+describe('ExportStage', () => {
+  it('previews the clip and summarizes the baked length, captions, and framing', () => {
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 45 } },
+      cues: [
+        { index: 1, start: 1, end: 2, text: 'Hi' },
+        { index: 2, start: 3, end: 4, text: 'there' },
+      ],
+      cropPlan: { engine: 'verthor' },
+    });
+    expect(q('.export-stage')).not.toBeNull();
+    expect(q('video')).not.toBeNull();
+    expect(labelValue('Length')).toBe('0:45');
+    expect(labelValue('Captions')).toBe('2 captions');
+    // Framing reads "Reframed" — never the raw engine id.
+    expect(labelValue('Framing')).toBe('Reframed');
+    expect(q('.export-stage')?.textContent).not.toContain('verthor');
+  });
+
+  it('summarizes an un-captioned, un-reframed clip', () => {
+    render({ video: { videoId: 'v2', window: { start: 0, end: 12 } } });
+    expect(labelValue('Captions')).toBe('No captions');
+    expect(labelValue('Framing')).toBe('Original framing');
+  });
+});

--- a/app/renderer/src/features/export/ExportStage.tsx
+++ b/app/renderer/src/features/export/ExportStage.tsx
@@ -1,0 +1,45 @@
+// ExportStage.tsx — the SHARED export stage (v1.5 §4, inspector-over-shared-stage).
+//
+// The one video surface the Export inspector talks about: a THIN CONSUMER of the
+// shared editor state (`useEditor`) that previews the exact clip being exported and
+// summarizes what is BAKED into it — its length, its captions (from the cues), and
+// its framing (reframed vs original, read from the cross-phase cropPlan WITHOUT
+// leaking the engine id). It owns no export controls; those live in the inspector.
+
+import React from 'react';
+import { Player } from '../../components/Player';
+import { fmtSeconds } from '../_api';
+import { useEditor } from '../EditorContext';
+import { captionSummary, framingSummary } from './exportModel';
+import './export.css';
+
+/** The shared export preview: the clip + a plain "what will be baked" summary. */
+export function ExportStage(): React.ReactElement {
+  const { state } = useEditor();
+  const { video } = state;
+  const win = video.window;
+
+  return (
+    <div className="export-stage" aria-label="Export preview">
+      <div className="export-stage__frame">
+        <Player videoId={video.videoId} src={video.src} window={win} controls />
+      </div>
+      <div className="export-stage__summary">
+        <div className="export-stage__item">
+          <span className="export-stage__label">Length</span>
+          <span className="export-stage__value">{fmtSeconds(win.end - win.start)}</span>
+        </div>
+        <div className="export-stage__item">
+          <span className="export-stage__label">Captions</span>
+          <span className="export-stage__value">{captionSummary(state)}</span>
+        </div>
+        <div className="export-stage__item">
+          <span className="export-stage__label">Framing</span>
+          <span className="export-stage__value">{framingSummary(state)}</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ExportStage;

--- a/app/renderer/src/features/export/PresetMatrix.test.tsx
+++ b/app/renderer/src/features/export/PresetMatrix.test.tsx
@@ -61,6 +61,15 @@ describe('PresetMatrix', () => {
     expect(optionFor('shorts')?.textContent).toContain('9:16');
   });
 
+  it('states that the aspect is set in Reframe so the badges never imply Export output', () => {
+    render({ value: 'tiktok' });
+    // The per-destination aspect is a TARGET set upstream in Reframe — the hint keeps the
+    // badge from implying Export re-crops the frame (Export keeps the current framing).
+    expect(q('.preset-matrix__hint')?.textContent).toBe(
+      'Aspect is set in Reframe — Export keeps your current framing.',
+    );
+  });
+
   it('reflects the selection through aria-checked + roving tabindex', () => {
     render({ value: 'reels' });
     expect(optionFor('reels')?.getAttribute('aria-checked')).toBe('true');

--- a/app/renderer/src/features/export/PresetMatrix.test.tsx
+++ b/app/renderer/src/features/export/PresetMatrix.test.tsx
@@ -1,0 +1,125 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { PresetMatrix } from './PresetMatrix';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+const onChange = vi.fn();
+
+beforeEach(() => {
+  onChange.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+const all = (sel: string): Element[] => Array.from(container.querySelectorAll(sel));
+
+function render(props: { value?: string; durationSec?: number; disabled?: boolean }): void {
+  act(() => {
+    root.render(
+      <PresetMatrix
+        value={props.value ?? 'tiktok'}
+        onChange={onChange}
+        durationSec={props.durationSec ?? 30}
+        disabled={props.disabled}
+      />,
+    );
+  });
+}
+
+function keyOnGroup(key: string): void {
+  const group = q<HTMLDivElement>('[role="radiogroup"]');
+  act(() => {
+    group?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  });
+}
+
+const optionFor = (id: string): HTMLButtonElement | null =>
+  q<HTMLButtonElement>(`[data-preset="${id}"]`);
+
+describe('PresetMatrix', () => {
+  it('renders a real fieldset/radiogroup of destination radios', () => {
+    render({ value: 'tiktok' });
+    expect(q('fieldset.preset-matrix')).not.toBeNull();
+    expect(q('legend')?.textContent).toBe('Deliver to');
+    const radios = all('[role="radio"]');
+    expect(radios.length).toBe(6);
+    // Named destinations, no codec jargon.
+    expect(optionFor('shorts')?.textContent).toContain('YouTube Shorts');
+    expect(optionFor('shorts')?.textContent).toContain('9:16');
+  });
+
+  it('reflects the selection through aria-checked + roving tabindex', () => {
+    render({ value: 'reels' });
+    expect(optionFor('reels')?.getAttribute('aria-checked')).toBe('true');
+    expect(optionFor('reels')?.tabIndex).toBe(0);
+    expect(optionFor('tiktok')?.getAttribute('aria-checked')).toBe('false');
+    expect(optionFor('tiktok')?.tabIndex).toBe(-1);
+  });
+
+  it('selects an available destination on click', () => {
+    render({ value: 'tiktok' });
+    act(() => optionFor('square')?.click());
+    expect(onChange).toHaveBeenCalledWith('square');
+  });
+
+  it('blocks a destination whose cap the clip exceeds (disabled + reason)', () => {
+    render({ value: 'tiktok', durationSec: 120 });
+    const shorts = optionFor('shorts');
+    expect(shorts?.disabled).toBe(true);
+    expect(shorts?.className).toContain('is-unavailable');
+    expect(shorts?.textContent).toContain('trim it first');
+    // A disabled option cannot be chosen.
+    act(() => shorts?.click());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('moves selection to the next SELECTABLE destination on ArrowRight (skipping blocked)', () => {
+    // 120s clip blocks reels (90) + shorts (60); ArrowRight from tiktok lands on feed.
+    render({ value: 'tiktok', durationSec: 120 });
+    keyOnGroup('ArrowRight');
+    expect(onChange).toHaveBeenCalledWith('feed');
+    // Focus follows the roving selection.
+    expect(document.activeElement).toBe(optionFor('feed'));
+  });
+
+  it('wraps to the last destination on ArrowLeft', () => {
+    render({ value: 'tiktok', durationSec: 30 });
+    keyOnGroup('ArrowLeft');
+    expect(onChange).toHaveBeenCalledWith('widescreen');
+  });
+
+  it('jumps to the first / last destination on Home / End', () => {
+    render({ value: 'square', durationSec: 30 });
+    keyOnGroup('Home');
+    expect(onChange).toHaveBeenLastCalledWith('tiktok');
+    keyOnGroup('End');
+    expect(onChange).toHaveBeenLastCalledWith('widescreen');
+  });
+
+  it('ignores non-navigation keys', () => {
+    render({ value: 'tiktok' });
+    keyOnGroup('Tab');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('locks the whole group (no click, no keyboard) while disabled', () => {
+    render({ value: 'tiktok', disabled: true });
+    expect(optionFor('reels')?.disabled).toBe(true);
+    act(() => optionFor('reels')?.click());
+    keyOnGroup('ArrowRight');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/app/renderer/src/features/export/PresetMatrix.tsx
+++ b/app/renderer/src/features/export/PresetMatrix.tsx
@@ -3,7 +3,9 @@
 // A REAL fieldset/radiogroup (role="radiogroup" of role="radio" options with
 // aria-checked + roving tabindex + arrow-key selection), NOT a grid of equal-weight
 // tiles. Every option is a recognizable DESTINATION (TikTok / Reels / Shorts…)
-// implying aspect + length — never codec/bitrate jargon. Options carry three
+// showing its TARGET aspect + length — never codec/bitrate jargon. A hint states
+// that aspect is set upstream in Reframe (Export keeps the current framing), so the
+// per-destination badge never implies Export re-crops the frame. Options carry three
 // states: SELECTED (the amber ring), AVAILABLE (selectable), and UNAVAILABLE (the
 // clip is longer than the platform's cap — blocked with a stated reason). While the
 // export is confirming/running the whole group is disabled so the choice is locked.
@@ -50,6 +52,9 @@ export function PresetMatrix({
   return (
     <fieldset className="preset-matrix">
       <legend className="preset-matrix__legend">Deliver to</legend>
+      <p className="preset-matrix__hint">
+        Aspect is set in Reframe — Export keeps your current framing.
+      </p>
       <div
         className="preset-matrix__grid"
         role="radiogroup"

--- a/app/renderer/src/features/export/PresetMatrix.tsx
+++ b/app/renderer/src/features/export/PresetMatrix.tsx
@@ -1,0 +1,95 @@
+// PresetMatrix.tsx — the per-platform destination matrix (v1.5 §4 Export).
+//
+// A REAL fieldset/radiogroup (role="radiogroup" of role="radio" options with
+// aria-checked + roving tabindex + arrow-key selection), NOT a grid of equal-weight
+// tiles. Every option is a recognizable DESTINATION (TikTok / Reels / Shorts…)
+// implying aspect + length — never codec/bitrate jargon. Options carry three
+// states: SELECTED (the amber ring), AVAILABLE (selectable), and UNAVAILABLE (the
+// clip is longer than the platform's cap — blocked with a stated reason). While the
+// export is confirming/running the whole group is disabled so the choice is locked.
+//
+// Controlled + presentational: the parent owns `value` and gets `onChange(id)`.
+// The keyboard math (skip-unavailable, wrap) is the pure `rovingIndex` helper.
+
+import React, { useRef } from 'react';
+import { PLATFORM_PRESETS, presetAvailability, rovingIndex } from './exportModel';
+import './export.css';
+
+export interface PresetMatrixProps {
+  /** The selected destination id (parent-owned). */
+  value: string;
+  /** Called with the chosen destination id. */
+  onChange: (id: string) => void;
+  /** The clip length (seconds) — drives per-destination availability. */
+  durationSec: number;
+  /** Locks the whole group while the export is confirming/running. */
+  disabled?: boolean;
+}
+
+export function PresetMatrix({
+  value,
+  onChange,
+  durationSec,
+  disabled = false,
+}: PresetMatrixProps): React.ReactElement {
+  const buttons = useRef<Array<HTMLButtonElement | null>>([]);
+  const selectable = PLATFORM_PRESETS.map(
+    (preset) => presetAvailability(preset, durationSec).status === 'available',
+  );
+  const current = PLATFORM_PRESETS.findIndex((preset) => preset.id === value);
+
+  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    if (disabled) return;
+    const next = rovingIndex(event.key, current, selectable);
+    if (next === current) return;
+    event.preventDefault();
+    onChange(PLATFORM_PRESETS[next].id);
+    buttons.current[next]?.focus();
+  };
+
+  return (
+    <fieldset className="preset-matrix">
+      <legend className="preset-matrix__legend">Deliver to</legend>
+      <div
+        className="preset-matrix__grid"
+        role="radiogroup"
+        aria-label="Delivery destination"
+        onKeyDown={onKeyDown}
+      >
+        {PLATFORM_PRESETS.map((preset, index) => {
+          const availability = presetAvailability(preset, durationSec);
+          const unavailable = availability.status === 'unavailable';
+          const selected = preset.id === value;
+          return (
+            <button
+              key={preset.id}
+              ref={(el) => {
+                buttons.current[index] = el;
+              }}
+              type="button"
+              role="radio"
+              aria-checked={selected}
+              tabIndex={selected ? 0 : -1}
+              disabled={disabled || unavailable}
+              className={`preset-option${selected ? ' is-selected' : ''}${unavailable ? ' is-unavailable' : ''}`}
+              data-preset={preset.id}
+              onClick={() => onChange(preset.id)}
+            >
+              <span className="preset-option__head">
+                <span className="preset-option__name">{preset.name}</span>
+                <span className="preset-option__aspect">{preset.aspect}</span>
+              </span>
+              <span className="preset-option__blurb">{preset.blurb}</span>
+              <span className="preset-option__length">{preset.lengthHint}</span>
+              {unavailable ? (
+                <span className="preset-option__reason">{availability.reason}</span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}
+
+export default PresetMatrix;

--- a/app/renderer/src/features/export/export.css
+++ b/app/renderer/src/features/export/export.css
@@ -24,6 +24,15 @@
   color: var(--text-muted);
 }
 
+/* Honesty beat: Export never re-crops — the per-destination aspect is a TARGET set
+ * upstream in Reframe, so this hint keeps the aspect badges from implying output. */
+.preset-matrix__hint {
+  margin: 0 0 var(--space-3);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+  color: var(--text-muted);
+}
+
 .preset-matrix__grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));

--- a/app/renderer/src/features/export/export.css
+++ b/app/renderer/src/features/export/export.css
@@ -1,0 +1,582 @@
+/* export.css — the Phase-5 Export screen components (v1.5 §4). Tokens ONLY.
+ *
+ * Hierarchy: the ONE amber approve action outranks the destination matrix via
+ * SCALE + the --elev ladder (not equal-weight tiles). Amber is the only accent
+ * (progress / active / approve); status is strictly green/amber/red. All motion is
+ * neutralized under prefers-reduced-motion. */
+
+/* ---- destination matrix (fieldset/radiogroup) --------------------------------- */
+
+.preset-matrix {
+  margin: 0;
+  padding: 0;
+  border: none;
+  min-width: 0;
+}
+
+.preset-matrix__legend {
+  padding: 0;
+  margin-bottom: var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.preset-matrix__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  gap: var(--space-3);
+}
+
+/* One destination — a raised, seated surface (--elev-1) that lifts on hover and
+ * rings amber when selected. Deliberately SECONDARY to the primary CTA. */
+.preset-option {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-4);
+  text-align: left;
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+  cursor: pointer;
+  transition:
+    transform var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out),
+    border-color var(--dur-fast) var(--ease-out);
+}
+
+.preset-option:hover:not(:disabled) {
+  transform: translateY(-2px);
+  background: var(--surface-hover);
+  box-shadow: var(--elev-2);
+}
+
+.preset-option:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.preset-option.is-selected {
+  border-color: var(--accent-edge);
+  background: var(--accent-soft);
+  box-shadow: var(--elev-2);
+}
+
+.preset-option.is-unavailable {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.preset-option__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.preset-option__name {
+  font-size: var(--type-card-title-size);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.preset-option__aspect {
+  font-family: var(--font-mono);
+  font-size: var(--type-chip-size);
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+}
+
+.preset-option__blurb {
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}
+
+.preset-option__length {
+  font-size: var(--type-chip-size);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.preset-option__reason {
+  margin-top: var(--space-1);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+  color: var(--status-warn);
+}
+
+/* ---- the shared export STAGE (video preview + bake summary) -------------------- */
+
+.export-stage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+.export-stage__frame {
+  position: relative;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  background: var(--atmos-well), var(--surface-deep);
+}
+
+.export-stage__summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-5);
+  padding: var(--space-4);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.export-stage__item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.export-stage__label {
+  font-size: var(--type-chip-size);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.export-stage__value {
+  font-size: var(--type-body-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+/* ---- the Export INSPECTOR (guarded commit) ------------------------------------ */
+
+/* overflow-y:auto so the primary CTA is never clipped at short window heights. */
+.export-inspector {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  min-width: 0;
+  max-height: calc(100vh - var(--space-8) - var(--space-8));
+  overflow-y: auto;
+}
+
+.export-inspector__preflight {
+  padding: var(--space-5);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.export-inspector__preflight-title {
+  margin: 0 0 var(--space-4);
+  font-size: var(--type-title-size);
+  font-weight: var(--type-title-weight);
+  letter-spacing: var(--type-title-tracking);
+  color: var(--text-primary);
+}
+
+.export-inspector__preflight-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: var(--space-4);
+}
+
+.export-inspector__cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.export-inspector__cell-label {
+  font-size: var(--type-chip-size);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.export-inspector__cell-value {
+  font-family: var(--font-mono);
+  font-size: var(--type-hook-size);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+/* The privacy beat — the AA-safe quiet step, never the rejected faint hex. */
+.export-inspector__privacy {
+  margin: 0;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-muted);
+}
+
+/* The ONE amber approve action — LARGER than any secondary control (scale
+ * hierarchy) and lifted on the elevation ladder. */
+.export-inspector__primary {
+  padding: var(--space-4) var(--space-5);
+  font-size: var(--type-title-size);
+  font-weight: var(--weight-bold);
+  color: var(--accent-ink);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-md);
+  box-shadow: var(--accent-glow);
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    box-shadow var(--dur-fast) var(--ease-out);
+}
+
+.export-inspector__primary:hover:not(:disabled) {
+  background: var(--accent-hover);
+  box-shadow: var(--accent-glow-hover);
+}
+
+.export-inspector__primary:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.export-inspector__primary:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+/* The explicit confirm gate — floats above the inspector on the overlay plane. */
+.export-inspector__confirm {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  background: var(--surface-overlay);
+  border: 1px solid var(--accent-edge);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-3);
+}
+
+.export-inspector__confirm-title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  color: var(--text-primary);
+}
+
+.export-inspector__confirm-blurb {
+  margin: 0;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}
+
+.export-inspector__confirm-actions {
+  display: flex;
+  gap: var(--space-3);
+}
+
+.export-inspector__confirm-approve {
+  flex: 1;
+  padding: var(--space-4) var(--space-5);
+  font-size: var(--type-title-size);
+  font-weight: var(--weight-bold);
+  color: var(--accent-ink);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-md);
+  box-shadow: var(--accent-glow);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-inspector__confirm-approve:hover {
+  background: var(--accent-hover);
+}
+
+.export-inspector__confirm-approve:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.export-inspector__confirm-cancel {
+  padding: var(--space-4) var(--space-5);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-inspector__confirm-cancel:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.export-inspector__confirm-cancel:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ---- determinate PROGRESS + a real cancel ------------------------------------- */
+
+.export-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-5);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+.export-progress__head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.export-progress__title {
+  margin: 0;
+  font-size: var(--type-title-size);
+  font-weight: var(--type-title-weight);
+  color: var(--text-primary);
+}
+
+.export-progress__pct {
+  font-family: var(--font-mono);
+  font-size: var(--type-rank-size);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--weight-bold);
+  color: var(--accent);
+}
+
+.export-progress__track {
+  width: 100%;
+  height: var(--space-3);
+  appearance: none;
+  border: none;
+  border-radius: var(--radius-pill);
+  background: var(--surface-deep);
+  overflow: hidden;
+}
+
+.export-progress__track::-webkit-progress-bar {
+  background: var(--surface-deep);
+  border-radius: var(--radius-pill);
+}
+
+.export-progress__track::-webkit-progress-value {
+  background: var(--accent);
+  border-radius: var(--radius-pill);
+  transition: width var(--dur-base) var(--ease-out);
+}
+
+.export-progress__track::-moz-progress-bar {
+  background: var(--accent);
+  border-radius: var(--radius-pill);
+}
+
+.export-progress__message {
+  font-size: var(--type-body-size);
+  color: var(--text-secondary);
+}
+
+.export-progress__cancel {
+  align-self: flex-start;
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-progress__cancel:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.export-progress__cancel:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ---- terminal RESULT (success / failure / cancel) ----------------------------- */
+
+.export-result {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  padding: var(--space-6);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  border-left: 3px solid var(--edge-strong);
+  box-shadow: var(--elev-1);
+}
+
+.export-result.is-done {
+  border-left-color: var(--status-success);
+}
+
+.export-result.is-failed {
+  border-left-color: var(--status-error);
+}
+
+.export-result.is-cancelled {
+  border-left-color: var(--status-warn);
+}
+
+.export-result__title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  color: var(--text-primary);
+}
+
+.export-result__blurb {
+  margin: 0;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}
+
+.export-result__error {
+  margin: 0;
+  padding: var(--space-3) var(--space-4);
+  font-size: var(--type-body-size);
+  color: var(--status-error);
+  background: var(--status-error-soft);
+  border-radius: var(--radius-sm);
+}
+
+.export-result__outputs {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.export-result__output {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  justify-content: space-between;
+  padding: var(--space-3);
+  background: var(--surface-deep);
+  border-radius: var(--radius-sm);
+}
+
+.export-result__path {
+  font-family: var(--font-mono);
+  font-size: var(--type-caption-size);
+  color: var(--text-secondary);
+  overflow-wrap: anywhere;
+}
+
+.export-result__reveal {
+  flex-shrink: 0;
+  padding: var(--control-pad-mini);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+  background: var(--surface-overlay);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-result__reveal:hover {
+  background: var(--surface-hover);
+}
+
+.export-result__reveal:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.export-result__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+/* "Continue to Deliver" is the primary next step (amber) — Phase-5 links INTO
+ * Deliver. "Export another" is the quiet secondary. */
+.export-result__deliver {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-bold);
+  color: var(--accent-ink);
+  background: var(--accent);
+  border: none;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--accent-glow);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-result__deliver:hover {
+  background: var(--accent-hover);
+  box-shadow: var(--accent-glow-hover);
+}
+
+.export-result__deliver:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.export-result__again {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-result__again:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.export-result__again:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* prefers-reduced-motion: neutralize every transition with a static fallback. */
+@media (prefers-reduced-motion: reduce) {
+  .preset-option,
+  .preset-option:hover:not(:disabled),
+  .export-inspector__primary,
+  .export-inspector__confirm-approve,
+  .export-inspector__confirm-cancel,
+  .export-progress__track::-webkit-progress-value,
+  .export-progress__cancel,
+  .export-result__reveal,
+  .export-result__deliver,
+  .export-result__again {
+    transition: none;
+    transform: none;
+  }
+}

--- a/app/renderer/src/features/export/exportModel.test.ts
+++ b/app/renderer/src/features/export/exportModel.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it } from 'vitest';
+import type { EditorState } from '../../lib/editorState';
+import { DEFAULT_CAPTION_DESIGN } from '../../lib/captionDesign';
+import type { Cue } from '../../lib/rpc';
+import {
+  PLATFORM_PRESETS,
+  type PlatformPreset,
+  buildPreflight,
+  captionSummary,
+  estimateRenderSec,
+  exportConvertOptions,
+  firstAvailablePresetId,
+  framingSummary,
+  presetAvailability,
+  presetById,
+  rovingIndex,
+  windowDurationSec,
+} from './exportModel';
+
+function stateWith(overrides: Partial<EditorState> = {}): EditorState {
+  return {
+    video: { videoId: 'v1', window: { start: 0, end: 30 }, durationSec: 30 },
+    cues: [],
+    cropPlan: null,
+    design: DEFAULT_CAPTION_DESIGN,
+    playhead: 0,
+    selection: null,
+    ...overrides,
+  };
+}
+
+const cue = (index: number): Cue => ({ index, start: index, end: index + 1, text: `w${index}` });
+
+describe('PLATFORM_PRESETS catalog', () => {
+  it('spans the four target aspects with recognizable destinations only', () => {
+    const aspects = new Set(PLATFORM_PRESETS.map((p) => p.aspect));
+    expect(aspects).toEqual(new Set(['9:16', '4:5', '1:1', '16:9']));
+    // No codec/bitrate jargon leaks into any user-visible field.
+    for (const preset of PLATFORM_PRESETS) {
+      expect(`${preset.name} ${preset.blurb} ${preset.lengthHint}`).not.toMatch(
+        /codec|bitrate|h\.?264|crf|kbps|mp4/i,
+      );
+    }
+    // At least one destination is uncapped (guarantees an always-available pick).
+    expect(PLATFORM_PRESETS.some((p) => p.maxSec === null)).toBe(true);
+  });
+});
+
+describe('presetById', () => {
+  it('resolves a known id', () => {
+    expect(presetById('shorts').name).toBe('YouTube Shorts');
+  });
+  it('falls back to the first preset for an unknown id', () => {
+    expect(presetById('nope')).toBe(PLATFORM_PRESETS[0]);
+  });
+});
+
+describe('presetAvailability', () => {
+  it('is available when the clip fits the cap', () => {
+    const shorts = presetById('shorts'); // maxSec 60
+    expect(presetAvailability(shorts, 45)).toEqual({ status: 'available', reason: '' });
+  });
+  it('is available exactly at the cap (boundary)', () => {
+    expect(presetAvailability(presetById('shorts'), 60).status).toBe('available');
+  });
+  it('is available for an uncapped destination regardless of length', () => {
+    expect(presetAvailability(presetById('widescreen'), 99999).status).toBe('available');
+  });
+  it('is unavailable — with a plain reason — when the clip exceeds the cap', () => {
+    const result = presetAvailability(presetById('shorts'), 75);
+    expect(result.status).toBe('unavailable');
+    expect(result.reason).toBe(
+      'This clip runs longer than the 1:00 limit for YouTube Shorts — trim it first.',
+    );
+  });
+});
+
+describe('firstAvailablePresetId', () => {
+  it('returns the first destination that fits the clip', () => {
+    // 80s clip: tiktok (600) fits first.
+    expect(firstAvailablePresetId(80)).toBe('tiktok');
+  });
+  it('falls back to the first entry when none fit (synthetic all-capped catalog)', () => {
+    const capped: PlatformPreset[] = [
+      { id: 'a', name: 'A', blurb: '', aspect: '9:16', maxSec: 10, lengthHint: '' },
+      { id: 'b', name: 'B', blurb: '', aspect: '1:1', maxSec: 20, lengthHint: '' },
+    ];
+    expect(firstAvailablePresetId(999, capped)).toBe('a');
+  });
+});
+
+describe('estimateRenderSec', () => {
+  it('floors a tiny clip at the minimum', () => {
+    expect(estimateRenderSec(2)).toBe(3);
+  });
+  it('scales with duration for a longer clip', () => {
+    expect(estimateRenderSec(40)).toBe(20);
+  });
+});
+
+describe('windowDurationSec', () => {
+  it('measures a normal window', () => {
+    expect(windowDurationSec(stateWith({ video: { window: { start: 5, end: 20 } } }))).toBe(15);
+  });
+  it('clamps a reversed window to zero', () => {
+    expect(windowDurationSec(stateWith({ video: { window: { start: 20, end: 5 } } }))).toBe(0);
+  });
+  it('treats a non-finite window as zero', () => {
+    expect(windowDurationSec(stateWith({ video: { window: { start: 0, end: Number.NaN } } }))).toBe(
+      0,
+    );
+  });
+});
+
+describe('buildPreflight', () => {
+  it('summarizes one local clip at the destination aspect', () => {
+    const pre = buildPreflight(
+      stateWith({ video: { window: { start: 5, end: 65 } } }),
+      presetById('shorts'),
+    );
+    expect(pre).toEqual({
+      clipCount: 1,
+      aspect: '9:16',
+      durationSec: 60,
+      durationLabel: '1:00',
+      estRenderLabel: '~0:30',
+      estSpendLabel: '$0.00',
+    });
+  });
+  it('clamps a reversed window to zero', () => {
+    const pre = buildPreflight(
+      stateWith({ video: { window: { start: 10, end: 4 } } }),
+      presetById('feed'),
+    );
+    expect(pre.durationSec).toBe(0);
+    expect(pre.durationLabel).toBe('0:00');
+  });
+  it('treats a non-finite window as zero', () => {
+    const pre = buildPreflight(
+      stateWith({ video: { window: { start: 0, end: Number.NaN } } }),
+      presetById('feed'),
+    );
+    expect(pre.durationSec).toBe(0);
+  });
+});
+
+describe('captionSummary', () => {
+  it('reports no captions', () => {
+    expect(captionSummary(stateWith({ cues: [] }))).toBe('No captions');
+  });
+  it('reports one caption (singular)', () => {
+    expect(captionSummary(stateWith({ cues: [cue(1)] }))).toBe('1 caption');
+  });
+  it('reports many captions (plural)', () => {
+    expect(captionSummary(stateWith({ cues: [cue(1), cue(2)] }))).toBe('2 captions');
+  });
+});
+
+describe('framingSummary', () => {
+  it('reads Original framing with no crop plan', () => {
+    expect(framingSummary(stateWith({ cropPlan: null }))).toBe('Original framing');
+  });
+  it('reads Reframed when a crop plan is present — never leaking the engine id', () => {
+    expect(framingSummary(stateWith({ cropPlan: { engine: 'verthor' } }))).toBe('Reframed');
+  });
+});
+
+describe('exportConvertOptions', () => {
+  it('is a universal share-ready mp4 profile', () => {
+    expect(exportConvertOptions()).toEqual({
+      container: 'mp4',
+      vcodec: 'libx264',
+      acodec: 'aac',
+      scale: '',
+      fps: '',
+      crf: '20',
+      audioOnly: false,
+      audioFormat: 'mp3',
+    });
+  });
+});
+
+describe('rovingIndex', () => {
+  const all = [true, true, true];
+  it('moves next on ArrowRight / ArrowDown (wrapping)', () => {
+    expect(rovingIndex('ArrowRight', 0, all)).toBe(1);
+    expect(rovingIndex('ArrowDown', 0, all)).toBe(1);
+    expect(rovingIndex('ArrowRight', 2, all)).toBe(0);
+  });
+  it('moves previous on ArrowLeft / ArrowUp (wrapping)', () => {
+    expect(rovingIndex('ArrowLeft', 0, all)).toBe(2);
+    expect(rovingIndex('ArrowUp', 1, all)).toBe(0);
+  });
+  it('jumps to first/last selectable on Home/End', () => {
+    expect(rovingIndex('Home', 2, all)).toBe(0);
+    expect(rovingIndex('End', 0, all)).toBe(2);
+  });
+  it('skips unavailable destinations when moving', () => {
+    const gap = [true, false, true];
+    expect(rovingIndex('ArrowRight', 0, gap)).toBe(2);
+    expect(rovingIndex('ArrowLeft', 0, gap)).toBe(2);
+    expect(rovingIndex('Home', 1, [false, true, true])).toBe(1);
+    expect(rovingIndex('End', 1, [true, true, false])).toBe(1);
+  });
+  it('stays put when nothing is selectable', () => {
+    expect(rovingIndex('ArrowRight', 1, [false, false])).toBe(1);
+  });
+  it('stays put for an empty group', () => {
+    expect(rovingIndex('ArrowRight', 0, [])).toBe(0);
+  });
+  it('ignores other keys', () => {
+    expect(rovingIndex('Tab', 1, all)).toBe(1);
+  });
+});

--- a/app/renderer/src/features/export/exportModel.ts
+++ b/app/renderer/src/features/export/exportModel.ts
@@ -1,0 +1,255 @@
+// exportModel.ts — the PURE core of the Phase-5 Export screen (v1.5 §4).
+//
+// Export is the ONE irreversible, spend/file-writing action, so it is designed as
+// a GUARDED COMMIT. This module holds the framework-free decisions that guard it —
+// the recognizable per-platform destinations (NEVER codec/bitrate jargon), their
+// availability against the clip length, the pre-flight summary the confirm step
+// restates, and the roving-radiogroup keyboard math — so the React panels stay thin
+// and every branch is unit-testable to 100% without a DOM.
+//
+// Division of labour (the naming fix, §4): Phase-5 "Export" renders/finishes ONE
+// video (this module); the rail "Deliver" owns cross-video/batch publish. The
+// aspect is COMPOSED upstream in Reframe — a destination here governs the length +
+// loudness EXPECTATION and tags the output, it does not re-crop the frame.
+
+import type { EditorState } from '../../lib/editorState';
+import type { ConvertOptions } from '../../lib/rpc';
+import { fmtSeconds } from '../_api';
+import { formatDollars } from '../spendCapLogic';
+
+/**
+ * One recognizable delivery DESTINATION. Named by where the clip is going
+ * (TikTok / Reels / Shorts…), implying its aspect + length — never a codec or
+ * bitrate. `maxSec` is the platform's hard length limit (null = no cap).
+ */
+export interface PlatformPreset {
+  /** Stable id (routing/selection key), never shown to the user. */
+  id: string;
+  /** The destination name shown to the user (e.g. "TikTok"). */
+  name: string;
+  /** One-line "what it's for" blurb. */
+  blurb: string;
+  /** The aspect the destination implies (e.g. "9:16") — display only. */
+  aspect: string;
+  /** The platform's hard length cap in seconds, or null when it has none. */
+  maxSec: number | null;
+  /** Human length expectation (e.g. "Up to 60 sec") — never a bitrate. */
+  lengthHint: string;
+}
+
+/**
+ * The curated destination set. Vertical shorts destinations lead (this is a
+ * shorts-first app), then the tall feed post, the square post, and widescreen.
+ * Together they span the four target aspects (9:16 / 4:5 / 1:1 / 16:9); the
+ * uncapped 1:1 + 16:9 destinations guarantee at least one is always available.
+ */
+export const PLATFORM_PRESETS: readonly PlatformPreset[] = [
+  {
+    id: 'tiktok',
+    name: 'TikTok',
+    blurb: 'Vertical, sound-on, hook first.',
+    aspect: '9:16',
+    maxSec: 600,
+    lengthHint: 'Up to 10 min',
+  },
+  {
+    id: 'reels',
+    name: 'Instagram Reels',
+    blurb: 'Vertical, tightly cut for the feed.',
+    aspect: '9:16',
+    maxSec: 90,
+    lengthHint: 'Up to 90 sec',
+  },
+  {
+    id: 'shorts',
+    name: 'YouTube Shorts',
+    blurb: 'Vertical, hook first, under a minute.',
+    aspect: '9:16',
+    maxSec: 60,
+    lengthHint: 'Up to 60 sec',
+  },
+  {
+    id: 'feed',
+    name: 'Instagram feed',
+    blurb: 'Tall feed post that fills more screen.',
+    aspect: '4:5',
+    maxSec: null,
+    lengthHint: 'Any length',
+  },
+  {
+    id: 'square',
+    name: 'Square post',
+    blurb: 'One-to-one for a grid post.',
+    aspect: '1:1',
+    maxSec: null,
+    lengthHint: 'Any length',
+  },
+  {
+    id: 'widescreen',
+    name: 'Widescreen',
+    blurb: 'Landscape for the big screen.',
+    aspect: '16:9',
+    maxSec: null,
+    lengthHint: 'Any length',
+  },
+];
+
+/** Resolve a preset by id, falling back to the first when the id is unknown. */
+export function presetById(id: string): PlatformPreset {
+  return PLATFORM_PRESETS.find((preset) => preset.id === id) ?? PLATFORM_PRESETS[0];
+}
+
+/** A preset is selectable (`available`) or blocked with a stated `reason`. */
+export type AvailabilityStatus = 'available' | 'unavailable';
+
+/** A destination's availability against the current clip, with a plain reason. */
+export interface PresetAvailability {
+  status: AvailabilityStatus;
+  /** Why it is blocked (plain language); '' when available. */
+  reason: string;
+}
+
+/**
+ * Decide whether a destination can take this clip. The only hard block is a clip
+ * that runs LONGER than the platform's length cap — a real, honest constraint the
+ * user must resolve (trim first) before the guarded commit. Uncapped destinations
+ * (`maxSec === null`) are always available.
+ */
+export function presetAvailability(
+  preset: PlatformPreset,
+  durationSec: number,
+): PresetAvailability {
+  if (preset.maxSec !== null && durationSec > preset.maxSec) {
+    return {
+      status: 'unavailable',
+      reason: `This clip runs longer than the ${fmtSeconds(preset.maxSec)} limit for ${preset.name} — trim it first.`,
+    };
+  }
+  return { status: 'available', reason: '' };
+}
+
+/**
+ * The first available destination id for a clip of this length (the default
+ * selection), falling back to the list's first entry when none fit — so the
+ * matrix always has a selection. `presets` is injectable for testing.
+ */
+export function firstAvailablePresetId(
+  durationSec: number,
+  presets: readonly PlatformPreset[] = PLATFORM_PRESETS,
+): string {
+  const found = presets.find(
+    (preset) => presetAvailability(preset, durationSec).status === 'available',
+  );
+  return found ? found.id : presets[0].id;
+}
+
+/**
+ * A rough LOCAL render-time estimate (seconds). A local h264 finish runs at a
+ * fraction of real time; floored to a few seconds so a tiny clip never estimates
+ * "0". Surfaced with a "~" so it always reads as an estimate, never a promise.
+ */
+export function estimateRenderSec(durationSec: number): number {
+  return Math.max(3, Math.ceil(durationSec * 0.5));
+}
+
+/** The editor window length in seconds — clamped non-negative + finite. */
+export function windowDurationSec(state: EditorState): number {
+  const raw = state.video.window.end - state.video.window.start;
+  return Number.isFinite(raw) ? Math.max(0, raw) : 0;
+}
+
+/** The pre-flight summary the confirm step restates before the guarded commit. */
+export interface Preflight {
+  /** Clips produced by this per-video export (always 1). */
+  clipCount: number;
+  /** The chosen destination's aspect (e.g. "9:16"). */
+  aspect: string;
+  /** The clip length in seconds. */
+  durationSec: number;
+  /** The clip length as M:SS. */
+  durationLabel: string;
+  /** The estimated render time as ~M:SS. */
+  estRenderLabel: string;
+  /** The estimated spend ($0.00 — a local render never spends). */
+  estSpendLabel: string;
+}
+
+/**
+ * Build the pre-flight summary from the shared editor state + the chosen
+ * destination. A per-video export is always ONE clip; the duration is the editor
+ * window (clamped non-negative + finite); the spend is $0 because the render is
+ * LOCAL (never egresses).
+ */
+export function buildPreflight(state: EditorState, preset: PlatformPreset): Preflight {
+  const durationSec = windowDurationSec(state);
+  return {
+    clipCount: 1,
+    aspect: preset.aspect,
+    durationSec,
+    durationLabel: fmtSeconds(durationSec),
+    estRenderLabel: `~${fmtSeconds(estimateRenderSec(durationSec))}`,
+    estSpendLabel: formatDollars(0),
+  };
+}
+
+/** Plain-language caption summary for the bake preview (never color-only). */
+export function captionSummary(state: EditorState): string {
+  const count = state.cues.length;
+  if (count === 0) return 'No captions';
+  return `${count} caption${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * Plain-language framing summary. The presence of a crop plan (Reframe-owned)
+ * means the clip was reframed; the raw engine id is NEVER surfaced (it is a model
+ * codename — the no-jargon rule), only the human "Reframed" vs "Original framing".
+ */
+export function framingSummary(state: EditorState): string {
+  return state.cropPlan ? 'Reframed' : 'Original framing';
+}
+
+/** The single, universal share-ready render profile (mp4/h264 — never shown). */
+export function exportConvertOptions(): ConvertOptions {
+  return {
+    container: 'mp4',
+    vcodec: 'libx264',
+    acodec: 'aac',
+    scale: '',
+    fps: '',
+    crf: '20',
+    audioOnly: false,
+    audioFormat: 'mp3',
+  };
+}
+
+/**
+ * Roving-tabindex math for the destination RADIOGROUP (WAI-ARIA). Arrow keys move
+ * the selection to the next/previous SELECTABLE destination (wrapping, skipping
+ * unavailable ones); Home/End jump to the first/last selectable; any other key
+ * leaves the selection where it is. Returns the next selected index.
+ */
+export function rovingIndex(key: string, current: number, selectable: readonly boolean[]): number {
+  const n = selectable.length;
+  if (n === 0) return current;
+  const scan = (from: number, step: number): number => {
+    for (let i = 0; i < n; i += 1) {
+      const idx = (((from + i * step) % n) + n) % n;
+      if (selectable[idx]) return idx;
+    }
+    return current;
+  };
+  switch (key) {
+    case 'ArrowRight':
+    case 'ArrowDown':
+      return scan(current + 1, 1);
+    case 'ArrowLeft':
+    case 'ArrowUp':
+      return scan(current - 1, -1);
+    case 'Home':
+      return scan(0, 1);
+    case 'End':
+      return scan(n - 1, -1);
+    default:
+      return current;
+  }
+}

--- a/app/renderer/src/views/Deliver.test.tsx
+++ b/app/renderer/src/views/Deliver.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Deliver } from './Deliver';
+import type { Video } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+// Deliver only COMPOSES the (separately-covered) cluster panels; stub them so this
+// test exercises Deliver's own tabs/routing, not the children's mount effects.
+vi.mock('../features/BatchQueue', () => ({
+  BatchQueue: () => <div data-stub="batch-queue" />,
+}));
+vi.mock('../features/ExportPresetsPanel', () => ({
+  ExportPresetsPanel: () => <div data-stub="export-presets" />,
+}));
+vi.mock('../features/NleExport', () => ({
+  NleExport: ({ videoId }: { videoId: string }) => (
+    <div data-stub="nle-export" data-video={videoId} />
+  ),
+}));
+
+const VIDEO: Video = {
+  id: 'v1',
+  path: '/clips/x.mp4',
+  title: 'My Clip',
+  addedAt: '2026-01-01',
+  durationSec: 40,
+  hasTranscript: true,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+const onBack = vi.fn();
+
+beforeEach(() => {
+  onBack.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+const all = (sel: string): Element[] => Array.from(container.querySelectorAll(sel));
+
+function render(video: Video | null): void {
+  act(() => {
+    root.render(<Deliver video={video} onBack={onBack} />);
+  });
+}
+
+const clickTab = (label: string): void => {
+  const tab = all('[role="tab"]').find((el) => el.textContent === label);
+  act(() => (tab as HTMLElement | undefined)?.click());
+};
+
+describe('Deliver view', () => {
+  it('scopes Deliver as batch/cross-video with the target aspect matrix, and routes back', () => {
+    render(VIDEO);
+    expect(q('.deliver-view__title')?.textContent).toBe('Deliver');
+    // The 9:16 / 4:5 / 1:1 / 16:9 aspect matrix is shown.
+    const ratios = all('.deliver-view__aspect-ratio').map((el) => el.textContent);
+    expect(ratios).toEqual(['9:16', '4:5', '1:1', '16:9']);
+    // Batch publish is the default landing.
+    expect(q('[data-stub="batch-queue"]')).not.toBeNull();
+    act(() => q<HTMLButtonElement>('.deliver-view__back')?.click());
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('switches to the platform-preset matrix', () => {
+    render(VIDEO);
+    clickTab('Platform presets');
+    expect(q('[data-stub="export-presets"]')).not.toBeNull();
+    expect(q('[data-stub="batch-queue"]')).toBeNull();
+  });
+
+  it('hands the open video off to the pro-editor export', () => {
+    render(VIDEO);
+    clickTab('Pro handoff');
+    expect(q('[data-stub="nle-export"]')?.getAttribute('data-video')).toBe('v1');
+  });
+
+  it('explains the pro handoff needs an open video when none is open', () => {
+    render(null);
+    clickTab('Pro handoff');
+    expect(q('[data-stub="nle-export"]')).toBeNull();
+    expect(q('.deliver-view__empty')?.textContent).toContain('Open a video from the Library');
+  });
+});

--- a/app/renderer/src/views/Deliver.tsx
+++ b/app/renderer/src/views/Deliver.tsx
@@ -1,0 +1,87 @@
+// Deliver.tsx — the rail "Deliver" destination (v1.5 §4): cross-video / batch
+// publish, the OTHER half of the Export/Deliver split.
+//
+// Naming fix (§4): Phase-5 "Export" finishes ONE video (a guarded commit); this
+// rail "Deliver" owns batch / cross-video publish, the platform-preset (aspect)
+// matrix, and the pro-editor handoff. It reconciles the old Deliver-cluster tabs
+// into ONE named home by COMPOSING the shipped, already-covered panels — BatchQueue
+// (batch publish), ExportPresetsPanel (the 9:16 / 4:5 / 1:1 / 16:9 preset matrix),
+// and NleExport (EDL / CSV pro handoff) — under the TabBar's role=tablist a11y.
+// Finishing Phase-5 links INTO here.
+
+import React, { useState } from 'react';
+import { TabBar, tabId, tabPanelId, type TabDef } from '../components/TabBar';
+import { BatchQueue } from '../features/BatchQueue';
+import { ExportPresetsPanel } from '../features/ExportPresetsPanel';
+import { NleExport } from '../features/NleExport';
+import type { Video } from '../lib/rpc';
+import './deliver.css';
+
+const TABS: TabDef[] = [
+  { id: 'batch', label: 'Batch publish' },
+  { id: 'presets', label: 'Platform presets' },
+  { id: 'handoff', label: 'Pro handoff' },
+];
+
+/** The target aspect matrix Deliver publishes across (display only). */
+const ASPECTS: readonly { ratio: string; label: string }[] = [
+  { ratio: '9:16', label: 'Vertical' },
+  { ratio: '4:5', label: 'Feed' },
+  { ratio: '1:1', label: 'Square' },
+  { ratio: '16:9', label: 'Widescreen' },
+];
+
+export interface DeliverProps {
+  /** The open video (drives the pro-handoff tab); null when none is open. */
+  video: Video | null;
+  onBack: () => void;
+}
+
+export function Deliver({ video, onBack }: DeliverProps): React.ReactElement {
+  const [active, setActive] = useState('batch');
+
+  return (
+    <section className="deliver-view" aria-label="Deliver">
+      <header className="deliver-view__head">
+        <button type="button" className="deliver-view__back" onClick={onBack}>
+          ← Library
+        </button>
+        <h2 className="deliver-view__title">Deliver</h2>
+      </header>
+      <p className="deliver-view__intro">
+        Publish across videos and platforms — batch renders, per-platform presets, and a handoff to
+        your pro editor.
+      </p>
+      <ul className="deliver-view__aspects" aria-label="Target aspect ratios">
+        {ASPECTS.map((aspect) => (
+          <li key={aspect.ratio} className="deliver-view__aspect">
+            <span className="deliver-view__aspect-ratio">{aspect.ratio}</span>
+            <span className="deliver-view__aspect-label">{aspect.label}</span>
+          </li>
+        ))}
+      </ul>
+
+      <TabBar tabs={TABS} active={active} onSelect={setActive} />
+      <div
+        className="deliver-view__panel"
+        role="tabpanel"
+        id={tabPanelId(active)}
+        aria-labelledby={tabId(active)}
+      >
+        {active === 'batch' ? <BatchQueue /> : null}
+        {active === 'presets' ? <ExportPresetsPanel /> : null}
+        {active === 'handoff' ? (
+          video ? (
+            <NleExport videoId={video.id} />
+          ) : (
+            <p className="deliver-view__empty">
+              Open a video from the Library to hand its clips off to Premiere or DaVinci Resolve.
+            </p>
+          )
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+export default Deliver;

--- a/app/renderer/src/views/Export.test.tsx
+++ b/app/renderer/src/views/Export.test.tsx
@@ -1,0 +1,324 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { Export } from './Export';
+import type { DoneEvent, ProgressEvent, Video } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+let hasApiReturn = true;
+let progressCb: ((event: ProgressEvent) => void) | null = null;
+let doneCb: ((event: DoneEvent) => void) | null = null;
+const cuesMock = vi.fn();
+const convertStartMock = vi.fn();
+const jobCancelMock = vi.fn();
+
+vi.mock('../lib/rpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../lib/rpc')>();
+  return {
+    ...actual,
+    hasApi: () => hasApiReturn,
+    onProgress: (cb: (event: ProgressEvent) => void) => {
+      progressCb = cb;
+      return () => {
+        progressCb = null;
+      };
+    },
+    onJobDone: (cb: (event: DoneEvent) => void) => {
+      doneCb = cb;
+      return () => {
+        doneCb = null;
+      };
+    },
+    client: {
+      ...actual.client,
+      captions: { cues: (...args: unknown[]) => cuesMock(...args) },
+      convert: {
+        ...actual.client.convert,
+        start: (...args: unknown[]) => convertStartMock(...args),
+      },
+      job: { ...actual.client.job, cancel: (...args: unknown[]) => jobCancelMock(...args) },
+    },
+  };
+});
+
+const VIDEO: Video = {
+  id: 'v1',
+  path: '/clips/x.mp4',
+  title: 'My Clip',
+  addedAt: '2026-01-01',
+  durationSec: 40,
+  hasTranscript: true,
+};
+
+let container: HTMLDivElement;
+let root: Root;
+const onBack = vi.fn();
+const onDeliver = vi.fn();
+
+beforeEach(() => {
+  hasApiReturn = true;
+  progressCb = null;
+  doneCb = null;
+  cuesMock.mockReset().mockResolvedValue({ cues: [] });
+  convertStartMock.mockReset();
+  jobCancelMock.mockReset().mockResolvedValue({ ok: true });
+  onBack.mockReset();
+  onDeliver.mockReset();
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (globalThis as { window?: { api?: unknown } }).window?.api;
+  vi.restoreAllMocks();
+});
+
+const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function render(video: Video | null): void {
+  act(() => {
+    root.render(<Export video={video} onBack={onBack} onDeliver={onDeliver} />);
+  });
+}
+
+/** Drive the two-step guarded commit: open the confirm gate, then approve. */
+async function commit(): Promise<void> {
+  act(() => q<HTMLButtonElement>('.export-inspector__primary')?.click());
+  act(() => q<HTMLButtonElement>('.export-inspector__confirm-approve')?.click());
+  await flush();
+}
+
+const stageValue = (label: string): string | undefined => {
+  const items = Array.from(container.querySelectorAll('.export-stage__item'));
+  return (
+    items
+      .find((el) => el.querySelector('.export-stage__label')?.textContent === label)
+      ?.querySelector('.export-stage__value')?.textContent ?? undefined
+  );
+};
+
+describe('Export view', () => {
+  it('shows a no-video empty state that routes back to the Library', () => {
+    render(null);
+    expect(q('.export-view__empty-title')?.textContent).toBe('Open a video to export');
+    act(() => q<HTMLButtonElement>('.export-view__back')?.click());
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(cuesMock).not.toHaveBeenCalled();
+  });
+
+  it('seeds the stage and loads the cues being exported', async () => {
+    cuesMock.mockResolvedValue({
+      cues: [
+        { index: 1, start: 1, end: 2, text: 'Hi' },
+        { index: 2, start: 3, end: 4, text: 'there' },
+      ],
+    });
+    render(VIDEO);
+    await flush();
+    expect(cuesMock).toHaveBeenCalledWith('v1');
+    expect(q('.export-view__title')?.textContent).toBe('My Clip');
+    expect(stageValue('Captions')).toBe('2 captions');
+    // Idle: the guarded inspector is shown with a default fitting destination.
+    expect(q('.export-inspector__primary')?.textContent).toBe('Export to TikTok');
+  });
+
+  it('tolerates a missing cue list and a cue-load failure', async () => {
+    cuesMock.mockResolvedValueOnce({});
+    render(VIDEO);
+    await flush();
+    expect(stageValue('Captions')).toBe('No captions');
+    // A rejecting cue load is silently non-blocking.
+    act(() => root.unmount());
+    cuesMock.mockReset().mockRejectedValue(new Error('no cues'));
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+    render(VIDEO);
+    await flush();
+    expect(q('.export-view__title')?.textContent).toBe('My Clip');
+    expect(stageValue('Captions')).toBe('No captions');
+  });
+
+  it('no-ops the whole flow when the bridge is unavailable', async () => {
+    hasApiReturn = false;
+    render(VIDEO);
+    await flush();
+    expect(cuesMock).not.toHaveBeenCalled();
+    await commit();
+    expect(convertStartMock).not.toHaveBeenCalled();
+    // Still idle — the inspector is shown, no progress.
+    expect(q('.export-inspector')).not.toBeNull();
+    expect(q('.export-progress')).toBeNull();
+  });
+
+  it('runs the guarded commit → determinate progress → terminal success (deferred file)', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    expect(convertStartMock).toHaveBeenCalledWith(
+      { videoId: 'v1' },
+      expect.objectContaining({ container: 'mp4', vcodec: 'libx264' }),
+    );
+    // Determinate progress.
+    act(() => progressCb?.({ jobId: 'j1', pct: 60, message: 'Rendering frames…' }));
+    expect(q('.export-progress__pct')?.textContent).toBe('60%');
+    expect(q('.export-progress__message')?.textContent).toBe('Rendering frames…');
+    // A foreign job's progress is ignored.
+    act(() => progressCb?.({ jobId: 'other', pct: 99, message: 'nope' }));
+    expect(q('.export-progress__pct')?.textContent).toBe('60%');
+    // Terminal file arrives via job.done.
+    await act(async () => {
+      doneCb?.({ jobId: 'j1', result: { path: '/exports/final.mp4' } });
+      await flush();
+    });
+    expect(q('.export-result')?.className).toContain('is-done');
+    expect(q('.export-result__path')?.textContent).toBe('/exports/final.mp4');
+  });
+
+  it('accepts an immediate output path (fast direct-return)', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1', path: '/exports/fast.mp4' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    expect(q('.export-result')?.className).toContain('is-done');
+    expect(q('.export-result__path')?.textContent).toBe('/exports/fast.mp4');
+  });
+
+  it('treats a finish with no file as a failure', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    await act(async () => {
+      doneCb?.({ jobId: 'j1', result: {} });
+      await flush();
+    });
+    expect(q('.export-result')?.className).toContain('is-failed');
+    expect(q('.export-result__error')?.textContent).toBe(
+      'The export finished without producing a file.',
+    );
+  });
+
+  it('surfaces a start failure as a terminal failure with a retry', async () => {
+    convertStartMock.mockRejectedValue(new Error('ffmpeg missing'));
+    render(VIDEO);
+    await flush();
+    await commit();
+    expect(q('.export-result')?.className).toContain('is-failed');
+    expect(q('.export-result__error')?.textContent).toBe('ffmpeg missing');
+    // Retry returns to the idle inspector.
+    act(() => q<HTMLButtonElement>('.export-result__again')?.click());
+    expect(q('.export-inspector')).not.toBeNull();
+  });
+
+  it('stringifies a non-Error start rejection', async () => {
+    convertStartMock.mockRejectedValue('weird failure');
+    render(VIDEO);
+    await flush();
+    await commit();
+    expect(q('.export-result')?.className).toContain('is-failed');
+    expect(q('.export-result__error')?.textContent).toBe('weird failure');
+  });
+
+  it('cancels an in-flight export (abort + job.cancel) → terminal cancelled', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    expect(q('.export-progress')).not.toBeNull();
+    await act(async () => {
+      q<HTMLButtonElement>('.export-progress__cancel')?.click();
+      await flush();
+    });
+    expect(jobCancelMock).toHaveBeenCalledWith('j1');
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+  });
+
+  it('cancels cleanly even when job.cancel rejects', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1' });
+    jobCancelMock.mockRejectedValue(new Error('cancel boom'));
+    render(VIDEO);
+    await flush();
+    await commit();
+    await act(async () => {
+      q<HTMLButtonElement>('.export-progress__cancel')?.click();
+      await flush();
+    });
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+  });
+
+  it('cancels before the job id resolves (abort settles the pending wait)', async () => {
+    let resolveStart!: (value: { jobId: string }) => void;
+    convertStartMock.mockReturnValue(
+      new Promise<{ jobId: string }>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    render(VIDEO);
+    await flush();
+    await commit(); // convert.start is still pending here
+    expect(q('.export-progress')).not.toBeNull();
+    // Cancel while there is no jobId yet: job.cancel is NOT called.
+    act(() => q<HTMLButtonElement>('.export-progress__cancel')?.click());
+    expect(jobCancelMock).not.toHaveBeenCalled();
+    // Now the start resolves; the already-aborted wait settles to cancelled.
+    await act(async () => {
+      resolveStart({ jobId: 'late' });
+      await flush();
+    });
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+  });
+
+  it('reveals the output file and continues into Deliver on success', async () => {
+    const openInFolderMock = vi.fn().mockResolvedValue(true);
+    (globalThis as { window: { api?: unknown } }).window.api = { openInFolder: openInFolderMock };
+    convertStartMock.mockResolvedValue({ jobId: 'j1', path: '/exports/final.mp4' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    act(() => q<HTMLButtonElement>('.export-result__reveal')?.click());
+    expect(openInFolderMock).toHaveBeenCalledWith('/exports/final.mp4');
+    act(() => q<HTMLButtonElement>('.export-result__deliver')?.click());
+    expect(onDeliver).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps reveal best-effort when the folder bridge rejects', async () => {
+    const openInFolderMock = vi.fn().mockRejectedValue(new Error('explorer crashed'));
+    (globalThis as { window: { api?: unknown } }).window.api = { openInFolder: openInFolderMock };
+    convertStartMock.mockResolvedValue({ jobId: 'j1', path: '/exports/final.mp4' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    await act(async () => {
+      q<HTMLButtonElement>('.export-result__reveal')?.click();
+      await flush();
+    });
+    expect(openInFolderMock).toHaveBeenCalled();
+    // No crash; the result still stands.
+    expect(q('.export-result')?.className).toContain('is-done');
+  });
+
+  it('hides the reveal control when no folder bridge is available', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1', path: '/exports/final.mp4' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    expect(q('.export-result__path')?.textContent).toBe('/exports/final.mp4');
+    expect(q('.export-result__reveal')).toBeNull();
+  });
+});

--- a/app/renderer/src/views/Export.tsx
+++ b/app/renderer/src/views/Export.tsx
@@ -1,0 +1,238 @@
+// Export.tsx — the Phase-5 EXPORT view (v1.5 §4): a per-video render as a GUARDED
+// COMMIT, and the ONE irreversible, spend/file-writing action.
+//
+// The integration point: it seeds the shared EditorContext from the open video,
+// best-effort loads that video's cues (so the stage summarizes the captions being
+// baked), and composes the shared Stage + the guarded-commit Inspector. On the
+// explicit confirm it starts the LOCAL render (`client.convert.start`), tracks
+// DETERMINATE progress (`onProgress`), waits for the terminal file
+// (`waitForJobDone`), and offers a REAL cancel (`job.cancel` + an abort). Terminal
+// SUCCESS wires the output file to a "Show in folder" reveal and links INTO Deliver;
+// terminal FAILURE/cancel surface an assertive alert with a recovery action.
+//
+// Division of labour (§4): this is Phase-5 (finish ONE video). The rail "Deliver"
+// owns cross-video/batch publish; finishing here links into it via `onDeliver`.
+
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { type ConvertOptions, type Video, client, hasApi, onJobDone, onProgress } from '../lib/rpc';
+import type { EditorSeed } from '../lib/editorState';
+import {
+  DEFAULT_JOB_TIMEOUT_MS,
+  JobAbortedError,
+  pickField,
+  waitForJobDone,
+} from '../features/_api';
+import { EditorProvider, useEditor } from '../features/EditorContext';
+import { ExportStage } from '../features/export/ExportStage';
+import { ExportInspector } from '../features/export/ExportInspector';
+import { ExportProgress } from '../features/export/ExportProgress';
+import { ExportResult, type ExportOutcome } from '../features/export/ExportResult';
+import type { PlatformPreset } from '../features/export/exportModel';
+import './export.css';
+
+/** idle → running → a terminal outcome (done / failed / cancelled). */
+type ExportPhase = 'idle' | 'running' | ExportOutcome;
+
+/** Resolve the OS "reveal in folder" bridge (window.api.openInFolder), or null. */
+function openInFolderBridge(): ((path: string) => Promise<boolean>) | null {
+  const api = (globalThis as { window?: { api?: { openInFolder?: unknown } } }).window?.api;
+  return api && typeof api.openInFolder === 'function'
+    ? (api.openInFolder as (path: string) => Promise<boolean>)
+    : null;
+}
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export interface ExportProps {
+  video: Video | null;
+  onBack: () => void;
+  /** Continue into the Deliver (batch/cross-video) surface after a finish. */
+  onDeliver: () => void;
+}
+
+/** Inner workspace: a context consumer that loads cues + drives the guarded render. */
+function ExportWorkspace({
+  video,
+  onBack,
+  onDeliver,
+}: {
+  video: Video;
+  onBack: () => void;
+  onDeliver: () => void;
+}): React.ReactElement {
+  const { dispatch } = useEditor();
+  const [phase, setPhase] = useState<ExportPhase>('idle');
+  const [pct, setPct] = useState(0);
+  const [message, setMessage] = useState('');
+  const [paths, setPaths] = useState<string[]>([]);
+  const [error, setError] = useState('');
+  const [destination, setDestination] = useState('');
+  const jobId = useRef<string | null>(null);
+  // A live controller is always present (replaced per commit) so `cancel` never
+  // needs a null guard — a stale abort with nothing awaiting it is harmless.
+  const abort = useRef<AbortController>(new AbortController());
+
+  // Best-effort: load the cues being exported so the stage can summarize them. The
+  // export never REQUIRES captions, so a load failure is silently non-blocking.
+  useEffect(() => {
+    if (!hasApi()) return;
+    void client.captions
+      .cues(video.id)
+      .then((res) => dispatch({ type: 'setCues', cues: res.cues ?? [] }))
+      .catch(() => {
+        // best-effort: the clip still exports without a caption summary.
+      });
+  }, [video.id, dispatch]);
+
+  const onCommit = useCallback(
+    async (preset: PlatformPreset, options: ConvertOptions): Promise<void> => {
+      if (!hasApi()) return;
+      setPhase('running');
+      setPct(0);
+      setMessage('Starting…');
+      setDestination(preset.name);
+      setPaths([]);
+      setError('');
+      const controller = new AbortController();
+      abort.current = controller;
+      let offProgress = (): void => {};
+      try {
+        const res = await client.convert.start({ videoId: video.id }, options);
+        const id = res.jobId;
+        jobId.current = id;
+        offProgress = onProgress((event) => {
+          if (event.jobId !== id) return;
+          setPct(event.pct);
+          setMessage(event.message);
+        });
+        let outPath: string | null = res.path ?? null;
+        if (!outPath) {
+          outPath = await waitForJobDone(
+            { onJobDone },
+            id,
+            (result) => pickField<string>(result, 'path'),
+            DEFAULT_JOB_TIMEOUT_MS,
+            controller.signal,
+          );
+        }
+        if (outPath) {
+          setPaths([outPath]);
+          setPct(100);
+          setMessage('Done');
+          setPhase('done');
+        } else {
+          setError('The export finished without producing a file.');
+          setPhase('failed');
+        }
+      } catch (err) {
+        if (err instanceof JobAbortedError) {
+          setPhase('cancelled');
+          return;
+        }
+        setError(errText(err));
+        setPhase('failed');
+      } finally {
+        offProgress();
+        jobId.current = null;
+      }
+    },
+    [video.id],
+  );
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // Abort the terminal wait (settles the UI to 'cancelled'), then stop the job.
+    abort.current.abort();
+    const id = jobId.current;
+    if (!id) return;
+    try {
+      await client.job.cancel(id);
+    } catch {
+      // best-effort: the abort already settled the UI to 'cancelled'.
+    }
+  }, []);
+
+  const reset = useCallback(() => setPhase('idle'), []);
+
+  const openFolder = openInFolderBridge();
+  const reveal = openFolder
+    ? (path: string): void => {
+        void openFolder(path).catch(() => {
+          // best-effort: opening the OS folder is a convenience, not the export.
+        });
+      }
+    : undefined;
+
+  return (
+    <section className="export-view" aria-label="Export">
+      <header className="export-view__head">
+        <button type="button" className="export-view__back" onClick={onBack}>
+          ← Library
+        </button>
+        <h2 className="export-view__title">{video.title}</h2>
+      </header>
+      <div className="export-view__body">
+        <div className="export-view__stage">
+          <ExportStage />
+        </div>
+        <div className="export-view__panel">
+          {phase === 'idle' ? (
+            <ExportInspector onCommit={(preset, options) => void onCommit(preset, options)} />
+          ) : phase === 'running' ? (
+            <ExportProgress
+              destination={destination}
+              pct={pct}
+              message={message}
+              onCancel={() => void cancel()}
+            />
+          ) : (
+            <ExportResult
+              outcome={phase}
+              destination={destination}
+              paths={paths}
+              error={error}
+              onReveal={reveal}
+              onDeliver={onDeliver}
+              onExportAgain={reset}
+            />
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function Export({ video, onBack, onDeliver }: ExportProps): React.ReactElement {
+  if (!video) {
+    return (
+      <section className="export-view export-view--empty" aria-label="Export">
+        <div className="export-view__empty">
+          <h2 className="export-view__empty-title">Open a video to export</h2>
+          <p className="export-view__empty-blurb">
+            Pick a video from the Library to render and finish it for a platform.
+          </p>
+          <button type="button" className="export-view__back" onClick={onBack}>
+            ← Library
+          </button>
+        </div>
+      </section>
+    );
+  }
+
+  const seed: EditorSeed = {
+    video: {
+      videoId: video.id,
+      window: { start: 0, end: video.durationSec },
+      durationSec: video.durationSec,
+    },
+  };
+
+  return (
+    <EditorProvider key={video.id} seed={seed}>
+      <ExportWorkspace video={video} onBack={onBack} onDeliver={onDeliver} />
+    </EditorProvider>
+  );
+}
+
+export default Export;

--- a/app/renderer/src/views/deliver.css
+++ b/app/renderer/src/views/deliver.css
@@ -1,0 +1,110 @@
+/* deliver.css — the rail Deliver view layout (v1.5 §4). Tokens ONLY. */
+
+.deliver-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  min-height: 0;
+}
+
+.deliver-view__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.deliver-view__back {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.deliver-view__back:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.deliver-view__back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.deliver-view__title {
+  margin: 0;
+  font-size: var(--type-title-size);
+  font-weight: var(--type-title-weight);
+  letter-spacing: var(--type-title-tracking);
+  color: var(--text-primary);
+}
+
+.deliver-view__intro {
+  margin: 0;
+  max-width: 60ch;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}
+
+/* The target aspect matrix — small, informational destination chips. */
+.deliver-view__aspects {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.deliver-view__aspect {
+  display: flex;
+  align-items: baseline;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-pill);
+  box-shadow: var(--elev-1);
+}
+
+.deliver-view__aspect-ratio {
+  font-family: var(--font-mono);
+  font-size: var(--type-control-size);
+  font-variant-numeric: tabular-nums;
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+}
+
+.deliver-view__aspect-label {
+  font-size: var(--type-chip-size);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.deliver-view__panel {
+  min-width: 0;
+}
+
+.deliver-view__empty {
+  margin: 0;
+  padding: var(--space-6);
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  box-shadow: var(--elev-1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .deliver-view__back {
+    transition: none;
+  }
+}

--- a/app/renderer/src/views/export.css
+++ b/app/renderer/src/views/export.css
@@ -1,0 +1,105 @@
+/* export.css — the Phase-5 Export view layout (v1.5 §4). Tokens ONLY. */
+
+.export-view {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding: var(--space-5);
+  min-height: 0;
+}
+
+.export-view__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.export-view__back {
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.export-view__back:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.export-view__back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+.export-view__title {
+  margin: 0;
+  font-size: var(--type-title-size);
+  font-weight: var(--type-title-weight);
+  letter-spacing: var(--type-title-tracking);
+  color: var(--text-primary);
+}
+
+/* Shared stage on the left; the guarded-commit panel on the right. Collapses to a
+ * single column on a narrow window so nothing overflows horizontally. */
+.export-view__body {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(320px, 400px);
+  gap: var(--space-5);
+  align-items: start;
+}
+
+.export-view__stage {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+.export-view__panel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .export-view__body {
+    grid-template-columns: minmax(0, 1fr);
+  }
+}
+
+/* No-video empty state. */
+.export-view--empty {
+  align-items: center;
+  justify-content: center;
+  min-height: 60vh;
+}
+
+.export-view__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  text-align: center;
+  padding: var(--space-8);
+}
+
+.export-view__empty-title {
+  margin: 0;
+  font-family: var(--font-editorial);
+  font-size: var(--type-subhead-size);
+  color: var(--text-primary);
+}
+
+.export-view__empty-blurb {
+  margin: 0;
+  max-width: 40ch;
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+  color: var(--text-secondary);
+}


### PR DESCRIPTION
## What & why

Builds the **Export** screen from the v1.5 direction (§4) — the most state-critical
screen, the ONE irreversible, spend/file-writing action — and reconciles the
**Export / Deliver** naming + division of labour.

- **Phase-5 "Export"** = per-video render/finish, designed as a **guarded commit**.
- **Rail "Deliver"** = cross-video/batch publish + platform presets + the aspect matrix.
- Finishing Phase-5 **links INTO** Deliver.

Built on the **shipped `tokens.css`** (never the prototype hex) and the **merged
`EditorContext`** (inspector-over-shared-stage), composing existing components — not
rewriting them.

## The guarded commit (Export)

- **Shared stage** (`ExportStage`) previews the clip and summarizes what is baked —
  length, captions (from the cues), framing (reframed vs original; the reframe engine
  id is never surfaced — no jargon). Consumes `video` / `cues` / `cropPlan`.
- **Pre-flight summary**: clips · aspect · duration · est. time · est. cost.
- **Per-platform preset matrix** (`PresetMatrix`): a real `fieldset`/`radiogroup`
  (`role="radio"` + `aria-checked`, roving-tabindex, **arrow-key** selectable) with
  **selected / disabled / unavailable** states (a clip longer than a platform's length
  cap is blocked with a stated reason). Destinations are recognizable (TikTok / Reels /
  Shorts / Feed / Square / Widescreen) implying aspect + length — **never** codec/bitrate.
- **Hierarchy**: ONE amber approve action, ranked **above** the matrix by scale + the
  `--elev` ladder (not equal-weight tiles).
- **Explicit confirm gate** before the render fires (two-step commit).
- **Determinate progress + a REAL cancel** (`ExportProgress`) — the Wave-0 real-cancel's
  UI home (`job.cancel` + an abort of the terminal wait); amber tabular-nums.
- **Terminal states** (`ExportResult`): SUCCESS wires the output file to a "Show in
  folder" reveal (`openInFolder`) and a **Continue to Deliver** link; FAILURE / partial /
  cancel surface an **assertive `role="alert"`** with a recovery action.
- **Privacy beat** restated in the AA-safe quiet step; panel `overflow-y:auto` so the CTA
  is never clipped.

## The Deliver split

`views/Deliver.tsx` composes the shipped, already-covered cluster under `TabBar`:
`BatchQueue` (batch publish) + `ExportPresetsPanel` (the 9:16 / 4:5 / 1:1 / 16:9 preset
matrix) + `NleExport` (EDL/CSV pro handoff), with the target-aspect strip. `Convert`'s
format/codec concern stays at Phase-5 render; Dub is NOT here (it's Edit & Audio).

## App wiring (minimal + additive)

Appended the Export + Deliver rail destinations, their routes, and the Export→Deliver
link. No restructuring of the existing nav.

## Gate results (actual)

- `tsc --noEmit`: **clean**.
- `vitest run --coverage`: **199 files / 3393 tests passed, 0 failed**;
  renderer coverage **100%** lines/branches/functions/statements (18903/18903 stmts,
  6278/6278 branches).
- `tokens.conformance.test.ts`: **green (25 tests)**.
- `oxlint --deny-warnings` + `biome format` + `pre-commit run`: **passed** (gitleaks clean).
- No new `/* v8 ignore */`, `istanbul ignore`, or `.skip`; all hardening kept.

## DoD (§8)

- **Contrast / tokens**: shipped tokens only; conformance ladder green. ✅
- **Keyboard**: matrix is a role-complete radiogroup with visible `--focus-ring`;
  every control is a native element. ✅
- **State completeness**: empty (no video), loading (cue best-effort), busy
  (confirm-locked matrix + determinate progress), terminal success + failure/cancel;
  errors announce via `aria-live`. ✅
- **Motion**: `prefers-reduced-motion` neutralizes all transitions. ✅
- **One-accent discipline**: amber only; status green/amber/red; no second hue. ✅
- **Voice**: no jargon/model codenames in user strings. ✅
- **IA integrity**: Export/Deliver both have wired homes; finishing links into Deliver. ✅

## Reviewer notes / judgment calls (honest)

- **Privacy sentence**: there is no single canonical "Studio inspector" privacy sentence
  in the codebase (`FirstRunChooser`/`ModelsSystemPanel`/`PresetPicker` each phrase it
  differently). Since a Phase-5 export is a genuinely **local** render, I used the
  established local-first phrasing — *"Everything runs on your computer — nothing is
  uploaded."* Flagging for alignment if a canonical sentence is preferred.
- **Terminal failure** is surfaced via `ExportResult`'s assertive `role="alert"` + the
  global `SidecarBanner`, matching the Caption pilot's inline-error convention (no extra
  toast). This satisfies the DoD "errors announce via aria-live".
- **Aspect is composed upstream in Reframe.** Phase-5 renders one universal share-ready
  mp4; the destination governs length/loudness expectation + the length-cap availability
  guard (documented in `exportModel.ts`). `cropPlan` is currently `null` (the Reframe
  phase isn't built yet) → framing reads "Original framing" until Reframe threads a
  cropPlan into the seed; the consumption path is already wired.
- **Spend guard**: a local export has no egress/spend, so est. cost is `$0.00` and the
  privacy beat is the reassurance — I did **not** fabricate a `providers.spend` call for a
  local action. `SpendCap`/`BatchConsentCard` remain on the batch/Deliver side (BatchQueue
  already consumes `BatchConsentCard`).
- **Two top tabs** (Export + Deliver) added, mirroring how the Caption pilot was added;
  the redesign will later consolidate the top bar into a rail + phase stepper.

https://claude.ai/code/session_01M7yMAVChqv4LXKjEPaV8Dq
