### PR TITLE
fix(build): unblock the Windows package — record the 3 empty SHA-256 pins, re-pin ffmpeg to a durable month-end tag

### DIFF
--- a/build/python-embed-setup.ps1
+++ b/build/python-embed-setup.ps1
@@ -39,28 +39,48 @@ param(
     [string]$PythonVersion = '3.12.10',
     [string]$Dest = (Join-Path $PSScriptRoot 'python-embed'),
     # REQUIRED (WU-S10): empty => the download is REFUSED, nothing is staged.
-    # Obtain with -RecordHashes and cross-check against python.org's published
-    # SHA-256 for python-<ver>-embed-amd64.zip before recording it here.
-    [string]$ExpectedPythonSha256 = '',
+    # RECORDED 2026-07-26. python.org publishes MD5 (NOT SHA-256) on the release
+    # page, so the two-signal check is: fetch over TLS, confirm the bytes against
+    # the vendor's published MD5 for THIS EXACT row, then pin the SHA-256 of those
+    # verified bytes. Vendor MD5 fe8ef205f2e9c3ba44d0cf9954e1abd3 (matched).
+    # PARSE WARNING: the release-page MD5 column follows the filename inside the
+    # same <tr>. Scanning BACKWARDS from the filename yields the PREVIOUS row's
+    # digest (arm64.exe) and a false "supply chain mismatch" — scope to the row.
+    [string]$ExpectedPythonSha256 = '4acbed6dd1c744b0376e3b1cf57ce906f9dc9e95e68824584c8099a63025a3c3',
     # The dedicated py3.14 embed for the isolated chatterbox env (A4).
     [string]$ChatterboxPythonVersion = '3.14.0',  # human pins the exact patch on first verified run
     [string]$ChatterboxDest = (Join-Path $PSScriptRoot 'python-embed-314'),
     # REQUIRED (WU-S10) — same as above, for the py3.14 embed zip.
-    [string]$ExpectedChatterboxPythonSha256 = '',
+    # RECORDED 2026-07-26, same two-signal method. Vendor MD5
+    # 7c5d8d8e3213a11bd0e36f8b8eb03431 (matched). NOTE: this URL 404'd as recently
+    # as 2026-07-18 (3.14.0 was not yet published), which is why an earlier CI run
+    # failed here for a DIFFERENT reason than the empty pin. It is live now.
+    [string]$ExpectedChatterboxPythonSha256 = '8d4d3590c10449d78aa4375f534e6d5f3027d67fdc362dd1a882279db6f90fdf',
     [switch]$WithFfmpeg,
     # Pinned ffmpeg build (WU A3): BtbN win64-LGPL STATIC (~138 MB zip). BtbN is
     # the only mainstream source with a redistribution-safe LGPL static Windows
     # build (gyan.dev main builds are all --enable-gpl); an UNMODIFIED LGPL exe
     # invoked as a separate child process is redistribution-safe in a closed-
-    # source app. PINNED release tag: autobuild-2026-07-03-13-21 (durable dated
-    # asset, not the rolling `latest` tag), FFmpeg n7.1.5 line. The extractor
-    # below also copies the zip's LICENSE.txt next to the exes (LGPL obligation:
-    # ship the license + record this exact source tag).
-    [string]$FfmpegUrl = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-07-03-13-21/ffmpeg-n7.1.5-1-g7d0e842004-win64-lgpl-7.1.zip',
+    # source app. FFmpeg n7.1.5 line. The extractor below also copies the zip's
+    # LICENSE.txt next to the exes (LGPL obligation: ship the license + record
+    # this exact source tag).
+    #
+    # *** PIN A MONTH-END TAG ONLY. *** BtbN's retention is TWO-TIER, and getting
+    # this wrong silently breaks the Windows build weeks later:
+    #   - the last ~2 weeks of DAILY autobuilds are kept, then deleted;
+    #   - only the LAST-DAY-OF-MONTH build is retained long-term (~2 years:
+    #     2026-06-30, 2026-05-31, ... back to 2024-08-31 as of 2026-07-26).
+    # The previous pin, autobuild-2026-07-03-13-21, was a MID-MONTH DAILY. It was
+    # pruned and began returning 404, which failed `Stage packaged runtime` on
+    # every Windows CI run. Re-pinned 2026-07-26 to the 2026-06-30 month-end tag,
+    # which carries the SAME asset (identical filename + ffmpeg commit
+    # g7d0e842004) and is retained for years rather than days.
+    [string]$FfmpegUrl = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n7.1.5-1-g7d0e842004-win64-lgpl-7.1.zip',
     # REQUIRED (WU-S10) when -WithFfmpeg is used: empty => the download is
-    # REFUSED. BtbN publishes no per-asset checksum file, so obtain it with
-    # -RecordHashes and record the digest of the exact pinned release asset.
-    [string]$ExpectedFfmpegSha256 = '',
+    # REFUSED. BtbN publishes no per-asset checksum file, so this is the digest of
+    # the exact pinned asset, recorded 2026-07-26 (132 MB; verified to contain
+    # bin/ffmpeg.exe, bin/ffprobe.exe and LICENSE.txt).
+    [string]$ExpectedFfmpegSha256 = 'ec1c6ae03fab10f316344973f83c549b4b662ec3d73f1658353ab1587f4cf727',
     [string]$FfmpegDest = (Join-Path (Join-Path $PSScriptRoot 'ffmpeg') 'win'),
     [string]$GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py',
     # get-pip.py is DOWNLOADED then EXECUTED, so it is the most important pin

--- a/sidecar/tests/test_supply_chain_pins.py
+++ b/sidecar/tests/test_supply_chain_pins.py
@@ -23,6 +23,7 @@ covers the WU-S10 pinning deltas.
 
 from __future__ import annotations
 
+import calendar
 import re
 from pathlib import Path
 
@@ -225,6 +226,59 @@ class TestEmbedSetupPinIsMandatory:
         # even set". It must be gone.
         body = self._body()
         assert "if ($ExpectedSha256 -and" not in body
+
+    def test_every_pin_default_is_populated(self):
+        """Every ``-Expected*Sha256`` default must BE a 64-hex digest, not ''.
+
+        WU-S10 made the pin mandatory but shipped three of them EMPTY
+        (``ExpectedPythonSha256``, ``ExpectedChatterboxPythonSha256``,
+        ``ExpectedFfmpegSha256``). The gate then did exactly what it promised and
+        refused every download, so `Stage packaged runtime` failed on every
+        Windows CI run and the Windows package could not be built at all. The
+        sibling tests above only prove the MECHANISM exists (Assert-Sha256Pin is
+        called, no `-and` short-circuit) — none of them notice that the mechanism
+        has nothing to check against. A fail-closed guard with no key is not a
+        guard, it is an outage.
+        """
+        body = self._body()
+        found = dict(re.findall(r"\$(Expected\w*Sha256)\s*=\s*'([^']*)'", body))
+        # All four artifacts the script can fetch must carry a pin default.
+        assert set(found) >= {
+            "ExpectedPythonSha256",
+            "ExpectedChatterboxPythonSha256",
+            "ExpectedFfmpegSha256",
+            "ExpectedGetPipSha256",
+        }, f"a pin parameter disappeared from the param block: {sorted(found)}"
+        empty = sorted(name for name, value in found.items() if not value)
+        assert not empty, (
+            f"these SHA-256 pins ship EMPTY, so the fail-closed gate refuses the "
+            f"download and nothing can ever be staged: {empty}. Obtain each digest "
+            f"with -RecordHashes, cross-check it against the vendor's published "
+            f"checksum, then record it as the parameter default."
+        )
+        malformed = sorted(name for name, value in found.items() if not re.fullmatch(r"[0-9a-f]{64}", value))
+        assert not malformed, f"pins are not lowercase 64-hex digests: {malformed}"
+
+    def test_pinned_ffmpeg_release_is_a_month_end_tag(self):
+        """BtbN prunes mid-month dailies; only month-end builds are durable.
+
+        Retention measured 2026-07-26: the last ~2 weeks of DAILY autobuilds plus
+        the LAST-DAY-OF-MONTH build of every month back to 2024-08-31. The former
+        pin ``autobuild-2026-07-03-13-21`` was a mid-month daily, so it was
+        deleted and started returning 404 — breaking the Windows build weeks after
+        it was chosen, with no code change. Pin a month-end tag or the same silent
+        expiry recurs.
+        """
+        body = self._body()
+        tag = re.search(r"releases/download/autobuild-(\d{4})-(\d{2})-(\d{2})-", body)
+        assert tag, "the ffmpeg pin is not a BtbN dated autobuild URL"
+        year, month, day = (int(part) for part in tag.groups())
+        last_day = calendar.monthrange(year, month)[1]
+        assert day == last_day, (
+            f"ffmpeg is pinned to autobuild-{year:04d}-{month:02d}-{day:02d}, a MID-MONTH "
+            f"daily that BtbN deletes after ~2 weeks. Pin the month-end build "
+            f"({year:04d}-{month:02d}-{last_day:02d}), which is retained for years."
+        )
 
     def test_get_pip_pin_matches_the_runtime_constant(self):
         # The build script and the runtime enforce the SAME get-pip.py digest;


### PR DESCRIPTION
## Why

`Stage packaged runtime (embeddable CPython + ffmpeg)` failed on **every** Windows CI run, so the Windows package could not be built at all. Two independent blockers — one of them introduced by WU-S10 in #304.

### Blocker 1 — WU-S10 shipped three mandatory pins EMPTY

WU-S10 made the SHA-256 pin mandatory and fail-closed. That part is correct. But `ExpectedPythonSha256`, `ExpectedChatterboxPythonSha256` and `ExpectedFfmpegSha256` were left as `''`, and the gate then did exactly what it promised:

```
FAILED:python-embed-setup refusing to download ...python-3.14.0-embed-amd64.zip
: -ExpectedChatterboxPythonSha256 is empty. A SHA-256 pin is MANDATORY
```

`e2e.yml:209` invokes the script with no pin arguments, so the parameter defaults are the only source. A fail-closed guard with no key is not a guard, it is an outage.

### Blocker 2 — the pinned ffmpeg asset was deleted upstream

BtbN retention is **two-tier**: the last ~2 weeks of *daily* autobuilds, plus the **last-day-of-month** build of every month back to `2024-08-31` (37 releases spanning 692 days, measured 2026-07-26). Our pin `autobuild-2026-07-03-13-21` was a **mid-month daily**, so it was pruned and began returning 404 weeks after it was chosen, with no code change. The source comment described it as a "durable dated asset" — false for that tag shape.

## What changed

- **Python pins recorded with two independent signals.** python.org publishes **MD5, not SHA-256**, on its release page, so: fetch over TLS → confirm the bytes against the vendor MD5 for *that exact table row* → pin the SHA-256 of the verified bytes.

  | artifact | vendor MD5 | recorded SHA-256 |
  |---|---|---|
  | `python-3.12.10-embed-amd64.zip` | `fe8ef205…abd3` | `4acbed6d…a3c3` |
  | `python-3.14.0-embed-amd64.zip` | `7c5d8d8e…3431` | `8d4d3590…0fdf` |

- **ffmpeg re-pinned to the `2026-06-30` month-end tag** — same asset (identical filename and ffmpeg commit `g7d0e842004`), retained for years instead of days. `ec1c6ae0…f727`, 132 MB.
- `get-pip.py` pin unchanged (already populated, already matches the runtime constant).

A parse trap is recorded in the source: the MD5 column **follows** the filename inside the same `<tr>`. Scanning backwards from the filename returns the *previous* row's digest (`arm64.exe`) and manufactures a false "supply-chain mismatch". That happened during this work and was caught only by re-parsing row-scoped.

## Verified end to end, not by inspection

The real script, `-WithFfmpeg`, against temp destinations:

```
SUCCESS:python-embed-setup staged python-embed + python-embed-314 + ffmpeg
EXITCODE=0

python-embed      36 files   23.6 MB   python.exe, get-pip.py present
python-embed-314  37 files   23.9 MB   python.exe present
ffmpeg-win         3 files  206.4 MB   ffmpeg.exe, ffprobe.exe, LICENSE.txt

staged binary executes:  ffmpeg version n7.1.5-1-g7d0e842004-20260630
```

All four downloads matched their recorded pins.

## Regression tests — the gap that let this ship

The existing WU-S10 tests prove the *mechanism* exists (`Assert-Sha256Pin` is called before the request, no `-and` short-circuit) but none of them notice the mechanism has nothing to check against.

- `test_every_pin_default_is_populated` — every `-Expected*Sha256` default must be a lowercase 64-hex digest, and all four artifacts must carry one.
- `test_pinned_ffmpeg_release_is_a_month_end_tag` — the BtbN tag day must equal the last day of its month, so a prunable mid-month daily cannot be pinned again.

**Both validated in both directions.** Against the broken state (empty pin + `2026-07-03` tag) they fail with actionable messages; restored, the module is `20 passed`.

## Gates

| gate | result |
|---|---|
| `pytest --cov --cov-branch --cov-fail-under=100` | **6069 passed**, 5 skipped, **100.00%**, exit 0 |
| `pre-commit run --files <changed>` | ruff lint + format + gitleaks **Passed** |
| PowerShell parser | 0 syntax errors |
| PSScriptAnalyzer | no new findings (pre-existing `Write-Host`, which is deliberate — the script emits `SUCCESS:`/`FAILED:` markers) |

## Not fixed here, and not caused by this change

`e2e-sidecar` fails 3 tests (`test_hub_budget_gate_refuses_unacked_cloud_run`, plus two `intel_repurpose` tests): the provider pool tries `local` first and exhausts on `no GGUF model configured` before reaching the mock HTTP endpoint.

Verified pre-existing **by cause, not by step name** — the baseline run at `97600e86` fails the identical three tests with the identical error (`3 failed, 44 passed`). That distinction matters: an earlier control comparison in this program matched only step *names* and produced a wrong "pre-existing" verdict, which is what let Blocker 1 above go unnoticed.
