### PR TITLE
chore(release): bump 1.4.1 -> 1.4.2 (maintenance: security + a11y + packaging)

### DIFF
--- a/app/main/brand.test.ts
+++ b/app/main/brand.test.ts
@@ -112,8 +112,15 @@ describe('app/package.json — v1.4 version + productName (WU A1 / WU-R2)', () =
     name: string;
   };
 
-  it('version is bumped to 1.4.1', () => {
-    expect(pkg.version).toBe('1.4.1');
+  // This pin is deliberate: it forces every version change to be a CONSCIOUS edit
+  // rather than drift. 1.4.2 is a maintenance bump over the shipped v1.4.1 tag —
+  // 8 security audit fixes (incl. the settings.set executable-path write refusal),
+  // the Windows packaged-runtime unblock, the critical dangling-aria-controls fix,
+  // and refreshed visual baselines. NOT 1.5.0: the locked v1.5 scope (4 flagships,
+  // keystone RPC refactor, full pro-shell redesign) is still unlanded, so claiming
+  // the 1.5 line here would overstate what shipped.
+  it('version is bumped to 1.4.2', () => {
+    expect(pkg.version).toBe('1.4.2');
   });
 
   it('productName is the display brand "Reframe"', () => {

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "media-studio",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "media-studio",
-      "version": "1.4.1",
+      "version": "1.4.2",
       "license": "UNLICENSED",
       "dependencies": {
         "electron-updater": "^6.8.9",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "media-studio",
   "productName": "Reframe",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Local personal video-manager desktop app (Electron + Python sidecar)",
   "private": true,
   "type": "module",


### PR DESCRIPTION
chore(release): bump 1.4.1 -> 1.4.2 (maintenance: security + a11y + packaging)

The tree still declared 1.4.1 — the version already SHIPPED and tagged (v1.4.1) —
so a local build produced `media-studio-1.4.1-win-x64.exe`, indistinguishable from
the installed app. Concretely that breaks three things:
  * NSIS treats an equal version as a repair/reinstall rather than an upgrade;
  * electron-updater compares versions, so the build is never seen as newer;
  * the artifact name mislabels real work (`artifactName: ${name}-${version}-...`).

1.4.2, NOT 1.5.0. What actually landed since the v1.4.1 tag is maintenance:
  * 8 security audit fixes (#304) — criticals C1-C3 incl. the `settings.set`
    executable/script-path write refusal that closed the RCE chain, plus
    T4/T5/T7/T8/T9a/T11/T12/T13;
  * the Windows packaged-runtime unblock (#307) — recorded the 3 empty SHA-256
    pins and re-pinned ffmpeg to a durable month-end BtbN tag;
  * the CRITICAL dangling-`aria-controls` a11y fix (#308), two defects: TabBar
    emitted the attribute on every tab while consumers render one panel, and
    MakeShorts rendered no tabpanel at all;
  * refreshed all 8 Windows visual baselines (stale since the 2026-07-11 shell
    token reconciliation and the 2026-07-18 font bundling).
No new features. The LOCKED v1.5 scope — 4 flagship features, the keystone
schema-first RPC refactor, and the full pro-shell redesign — is still unlanded, so
tagging this 1.5.0 would tell a future reader the v1.5 program shipped when it has
not. Owner decision, recorded as B-1 in .audit/GRILL-DECISION-QUEUE.md.

VERSION-PIN TEST UPDATED, NOT DELETED. `app/main/brand.test.ts` asserts the exact
version on purpose — it forces every bump to be a conscious edit instead of drift.
Retargeted to 1.4.2 with the rationale inline so the next reader knows why it is
not 1.5.0.

LOCKFILE kept in sync (`app/package-lock.json` root `.version` and
`packages[""].version`), because CI runs `npm ci` and compares them.

TRAP AVOIDED: a naive find/replace of "1.4.1" would have corrupted ~10 unrelated
references to **WCAG 1.4.1** ("Use of Color") across the renderer — readinessMeta,
ReadinessBadge, providersKeysLogic, spendCapLogic, schemas.ts and others. Only the
two genuine version sites were touched. (`updateVerify.test.ts` also contains
'1.4.1'/'1.4.2' but as DOWNGRADE-CHECK FIXTURES, not as the app version — left alone.)

VERIFIED
    app/main/brand.test.ts + main/updateVerify.test.ts   46/46 passed
    npm ls                                              exit 0, lock in sync
    pre-commit (oxlint, biome, gitleaks)                 Passed

The full 1.4.1 packaging pipeline was already validated end-to-end before this bump
(electron-builder exit 0: win-unpacked/Reframe.exe, NSIS .exe, portable .zip and
blockmap all produced), so this changes only the version the same pipeline stamps.
