### PR TITLE
fix: audit batch A — sidecar + main process (12 findings, 6 batches)

### DIFF
--- a/app/main/preload.ts
+++ b/app/main/preload.ts
@@ -69,6 +69,18 @@ export interface ProxyStateEvent {
 export type SidecarStatus = 'running' | 'restarting' | 'down';
 
 /**
+ * WHY the on-disk keystore could not be read (mirrors keystore.ts
+ * KeystoreUnreadableReason). Declared inline rather than imported ON PURPOSE: this
+ * module imports ONLY from `electron` (see the import above), and a value import of
+ * ./keystore would pull node:fs / node:path into the preload bundle.
+ */
+export type KeystoreUnreadableReason =
+  | 'read-failed'
+  | 'parse-failed'
+  | 'shape-invalid'
+  | 'decrypt-failed';
+
+/**
  * WU-D2b-1: the secure-key-storage availability decision (mirrors keystore.ts
  * SecureStatus). `sessionOnly` true means keys cannot be saved at rest on this
  * system, so the renderer shows the loud session-only banner.
@@ -83,6 +95,17 @@ export interface SecureStatus {
    * shred; the renderer banner names them so the user can delete them manually.
    */
   unshreddable?: string[];
+  /**
+   * WHY the on-disk keystore could not be read, or null when healthy/absent. While it
+   * is non-null the bridge fail-closed REFUSES to overwrite the keystore, so the
+   * renderer must surface it or a refused save looks like a successful one.
+   *
+   * This declaration is TYPE-LEVEL PARITY, not a functional prerequisite: the `as`
+   * assertion on the invoke below is erased at compile time and never filters
+   * properties, so the field already crossed intact. It is declared here because this
+   * mirror silently going stale is how the renderer came to drop the field at all.
+   */
+  keystoreUnreadable?: KeystoreUnreadableReason | null;
 }
 
 /** WU A5: outcome of an on-demand "Retry setup / Repair" bootstrap re-run. */

--- a/app/renderer/src/components/AddKeyRow.test.tsx
+++ b/app/renderer/src/components/AddKeyRow.test.tsx
@@ -75,4 +75,31 @@ describe('AddKeyRow', () => {
     act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true })));
     expect(onAdd).not.toHaveBeenCalled();
   });
+
+  // --- F41: an in-flight add must not be re-entered ---------------------------
+  // `ProvidersKeys.addKey` builds its upsert payload from a pre-await snapshot of
+  // `providers`, so a second Add accepted inside the first round-trip stores a list
+  // that omits the first key. Gating the CONTROL is what closes that window.
+
+  it('refuses BOTH submit paths while the panel is busy and preserves the draft', () => {
+    const onAdd = vi.fn();
+    act(() => root.render(<AddKeyRow providerId="groq" busy onAdd={onAdd} />));
+    // A NON-EMPTY draft first, so `disabled` is only ever true because of `busy`
+    // (an empty-field assertion would pass for the wrong reason).
+    typeValue('gsk-during-flight');
+    expect(addBtn().disabled).toBe(true);
+    // Enter bypasses `disabled` BY DESIGN, so the guard has to live inside submit:
+    // a disabled-only fix would still accept this keystroke.
+    act(() => input().dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })));
+    expect(onAdd).not.toHaveBeenCalled();
+    // The refused submit keeps the pasted key for a deliberate retry.
+    expect(input().value).toBe('gsk-during-flight');
+    // A real busy affordance, not opacity alone.
+    expect(addBtn().getAttribute('title')).toBe('Working…');
+  });
+
+  it('carries no busy title when idle', () => {
+    act(() => root.render(<AddKeyRow providerId="groq" busy={false} onAdd={vi.fn()} />));
+    expect(addBtn().getAttribute('title')).toBeNull();
+  });
 });

--- a/app/renderer/src/components/AddKeyRow.tsx
+++ b/app/renderer/src/components/AddKeyRow.tsx
@@ -13,12 +13,21 @@ export interface AddKeyRowProps {
   providerId: string;
   /** Receives the trimmed RAW pasted key. Only called for a non-empty value. */
   onAdd: (providerId: string, key: string) => void;
+  /**
+   * True while the owning panel already has a mutating providers RPC in flight.
+   * The panel's add builds its upsert payload from a `providers` snapshot taken
+   * BEFORE its own await, so a second add accepted inside that window stores a
+   * list that omits the first key. Folded into `canAdd` (not just the button's
+   * `disabled`) because the Enter path below is deliberately not gated by the
+   * attribute.
+   */
+  busy?: boolean;
 }
 
-export function AddKeyRow({ providerId, onAdd }: AddKeyRowProps): React.ReactElement {
+export function AddKeyRow({ providerId, onAdd, busy }: AddKeyRowProps): React.ReactElement {
   const [draft, setDraft] = useState<string>('');
   const trimmed = draft.trim();
-  const canAdd = trimmed.length > 0;
+  const canAdd = trimmed.length > 0 && !busy;
 
   const submit = useCallback(() => {
     if (!canAdd) return;
@@ -46,6 +55,7 @@ export function AddKeyRow({ providerId, onAdd }: AddKeyRowProps): React.ReactEle
         className="add-key-row__add"
         aria-label={`Add key to ${providerId}`}
         disabled={!canAdd}
+        title={busy ? 'Working…' : undefined}
         onClick={submit}
       >
         Add key

--- a/app/renderer/src/components/PathsPanel.test.tsx
+++ b/app/renderer/src/components/PathsPanel.test.tsx
@@ -3,9 +3,9 @@
 //
 // Fake `paths.describe` payload + a fake bridge (no preload). Pins the falsifiable
 // acceptance:
-//   * each dir row exposes a real <button> named "Open <label> folder" (no
+//   * each OPENABLE row exposes a real <button> named "Open <label> folder" (no
 //     icon-only control) and renders its path as selectable TEXT (queryable, not
-//     a button);
+//     a button); a `subDirs` value that is a PATTERN gets text but no button;
 //   * "Change data folder" calls bridge.pickDataFolder THEN bridge.setDataFolder
 //     in order, then shows the chosen path + a restart hint;
 //   * loading / unavailable-bridge / error branches all render.
@@ -24,13 +24,16 @@ function layout(): PathsDescribe {
     projectsDir: 'C:/data/projects',
     exportsDir: 'C:/data/exports',
     settingsPath: 'C:/data/settings.json',
-    libraryPath: 'C:/data/library.json',
+    // Mirrors the WIRE, not the old label: `paths.describe` reports the SQLite
+    // store (`library.db`), never the legacy `library.json` index.
+    libraryPath: 'C:/data/library.db',
     subDirs: {
       dubs: 'C:/data/dubs',
       shorts: 'C:/data/exports/shorts-*',
       stabilized: 'C:/data/exports/stabilized',
       audiomix: 'C:/data/exports/audiomix',
       trimmed: 'C:/data/exports/trimmed',
+      'managed-copies': 'C:/data/managed-copies',
     },
   };
 }
@@ -91,16 +94,17 @@ describe('<PathsPanel />', () => {
     const rpc = makeRpc();
     await mount({ rpc, bridge: makeBridge() });
     expect(rpc.describe).toHaveBeenCalledTimes(1);
-    // One row per layout entry (5 top-level + 5 subDirs = 10).
+    // One row per layout entry (5 top-level + 6 subDirs = 11).
     const rows = container.querySelectorAll('.paths-panel__row');
-    expect(rows.length).toBe(10);
+    expect(rows.length).toBe(11);
     // The path string is rendered as TEXT, not a button.
     const dataRow = container.querySelector('[data-path-key="dataDir"]') as HTMLElement;
     const pathEl = dataRow.querySelector('.paths-panel__path') as HTMLElement;
     expect(pathEl.tagName).not.toBe('BUTTON');
     expect(pathEl.textContent).toBe('C:/data');
-    // Each DIRECTORY row's Open control is a real <button> with a row-specific
-    // accessible name (8 dirs = 3 top-level + 5 subDirs; the 2 file rows have none).
+    // Each OPENABLE row's control is a real <button> with a row-specific
+    // accessible name (8 = 3 top-level dirs + 5 concrete subDirs; the 2 file rows
+    // and the `shorts-*` PATTERN row have none).
     const buttons = openButtons();
     expect(buttons.length).toBe(8);
     for (const btn of buttons) {
@@ -136,6 +140,48 @@ describe('<PathsPanel />', () => {
     );
     // Files have no own-folder Open button (they are not directories).
     expect(settingsRow.querySelector('.paths-panel__open')).toBeNull();
+  });
+
+  it('renders no Open button for a glob-pattern subDir (shorts-* names no directory)', async () => {
+    // `paths.describe` deliberately reports shorts as the PATTERN
+    // `exports/shorts-*` because output is per-video `exports/shorts-<videoId>`.
+    // MEASURED on this machine (Electron 43.2.0, Windows 11), two independent
+    // detectors (Shell.Application LocationURL + Win32 EnumWindows/CabinetWClass),
+    // both orders: `shell.showItemInFolder('…\\exports\\shorts-abc123')` opens
+    // `…\\exports` (detector FIRED) while `shell.showItemInFolder('…\\exports\\shorts-*')`
+    // opens NOTHING (detector SILENT). So the control is a silent no-op, not a
+    // reveal-the-parent affordance — remove it rather than retarget it.
+    await mount({ rpc: makeRpc(), bridge: makeBridge() });
+    const shortsRow = container.querySelector('[data-path-key="subDir:shorts"]') as HTMLElement;
+    expect(shortsRow).not.toBeNull();
+    // The pattern is still SHOWN — the panel is a layout view, not an opener.
+    expect((shortsRow.querySelector('.paths-panel__path') as HTMLElement).textContent).toBe(
+      'C:/data/exports/shorts-*',
+    );
+    expect(shortsRow.querySelector('.paths-panel__open')).toBeNull();
+  });
+
+  it('names the managed-copies store as its own row, with an Open control', async () => {
+    // `paths.describe` now reports `managed-copies` (the opt-in byte-copy store
+    // beside the library DB), which ManagedStoreMeter renders in this same
+    // sub-tab while naming its path nowhere. The subDirs KEY is the visible
+    // label verbatim, so the hyphenated form is deliberate.
+    // ACCEPTED trade-off: keepcopy creates that folder LAZILY on the first
+    // kept copy, so on a fresh install this button reveals a not-yet-existing
+    // path — the same shape the concrete dubs/stabilized/audiomix/trimmed rows
+    // already have. It is a real directory (no wildcard), so it is openable in
+    // principle; suppressing it would need an existence probe the layout
+    // handler is contractually forbidden to do (it is a pure path-join).
+    await mount({ rpc: makeRpc(), bridge: makeBridge() });
+    const row = container.querySelector('[data-path-key="subDir:managed-copies"]') as HTMLElement;
+    expect(row).not.toBeNull();
+    expect((row.querySelector('.paths-panel__row-label') as HTMLElement).textContent).toBe(
+      'managed-copies',
+    );
+    expect((row.querySelector('.paths-panel__path') as HTMLElement).textContent).toBe(
+      'C:/data/managed-copies',
+    );
+    expect(row.querySelector('.paths-panel__open')).not.toBeNull();
   });
 
   it('hydrates and shows the current data folder from the bridge', async () => {
@@ -233,7 +279,7 @@ describe('<PathsPanel />', () => {
     });
     await flush();
     expect(container.querySelector('.paths-panel__loading')).toBeNull();
-    expect(container.querySelectorAll('.paths-panel__row').length).toBe(10);
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(11);
   });
 
   it('surfaces a describe error and stops loading', async () => {
@@ -256,7 +302,7 @@ describe('<PathsPanel />', () => {
     expect(container.querySelector('.paths-panel__change-root')).toBeNull();
     expect(container.querySelector('.paths-panel__root-unavailable')).not.toBeNull();
     // The layout rows still render (the describe RPC is independent of the bridge).
-    expect(container.querySelectorAll('.paths-panel__row').length).toBe(10);
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(11);
   });
 
   it('keeps the Open button inert when the bridge lacks openInFolder', async () => {
@@ -285,6 +331,6 @@ describe('<PathsPanel />', () => {
     expect((container.querySelector('.paths-panel__root-value') as HTMLElement).textContent).toBe(
       'Unknown',
     );
-    expect(container.querySelectorAll('.paths-panel__row').length).toBe(10);
+    expect(container.querySelectorAll('.paths-panel__row').length).toBe(11);
   });
 });

--- a/app/renderer/src/components/PathsPanel.tsx
+++ b/app/renderer/src/components/PathsPanel.tsx
@@ -4,10 +4,12 @@
 // Two independent sources, both INJECTED so the component unit-tests with no
 // preload bridge (mirrors SavePresetsControls' injected `savePresets` slice):
 //   * `rpc.describe()` (sidecar `paths.describe`, WU-1, read-only) -> the resolved
-//     on-disk layout. Each DIRECTORY entry renders its path as selectable text +
+//     on-disk layout. Each OPENABLE entry renders its path as selectable text +
 //     a real <button> ("Open <label> folder") that reveals it via the bridge's
 //     `openInFolder` (the existing `shell.showItemInFolder` channel — no new
-//     channel). FILE entries (settings/library) are text-only (not directories).
+//     channel). FILE entries (settings/library) are text-only (not directories),
+//     and so is any `subDirs` value that is a PATTERN rather than a path (see
+//     `isOpenableDir`): a wildcard names no directory, so it gets no control.
 //   * `bridge` — the MAIN-process data-root flow (`dataFolder.get/pick/set`, NOT
 //     sidecar RPCs) + `openInFolder`. Each capability is optional: a missing piece
 //     degrades that control to an "Unavailable" state rather than crashing the
@@ -56,15 +58,35 @@ export interface PathsPanelProps {
   bridge: PathsBridge;
 }
 
-/** A single layout row: a human label, its path, and whether it is a directory. */
+/**
+ * A single layout row: a human label, its path, and whether the path can be
+ * handed to `openInFolder`. NOT "is this a directory" — a `subDirs` value can be
+ * a directory-shaped PATTERN that no reveal call can resolve, so the two are
+ * deliberately different questions (conflating them is what produced a
+ * permanently dead control).
+ */
 interface PathRow {
   key: string;
   label: string;
   path: string;
-  isDir: boolean;
+  canOpen: boolean;
 }
 
 const ROOT_UNKNOWN = 'Unknown';
+
+/** Wildcards are illegal in a Windows filename, so they can only be a pattern. */
+const GLOB_CHARS = /[*?]/;
+
+/**
+ * A `subDirs` value can be a PATTERN, not a path: the sidecar reports shorts as
+ * `exports/shorts-*` because output is per-video `exports/shorts-<videoId>`.
+ * MEASURED (Electron 43.2.0 / Windows 11): `shell.showItemInFolder` on such a
+ * path opens NOTHING — not even the parent — so a control here would be a silent
+ * dead click. The row keeps its label + path text; it just gets no button.
+ */
+function isOpenableDir(path: string): boolean {
+  return !GLOB_CHARS.test(path);
+}
 
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
@@ -73,19 +95,19 @@ function errText(err: unknown): string {
 /** Build the ordered display rows from a `paths.describe` payload. */
 function buildRows(layout: PathsDescribe): PathRow[] {
   const dirs: PathRow[] = [
-    { key: 'dataDir', label: 'Data', path: layout.dataDir, isDir: true },
-    { key: 'projectsDir', label: 'Projects', path: layout.projectsDir, isDir: true },
-    { key: 'exportsDir', label: 'Exports', path: layout.exportsDir, isDir: true },
+    { key: 'dataDir', label: 'Data', path: layout.dataDir, canOpen: true },
+    { key: 'projectsDir', label: 'Projects', path: layout.projectsDir, canOpen: true },
+    { key: 'exportsDir', label: 'Exports', path: layout.exportsDir, canOpen: true },
   ];
   const files: PathRow[] = [
-    { key: 'settingsPath', label: 'Settings file', path: layout.settingsPath, isDir: false },
-    { key: 'libraryPath', label: 'Library file', path: layout.libraryPath, isDir: false },
+    { key: 'settingsPath', label: 'Settings file', path: layout.settingsPath, canOpen: false },
+    { key: 'libraryPath', label: 'Library file', path: layout.libraryPath, canOpen: false },
   ];
   const subDirs = Object.entries(layout.subDirs ?? {}).map(([name, path]) => ({
     key: `subDir:${name}`,
     label: name,
     path,
-    isDir: true,
+    canOpen: isOpenableDir(path),
   }));
   return [...dirs, ...files, ...subDirs];
 }
@@ -214,7 +236,7 @@ export function PathsPanel({ rpc, bridge }: PathsPanelProps): React.ReactElement
             <li key={row.key} className="paths-panel__row" data-path-key={row.key}>
               <span className="paths-panel__row-label">{row.label}</span>
               <span className="paths-panel__path">{row.path}</span>
-              {row.isDir && openInFolder ? (
+              {row.canOpen && openInFolder ? (
                 <button
                   type="button"
                   className="paths-panel__open"

--- a/app/renderer/src/components/ProviderKeyRow.test.tsx
+++ b/app/renderer/src/components/ProviderKeyRow.test.tsx
@@ -53,7 +53,12 @@ function makeHandlers(over: Partial<Handlers> = {}): Handlers {
 
 function render(
   h: Handlers,
-  props: Partial<{ redactedKey: string; index: number; revealTimeoutMs: number }> = {},
+  props: Partial<{
+    redactedKey: string;
+    index: number;
+    revealTimeoutMs: number;
+    panelBusy: boolean;
+  }> = {},
 ): void {
   act(() => {
     root.render(
@@ -66,6 +71,7 @@ function render(
         onRevalidate={h.onRevalidate}
         onReplace={h.onReplace}
         {...(props.revealTimeoutMs !== undefined ? { revealTimeoutMs: props.revealTimeoutMs } : {})}
+        {...(props.panelBusy !== undefined ? { panelBusy: props.panelBusy } : {})}
       />,
     );
   });
@@ -337,5 +343,139 @@ describe('ProviderKeyRow — Replace (re-runs validation, preferred over in-plac
     await flush();
     root = createRoot(container);
     expect(true).toBe(true);
+  });
+});
+
+// --- F38: a REJECTED key op must never leave a stale in-progress label -------
+// Every one of Reveal / Re-validate / Replace was `try/finally` with NO `catch`,
+// so an RPC rejection (e.g. the sidecar's Offline refusal, which exists precisely
+// "so the message reaches the UI verbatim") skipped the status write and left the
+// row rendering a lying label — or, for Reveal, no feedback node at all.
+
+describe('ProviderKeyRow — rejected key ops surface the error (F38)', () => {
+  const OFFLINE =
+    'Offline mode is on — testing a provider key needs the network. Turn off Offline mode in System Health to allow it.';
+
+  it('replaces the stale "Re-validating…" label with the rejection message', async () => {
+    const h = makeHandlers({ onRevalidate: vi.fn(() => Promise.reject(new Error(OFFLINE))) });
+    render(h);
+    click('.provider-key-row__revalidate');
+    await flush();
+    const status = q('.provider-key-row__status');
+    expect(status.textContent).not.toBe('Re-validating…');
+    expect(status.textContent).toContain('Offline mode is on');
+  });
+
+  it('drops a re-validate rejection that lands after unmount (alive guard)', async () => {
+    let rejectCheck: (e: Error) => void = () => {};
+    const onRevalidate = vi.fn(
+      () => new Promise<KeyCheckResult>((_res, rej) => (rejectCheck = rej)),
+    );
+    const h = makeHandlers({ onRevalidate });
+    render(h);
+    click('.provider-key-row__revalidate');
+    act(() => root.unmount());
+    rejectCheck(new Error('late revalidate failure'));
+    await flush();
+    root = createRoot(container);
+    expect(container.querySelector('.provider-key-row')).toBeNull();
+  });
+
+  it('shows a reveal rejection in the status line and stays masked', async () => {
+    const h = makeHandlers({
+      onReveal: vi.fn(() =>
+        Promise.reject(new Error("providers.revealKey: no key at index 0 for 'groq'")),
+      ),
+    });
+    render(h);
+    click('.provider-key-row__reveal');
+    await flush();
+    // Pre-fix `status` was never written, so the <p> was not even in the DOM.
+    const status = container.querySelector('.provider-key-row__status');
+    expect(status).not.toBeNull();
+    expect(status?.textContent).toContain('no key at index 0');
+    // The R7 secret contract is untouched: still redacted, still masked.
+    expect(q('.provider-key-row__value').textContent).toBe('…WXYZ');
+    expect(q('.provider-key-row__value').getAttribute('data-revealed')).toBe('false');
+  });
+
+  it('stringifies a NON-Error reveal rejection', async () => {
+    const h = makeHandlers({
+      // eslint-disable-next-line prefer-promise-reject-errors -- deliberately a non-Error.
+      onReveal: vi.fn(() => Promise.reject('plain string reveal failure')),
+    });
+    render(h);
+    click('.provider-key-row__reveal');
+    await flush();
+    expect(container.querySelector('.provider-key-row__status')?.textContent).toContain(
+      'plain string reveal failure',
+    );
+  });
+
+  it('drops a reveal rejection that lands after unmount (alive guard)', async () => {
+    let rejectReveal: (e: Error) => void = () => {};
+    const onReveal = vi.fn(() => new Promise<string>((_res, rej) => (rejectReveal = rej)));
+    const h = makeHandlers({ onReveal });
+    render(h);
+    click('.provider-key-row__reveal');
+    act(() => root.unmount());
+    rejectReveal(new Error('late reveal failure'));
+    await flush();
+    root = createRoot(container);
+    expect(container.querySelector('.provider-key-row')).toBeNull();
+  });
+
+  it('keeps the replace editor open and the typed draft on a rejection', async () => {
+    const h = makeHandlers({ onReplace: vi.fn(() => Promise.reject(new Error('replace boom'))) });
+    render(h);
+    click('.provider-key-row__replace-toggle');
+    setInputValue(q<HTMLInputElement>('.provider-key-row__replace-input'), 'sk-typed-x');
+    await flush();
+    click('.provider-key-row__replace-save');
+    await flush();
+    const status = q('.provider-key-row__status');
+    expect(status.textContent).not.toBe('Validating new key…');
+    expect(status.textContent).toContain('replace boom');
+    // The editor stays open and the pasted key survives for a deliberate retry.
+    expect(container.querySelector('.provider-key-row__replace')).not.toBeNull();
+    expect(q<HTMLInputElement>('.provider-key-row__replace-input').value).toBe('sk-typed-x');
+  });
+
+  it('drops a replace rejection that lands after unmount (alive guard)', async () => {
+    let rejectCheck: (e: Error) => void = () => {};
+    const onReplace = vi.fn(() => new Promise<KeyCheckResult>((_res, rej) => (rejectCheck = rej)));
+    const h = makeHandlers({ onReplace });
+    render(h);
+    click('.provider-key-row__replace-toggle');
+    setInputValue(q<HTMLInputElement>('.provider-key-row__replace-input'), 'sk-unmount-reject');
+    await flush();
+    click('.provider-key-row__replace-save');
+    act(() => root.unmount());
+    rejectCheck(new Error('late replace failure'));
+    await flush();
+    root = createRoot(container);
+    expect(container.querySelector('.provider-key-row')).toBeNull();
+  });
+});
+
+// --- F41: a PANEL-level mutation in flight must lock this row's controls -----
+// `removeKey` / `replaceKey` both build their upsert payload from a pre-await
+// `providers` snapshot, so a second mutation started while the first is in flight
+// drops one of the two keys. The row had no panel-busy input at all.
+
+describe('ProviderKeyRow — panelBusy locks the mutating controls (F41)', () => {
+  it('disables Re-validate / Replace / Remove while the panel is mutating', () => {
+    const h = makeHandlers();
+    render(h, { panelBusy: true });
+    expect(q<HTMLButtonElement>('.provider-key-row__revalidate').disabled).toBe(true);
+    expect(q<HTMLButtonElement>('.provider-key-row__replace-toggle').disabled).toBe(true);
+    expect(q<HTMLButtonElement>('.provider-key-row__remove').disabled).toBe(true);
+  });
+
+  it('leaves them enabled when the panel is idle', () => {
+    const h = makeHandlers();
+    render(h, { panelBusy: false });
+    expect(q<HTMLButtonElement>('.provider-key-row__revalidate').disabled).toBe(false);
+    expect(q<HTMLButtonElement>('.provider-key-row__remove').disabled).toBe(false);
   });
 });

--- a/app/renderer/src/components/ProviderKeyRow.tsx
+++ b/app/renderer/src/components/ProviderKeyRow.tsx
@@ -45,6 +45,13 @@ export interface ProviderKeyRowProps {
   onReplace: (providerId: string, index: number, newKey: string) => Promise<KeyCheckResult>;
   /** Auto-re-mask delay (ms) after a reveal. Injectable for tests; default 15s. */
   revealTimeoutMs?: number;
+  /**
+   * True while the OWNING PANEL has a mutating providers RPC in flight. Both
+   * `onRemove` and `onReplace` re-upsert a key list the panel read BEFORE its
+   * own await, so a second mutation started inside that window drops one of the
+   * two keys; locking this row's mutating controls closes that window.
+   */
+  panelBusy?: boolean;
 }
 
 const DEFAULT_REVEAL_TIMEOUT_MS = 15_000;
@@ -52,6 +59,11 @@ const DEFAULT_REVEAL_TIMEOUT_MS = 15_000;
 /** Status text for a pass/fail validation outcome (never contains a key). */
 function checkStatus(result: KeyCheckResult): string {
   return result.ok ? 'Key verified — working.' : `Key failed: ${result.error ?? 'invalid'}`;
+}
+
+/** Error text from an unknown thrown value (mirrors the sibling panels). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 export function ProviderKeyRow({
@@ -63,6 +75,7 @@ export function ProviderKeyRow({
   onRevalidate,
   onReplace,
   revealTimeoutMs = DEFAULT_REVEAL_TIMEOUT_MS,
+  panelBusy,
 }: ProviderKeyRowProps): React.ReactElement {
   // The revealed plaintext lives ONLY here — never in React state/store (R7).
   const revealedRef = useRef<string | null>(null);
@@ -111,6 +124,12 @@ export function ProviderKeyRow({
       setRevealed(true);
       clearTimer();
       timerRef.current = setTimeout(remask, revealTimeoutMs);
+    } catch (err) {
+      // A rejected reveal (locked/unreadable keystore, Offline, sidecar down) used
+      // to be discarded, leaving the row with NO feedback node at all. Surface it
+      // in the status line; the secret contract is untouched — `revealedRef` stays
+      // null and `revealed` stays false, so nothing is unmasked.
+      if (aliveRef.current) setStatus(`Reveal failed: ${errText(err)}`);
     } finally {
       if (aliveRef.current) setBusy(false);
     }
@@ -122,6 +141,9 @@ export function ProviderKeyRow({
     try {
       const result = await onRevalidate(providerId, index);
       if (aliveRef.current) setStatus(checkStatus(result));
+    } catch (err) {
+      // Without this the row kept rendering the stale, lying 'Re-validating…'.
+      if (aliveRef.current) setStatus(`Key check failed: ${errText(err)}`);
     } finally {
       if (aliveRef.current) setBusy(false);
     }
@@ -136,12 +158,23 @@ export function ProviderKeyRow({
       const result = await onReplace(providerId, index, trimmed);
       if (!aliveRef.current) return;
       setStatus(checkStatus(result));
-      setDraft(''); // clear so the new key does not linger in the field
-      if (result.ok) setReplacing(false);
+      // Clear the field ONLY once the new key was accepted: a rejected/failed
+      // replacement must keep what the user pasted so they can retry it.
+      if (result.ok) {
+        setDraft('');
+        setReplacing(false);
+      }
+    } catch (err) {
+      // Keep the editor open AND the draft intact so the paste is not lost.
+      if (aliveRef.current) setStatus(`Key check failed: ${errText(err)}`);
     } finally {
       if (aliveRef.current) setBusy(false);
     }
   }, [draft, onReplace, providerId, index]);
+
+  // Any in-flight mutation — this row's own, or the owning panel's — locks the
+  // controls that would re-upsert a stale key list (F41).
+  const locked = busy || panelBusy === true;
 
   // Render reads the ref directly; `revealed` (a bool, no secret) gates it.
   const shown: string | null = revealed ? revealedRef.current : redactedKey;
@@ -175,7 +208,7 @@ export function ProviderKeyRow({
           type="button"
           className="provider-key-row__revalidate"
           aria-label={`Re-validate key for ${providerId}`}
-          disabled={busy}
+          disabled={locked}
           onClick={() => void revalidate()}
         >
           Re-validate
@@ -186,7 +219,7 @@ export function ProviderKeyRow({
           className="provider-key-row__replace-toggle"
           aria-label={`Replace key for ${providerId}`}
           aria-expanded={replacing}
-          disabled={busy}
+          disabled={locked}
           onClick={() => {
             setStatus('');
             setDraft('');
@@ -200,7 +233,7 @@ export function ProviderKeyRow({
           type="button"
           className="provider-key-row__remove"
           aria-label={`Remove key ${redactedKey} from ${providerId}`}
-          disabled={busy}
+          disabled={locked}
           onClick={() => onRemove(providerId, index)}
         >
           Remove
@@ -224,7 +257,7 @@ export function ProviderKeyRow({
             type="button"
             className="provider-key-row__replace-save"
             aria-label={`Save replacement key for ${providerId}`}
-            disabled={busy || draft.trim().length === 0}
+            disabled={locked || draft.trim().length === 0}
             onClick={() => void submitReplace()}
           >
             Save &amp; validate

--- a/app/renderer/src/components/SecureKeysBanner.test.tsx
+++ b/app/renderer/src/components/SecureKeysBanner.test.tsx
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import {
+  keystoreUnreadableBannerText,
   SecureKeysBanner,
   SESSION_ONLY_BANNER,
   unshreddableBannerText,
@@ -203,6 +204,69 @@ describe('SecureKeysBanner', () => {
     await flush();
     expect(banner()).toBeNull();
   });
+
+  it('surfaces the keystore-unreadable warning even when secure storage is healthy (sessionOnly false)', async () => {
+    // F39: main COMPUTES this (keyBridge.ts:234 `keystoreUnreadable: this.readDisk().reason`)
+    // and refuses to overwrite the keystore while it is set (keyBridge.ts:276-279), so a
+    // saved key silently does not persist. The reason crosses IPC intact, and the renderer
+    // dropped it: `messagesFor` emitted lines only for sessionOnly/unshreddable, so with a
+    // healthy store and no lingering plaintext the component returned null and the user was
+    // told NOTHING. Modelled on the passing additive-axis test above so a harness fault is
+    // excluded by construction: identical bridge, identical `sessionOnly:false` shape.
+    installBridge();
+    getSecureStatus.mockResolvedValue({
+      available: true,
+      backend: null,
+      sessionOnly: false,
+      banner: null,
+      unshreddable: [],
+      keystoreUnreadable: 'decrypt-failed',
+    });
+    mount();
+    await flush();
+    const el = banner();
+    expect(el).not.toBeNull();
+    expect(el?.getAttribute('role')).toBe('alert');
+    expect(el?.textContent).toContain('could not be read');
+  });
+
+  it('stacks all THREE warnings when sessionOnly, unshreddable and unreadable all apply', async () => {
+    installBridge();
+    getSecureStatus.mockResolvedValue({
+      available: false,
+      backend: 'basic_text',
+      sessionOnly: true,
+      banner: 'Keys cannot be saved — session only.',
+      unshreddable: ['/a/x.bak'],
+      keystoreUnreadable: 'read-failed',
+    });
+    mount();
+    await flush();
+    const el = banner();
+    expect(el?.querySelectorAll('.secure-keys-banner__message')).toHaveLength(3);
+    expect(el?.textContent).toContain('Keys cannot be saved — session only.');
+    expect(el?.textContent).toContain('/a/x.bak');
+    expect(el?.textContent).toContain('could not be read');
+  });
+
+  // REGRESSION GUARD — passes BOTH before and after the fix (stated honestly: this is not
+  // a red-proof). It pins the falsy arm of the new branch for the explicit `null` the wire
+  // actually sends for a healthy/absent keystore (keyBridge.test.ts:305-310), so a future
+  // truthiness slip cannot start alerting on a perfectly healthy store.
+  it('stays hidden when keystoreUnreadable is null (healthy or absent keystore)', async () => {
+    installBridge();
+    getSecureStatus.mockResolvedValue({
+      available: true,
+      backend: null,
+      sessionOnly: false,
+      banner: null,
+      unshreddable: [],
+      keystoreUnreadable: null,
+    });
+    mount();
+    await flush();
+    expect(banner()).toBeNull();
+  });
 });
 
 describe('unshreddableBannerText', () => {
@@ -218,5 +282,37 @@ describe('unshreddableBannerText', () => {
     expect(text).toContain('2 old plaintext API-key files ');
     expect(text).toContain('remain readable on disk');
     expect(text).toContain('Delete them manually: /a/x.bak, /b/y.old');
+  });
+});
+
+describe('keystoreUnreadableBannerText', () => {
+  // One case per KeystoreUnreadableReason. These PIN THE COPY; they are not needed for
+  // the branch gate (a Record property read is a statement, not a branch under v8).
+  it.each([
+    ['read-failed', 'another program may be holding it open'],
+    ['parse-failed', 'an earlier save was probably interrupted'],
+    ['shape-invalid', 'not in the expected format'],
+    ['decrypt-failed', 'copied from another machine or user profile'],
+  ] as const)('names the cause for %s', (reason, cause) => {
+    const text = keystoreUnreadableBannerText(reason);
+    expect(text).toContain('could not be read');
+    expect(text).toContain(cause);
+  });
+
+  it('never claims permanent loss and never names a data folder', () => {
+    // Both refusals are load-bearing: a `read-failed` lock can be transient, and the
+    // keystore lives under Electron's userData dir — NOT the user-chosen data folder —
+    // so naming that folder would send the user to the wrong place.
+    for (const reason of [
+      'read-failed',
+      'parse-failed',
+      'shape-invalid',
+      'decrypt-failed',
+    ] as const) {
+      const text = keystoreUnreadableBannerText(reason);
+      expect(text).toContain('Try restarting the app');
+      expect(text).not.toMatch(/permanent|lost forever|deleted/i);
+      expect(text).not.toMatch(/data folder/i);
+    }
   });
 });

--- a/app/renderer/src/components/SecureKeysBanner.tsx
+++ b/app/renderer/src/components/SecureKeysBanner.tsx
@@ -13,6 +13,17 @@
 // absent (tests / early boot) — it simply renders nothing.
 import React, { useEffect, useState } from 'react';
 
+/**
+ * WHY the on-disk keystore could not be read — mirror of keystore.ts
+ * KeystoreUnreadableReason. Every value means "the blob EXISTS but its contents could
+ * not be trusted", never "there is no keystore yet".
+ */
+export type KeystoreUnreadableReason =
+  | 'read-failed'
+  | 'parse-failed'
+  | 'shape-invalid'
+  | 'decrypt-failed';
+
 /** Mirror of keystore.ts SecureStatus / preload SecureStatus. */
 export interface SecureStatus {
   available: boolean;
@@ -29,6 +40,15 @@ export interface SecureStatus {
    * the surface that actually reaches the user.
    */
   unshreddable?: string[];
+  /**
+   * WHY the on-disk keystore could not be read, or `null` when it is healthy /
+   * genuinely absent. Optional so an older/partial payload degrades to "no problem";
+   * main always sends it (KeyBridge.secureStatus overlays the live value). While this
+   * is non-null the bridge REFUSES to overwrite the keystore (fail-closed), so a key
+   * the user enters does NOT persist — hence it must be shown, or saving looks like
+   * it worked and silently did not.
+   */
+  keystoreUnreadable?: KeystoreUnreadableReason | null;
 }
 
 interface SecureBridge {
@@ -63,7 +83,34 @@ export function unshreddableBannerText(paths: readonly string[]): string {
   );
 }
 
-/** One rendered warning line (session-only refusal or a lingering-plaintext notice). */
+/**
+ * The per-reason cause clause appended to the unreadable-keystore warning. Named
+ * CAUSES only — never the offending value — so nothing here can carry key material.
+ */
+const KEYSTORE_UNREADABLE_CAUSE: Record<KeystoreUnreadableReason, string> = {
+  'read-failed': 'the file could not be opened — another program may be holding it open',
+  'parse-failed': 'the file is incomplete, so an earlier save was probably interrupted',
+  'shape-invalid': 'the file contents are not in the expected format',
+  'decrypt-failed':
+    'this computer could not decrypt it — it may have been copied from another machine or user profile',
+};
+
+/**
+ * Concrete text for a keystore whose contents could not be trusted. Deliberately does
+ * NOT name a path (the keystore lives under Electron's userData directory, which is
+ * NOT the user-chosen data folder, so naming that folder would be actively wrong) and
+ * deliberately does NOT claim permanent loss — a `read-failed` lock can be transient,
+ * so restarting is the first thing to try.
+ */
+export function keystoreUnreadableBannerText(reason: KeystoreUnreadableReason): string {
+  return (
+    'Your saved API keys could not be read, so new keys cannot be saved and will only ' +
+    `work until you quit. Cause: ${KEYSTORE_UNREADABLE_CAUSE[reason]}. ` +
+    'Try restarting the app; the existing key file is left untouched.'
+  );
+}
+
+/** One rendered warning line (session-only, lingering-plaintext, or unreadable-keystore). */
 interface BannerMessage {
   key: string;
   text: string;
@@ -78,16 +125,43 @@ function messagesFor(status: SecureStatus): BannerMessage[] {
   if (status.unshreddable && status.unshreddable.length > 0) {
     messages.push({ key: 'unshreddable', text: unshreddableBannerText(status.unshreddable) });
   }
+  // One truthiness test covers BOTH `undefined` (an older/partial payload) and the
+  // `null` main actually sends for a healthy or absent keystore.
+  if (status.keystoreUnreadable) {
+    messages.push({
+      key: 'keystore-unreadable',
+      text: keystoreUnreadableBannerText(status.keystoreUnreadable),
+    });
+  }
   return messages;
 }
 
 /**
  * Renders nothing while secure storage is healthy AND no plaintext copy was left
- * behind (or the bridge is absent). Surfaces a persistent non-blocking alert for two
- * independent, possibly-simultaneous keystore conditions: `sessionOnly` (keys can't
- * be saved at rest) and `unshreddable` (a legacy plaintext copy the migration could
- * not delete) — so a user never silently loses a key NOR silently keeps a recoverable
- * plaintext one on disk.
+ * behind AND the keystore reads cleanly (or the bridge is absent). Surfaces a
+ * persistent non-blocking alert for three independent, possibly-simultaneous keystore
+ * conditions: `sessionOnly` (keys can't be saved at rest), `unshreddable` (a legacy
+ * plaintext copy the migration could not delete), and `keystoreUnreadable` (the stored
+ * keys could not be read, so the bridge fail-closed refuses to overwrite them) — so a
+ * user never silently loses a key NOR silently keeps a recoverable plaintext one on
+ * disk NOR believes a save succeeded that was actually refused.
+ *
+ * KNOWN LIMITS of this surface (deliberate scope, not oversights):
+ *  1. MOUNT-ONCE SNAPSHOT, stale in BOTH directions. `getSecureStatus()` runs exactly
+ *     once in a `[]` effect below, and each call costs a full synchronous read+decrypt
+ *     of the keystore in main, so it is not polled. Consequences: (a) FALSE NEGATIVE —
+ *     a lock that appears mid-session (the `read-failed` AV/indexer case, typically at
+ *     the moment the user clicks Add key and the bridge refuses) renders NOTHING here,
+ *     while the Providers panel still reports the key as verified; (b) FALSE POSITIVE —
+ *     a keystore unreadable at mount but healthy afterwards leaves this alert up for
+ *     the rest of the session. The cheap remedy is to re-query after an explicit
+ *     `providers.upsert` (one read per deliberate user action, not a poll), or to have
+ *     main push `secure.status` when the refusal branch is taken. Neither is wired yet.
+ *  2. DISPLAY-ONLY. This tells the user; it does not repair anything. In particular the
+ *     key-LIST shrinkage that accompanies an unreadable keystore is NOT fixed: an add
+ *     re-sends the provider's existing REDACTED keys, `planUpsert` resolves the stored
+ *     set as empty, and the raw-key filter drops every redacted stand-in, so previously
+ *     listed keys also disappear from the Providers list. That is a separate defect.
  */
 export function SecureKeysBanner(): React.ReactElement | null {
   const [messages, setMessages] = useState<readonly BannerMessage[]>([]);

--- a/app/renderer/src/components/SetupStatusPanel.test.tsx
+++ b/app/renderer/src/components/SetupStatusPanel.test.tsx
@@ -123,7 +123,7 @@ describe('<SetupStatusPanel /> — WU-2 first-run diagnostic', () => {
         }),
         check({
           id: 'cv2',
-          label: 'Reframe engine (OpenCV + MediaPipe)',
+          label: 'Reframe engine (OpenCV)',
           required: true,
           ok: false,
           detail: 'missing: cv2',

--- a/app/renderer/src/features/BatchQueue.test.tsx
+++ b/app/renderer/src/features/BatchQueue.test.tsx
@@ -22,6 +22,7 @@ const batchPlanMock = vi.fn();
 const batchStartMock = vi.fn();
 const batchStatusMock = vi.fn();
 const batchResumeMock = vi.fn();
+const batchDeleteMock = vi.fn();
 const settingsGetMock = vi.fn();
 
 let progressCbs: Array<(e: ProgressEvent) => void> = [];
@@ -38,6 +39,7 @@ vi.mock('../lib/rpc', () => ({
       start: (...a: unknown[]) => batchStartMock(...a),
       status: (...a: unknown[]) => batchStatusMock(...a),
       resume: (...a: unknown[]) => batchResumeMock(...a),
+      delete: (...a: unknown[]) => batchDeleteMock(...a),
     },
     settings: { get: (...a: unknown[]) => settingsGetMock(...a) },
   },
@@ -147,6 +149,20 @@ async function render(props: { resumeId?: string } = {}): Promise<void> {
   });
 }
 
+/**
+ * Mount WITHOUT the trailing microtask flush, so the initial `reload()` stays in
+ * flight. It MUST assign the module-level `container`/`root` or the shared
+ * `afterEach` unmounts the previous test's tree and leaks this one.
+ */
+function renderPending(): void {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root.render(<BatchQueue />);
+  });
+}
+
 beforeEach(() => {
   progressCbs = [];
   doneCbs = [];
@@ -158,6 +174,7 @@ beforeEach(() => {
   batchStartMock.mockResolvedValue({ jobId: 'job-1' });
   batchStatusMock.mockResolvedValue({ batch: state([{ videoId: 'v1', status: 'queued' }]) });
   batchResumeMock.mockResolvedValue({ jobId: 'job-2' });
+  batchDeleteMock.mockResolvedValue({ ok: true });
   // The §9.1 budget setting defaults ON (settings_store confirmCloudBudget=True).
   settingsGetMock.mockResolvedValue({ confirmCloudBudget: true });
 });
@@ -183,6 +200,60 @@ describe('BatchQueue', () => {
     expect(container.querySelector('.batch-queue__resume')?.textContent).toContain('Prior run');
     // remaining = 3 - 1 done - 0 skipped = 2
     expect(container.textContent).toContain('2 of 3 left');
+  });
+
+  it('renders an empty state instead of a bare Sources legend', async () => {
+    // The Sources fieldset was a bare `{videos.map(...)}` with no fallback, so a
+    // fresh install rendered `<legend>Sources</legend>` and nothing else.
+    libListMock.mockResolvedValue({ videos: [] });
+    tmplListMock.mockResolvedValue({ templates: [] });
+    await render();
+    expect(container.querySelector('.batch-queue__empty')).not.toBeNull();
+    // The Template <select> stays mounted (other tests query it directly).
+    expect(container.querySelector('select[aria-label="Template"]')).not.toBeNull();
+    expect(container.querySelector('.batch-queue__template-hint')).not.toBeNull();
+  });
+
+  it('names the unmet precondition behind the disabled Run button', async () => {
+    libListMock.mockResolvedValue({ videos: [] });
+    tmplListMock.mockResolvedValue({ templates: [] });
+    await render();
+    const run = [...container.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Run batch',
+    ) as HTMLButtonElement;
+    expect(run.disabled).toBe(true); // PASSES today — proves canRun is genuinely false
+    const id = run.getAttribute('aria-describedby');
+    expect(id).not.toBeNull();
+    // A native `disabled` button is out of the tab order, so the VISIBLE sibling is
+    // the real fix; the attribute only ties them together.
+    expect(container.querySelector(`#${id}`)?.textContent ?? '').toMatch(/source|template/i);
+  });
+
+  it('is busy (not empty) while the initial load is in flight', async () => {
+    // `reload` awaits Promise.all, so holding library.list holds the whole load.
+    // Today that render is byte-identical to the loaded-but-empty render.
+    let release!: (v: { videos: Video[] }) => void;
+    libListMock.mockReturnValue(
+      new Promise<{ videos: Video[] }>((r) => {
+        release = r;
+      }),
+    );
+    renderPending();
+    expect(container.querySelector('[aria-busy="true"]')).not.toBeNull();
+    await act(async () => {
+      release({ videos: VIDEOS });
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    // The both-states check: the probe must go from satisfied to unsatisfiable.
+    expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+  });
+
+  it('clears the busy state when the initial load FAILS', async () => {
+    libListMock.mockRejectedValueOnce(new Error('load-bad'));
+    await render();
+    expect(container.querySelector('[aria-busy="true"]')).toBeNull();
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('load-bad');
   });
 
   it('disables Run until a source AND template are chosen', async () => {
@@ -382,6 +453,90 @@ describe('BatchQueue', () => {
     expect(batchResumeMock).toHaveBeenCalledWith('bA');
   });
 
+  it('removes an abandoned batch from the resume list', async () => {
+    // Every Run click persists a durable record BEFORE the default-ON consent gate,
+    // so an abandoned run stays `queued` forever in "Incomplete batches" (and in
+    // the tab badge + launch toast) with no in-app removal. `batch.delete` shipped
+    // end-to-end; only the affordance was missing.
+    batchListMock
+      .mockResolvedValueOnce({ batches: [summary({ id: 'bA', status: 'queued' })] })
+      .mockResolvedValueOnce({ batches: [] });
+    await render();
+    await act(async () => {
+      clickText('Remove');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(batchDeleteMock).toHaveBeenCalledWith('bA');
+    expect(batchListMock).toHaveBeenCalledTimes(2); // the reload
+    expect(container.querySelector('.batch-queue__resume')).toBeNull();
+  });
+
+  it('surfaces a remove failure with an Error message (instanceof arm)', async () => {
+    batchListMock.mockResolvedValue({ batches: [summary()] });
+    batchDeleteMock.mockRejectedValueOnce(new Error('delete-boom'));
+    await render();
+    await act(async () => {
+      clickText('Remove');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('delete-boom');
+  });
+
+  it('surfaces a remove failure on a non-Error rejection (Delete failed)', async () => {
+    batchListMock.mockResolvedValue({ batches: [summary()] });
+    batchDeleteMock.mockRejectedValueOnce('x');
+    await render();
+    await act(async () => {
+      clickText('Remove');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.batch-queue__error')?.textContent).toBe('Delete failed');
+  });
+
+  it('surfaces a refused resume instead of clobbering the live progress gate', async () => {
+    // The sidecar refuses a resume while a parent job is still live and answers
+    // with the {jobId: null} no-op shape. Two things must hold: the panel must NOT
+    // overwrite the tracked parent jobId with '' (that makes the onProgress gate
+    // drop every event for the run that IS in flight, freezing the bar and the
+    // a11y announcer), and the click must not be silently dead.
+    settingsGetMock.mockResolvedValue({ confirmCloudBudget: false });
+    batchListMock.mockResolvedValue({ batches: [summary()] });
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const barNow = (): string | null | undefined =>
+      container
+        .querySelector('.batch-queue__live [role="progressbar"]')
+        ?.getAttribute('aria-valuenow');
+    act(() =>
+      progressCbs.forEach((c) => c({ jobId: 'job-1', pct: 44, message: 'source 1/2 · A' })),
+    );
+    expect(barNow()).toBe('44'); // PASSES today — proves the live gate tracks job-1
+    batchResumeMock.mockResolvedValueOnce({ jobId: null, status: 'running' });
+    await act(async () => {
+      clickText('Resume');
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const notice = container.querySelector('.batch-queue__notice');
+    expect(notice).not.toBeNull();
+    expect(notice?.textContent).toContain('already running');
+    // ...and the live run's progress still applies.
+    act(() =>
+      progressCbs.forEach((c) => c({ jobId: 'job-1', pct: 66, message: 'source 2/2 · B' })),
+    );
+    expect(barNow()).toBe('66');
+  });
+
   it('deep-links a resume on mount via resumeId', async () => {
     await render({ resumeId: 'bZ' });
     expect(batchResumeMock).toHaveBeenCalledWith('bZ');
@@ -453,6 +608,37 @@ describe('BatchQueue', () => {
     );
     const bar = container.querySelector('.batch-queue__live [role="progressbar"]');
     expect(bar?.getAttribute('aria-valuenow')).toBe('73');
+  });
+
+  it('keeps the last live pct when the terminal status snapshot omits it', async () => {
+    // `pct` is a live-ONLY overlay: `_merge_live_status` (batch.py) adds nothing
+    // once the parent job is finished, so the terminal `batch.status` snapshot has
+    // no pct and the bar fell back to `pct ?? 0` — width 0% / aria-valuenow="0"
+    // beside its own "done" label and a full row of terminal tokens.
+    settingsGetMock.mockResolvedValue({ confirmCloudBudget: false });
+    await render();
+    const cb = container.querySelectorAll('.batch-queue__source input')[0] as HTMLInputElement;
+    act(() => cb.dispatchEvent(new MouseEvent('click', { bubbles: true })));
+    await act(async () => {
+      clickText('Run batch');
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const barNow = (): string | null | undefined =>
+      container
+        .querySelector('.batch-queue__live [role="progressbar"]')
+        ?.getAttribute('aria-valuenow');
+    act(() => progressCbs.forEach((c) => c({ jobId: 'job-1', pct: 100, message: 'done' })));
+    expect(barNow()).toBe('100'); // PASSES today — proves the live overlay arrived
+    batchStatusMock.mockResolvedValue({
+      batch: state([{ videoId: 'v1', status: 'done' }], { status: 'done' }),
+    });
+    await act(async () => {
+      doneCbs.forEach((c) => c());
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(barNow()).toBe('100'); // FAILS today with "0"
   });
 
   it('surfaces a status failure with an Error message (instanceof arm)', async () => {
@@ -717,6 +903,50 @@ describe('announceTransitions (pure)', () => {
       () => {},
     );
     expect(polite).toEqual([]);
+  });
+
+  it('carries the last known pct forward when the next snapshot omits it', () => {
+    const prev = state([{ videoId: 'a', status: 'running' }], { pct: 100 });
+    const next = state([{ videoId: 'a', status: 'done' }], { status: 'done' });
+    expect(
+      announceTransitions(
+        prev,
+        next,
+        titleFor,
+        () => {},
+        () => {},
+      ).pct,
+    ).toBe(100);
+  });
+
+  it('lets a defined next pct win over the carried one', () => {
+    const prev = state([{ videoId: 'a', status: 'running' }], { pct: 10 });
+    const next = state([{ videoId: 'a', status: 'running' }], { pct: 55 });
+    expect(
+      announceTransitions(
+        prev,
+        next,
+        titleFor,
+        () => {},
+        () => {},
+      ).pct,
+    ).toBe(55);
+  });
+
+  it('never carries a DIFFERENT batch pct forward (the resume refresh path)', () => {
+    // `resume` calls refreshBatch(id) WITHOUT resetting `batch`, so an evicted or
+    // already-terminal resume would otherwise leak the previous batch's pct.
+    const prev = state([{ videoId: 'a', status: 'running' }], { id: 'bOld', pct: 90 });
+    const next = state([{ videoId: 'a', status: 'running' }], { id: 'bNew' });
+    expect(
+      announceTransitions(
+        prev,
+        next,
+        titleFor,
+        () => {},
+        () => {},
+      ).pct,
+    ).toBeUndefined();
   });
 
   it('ignores a terminal status with no announcement mapping is impossible (cancelled is polite)', () => {

--- a/app/renderer/src/features/BatchQueue.tsx
+++ b/app/renderer/src/features/BatchQueue.tsx
@@ -53,6 +53,13 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
   const [batch, setBatch] = useState<BatchState | null>(null);
   const [incomplete, setIncomplete] = useState<BatchSummary[]>([]);
   const [error, setError] = useState('');
+  // A non-error explanation for an action the sidecar declined (today: a resume
+  // refused because the batch's parent job is still live). Kept separate from
+  // `error` so it announces politely (role="status") and never reads as a failure.
+  const [notice, setNotice] = useState('');
+  // The initial load is indistinguishable from "loaded and empty" without this
+  // (docs/design-system.md defines both a skeleton and an empty-state pattern).
+  const [loading, setLoading] = useState(true);
 
   // §9.1 pre-run cloud-egress consent (DESIGN §9 / §9.1). `consent` holds the
   // pure run/skip surface from `batch.plan`; the card is shown until the user
@@ -101,6 +108,9 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
       // own clear.
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load');
+    } finally {
+      // In a `finally` so a FAILED load also stops claiming to be busy.
+      setLoading(false);
     }
   }, []);
 
@@ -185,6 +195,7 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
       // Clear optimistically up front; an internal failure (e.g. refreshBatch)
       // owns its own error and we must NOT clobber it after the await.
       setError('');
+      setNotice('');
       const { batch: created } = await client.batch.create('Batch run', templateId, selected);
       setBatch(created);
       pendingBatchRef.current = created;
@@ -232,10 +243,21 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
     async (id: string) => {
       try {
         setError('');
-        // Track the resumed run's parent jobId so its live progress is honoured
-        // by the onProgress gate (batch.resume returns {jobId}).
+        setNotice('');
         const out = await client.batch.resume(id);
-        parentJobIdRef.current = jobIdOf(out);
+        const jobId = jobIdOf(out);
+        if (jobId === '') {
+          // The sidecar declined: this batch's parent job is still live, so it
+          // returned the {jobId: null} no-op shape. Do NOT assign the ref — '' makes
+          // the onProgress gate (:129) drop every event for the run that IS in
+          // flight, freezing the bar and the a11y announcer. Say why instead; a
+          // silent no-op click would be a new dead control.
+          setNotice('That batch is already running.');
+        } else {
+          // Track the resumed run's parent jobId so its live progress is honoured
+          // by the onProgress gate (batch.resume returns {jobId}).
+          parentJobIdRef.current = jobId;
+        }
         await refreshBatch(id);
         await reload();
       } catch (err) {
@@ -243,6 +265,25 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
       }
     },
     [refreshBatch, reload],
+  );
+
+  // Drop an abandoned batch record. NO renderer liveness guard on purpose: the
+  // durable aggregate status cannot distinguish live from crashed (and is `queued`
+  // for the whole window between resume's on-disk re-enqueue and the pooled
+  // worker's first `running` checkpoint), so `BatchService.delete` refuses a live
+  // batch server-side and that refusal surfaces here as an error.
+  const removeBatch = useCallback(
+    async (id: string) => {
+      try {
+        setError('');
+        setNotice('');
+        await client.batch.delete(id);
+        await reload();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Delete failed');
+      }
+    },
+    [reload],
   );
 
   // Deep-linked resume from the launch toast — fire ONCE per resumeId (guard
@@ -265,6 +306,22 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
         </p>
       ) : null}
 
+      {notice !== '' ? (
+        <p role="status" className="batch-queue__notice">
+          {notice}
+        </p>
+      ) : null}
+
+      {loading ? (
+        // Rendered INLINE, not as an early return: unlike ProvidersKeys this panel
+        // can set an error DURING the load (the `resumeId` deep-link resumes
+        // concurrently), and an early return would hide that alert and the resume
+        // list until the load settled.
+        <p className="batch-queue__loading" role="status" aria-busy="true">
+          Loading your sources and templates…
+        </p>
+      ) : null}
+
       {incomplete.length > 0 ? (
         <div className="batch-queue__resume">
           <h4>Incomplete batches</h4>
@@ -277,6 +334,13 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
                 <button type="button" onClick={() => void resume(b.id)}>
                   Resume
                 </button>
+                <button
+                  type="button"
+                  aria-label={`Remove ${b.name}`}
+                  onClick={() => void removeBatch(b.id)}
+                >
+                  Remove
+                </button>
               </li>
             ))}
           </ul>
@@ -286,16 +350,20 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
       <div className="batch-queue__setup">
         <fieldset className="batch-queue__sources">
           <legend>Sources</legend>
-          {videos.map((video) => (
-            <label key={video.id} className="batch-queue__source">
-              <input
-                type="checkbox"
-                checked={selected.includes(video.id)}
-                onChange={() => toggleVideo(video.id)}
-              />
-              {video.title}
-            </label>
-          ))}
+          {videos.length === 0 ? (
+            <p className="batch-queue__empty">Add videos in your Library first.</p>
+          ) : (
+            videos.map((video) => (
+              <label key={video.id} className="batch-queue__source">
+                <input
+                  type="checkbox"
+                  checked={selected.includes(video.id)}
+                  onChange={() => toggleVideo(video.id)}
+                />
+                {video.title}
+              </label>
+            ))
+          )}
         </fieldset>
 
         <label className="batch-queue__template">
@@ -312,15 +380,29 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
             ))}
           </select>
         </label>
+        {/* Mount-agnostic wording on purpose: the Deliver mount (Deliver.tsx) has
+            no Templates tab, so "see the Templates tab" would point at nothing. */}
+        {templates.length === 0 ? (
+          <p className="batch-queue__template-hint">Save a template first.</p>
+        ) : null}
 
         <button
           type="button"
           className="batch-queue__run"
           disabled={!canRun}
+          aria-describedby={canRun ? undefined : 'batch-queue-run-hint'}
           onClick={() => void runBatch()}
         >
           Run batch
         </button>
+        {/* The hint text MUST live outside the button (≈15 tests match its exact
+            textContent) and stays visible-sibling-first: a native disabled button is
+            out of the tab order, so aria-describedby alone would announce nothing. */}
+        {canRun ? null : (
+          <p id="batch-queue-run-hint" className="batch-queue__run-hint">
+            Select at least one source and a template to run a batch.
+          </p>
+        )}
       </div>
 
       {consent ? (
@@ -371,6 +453,15 @@ export function BatchQueue({ resumeId }: BatchQueueProps): React.ReactElement {
  * Compute the new batch state and push per-source TERMINAL announcements for any
  * item that newly reached a terminal state (queued/running flips are silent,
  * §7.1). Exported for unit coverage of the announce-on-terminal contract.
+ *
+ * Also carries the last-known `pct` forward. `pct` is a LIVE-ONLY overlay —
+ * `_merge_live_status` (`batch.py`) adds nothing once the parent job is finished or
+ * evicted — so a terminal snapshot arrives with no `pct` and the aggregate bar
+ * would fall back to 0% next to its own "done" label. The last OBSERVED pct is
+ * carried instead of forcing 100: a cancelled or halted-early batch never reached
+ * 100 and claiming it did would be a fresh lie. The carry-forward is scoped to the
+ * SAME batch id because `resume` refreshes without resetting `batch`, so an
+ * evicted/terminal resume would otherwise leak the previous batch's pct.
  */
 export function announceTransitions(
   prev: BatchState | null,
@@ -394,7 +485,8 @@ export function announceTransitions(
       pushPolite((log) => [...log, ann.text]);
     }
   }
-  return next;
+  const carried = prev !== null && prev.id === next.id ? prev.pct : undefined;
+  return { ...next, pct: next.pct ?? carried };
 }
 
 export default BatchQueue;

--- a/app/renderer/src/features/ProvidersKeys.test.tsx
+++ b/app/renderer/src/features/ProvidersKeys.test.tsx
@@ -650,6 +650,93 @@ describe('ProvidersKeys — configured provider card', () => {
     expect(container.querySelector('.provider-card')).toBeNull();
   });
 
+  // --- F41: a second Add inside the first round-trip must not drop a key -------
+
+  it('does not drop the first key when a second Add is submitted before the first round-trip finishes', async () => {
+    let release: (v: TestKeyResult) => void = () => {};
+    let calls = 0;
+    const testKey = vi.fn(() => {
+      calls += 1;
+      if (calls === 1) {
+        return new Promise<TestKeyResult>((res) => {
+          release = res;
+        });
+      }
+      return Promise.resolve({ ok: true } as TestKeyResult);
+    });
+    const upsert = vi.fn((params: { id: string; apiKeys: string[] }) =>
+      Promise.resolve({ providers: [{ id: params.id, provider: 'Groq', apiKeys: ['…ey-A'] }] }),
+    );
+    const api = makeApi({
+      list: () =>
+        Promise.resolve({
+          providers: [{ id: 'groq', provider: 'Groq', baseUrl: 'https://b/v1', apiKeys: [] }],
+        }),
+      testKey,
+      upsert,
+    });
+    await mount({ rpcClient: api });
+    const input = container.querySelector<HTMLInputElement>('.add-key-row__input')!;
+    await act(async () => setInputValue(input, 'sk-key-A'));
+    await act(async () => container.querySelector<HTMLButtonElement>('.add-key-row__add')!.click());
+    // The first add is now parked on a hung testKey; the panel is busy.
+    await act(async () => setInputValue(input, 'sk-key-B'));
+    // Enter, NOT a button click — Enter bypasses `disabled`, so a fix that only
+    // sets disabled={busy} on the button still fails this test.
+    await act(async () => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    });
+    await act(async () => release({ ok: true } as TestKeyResult));
+    await flush();
+
+    const payloads = upsert.mock.calls.map((c) => c[0].apiKeys);
+    // LOAD-BEARING: no stored list may omit a key the panel already accepted.
+    expect(payloads.filter((k) => !k.includes('sk-key-A'))).toEqual([]);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(payloads[0]).toEqual(['sk-key-A']);
+    // The refused submit preserves the pasted second key for a deliberate retry.
+    expect(input.value).toBe('sk-key-B');
+  });
+
+  it('locks every per-key control while a panel mutation is in flight', async () => {
+    let release: (v: ProvidersListResponse) => void = () => {};
+    const upsert = vi.fn(
+      () =>
+        new Promise<ProvidersListResponse>((res) => {
+          release = res;
+        }),
+    );
+    const api = makeApi({
+      list: () =>
+        Promise.resolve({
+          providers: [
+            { id: 'groq', provider: 'Groq', apiKeys: ['…WXYZ'] },
+            { id: 'openai', provider: 'OpenAI API', apiKeys: ['…1234'] },
+          ],
+        }),
+      upsert,
+    });
+    await mount({ rpcClient: api });
+    // Start a remove-key mutation on the first card; the panel is now busy.
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('.provider-key-row__remove')!.click();
+    });
+    // Every key row — including the untouched second provider's — is locked, so no
+    // second mutation can re-upsert a list built from the pre-await snapshot.
+    const removes = [...container.querySelectorAll<HTMLButtonElement>('.provider-key-row__remove')];
+    expect(removes.length).toBe(2);
+    expect(removes.every((b) => b.disabled)).toBe(true);
+    const toggles = [
+      ...container.querySelectorAll<HTMLButtonElement>('.provider-key-row__replace-toggle'),
+    ];
+    expect(toggles.every((b) => b.disabled)).toBe(true);
+    // Add is gated on the same flag, on every card.
+    const adds = [...container.querySelectorAll<HTMLButtonElement>('.add-key-row__add')];
+    expect(adds.every((b) => b.getAttribute('title') === 'Working…')).toBe(true);
+    await act(async () => release({ providers: [] }));
+    await flush();
+  });
+
   it('uses the provider id as the display name + empty baseUrl for an unknown custom provider', async () => {
     const testKey = vi.fn(() => Promise.resolve({ ok: true }));
     const api = makeApi({
@@ -881,6 +968,65 @@ describe('ProvidersKeys — WU-D3 reveal / re-validate / replace', () => {
       id: 'groq',
       apiKeys: ['sk-replacement-key', '…1234'],
     });
+  });
+
+  // --- F38: the panel must not swallow a reveal/revalidate/replace rejection --
+  // `revealKey` / `revalidateKey` / `replaceKey` had no try/catch at all, so the
+  // role="alert" banner stayed empty while the sidecar's actionable refusal was
+  // dropped on the floor — unlike the sibling `addKey`, which already reports.
+
+  it('surfaces a rejected re-validate in the panel banner (F38)', async () => {
+    const revealKey = vi.fn(() => Promise.resolve({ key: REVEALED }));
+    const testKey = vi.fn(() => Promise.reject(new Error('net down')));
+    const api = configuredApi({ revealKey, testKey });
+    await mount({ rpcClient: api });
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('.provider-key-row__revalidate')!.click(),
+    );
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('net down');
+  });
+
+  it('surfaces a rejected replace AND preserves the typed replacement key (F38)', async () => {
+    const testKey = vi.fn(() => Promise.reject(new Error('replace net down')));
+    const api = configuredApi({ testKey });
+    await mount({ rpcClient: api });
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('.provider-key-row__replace-toggle')!.click(),
+    );
+    const input = container.querySelector<HTMLInputElement>('.provider-key-row__replace-input')!;
+    await act(async () => setInputValue(input, 'sk-keep-me'));
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('.provider-key-row__replace-save')!.click(),
+    );
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('replace net down');
+    // LOAD-BEARING: the panel degrades the rejection to a resolved {ok:false}, so
+    // the row takes its SUCCESS path — an unconditional setDraft('') there would
+    // erase the key the user just pasted (strictly worse than the original bug).
+    expect(
+      container.querySelector<HTMLInputElement>('.provider-key-row__replace-input')?.value,
+    ).toBe('sk-keep-me');
+    expect(container.querySelector('.provider-key-row__replace')).not.toBeNull();
+  });
+
+  it('surfaces a rejected reveal in the banner and re-throws so the row shows it too (F38)', async () => {
+    const revealKey = vi.fn(() => Promise.reject(new Error('key is locked')));
+    const api = configuredApi({ revealKey });
+    await mount({ rpcClient: api });
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('.provider-key-row__reveal')!.click(),
+    );
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('key is locked');
+    // revealKey returns Promise<string> and cannot degrade, so it re-throws — the
+    // row's own catch is what renders the local status line.
+    expect(container.querySelector('.provider-key-row__status')?.textContent).toContain(
+      'key is locked',
+    );
+    expect(container.querySelector('.provider-key-row__value')?.getAttribute('data-revealed')).toBe(
+      'false',
+    );
   });
 
   it('tolerates a malformed upsert response after replace (non-array → empty list)', async () => {

--- a/app/renderer/src/features/ProvidersKeys.tsx
+++ b/app/renderer/src/features/ProvidersKeys.tsx
@@ -185,6 +185,7 @@ function ProviderCard({
               onReveal={onRevealKey}
               onRevalidate={onRevalidateKey}
               onReplace={onReplaceKey}
+              panelBusy={busy}
             />
           ))}
         </ul>
@@ -194,7 +195,11 @@ function ProviderCard({
         </p>
       )}
 
-      <AddKeyRow providerId={entry.id} onAdd={onAddKey} />
+      {/* Every mutating key control is gated on the SAME panel-wide in-flight flag
+          (as Remove provider and the picker already are): each of addKey /
+          removeKey / replaceKey re-upserts a key list read BEFORE its own await, so
+          a second one accepted inside that window silently drops a key. */}
+      <AddKeyRow providerId={entry.id} busy={busy} onAdd={onAddKey} />
 
       <ConsentToggle
         providerId={name}
@@ -420,10 +425,20 @@ export function ProvidersKeys({
   // WU-D3 reveal: fetch the ONE full key for a transient, masked-by-default display.
   // The plaintext is RETURNED to the row (held in its ref only) — never stored in
   // this panel's state/store, never logged. This is the sole full-key RPC.
+  // A rejection here (locked/unreadable keystore, Offline, sidecar down) must not
+  // vanish: report it in the banner AND re-throw. This callback returns
+  // Promise<string>, so it cannot degrade to a resolved value — providers_ops.py
+  // forbids a silent empty reveal that the UI could mistake for a real key — and
+  // the row's own catch renders the local status line from the re-thrown error.
   const revealKey = useCallback(
     async (id: string, index: number): Promise<string> => {
-      const res = await api.providers.revealKey(id, index);
-      return res.key;
+      try {
+        const res = await api.providers.revealKey(id, index);
+        return res.key;
+      } catch (err) {
+        setError(errText(err));
+        throw err;
+      }
     },
     [api],
   );
@@ -437,15 +452,24 @@ export function ProvidersKeys({
       /* v8 ignore next -- bound to a live key row; the guard is defensive. */
       if (!entry) return { ok: false, error: 'unknown provider' };
       const { baseUrl, model, capabilities } = resolveKeyTarget(entry);
-      const revealed = await api.providers.revealKey(id, index);
-      const result = await api.providers.testKey({
-        baseUrl,
-        apiKey: revealed.key,
-        model,
-        capabilities,
-      });
-      setTested((t) => ({ ...t, [id]: result.ok }));
-      return result;
+      try {
+        const revealed = await api.providers.revealKey(id, index);
+        const result = await api.providers.testKey({
+          baseUrl,
+          apiKey: revealed.key,
+          model,
+          capabilities,
+        });
+        setTested((t) => ({ ...t, [id]: result.ok }));
+        return result;
+      } catch (err) {
+        // Mirror addKey (which already reports): the banner is the owner of the
+        // message, and the degraded KeyCheckResult keeps the row out of a stale
+        // 'Re-validating…' label instead of an unhandled rejection.
+        const msg = errText(err);
+        setError(msg);
+        return { ok: false, error: msg };
+      }
     },
     [api, providers],
   );
@@ -460,12 +484,25 @@ export function ProvidersKeys({
       /* v8 ignore next -- bound to a live key row, so entry AND its apiKeys array exist; defensive. */
       if (!entry || !Array.isArray(entry.apiKeys)) return { ok: false, error: 'unknown provider' };
       const { baseUrl, model, capabilities } = resolveKeyTarget(entry);
-      const result = await api.providers.testKey({ baseUrl, apiKey: newKey, model, capabilities });
-      setTested((t) => ({ ...t, [id]: result.ok }));
-      const keys = entry.apiKeys.map((k, i) => (i === index ? newKey : k));
-      const res = await api.providers.upsert({ id, apiKeys: keys });
-      setProviders(Array.isArray(res?.providers) ? res.providers : []);
-      return result;
+      try {
+        const result = await api.providers.testKey({
+          baseUrl,
+          apiKey: newKey,
+          model,
+          capabilities,
+        });
+        setTested((t) => ({ ...t, [id]: result.ok }));
+        const keys = entry.apiKeys.map((k, i) => (i === index ? newKey : k));
+        const res = await api.providers.upsert({ id, apiKeys: keys });
+        setProviders(Array.isArray(res?.providers) ? res.providers : []);
+        return result;
+      } catch (err) {
+        // Same contract as revalidateKey: the banner reports, and the degraded
+        // result leaves the row's editor open with the typed key intact.
+        const msg = errText(err);
+        setError(msg);
+        return { ok: false, error: msg };
+      }
     },
     [api, providers],
   );

--- a/docs/plans/repurpose/DESIGN.md
+++ b/docs/plans/repurpose/DESIGN.md
@@ -150,7 +150,7 @@ All registered through the existing single composition root (`handlers.py:1982` 
 | `batch.list` | — | `{batches:[BatchSummary]}` | including finished ones |
 | `batch.cancel` | `{id}` | `{ok}` | cancels the parent job (→ cooperative item cancel, `jobs.py:447`) |
 | `batch.resume` | `{id}` | `{jobId}` | re-enqueue not-yet-done items (§10.1) |
-| `batch.delete` | `{id}` | `{ok}` | drops a finished/cancelled batch record |
+| `batch.delete` | `{id}` | `{ok}` | drops a batch record whose parent job is not live (finished/cancelled/abandoned); REFUSES `INVALID_PARAMS` while it is still running |
 
 **No new provider RPC.** Every AI-bearing step a template runs (`shortmaker.select`, `phase8.select`, `subtitles.translate`) is an EXISTING method that already enters `run_ai_job` (`handlers.py:849,1292`). The batch/template layer never builds a provider, never reads a key — it only invokes already-wired handlers through `protocol.METHODS` (the `recipes` mechanism, `recipes.py:313-317`). This keeps the "ONE RPC site" and "AI rides the envelope" invariants intact.
 

--- a/sidecar/media_studio/features/batch.py
+++ b/sidecar/media_studio/features/batch.py
@@ -796,8 +796,20 @@ class Batch:
         return {"batches": self.store.list()}
 
     def delete(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
-        """``batch.delete({id})`` -> ``{ok}`` (drops a finished/cancelled record)."""
+        """``batch.delete({id})`` -> ``{ok}`` (drops a NOT-LIVE batch record).
+
+        REFUSES with ``INVALID_PARAMS`` while the batch's parent job is still live
+        (:meth:`_parent_job_is_live`). This is the only place liveness is knowable, so
+        it is the backstop rather than a renderer hint: the runner checkpoints through
+        ``store.update_item``, which raises ``unknown batch`` (``:282-284``) once the
+        file is unlinked, so a delete mid-run kills the parent job with partial
+        outputs and no record. A renderer ``status != 'running'`` check cannot cover
+        it — ``resume_batch`` resets pending items to ``queued`` on disk BEFORE the
+        pooled worker reaches ``running``, and the panel reloads inside that window.
+        """
         batch_id = _require_id(params)
+        if self._parent_job_is_live(batch_id, ctx):
+            raise _invalid(f"batch is still running: {batch_id}")
         ok = self.store.delete(batch_id)
         self._parent_jobs.pop(batch_id, None)
         return {"ok": ok}
@@ -898,7 +910,13 @@ class Batch:
 
         Re-runs ONLY the not-yet-done sources of an incomplete batch as a fresh
         parent job (:func:`resume_batch`); finished work is never redone (G-DUR).
-        A fully-terminal batch is a no-op (``{jobId: None, status}``).
+        A fully-terminal batch is a no-op (``{jobId: None, status}``), and so is a
+        batch whose parent job is still LIVE (:meth:`_parent_job_is_live`).
+
+        The liveness gate runs BEFORE :func:`resume_batch`, not before the
+        ``starter(...)`` call inside it: the durable re-enqueue rewrites the live
+        run's in-flight item from ``running`` to ``queued`` ON DISK, so a later
+        guard would still corrupt the running batch's checkpoint.
         """
         batch_id = _require_id(params)
         state = self.store.load(batch_id)
@@ -906,6 +924,11 @@ class Batch:
             raise _invalid(f"unknown batch: {batch_id}")
         if ctx.jobs is None:
             raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        if self._parent_job_is_live(batch_id, ctx):
+            # Re-use the no-op wire shape resume_batch already returns for a
+            # fully-terminal batch, so no schema/type changes: the renderer's
+            # jobIdOf() already tolerates a null jobId.
+            return {"jobId": None, "status": state.get("status")}
         template_id = str(state.get("templateId") or "")
         out = resume_batch(
             self.store,
@@ -942,6 +965,29 @@ class Batch:
         if parent_job_id is None or ctx.jobs is None:
             return None
         return ctx.jobs.get(parent_job_id)
+
+    def _parent_job_is_live(self, batch_id: str, ctx: RpcContext) -> bool:
+        """``True`` while a tracked parent job is still doing work for ``batch_id``.
+
+        The ONE liveness gate shared by :meth:`resume` and :meth:`delete` — both
+        mutate a batch the runner may be checkpointing through
+        (``store.update_item`` raises ``unknown batch`` the moment the file is
+        gone), and liveness is knowable ONLY here: ``_parent_jobs`` is in-memory,
+        and the durable aggregate ``status`` cannot distinguish "live right now"
+        from "the process died mid-flight" (both read ``running``,
+        :func:`derive_status`). That is why the renderer must not gate on status.
+
+        A job with ``cancel_requested`` set is deliberately NOT live: ``cancel``
+        only sets a cooperative flag and the parent stays un-``finished`` until the
+        in-flight sub-job relay unwinds (bounded by ``recipes.SUBJOB_TIMEOUT``, one
+        hour), so treating it as live would turn today's working Cancel -> Resume
+        into a silent no-op for that whole window.
+
+        Absent / evicted / post-restart it returns ``False``, so a crash-interrupted
+        batch stays resumable — the headline case resume exists for (§10.1).
+        """
+        job = self._live_parent_job(batch_id, ctx)
+        return job is not None and not job.finished and not job.cancel_requested
 
     def _runner_for(self, template_id: str) -> TemplateRunner:
         """The per-source template seam for ``template_id`` (injected or default).

--- a/sidecar/media_studio/features/self_test.py
+++ b/sidecar/media_studio/features/self_test.py
@@ -11,7 +11,9 @@ Checks (the wire ``id`` the panel keys on):
   * ``data``   — the per-user data dir is writable (write+read+delete a probe).
   * ``device`` — the hardware probe (:mod:`system_advisor`) runs: GPU / VRAM / RAM
     / free disk (informational — a missing GPU degrades speed, not capability).
-  * ``cv2``    — OpenCV + MediaPipe importable (the reframe subject-tracking core).
+  * ``cv2``    — OpenCV importable (the reframe subject-tracking core: YuNet runs
+    entirely through ``cv2.FaceDetectorYN``, see ``reframe_claudeshorts`` whose
+    ``NATIVE_MODULES_FOR_PREIMPORT`` is likewise ``("cv2",)``).
   * ``asr``    — the Whisper ASR backend (``faster_whisper``) importable.
   * ``ffmpeg`` — ffmpeg + ffprobe resolvable via :mod:`tools_resolver`.
 
@@ -42,8 +44,8 @@ DATA_FIX = "Choose a different data folder in Settings, or fix the folder's perm
 DEVICE_LABEL = "Device probe"
 DEVICE_FIX = "Update your GPU driver. The app still works without a GPU — moment-finding just runs slower on CPU."
 
-CV2_LABEL = "Reframe engine (OpenCV + MediaPipe)"
-CV2_FIX = "Reframe needs OpenCV + MediaPipe — reinstall the app or run setup to restore the bundled Python deps."
+CV2_LABEL = "Reframe engine (OpenCV)"
+CV2_FIX = "Reframe needs OpenCV — reinstall the app or run setup to restore the bundled Python deps."
 
 ASR_LABEL = "Speech-to-text engine (Whisper)"
 ASR_FIX = "The Whisper engine needs faster-whisper — reinstall the app or run setup to restore the bundled Python deps."
@@ -52,9 +54,17 @@ FFMPEG_LABEL = "Media tools (FFmpeg)"
 FFMPEG_FIX = "ffmpeg/ffprobe were not found — install FFmpeg and add it to PATH, or set its path in Settings."
 
 # Probe-key module names (a single import-availability family per dependency).
-_CV2_MODULES: tuple[str, ...] = ("cv2", "mediapipe")
+#
+# INVARIANT (pinned by tests/test_self_test.py): every module named below feeds a
+# REQUIRED check, so it MUST be one ``runtime_setup/requirements-sidecar.txt``
+# actually installs. ``mediapipe`` is DELIBERATELY not provisioned there (its
+# Solutions-API wheels declare ``numpy<2``, a hard conflict with the pinned
+# ``numpy==2.5.1``), so listing it here made every healthy install report the
+# blocking "Some required components are missing" banner with an unfollowable fix
+# hint. Reframe does not need it: YuNet runs entirely through ``cv2``.
+_CV2_MODULES: tuple[str, ...] = ("cv2",)
 _ASR_MODULES: tuple[str, ...] = ("faster_whisper",)
-_DEP_MODULES: tuple[str, ...] = ("cv2", "mediapipe", "faster_whisper")
+_DEP_MODULES: tuple[str, ...] = ("cv2", "faster_whisper")
 _FFMPEG_TOOLS: tuple[str, ...] = ("ffmpeg", "ffprobe")
 
 #: the probe file the data-dir writability check writes/reads/deletes.

--- a/sidecar/media_studio/features/shortmaker.py
+++ b/sidecar/media_studio/features/shortmaker.py
@@ -1412,10 +1412,23 @@ class ShortMaker:
         #             missing libvidstab is reported via job.progress, never
         #             silently skipped (so default-on degrades gracefully). An
         #             explicit ``stabilize: false`` from the caller disables it.
-        for key in ("hookTitle", "removeFillers", "emphasis", "autoZoom", "silenceTrim", "stabilize"):
+        #   hookCard (default true) -> the OpusClip hook-card overlay drawn on the
+        #             top-N clips by virality rank (hook_card.resolve_hook_card_config
+        #             owns the default); an explicit ``hookCard: false`` disables it.
+        for key in ("hookTitle", "removeFillers", "emphasis", "autoZoom", "silenceTrim", "stabilize", "hookCard"):
             value = params.get(key)
             if isinstance(value, bool):
                 settings[key] = value
+        # WU SP2: hookCardTopN is an int COUNT, not a toggle, so it needs its own
+        # typed gate — the bool loop above would skip it and the string loop would
+        # reject it. ``isinstance(True, int)`` is True in Python, so the explicit
+        # bool exclusion is what keeps a stray ``hookCardTopN: true`` out of settings
+        # (hook_card._as_int_count would reject it and silently revert to the default
+        # 10). Gating here, not passing raw, matches this handler's boundary-validation
+        # convention above: a malformed value never lands under a count key.
+        hook_card_top_n = params.get("hookCardTopN")
+        if isinstance(hook_card_top_n, int) and not isinstance(hook_card_top_n, bool):
+            settings["hookCardTopN"] = hook_card_top_n
         # A2: optional audioTrackId — carry the chosen audio track into clips.
         audio_track_id = params.get("audioTrackId")
         if audio_track_id is not None and not isinstance(audio_track_id, str):

--- a/sidecar/media_studio/handlers/library_ops.py
+++ b/sidecar/media_studio/handlers/library_ops.py
@@ -391,12 +391,19 @@ def paths_describe(self: Services, params: dict[str, Any], ctx: RpcContext) -> d
     repeated calls are identical. Derives the dirs from
     :attr:`data_dir`/:attr:`projects_dir`/:attr:`exports_dir` and the file
     paths from the injected stores' own path attributes (robust to a custom
-    settings/library location). ``subDirs`` names the per-feature derivative
-    folders the sidecar writes into — ``dubs`` under the data dir; the
-    ffmpeg-derivative folders (``stabilized``/``audiomix``/``trimmed``)
-    under the exports root, matching ``register_all``'s wiring. ``shorts`` is
-    written PER-VIDEO as ``exports/shorts-<videoId>``, so it is reported as the
-    honest ``shorts-*`` pattern (no flat ``exports/shorts`` dir exists). NO key/secret
+    settings/library location). ``libraryPath`` is the SQLite store
+    (:attr:`Library.db_path`, ``library.db``) — NOT ``index_path``, which names the
+    legacy JSON index the store only reads-then-demotes and never writes.
+    ``subDirs`` names the per-feature derivative folders the sidecar writes into —
+    ``dubs`` under the data dir; the ffmpeg-derivative folders
+    (``stabilized``/``audiomix``/``trimmed``) under the exports root, matching
+    ``register_all``'s wiring; and ``managed-copies``, the opt-in byte-copy store
+    beside the library DB (``keepcopy.STORE_DIRNAME``, rendered by
+    ``ManagedStoreMeter`` in the same Settings sub-tab but named nowhere else).
+    ``shorts`` is written PER-VIDEO as ``exports/shorts-<videoId>``, so it is
+    reported as the honest ``shorts-*`` pattern (no flat ``exports/shorts`` dir
+    exists). Several of these folders are created LAZILY on first use, so a value
+    here is "where it will live", not a promise that it exists yet. NO key/secret
     string ever appears in this payload (it is layout-only).
     """
     return {
@@ -404,13 +411,14 @@ def paths_describe(self: Services, params: dict[str, Any], ctx: RpcContext) -> d
         "projectsDir": str(self.projects_dir),
         "exportsDir": str(self.exports_dir),
         "settingsPath": str(self.settings.config_path),
-        "libraryPath": str(self.library.index_path),
+        "libraryPath": str(self.library.db_path),
         "subDirs": {
             "dubs": str(self.data_dir / "dubs"),
             "shorts": str(self.exports_dir / "shorts-*"),
             "stabilized": str(self.exports_dir / "stabilized"),
             "audiomix": str(self.exports_dir / "audiomix"),
             "trimmed": str(self.exports_dir / "trimmed"),
+            "managed-copies": str(Path(self.library.index_path).parent / _keepcopy.STORE_DIRNAME),
         },
     }
 

--- a/sidecar/media_studio/handlers/providers_ops.py
+++ b/sidecar/media_studio/handlers/providers_ops.py
@@ -150,9 +150,14 @@ def providers_reveal_key(self: Services, params: dict[str, Any], ctx: RpcContext
     diagnostics, and the RESPONSE is never written to a log line.
 
     ``index`` (default 0) selects among a provider's rotation-pool keys. An unknown
-    id, an out-of-range / negative / non-``int`` (incl. ``bool``) index, or an empty
-    stored slot is a typed ``INVALID_PARAMS`` error — never a crash, and never a
-    silent empty reveal that the UI could mistake for a real key.
+    id, an out-of-range / negative / non-``int`` (incl. ``bool``) index, an empty
+    stored slot, or a slot still holding its at-rest last-4 REDACTION MARKER is a
+    typed ``INVALID_PARAMS`` error — never a crash, and never a silent empty (or
+    marker-shaped) reveal that the UI could mistake for a real key. The marker arm
+    is what a request whose overlay does not carry this provider resolves to (the
+    keystore read back unreadable, or the entry was never written), and its message
+    stays CAUSE-AGNOSTIC: this handler cannot distinguish those causes, so cause
+    attribution belongs to the secure-keys surface, not here.
     """
     provider_id = _require_str(params, "id")
     index = params.get("index", 0)
@@ -170,6 +175,13 @@ def providers_reveal_key(self: Services, params: dict[str, Any], ctx: RpcContext
     key = keys[index]
     if not isinstance(key, str) or not key:
         raise _invalid(f"providers.revealKey: no key at index {index} for {provider_id!r}")
+    from ..models.secrets import is_redacted  # local: import-light pure predicate
+
+    if is_redacted(key):
+        raise _invalid(
+            f"providers.revealKey: the stored key at index {index} for {provider_id!r} "
+            "could not be unlocked — it is not present in the secure keystore for this session"
+        )
     return {"key": key}
 
 

--- a/sidecar/media_studio/library.py
+++ b/sidecar/media_studio/library.py
@@ -144,6 +144,17 @@ class Library:
         self._db_path = self.index_path.with_suffix(".db")
         self._probe = probe_duration or _default_probe
 
+    @property
+    def db_path(self) -> Path:
+        """The REAL store: the SQLite DB (``-wal``/``-shm`` are its siblings).
+
+        ``index_path`` is the legacy JSON index — only ever read, then demoted to
+        ``library.json.bak``; it is never written. Callers that want to NAME the
+        store (e.g. ``paths.describe``) must use this, not ``index_path``, and must
+        not re-derive the ``.db`` suffix convention themselves.
+        """
+        return self._db_path
+
     # ---- connection + migration -------------------------------------------
     @contextmanager
     def _open(self) -> Iterator[sqlite3.Connection]:

--- a/sidecar/media_studio/models/secrets.py
+++ b/sidecar/media_studio/models/secrets.py
@@ -54,6 +54,23 @@ def redact(key: str) -> str:
     return _ELLIPSIS
 
 
+def is_redacted(value: str) -> bool:
+    """Return ``True`` when ``value`` is a :func:`redact` MARKER, not a real key.
+
+    The inverse of "this string is usable key material". Every marker :func:`redact`
+    produces starts with :data:`_ELLIPSIS` (``"…WXYZ"`` for a long key, a bare
+    ``"…"`` for a short/empty one), and no provider issues a key beginning with an
+    ellipsis, so the prefix test is exact for the values this codebase creates.
+
+    This exists because "non-empty string" is NOT the same predicate as "a real
+    key": the at-rest store holds only markers (the WU-D2b-2 NO-PERSIST invariant),
+    so any read that misses the request-scoped key overlay resolves to a marker that
+    a bare emptiness check happily admits. Callers that must never hand a marker
+    onward (``providers.revealKey``) gate on this instead.
+    """
+    return value.startswith(_ELLIPSIS)
+
+
 def scrub_error_body(text: str, keys: Sequence[str]) -> str:
     """Strip every key in ``keys`` and any ``Authorization: Bearer`` token from ``text``.
 

--- a/sidecar/tests/test_batch.py
+++ b/sidecar/tests/test_batch.py
@@ -1204,6 +1204,27 @@ def _created(service: batch.Batch, ctx: RpcContext, ids=("v1", "v2")) -> str:
     return out["batch"]["id"]
 
 
+class _FakeParentJob:
+    """A stand-in for a tracked parent :class:`jobs.Job` (liveness fields only).
+
+    ``finished`` and ``cancel_requested`` are the two properties the batch
+    liveness gate reads (``jobs.py`` ``Job.finished`` / ``Job.cancel_requested``);
+    ``pct`` is what ``_merge_live_status`` overlays.
+    """
+
+    pct = 10
+
+    def __init__(self, *, finished: bool = False, cancel_requested: bool = False) -> None:
+        self.finished = finished
+        self.cancel_requested = cancel_requested
+
+
+def _track_parent(service: batch.Batch, reg: JobRegistry, batch_id: str, job: _FakeParentJob) -> None:
+    """Point ``batch_id``'s tracked parent job at ``job`` (the liveness seam)."""
+    service._parent_jobs[batch_id] = "j1"
+    reg.get = lambda _jid: job  # type: ignore[method-assign, return-value]
+
+
 class TestBatchServiceCrud:
     def test_create_persists_queued_batch(self, tmp_path):
         reg = _registry()
@@ -1239,6 +1260,25 @@ class TestBatchServiceCrud:
     def test_delete_unknown_is_false(self, tmp_path):
         service = _service(tmp_path)
         assert service.delete({"id": "nope"}, _ctx(_registry()))["ok"] is False
+
+    def test_delete_refuses_while_parent_job_is_live(self, tmp_path):
+        """Deleting a LIVE batch kills the run; only the sidecar can tell it is live.
+
+        The runner checkpoints through ``store.update_item``, which raises
+        ``unknown batch`` the moment the file is unlinked, so a delete mid-run kills
+        the parent job with partial outputs and no record. A renderer status guard
+        cannot prevent it: ``resume_batch`` rewrites the pending items to ``queued``
+        BEFORE the worker reaches ``running``, and the panel reloads inside that
+        window, so a live batch legitimately renders as ``queued``.
+        """
+        reg = _registry()
+        service = _service(tmp_path)
+        batch_id = _created(service, _ctx(reg))
+        _track_parent(service, reg, batch_id, _FakeParentJob())
+        with pytest.raises(RpcError, match="still running"):
+            service.delete({"id": batch_id}, _ctx(reg))
+        assert service.store.load(batch_id) is not None
+        assert service._parent_jobs[batch_id] == "j1"
 
     @pytest.mark.parametrize("svc_method", ["start", "status", "cancel", "resume", "delete"])
     def test_id_param_required(self, tmp_path, svc_method):
@@ -1429,6 +1469,60 @@ class TestBatchServiceResume:
         service = _service(tmp_path)
         with pytest.raises(RpcError, match="unknown batch"):
             service.resume({"id": "nope"}, _ctx(_registry()))
+
+    def test_resume_refuses_while_parent_job_is_live(self, tmp_path):
+        """A resume must NOT touch a batch whose parent job is still working.
+
+        ``resume_batch`` rewrites the in-flight ``running`` item to ``queued`` ON
+        DISK (the durable re-enqueue) and starts a FRESH parent job, so without a
+        liveness gate one Resume click corrupts the live run's checkpoint, stacks a
+        second parent on a 2-slot pool, and clobbers ``_parent_jobs`` (losing the
+        only cancel handle for the run that is actually going).
+        """
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1", "v2"])
+        # A LIVE run's checkpoint: v1 in flight, v2 still pending. Without this the
+        # pre-existing all-terminal no-op would make the test green with no fix.
+        service.store.update_item(batch_id, "v1", status="running")
+        _track_parent(service, reg, batch_id, _FakeParentJob())
+        out = service.resume({"id": batch_id}, _ctx(reg))
+        assert out == {"jobId": None, "status": "running"}
+        assert service._parent_jobs[batch_id] == "j1"  # cancel handle preserved
+        assert _statuses(service.store, batch_id) == ["running", "queued"]  # checkpoint untouched
+        reg.join()
+        assert invoked == []
+
+    def test_resume_proceeds_once_the_parent_job_finished(self, tmp_path):
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        _track_parent(service, reg, batch_id, _FakeParentJob(finished=True))
+        out = service.resume({"id": batch_id}, _ctx(reg))
+        assert isinstance(out["jobId"], str)
+        reg.join()
+        assert invoked == ["v1"]
+
+    def test_resume_proceeds_when_cancellation_was_requested(self, tmp_path):
+        """Cancel -> Resume keeps working (the explicit ``cancel_requested`` call).
+
+        ``batch.cancel`` only SETS a cooperative flag; the parent job is not
+        ``finished`` until the in-flight sub-job relay unwinds (bounded by
+        ``recipes.SUBJOB_TIMEOUT`` = 3600 s). Gating purely on ``finished`` would
+        turn today's working Cancel -> Resume into a silent no-op for up to an
+        hour, so a cancel-requested parent is deliberately NOT treated as live.
+        """
+        reg = _registry()
+        runner, invoked = _make_runner(reg)
+        service = _service(tmp_path, template_runner=runner)
+        batch_id = _created(service, _ctx(reg), ids=["v1"])
+        _track_parent(service, reg, batch_id, _FakeParentJob(cancel_requested=True))
+        out = service.resume({"id": batch_id}, _ctx(reg))
+        assert isinstance(out["jobId"], str)
+        reg.join()
+        assert invoked == ["v1"]
 
 
 class TestBatchServiceDefaultSeams:

--- a/sidecar/tests/test_handlers_paths.py
+++ b/sidecar/tests/test_handlers_paths.py
@@ -14,6 +14,7 @@ from typing import Any
 import pytest
 from media_studio import handlers
 from media_studio.handlers import Services
+from media_studio.keepcopy import ManagedStore
 from media_studio.protocol import RpcContext
 
 
@@ -45,7 +46,35 @@ def test_paths_describe_projects_dir_matches_services(services: Services, ctx: R
 def test_paths_describe_settings_and_library_paths(services: Services, ctx: RpcContext) -> None:
     result = services.paths_describe({}, ctx)
     assert result["settingsPath"] == str(services.settings.config_path)
-    assert result["libraryPath"] == str(services.library.index_path)
+    # NOT ``index_path``: that is the LEGACY JSON index the SQLite store only ever
+    # reads-then-renames. Comparing against ``db_path`` is what makes this assertion
+    # falsifiable — the old ``index_path == index_path`` form was a tautology.
+    assert result["libraryPath"] == str(services.library.db_path)
+
+
+def test_paths_describe_library_path_names_the_real_sqlite_store(services: Services, ctx: RpcContext) -> None:
+    """The reported "Library file" must be the file the store actually uses.
+
+    ``Library.list()`` enters ``_open()``, which mkdirs the data root and
+    ``sqlite3.connect``s ``library.db`` — so that file genuinely exists when the
+    assertion runs, while NOTHING in ``Library`` ever writes ``library.json``
+    (it is only read, then demoted to ``library.json.bak``).
+    """
+    services.library.list()
+    reported = Path(services.paths_describe({}, ctx)["libraryPath"])
+    assert reported.exists(), f"paths.describe names a file that is not on disk: {reported}"
+    assert reported.name == "library.db"
+    assert reported == services.library.db_path
+
+
+def test_paths_describe_names_the_managed_copy_store(services: Services, ctx: RpcContext) -> None:
+    """The managed-copy folder is rendered by the very next Settings panel, so name it.
+
+    The expected value is derived from :class:`ManagedStore` itself, so the entry
+    cannot drift from the folder the store actually writes into.
+    """
+    sub = services.paths_describe({}, ctx)["subDirs"]
+    assert sub["managed-copies"] == str(ManagedStore(services.library).store_dir)
 
 
 def test_paths_describe_subdirs_cover_required_features(services: Services, ctx: RpcContext) -> None:

--- a/sidecar/tests/test_handlers_providers_reveal.py
+++ b/sidecar/tests/test_handlers_providers_reveal.py
@@ -136,3 +136,29 @@ def test_reveal_no_providers_configured_is_invalid_params(tmp_path: Path) -> Non
     svc = _svc(tmp_path)
     with pytest.raises(RpcError):
         svc.providers_reveal_key({"id": "groq"}, _ctx())
+
+
+def test_reveal_refuses_a_redaction_marker_when_the_overlay_lacks_the_provider(tmp_path: Path) -> None:
+    """A last-4 MARKER must never be returned as if it were a plaintext key.
+
+    The empty-slot guard covered ``""`` but NOT ``"…AAAA"`` — a non-empty string —
+    so whenever the request-scoped overlay does not carry this provider id (the
+    keystore read back UNREADABLE, so ``KeyBridge.overlay(null)`` contributes
+    nothing from disk) the RPC handed the renderer the marker and the row displayed
+    it under the accessible name "Revealed API key for groq". That contradicts this
+    handler's own documented contract: "never a silent empty reveal that the UI
+    could mistake for a real key".
+    """
+    svc = _seed(_svc(tmp_path), [KEY_A])
+    # Precondition, proven independently of the assertion under test: at rest the
+    # FACTORY accessor holds only the marker.
+    assert svc.settings.get_raw()["providers"][0]["apiKeys"] == ["…AAAA"]
+    with svc.settings.key_overlay({"providers": {}}), pytest.raises(RpcError) as excinfo:
+        svc.providers_reveal_key({"id": "groq"}, _ctx())
+    message = str(excinfo.value)
+    # The message names the slot + provider and stays CAUSE-AGNOSTIC: the handler
+    # cannot tell "keystore unreadable" from "the write silently failed", and cause
+    # attribution belongs to the secure-keys banner, not here.
+    assert "groq" in message
+    assert "index 0" in message
+    assert "could not be unlocked" in message

--- a/sidecar/tests/test_handlers_self_test.py
+++ b/sidecar/tests/test_handlers_self_test.py
@@ -9,6 +9,7 @@ returns the camelCase wire report the Electron setup-status panel renders 1:1.
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 from typing import Any
 
@@ -57,6 +58,35 @@ def test_self_test_returns_wire_report(tmp_path: Path, ctx: RpcContext, monkeypa
     assert by_id["data"]["ok"] is True
     assert by_id["device"]["ok"] is True
     assert by_id["ffmpeg"]["ok"] is True
+
+
+def test_self_test_cv2_row_is_green_when_opencv_is_importable(
+    tmp_path: Path, ctx: RpcContext, monkeypatch: Any
+) -> None:
+    """F37 end-to-end: a provisioned install must not report the reframe row red.
+
+    Runs over the REAL ``importlib.find_spec`` seam (``system_self_test`` injects
+    none), so this asserts the actual wire values the setup-status panel renders —
+    not a fixture's own copy.
+
+    SCOPED TO THE ``cv2`` ROW DELIBERATELY. ``out["ok"]``/``out["problems"]`` also
+    fold in the REQUIRED ``asr`` row, and .github/workflows/quality.yml installs
+    neither faster-whisper nor a stub for it (``pip install -e "sidecar[dev]"
+    --no-deps`` plus only httpx/numpy/opencv-python-headless/blake3), so asserting
+    the rollup would be permanently red in CI regardless of this fix.
+    ``opencv-python-headless`` IS installed there, so the ``cv2`` row is a valid
+    CI assertion.
+    """
+    if importlib.util.find_spec("cv2") is None:  # pragma: no cover - env guard
+        pytest.skip("opencv is not importable here, so the cv2 row cannot be green")
+    monkeypatch.setattr(tools_resolver, "resolve_tool", lambda name, _s=None: f"/usr/bin/{name}")
+    out = _services(tmp_path).system_self_test({}, ctx)
+
+    by_id = {c["id"]: c for c in out["checks"]}
+    assert by_id["cv2"]["ok"] is True, by_id["cv2"]["detail"]
+    assert by_id["cv2"]["fixHint"] == ""
+    # No OpenCV problem line may reach the panel on a correctly provisioned env.
+    assert not any("OpenCV" in p for p in out["problems"]), out["problems"]
 
 
 def test_self_test_surfaces_missing_ffmpeg(tmp_path: Path, ctx: RpcContext, monkeypatch: Any) -> None:

--- a/sidecar/tests/test_key_injection_overlay.py
+++ b/sidecar/tests/test_key_injection_overlay.py
@@ -72,11 +72,29 @@ def test_wrapper_strips_injected_keys_from_params_in_place(wired: Services) -> N
 
 
 def test_wrapper_passthrough_without_injected_keys(wired: Services) -> None:
+    # No `_injectedKeys` -> no overlay is opened -> the ordinary (non-key-bearing)
+    # call path is unchanged.
+    #
+    # This used to be pinned as `revealKey -> {"key": "…WXYZ"}`, i.e. the handler
+    # returning the at-rest MARKER. That is now a typed refusal (a marker must never
+    # be revealed as if it were a key), so the observable moved — deliberately NOT to
+    # `pytest.raises(RpcError)`, which would ALSO be satisfied if the wrapper wrongly
+    # opened an EMPTY overlay, and would therefore stop discriminating the thing this
+    # characterization test exists to pin. Instead observe the overlay state itself
+    # through the FACTORY accessor while the handler runs, via a NON-key handler.
     _seed_provider(wired)
-    # No `_injectedKeys` -> no overlay -> the at-rest marker is what reveal sees,
-    # i.e. the ordinary (non-key-bearing) call path is unchanged.
-    out = protocol.METHODS["providers.revealKey"]({"id": "groq"}, _ctx())
-    assert out == {"key": "…WXYZ"}
+    seen: list[Any] = []
+
+    def spy(params: dict[str, Any], ctx: RpcContext) -> str:
+        seen.append(wired.settings.get_raw()["providers"][0]["apiKeys"])
+        return "ok"
+
+    assert _key_overlay_wrapper(wired, spy)({"id": "groq"}, _ctx()) == "ok"
+    # The at-rest marker is what `get_raw()` resolved DURING the call: no overlay.
+    assert seen == [["…WXYZ"]]
+    # ...and a real non-key method still round-trips through the wrapped registry.
+    listed = protocol.METHODS["providers.list"]({}, _ctx())
+    assert listed["providers"][0]["apiKeys"] == ["…WXYZ"]
 
 
 def test_wrapper_tolerates_non_dict_params() -> None:

--- a/sidecar/tests/test_self_test.py
+++ b/sidecar/tests/test_self_test.py
@@ -2,8 +2,8 @@
 
 The diagnostic validates a fresh install END-TO-END and reports LOUDLY: a data-dir
 writability probe, a device probe (system_advisor hardware), the required native
-deps (cv2/mediapipe for reframe, the faster-whisper ASR backend), and ffmpeg/
-ffprobe resolution. Every probe is an INJECTED seam here so the suite touches no
+deps (cv2 for reframe's YuNet detector, the faster-whisper ASR backend), and
+ffmpeg/ffprobe resolution. Every probe is an INJECTED seam here so the suite touches no
 real GPU, no heavy import, and (mostly) no real filesystem — the §WU-2 acceptance
 criteria are pinned directly on the pure :func:`run` composition:
 
@@ -20,6 +20,7 @@ from typing import Any
 import pytest
 from media_studio.features import self_test as st
 from media_studio.features.system_advisor import HardwareInfo
+from runtime_setup.bootstrap import SIDECAR_REQUIREMENTS, load_requirements
 
 
 class _FakeProbe:
@@ -46,7 +47,7 @@ def _disk(free_mb: int):
 
 
 def _all_present() -> set[str]:
-    return {"cv2", "mediapipe", "faster_whisper"}
+    return {"cv2", "faster_whisper"}
 
 
 def _run(tmp_path: Path, **over: Any) -> st.SelfTestReport:
@@ -73,7 +74,7 @@ def test_ok_path_all_green(tmp_path: Path) -> None:
 
 
 def test_missing_cv2_is_reported_with_fix_hint(tmp_path: Path) -> None:
-    report = _run(tmp_path, find_spec=_find_spec({"mediapipe", "faster_whisper"}))
+    report = _run(tmp_path, find_spec=_find_spec({"faster_whisper"}))
     assert report.ok is False
     cv2 = next(c for c in report.checks if c.id == "cv2")
     assert cv2.ok is False
@@ -137,25 +138,26 @@ def test_device_check_failure_when_probe_raised() -> None:
 
 
 def test_dependency_check_all_present() -> None:
+    # A generic MULTI-module family (the builder takes any ``modules`` tuple).
     c = st.dependency_check(
-        "cv2",
-        "OpenCV + MediaPipe",
+        "deps",
+        "Native deps",
         "reinstall",
-        present_map={"cv2": True, "mediapipe": True},
-        modules=("cv2", "mediapipe"),
+        present_map={"cv2": True, "faster_whisper": True},
+        modules=("cv2", "faster_whisper"),
     )
     assert c.ok is True and c.fix_hint == ""
 
 
 def test_dependency_check_reports_missing() -> None:
     c = st.dependency_check(
-        "cv2",
-        "OpenCV + MediaPipe",
+        "deps",
+        "Native deps",
         "reinstall",
-        present_map={"cv2": True, "mediapipe": False},
-        modules=("cv2", "mediapipe"),
+        present_map={"cv2": True, "faster_whisper": False},
+        modules=("cv2", "faster_whisper"),
     )
-    assert c.ok is False and "mediapipe" in c.detail and c.fix_hint == "reinstall"
+    assert c.ok is False and "faster_whisper" in c.detail and c.fix_hint == "reinstall"
 
 
 def test_tool_check_all_present() -> None:
@@ -231,7 +233,7 @@ def test_probe_data_dir_detects_readback_mismatch(tmp_path: Path) -> None:
 
 def test_probe_dependencies_with_injected_find_spec() -> None:
     out = st.probe_dependencies(find_spec=_find_spec({"cv2"}))
-    assert out["cv2"] is True and out["mediapipe"] is False and out["faster_whisper"] is False
+    assert out["cv2"] is True and out["faster_whisper"] is False
 
 
 def test_probe_dependencies_fail_open_on_find_spec_error() -> None:
@@ -239,13 +241,15 @@ def test_probe_dependencies_fail_open_on_find_spec_error() -> None:
         raise ImportError("broken loader")
 
     out = st.probe_dependencies(find_spec=boom)
-    assert out == {"cv2": False, "mediapipe": False, "faster_whisper": False}
+    assert out == {"cv2": False, "faster_whisper": False}
 
 
 def test_probe_dependencies_default_find_spec_runs() -> None:
-    # Exercises the real importlib seam (no injection); numpy is always installed.
+    # Exercises the real importlib seam (no injection). Only the KEY SET is
+    # asserted: whether each dep is present is environment-dependent (CI installs
+    # opencv-python-headless but deliberately not faster-whisper).
     out = st.probe_dependencies()
-    assert set(out) == {"cv2", "mediapipe", "faster_whisper"}
+    assert set(out) == {"cv2", "faster_whisper"}
 
 
 def test_probe_disk_free_mb_with_seam() -> None:
@@ -291,3 +295,43 @@ def test_run_reports_missing_ffmpeg_tool(tmp_path: Path, missing: str) -> None:
     ffmpeg = next(c for c in report.checks if c.id == "ffmpeg")
     assert ffmpeg.ok is False and missing in ffmpeg.detail
     assert report.ok is False
+
+
+# --------------------------------------------------------------------------- #
+# INVARIANT — a REQUIRED probe may only name a module the provisioner installs
+# --------------------------------------------------------------------------- #
+#: pinned dist name (in requirements-sidecar.txt) -> the import name probed here.
+#: Only dists whose import name differs from a ``-``->``_`` normalisation need a row.
+_DIST_TO_IMPORT_NAME = {"opencv-python": "cv2", "faster-whisper": "faster_whisper"}
+
+
+def _provisioned_import_names() -> set[str]:
+    """Import names the FIRST-RUN provisioner actually installs.
+
+    Derived from the shipped pin list that :mod:`runtime_setup.bootstrap` installs
+    from (``SIDECAR_REQUIREMENTS``), so the invariant below is HERMETIC — it reads
+    a committed file and never consults the ambient environment.
+    """
+    dists = {pin.split("==", 1)[0].strip() for pin in load_requirements(SIDECAR_REQUIREMENTS).pins}
+    return {_DIST_TO_IMPORT_NAME.get(d, d.replace("-", "_")) for d in dists}
+
+
+@pytest.mark.parametrize("attr", ["_DEP_MODULES", "_CV2_MODULES", "_ASR_MODULES"])
+def test_every_required_probe_module_is_provisioned(attr: str) -> None:
+    """A REQUIRED check may only probe modules first-run provisioning installs.
+
+    F37: ``mediapipe`` sat in ``_CV2_MODULES``/``_DEP_MODULES`` while
+    ``requirements-sidecar.txt`` DELIBERATELY excludes it (the Solutions-API
+    wheels declare ``numpy<2``, a hard conflict with the pinned ``numpy==2.5.1``),
+    so EVERY correctly-provisioned install reported the blocking red setup banner
+    with a fix hint that could not possibly work. This pins the whole regression
+    class shut — any future required module that is not pinned — not just the one
+    stale name. ``_ASR_MODULES`` is the passing control: it proves the detector
+    can also report a clean subset, so a red here is a real violation.
+    """
+    unprovisioned = sorted(set(getattr(st, attr)) - _provisioned_import_names())
+    assert unprovisioned == [], (
+        f"self_test.{attr} makes a REQUIRED check probe module(s) that "
+        f"runtime_setup/requirements-sidecar.txt never installs: {unprovisioned}. "
+        f"Either pin the dist there, or stop requiring the module."
+    )

--- a/sidecar/tests/test_shortmaker.py
+++ b/sidecar/tests/test_shortmaker.py
@@ -2421,6 +2421,55 @@ class TestExportTogglesFlowToSettings:
         assert "remove_fillers" not in calls
         assert rec.caption_kwargs[0]["hook_title"] == "h"  # default ON
 
+    def test_hookCard_false_param_threads_into_settings(self, registry, transcript, tmp_path):
+        """WU SP2 (F07): ``hookCard: False`` off the wire must reach ``settings`` so
+        unchecking the renderer's "Hook card" box actually suppresses the overlay.
+
+        Routed through ``maker.export`` (NOT ``sm.run_export``) on purpose: the defect
+        is at the params->settings ALLOWLIST boundary, and ``run_export`` takes
+        ``settings`` directly, bypassing the very gate under test.
+        """
+        rec = RecordingStages([])
+        maker = self._maker(tmp_path, transcript, rec)
+        candidate = {
+            "rank": 1,
+            "start": 0.0,
+            "end": 25.0,
+            "sourceStart": 0.0,
+            "hook": "h",
+            "score": 9,
+        }
+        out = maker.export(
+            {"videoId": "v1", "candidates": [candidate], "hookCard": False},
+            _rpc_ctx(registry),
+        )
+        registry.get(out["jobId"]).wait(timeout=5)
+        assert rec.caption_kwargs[0]["hook_card"] is False
+
+    def test_hookCardTopN_param_threads_into_settings(self, registry, transcript, tmp_path):
+        """WU SP2 (F07): ``hookCardTopN`` off the wire must reach ``settings`` so
+        lowering the renderer's "Hook card top N" actually narrows the carded set.
+        Ranks 1/2/3 with ``hookCardTopN: 2`` -> only the top two get a card."""
+        rec = RecordingStages([])
+        maker = self._maker(tmp_path, transcript, rec)
+        cands = [
+            {
+                "rank": rank,
+                "start": float(rank) * 30.0,
+                "end": float(rank) * 30.0 + 25.0,
+                "sourceStart": float(rank) * 30.0,
+                "hook": "h",
+                "score": 9,
+            }
+            for rank in (1, 2, 3)
+        ]
+        out = maker.export(
+            {"videoId": "v1", "candidates": cands, "hookCardTopN": 2},
+            _rpc_ctx(registry),
+        )
+        registry.get(out["jobId"]).wait(timeout=5)
+        assert [k["hook_card"] for k in rec.caption_kwargs] == [True, True, False]
+
 
 # -- P3-B default filler adapter (_lazy_remove_fillers) ----------------------
 


### PR DESCRIPTION
Integration PR **A of 4** for the 50-finding audit programme — the only PR carrying Python and `app/main/**`, so a `pytest` / `basedpyright` / `ruff` failure is localised here and cannot be confused with a renderer failure.

## Attribution

| batch | branch | source sha | findings |
|---|---|---|---|
| B14 | `fix/sidecar-hookcard-params` | `0458b667` | F07 |
| B05 | `fix/selftest-mediapipe` | `5b63003b` | F37 |
| B22 | `fix/paths-panel-truth` | `76b5b8fe` | F42, F43 |
| B10 | `fix/providers-key-errors` | `f3eecb1c` | F38, F40, F41 |
| B01 | `fix/batchqueue-liveness` | `a0b5eabf` | F11, F14, F15, F16 |
| B23 | `fix/secure-keys-unreadable` | `ffb86696` | F39 |

Merged with `--no-ff`, so each batch commit survives and any single batch stays revertable.

## What these fix

- **F37** — the self-test declared `mediapipe` a REQUIRED check while the provisioner deliberately never installs it, so a perfectly healthy install reported red.
- **F11/F14/F15/F16** — mutating batch RPCs were not gated on real job liveness, and a terminal snapshot zeroed the progress bar.
- **F38/F40/F41** — provider key operations swallowed rejections, a redaction *marker* could be revealed as though it were a real key, and a double-Add dropped a key.
- **F39** — `keystoreUnreadable` was computed and shipped to the renderer, then dropped by two stale type mirrors and never displayed; keys added in that state looked saved and were silently discarded.
- **F42/F43** — the paths panel named the wrong store and offered an Open button for a path that cannot exist.
- **F07** — `hookCard` / `hookCardTopN` were dropped at the export allowlist, making both controls inert.

## Provenance

Each finding was independently re-verified against source before implementation, then implemented under strict TDD, then reviewed by two adversarial reviewers who both had to accept. The verification pass **downgraded 11 of 18 original "high" findings** and reclassified two as unpatchable feature gaps rather than bugs, so what lands here is the residue that survived scrutiny — not the raw audit output.

## Local gate (run before pushing, on the merged tree)

- `uvx pre-commit run --all-files` → ruff lint, ruff format, oxlint, biome 2.5.0 format, gitleaks — **all Passed**
- `node app/node_modules/typescript/bin/tsc --noEmit` → **exit 0**  *(the local binary deliberately, never bare `npx tsc`: with no `node_modules` that resolves a same-named public package which prints "This is not the tsc command you are looking for" and exits 0, so a clean exit there checks nothing)*
- `npx vitest run --coverage` → **100% statements / branches / functions / lines**, 19371 stmts and 6406 branches, up from main's 19263 / 6352 — the added code is fully covered, not exempted
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → see the run below

## Honest scope

This PR does not include batches B03 and B12. Both were **rejected by their adversarial reviewers for real reasons** and are being fixed separately rather than waved through:

- **B03** introduced a `React.StrictMode` `AbortController` defect in the exact flow it was meant to repair — the reviewer measured it with a control probe (`setups=2 cleanups=1`, signal aborted at click time, with `Export.tsx`'s per-job pattern as a passing control). All three green gates are structurally blind to it, because vitest installs no StrictMode and e2e drives the built bundle.
- **B12**'s code is correct but one load-bearing line has no discriminating oracle: delete `Export.tsx:100` and all 3577 tests stay green while the user's next export is silently cancelled.
