### PR TITLE
chore: gitignore transient agent probe scratch (.tmp-*)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,11 @@ build/icon/
 # Findings are transient investigation data; the FIX lands as code + tests, so
 # the raw report is never committed.
 app/audit-artifacts/
+
+# Transient agent probe scripts. A fan-out agent asked to VERIFY a finding will
+# sometimes write a throwaway probe next to the code it is testing (e.g. a Playwright
+# control that proves a CSS rule really does defeat [hidden]). That is the executable
+# rigor we want, but the files are scratch and must never become commit-eligible --
+# a prior wave leaked zz*/__* scratch into app/renderer/src and broke tsc --noEmit.
+.tmp-*
+**/.tmp-*


### PR DESCRIPTION
Closes the leak path that let agent probe scratch become commit-eligible.

A verification agent writing a throwaway probe next to the code under test is **desirable** — one F17 reviewer produced \pp/.tmp-f17-probe.mjs\, a Playwright control proving whether an author \display: flex\ defeats the UA \[hidden] { display: none }\ rule. That is the executable rigor the prompt asks for, so the fix is to make such files non-committable rather than to forbid them.

Motivated by a real prior incident: \zz*/__*\ scratch leaked into \pp/renderer/src\ and broke \	sc --noEmit\.

Scoped to the \.tmp-\ prefix (root + any depth) so it cannot swallow real sources. Verified with \git check-ignore\: both live scratch files are now ignored, and the working tree is otherwise clean.