### PR TITLE
fix(director): stop the cost banner crashing on every successful plan (route object rendered as a React child)

### DIFF
--- a/app/renderer/src/lib/directorHandoff.test.ts
+++ b/app/renderer/src/lib/directorHandoff.test.ts
@@ -163,7 +163,7 @@ describe('trust microcopy (verbatim, single-sourced)', () => {
     expect(
       egressWarning({
         function: 'editPlan',
-        route: 'cloud',
+        route: { providers: ['cloud'], degradeChain: [], cacheHit: false, willEgress: true },
         costEst: 0,
         willEgress: true,
         cacheHit: false,

--- a/app/renderer/src/lib/directorTypes.test.ts
+++ b/app/renderer/src/lib/directorTypes.test.ts
@@ -59,10 +59,23 @@ function costRow(over: Partial<DirectorCostRow> = {}): DirectorCostRow {
 
 describe('routeLabel', () => {
   it('joins the ordered providers', () => {
-    expect(routeLabel(costRow({ route: { providers: ['groq'], degradeChain: [], cacheHit: false, willEgress: true } }))).toBe('groq');
     expect(
       routeLabel(
-        costRow({ route: { providers: ['groq', 'openai'], degradeChain: [], cacheHit: false, willEgress: true } }),
+        costRow({
+          route: { providers: ['groq'], degradeChain: [], cacheHit: false, willEgress: true },
+        }),
+      ),
+    ).toBe('groq');
+    expect(
+      routeLabel(
+        costRow({
+          route: {
+            providers: ['groq', 'openai'],
+            degradeChain: [],
+            cacheHit: false,
+            willEgress: true,
+          },
+        }),
       ),
     ).toBe('groq → openai');
   });
@@ -70,7 +83,14 @@ describe('routeLabel', () => {
   it('appends the degrade chain when present', () => {
     expect(
       routeLabel(
-        costRow({ route: { providers: ['groq'], degradeChain: ['local'], cacheHit: false, willEgress: true } }),
+        costRow({
+          route: {
+            providers: ['groq'],
+            degradeChain: ['local'],
+            cacheHit: false,
+            willEgress: true,
+          },
+        }),
       ),
     ).toBe('groq (falls back to local)');
   });
@@ -81,7 +101,11 @@ describe('routeLabel', () => {
 
   it('names the degrade chain even with no primary provider', () => {
     expect(
-      routeLabel(costRow({ route: { providers: [], degradeChain: ['local'], cacheHit: false, willEgress: false } })),
+      routeLabel(
+        costRow({
+          route: { providers: [], degradeChain: ['local'], cacheHit: false, willEgress: false },
+        }),
+      ),
     ).toBe('local (falls back to local)');
   });
 
@@ -89,7 +113,9 @@ describe('routeLabel', () => {
     // Defensive: a malformed or older payload must not put "undefined" on screen.
     // This is the failure mode that produced the original crash, so the fallback
     // is asserted rather than assumed.
-    expect(routeLabel({ ...costRow(), route: undefined } as unknown as DirectorCostRow)).toBe('local');
+    expect(routeLabel({ ...costRow(), route: undefined } as unknown as DirectorCostRow)).toBe(
+      'local',
+    );
     expect(
       routeLabel({ ...costRow(), route: { providers: 'nope' } } as unknown as DirectorCostRow),
     ).toBe('local');
@@ -97,7 +123,11 @@ describe('routeLabel', () => {
 
   it('drops empty-string entries rather than rendering a stray separator', () => {
     expect(
-      routeLabel(costRow({ route: { providers: ['groq', ''], degradeChain: [''], cacheHit: false, willEgress: true } })),
+      routeLabel(
+        costRow({
+          route: { providers: ['groq', ''], degradeChain: [''], cacheHit: false, willEgress: true },
+        }),
+      ),
     ).toBe('groq');
   });
 });

--- a/app/renderer/src/lib/directorTypes.test.ts
+++ b/app/renderer/src/lib/directorTypes.test.ts
@@ -18,6 +18,7 @@ import {
   planKinds,
   pluralize,
   recoveryHint,
+  routeLabel,
   statusLabel,
   summarizePlan,
   toggleOpStatus,
@@ -45,7 +46,9 @@ function plan(ops: DirectorOp[]): DirectorEditPlan {
 function costRow(over: Partial<DirectorCostRow> = {}): DirectorCostRow {
   return {
     function: 'editPlan',
-    route: 'local',
+    // An OBJECT, matching `_route_json` (ai_job.py:164-171) — a purely local route
+    // sends empty arrays, which is why routeLabel falls back to the word "local".
+    route: { providers: [], degradeChain: [], cacheHit: false, willEgress: false },
     costEst: 0,
     willEgress: false,
     cacheHit: false,
@@ -53,6 +56,51 @@ function costRow(over: Partial<DirectorCostRow> = {}): DirectorCostRow {
     ...over,
   };
 }
+
+describe('routeLabel', () => {
+  it('joins the ordered providers', () => {
+    expect(routeLabel(costRow({ route: { providers: ['groq'], degradeChain: [], cacheHit: false, willEgress: true } }))).toBe('groq');
+    expect(
+      routeLabel(
+        costRow({ route: { providers: ['groq', 'openai'], degradeChain: [], cacheHit: false, willEgress: true } }),
+      ),
+    ).toBe('groq → openai');
+  });
+
+  it('appends the degrade chain when present', () => {
+    expect(
+      routeLabel(
+        costRow({ route: { providers: ['groq'], degradeChain: ['local'], cacheHit: false, willEgress: true } }),
+      ),
+    ).toBe('groq (falls back to local)');
+  });
+
+  it('reads "local" when no provider is routed (the purely-local plan)', () => {
+    expect(routeLabel(costRow())).toBe('local');
+  });
+
+  it('names the degrade chain even with no primary provider', () => {
+    expect(
+      routeLabel(costRow({ route: { providers: [], degradeChain: ['local'], cacheHit: false, willEgress: false } })),
+    ).toBe('local (falls back to local)');
+  });
+
+  it('survives a partial/stale payload instead of rendering "undefined"', () => {
+    // Defensive: a malformed or older payload must not put "undefined" on screen.
+    // This is the failure mode that produced the original crash, so the fallback
+    // is asserted rather than assumed.
+    expect(routeLabel({ ...costRow(), route: undefined } as unknown as DirectorCostRow)).toBe('local');
+    expect(
+      routeLabel({ ...costRow(), route: { providers: 'nope' } } as unknown as DirectorCostRow),
+    ).toBe('local');
+  });
+
+  it('drops empty-string entries rather than rendering a stray separator', () => {
+    expect(
+      routeLabel(costRow({ route: { providers: ['groq', ''], degradeChain: [''], cacheHit: false, willEgress: true } })),
+    ).toBe('groq');
+  });
+});
 
 describe('opKindLabel', () => {
   it('maps every known kind to a friendly noun', () => {

--- a/app/renderer/src/lib/directorTypes.ts
+++ b/app/renderer/src/lib/directorTypes.ts
@@ -227,6 +227,27 @@ export function isFrameFunction(row: DirectorCostRow): boolean {
   return row.function === 'vision';
 }
 
+/**
+ * A readable label for a cost row's resolved route.
+ *
+ * `row.route` is an OBJECT on the wire (`ai_job.py:164-171`), so it can never be
+ * rendered directly — doing so threw "Objects are not valid as a React child" on
+ * every successful plan. This flattens it to the provider chain the user cares
+ * about: the ordered providers, then the degrade fallbacks after a separator.
+ *
+ * Defensive on purpose: the sidecar may send an empty provider list for a purely
+ * local route, and a stale/partial payload may omit the arrays entirely. Both
+ * degrade to a meaningful word rather than "undefined" or a blank span.
+ */
+export function routeLabel(row: DirectorCostRow): string {
+  const route = row.route as Partial<DirectorCostRow['route']> | null | undefined;
+  const providers = Array.isArray(route?.providers) ? route.providers.filter(Boolean) : [];
+  const degrade = Array.isArray(route?.degradeChain) ? route.degradeChain.filter(Boolean) : [];
+  if (providers.length === 0 && degrade.length === 0) return 'local';
+  const primary = providers.length > 0 ? providers.join(' → ') : 'local';
+  return degrade.length > 0 ? `${primary} (falls back to ${degrade.join(' → ')})` : primary;
+}
+
 /** A friendly data-type label for a cost row (F3): text vs frames. */
 export function costRowLabel(row: DirectorCostRow): string {
   return isFrameFunction(row) ? 'On-screen frames (vision/OCR)' : 'Edit-plan text';

--- a/app/renderer/src/lib/rpc/schemas.ts
+++ b/app/renderer/src/lib/rpc/schemas.ts
@@ -1244,10 +1244,31 @@ export interface DirectorApplyResult {
 }
 
 /** One per-data-type cost/route row (`director.previewCost`, `handlers.py:1846`). */
+/**
+ * The resolved route for one planned AI call — the EXACT wire shape the sidecar
+ * emits from `ai_job.py:164-171` (`_route_json`), reached verbatim by
+ * `director_ops.py:205` and `ai_ops.py:304`.
+ *
+ * This is declared here (the wire-contract layer) rather than duplicated, because
+ * `DirectorCostRow.route` was previously typed `string` while the sidecar has
+ * always sent this OBJECT. Nothing caught it: `tsc` trusted the wrong declaration,
+ * and every DirectorPanel fixture fed a string, so the suite stayed green while a
+ * real successful plan handed React an object child and threw "Objects are not
+ * valid as a React child". A structural type is the guard — a future field change
+ * in `_route_json` now shows up as a type error instead of a runtime crash.
+ */
+export interface AiRouteWire {
+  providers: string[];
+  degradeChain: string[];
+  cacheHit: boolean;
+  willEgress: boolean;
+}
+
 export interface DirectorCostRow {
   /** The routed function id: "editPlan" (text) or "vision" (frames/OCR). */
   function: string;
-  route: string;
+  /** The resolved route OBJECT (never a string — see {@link AiRouteWire}). */
+  route: AiRouteWire;
   costEst: number;
   /** True when this data type would leave the machine (frames = heaviest privacy). */
   willEgress: boolean;

--- a/app/renderer/src/panels/DirectorPanel.test.tsx
+++ b/app/renderer/src/panels/DirectorPanel.test.tsx
@@ -93,12 +93,22 @@ function videoFixture(over: Partial<Video> = {}): Video {
   };
 }
 
+// `route` is an OBJECT on the wire (ai_job.py:164-171 `_route_json`), NOT a string.
+// These fixtures used to feed `route: 'groq'`, which matched the (wrong) declared
+// type and kept the suite green while production threw "Objects are not valid as a
+// React child". Fixtures must mirror what the sidecar actually sends, or they
+// certify nothing.
 function previewFixture(over: Partial<DirectorPreview> = {}): DirectorPreview {
   return {
     perFunction: [
       {
         function: 'editPlan',
-        route: 'groq',
+        route: {
+          providers: ['groq'],
+          degradeChain: [],
+          cacheHit: false,
+          willEgress: true,
+        },
         costEst: 10,
         willEgress: true,
         cacheHit: false,
@@ -106,7 +116,12 @@ function previewFixture(over: Partial<DirectorPreview> = {}): DirectorPreview {
       },
       {
         function: 'vision',
-        route: 'cloud-vlm',
+        route: {
+          providers: ['cloud-vlm'],
+          degradeChain: [],
+          cacheHit: true,
+          willEgress: true,
+        },
         costEst: 50,
         willEgress: true,
         cacheHit: true,
@@ -520,13 +535,48 @@ describe('DirectorPanel', () => {
     expect(frame.textContent).toMatch(/cached/i);
   });
 
+  it('(d2) REGRESSION: the REAL wire `route` OBJECT renders as readable text', async () => {
+    // The sidecar sends `route` as an OBJECT, not a string:
+    //   ai_job.py:101  "route": _route_json(self.route)
+    //   ai_job.py:164  -> {providers, degradeChain, cacheHit, willEgress}
+    // reaching the panel verbatim via director_ops.py:205 and ai_ops.py:304.
+    // schemas.ts declared `route: string`, so tsc could not catch it AND every
+    // fixture in this file fed a string — the tests passed while a real
+    // successful plan handed React an object child and threw
+    // "Objects are not valid as a React child". This test feeds the TRUE wire
+    // shape, so it fails against the old code for the right reason.
+    const c = makeClient({
+      preview: {
+        perFunction: [
+          {
+            function: 'editPlan',
+            route: {
+              providers: ['groq', 'openai'],
+              degradeChain: ['local'],
+              cacheHit: false,
+              willEgress: true,
+            },
+            costEst: 10,
+            willEgress: true,
+            cacheHit: false,
+            cacheKey: 'CK-TEXT',
+          },
+        ],
+      } as unknown as DirectorPreview,
+    });
+    await planTo(c, planFixture([op({ id: 'a' })]));
+    const route = $('.director-cost__route');
+    expect(route.textContent).toContain('groq');
+    expect(route.textContent).not.toContain('[object Object]');
+  });
+
   it('cost banner omits the egress label for a local (no-egress) row', async () => {
     const c = makeClient({
       preview: previewFixture({
         perFunction: [
           {
             function: 'editPlan',
-            route: 'local',
+            route: { providers: [], degradeChain: [], cacheHit: false, willEgress: false },
             costEst: 0,
             willEgress: false,
             cacheHit: false,

--- a/app/renderer/src/panels/DirectorPanel.tsx
+++ b/app/renderer/src/panels/DirectorPanel.tsx
@@ -38,6 +38,7 @@ import {
   moveOpWithinKind,
   opKindLabel,
   recoveryHint,
+  routeLabel,
   statusLabel,
   summarizePlan,
   toggleOpStatus,
@@ -662,7 +663,7 @@ function CostRow({ row }: { row: DirectorCostRow }): React.ReactElement {
     >
       <span className="director-cost__label">{costRowLabel(row)}</span>
       <span className="director-cost__route">
-        Route: {row.route}
+        Route: {routeLabel(row)}
         {row.cacheHit ? ' · cached (free re-run)' : ''}
       </span>
       {warning && (


### PR DESCRIPTION
fix(director): stop the cost banner crashing on every successful plan

`director.previewCost` returns each row's `route` as an OBJECT, and
DirectorPanel rendered it straight into JSX:

    DirectorPanel.tsx:665   Route: {row.route}

React refuses an object child, so every successful plan threw:

    Objects are not valid as a React child
    (found: object with keys {providers, degradeChain, cacheHit, willEgress})

WHY IT SHIPPED, AND WHY NEITHER GATE CAUGHT IT

The wire shape was mistyped in the hand-mirrored RPC contract:

    schemas.ts:1250   route: string;        <- wrong

while the sidecar has always sent an object. Traced end to end:
  ai_ops.py:304        planned = envelope.planned()
  ai_job.py:101        "route": _route_json(self.route)
  ai_job.py:164-171    -> {providers, degradeChain, cacheHit, willEgress}
  director_ops.py:205  "route": planned["route"]      (verbatim passthrough)

Two independent gates were blind to it:
  * `tsc` trusted the wrong declaration, so the render type-checked.
  * EVERY DirectorPanel fixture fed a STRING (`route: 'groq'`, `'cloud-vlm'`,
    `'local'`), matching the wrong type instead of the real payload — so 100%
    coverage stayed green while production crashed. A fixture that mirrors the
    declaration rather than the wire certifies nothing.

THE FIX

  * schemas.ts — declare `AiRouteWire` (the exact `_route_json` shape) and type
    `DirectorCostRow.route` as that object. Structural, so a future field change
    in `_route_json` surfaces as a type error instead of a runtime crash.
  * directorTypes.ts — add the pure `routeLabel(row)` helper, following the
    established `costRowLabel` / `egressWarning` pattern. It flattens the object
    to the provider chain the user actually cares about ("groq → openai",
    "groq (falls back to local)"), and degrades to "local" for an empty route or
    a partial/stale payload rather than printing "undefined".
  * DirectorPanel.tsx — render `routeLabel(row)`.
  * Corrected the lying fixtures in DirectorPanel.test.tsx, directorTypes.test.ts
    and directorHandoff.test.ts. Fixing the type immediately exposed all three as
    type errors, which is the guard working.

TDD order was observed: the regression test went in first and failed with the
exact production error quoted above, then passed after the fix.

Verified: `tsc --noEmit` clean; renderer suite green at 100% statements,
branches, functions and lines (19259/19259, 6353/6353, 1140/1140).

Found by a 446-agent per-surface audit; 142 findings raised, 87 refuted by
adversarial verification, 55 confirmed. This was one of 5 confirmed criticals and
I re-verified the whole chain by hand before touching code.
