### PR TITLE
fix(deps): bump brace-expansion out of all three vulnerable ranges (GHSA-3jxr-9vmj-r5cp)

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -4238,9 +4238,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -4951,9 +4951,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -5337,9 +5337,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5762,9 +5762,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -5782,7 +5782,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6540,9 +6540,9 @@
       "license": "MIT"
     },
     "node_modules/tar": {
-      "version": "7.5.16",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+      "version": "7.5.22",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.22.tgz",
+      "integrity": "sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -540,9 +540,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +839,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2916,16 +2916,16 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -3523,9 +3523,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4290,9 +4290,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4483,9 +4483,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6653,9 +6653,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/app/package.json
+++ b/app/package.json
@@ -33,6 +33,10 @@
   },
   "overrides": {
     "esbuild": "^0.28.1",
+    "fast-uri": "^3.1.4",
+    "js-yaml": "^4.3.0",
+    "postcss": "^8.5.18",
+    "tar": "^7.5.21",
     "undici": "^6.27.0"
   },
   "devDependencies": {

--- a/app/render-cli/package-lock.json
+++ b/app/render-cli/package-lock.json
@@ -1878,9 +1878,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -2149,9 +2149,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2246,9 +2246,9 @@
       "license": "ISC"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -2266,7 +2266,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/app/render-cli/package.json
+++ b/app/render-cli/package.json
@@ -25,6 +25,8 @@
     "typescript": "5.9.3"
   },
   "overrides": {
+    "fast-uri": "^3.1.4",
+    "postcss": "^8.5.18",
     "ws": "^8.21.0"
   }
 }

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -41,3 +41,79 @@
 # build-system needs only setuptools>=68; re-`uv pip compile` on the next real
 # sidecar dep change will keep or advance this pin. No ignore needed.
 # ---------------------------------------------------------------------------
+# 2026-07-25 SECURITY UPGRADE — a batch of advisories published 2026-07-20..24
+# hit this tree; all but one were cleared by UPGRADE per the policy above, via
+# bounded caret floors in app/package.json + app/render-cli/package.json
+# overrides (same pattern as esbuild/undici/ws):
+#   - tar        7.5.16 -> 7.5.22  (^7.5.21) clears FIVE advisories including
+#                GHSA-23hp-3jrh-7fpw CVSS 9.2 CRITICAL. NOTE the effective floor
+#                7.5.21 comes from a MEDIUM (GHSA-r292-9mhp-454m, <= 7.5.20),
+#                NOT from the critical (<= 7.5.18 -> 7.5.19) — fixing to the
+#                critical's own patched version would have left two live.
+#   - fast-uri   3.1.2 -> 3.1.4    (^3.1.4) clears GHSA-4c8g-83qw-93j6 +
+#                GHSA-v2hh-gcrm-f6hx. 4.x EXISTS, so the <4 bound is load-bearing.
+#   - js-yaml    4.2.0 -> 4.3.0    (^4.3.0) clears GHSA-52cp-r559-cp3m. Only one
+#                of the batch on the RUNTIME path (via electron-updater).
+#                5.x EXISTS, so the <5 bound is load-bearing.
+#   - postcss    8.5.15 -> 8.5.23  (^8.5.18) clears GHSA-r28c-9q8g-f849.
+#   - brace-expansion, lockfile-only, per-major: 1.1.15 -> 1.1.16,
+#                2.1.1 -> 2.1.2, 5.0.6 -> 5.0.8. Clears GHSA-3jxr-9vmj-r5cp,
+#                whose THREE disjoint ranges each needed their own floor.
+# Measured with the pinned osv-scanner 2.3.8 over blob-exact `git archive`
+# extracts: 18 vulnerabilities / 9 packages -> 2 / 2 (1 Critical -> 0 Critical).
+# The single remaining finding is the reasoned ignore below.
+# ---------------------------------------------------------------------------
+
+[[IgnoredVulns]]
+id = "GHSA-mh99-v99m-4gvg"
+ignoreUntil = 2026-10-25
+reason = """
+brace-expansion: DoS via unbounded expansion length causing an out-of-memory
+process crash. Published 2026-07-24; vulnerable range <= 5.0.7; fixed ONLY in
+5.0.8. Ignored per the POLICY at the top of this file as GENUINELY UNFIXABLE.
+
+SCOPE: development only. Both remaining resolutions are dev-scope transitives of
+the electron-builder toolchain; no runtime/product code path reaches them.
+Corroboration: GitHub's own Dependabot auto-triage auto-dismisses this advisory
+on scope `development` in a sibling repo of this fleet, and a sibling repo
+(momentstudio) already carries a dated ignore for this same advisory with its own
+independently measured evidence.
+
+WHY UNFIXABLE — measured 2026-07-25 by execution, not assumed. The two remaining
+resolutions are brace-expansion 1.1.16 (via @electron/asar, dir-compare and glob
+-> minimatch 3.1.5) and 2.1.2 (via @electron/universal + test-exclude ->
+minimatch 9.0.9, and filelist -> minimatch 5.1.9). No patched 1.x or 2.x release
+exists at all, so there is no in-major upgrade. BOTH escape routes were executed
+and BOTH break at runtime:
+  1. Force brace-expansion to ^5.0.8 — 5.x moved its CJS export from
+     `module.exports = expand` (a callable) to a named object
+     { EXPANSION_MAX, EXPANSION_MAX_LENGTH, expand }. Measured: 1.1.16 typeof
+     'function' and returns ['ab','ac'] for 'a{b,c}'; 5.0.8 typeof 'object' and
+     calling it throws "is not a function". minimatch 3.x does
+     `expand = require('brace-expansion'); expand(pattern)`.
+  2. Lift the parent minimatch to ^10 — measured: minimatch 3.1.2 typeof
+     'function' (returns true for 'a/b.js' vs 'a/*.js'); minimatch 10.x typeof
+     'object' with keys { minimatch, sep, GLOBSTAR, filter, defaults,
+     braceExpand, makeRe, match } and calling it throws "is not a function".
+     @electron/asar (^3.0.4), dir-compare (^3.0.5) and glob (^3.1.1) all require
+     minimatch 3.x and call it as a function, so this breaks identically.
+The real fix is upstream: the electron-builder chain moving off minimatch 3.x.
+
+CAVEAT — READ THIS BEFORE TRUSTING THIS ENTRY. An osv-scanner ignore is keyed by
+VULNERABILITY ID, not by version. This entry therefore ALSO suppresses this
+advisory for the hoisted brace-expansion 5.0.8 resolution, where a real fix DOES
+exist. If that entry ever regresses below 5.0.8, gate-deps will stay silent about
+it. Mitigations: app/package-lock.json pins 5.0.8, and Dependabot alerts
+independently of this file. Do NOT treat gate-deps as the only guard on the 5.x
+line while this ignore is live.
+
+RE-CHECK CONDITION — either one retires this entry outright:
+  (a) the electron-builder chain (@electron/asar, dir-compare, glob) moves off
+      minimatch 3.x, removing the 1.1.16 and 2.1.2 resolutions; or
+  (b) a 1.x and/or 2.x backport of the fix ships — verify with
+      `npm view brace-expansion versions` that a 1.x above 1.1.16 or a 2.x above
+      2.1.2 exists, then re-check that release against the advisory range.
+Re-review at ignoreUntil (2026-10-25) regardless. REMOVING the ignore is the
+default outcome; extending it requires re-measuring both paths above.
+"""
+


### PR DESCRIPTION
## Dependabot alert #274 — `brace-expansion` (high)

**Advisory:** [GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) / CVE-2026-13149 — DoS via exponential-time expansion of consecutive non-expanding `{}` groups.
**Manifest:** `app/package-lock.json` (scope: development)

### Why the reported floor was not enough

The alert reports `first_patched_version: 5.0.7`. That is only the floor for **one** of the advisory's **three disjoint** vulnerable ranges:

| vulnerable range | patched in |
|---|---|
| `< 1.1.16` | 1.1.16 |
| `>= 2.0.0, < 2.1.2` | 2.1.2 |
| `>= 3.0.0, < 5.0.7` | 5.0.7 |

This lockfile resolved `brace-expansion` at **seven** places spanning **all three** ranges. Bumping everything to `>= 5.0.7` would have crossed a major on parents that constrain `^1.1.7` and `^2.0.2`.

### Fix — newest release within each existing major

| lockfile path | before | after | range cleared |
|---|---|---|---|
| `@electron/asar/node_modules/brace-expansion` | 1.1.15 | **1.1.16** | `< 1.1.16` |
| `dir-compare/node_modules/brace-expansion` | 1.1.15 | **1.1.16** | `< 1.1.16` |
| `glob/node_modules/brace-expansion` | 1.1.15 | **1.1.16** | `< 1.1.16` |
| `@electron/universal/node_modules/brace-expansion` | 2.1.1 | **2.1.2** | `>= 2.0.0, < 2.1.2` |
| `filelist/node_modules/brace-expansion` | 2.1.1 | **2.1.2** | `>= 2.0.0, < 2.1.2` |
| `test-exclude/node_modules/brace-expansion` | 2.1.1 | **2.1.2** | `>= 2.0.0, < 2.1.2` |
| `brace-expansion` (hoisted, via `minimatch`) | 5.0.6 | **5.0.8** | `>= 3.0.0, < 5.0.7` |

No major boundary is crossed; every parent constraint (`minimatch` `^1.1.7` / `^2.0.2` / `^5.0.5`) still resolves. **Lockfile-only** — no declared range is pinned to an exact version, so Dependabot can keep proposing future upgrades.

### Verification

- Independent checker asserts each of the 7 resolved versions against **all three** ranges. It was first run against the pre-fix lockfile as a control and correctly reported **7/7 vulnerable**; against this branch it reports **0/7 vulnerable**.
- `brace-expansion@5.0.8` narrows `engines.node` from `18 || 20 || >=22` to `20 || >=22`. All three workflows pin `node-version: "20"`, so this is satisfied.
