### PR TITLE
fix: resolve code-scanning alert #1752 (critical WSL command-line injection)

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -85,8 +85,10 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 
 ## 4. Engine interfaces (exactly ONE impl each in this build)
 - `ReframeEngine.reframe(in_path, out_path, aspect="9:16") -> out_path` — sole impl = **verthor** adapter.
-  Verthor runs under **WSL2**; invoke its script **FROM A FILE** (`wsl bash <script> <args>`), NEVER pipe a
-  script via `tr|bash` (mediapipe consumes stdin and corrupts the script — proven gotcha). Output 1080x1920 h264.
+  Verthor runs under **WSL2**; invoke its script **FROM A FILE** (`wsl --exec bash <script> <args>` — `--exec`
+  bypasses the WSL default shell so every arg reaches bash as verbatim exec argv, never re-joined/re-parsed;
+  without it wsl.exe space-joins the tail into `$SHELL -c`, an in-WSL injection surface, CodeQL #1752), NEVER pipe
+  a script via `tr|bash` (mediapipe consumes stdin and corrupts the script — proven gotcha). Output 1080x1920 h264.
 - `CaptionEngine.render(clip_path, cues, out_path, burn=True, width=1080, height=1920) -> out_path` — sole impl
   = **libass via ffmpeg**. Generate ASS sized for width x height; **cue times re-based to the clip (subtract
   sourceStart)**; **escape cue text** (no raw `{`/`}` ASS override injection). burn=True hardcodes; burn=False soft-mux.

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -34,3 +34,10 @@
 # GHSA-35p6-xmwp-9g52, GHSA-g8m3-5g58-fq7m). Fixed by adding "undici": "^6.27.0" to
 # app/package.json overrides (same pattern as esbuild/ws). No ignore needed.
 # ---------------------------------------------------------------------------
+# 2026-07-18 SECURITY UPGRADE — setuptools (sidecar transitive via ctranslate2)
+# bumped 82.0.1 -> 83.0.0 in sidecar/requirements.lock.txt to clear
+# PYSEC-2026-3447 (CVSS 6.1 Medium; fixed release exists, so per the policy
+# above it is an upgrade, not an ignore). Surgical one-pin edit — pyproject's
+# build-system needs only setuptools>=68; re-`uv pip compile` on the next real
+# sidecar dep change will keep or advance this pin. No ignore needed.
+# ---------------------------------------------------------------------------

--- a/sidecar/media_studio/features/reframe.py
+++ b/sidecar/media_studio/features/reframe.py
@@ -14,21 +14,30 @@ rather than being silently substituted.
 
 The verthor adapter: verthor (a mediapipe-based auto-reframer) runs inside its
 own **WSL2** environment, so we invoke it as a Windows-host subprocess that
-shells into WSL:
+enters WSL:
 
-    ["wsl", "bash", <script_path_in_wsl>, <in>, <out>, <aspect>, <w>, <h>]
+    ["wsl", "--exec", "bash", <script_path_in_wsl>, <in>, <out>, <aspect>, <w>, <h>]
+
+``--exec`` is load-bearing: without it, ``wsl.exe`` space-joins the argument
+tail and runs it through the WSL DEFAULT SHELL (``$SHELL -c``), so shell
+metacharacters in the translated media paths would be interpreted inside WSL
+and paths with spaces would word-split (CodeQL #1752,
+``py/command-line-injection``). With ``--exec`` the command is exec'd with this
+verbatim argv — no inner shell ever re-parses the arguments.
 
 THE GOTCHA (proven, see §4): NEVER pipe the verthor script into bash via
 ``tr | bash`` over **stdin**. mediapipe inside verthor reads from stdin and
 corrupts a script delivered that way. The script MUST be passed as an *argv*
-element (``wsl bash <script> ...``) so it is read FROM A FILE, leaving stdin free.
+element (``wsl --exec bash <script> ...``) so it is read FROM A FILE, leaving
+stdin free.
 
 Everything here is pure argv construction + a thin, injectable ``runner`` seam so
 the whole module is unit-testable with no WSL, no mediapipe, and no real verthor.
 Output is 1080x1920 h264 (vertical 9:16) per the contract.
 
-CONTRACTS.md §4/§6: argv-list subprocess only (never ``shell=True``); paths with
-spaces stay intact because each is its own argv element; logs go to stderr.
+CONTRACTS.md §4/§6: argv-list subprocess only (never ``shell=True``, never an
+inner WSL shell — ``--exec``); paths with spaces stay intact because each is its
+own argv element and nothing re-joins them; logs go to stderr.
 """
 
 from __future__ import annotations
@@ -53,10 +62,10 @@ DEFAULT_ASPECT = "9:16"
 OUT_WIDTH = 1080
 OUT_HEIGHT = 1920
 
-# CONTRACT-NOTE: §4 names "verthor" and "wsl bash <script>" but does not pin the
-# script's on-disk location. We resolve it (settings -> env -> bundled default)
-# the same way ffmpeg.py resolves its binary, and translate it (plus the media
-# paths) to a WSL path so `wsl bash` can read the file. The bundled default is
+# CONTRACT-NOTE: §4 names "verthor" and "wsl --exec bash <script>" but does not
+# pin the script's on-disk location. We resolve it (settings -> env -> bundled
+# default) the same way ffmpeg.py resolves its binary, and translate it (plus the
+# media paths) to a WSL path so `wsl --exec bash` can read the file. The bundled default is
 # the package's own scripts/verthor_reframe.sh (matches build_reframe_argv's
 # argv contract; Phase-0 fix — the old /opt/verthor placeholder existed nowhere).
 # Override via settings.verthorScript / env.
@@ -158,8 +167,9 @@ def resolve_script(settings: dict[str, Any] | None = None) -> str:
 
     Order: ``settings.verthorScript`` -> env ``MEDIA_STUDIO_VERTHOR_SCRIPT`` ->
     the bundled default. The result is always translated to a WSL path so
-    ``wsl bash <script>`` can open the file. The script is read FROM A FILE — it
-    is never piped through stdin (the proven mediapipe-corruption gotcha).
+    ``wsl --exec bash <script>`` can open the file. The script is read FROM A
+    FILE — it is never piped through stdin (the proven mediapipe-corruption
+    gotcha).
     """
     settings = settings or {}
     raw = settings.get("verthorScript") or os.environ.get("MEDIA_STUDIO_VERTHOR_SCRIPT") or _DEFAULT_VERTHOR_SCRIPT
@@ -177,21 +187,28 @@ def build_reframe_argv(
     aspect: str = DEFAULT_ASPECT,
     settings: dict[str, Any] | None = None,
 ) -> list[str]:
-    """Build the ``wsl bash <script> ...`` argv for a verthor reframe.
+    """Build the ``wsl --exec bash <script> ...`` argv for a verthor reframe.
 
-    Shape (§4): ``["wsl", "bash", <script>, <in>, <out>, <aspect>, <w>, <h>]``.
+    Shape (§4): ``["wsl", "--exec", "bash", <script>, <in>, <out>, <aspect>, <w>, <h>]``.
 
-    - The script is the THIRD argv element (``bash``'s positional file argument),
-      i.e. read FROM A FILE. There is no ``-c``, no ``tr``, no ``|``, and nothing
-      goes to bash's stdin — that is the whole point of the contract gotcha.
+    - ``--exec`` makes ``wsl.exe`` exec the command with this VERBATIM argv.
+      Without it, wsl space-joins the tail and runs it through the WSL default
+      shell (``$SHELL -c``) — metacharacters in the translated media paths would
+      be shell-interpreted inside WSL and spaces would word-split (CodeQL #1752,
+      ``py/command-line-injection``).
+    - The script is ``bash``'s positional file argument, i.e. read FROM A FILE.
+      There is no ``-c``, no ``tr``, no ``|``, and nothing goes to bash's stdin —
+      that is the whole point of the contract gotcha.
     - Media paths are translated to ``/mnt/...`` WSL paths and kept as single
-      argv elements, so paths with spaces survive (no ``shell=True``).
+      argv elements, so paths with spaces survive (no ``shell=True``, no inner
+      shell).
     - Width/height are passed so the script targets 1080x1920 (h264) for 9:16.
     """
     width, height = output_dimensions(aspect)
     script = resolve_script(settings)
     return [
         "wsl",
+        "--exec",
         "bash",
         script,
         to_wsl_path(in_path),
@@ -291,7 +308,8 @@ class ReframeEngine:
     ) -> str:
         """Reframe ``in_path`` to vertical and write ``out_path``; return it.
 
-        Invokes verthor under WSL as ``wsl bash <script> <args>`` (script read
+        Invokes verthor under WSL as ``wsl --exec bash <script> <args>``
+        (``--exec`` = no WSL default shell, args reach bash verbatim; script read
         FROM A FILE, never piped via ``tr|bash`` on stdin). Output is 1080x1920
         h264 for the default 9:16 aspect. Raises :class:`ReframeError` on a
         non-zero exit code.

--- a/sidecar/requirements.lock.txt
+++ b/sidecar/requirements.lock.txt
@@ -166,7 +166,7 @@ scenedetect==0.7
     # via media-studio-sidecar (sidecar/pyproject.toml)
 segments==2.4.0
     # via phonemizer-fork
-setuptools==82.0.1
+setuptools==83.0.0
     # via ctranslate2
 shellingham==1.5.4
     # via typer

--- a/sidecar/tests/test_reframe.py
+++ b/sidecar/tests/test_reframe.py
@@ -205,10 +205,11 @@ def test_build_reframe_argv_is_wsl_bash_script_from_file():
         {"verthorScript": "/opt/verthor/reframe.sh"},
     )
     assert isinstance(argv, list)
-    # wsl bash <script> ... — script is the THIRD element, read FROM A FILE.
+    # wsl --exec bash <script> ... — script read FROM A FILE; --exec means
+    # wsl.exe execs this verbatim argv (no WSL default-shell re-parse).
     assert argv[0] == "wsl"
-    assert argv[1] == "bash"
-    assert argv[2] == "/opt/verthor/reframe.sh"
+    assert argv[1:3] == ["--exec", "bash"]
+    assert argv[3] == "/opt/verthor/reframe.sh"
     # The script is a bare positional path: NOT bash -c, NOT a stdin string.
     assert "-c" not in argv
 
@@ -221,8 +222,8 @@ def test_build_reframe_argv_no_stdin_script_no_tr_bash_pipe():
     assert "|" not in joined  # no shell pipe anywhere in the argv
     assert "<" not in joined  # no stdin redirection
     # bash receives a FILE argument, not "-c" inline source.
-    assert argv[1] == "bash"
-    assert argv[2].endswith(".sh")
+    assert argv[1:3] == ["--exec", "bash"]
+    assert argv[3].endswith(".sh")
     assert "-c" not in argv
 
 
@@ -266,6 +267,28 @@ def test_build_reframe_argv_each_path_is_one_element():
     )
     assert "/mnt/c/My Clips/talk one.mp4" in argv
     assert "/mnt/c/Out Dir/talk one v.mp4" in argv
+
+
+def test_build_reframe_argv_exec_keeps_hostile_paths_verbatim_single_elements():
+    # CodeQL #1752 regression (py/command-line-injection): WITHOUT --exec,
+    # wsl.exe space-joins the argument tail and runs it through the WSL DEFAULT
+    # SHELL ($SHELL -c), so `$(...)`/`;`/backticks in a translated media path
+    # would execute inside WSL and spaces would word-split. --exec makes wsl
+    # exec bash with this VERBATIM argv — the no-inner-shell contract: every
+    # hostile path stays exactly ONE argv element, and --exec precedes any
+    # user-derived argument.
+    argv = reframe.build_reframe_argv(
+        r"C:\Downloads\clip $(touch pwned); rm -rf x.mp4",
+        r"C:\Out Dir\a & b `id`.mp4",
+        "9:16",
+        {"verthorScript": "/opt/verthor/reframe.sh"},
+    )
+    assert argv[:3] == ["wsl", "--exec", "bash"]
+    # in/out land as single, byte-identical elements — never re-joined or split.
+    assert argv[4] == "/mnt/c/Downloads/clip $(touch pwned); rm -rf x.mp4"
+    assert argv[5] == "/mnt/c/Out Dir/a & b `id`.mp4"
+    # full fixed shape: wsl --exec bash <script> <in> <out> <aspect> <w> <h>
+    assert len(argv) == 9
 
 
 # --------------------------------------------------------------------------- #
@@ -331,8 +354,8 @@ def test_reframe_call_is_from_file_not_stdin_script():
     engine.reframe(r"C:\in\clip.mp4", r"C:\out\clip.mp4")
 
     argv = popen.calls[0]["argv"]
-    # 1) script is read FROM A FILE: wsl bash <script-path> ...
-    assert argv[:3] == ["wsl", "bash", "/opt/verthor/reframe.sh"]
+    # 1) script is read FROM A FILE: wsl --exec bash <script-path> ...
+    assert argv[:4] == ["wsl", "--exec", "bash", "/opt/verthor/reframe.sh"]
     # 2) no inline source / no stdin script delivery
     assert "-c" not in argv
     joined = " ".join(argv)


### PR DESCRIPTION
## What

Fixes the single open code-scanning alert on `Prekzursil/Reframe`:

- **#1752 — `py/command-line-injection` (severity: critical)** at `sidecar/media_studio/features/reframe.py:319` — CodeQL: "This command line depends on a user-provided value." ([alert](https://github.com/Prekzursil/Reframe/security/code-scanning/1752))

## Root cause

The verthor reframe adapter invoked WSL as `["wsl", "bash", <script>, <in>, <out>, ...]`. Without `--exec`, `wsl.exe` **space-joins the argument tail and runs it through the WSL default shell (`$SHELL -c`)**. That inner shell is a real injection surface: shell metacharacters in the translated media paths (`$(...)`, backticks, `;`, `&`) would be interpreted inside WSL, and paths containing spaces would word-split.

## Fix

- `build_reframe_argv` now emits `["wsl", "--exec", "bash", <script>, ...]` — `--exec` makes `wsl.exe` exec the command with the verbatim argv; **no inner shell ever re-parses the arguments** (host side was already argv-list `Popen`, never `shell=True`).
- New regression test `test_build_reframe_argv_exec_keeps_hostile_paths_verbatim_single_elements` drives hostile paths (`$(touch pwned); rm -rf`, backticks, `&`, spaces) through the builder and pins: `--exec` precedes any user-derived argument, every hostile path stays exactly ONE byte-identical argv element, fixed 9-element shape.
- Existing argv-shape tests updated for the new element order.
- `CONTRACTS.md` §4 updated so the load-bearing `--exec` is contract, not accident (this repo treats CONTRACTS.md as the frozen wire surface).

Files: `sidecar/media_studio/features/reframe.py`, `sidecar/tests/test_reframe.py`, `CONTRACTS.md`.

## For the human reviewer — dismissal guidance

- **If CodeQL re-analysis still reports alert #1752 after this change:** the remaining "taint" is inherent — the user's own media paths must reach the subprocess argv for the app to function (that is its purpose). With `--exec` + argv-list `Popen`, no shell interprets those arguments on either side of the WSL boundary. In that case, dismiss #1752 as **"won't fix / used in safe context"** with the reason: *"argv-list exec via `wsl --exec`; no inner shell; each user-derived path is a single verbatim argv element (regression-tested with hostile paths)"*.
- Nothing else to dismiss: Reframe had exactly **one** open code-scanning alert at branch time.

## Second commit — unrelated osv-gate unblock (disclosed)

The PR's first CI run went red on exactly one step: `quality / gate-deps osv-scanner`, because the **brand-new advisory [PYSEC-2026-3447](https://osv.dev/PYSEC-2026-3447)** (setuptools 82.0.1, CVSS 6.1 Medium, fixed in 83.0.0) landed in the live OSV database *after* main's last green `quality` run — **main's identical lockfile would fail the same gate today**; this is environmental drift, not something this branch introduced. All other gates (tests+coverage 100%, lint, SAST, licenses, and all three CodeQL analyses) passed on that same run.

Per the repo's own `osv-scanner.toml` policy (clean-zero via upgrade when a safe fix exists; ignores only for unfixable/unreachable), commit `5a72267` surgically bumps the one pin `setuptools 82.0.1 -> 83.0.0` in `sidecar/requirements.lock.txt` (+ dated chronicle entry in `osv-scanner.toml`). Kept as its own commit, clearly separated from the CodeQL #1752 fix, so it can be reviewed (or dropped) independently.

## Scope + honesty notes

- Fleet-sweep context: the sweep covers "ReDoS + errors + trivial cleanups" across repos; on THIS repo the single alert is a critical command-line injection — there are **no ReDoS alerts in Reframe** (those are in momentstudio).
- **Pre-existing red on main (unrelated, untouched):** the nightly/on-demand `e2e` workflow legs `e2e-gui (windows-latest)` and `e2e-sidecar (real pipeline + AI/nasty markers)` were already failing on main head `396d950` before this branch existed. `e2e.yml` has no `push`/`pull_request` trigger, so it never gates this PR. This PR is scoped to the alert fix only.
- The PR-gating `quality` workflow (and all three CodeQL analyses) were GREEN on main head `396d950`.

## Verification

- Full sidecar suite with the exact CI gate command (`pytest --cov=media_studio --cov-branch --cov-fail-under=100`): **5840 passed, 5 skipped, 51 deselected — TOTAL 100.00% (18775 stmts / 4792 branches, 0 missed, 0 partial)**.
- `ruff check` + `ruff format --check` clean on both changed Python files.
- `gitleaks` on the diff: no leaks. No `--no-verify` anywhere; the diff is argv construction, tests, and docs only.
