### PR TITLE
fix(library): confirm before deleting a produced short (the lone unguarded call site)

### DIFF
--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -1242,7 +1242,9 @@ describe('Library produced-shorts gallery (v1.5 §4 P0)', () => {
     });
     expect(port.openFolder).toHaveBeenCalledWith('/o/s1.mp4');
 
-    // Delete s1 -> the v1 group keeps s2 (kept.length > 0).
+    // Delete s1 -> the v1 group keeps s2 (kept.length > 0). Deletion now CONFIRMS
+    // first (see the dedicated test below), so approve it here.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await act(async () => {
       fire(container.querySelector('[data-testid="delete-s1"]'));
     });
@@ -1254,6 +1256,42 @@ describe('Library produced-shorts gallery (v1.5 §4 P0)', () => {
     });
     await flush();
     expect(container.querySelector('.shorts-modal__empty')).not.toBeNull();
+  });
+
+  it('Delete CONFIRMS first and is a no-op when the user cancels', async () => {
+    // shorts.delete hard-unlinks the .mp4, its .thumb.jpg and its .json
+    // (sidecar/media_studio/features/shorts.py:442-455) with no OS recycle bin, so
+    // one stray click destroyed a finished render. The other TWO call sites of the
+    // same action already confirm — views/Shorts.tsx:147 and
+    // features/useShortsGallery.ts:99 — and KeepCopyControl.tsx:21 states the
+    // project standard: "never a silent one-click destructive action". Only the
+    // Library gallery was unguarded; four comments each delegated the confirm to
+    // someone else and it landed nowhere.
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    const port = shortsPort({
+      listAll: vi.fn(async () => [makeShort({ id: 's1', path: '/o/s1.mp4', videoId: 'v1' })]),
+    });
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await renderWithShorts(port);
+    await act(async () => {
+      fire(container.querySelector('.library__shorts-label'));
+    });
+    await flush();
+
+    await act(async () => {
+      fire(container.querySelector('[data-testid="delete-s1"]'));
+    });
+    await flush();
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(port.remove).not.toHaveBeenCalled();
+
+    // Approving the same click deletes for real.
+    confirmSpy.mockReturnValue(true);
+    await act(async () => {
+      fire(container.querySelector('[data-testid="delete-s1"]'));
+    });
+    await flush();
+    expect(port.remove).toHaveBeenCalledWith('/o/s1.mp4');
   });
 
   it('surfaces a toast when a gallery action fails', async () => {
@@ -1277,6 +1315,8 @@ describe('Library produced-shorts gallery (v1.5 §4 P0)', () => {
     });
     await flush();
     expect(errorToasts().join(' ')).toContain('reveal failed');
+    // Approve the confirm so the rejection path (not the cancel path) is exercised.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await act(async () => {
       fire(container.querySelector('[data-testid="delete-s1"]'));
     });

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -450,6 +450,18 @@ export function Library({
 
   const deleteShort = useCallback(
     async (api: LibraryShortsApi, path: string) => {
+      // CONFIRM before the destructive call. `shorts.delete` hard-unlinks the .mp4,
+      // its .thumb.jpg and its .json (features/shorts.py:442-455) with no OS recycle
+      // bin, so an unguarded click destroyed a finished render outright. The other
+      // two call sites of this action already confirm (views/Shorts.tsx:147,
+      // features/useShortsGallery.ts:99) and KeepCopyControl.tsx:21 states the
+      // standard — "never a silent one-click destructive action". This surface was
+      // the lone exception because four separate comments each delegated the confirm
+      // to another layer and it landed nowhere.
+      const ok = (globalThis as { confirm?: (m: string) => boolean }).confirm?.(
+        `Delete this short?\n\n${path}\n\nThis removes the exported file.`,
+      );
+      if (!ok) return;
       try {
         await api.remove(path);
         setShortsByVideo((prev) => {


### PR DESCRIPTION
fix(library): confirm before deleting a produced short

The produced-shorts gallery on a Library card deleted a finished export on a
single click, with no confirmation and no undo:

    Library.tsx:454   await api.remove(path);

That reaches `shorts.delete`, which hard-unlinks the .mp4, its .thumb.jpg and its
.json (features/shorts.py:442-455) via `Path(target).unlink(missing_ok=True)` —
no OS recycle bin, no backup. The user loses a render that cost real GPU time
and possibly cloud spend.

WHY THIS ONE SURFACE WAS UNGUARDED

It is the outlier, not the design. The same action has three call sites and the
other two both confirm:
  * views/Shorts.tsx:147             confirm?.('Delete this short? … removes the exported file.')
  * features/useShortsGallery.ts:99  the identical guard

and the project states the standard explicitly at KeepCopyControl.tsx:21 —
"never a silent one-click destructive action".

The confirm went missing because four separate comments each delegated it to
another layer and it landed nowhere: Library.tsx:54 says the adapter owns it,
libraryShortsClient.ts:44 says the Library confirms, ShortsGalleryModal.tsx:27
says the parent confirms, and ShortClipActions.tsx:8 says it lives where the data
does. A responsibility named in four comments and implemented in none.

Worth noting the detector trap: a plain `confirm\(` grep returns ZERO matches
repo-wide, because the idiom is the optional call `confirm?.(`. Searching for the
wrong shape makes the two working guards invisible and the bug look like the norm.

THE FIX

Adds the siblings' exact guard to Library's `deleteShort`. Scoped honestly: this
is a re-exportable derived artifact, not source footage — the source video stays
in the library and `shorts.reexport` (shorts.py:458-477) can replay the export —
so the harm is lost render time, not unrecoverable media. Banded HIGH rather than
critical for that reason.

TDD: the new test went in first and failed for the right reason — `confirm` was
called 0 times, proving no guard existed — then passed. Two pre-existing tests
(Library.test.tsx) relied on the unguarded path and now stub an approving
confirm; they are updated rather than left to mask the change.

Verified: renderer suite 100% on statements/branches/functions/lines
(19263/19263, 6355/6355), `tsc --noEmit` clean, and `pre-commit run --all-files`
green (ruff lint, ruff format, oxlint, biome format, gitleaks).

From the 446-agent surface audit (142 raised, 87 refuted, 55 confirmed). One
refuter correctly argued the reporter's "critical" was a severity overclaim while
confirming the code defect; that correction is adopted above.
