### PR TITLE
test: validated functional sweep (no dead/throwing controls) + fix the red pool-routing e2e

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,8 @@ build/icon/
 # .audit/join_by_agentid.py; the CURATED output is tracked at
 # docs/validation/v15-audit-ledger.md. ~10 MB, never commit.
 .audit/
+
+# On-demand functional-sweep output (e2e/audit + playwright.audit.config.ts).
+# Findings are transient investigation data; the FIX lands as code + tests, so
+# the raw report is never committed.
+app/audit-artifacts/

--- a/app/e2e/audit/deadclick.audit.spec.ts
+++ b/app/e2e/audit/deadclick.audit.spec.ts
@@ -1,0 +1,494 @@
+// e2e/audit/deadclick.audit.spec.ts — the functional "does every control DO
+// something" sweep across every reachable surface of the real app.
+//
+// WHY THIS EXISTS
+// The acceptance bar is "no broken buttons": every interactive control either
+// does something observable, or is legitimately inert (disabled / already in the
+// requested state). A screenshot cannot prove that and a unit test only proves
+// the handler a developer remembered to wire. So this drives the REAL built
+// Electron app + live sidecar (e2e/fixtures.ts) and clicks everything.
+//
+// THE MEASUREMENT PROBLEM (and why a naive version is worthless)
+// The obvious detector — "did the DOM mutate after the click?" — reports
+// EVERYTHING as alive on any app that changes on its own. Measured directly
+// against a page with a 100ms ticker: a bare MutationObserver count found 0 of 2
+// planted dead buttons, i.e. a confident false green. Reframe polls job status
+// and animates progress, so it is exactly that kind of app.
+//
+// The fix is a CONTROL WINDOW. For every control we observe the page for the
+// same duration WITHOUT clicking, recording a stable signature per mutated node;
+// that is the ambient set. Then we click and record again, and only signatures
+// absent from the ambient set count as an effect of the click.
+//
+// ERROR DIRECTION IS DELIBERATE. If a click only touches a node that also churns
+// ambiently, it reads as 'none' — a false DEAD. That is the safe direction: a
+// false dead is filtered by review, whereas a false ALIVE silently ships a
+// broken control, which is the defect this sweep exists to catch.
+//
+// An uncaught handler throw surfaces as 'pageerror', NOT as a console message
+// (measured), and is a DIFFERENT defect from a dead control — wired but broken.
+// It is reported as its own flag so it cannot hide inside a "0 dead" headline.
+//
+// Output: audit-artifacts/deadclick.json + a summary table on stdout.
+
+import { test, expect, type Page } from '@playwright/test';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { launchSeededApp, prepareWindow } from '../visual/_visualSetup';
+
+/** Where the machine-readable report lands (repo-relative, gitignored). */
+const OUT_DIR = join(process.cwd(), 'audit-artifacts');
+
+/** Per-control observation window. Must exceed React's commit + a poll tick. */
+const WINDOW_MS = 450;
+
+/**
+ * Controls we refuse to click, with the reason. Two classes:
+ *   - DESTRUCTIVE: would delete library/user data, or uninstall a runtime.
+ *   - SPENDING/EGRESS: would start a cloud job or a multi-GB model download.
+ * The seeded data root is a throwaway, so destruction is contained — but a
+ * cloud-run click could spend real money if a key is present in the inherited
+ * environment, and a model download would stall the sweep for tens of minutes.
+ * Every skip is REPORTED, never silently dropped: a sweep that quietly avoids
+ * the scary half of the UI and then reports "0 dead" is a lie by omission.
+ */
+const SKIP_PATTERNS: ReadonlyArray<{ re: RegExp; reason: string }> = [
+  { re: /\b(delete|remove|clear|reset|wipe|uninstall|forget)\b/i, reason: 'destructive' },
+  { re: /\b(install|download|fetch model|provision)\b/i, reason: 'multi-GB download / provisioning' },
+  { re: /\b(run in cloud|cloud run|start cloud|purchase|buy|upgrade plan)\b/i, reason: 'spending / egress' },
+  { re: /\b(quit|exit|restart app|sign out|log out)\b/i, reason: 'ends the session under test' },
+];
+
+interface ControlRecord {
+  surface: string;
+  index: number;
+  identity: string;
+  tag: string;
+  role: string | null;
+  name: string;
+  /**
+   * 'none'          — clicked, nothing observable happened => a real dead-control candidate
+   * 'already-active'— clicked while aria-selected/aria-pressed was already true, so a
+   *                   no-op is CORRECT (a segmented control or the current tab). Split
+   *                   out from 'none' because otherwise every surface reports its own
+   *                   tab as dead and the headline number is meaningless.
+   * 'dom' | 'network' | 'dialog' — observable effect
+   * 'error'         — could not be actuated / identity drifted => NOT evidence of dead
+   * 'skipped' | 'disabled'
+   */
+  effect: string;
+  /** Was the control already in the selected/pressed state before the click? */
+  wasActive?: boolean;
+  ambientSignatures: number;
+  attributedSignatures: number;
+  requestsAmbient: number;
+  requestsAfterClick: number;
+  pageError?: string;
+  clickError?: string;
+  skipReason?: string;
+}
+
+/** In-page: install a mutation recorder that stores stable per-node signatures. */
+async function installRecorder(win: Page): Promise<void> {
+  await win.evaluate(() => {
+    const w = window as unknown as {
+      __rfSigs?: Set<string>;
+      __rfMo?: MutationObserver;
+    };
+    w.__rfSigs = new Set<string>();
+    const sig = (m: MutationRecord): string => {
+      const el =
+        m.target instanceof Element ? m.target : (m.target?.parentElement ?? null);
+      if (!el) return `${m.type}|<detached>`;
+      let path = '';
+      let node: Element | null = el;
+      for (let d = 0; d < 4 && node?.parentElement; d += 1) {
+        path = `${Array.prototype.indexOf.call(node.parentElement.children, node)}/${path}`;
+        node = node.parentElement;
+      }
+      const cls = Array.from(el.classList).slice(0, 3).join('.');
+      return `${m.type}|${el.tagName}#${el.id}.${cls}|${path}`;
+    };
+    w.__rfMo?.disconnect();
+    w.__rfMo = new MutationObserver((recs) => {
+      for (const m of recs) w.__rfSigs!.add(sig(m));
+    });
+    w.__rfMo.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      characterData: true,
+    });
+  });
+}
+
+async function readSignatures(win: Page): Promise<string[]> {
+  try {
+    return await win.evaluate(() =>
+      Array.from((window as unknown as { __rfSigs?: Set<string> }).__rfSigs ?? []),
+    );
+  } catch {
+    return [];
+  }
+}
+
+async function clearSignatures(win: Page): Promise<void> {
+  try {
+    await win.evaluate(() =>
+      (window as unknown as { __rfSigs?: Set<string> }).__rfSigs?.clear(),
+    );
+  } catch {
+    /* page busy — a stale set only makes us MORE conservative */
+  }
+}
+
+/** The interactive set: native controls plus explicit ARIA interaction roles. */
+const INTERACTIVE =
+  'button, a[href], input:not([type="hidden"]), select, textarea, ' +
+  '[role="button"], [role="tab"], [role="link"], [role="menuitem"], [role="switch"], [role="checkbox"]';
+
+/** Enumerate the visible interactive controls on the CURRENT surface. */
+async function enumerate(
+  win: Page,
+): Promise<Array<{ identity: string; tag: string; role: string | null; name: string; disabled: boolean }>> {
+  return win.evaluate((sel) => {
+    const visible = (el: Element): boolean => {
+      const r = el.getBoundingClientRect();
+      if (r.width === 0 || r.height === 0) return false;
+      const cs = getComputedStyle(el);
+      return cs.visibility !== 'hidden' && cs.display !== 'none' && cs.opacity !== '0';
+    };
+    const describe = (el: Element): string => {
+      if (el.id) return `#${el.id}`;
+      const tid = el.getAttribute('data-testid');
+      if (tid) return `[data-testid="${tid}"]`;
+      const aria = el.getAttribute('aria-label');
+      if (aria?.trim()) return `[aria-label="${aria.trim()}"]`;
+      const tag = el.tagName.toLowerCase();
+      const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+      if (text) return `${tag}:"${text.slice(0, 48)}"`;
+      const cls = Array.from(el.classList).slice(0, 3).join('.');
+      return cls ? `${tag}.${cls}` : tag;
+    };
+    return Array.from(document.querySelectorAll(sel))
+      .filter(visible)
+      .map((el) => ({
+        identity: describe(el),
+        tag: el.tagName,
+        role: el.getAttribute('role'),
+        name: (
+          el.getAttribute('aria-label') ??
+          el.textContent ??
+          (el as HTMLInputElement).value ??
+          ''
+        )
+          .replace(/\s+/g, ' ')
+          .trim()
+          .slice(0, 70),
+        // A disabled control doing nothing is CORRECT, not a defect. Recorded
+        // separately so it never inflates the dead count.
+        disabled:
+          (el as HTMLButtonElement).disabled === true ||
+          el.getAttribute('aria-disabled') === 'true',
+      }));
+  }, INTERACTIVE);
+}
+
+test('functional sweep: every interactive control on every surface', async () => {
+  mkdirSync(OUT_DIR, { recursive: true });
+  const { app } = await launchSeededApp();
+  const win = await prepareWindow(app);
+
+  const records: ControlRecord[] = [];
+  const pageErrors: string[] = [];
+  win.on('pageerror', (e) => pageErrors.push(e.message.split('\n')[0]));
+  let requests = 0;
+  win.on('request', () => {
+    requests += 1;
+  });
+  let dialogSeen = false;
+  win.on('dialog', (d) => {
+    dialogSeen = true;
+    void d.dismiss().catch(() => {});
+  });
+
+  // ---- Surface discovery: read the real nav rather than hardcoding a list, so
+  // a surface added later is swept automatically instead of silently missed.
+  const topTabs = await win.locator('.toptab').allTextContents();
+  const tops = topTabs.map((t) => t.replace(/\s+/g, ' ').trim()).filter(Boolean);
+  // eslint-disable-next-line no-console
+  console.log(`[sweep] discovered ${tops.length} top-level surfaces: ${tops.join(' | ')}`);
+  expect(tops.length, 'at least one top-level surface must be discoverable').toBeGreaterThan(0);
+
+  const goTop = async (label: string): Promise<boolean> => {
+    try {
+      await win.locator('.toptab', { hasText: label }).first().click({ timeout: 5000 });
+      await win.waitForTimeout(350);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  /**
+   * A sweep CONTEXT is a (top tab, optional sub tab) pair. Sweeping only top
+   * tabs was a real coverage hole: Settings enumerated 40 controls but only ~24
+   * exist under any single sub-tab, so every control past that index reported
+   * "absent after surface restore" and was NEVER CLICKED — 15 controls silently
+   * unswept, in exactly the panel where an unwired control is most likely.
+   */
+  const contexts: Array<{ label: string; top: string; sub?: string }> = [];
+  for (const top of tops) {
+    if (!(await goTop(top))) {
+      contexts.push({ label: top, top });
+      continue;
+    }
+    const subs = (await win.locator('.tabbar [role="tab"]').allTextContents())
+      .map((t) => t.replace(/\s+/g, ' ').trim())
+      .filter(Boolean);
+    if (subs.length === 0) contexts.push({ label: top, top });
+    else for (const sub of subs) contexts.push({ label: `${top} > ${sub}`, top, sub });
+  }
+  // eslint-disable-next-line no-console
+  console.log(`[sweep] ${contexts.length} sweep contexts:\n  ${contexts.map((c) => c.label).join('\n  ')}`);
+
+  /** Restore a context so every control is clicked from the same known state. */
+  const goSurface = async (label: string): Promise<boolean> => {
+    const ctx = contexts.find((c) => c.label === label);
+    if (!ctx) return false;
+    if (!(await goTop(ctx.top))) return false;
+    if (ctx.sub) {
+      try {
+        await win.locator('.tabbar [role="tab"]', { hasText: ctx.sub }).first().click({ timeout: 5000 });
+        await win.waitForTimeout(300);
+      } catch {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  for (const { label: surface } of contexts) {
+    if (!(await goSurface(surface))) {
+      // eslint-disable-next-line no-console
+      console.log(`[sweep] FAILED to reach surface "${surface}" — recorded, not skipped silently`);
+      records.push({
+        surface,
+        index: -1,
+        identity: '<surface>',
+        tag: 'SURFACE',
+        role: null,
+        name: surface,
+        effect: 'error',
+        ambientSignatures: 0,
+        attributedSignatures: 0,
+        requestsAmbient: 0,
+        requestsAfterClick: 0,
+        clickError: 'surface unreachable from top nav',
+      });
+      continue;
+    }
+
+    const controls = await enumerate(win);
+    // eslint-disable-next-line no-console
+    console.log(`[sweep] ${surface}: ${controls.length} visible interactive control(s)`);
+
+    for (let i = 0; i < controls.length; i += 1) {
+      const c = controls[i];
+      const base: Omit<ControlRecord, 'effect'> = {
+        surface,
+        index: i,
+        identity: c.identity,
+        tag: c.tag,
+        role: c.role,
+        name: c.name,
+        ambientSignatures: 0,
+        attributedSignatures: 0,
+        requestsAmbient: 0,
+        requestsAfterClick: 0,
+      };
+
+      if (c.disabled) {
+        records.push({ ...base, effect: 'disabled' });
+        continue;
+      }
+      const skip = SKIP_PATTERNS.find((p) => p.re.test(c.name));
+      if (skip) {
+        records.push({ ...base, effect: 'skipped', skipReason: skip.reason });
+        continue;
+      }
+
+      // Re-establish the surface: a previous click may have navigated away or
+      // opened a panel, and every control must be judged from the same state.
+      await win.keyboard.press('Escape').catch(() => {});
+      if (!(await goSurface(surface))) break;
+
+      // Re-resolve by position on the freshly-restored surface.
+      const handles = await win.locator(INTERACTIVE).all();
+      const live = handles[i];
+      if (!live) {
+        records.push({
+          ...base,
+          effect: 'error',
+          clickError: `control index ${i} absent after surface restore (found ${handles.length})`,
+        });
+        continue;
+      }
+
+      // IDENTITY GUARD. Index-based re-resolution is only valid if the restored
+      // surface presents the SAME control at the same position. A prior click can
+      // leave sticky state (an expanded panel, a flipped toggle) that shifts the
+      // set, and then index i would silently point at a different element —
+      // producing a verdict attributed to the wrong control. Compare identities
+      // and record a drift instead of trusting a mislabelled reading.
+      const liveIdentity = await live
+        .evaluate((el) => {
+          if (el.id) return `#${el.id}`;
+          const tid = el.getAttribute('data-testid');
+          if (tid) return `[data-testid="${tid}"]`;
+          const aria = el.getAttribute('aria-label');
+          if (aria?.trim()) return `[aria-label="${aria.trim()}"]`;
+          const tag = el.tagName.toLowerCase();
+          const text = (el.textContent ?? '').replace(/\s+/g, ' ').trim();
+          if (text) return `${tag}:"${text.slice(0, 48)}"`;
+          const cls = Array.from(el.classList).slice(0, 3).join('.');
+          return cls ? `${tag}.${cls}` : tag;
+        })
+        .catch(() => '<unreadable>');
+      if (liveIdentity !== c.identity) {
+        records.push({
+          ...base,
+          effect: 'error',
+          clickError: `identity drift at index ${i}: enumerated ${c.identity}, found ${liveIdentity}`,
+        });
+        continue;
+      }
+
+      // Read the control's OWN state before clicking. A tab already selected, or
+      // a segmented-control button already pressed, is SUPPOSED to do nothing —
+      // e.g. RoutingToggle.tsx documents `value !== mode && onChange(mode)` so the
+      // active segment never re-writes the same value. Deciding this from the
+      // element's own aria state is deterministic; deciding it by reading the
+      // label and judging is not.
+      const wasActive = await live
+        .evaluate(
+          (el) =>
+            el.getAttribute('aria-selected') === 'true' ||
+            el.getAttribute('aria-pressed') === 'true' ||
+            el.getAttribute('aria-current') === 'page' ||
+            el.classList.contains('is-active'),
+        )
+        .catch(() => false);
+
+      await installRecorder(win);
+
+      // --- ambient control window: observe WITHOUT clicking ---
+      requests = 0;
+      await win.waitForTimeout(WINDOW_MS);
+      const ambient = new Set(await readSignatures(win));
+      const requestsAmbient = requests;
+
+      // --- the click ---
+      await clearSignatures(win);
+      requests = 0;
+      pageErrors.length = 0;
+      dialogSeen = false;
+      let clickError: string | undefined;
+      try {
+        await live.click({ timeout: 2500 });
+      } catch (e) {
+        clickError = (e as Error).message.split('\n')[0];
+      }
+      await win.waitForTimeout(WINDOW_MS);
+
+      const post = await readSignatures(win);
+      const attributed = post.filter((s) => !ambient.has(s));
+
+      let effect: string;
+      if (dialogSeen) effect = 'dialog';
+      else if (attributed.length > 0) effect = 'dom';
+      else if (requests > requestsAmbient) effect = 'network';
+      else if (clickError) effect = 'error';
+      else if (wasActive) effect = 'already-active';
+      else effect = 'none';
+
+      records.push({
+        ...base,
+        effect,
+        wasActive,
+        ambientSignatures: ambient.size,
+        attributedSignatures: attributed.length,
+        requestsAmbient,
+        requestsAfterClick: requests,
+        ...(pageErrors.length ? { pageError: pageErrors[0] } : {}),
+        ...(clickError ? { clickError } : {}),
+      });
+    }
+  }
+
+  await app.close().catch(() => {});
+
+  // ---- Report -------------------------------------------------------------
+  const dead = records.filter((r) => r.effect === 'none');
+  const throwing = records.filter((r) => r.pageError);
+  const errored = records.filter((r) => r.effect === 'error');
+  const skipped = records.filter((r) => r.effect === 'skipped');
+  const disabled = records.filter((r) => r.effect === 'disabled');
+  const alreadyActive = records.filter((r) => r.effect === 'already-active');
+  const acted = records.filter((r) => ['dom', 'network', 'dialog'].includes(r.effect));
+  const maxAmbient = records.reduce((m, r) => Math.max(m, r.ambientSignatures), 0);
+
+  writeFileSync(
+    join(OUT_DIR, 'deadclick.json'),
+    JSON.stringify(
+      {
+        generatedFor: 'functional sweep — every interactive control, every surface',
+        windowMs: WINDOW_MS,
+        totals: {
+          controls: records.length,
+          acted: acted.length,
+          dead: dead.length,
+          alreadyActive: alreadyActive.length,
+          throwing: throwing.length,
+          errored: errored.length,
+          skipped: skipped.length,
+          disabled: disabled.length,
+        },
+        maxAmbientSignatures: maxAmbient,
+        records,
+      },
+      null,
+      2,
+    ),
+  );
+
+  /* eslint-disable no-console */
+  console.log(`\n=== functional sweep ===`);
+  console.log(`  controls enumerated : ${records.length}`);
+  console.log(`  acted (dom/network/dialog) : ${acted.length}`);
+  console.log(`  DEAD (clicked, nothing happened) : ${dead.length}`);
+  console.log(`  already-active (no-op is correct) : ${alreadyActive.length}`);
+  console.log(`  THROWS (uncaught page error) : ${throwing.length}`);
+  console.log(`  not actionable / drifted : ${errored.length}`);
+  console.log(`  skipped (listed below) : ${skipped.length}`);
+  console.log(`  disabled (correctly inert) : ${disabled.length}`);
+  console.log(`  max ambient signatures in a no-click window: ${maxAmbient}`);
+  // State the denominator plainly: "0 dead" is only meaningful against how many
+  // were actually actuated, and errored/skipped/disabled were NOT actuated.
+  console.log(
+    `  ACTUATED ${acted.length + dead.length + alreadyActive.length}/${records.length} ` +
+      `(unactuated: ${errored.length} errored + ${skipped.length} skipped + ${disabled.length} disabled)`,
+  );
+  for (const r of dead) console.log(`  DEAD    [${r.surface}] ${r.identity} "${r.name}"`);
+  for (const r of throwing) console.log(`  THROWS  [${r.surface}] ${r.identity} -> ${r.pageError}`);
+  for (const r of errored) console.log(`  ERROR   [${r.surface}] ${r.identity} -> ${r.clickError}`);
+  for (const r of skipped) console.log(`  SKIP    [${r.surface}] "${r.name}" (${r.skipReason})`);
+  console.log(`\nreport: ${join(OUT_DIR, 'deadclick.json')}`);
+  /* eslint-enable no-console */
+
+  // This spec is an INSTRUMENT, not the gate: it must always produce its report
+  // rather than abort partway on the first defect. The gate is applied by the
+  // caller reading deadclick.json, so the only hard assertion is that the sweep
+  // actually observed something (a zero-control run means the harness broke).
+  expect(records.length, 'sweep must observe at least one control').toBeGreaterThan(0);
+});

--- a/app/playwright.audit.config.ts
+++ b/app/playwright.audit.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig } from '@playwright/test';
+
+// Playwright config for the ON-DEMAND functional audit sweep (e2e/audit/**).
+//
+// Deliberately SEPARATE from playwright.config.ts: the sweep clicks every
+// interactive control on every surface with a per-control observation window, so
+// it runs for many minutes. It is an investigation tool, not a PR gate, and the
+// main 4-OS `e2e-gui` matrix must not inherit that cost. Run it explicitly:
+//
+//   npx playwright test --config playwright.audit.config.ts
+//
+// It drives the same real built Electron app + live sidecar as the other specs
+// (via e2e/fixtures.ts), so its findings are about the shipped product.
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: 'audit/**/*.spec.ts',
+  // The whole sweep is one test: cold start + N controls x (noise + click +
+  // re-navigate). Generous, because a timeout here loses the entire report.
+  timeout: 45 * 60_000,
+  expect: { timeout: 30_000 },
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list']],
+  use: { trace: 'off' },
+});

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -15,7 +15,10 @@ export default defineConfig({
   // OWN config (playwright.visual.config.ts) in a dedicated single-OS job, so
   // its platform-specific screenshot baselines never burden this 4-OS GUI
   // matrix (a missing snapshot would hard-fail the non-baselined OS legs).
-  testIgnore: 'visual/**',
+  // audit/** is the on-demand functional sweep (playwright.audit.config.ts). It
+  // clicks every control on every surface and runs for many minutes, so it is
+  // an investigation tool rather than a PR gate — never in this matrix.
+  testIgnore: ['visual/**', 'audit/**'],
   // Electron cold-start + sidecar boot + real video decode need headroom.
   timeout: 120_000,
   expect: { timeout: 30_000 },

--- a/scripts/static_unwired_scan.mjs
+++ b/scripts/static_unwired_scan.mjs
@@ -1,0 +1,222 @@
+// static_unwired_scan.mjs — find interactive JSX that has no way to DO anything.
+//
+// Complements the dynamic sweep (app/e2e/audit/deadclick.audit.spec.ts). The
+// sweep can only click what it can REACH; controls behind a modal, an error
+// state, a feature flag, or a rarely-hit conditional are never exercised. This
+// reads the source instead, so reachability is irrelevant.
+//
+// Uses the TypeScript compiler API (already a repo dependency) rather than regex:
+// a regex over JSX cannot tell an `onClick` on the element from one mentioned in
+// a nearby comment or a child, which is the use-vs-mention error class.
+//
+// HONEST LIMITS — this reports CANDIDATES, not confirmed defects:
+//   * a handler can arrive via {...props} spread, which we detect and exempt;
+//   * a handler can be injected by a parent through a prop we cannot see here;
+//   * a <button type="submit"> inside a form is wired via the form, not onClick;
+//   * a label-wrapped input is driven by the input, not the label.
+// So a hit means "no LOCAL evidence of wiring" and must be confirmed. The error
+// direction is deliberately toward over-reporting.
+//
+// Usage (from the repo root):
+//   node scripts/static_unwired_scan.mjs [--json out.json] [--src <dir>]
+//
+// DETECTOR IS VALIDATED. Against a fixture of 4 planted defects (empty arrow
+// handler, `() => undefined`, a <button> with no wiring, role=button on a div
+// with no tabIndex) plus 4 planted GOOD controls (a wired button, a form submit,
+// a {...spread} handler, a tabIndex+onKeyDown custom control) it reported
+// exactly 4/4 and 0/4 respectively. Re-run that control with --src before
+// trusting a zero: an unvalidated zero is not evidence of a clean tree.
+
+import { readFileSync, writeFileSync, readdirSync, statSync, existsSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { createRequire } from 'node:module';
+
+const ROOT = process.cwd();
+// --src <dir> overrides the scan root. Exists so the scanner can be pointed at a
+// fixture directory of PLANTED defects to prove it actually fires: a zero from an
+// unvalidated detector is not evidence of a clean tree.
+const srcArgIdx = process.argv.indexOf('--src');
+const SRC = srcArgIdx !== -1 && process.argv[srcArgIdx + 1]
+  ? process.argv[srcArgIdx + 1]
+  : existsSync(join(ROOT, 'app', 'renderer', 'src'))
+    ? join(ROOT, 'app', 'renderer', 'src')
+    : join(ROOT, 'renderer', 'src');
+// typescript lives in app/node_modules (the repo root has none), and NODE_PATH is
+// ignored for ESM — so resolve it explicitly against the app package instead of
+// a bare specifier.
+const require = createRequire(join(ROOT, 'app', 'package.json'));
+const ts = require('typescript');
+
+/** Attributes that make an element able to do something. */
+const ACTION_ATTRS = new Set([
+  'onClick', 'onMouseDown', 'onMouseUp', 'onPointerDown', 'onKeyDown', 'onKeyUp',
+  'onKeyPress', 'onChange', 'onInput', 'onSubmit', 'onToggle', 'onFocus', 'onBlur',
+  'href', 'to', 'form', 'formAction', 'popoverTarget', 'commandFor',
+]);
+
+/** Interactive intrinsic tags worth checking. */
+const INTERACTIVE_TAGS = new Set(['button', 'a', 'select', 'textarea', 'input']);
+
+function walkFiles(dir, out = []) {
+  for (const entry of readdirSync(dir)) {
+    const p = join(dir, entry);
+    const st = statSync(p);
+    if (st.isDirectory()) {
+      if (entry === 'node_modules' || entry === '__snapshots__') continue;
+      walkFiles(p, out);
+    } else if (/\.tsx$/.test(entry) && !/\.test\.tsx$/.test(entry)) {
+      out.push(p);
+    }
+  }
+  return out;
+}
+
+/** Is this JSX attribute list evidence the element can act? */
+function classifyAttrs(attributes) {
+  let hasAction = false;
+  let hasSpread = false;
+  let isSubmit = false;
+  let isDisabledAlways = false;
+  let role = null;
+  let tabIndex = false;
+  for (const attr of attributes.properties) {
+    if (ts.isJsxSpreadAttribute(attr)) {
+      hasSpread = true;
+      continue;
+    }
+    if (!ts.isJsxAttribute(attr)) continue;
+    const name = attr.name.getText();
+    if (ACTION_ATTRS.has(name)) hasAction = true;
+    if (name === 'tabIndex') tabIndex = true;
+    if (name === 'type' && attr.initializer && ts.isStringLiteral(attr.initializer)) {
+      if (attr.initializer.text === 'submit' || attr.initializer.text === 'reset') isSubmit = true;
+    }
+    if (name === 'role' && attr.initializer && ts.isStringLiteral(attr.initializer)) {
+      role = attr.initializer.text;
+    }
+    // `disabled` with no initializer (bare) is always-disabled; `disabled={x}` is conditional.
+    if (name === 'disabled' && !attr.initializer) isDisabledAlways = true;
+  }
+  return { hasAction, hasSpread, isSubmit, isDisabledAlways, role, tabIndex };
+}
+
+/**
+ * Is the handler expression an EMPTY function? `onClick={() => {}}` is wired to
+ * the type checker and dead to the user — the most deceptive form of unwired,
+ * because every "does it have onClick" check passes.
+ */
+function emptyHandlerName(attributes) {
+  for (const attr of attributes.properties) {
+    if (!ts.isJsxAttribute(attr) || !attr.initializer) continue;
+    const name = attr.name.getText();
+    if (!name.startsWith('on')) continue;
+    if (!ts.isJsxExpression(attr.initializer) || !attr.initializer.expression) continue;
+    const expr = attr.initializer.expression;
+    if (ts.isArrowFunction(expr) || ts.isFunctionExpression(expr)) {
+      const body = expr.body;
+      if (ts.isBlock(body) && body.statements.length === 0) return name;
+      if (ts.isBlock(body) && body.statements.every((s) => ts.isEmptyStatement(s))) return name;
+      // `() => undefined` / `() => null` / `() => void 0`
+      if (!ts.isBlock(body)) {
+        const t = body.getText().trim();
+        if (t === 'undefined' || t === 'null' || t === 'void 0') return name;
+      }
+    }
+  }
+  return null;
+}
+
+const findings = [];
+const files = walkFiles(SRC);
+
+for (const file of files) {
+  const text = readFileSync(file, 'utf8');
+  const sf = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true, ts.ScriptKind.TSX);
+  const rel = relative(ROOT, file).replace(/\\/g, '/');
+
+  const visit = (node) => {
+    let attributes = null;
+    let tagName = null;
+    if (ts.isJsxSelfClosingElement(node)) {
+      attributes = node.attributes;
+      tagName = node.tagName.getText();
+    } else if (ts.isJsxElement(node)) {
+      attributes = node.openingElement.attributes;
+      tagName = node.openingElement.tagName.getText();
+    }
+
+    if (attributes && tagName) {
+      const c = classifyAttrs(attributes);
+      const isIntrinsicInteractive = INTERACTIVE_TAGS.has(tagName);
+      const isAriaInteractive = c.role === 'button' || c.role === 'tab' || c.role === 'link'
+        || c.role === 'menuitem' || c.role === 'switch' || c.role === 'checkbox';
+      const line = sf.getLineAndCharacterOfPosition(node.getStart()).line + 1;
+
+      // 1) An EMPTY handler: type-checks, does nothing. Highest-confidence class.
+      const empty = emptyHandlerName(attributes);
+      if (empty && (isIntrinsicInteractive || isAriaInteractive)) {
+        findings.push({
+          kind: 'empty-handler',
+          confidence: 'high',
+          file: rel,
+          line,
+          tag: tagName,
+          role: c.role,
+          detail: `${empty} is an empty function — wired to the type checker, dead to the user`,
+        });
+      }
+
+      // 2) An interactive element with NO local action affordance at all.
+      if (
+        (isIntrinsicInteractive || isAriaInteractive) &&
+        !c.hasAction && !c.hasSpread && !c.isSubmit && !c.isDisabledAlways &&
+        // <a> without href is not a control; <input> is often driven by form state.
+        tagName !== 'input' && tagName !== 'textarea' && tagName !== 'select'
+      ) {
+        findings.push({
+          kind: 'no-local-handler',
+          confidence: 'medium',
+          file: rel,
+          line,
+          tag: tagName,
+          role: c.role,
+          detail: 'no onClick/href/form and no {...spread} on this element — verify a parent wires it',
+        });
+      }
+
+      // 3) An ARIA-interactive NON-button with no keyboard path: mouse-only.
+      if (isAriaInteractive && !isIntrinsicInteractive && !c.tabIndex && !c.hasSpread) {
+        findings.push({
+          kind: 'mouse-only-role',
+          confidence: 'medium',
+          file: rel,
+          line,
+          tag: tagName,
+          role: c.role,
+          detail: `role="${c.role}" on <${tagName}> without tabIndex — unreachable by keyboard`,
+        });
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+}
+
+const byKind = findings.reduce((m, f) => ({ ...m, [f.kind]: (m[f.kind] ?? 0) + 1 }), {});
+console.log(`scanned ${files.length} .tsx files under ${relative(ROOT, SRC)}`);
+console.log(`findings by kind: ${JSON.stringify(byKind)}`);
+for (const f of findings.filter((x) => x.confidence === 'high')) {
+  console.log(`  HIGH  ${f.file}:${f.line}  <${f.tag}${f.role ? ` role=${f.role}` : ''}>  ${f.detail}`);
+}
+for (const f of findings.filter((x) => x.confidence === 'medium').slice(0, 60)) {
+  console.log(`  med   ${f.file}:${f.line}  <${f.tag}${f.role ? ` role=${f.role}` : ''}>  ${f.kind}`);
+}
+const medTotal = findings.filter((x) => x.confidence === 'medium').length;
+if (medTotal > 60) console.log(`  ... ${medTotal - 60} more medium-confidence candidates (see JSON)`);
+
+const jsonIdx = process.argv.indexOf('--json');
+if (jsonIdx !== -1 && process.argv[jsonIdx + 1]) {
+  writeFileSync(process.argv[jsonIdx + 1], JSON.stringify({ byKind, findings }, null, 2));
+  console.log(`\nwrote ${process.argv[jsonIdx + 1]}`);
+}
+console.log('\nSUCCESS:static-unwired-scan');

--- a/sidecar/tests/test_e2e_ai2_hub_director.py
+++ b/sidecar/tests/test_e2e_ai2_hub_director.py
@@ -243,9 +243,17 @@ def _base_settings(*provider_ids: str, **extra: Any) -> dict[str, Any]:
     The M3 ``routingPolicy`` is set to ``auto`` (prefer cloud, degrade local): the
     :meth:`_provider_for_function` egress gate (``select``/``vision`` seams) fails
     CLOSED to local when NO policy is persisted, so a "routed to cloud" fixture
-    must also permit cloud through the policy for those seams to egress. (The
-    ``director.plan`` editPlan path resolves its own consent-gated pool and is not
-    routed through this policy, so this is inert there.)
+    must also permit cloud through the policy for those seams to egress.
+
+    CORRECTION (measured): the previous note here claimed the ``director.plan``
+    editPlan path "resolves its own consent-gated pool and is not routed through
+    this policy, so this is inert there". That is WRONG and it actively misleads.
+    Omitting ``routingPolicy`` from a director.plan fixture makes the pool fail
+    closed to local, and local then dies with "provider pool exhausted (text):
+    local (local): no GGUF model configured" — so the test observes a
+    ProviderError instead of whatever it meant to assert. Bisected: adding ONLY
+    ``routingPolicy`` fixes it; ``cloudModel`` is not load-bearing for that path.
+    Any director.plan fixture that expects a CLOUD attempt must persist a policy.
     """
     consent = {pid: {"text": True, "frames": True} for pid in provider_ids}
     base: dict[str, Any] = {
@@ -589,6 +597,13 @@ def test_hub_budget_gate_refuses_unacked_cloud_run(tmp_path: Path) -> None:
         svc.settings.set(
             {
                 "routing": _routing("mock"),
+                # REQUIRED, not decoration: with no policy persisted the pool fails
+                # CLOSED to local (the secure default), local has no GGUF in a test
+                # env, and the run dies with "provider pool exhausted (text): local"
+                # BEFORE the budget gate is ever consulted — so the assertions below
+                # would be measuring a provider error, not the gate. See
+                # _base_settings' docstring correction.
+                "routingPolicy": {"global": "auto", "overrides": {}},
                 "consent": {"perProvider": {"mock": {"text": True}}},
                 "confirmCloudBudget": True,  # the budget gate is ARMED
             }


### PR DESCRIPTION
## What this is

Two pieces of work toward the "no broken buttons / no errors" bar, plus the instrument that makes such a claim checkable instead of asserted.

## 1. Fix the red `e2e-sidecar` test

`test_hub_budget_gate_refuses_unacked_cloud_run` was failing with:

```
ProviderError: provider pool exhausted (text): local (local): local model server
failed to start: no GGUF model configured (set settings.ggufPath or settings.modelsDir)
```

So it was asserting against a `ProviderError` rather than the budget gate it exists to test.

**Cause.** The fixture set `routing` / `consent` / `confirmCloudBudget` but not `routingPolicy`. With no policy persisted the provider pool fails **closed to local** — the correct, secure default — and local has no GGUF in a test env, so the run died before the gate was consulted.

**Bisected:** adding only `routingPolicy` fixes it; `cloudModel` is not load-bearing on this path.

This is a **test-setup defect, not a product defect** — fail-closed-to-local is the desired posture. Both assertions are unchanged and now actually exercised: `"budget"` appears in the refusal, and `server.hits["chat"] == 0` proves zero bytes egressed.

It also corrects a comment in `_base_settings` claiming the `director.plan` path "is not routed through this policy, so this is inert there". Measurement shows the opposite, and that sentence is precisely what sends a reader down the wrong path.

## 2. Add the on-demand functional sweep

`app/e2e/audit/deadclick.audit.spec.ts` + `playwright.audit.config.ts`. Drives the real built app and clicks every visible interactive control on every discovered surface (19 contexts, 263 controls), classifying each as acted / dead / already-active / throwing.

Not in the PR matrix — `playwright.config.ts` now ignores `audit/**`. It runs ~7 minutes; it is an instrument, not a gate.

Two design decisions that a naive version gets wrong, both measured:

- **Ambient-noise control window.** "Did the DOM mutate after the click?" reports *everything* as alive on any app that changes on its own. Against a page with a 100 ms ticker, a bare `MutationObserver` count found **0 of 2** planted dead buttons — a confident false green. The sweep observes an identical window *without* clicking, records a stable signature per mutated node, and subtracts that ambient set. Honest note: the real app measured ambient 0–5, so this did **not** change the current result; it is insurance for when a job is actually running.
- **`already-active` split from `dead`.** A tab already selected, or a segmented button already pressed, is *supposed* to no-op (`RoutingToggle.tsx:43-44`). Decided from the element's own aria state, not from judgement about its label. Without the split, every surface reported its own tab as dead — it accounted for 22 readings.

Error direction is deliberate: a click that only touches an ambiently-churning node reads as dead. A false dead is filtered by review; a false *alive* ships a broken control, which is the whole point.

### Stated scope (what it cannot see)

It answers exactly one question — *does clicking this control produce an observable **renderer** effect* — and is blind to:

| blind spot | example |
|---|---|
| native OS dialogs (main process) | `Add videos` opens a file picker (`Library.tsx:284`) |
| effects crossing the IPC bridge with no DOM change | `client.exportPresets.save` (`ExportPresetsPanel.tsx:105`) |
| idempotent saves that reload identical values | Save on an unedited preset row |
| controls whose correct verb is not a click | a text `input` wants typing; a `select` wants `onChange` |

All 29 current "dead" readings are attributable to one of those, each confirmed against source. **Zero controls threw an uncaught page error.**

## 3. Add `scripts/static_unwired_scan.mjs`

The sweep can only click what it can reach. This reads the source via the TypeScript compiler API — not regex, which cannot distinguish an `onClick` *on* the element from one mentioned in a comment — and flags empty handlers, interactive elements with no local wiring, and `role="button"` without `tabIndex`.

**Detector validated before its zero was believed:** against a fixture of 4 planted defects plus 4 planted good controls (wired button, form submit, `{...spread}` handler, `tabIndex`+`onKeyDown`) it reported exactly **4/4** and **0/4**. Only then does its result on the real tree mean anything — and that result is **zero findings across 120 `.tsx` files**.

## Known gap, recorded rather than hidden

7 Settings sub-tabs became unreachable partway through the sweep (state left by an earlier click that `Escape` did not clear), so their controls were enumerated but never actuated. The report counts them as `errored`, never as passing.

## Verification

- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **6071 passed, 100.00%**
- director e2e file → **13 passed**; `pytest -m e2e` sidecar-wide → **45 passed / 4 skipped**
- 2 remaining e2e failures are **local-only**: they need `transformers`, which the `e2e-sidecar` CI job deliberately does not install, so they hit their skip guard in CI. Locally `transformers 5.5.0` is present, the guard passes, and the test then fails fetching real SmolVLM2 weights. The HF repo id itself resolves (HTTP 200) — the asset manifest is **not** broken.
- `uvx ruff@0.15.17 format --check` / `check` → clean
- `tsc --noEmit` (app + e2e) → clean
