### PR TITLE
fix: audit batch B — renderer shared seams (4 findings, 4 batches)

### DIFF
--- a/app/renderer/src/App.director-state.test.tsx
+++ b/app/renderer/src/App.director-state.test.tsx
@@ -1,0 +1,328 @@
+// App.director-state.test.tsx — F32: an unapplied Director plan must survive a
+// top-level tab switch.
+//
+// WHY THIS FILE EXISTS SEPARATELY FROM App.test.tsx: that suite mocks
+// `./views/Director` (App.test.tsx:102) with a marker div, so the whole Director
+// subtree — and therefore this defect — is invisible to it. Here the REAL Director
+// view (and the real composed DirectorPanel) mounts, so the route switch genuinely
+// unmounts the subtree the way it does in the shipped app.
+//
+// The heavy SIBLING views (Library / Make Shorts / Settings) are still stubbed:
+// their realness is irrelevant to "does Director state survive leaving the tab",
+// and stubbing them keeps a setup failure from masquerading as the defect.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import type { DirectorEditPlan, DirectorOp, DirectorPreview, Video } from './lib/rpc';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---- fixtures ---------------------------------------------------------------
+
+function makeVideo(over: Partial<Video> = {}): Video {
+  return {
+    id: 'vid-1',
+    path: '/movies/talk.mp4',
+    title: 'Talk',
+    addedAt: '2026-06-11T00:00:00Z',
+    durationSec: 600,
+    hasTranscript: false,
+    ...over,
+  };
+}
+
+function op(over: Partial<DirectorOp> = {}): DirectorOp {
+  return {
+    id: 'op-1',
+    kind: 'trim',
+    span: [0, 1000],
+    params: {},
+    reversible: true,
+    rationale: '',
+    status: 'planned',
+    statusReason: null,
+    ...over,
+  };
+}
+
+const PLAN: DirectorEditPlan = {
+  planId: 'plan-1',
+  videoId: 'vid-1',
+  goal: 'tighten the pacing',
+  sourceHash: 'h',
+  ops: [op({ id: 'op-1', kind: 'trim' }), op({ id: 'op-2', kind: 'reorder' })],
+  inverse: [],
+};
+
+/** `summarizePlan(PLAN)` as first planned (both ops enabled). */
+const PLANNED_SUMMARY = '1 trim, 1 reorder';
+/** …and after op-1 is dropped — the witness that the REVIEW DECISION survived. */
+const REVIEWED_SUMMARY = '1 reorder · 1 dropped op';
+
+// `route` is an OBJECT on the wire (ai_job.py `_route_json`), never a string —
+// mirror the sidecar, not the declared type.
+const PREVIEW: DirectorPreview = {
+  perFunction: [
+    {
+      function: 'editPlan',
+      route: { providers: ['groq'], degradeChain: [], cacheHit: false, willEgress: true },
+      costEst: 10,
+      willEgress: true,
+      cacheHit: false,
+      cacheKey: 'CK-TEXT',
+    },
+  ],
+};
+
+// ---- mocks -----------------------------------------------------------------
+
+const rpcMock = vi.fn();
+const libraryListMock = vi.fn();
+const batchListMock = vi.fn();
+const setRoutingPolicyMock = vi.fn();
+const settingsGetMock = vi.fn();
+const settingsSetMock = vi.fn();
+const cuesMock = vi.fn();
+const planMock = vi.fn();
+const previewCostMock = vi.fn();
+
+/** The real preload job-event relay, driven by the test. */
+const doneCbs = new Set<(e: { jobId: string; result?: unknown }) => void>();
+function emitDone(event: { jobId: string; result?: unknown }): void {
+  for (const cb of doneCbs) cb(event);
+}
+
+vi.mock('./lib/rpc', () => ({
+  rpc: (...a: unknown[]) => rpcMock(...a),
+  hasApi: () => true,
+  onProgress: () => () => undefined,
+  onJobDone: (cb: (e: { jobId: string; result?: unknown }) => void) => {
+    doneCbs.add(cb);
+    return () => doneCbs.delete(cb);
+  },
+  client: {
+    library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    batch: { list: (...a: unknown[]) => batchListMock(...a) },
+    models: { setRoutingPolicy: (...a: unknown[]) => setRoutingPolicyMock(...a) },
+    settings: {
+      get: (...a: unknown[]) => settingsGetMock(...a),
+      set: (...a: unknown[]) => settingsSetMock(...a),
+    },
+    captions: { cues: (...a: unknown[]) => cuesMock(...a) },
+    director: {
+      plan: (...a: unknown[]) => planMock(...a),
+      previewCost: (...a: unknown[]) => previewCostMock(...a),
+    },
+  },
+}));
+
+// Sibling views stubbed (they own their own suites); `./views/Director` is
+// DELIBERATELY NOT mocked — mocking it is what blinds App.test.tsx to this defect.
+vi.mock('./views/Library', () => ({
+  Library: ({ onOpen }: { onOpen: (v: Video) => void }) => (
+    <div data-testid="library">
+      <button type="button" onClick={() => onOpen(makeVideo())}>
+        open-video
+      </button>
+      {/* A SECOND video, so the per-video isolation rule can be exercised through
+          the real shell + provider rather than only as a unit test. */}
+      <button type="button" onClick={() => onOpen(makeVideo({ id: 'vid-2', title: 'Other' }))}>
+        open-other-video
+      </button>
+    </div>
+  ),
+}));
+vi.mock('./views/MakeShorts', () => ({ MakeShorts: () => <div data-testid="makeshorts" /> }));
+vi.mock('./views/Settings', () => ({ Settings: () => <div data-testid="settings" /> }));
+vi.mock('./components/JobQueue', () => ({
+  JobQueue: () => <div />,
+  JOBQUEUE_PANEL_ID: 'jobqueue-panel',
+}));
+vi.mock('./components/SidecarBanner', () => ({ SidecarBanner: () => <div /> }));
+
+import { App } from './App';
+
+// ---- harness ---------------------------------------------------------------
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  doneCbs.clear();
+  rpcMock.mockReset();
+  rpcMock.mockResolvedValue({});
+  libraryListMock.mockReset();
+  libraryListMock.mockResolvedValue({ videos: [] });
+  batchListMock.mockReset();
+  batchListMock.mockResolvedValue({ batches: [] });
+  setRoutingPolicyMock.mockReset();
+  setRoutingPolicyMock.mockResolvedValue({ routingPolicy: { global: 'local', overrides: {} } });
+  settingsGetMock.mockReset();
+  // Keep the focus-trapped first-run tour CLOSED; otherwise it sits over the panel.
+  settingsGetMock.mockResolvedValue({ directorOnboardingSeen: true });
+  settingsSetMock.mockReset();
+  settingsSetMock.mockResolvedValue({});
+  cuesMock.mockReset();
+  cuesMock.mockResolvedValue({ cues: [] });
+  planMock.mockReset();
+  planMock.mockResolvedValue({ jobId: 'job-plan' });
+  previewCostMock.mockReset();
+  previewCostMock.mockResolvedValue(PREVIEW);
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+/**
+ * Flush pending work. Uses a MACROTASK (`setTimeout 0`), not just microtasks: the
+ * Director route is a `lazy(() => import('./views/Director'))`, and a microtask-only
+ * flush leaves the Suspense fallback ("Loading…") on screen — which then fails as
+ * "no element for textarea[data-action=goal]" and looks exactly like the defect.
+ */
+async function flush(times = 4): Promise<void> {
+  for (let i = 0; i < times; i += 1) {
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+  }
+}
+
+function $(sel: string): HTMLElement {
+  const el = container.querySelector(sel);
+  if (!el) throw new Error(`no element for ${sel}`);
+  return el as HTMLElement;
+}
+
+function tab(label: string): HTMLButtonElement {
+  const btns = Array.from(container.querySelectorAll<HTMLButtonElement>('.toptab'));
+  const found = btns.find((b) => b.querySelector('.toptab__label')?.textContent === label);
+  if (!found) throw new Error(`tab "${label}" not found`);
+  return found;
+}
+
+async function click(el: HTMLElement): Promise<void> {
+  await act(async () => {
+    el.click();
+  });
+  await flush();
+}
+
+/** Find a button in the Library stub by its exact text. */
+function buttonByText(text: string): HTMLElement {
+  const btns = Array.from(container.querySelectorAll<HTMLButtonElement>('button'));
+  const found = btns.find((b) => b.textContent === text);
+  if (!found) throw new Error(`button "${text}" not found`);
+  return found;
+}
+
+async function typeGoal(text: string): Promise<void> {
+  const ta = $('textarea[data-action="goal"]') as HTMLTextAreaElement;
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    'value',
+  )?.set;
+  await act(async () => {
+    setter?.call(ta, text);
+    ta.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+  await flush(1);
+}
+
+/**
+ * Drive the shell to a REVIEWED Director plan: open a video, enter the Director
+ * tab, plan, land the plan on `job.done`, then drop one op.
+ */
+async function planAndReview(): Promise<void> {
+  // Warm the lazy chunk's module cache. Without this the `lazy()` import stays
+  // pending for the whole test and every assertion fails on the Suspense fallback.
+  await import('./views/Director');
+  await act(async () => {
+    root.render(<App />);
+  });
+  await flush();
+  // Open a video (routes into Edit), then switch to the Director tab.
+  await click(buttonByText('open-video'));
+  await click(tab('Director'));
+  // The Director route is lazy — give Suspense room to resolve it.
+  await flush(6);
+  await typeGoal(PLAN.goal);
+  await click($('button[data-action="plan"]'));
+  await act(async () => {
+    emitDone({ jobId: 'job-plan', result: { planId: PLAN.planId, editPlan: PLAN, preview: '{}' } });
+  });
+  await flush();
+  // Precondition (passes BOTH before and after the fix): the storyboard is up.
+  expect($('[data-testid="plan-summary"]').textContent).toBe(PLANNED_SUMMARY);
+  // One review decision: drop op-1. The plain-language summary re-derives from the
+  // edited plan, so it is itself a witness that the decision landed.
+  await click($('button[data-action="op-disable"][data-op="op-1"]'));
+  expect($('.director-op[data-op-id="op-1"]').getAttribute('data-status')).toBe('dropped');
+  expect($('[data-testid="plan-summary"]').textContent).toBe(REVIEWED_SUMMARY);
+}
+
+// ---- the test --------------------------------------------------------------
+
+describe('App — Director session state across a tab switch (F32)', () => {
+  it('keeps an unapplied plan, its goal and its review decisions when the user leaves and returns', async () => {
+    await planAndReview();
+
+    // Leave the Director tab and come back. This UNMOUNTS the whole Director
+    // subtree (App's renderRoute switch), which is what used to discard the plan.
+    await click(tab('Library'));
+    expect(container.querySelector('[data-testid="library"]')).not.toBeNull();
+    expect(container.querySelector('[data-testid="plan-summary"]')).toBeNull();
+    await click(tab('Director'));
+    await flush(6);
+
+    // The plan, the goal it was made from, and the review decision all survive.
+    // Asserting the REVIEWED summary (not the as-planned one) is what proves the
+    // keep/drop decision came back too, rather than just a pristine re-fetched plan.
+    expect($('[data-testid="plan-summary"]').textContent).toBe(REVIEWED_SUMMARY);
+    expect(($('textarea[data-action="goal"]') as HTMLTextAreaElement).value).toBe(PLAN.goal);
+    expect($('.director-op[data-op-id="op-1"]').getAttribute('data-status')).toBe('dropped');
+    expect($('.director-op[data-op-id="op-2"]').getAttribute('data-status')).toBe('planned');
+    // director.plan was NOT re-run: recovery must not cost another plan pass.
+    expect(planMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-fetches the cost/egress banner for a restored plan (preview is transient)', async () => {
+    await planAndReview();
+    expect(container.querySelector('.director-cost')).not.toBeNull();
+
+    await click(tab('Library'));
+    await click(tab('Director'));
+    await flush(6);
+
+    // `preview` is deliberately NOT hoisted (it is cheaply re-fetchable by planId),
+    // so the restored plan must re-request it or the banner + the budget ack that
+    // gates Apply would be silently missing after every re-entry.
+    expect(container.querySelector('.director-cost')).not.toBeNull();
+    expect(previewCostMock).toHaveBeenCalledWith(PLAN.planId);
+    expect(previewCostMock.mock.calls.length).toBeGreaterThan(1);
+  });
+
+  it('serves a CLEAN Director form when a DIFFERENT video is opened', async () => {
+    await planAndReview();
+
+    // Open a different video, then return to Director. vid-1's session must NOT be
+    // served for vid-2 — applying it would run vid-1's ops against the wrong source.
+    await click(tab('Library'));
+    await click(buttonByText('open-other-video'));
+    await click(tab('Director'));
+    await flush(6);
+
+    expect(container.querySelector('[data-testid="plan-summary"]')).toBeNull();
+    expect(($('textarea[data-action="goal"]') as HTMLTextAreaElement).value).toBe('');
+  });
+});

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -28,6 +28,7 @@ import { Deliver } from './views/Deliver';
 import { MakeShorts } from './views/MakeShorts';
 import { Settings } from './views/Settings';
 import { incompleteBatches, remainingCount } from './features/repurposeLogic';
+import { DirectorSessionProvider } from './features/directorSession';
 import { lineageActions } from './features/lineageActionsClient';
 import { libraryShortsClient } from './features/libraryShortsClient';
 import { useToast } from './components/toast/useToast';
@@ -527,7 +528,11 @@ function AppShell(): React.ReactElement {
   }
 
   return (
-    <>
+    // F32: the Director's session (goal / plan / review decisions) lives here,
+    // OUTSIDE renderRoute()'s switch, so a tab click no longer destroys an
+    // unapplied plan along with the subtree. It must stay outside the switch —
+    // mounted inside it, it would be unmounted by the very navigation it guards.
+    <DirectorSessionProvider>
       <div className="app">
         <header className="app__bar">
           <span className="app__brand">Reframe</span>
@@ -576,7 +581,7 @@ function AppShell(): React.ReactElement {
       <SecureKeysBanner />
       <UpdateBanner />
       <ToastHost />
-    </>
+    </DirectorSessionProvider>
   );
 }
 

--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -278,4 +278,37 @@ describe('TabBar keyboard model (roving tabindex + arrow nav)', () => {
     expect(onSelect).toHaveBeenLastCalledWith('t3');
     expect(document.activeElement).toBe(btn('t3'));
   });
+
+  // F18: `navIds` marks the tabs whose activation navigates AWAY and unmounts this
+  // tablist. Arrow-stepping onto one of those must MOVE FOCUS ONLY (ARIA APG
+  // manual activation) — automatic activation there ejected the keyboard user out
+  // of the surface being navigated.
+  it('arrow-stepping onto a navIds tab moves focus only, never activating it', () => {
+    const onSelect = vi.fn();
+    renderBar({ tabs: GROUP_TABS, active: 't1', onSelect, groups: GROUPS, navIds: ['t2'] });
+    key(btn('t1'), 'ArrowRight');
+    expect(onSelect).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(btn('t2'));
+  });
+
+  // Membership is per-TARGET, not "navIds is non-empty ⇒ the whole strip is
+  // manual". This pins the scope so a later implementation cannot silently convert
+  // every tab to manual activation the moment one nav id exists.
+  it('arrow-stepping onto a NON-member still activates while navIds is present', () => {
+    const onSelect = vi.fn();
+    renderBar({ tabs: GROUP_TABS, active: 't2', onSelect, groups: GROUPS, navIds: ['t2'] });
+    // ArrowRight from t2 (last reachable) wraps to t1, which is NOT a nav id.
+    key(btn('t2'), 'ArrowRight');
+    expect(onSelect).toHaveBeenLastCalledWith('t1');
+    expect(document.activeElement).toBe(btn('t1'));
+  });
+
+  it('still ACTIVATES a navIds tab on a deliberate click', () => {
+    const onSelect = vi.fn();
+    renderBar({ tabs: GROUP_TABS, active: 't1', onSelect, groups: GROUPS, navIds: ['t2'] });
+    act(() => {
+      btn('t2').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onSelect).toHaveBeenCalledWith('t2');
+  });
 });

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -54,6 +54,27 @@ export interface TabBarProps {
    * (jump to the deliver panel), keeping this component presentational.
    */
   onExport?: () => void;
+  /**
+   * ADDITIVE (F18): ids whose activation navigates AWAY from this tablist, so
+   * arrow-stepping must MOVE FOCUS onto them WITHOUT activating them. This is the
+   * ARIA APG "manual activation" carve-out: automatic activation is only legal
+   * when activation is instantaneous, and these ids activate into a route change
+   * that UNMOUNTS the very tablist being navigated (focus would land on `<body>`
+   * on another screen, unannounced). Deliberate activation still works — the
+   * button's own `onClick` fires on click and on Enter/Space. Omitted → every tab
+   * activates on arrow (the original behaviour, unchanged).
+   *
+   * TWO DISCLOSED RESIDUALS (do not read this prop as a complete APG fix):
+   *   1. The roving tabindex DESYNCS. Skipping `onSelect` leaves `active`
+   *      unchanged, so the DOM-focused nav tab keeps `tabIndex={-1}` while the
+   *      still-active tab keeps `tabIndex={0}` — Tab away and Shift+Tab back
+   *      returns to `active`, not to the arrowed-onto tab. A full fix needs a
+   *      focused-tab state separate from `active` (a contract refactor).
+   *   2. The tablist now has a MIXED activation model (automatic for most tabs,
+   *      manual for the `navIds` members). Defensible under the APG carve-out
+   *      above, but non-obvious — hence documented here, at the prop.
+   */
+  navIds?: string[];
 }
 
 /**
@@ -145,6 +166,7 @@ export function TabBar({
   advancedOpen = false,
   onToggleAdvanced,
   onExport,
+  navIds,
 }: TabBarProps): React.ReactElement {
   // A plain ref map (NOT useRef) so this presentational component stays hook-free
   // and can still be invoked directly in unit tests. React populates it via each
@@ -167,8 +189,13 @@ export function TabBar({
 
   const move = (toIndex: number): void => {
     const nextId = orderedIds[toIndex];
-    onSelect(nextId);
-    // Move focus to the newly-selected tab so keyboard users stay in sync. A
+    // MANUAL activation, scoped to the `navIds` members only (see the prop doc):
+    // their activation destroys this tablist, so an arrow key may only move focus.
+    // Every other tab keeps automatic activation (the ARIA APG default).
+    if (!navIds?.includes(nextId)) {
+      onSelect(nextId);
+    }
+    // Move focus to the newly-focused tab so keyboard users stay in sync. A
     // rendered, reachable tab always has its ref recorded, so assert non-null and
     // fail loud rather than silently skip focus (no silent fallback).
     btnRefs.current[nextId]!.focus();

--- a/app/renderer/src/features/ProducedShorts.test.tsx
+++ b/app/renderer/src/features/ProducedShorts.test.tsx
@@ -332,18 +332,80 @@ describe('<ProducedShorts />', () => {
 
   it('renders the visible + announced midpoint note on a degraded done (AC c)', async () => {
     const api = installApi();
+    mount([short({ thumbnailPath: '/out/poster.jpg' })]);
+    await act(async () => {
+      pickBtn().click();
+    });
+    // The LITERAL degrade payload the sidecar emits (handlers/vision_ops.py:310,
+    // pinned by sidecar/tests/test_handlers_thumbnail.py:151-166): no
+    // `thumbnailPath`, because the writer never runs on that branch.
+    api.fireDone({ jobId: 'job-1', result: { frameTimeSec: 5, score: 0, degraded: true } });
+    // A degrade is a SUCCESS, not a failure — assert that FIRST so a regression
+    // reports "a red alert rendered on the degrade path", not a selector miss.
+    expect(container.querySelector('[role="alert"]')?.textContent ?? null).toBeNull();
+    expect(
+      container.querySelector('.shorts__degrade-note')?.textContent ??
+        '<no .shorts__degrade-note rendered>',
+    ).toContain('No vision model available — used the middle frame');
+    const live = container.querySelector('[aria-live="polite"]');
+    expect(live?.textContent).toContain('No vision model available — used the middle frame');
+    // No file was written, so the poster must stay put AND its alt must not
+    // claim a frame time the pixels do not show (pickedSec stays null).
+    const img = container.querySelector('.shorts__thumb-img') as HTMLImageElement;
+    expect(img.getAttribute('src')).toContain(encodeURIComponent('short:/out/poster.jpg'));
+    expect(img.alt).toBe('Thumbnail for My talk');
+    expect(pickBtn().getAttribute('aria-busy')).toBe('false');
+  });
+
+  it('surfaces the sidecar failure message from a job.done error payload', async () => {
+    const api = installApi();
     mount([short()]);
     await act(async () => {
       pickBtn().click();
     });
-    api.fireDone({ jobId: 'job-1', result: bestFrame({ degraded: true, score: 0 }) });
-    const note = container.querySelector('.shorts__degrade-note');
-    expect(note?.textContent).toContain('No vision model available — used the middle frame');
-    const live = container.querySelector('[aria-live="polite"]');
-    expect(live?.textContent).toContain('No vision model available — used the middle frame');
-    // Still a real swap (img updated), just flagged as degraded.
-    const img = container.querySelector('.shorts__thumb-img') as HTMLImageElement;
-    expect(img.getAttribute('src')).toContain(encodeURIComponent('short:/out/clip-1.thumb.jpg'));
+    // jobs.py:808-811 `_finish_error` — the rpc START succeeded, the FAILURE
+    // arrives on the job.done channel carrying the real message.
+    api.fireDone({
+      jobId: 'job-1',
+      result: { error: { message: 'vision backend exploded', type: 'RuntimeError' } },
+    });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'vision backend exploded',
+    );
+    expect(pickBtn().getAttribute('aria-busy')).toBe('false');
+    expect(api.doneUnsubscribed()).toBe(true);
+  });
+
+  it('treats a cancelled job as a clean finish, not an error', async () => {
+    const api = installApi();
+    mount([short()]);
+    await act(async () => {
+      pickBtn().click();
+    });
+    // jobs.py:793-796 `_finish_cancelled` emits a TERMINAL job.done carrying a
+    // JobCancelled envelope; every other panel treats it as a clean finish.
+    api.fireDone({
+      jobId: 'job-1',
+      result: { error: { message: 'cancelled', type: 'JobCancelled' } },
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('.shorts__degrade-note')).toBeNull();
+    expect(pickBtn().getAttribute('aria-busy')).toBe('false');
+    expect((pickBtn() as HTMLButtonElement).disabled).toBe(false);
+    expect(api.doneUnsubscribed()).toBe(true);
+  });
+
+  it('still fails loud for a scored payload that lost its thumbnailPath', async () => {
+    const api = installApi();
+    mount([short()]);
+    await act(async () => {
+      pickBtn().click();
+    });
+    // Numeric frameTimeSec but no path and NOT degraded: genuinely unrecognisable,
+    // so the widened predicate must not silently accept it as a swap.
+    api.fireDone({ jobId: 'job-1', result: { frameTimeSec: 5, score: 0.9 } });
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('unreadable result');
+    expect(container.querySelector('.shorts__thumb-img')).toBeNull();
   });
 
   it('surfaces a role="alert" when the job fails (AC error)', async () => {

--- a/app/renderer/src/features/ProducedShorts.tsx
+++ b/app/renderer/src/features/ProducedShorts.tsx
@@ -16,6 +16,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { Player, shortMediaUrl } from '../components/Player';
 import { ShortClipActions } from '../components/ShortClipActions';
+import { extractJobError } from '../components/useJob';
 import { fmtSeconds, getApi } from './_api';
 // R5 virality-score dashboard: the score badge reuses the candidate-card
 // `displayVirality` (clamped 0-100 int / null); the sort order + duration format
@@ -28,7 +29,7 @@ import {
   sortShorts,
   formatShortDuration,
 } from './shortsGallery';
-import type { BestFrame, ShortInfo } from '../lib/rpc';
+import type { ShortInfo } from '../lib/rpc';
 
 export interface ProducedShortsProps {
   shorts: ShortInfo[];
@@ -44,16 +45,37 @@ const DEGRADE_NOTE = 'No vision model available — used the middle frame';
 
 type PickPhase = 'idle' | 'running' | 'done' | 'error';
 
-/** Read a {@link BestFrame} off a `job.done` result, or `null` if malformed. */
-function asBestFrame(result: unknown): BestFrame | null {
-  if (
-    result &&
-    typeof result === 'object' &&
-    typeof (result as { frameTimeSec?: unknown }).frameTimeSec === 'number' &&
-    typeof (result as { thumbnailPath?: unknown }).thumbnailPath === 'string'
-  ) {
-    return result as BestFrame;
+/**
+ * The two SUCCESS shapes `thumbnail.select` actually emits.
+ *
+ * - `scored`   — a frame was scored and a poster written (`vision_ops.py:342-347`).
+ * - `degraded` — no consented cloud vision provider and no local weights, so the
+ *   deterministic clip midpoint was used and NO thumbnail was written
+ *   (`vision_ops.py:303-312`). This is the OUT-OF-BOX path on a fresh install and
+ *   in offline mode, so it must read as success, not as a malformed payload.
+ */
+type PickOutcome =
+  | { kind: 'scored'; frameTimeSec: number; thumbnailPath: string }
+  | { kind: 'degraded'; frameTimeSec: number };
+
+/** Read a pick outcome off a `job.done` result, or `null` if unrecognisable. */
+function asPickOutcome(result: unknown): PickOutcome | null {
+  // Kept as ONE fused guard (like the predicate this replaces): a nullish result
+  // short-circuits on `!r`, and any non-object primitive reads `frameTimeSec` as
+  // undefined and fails the same check — so no extra arm is introduced that only a
+  // fabricated payload could reach.
+  const r = result as
+    | { frameTimeSec?: unknown; thumbnailPath?: unknown; degraded?: unknown }
+    | null
+    | undefined;
+  if (!r || typeof r.frameTimeSec !== 'number') return null;
+  const frameTimeSec = r.frameTimeSec;
+  if (typeof r.thumbnailPath === 'string') {
+    return { kind: 'scored', frameTimeSec, thumbnailPath: r.thumbnailPath };
   }
+  // Only `degraded === true` may go pathless; a scored payload that LOST its path
+  // is still unrecognisable and must fail loud.
+  if (r.degraded === true) return { kind: 'degraded', frameTimeSec };
   return null;
 }
 
@@ -106,23 +128,45 @@ function ShortThumbCard({
     if (typeof api.onJobDone !== 'function') return undefined;
     const off = api.onJobDone((ev) => {
       if (ev.jobId !== jobId) return;
-      const best = asBestFrame(ev.result);
-      if (!best) {
-        // A malformed payload can't drive a swap; fail loud rather than silent.
+      // A failure AND a user cancel both arrive through the shared A3 error
+      // envelope (`jobs.py:808-811` / `:793-796`), so read that FIRST — reading it
+      // last is what collapsed every real sidecar message into one fixed string.
+      const failure = extractJobError(ev.result);
+      if (failure) {
+        if (failure.type === 'JobCancelled') {
+          // The user's own cancel is a clean finish, not an error (mirrors the
+          // shared waiter in `features/_api.ts`).
+          setProgress('');
+          setPhase('idle');
+        } else {
+          setError(failure.message);
+          setPhase('error');
+        }
+        setJobId(null);
+        off();
+        return;
+      }
+      const picked = asPickOutcome(ev.result);
+      if (!picked) {
+        // A genuinely unrecognisable payload can't drive a swap; fail loud.
         setError('The best-frame job returned an unreadable result.');
         setPhase('error');
         setJobId(null);
         off();
         return;
       }
-      setPickedPath(best.thumbnailPath);
-      setPickedSec(best.frameTimeSec);
-      setDegraded(best.degraded);
-      setSwapMessage(
-        best.degraded
-          ? DEGRADE_NOTE
-          : `Thumbnail updated to the frame at ${fmtSeconds(best.frameTimeSec)}`,
-      );
+      if (picked.kind === 'scored') {
+        setPickedPath(picked.thumbnailPath);
+        setPickedSec(picked.frameTimeSec);
+        setDegraded(false);
+        setSwapMessage(`Thumbnail updated to the frame at ${fmtSeconds(picked.frameTimeSec)}`);
+      } else {
+        // No poster was written, so keep the existing one AND leave pickedSec null:
+        // setting it would make `posterAlt` announce "frame at 0:05" over pixels
+        // that never changed. The visible + announced note carries the information.
+        setDegraded(true);
+        setSwapMessage(DEGRADE_NOTE);
+      }
       setPhase('done');
       setJobId(null);
       off();

--- a/app/renderer/src/features/Subtitles.test.tsx
+++ b/app/renderer/src/features/Subtitles.test.tsx
@@ -123,6 +123,39 @@ describe('<Subtitles />', () => {
     expect(genBtn().disabled).toBe(false);
   });
 
+  // F19: `initialTrack` arrives LATE. Workspace derives it from `project.tracks[0]`
+  // and `project.open` is fired from a post-commit effect, so this lazily-imported
+  // panel can mount BEFORE the project lands. `mount()` re-renders the SAME fiber
+  // (same element type, same position under one persistent root), so state is
+  // preserved — exactly the vehicle needed to model a late prop.
+  it('adopts a track that arrives AFTER mount (project.open resolves late)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake); // initialTrack: null
+    // precondition guard: a genuine red here (rather than a setup error) requires
+    // the first render to really show no track.
+    expect(container.querySelector('.track-meta')).toBeNull();
+    await mount(fake, { initialTrack: track() }); // prop arrives; NOT a remount
+    expect(container.querySelector('.track-meta')).not.toBeNull();
+    expect([...container.querySelectorAll('.cue-text')]).toHaveLength(2);
+  });
+
+  it('does not clobber a locally-edited track when the initialTrack prop re-renders', async () => {
+    const fake = makeFakeApi();
+    await mount(fake, { initialTrack: track() });
+    const cue = container.querySelector('[aria-label="Cue 1 text"]') as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+    await act(async () => {
+      setter.call(cue, 'edited first');
+      cue.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    // A NEW track object from the parent must not overwrite the in-panel edit.
+    await mount(fake, { initialTrack: track({ id: 'tr2', name: 'Reloaded' }) });
+    expect((container.querySelector('[aria-label="Cue 1 text"]') as HTMLInputElement).value).toBe(
+      'edited first',
+    );
+    expect(container.querySelector('.track-meta')?.textContent).toContain('English');
+  });
+
   it('generate calls subtitles.generate, renders the track meta + sorted cues', async () => {
     const fake = makeFakeApi();
     const onTrackChange = vi.fn();

--- a/app/renderer/src/features/Subtitles.tsx
+++ b/app/renderer/src/features/Subtitles.tsx
@@ -68,6 +68,26 @@ export function Subtitles({
     'original-first',
   );
 
+  // F19: the Workspace derives `initialTrack` from `project.tracks[0]`, but
+  // `project.open` is fired from a POST-COMMIT effect (Workspace.tsx:173-176) and
+  // can land AFTER this lazily-imported panel has mounted — so the prop must be
+  // ADOPTED, not only captured once at mount by `useState(initialTrack)` above.
+  // Without this the panel shows "Generate subtitles" forever and the project's
+  // existing (possibly hand-edited) track is invisible for the panel's lifetime.
+  //
+  // Guarded on `!track` so it hydrates the EMPTY panel only, and never clobbers a
+  // generated / translated / locally-edited track (a later project reload would
+  // otherwise overwrite unsaved keystrokes). `setTrack`, NOT `applyTrack`
+  // (:81-87): hydrating from the parent's own data must not fire `onTrackChange`
+  // back at the parent.
+  //
+  // Accepted residual: a Generate clicked BEFORE `project.open` lands is visibly
+  // superseded — the hydrate fills the empty slot first, then the generate
+  // response replaces it. Cosmetic only; the generated track still wins.
+  useEffect(() => {
+    if (initialTrack && !track) setTrack(initialTrack);
+  }, [initialTrack, track]);
+
   useEffect(() => {
     if (!jobId) return;
     const off = getApi().onProgress((ev) => {

--- a/app/renderer/src/features/directorSession.test.tsx
+++ b/app/renderer/src/features/directorSession.test.tsx
@@ -1,0 +1,222 @@
+// directorSession.test.tsx — the hoisted Director session store (F32).
+//
+// Covers the resolution rule (which is where the subtle bug lives: keying purely on
+// the OPEN video is circular when no video is open but a plan is on screen), the
+// store/replace/per-video-isolation behaviour, and the provider-vs-fallback split.
+
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+import {
+  CLEAN_SESSION,
+  DirectorSessionProvider,
+  resolveSession,
+  useDirectorSession,
+  type DirectorSessionEntry,
+  type DirectorSessionStore,
+} from './directorSession';
+import type { DirectorEditPlan, DirectorOp } from '../lib/directorTypes';
+
+// ---- fixtures ---------------------------------------------------------------
+
+function op(over: Partial<DirectorOp> = {}): DirectorOp {
+  return {
+    id: 'op-1',
+    kind: 'trim',
+    span: [0, 1000],
+    params: {},
+    reversible: true,
+    rationale: '',
+    status: 'planned',
+    statusReason: null,
+    ...over,
+  };
+}
+
+function planFixture(videoId = 'vid-1'): DirectorEditPlan {
+  return {
+    planId: `plan-${videoId}`,
+    videoId,
+    goal: 'tighten',
+    sourceHash: 'h',
+    ops: [op()],
+    inverse: [],
+  };
+}
+
+function entry(videoId = 'vid-1', over: Partial<DirectorSessionEntry> = {}): DirectorSessionEntry {
+  return {
+    videoId,
+    goal: `goal for ${videoId}`,
+    plan: planFixture(videoId),
+    opsStatus: null,
+    applied: false,
+    ...over,
+  };
+}
+
+// ---- resolveSession --------------------------------------------------------
+
+describe('resolveSession', () => {
+  it('serves a clean session when nothing is stored', () => {
+    expect(resolveSession(null, 'vid-1')).toBe(CLEAN_SESSION);
+    expect(resolveSession(null, null)).toBe(CLEAN_SESSION);
+  });
+
+  it('serves the stored session for the SAME open video', () => {
+    const stored = entry('vid-1');
+    expect(resolveSession(stored, 'vid-1')).toBe(stored);
+  });
+
+  it('serves the stored session when NO video is open (WU-E1: no id to key by)', () => {
+    // This is the case a naive "key by the open video id" rule gets wrong: with
+    // video===null the only videoId in existence is the one INSIDE the session being
+    // read, so refusing here would drop the "a video closed after planning keeps its
+    // plan" guarantee that DirectorPanel deliberately implements.
+    const stored = entry('vid-1');
+    expect(resolveSession(stored, null)).toBe(stored);
+  });
+
+  it('REFUSES the stored session when a DIFFERENT video is open', () => {
+    const stored = entry('vid-1');
+    expect(resolveSession(stored, 'vid-2')).toBe(CLEAN_SESSION);
+  });
+
+  it('CLEAN_SESSION carries no work', () => {
+    expect(CLEAN_SESSION).toEqual({ goal: '', plan: null, opsStatus: null, applied: false });
+  });
+});
+
+// ---- the store (through the provider AND the fallback) ----------------------
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(async () => {
+  await act(async () => {
+    root.unmount();
+  });
+  container.remove();
+});
+
+/** Capture the live store from inside the tree so a test can drive it. */
+function Probe({ onStore }: { onStore: (s: DirectorSessionStore) => void }): React.ReactElement {
+  const store = useDirectorSession();
+  onStore(store);
+  return <div data-testid="probe" data-goal={store.stored?.goal ?? ''} />;
+}
+
+/** Render `Probe`, optionally wrapped in the provider; returns the latest store. */
+async function renderProbe(withProvider: boolean): Promise<() => DirectorSessionStore> {
+  let latest: DirectorSessionStore | null = null;
+  const capture = (s: DirectorSessionStore): void => {
+    latest = s;
+  };
+  await act(async () => {
+    root.render(
+      withProvider ? (
+        <DirectorSessionProvider>
+          <Probe onStore={capture} />
+        </DirectorSessionProvider>
+      ) : (
+        <Probe onStore={capture} />
+      ),
+    );
+  });
+  // Non-null by construction: Probe runs during the act() render above.
+  return () => latest as unknown as DirectorSessionStore;
+}
+
+describe('useDirectorSession store', () => {
+  it('starts empty', async () => {
+    const store = await renderProbe(true);
+    expect(store().stored).toBeNull();
+  });
+
+  it('stores a session under its videoId', async () => {
+    const store = await renderProbe(true);
+    await act(async () => {
+      store().update('vid-1', (prev) => ({ ...prev, goal: 'tighten the pacing' }));
+    });
+    expect(store().stored).toEqual({
+      videoId: 'vid-1',
+      goal: 'tighten the pacing',
+      plan: null,
+      opsStatus: null,
+      applied: false,
+    });
+  });
+
+  it('REPLACES fields on a second update for the same video', async () => {
+    const store = await renderProbe(true);
+    const plan = planFixture('vid-1');
+    await act(async () => {
+      store().update('vid-1', (prev) => ({ ...prev, goal: 'first' }));
+    });
+    await act(async () => {
+      store().update('vid-1', (prev) => ({ ...prev, plan, applied: true }));
+    });
+    // The updater saw the PREVIOUS session, so the earlier goal is preserved.
+    expect(store().stored).toEqual({
+      videoId: 'vid-1',
+      goal: 'first',
+      plan,
+      opsStatus: null,
+      applied: true,
+    });
+  });
+
+  it('ISOLATION: an update for a different video starts from a clean session', async () => {
+    const store = await renderProbe(true);
+    await act(async () => {
+      store().update('vid-1', (prev) => ({ ...prev, goal: 'vid-1 goal', plan: planFixture() }));
+    });
+    let seen: string | null = null;
+    await act(async () => {
+      store().update('vid-2', (prev) => {
+        seen = prev.goal;
+        return { ...prev, goal: 'vid-2 goal' };
+      });
+    });
+    // vid-2's updater must NOT inherit vid-1's goal or plan.
+    expect(seen).toBe('');
+    expect(store().stored).toEqual({
+      videoId: 'vid-2',
+      goal: 'vid-2 goal',
+      plan: null,
+      opsStatus: null,
+      applied: false,
+    });
+  });
+
+  it('carries opsStatus (the apply result) like any other field', async () => {
+    const store = await renderProbe(true);
+    const opsStatus = [op({ id: 'a', status: 'applied' })];
+    await act(async () => {
+      store().update('vid-1', (prev) => ({ ...prev, opsStatus, applied: true }));
+    });
+    expect(store().stored?.opsStatus).toBe(opsStatus);
+  });
+
+  it('FALLBACK: works with no provider mounted (a bare panel stays usable)', async () => {
+    const store = await renderProbe(false);
+    expect(store().stored).toBeNull();
+    await act(async () => {
+      store().update('vid-1', (prev) => ({ ...prev, goal: 'bare' }));
+    });
+    expect(store().stored?.goal).toBe('bare');
+    expect(container.querySelector('[data-testid="probe"]')?.getAttribute('data-goal')).toBe(
+      'bare',
+    );
+  });
+});

--- a/app/renderer/src/features/directorSession.tsx
+++ b/app/renderer/src/features/directorSession.tsx
@@ -1,0 +1,152 @@
+// directorSession.tsx — the Director's SESSION state, hoisted ABOVE the route switch.
+//
+// F32: every top-level tab click re-runs App's `renderRoute()` switch, which
+// UNMOUNTS the whole Director subtree. The panel's goal / plan / per-op review
+// decisions lived in component-local `useState`, so leaving the tab silently threw
+// away an unapplied plan and every keep/drop + reorder decision made on it — with
+// no warning, no confirm, and no read path back. Nothing new is needed at the wire
+// to fix that: the renderer already OWNS the complete plan object from the
+// `job.done` payload (`director_ops.py` returns `{planId, editPlan, preview}`); it
+// was simply being discarded. This provider keeps it alive for the app run.
+//
+// WHAT IS STORED (and what deliberately is NOT):
+//   stored here  — goal, plan, opsStatus, applied  (the user's WORK: irrecoverable
+//                  without a re-plan, and a re-plan yields a NON-IDENTICAL plan
+//                  because the model is re-run)
+//   left local   — preview, evaluation, busy, error, progress, kindFilter, showTour
+//                  (transient UI, or cheaply re-fetchable by planId — the panel
+//                  re-requests `previewCost` for a restored plan on mount)
+//
+// SCOPE (both limits are real and deliberate):
+//   * IN-MEMORY ONLY. Durable recovery across an app/sidecar restart is a separate,
+//     genuinely-unbuilt capability and is NOT folded in here.
+//   * ONE SLOT. A session is stamped with its `videoId` and is refused when a
+//     DIFFERENT video is open (see resolveSession). Storing a session for video B
+//     replaces video A's, so A -> B -> A does not restore A once B was worked on.
+//     A `Record<videoId, …>` would remove that, at the cost of an unbounded map.
+//
+// RESIDUAL, STATED INLINE (NOT closed by this file): the IN-FLIGHT window is still
+// lost. The job identity is a per-panel `useRef` and the `job.done` subscription is
+// a per-MOUNT effect, so if the user clicks "Plan edit" and tabs away BEFORE the
+// job finishes, nobody is subscribed when the result arrives and it is discarded —
+// and on return the panel looks coherent and idle while holding the PREVIOUS plan.
+// Closing it requires moving the whole job seam (subscription + handleDone + the
+// result narrowing) above the route switch, because hoisting the job id alone does
+// not help while no component is listening. That is a larger refactor of the
+// panel's job seam and is out of this batch's scope; JobQueue still lists the job.
+
+import React, { createContext, useCallback, useContext, useMemo, useState } from 'react';
+import type { DirectorEditPlan, DirectorOp } from '../lib/directorTypes';
+
+/** The user's in-progress Director work for ONE video. */
+export interface DirectorSessionFields {
+  /** The editing goal as typed (survives so "Adjust & re-plan" keeps its text). */
+  goal: string;
+  /** The reviewable plan, including any keep/drop + reorder edits made on it. */
+  plan: DirectorEditPlan | null;
+  /** Per-op statuses returned by an apply/undo (server truth once present). */
+  opsStatus: DirectorOp[] | null;
+  /** True once this plan has been applied (gates Evaluate / Undo). */
+  applied: boolean;
+}
+
+/** A stored session, stamped with the video it belongs to (WU-E1: the plan target). */
+export interface DirectorSessionEntry extends DirectorSessionFields {
+  videoId: string;
+}
+
+/** A session with no work in it — what a first visit (or a different video) gets. */
+export const CLEAN_SESSION: DirectorSessionFields = {
+  goal: '',
+  plan: null,
+  opsStatus: null,
+  applied: false,
+};
+
+/**
+ * Decide whether the stored session may be served for the currently-open video.
+ *
+ * The rule is NOT "key by the open video id" — that is circular in the one state
+ * the panel deliberately supports. `DirectorPanel` resolves its plan target as
+ * `video?.id ?? plan?.videoId`, so a video CLOSED after planning keeps its plan
+ * (pinned by DirectorPanel.test.tsx's "a video closed AFTER planning keeps the
+ * plan…"). With `video === null` the only videoId in existence is the one INSIDE
+ * the session being read, so keying on the open video would refuse to serve the
+ * very session that holds the answer, and the WU-E1 guard would be dropped.
+ *
+ * So: serve the stored slot when NO video is open; refuse ONLY when a DIFFERENT
+ * video is open (that plan's ops must never be applied to another source).
+ */
+export function resolveSession(
+  stored: DirectorSessionEntry | null,
+  openVideoId: string | null,
+): DirectorSessionFields {
+  if (stored === null) return CLEAN_SESSION;
+  if (openVideoId === null) return stored;
+  if (stored.videoId !== openVideoId) return CLEAN_SESSION;
+  return stored;
+}
+
+/** A functional session update (mirrors `useState`'s updater contract). */
+export type DirectorSessionUpdater = (prev: DirectorSessionFields) => DirectorSessionFields;
+
+/** What `useDirectorSession()` hands back. */
+export interface DirectorSessionStore {
+  /** The raw stored slot (null when nothing has been stored yet). */
+  stored: DirectorSessionEntry | null;
+  /**
+   * Store/replace the session for `videoId`. The updater receives whatever
+   * {@link resolveSession} would serve for that video, so an edit against a
+   * DIFFERENT video's slot starts from a clean session instead of inheriting it.
+   */
+  update(videoId: string, next: DirectorSessionUpdater): void;
+}
+
+const DirectorSessionContext = createContext<DirectorSessionStore | null>(null);
+
+/**
+ * The store implementation. Used BOTH by {@link DirectorSessionProvider} and as
+ * the no-provider fallback in {@link useDirectorSession}, so there is exactly one
+ * copy of the semantics.
+ */
+export function useDirectorSessionStore(): DirectorSessionStore {
+  const [stored, setStored] = useState<DirectorSessionEntry | null>(null);
+  const update = useCallback((videoId: string, next: DirectorSessionUpdater): void => {
+    setStored((prev) => ({ videoId, ...next(resolveSession(prev, videoId)) }));
+  }, []);
+  return useMemo<DirectorSessionStore>(() => ({ stored, update }), [stored, update]);
+}
+
+export interface DirectorSessionProviderProps {
+  children: React.ReactNode;
+}
+
+/**
+ * Hold the Director session ABOVE the route switch. It MUST be mounted outside
+ * App's `renderRoute()` switch — inside it, it would be part of the very subtree a
+ * tab click unmounts, and would fix nothing.
+ */
+export function DirectorSessionProvider({
+  children,
+}: DirectorSessionProviderProps): React.ReactElement {
+  const store = useDirectorSessionStore();
+  return (
+    <DirectorSessionContext.Provider value={store}>{children}</DirectorSessionContext.Provider>
+  );
+}
+
+/**
+ * Read the Director session store.
+ *
+ * Outside a provider this falls back to a panel-LOCAL store, so `DirectorPanel`
+ * stays independently mountable (its own suite renders it bare, as does any
+ * one-off host). The fallback behaves identically for a single mount — it just
+ * cannot survive an unmount, which is precisely what the provider adds.
+ */
+export function useDirectorSession(): DirectorSessionStore {
+  const ctx = useContext(DirectorSessionContext);
+  const fallback = useDirectorSessionStore();
+  return ctx ?? fallback;
+}
+
+export default DirectorSessionProvider;

--- a/app/renderer/src/lib/rpc/schemas.ts
+++ b/app/renderer/src/lib/rpc/schemas.ts
@@ -162,8 +162,17 @@ export interface ShortInfo {
 export interface BestFrame {
   /** Source-absolute time (seconds) of the chosen thumbnail frame. */
   frameTimeSec: number;
-  /** Absolute path of the written poster (inside the exports root). */
-  thumbnailPath: string;
+  /**
+   * Absolute path of the written poster (inside the exports root).
+   *
+   * OPTIONAL, and absent on the whole degrade branch: `handlers/vision_ops.py:310`
+   * returns `{frameTimeSec, score, degraded}` only, because the thumbnail writer
+   * never runs there ("NO thumbnailPath is advertised here", vision_ops.py:305-307)
+   * — a path would name a file that was never written. The scored branch
+   * (`vision_ops.py:342-347`) does carry it. Declaring it required made every
+   * default-install degrade look like a malformed payload.
+   */
+  thumbnailPath?: string;
   /** The scorer's confidence for the picked frame (0.0 on the degrade path). */
   score: number;
   /** True when the midpoint fallback was used (no vision model available). */

--- a/app/renderer/src/panels/DirectorPanel.test.tsx
+++ b/app/renderer/src/panels/DirectorPanel.test.tsx
@@ -22,6 +22,7 @@ import {
   errText,
   type JobEventBridge,
 } from './DirectorPanel';
+import { DirectorSessionProvider } from '../features/directorSession';
 import type {
   DirectorApplyResult,
   DirectorEditPlan,
@@ -374,6 +375,28 @@ async function planTo(c: FakeClient, plan: DirectorEditPlan): Promise<void> {
   await emitPlanDone(c, plan);
 }
 
+/**
+ * Render the panel inside a REAL DirectorSessionProvider, with the panel itself
+ * swappable. `mounted:false` unmounts ONLY the panel while the provider stays —
+ * reproducing App's route switch, which is the one thing a prop-change re-render
+ * cannot simulate (that reuses the fiber, so even a component-local useState
+ * survives it and the provider path goes untested).
+ */
+async function renderInProvider(c: FakeClient, video: Video | null, mounted = true): Promise<void> {
+  await act(async () => {
+    root.render(
+      <DirectorSessionProvider>
+        {mounted ? (
+          <DirectorPanel rpcClient={c.client} jobEvents={events} video={video} />
+        ) : (
+          <div data-testid="away" />
+        )}
+      </DirectorSessionProvider>,
+    );
+  });
+  await flush();
+}
+
 // ---- tests -----------------------------------------------------------------
 
 describe('DirectorPanel', () => {
@@ -464,6 +487,72 @@ describe('DirectorPanel', () => {
     await clickPlan();
     const planCalls = c.calls.filter((x) => x.method === 'director.plan');
     expect(planCalls[planCalls.length - 1].args[0]).toBe('vid-1');
+  });
+
+  // F32 — the SAME WU-E1 guarantee as the test above, but exercised THROUGH the
+  // provider across a real unmount. The test above re-renders with a changed prop,
+  // which reuses the fiber, so the panel-local fallback store satisfies it; only an
+  // unmount-and-remount inside a surviving provider proves the shipped path keeps
+  // WU-E1 intact. Without this, the suite could stay green while the provider path
+  // silently dropped "a video closed after planning keeps its plan".
+  it('THROUGH THE PROVIDER: a plan survives an unmount and is still served with NO video open (WU-E1)', async () => {
+    const c = makeClient();
+    await renderInProvider(c, videoFixture());
+    await setGoal('q&a');
+    await clickPlan();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-plan',
+        result: {
+          planId: 'plan-1',
+          editPlan: planFixture([op({ id: 'a', kind: 'trim' })], 'q&a'),
+          preview: '{}',
+        },
+      });
+    });
+    await flush();
+    expect($('[data-testid="plan-summary"]').textContent).toBe('1 trim');
+
+    // Route away (the panel unmounts, the provider does not), then back with NO
+    // video open — the exact state where keying on the open video would be circular.
+    await renderInProvider(c, null, false);
+    expect(container.querySelector('[data-testid="away"]')).not.toBeNull();
+    await renderInProvider(c, null, true);
+
+    // Not the "No video open" empty state: the plan's own videoId is the target.
+    expect(container.querySelector('[data-section="empty"]')).toBeNull();
+    expect($('[data-testid="plan-summary"]').textContent).toBe('1 trim');
+    expect(($('textarea[data-action="goal"]') as HTMLTextAreaElement).value).toBe('q&a');
+    // And a re-plan still targets the plan's videoId, never the goal text.
+    await clickPlan();
+    const planCalls = c.calls.filter((x) => x.method === 'director.plan');
+    expect(planCalls[planCalls.length - 1].args[0]).toBe('vid-1');
+  });
+
+  it('THROUGH THE PROVIDER: a DIFFERENT open video gets a clean form, not the stored plan', async () => {
+    const c = makeClient();
+    await renderInProvider(c, videoFixture());
+    await setGoal('q&a');
+    await clickPlan();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-plan',
+        result: {
+          planId: 'plan-1',
+          editPlan: planFixture([op({ id: 'a', kind: 'trim' })], 'q&a'),
+          preview: '{}',
+        },
+      });
+    });
+    await flush();
+    expect($('[data-testid="plan-summary"]').textContent).toBe('1 trim');
+
+    // vid-2 must NOT inherit vid-1's plan — applying it would run vid-1's ops
+    // against the wrong source.
+    await renderInProvider(c, null, false);
+    await renderInProvider(c, videoFixture({ id: 'vid-2', title: 'Other' }), true);
+    expect(container.querySelector('[data-testid="plan-summary"]')).toBeNull();
+    expect(($('textarea[data-action="goal"]') as HTMLTextAreaElement).value).toBe('');
   });
 
   it('(b) a 50-op plan renders grouped collapsible sections, not 50 flat rows', async () => {
@@ -1094,6 +1183,143 @@ describe('DirectorPanel', () => {
     });
     await flush();
     expect($('p.error').textContent).toBe('Undo returned an unexpected result.');
+  });
+
+  // ---- F30: the sidecar's ASYNC (in-job) failure payload ---------------------
+  //
+  // A job that raises emits `job.done {jobId, result:{error:{message,type}}}`
+  // (jobs.py `_finish_error`), and a user cancel emits the same shape with
+  // `type:'JobCancelled'` (jobs.py `_finish_cancelled` — its CONTRACT-NOTE is
+  // explicit that cancellation DOES emit a terminal job.done). Neither payload
+  // carries a `planId`, so `asPlanResult`/`asApplyResult` reject both and the
+  // panel used to replace the real cause with its generic "unexpected result"
+  // copy — masking a 401/quota/ffmpeg failure AND mis-reporting a clean cancel as
+  // an error. These fixtures mirror that exact wire shape (verified in jobs.py),
+  // NOT the declared DirectorPlanResult type.
+
+  it('a plan job.done error payload surfaces the sidecar cause', async () => {
+    const c = makeClient();
+    await mount(c);
+    await setGoal('go');
+    await clickPlan();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-plan',
+        result: {
+          error: { message: 'provider rejected the request (401)', type: 'ProviderError' },
+        },
+      });
+    });
+    await flush();
+    expect($('p.error').textContent).toBe('Planning failed: provider rejected the request (401)');
+    expect(container.querySelector('[data-testid="plan-summary"]')).toBeNull();
+    // The panel is usable again (the failure is terminal, not a hang).
+    expect(($('button[data-action="plan"]') as HTMLButtonElement).disabled).toBe(false);
+    expect($('[data-section="progress"]').textContent).toBe('');
+  });
+
+  it('a cancelled plan job finishes quietly and is not reported as an error', async () => {
+    const c = makeClient();
+    await mount(c);
+    await setGoal('go');
+    await clickPlan();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-plan',
+        result: { error: { message: 'cancelled', type: 'JobCancelled' } },
+      });
+    });
+    await flush();
+    expect(container.querySelector('p.error')).toBeNull();
+    expect(($('button[data-action="plan"]') as HTMLButtonElement).disabled).toBe(false);
+    expect($('[data-section="progress"]').textContent).toBe('');
+  });
+
+  // The phase prefix is a Record lookup, which is INVISIBLE to v8 branch
+  // coverage — a wrong copy value would ship 100%-green. Assert the rendered
+  // apply and undo strings so the labels cannot drift silently.
+  it('an apply job.done error payload surfaces the sidecar cause', async () => {
+    const c = makeClient();
+    await planTo(c, planFixture([op({ id: 'a' })]));
+    await act(async () => {
+      $('button[data-action="apply"]').click();
+    });
+    await flush();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-apply',
+        result: { error: { message: 'ffmpeg exited 1', type: 'RuntimeError' } },
+      });
+    });
+    await flush();
+    expect($('p.error').textContent).toBe('Apply failed: ffmpeg exited 1');
+  });
+
+  it('an undo job.done error payload surfaces the sidecar cause', async () => {
+    const c = makeClient();
+    await planTo(c, planFixture([op({ id: 'a' })]));
+    await act(async () => {
+      $('button[data-action="apply"]').click();
+    });
+    await flush();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-apply',
+        result: { planId: 'plan-1', opsStatus: [op({ id: 'a' })], projectCopyPath: '/c' },
+      });
+    });
+    await flush();
+    await act(async () => {
+      $('button[data-action="undo"]').click();
+    });
+    await flush();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-undo',
+        result: { error: { message: 'inverse op missing', type: 'RuntimeError' } },
+      });
+    });
+    await flush();
+    expect($('p.error').textContent).toBe('Undo failed: inverse op missing');
+  });
+
+  it('a cancelled apply job finishes quietly and keeps the plan reviewable', async () => {
+    const c = makeClient();
+    await planTo(c, planFixture([op({ id: 'a', kind: 'trim' })]));
+    await act(async () => {
+      $('button[data-action="apply"]').click();
+    });
+    await flush();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-apply',
+        result: { error: { message: 'cancelled', type: 'JobCancelled' } },
+      });
+    });
+    await flush();
+    expect(container.querySelector('p.error')).toBeNull();
+    // Nothing was applied, so the plan stays on screen and reviewable.
+    expect($('[data-testid="plan-summary"]').textContent).toBe('1 trim');
+    expect(container.querySelector('button[data-action="undo"]')).toBeNull();
+    expect(($('button[data-action="op-disable"]') as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  // A post-restart synthetic interrupt uses the same envelope (jobs.py rehydrate
+  // emits `{error:{message:'job interrupted by restart', type:'JobInterrupted'}}`).
+  // It is a real failure, so it is reported — deliberately, not by accident.
+  it('a JobInterrupted restart payload is reported as a plan failure', async () => {
+    const c = makeClient();
+    await mount(c);
+    await setGoal('go');
+    await clickPlan();
+    await act(async () => {
+      events.emitDone({
+        jobId: 'job-plan',
+        result: { error: { message: 'job interrupted by restart', type: 'JobInterrupted' } },
+      });
+    });
+    await flush();
+    expect($('p.error').textContent).toBe('Planning failed: job interrupted by restart');
   });
 
   it('director.plan rejection surfaces an error and clears busy', async () => {

--- a/app/renderer/src/panels/DirectorPanel.tsx
+++ b/app/renderer/src/panels/DirectorPanel.tsx
@@ -21,6 +21,12 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import '../features/panels.css';
 import './directorPanel.css';
 import { DirectorOnboarding } from '../components/DirectorOnboarding';
+import { extractJobError } from '../components/useJob';
+import {
+  resolveSession,
+  useDirectorSession,
+  type DirectorSessionUpdater,
+} from '../features/directorSession';
 import {
   client,
   onJobDone as bridgeOnJobDone,
@@ -44,7 +50,6 @@ import {
   toggleOpStatus,
   type DirectorApplyResult,
   type DirectorCostRow,
-  type DirectorEditPlan,
   type DirectorEval,
   type DirectorOp,
   type DirectorOpKind,
@@ -150,6 +155,18 @@ interface PendingJob {
   kind: 'plan' | 'apply' | 'undo';
 }
 
+/**
+ * The phase name used in an ASYNC (in-job) failure message, single-sourced so the
+ * three copies cannot drift from the generic malformed-payload strings below.
+ * A `Record` lookup is invisible to v8 branch coverage, so each value is pinned by
+ * an assertion on the rendered string in DirectorPanel.test.tsx.
+ */
+const PHASE_LABEL: Record<PendingJob['kind'], string> = {
+  plan: 'Planning',
+  apply: 'Apply',
+  undo: 'Undo',
+};
+
 export function DirectorPanel({
   rpcClient,
   jobEvents,
@@ -160,12 +177,16 @@ export function DirectorPanel({
   const api = useMemo(() => rpcClient ?? client, [rpcClient]);
   const events = useMemo(() => jobEvents ?? realJobEvents, [jobEvents]);
 
-  const [goal, setGoal] = useState<string>('');
-  const [plan, setPlan] = useState<DirectorEditPlan | null>(null);
+  // F32: goal / plan / opsStatus / applied are the user's WORK, so they live in the
+  // DirectorSession store ABOVE App's route switch and survive a tab switch. The
+  // rest below stays component-local: transient UI, or cheaply re-fetchable by
+  // planId (see the mount effect that re-requests `previewCost` for a restored plan).
+  const sessionStore = useDirectorSession();
+  const openVideoId: string | null = video?.id ?? null;
+  const { goal, plan, opsStatus, applied } = resolveSession(sessionStore.stored, openVideoId);
+
   const [preview, setPreview] = useState<DirectorPreview | null>(null);
   const [evaluation, setEvaluation] = useState<DirectorEval | null>(null);
-  const [opsStatus, setOpsStatus] = useState<DirectorOp[] | null>(null);
-  const [applied, setApplied] = useState<boolean>(false);
   const [kindFilter, setKindFilter] = useState<DirectorOpKind | 'all'>('all');
   const [busy, setBusy] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
@@ -189,6 +210,31 @@ export function DirectorPanel({
   // own `videoId`. NEVER the goal text. `null` == no video and no plan → the
   // panel renders the "Choose a video" empty state instead of the prompt form.
   const activeVideoId: string | null = video?.id ?? plan?.videoId ?? null;
+
+  // F32: write the hoisted session, keyed by the resolved plan target. Every caller
+  // sits inside the `activeVideoId !== null` return branch (the prompt form / the
+  // storyboard), and a job.done can only arrive after `submit` ran from there, so a
+  // target always exists — the same justification as `goalRef.current!` below.
+  const patchSession = useCallback(
+    (next: DirectorSessionUpdater): void => {
+      sessionStore.update(activeVideoId!, next);
+    },
+    [sessionStore, activeVideoId],
+  );
+  // The once-mounted job.done/progress subscriptions read the writer through a ref
+  // so a session write does not churn the subscription (mirroring `pending`).
+  const patchRef = useRef(patchSession);
+  patchRef.current = patchSession;
+
+  const setGoal = useCallback(
+    (next: string): void => patchSession((prev) => ({ ...prev, goal: next })),
+    [patchSession],
+  );
+
+  // Read through a ref by the mount-only restore effect below (which must not
+  // re-fire when the plan is edited).
+  const restoredPlan = useRef(plan);
+  restoredPlan.current = plan;
 
   // WU-E2 + WU-D6a: read settings and open the first-run tour when the user has
   // not seen it — but ONLY once a video is actually open. Best-effort: a failed
@@ -239,6 +285,18 @@ export function DirectorPanel({
     [api],
   );
 
+  // F32: `preview` is deliberately NOT hoisted (it is re-derivable from planId), so a
+  // session RESTORED on re-entry arrives without its cost/egress banner — and without
+  // the budget cacheKey `apply` echoes. Re-request it ONCE PER MOUNT for a plan that
+  // was already there at mount (i.e. restored); a freshly-planned one is fetched by
+  // handleDone instead, so this never double-fetches. `loadPreview` is stable (it
+  // depends only on `api`), and the plan is read through a ref, so editing the plan
+  // does not re-fire this.
+  useEffect(() => {
+    const onMount = restoredPlan.current;
+    if (onMount) void loadPreview(onMount.planId);
+  }, [loadPreview]);
+
   // Resolve a terminal job.done for the active director job.
   const handleDone = useCallback(
     (event: DoneEvent): void => {
@@ -247,17 +305,40 @@ export function DirectorPanel({
       pending.current = null;
       setBusy(false);
       setProgress('');
+      // F30: an ASYNC (in-job) outcome arrives as `{error:{message,type}}` with NO
+      // planId (jobs.py `_finish_error` / `_finish_cancelled` / the post-restart
+      // rehydrate interrupt), so asPlanResult/asApplyResult reject it. Surface the
+      // sidecar's REAL cause here — a provider 401/quota, an unparseable model
+      // reply, validate_and_reject, or an ffmpeg op-engine failure — instead of
+      // letting it fall through to the generic "unexpected result" copy, which
+      // discarded the only actionable information the user had. A user-initiated
+      // cancel uses the SAME envelope and is a clean finish, not a failure — the
+      // same treatment useJob/features/_api give a JobCancelled type. NOTE for the
+      // next reader: useJob.ts's CONTRACT-NOTE claiming "cancelled jobs emit no
+      // job.done today" is STALE — jobs.py `_finish_cancelled` does emit one, and
+      // that is exactly the payload handled here. busy/progress are already cleared
+      // above, so a cancel needs no error at all.
+      const failure = extractJobError(event.result);
+      if (failure) {
+        if (failure.type !== 'JobCancelled') {
+          setError(`${PHASE_LABEL[active.kind]} failed: ${failure.message}`);
+        }
+        return;
+      }
       if (active.kind === 'plan') {
         const result = asPlanResult(event.result);
         if (!result) {
           setError('Planning returned an unexpected result.');
           return;
         }
-        setPlan(result.editPlan);
         // A fresh plan invalidates any prior apply/eval state (F6 keeps the prior
         // plan visible until HERE — the moment the new one arrives).
-        setOpsStatus(null);
-        setApplied(false);
+        patchRef.current((prev) => ({
+          ...prev,
+          plan: result.editPlan,
+          opsStatus: null,
+          applied: false,
+        }));
         setEvaluation(null);
         setKindFilter('all');
         void loadPreview(result.planId);
@@ -273,8 +354,11 @@ export function DirectorPanel({
         );
         return;
       }
-      setOpsStatus(result.opsStatus);
-      setApplied(active.kind === 'apply');
+      patchRef.current((prev) => ({
+        ...prev,
+        opsStatus: result.opsStatus,
+        applied: active.kind === 'apply',
+      }));
       if (active.kind === 'undo') setEvaluation(null);
     },
     [loadPreview],
@@ -395,21 +479,31 @@ export function DirectorPanel({
   // the plain-language summary update; `apply` then transmits the reviewed op
   // statuses + order (opOverrides/order) so the server honours the edit on the
   // next director.apply. A no-op while busy or post-apply.
-  const toggleOp = useCallback((opId: string): void => {
-    setPlan((prev) =>
-      /* v8 ignore next -- presence guard: the controls only render inside `plan && …`, so `prev` is non-null whenever this fires. */
-      prev ? { ...prev, ops: toggleOpStatus(prev.ops, opId) } : prev,
-    );
-  }, []);
+  const toggleOp = useCallback(
+    (opId: string): void => {
+      patchSession((prev) =>
+        /* v8 ignore next 3 -- presence guard: the controls only render inside `plan && …`, so `prev.plan` is non-null whenever this fires. (Counts 3 lines: the whole ternary — a bare `next` would leave the `: prev` arm uncovered and red the 100% gate.) */
+        prev.plan
+          ? { ...prev, plan: { ...prev.plan, ops: toggleOpStatus(prev.plan.ops, opId) } }
+          : prev,
+      );
+    },
+    [patchSession],
+  );
 
   // WU-director-controls: reorder one op up/down past its nearest same-kind
   // neighbour (within-group, so the move is visible) in the reviewable plan.
-  const moveOp = useCallback((opId: string, dir: OpMoveDirection): void => {
-    setPlan((prev) =>
-      /* v8 ignore next -- presence guard: the controls only render inside `plan && …`, so `prev` is non-null whenever this fires. */
-      prev ? { ...prev, ops: moveOpWithinKind(prev.ops, opId, dir) } : prev,
-    );
-  }, []);
+  const moveOp = useCallback(
+    (opId: string, dir: OpMoveDirection): void => {
+      patchSession((prev) =>
+        /* v8 ignore next 3 -- presence guard: the controls only render inside `plan && …`, so `prev.plan` is non-null whenever this fires. (Counts 3 lines: the whole ternary — see toggleOp above.) */
+        prev.plan
+          ? { ...prev, plan: { ...prev.plan, ops: moveOpWithinKind(prev.plan.ops, opId, dir) } }
+          : prev,
+      );
+    },
+    [patchSession],
+  );
 
   // Merge per-op apply statuses (when present) over the planned ops so the
   // storyboard reflects applied/failed AFTER an apply, planned/dropped before it.

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -1,0 +1,168 @@
+// Workspace.seam.test.tsx — the Workspace ↔ Subtitles COMPOSITION seam (F19).
+//
+// This is a SEPARATE file from Workspace.test.tsx on purpose: that suite's
+// file-wide `vi.mock('../features/Subtitles')` (Workspace.test.tsx:62) is hoisted
+// and replaces the panel with a marker div, so it can never observe how the real
+// panel treats a LATE `initialTrack`. Here the REAL panel renders.
+//
+// The defect this pins: `Workspace.renderPanel()` passes
+// `initialTrack={tracks[0] ?? null}` derived from `project.tracks`, but
+// `project.open` is fired from a POST-COMMIT effect (Workspace.tsx:173-176) while
+// the lazy panel chunk is already in flight. When the chunk wins that race the
+// panel mounts with `initialTrack === null`, and `useState(initialTrack)`
+// (Subtitles.tsx:52) captures the null once — so the track that arrives moments
+// later is ignored for the panel's whole lifetime.
+//
+// Scaffolding required for the REAL Workspace under jsdom (without these the test
+// throws before reaching its assertion, i.e. it would be red in BOTH states and
+// measure nothing):
+//   * `../lib/rpc` must be mocked — Workspace.tsx:207-212 subscribes via
+//     onProxyState, whose bridge() (lib/rpc/client.ts:96-102) THROWS when
+//     window.api is absent;
+//   * HTMLMediaElement load/play/pause must be backed — Workspace.tsx:317 mounts
+//     the real <Player>, and jsdom does not implement media playback.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+beforeAll(() => {
+  Object.defineProperty(HTMLMediaElement.prototype, 'load', {
+    configurable: true,
+    value: vi.fn(),
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, 'play', {
+    configurable: true,
+    value: vi.fn(() => Promise.resolve()),
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, 'pause', {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+const rpcMock = vi.fn();
+vi.mock('../components/api', () => ({
+  rpc: (...args: unknown[]) => rpcMock(...args),
+  onProgress: () => () => {},
+  hasApi: () => true,
+}));
+
+type ProxyStateEvt = {
+  videoId: string;
+  state: 'building' | 'direct' | 'ready' | 'error';
+  detail: string;
+};
+const onProxyStateMock = vi.fn<(cb: (e: ProxyStateEvt) => void) => () => void>();
+vi.mock('../lib/rpc', () => ({
+  onProxyState: (cb: (e: ProxyStateEvt) => void) => onProxyStateMock(cb),
+}));
+
+// NOTE: ../features/Subtitles is deliberately NOT mocked here.
+
+import { Workspace } from './Workspace';
+import type { Project, SubtitleTrack, Video } from '../components/api';
+
+const video: Video = {
+  id: 'v1',
+  path: '/movies/talk.mp4',
+  title: 'Talk',
+  addedAt: '2026-06-11T00:00:00Z',
+  durationSec: 605,
+  hasTranscript: true,
+};
+
+const project: Project = { id: 'v1', video, tracks: [], clips: [], settings: {} };
+
+// Mirrors the WIRE, not the declaration: tracks inside a persisted project pass
+// through tracks._normalise (sidecar/media_studio/features/tracks.py:157-180),
+// which guarantees all six frozen fields with `cues` a real list; a cue is
+// {index, start, end, text} (features/subtitles.py:110).
+const wireTrack: SubtitleTrack = {
+  id: 'tr1',
+  lang: 'en',
+  name: 'English',
+  format: 'srt',
+  kind: 'soft',
+  cues: [
+    { index: 1, start: 0, end: 2, text: 'first' },
+    { index: 2, start: 5, end: 7, text: 'second' },
+  ],
+};
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  rpcMock.mockReset();
+  onProxyStateMock.mockReset();
+  onProxyStateMock.mockReturnValue(() => undefined);
+  // The real panel reads the frozen bridge through getApi() (features/_api.ts:99)
+  // inside effects/callbacks only; install a fake so any later interaction has one.
+  (globalThis as { api?: unknown }).api = {
+    rpc: vi.fn(async () => ({})),
+    onProgress: () => () => {},
+    onJobDone: () => () => {},
+  };
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  delete (globalThis as { api?: unknown }).api;
+});
+
+// Real macrotask turns (not just microtasks): the lazy chunk is a genuine dynamic
+// import, so a microtask-only drain can leave the Suspense fallback mounted.
+async function flush(turns = 10): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await new Promise((resolve) => {
+        setTimeout(resolve, 0);
+      });
+    });
+  }
+}
+
+describe('Workspace ↔ Subtitles seam', () => {
+  it('adopts project.tracks[0] when project.open resolves AFTER the panel mounts', async () => {
+    // Warm the chunk so the losing-race ordering (panel mounts first) is pinned
+    // deterministically instead of left to transform timing.
+    await import('../features/Subtitles');
+
+    let resolveOpen: (value: { project: Project }) => void = () => undefined;
+    rpcMock.mockImplementation((method: string) => {
+      if (method === 'project.open') {
+        return new Promise<{ project: Project }>((resolve) => {
+          resolveOpen = resolve;
+        });
+      }
+      return Promise.resolve({});
+    });
+
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} />);
+    });
+    await flush();
+
+    // Preconditions — these are what make the assertion below a genuine red for
+    // the DEFECT rather than a setup error: the REAL panel is mounted (not the
+    // Suspense fallback) and it currently has no track.
+    expect(container.querySelector('.subtitles-panel')).not.toBeNull();
+    expect(container.querySelector('.track-meta')).toBeNull();
+
+    await act(async () => {
+      resolveOpen({ project: { ...project, tracks: [wireTrack] } });
+    });
+    await flush();
+
+    expect(container.querySelector('.track-meta')).not.toBeNull();
+    expect(container.querySelector('.track-meta')?.textContent).toContain('English');
+    expect([...container.querySelectorAll('.cue-text')]).toHaveLength(2);
+  });
+});

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -758,4 +758,41 @@ describe('Short-maker tab single-owner deep-link (WU-3a4)', () => {
     expect(container.querySelector('[data-panel="ShortMaker"]')).not.toBeNull();
     expect(selected('shortmaker')).toBe('true');
   });
+
+  // F18: 'shortmaker' sits at index 5 of the keyboard-reachable order
+  // (transcribe, search, subtitles, diarize, refine, shortmaker, timeline, dub),
+  // so stepping FORWARD through the strip walks onto it. TabBar.move() ACTIVATED
+  // the next tab before focusing it, and handleSelect turns a 'shortmaker'
+  // activation into a top-level route change that UNMOUNTS this very tablist — so
+  // one ArrowRight from Refine ejected the keyboard user out of the Workspace with
+  // no announcement. ARIA APG mandates MANUAL activation when activation has a
+  // non-instantaneous side effect, so the arrow must MOVE FOCUS ONLY here.
+  it('ArrowRight from Refine moves focus to Short-maker WITHOUT ejecting to Make Shorts', async () => {
+    const onOpenMakeShorts = vi.fn();
+    await act(async () => {
+      root.render(
+        <Workspace video={video} onBack={() => {}} onOpenMakeShorts={onOpenMakeShorts} />,
+      );
+    });
+    await flush();
+
+    const refine = container.querySelector(
+      '[role="tab"][data-tab-id="refine"]',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      refine.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true, cancelable: true }),
+      );
+    });
+    await flush();
+
+    // THE red-proof assertion: arrow-stepping must not fire the deep-link.
+    expect(onOpenMakeShorts).not.toHaveBeenCalled();
+    // Focus still MOVES (this one is deliberately NOT red-proof — move() focuses
+    // the tab pre-fix too — it pins that the fix did not swallow the key instead).
+    expect(document.activeElement).toBe(shortmakerTab());
+    // Nothing activated: the default tab keeps the selection.
+    expect(selected('subtitles')).toBe('true');
+    expect(selected('shortmaker')).toBe('false');
+  });
 });

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -341,6 +341,19 @@ export function Workspace({
         advancedOpen={advancedOpen}
         onToggleAdvanced={toggleAdvanced}
         onExport={handleExport}
+        // F18: 'shortmaker' sits mid-strip in the arrow-nav order, and when the
+        // deep-link is wired its activation is a top-level route change that
+        // UNMOUNTS this tablist — so arrow-stepping onto it must MOVE FOCUS ONLY
+        // (ARIA APG manual activation). Deliberate click/Enter still deep-links.
+        //
+        // The ternary is BEHAVIOURAL, not merely test-preserving: do NOT
+        // "simplify" it to an unconditional navIds={['shortmaker']}. Without
+        // onOpenMakeShorts there is no redirect, so 'shortmaker' legitimately
+        // activates IN PLACE and mounts ShortMaker here; marking it manual in that
+        // configuration would make that panel unreachable by forward arrow-stepping
+        // (click/Enter only). Note the pinned additive-fallback test does not catch
+        // this — it dispatches no key — so only this comment protects it.
+        navIds={onOpenMakeShorts ? ['shortmaker'] : undefined}
       />
 
       {error ? (


### PR DESCRIPTION
Integration PR **B of 4** for the 50-finding audit programme — the renderer's **shared seams**. Deliberately kept small and separate from the leaf-panel PR because all three cross-file risks in the programme live here: the wire type in `schemas.ts`, `App.tsx`, and `Workspace.tsx`'s props plus its real-Workspace seam test. Small enough that a `tsc` error names its own file.

## Attribution

| batch | branch | findings | what it fixes |
|---|---|---|---|
| B07 | `fix/producedshorts-jobdone` | F10 | four real `job.done` payload shapes — including the **default-path degrade SUCCESS** — were collapsed into one fake "unreadable result" error |
| B09 | `fix/director-job-errors` | F30, F32 | every async plan/apply/undo failure was masked behind "Planning returned an unexpected result"; a tab switch discarded an unapplied plan |
| B15 | `fix/tabbar-manual-activation` | F18 | tab activation semantics |
| B16 | `fix/subtitles-late-track` | F19 | a late-arriving subtitle track |

Merged with `--no-ff`, so each batch commit survives and any one batch stays revertable.

## Why F10 and F30 matter more than their severity suggests

Both are the same failure shape as the one crash this programme has already shipped: **the UI asserting something the backend never said.** F10 turned a legitimate degrade-to-local success into a user-visible error; F30 threw away the sidecar's real failure text — including a user *cancel* — and replaced it with a generic string. In both cases the truth was on the wire and the renderer discarded it.

## Honest note on B09's skips

The implementer **declined three items** from its own brief and said why, rather than forcing them. I read all three and agree with each:

1. **Gating Apply on `preview !== null`** was refused because `preview` is also null when `previewCost` *rejects* (e.g. offline), so the gate would permanently disable Apply on the **default local route** — where `routing_policy` `DEFAULT_GLOBAL='local'` means no budget ack is needed at all. Narrowing a race by killing a legitimate flow is a net regression.
2. **Editing `components/useJob.ts`** was refused because that file appears in no batch's declared file list, so touching it would break the mechanically-verified 95-file disjoint partition against an undeclared sibling edit. The stale comment it wanted to correct is instead fixed inline where the payload is actually handled.
3. **Hoisting `{jobId,kind}` to fix the unmount case** was refused as provably insufficient: the `job.done` subscription is a *per-mount* effect, so while the tab is unmounted nobody is listening and the result is unreachable regardless of where the id lives. The real fix moves the whole job seam above the route switch — a larger refactor the evidence assigns its own work unit. The residual is documented inline.

That third one is the kind of judgement I want from an implementer: it recognised that the prescribed fix could not work, and said so instead of shipping a change that looked like a fix.

## Local gate (on the merged tree)

- `uvx pre-commit run --all-files` → ruff lint, ruff format, oxlint, biome 2.5.0, gitleaks — **all Passed**
- `node app/node_modules/typescript/bin/tsc --noEmit` → **exit 0** *(local binary deliberately — a bare `npx tsc` in a tree without `node_modules` resolves a same-named public package that prints "This is not the tsc command you are looking for" and exits 0, so a clean exit there proves nothing)*
- `npx vitest run --coverage` → **100% statements / branches / functions / lines** (19365 stmts, 6402 branches)
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **100%, 6071 passed** (unchanged — this PR is renderer-only)
