### PR TITLE
fix(renderer): eight leaf-panel audit batches — B02, B04, B11, B13, B17, B18, B21, B24 (PR-C of 4)

### DIFF
--- a/app/renderer/src/components/CaptionPreferences.test.tsx
+++ b/app/renderer/src/components/CaptionPreferences.test.tsx
@@ -236,6 +236,98 @@ describe('<CaptionPreferences />', () => {
     expect(container.querySelector('.caption-prefs__error')).toBeNull();
   });
 
+  it('does not paint the "No captions" sample with the transparent none fill', async () => {
+    const rpc: SettingsBridge = {
+      get: vi.fn().mockResolvedValue({ [PREFERENCE_KEYS.style]: 'none' }),
+      set: vi.fn(),
+    };
+    mountWith(rpc);
+    await flush();
+    const sample = container.querySelector('.caption-prefs__sample') as HTMLElement;
+    // Control (green before AND after) — the none style really is selected.
+    expect(sample.textContent).toBe('No captions');
+    // DEFECT: NONE_VISUAL.activeColor is the literal 'transparent'
+    // (captionTemplates.ts), so the position preview's own explanatory label was
+    // painted at zero alpha. No inline colour => it inherits --text-primary.
+    // NOT asserted: the resolved colour — jsdom applies no stylesheet, so
+    // legibility is a Playwright/visual claim, never a green unit test.
+    expect(sample.style.color).toBe('');
+    expect(sample.classList.contains('caption-prefs__sample--none')).toBe(true);
+  });
+
+  it('clears the saved confirmation on any later edit', async () => {
+    const rpc: SettingsBridge = {
+      get: vi.fn().mockResolvedValue({}),
+      set: vi.fn().mockResolvedValue({}),
+    };
+    mountWith(rpc);
+    await flush();
+    const status = (): Element | null => container.querySelector('.caption-prefs__status');
+    const save = async (): Promise<void> => {
+      await act(async () => {
+        saveBtn().click();
+        await Promise.resolve();
+      });
+    };
+
+    // Control (already pinned by the save test above) — a broken mount/save path
+    // fails HERE, not on the defect assertions below.
+    await save();
+    expect(status()?.textContent).toBe('Preferences saved.');
+
+    // DEFECT: `Preferences saved.` is only ever cleared by the NEXT save, so the
+    // success live region keeps asserting a state that no longer matches disk.
+    act(() => swatch('neon').click());
+    expect(status()).toBeNull();
+
+    // A structurally different handler (a checkbox, not the style picker) too, so
+    // the regression is not pinned to one of the six edit paths.
+    await save();
+    expect(status()?.textContent).toBe('Preferences saved.');
+    act(() => polishToggle().click());
+    expect(status()).toBeNull();
+  });
+
+  it('scopes the caption-quality promise to the surfaces those flags reach', async () => {
+    const rpc: SettingsBridge = { get: vi.fn().mockResolvedValue({}), set: vi.fn() };
+    mountWith(rpc);
+    await flush();
+    // Control (green before AND after the fix) — the panel mounted with its five
+    // groups and both caption-quality toggles. A failure HERE is a setup break.
+    expect(container.querySelectorAll('.caption-prefs__group')).toHaveLength(5);
+    expect(polishToggle()).not.toBeNull();
+
+    // DEFECT (a) — the "Caption quality" group is a bare <div> with an <h3>, so a
+    // scope disclosure cannot be programmatically associated with it.
+    const group = container.querySelector('.caption-prefs__group[role="group"]');
+    expect(group).not.toBeNull();
+    const quality = group as HTMLElement;
+    expect(
+      document.getElementById(quality.getAttribute('aria-labelledby') ?? '')?.textContent,
+    ).toBe('Caption quality');
+    // It owns exactly the two controls the panel-wide promise is false for.
+    expect(quality.contains(polishToggle())).toBe(true);
+    expect(quality.contains(speakersToggle())).toBe(true);
+
+    // DEFECT (b) — no scope text exists anywhere in the panel. captionPolish /
+    // captionSpeakerLabels are read only by subtitles.generate, which the
+    // Caption, Subtitles and Recipes surfaces reach — never the shorts export.
+    const scope =
+      document.getElementById(quality.getAttribute('aria-describedby') ?? '')?.textContent ?? '';
+    expect(scope).toContain('Caption');
+    expect(scope).toContain('Subtitles');
+    expect(scope).toContain('Recipes');
+
+    // DEFECT (c) — the panel hint made a blanket "every new short" promise over
+    // all six controls; it must now enumerate only the four that do seed a short.
+    const hint = container.querySelector('.caption-prefs__hint')?.textContent ?? '';
+    expect(hint).toContain('seed every new short');
+    expect(hint).toMatch(/style/i);
+    expect(hint).toMatch(/position/i);
+    expect(hint).toMatch(/subtitle/i);
+    expect(hint).toMatch(/language/i);
+  });
+
   it('defaults to the live client settings rpc when none injected', async () => {
     // Render WITHOUT an rpc prop -> uses client.settings, which reads window.api.
     const win = globalThis as unknown as { window?: { api?: unknown } };

--- a/app/renderer/src/components/CaptionPreferences.tsx
+++ b/app/renderer/src/components/CaptionPreferences.tsx
@@ -33,6 +33,15 @@ export interface CaptionPreferencesProps {
   rpc?: SettingsBridge;
 }
 
+/**
+ * DOM ids wiring the "Caption quality" group to its heading + scope note, so the
+ * disclosure is programmatically associated (aria-labelledby/-describedby) and not
+ * merely adjacent. Static string ids follow the panel idiom (LocalRunners.tsx,
+ * RoutingToggle.tsx) — this panel renders once per Settings sub-tab.
+ */
+const QUALITY_LABEL_ID = 'prefs-caption-quality-label';
+const QUALITY_SCOPE_ID = 'prefs-caption-quality-scope';
+
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
@@ -74,13 +83,33 @@ export function CaptionPreferences({
     }
   }, [rpc, prefs]);
 
+  /**
+   * Apply a draft edit. ANY edit makes `prefs` diverge from what is on disk, so
+   * the green "Preferences saved." live region must stop asserting a state that
+   * no longer holds — it is otherwise cleared only by the NEXT save. Every edit
+   * handler below routes through this, so the invariant lives in one place.
+   *
+   * `error` is deliberately NOT cleared: a save failure stays relevant until the
+   * next save attempt. Nor is the Save button gated on dirtiness — an
+   * unsaved-changes guard is a separate, unbuilt capability.
+   */
+  const editPrefs = useCallback((next: (p: Prefs) => Prefs): void => {
+    setStatus('');
+    setPrefs(next);
+  }, []);
+
   const visual = captionVisualFor(prefs.design.style);
+  // The "none" template's fill is the literal `transparent` (NONE_VISUAL in
+  // captionTemplates.ts), so applying it would paint the preview's own
+  // explanatory "No captions" label at zero alpha.
+  const none = isNoCaption(prefs.design.style);
 
   return (
     <section className="caption-prefs panel" aria-label="Caption defaults">
       <h2 className="caption-prefs__title">Caption &amp; output defaults</h2>
       <p className="caption-prefs__hint">
-        These defaults seed every new short — you can still tweak each clip in Make Shorts.
+        Caption style, position, subtitle delivery and language seed every new short — you can still
+        tweak each clip in Make Shorts.
       </p>
 
       <div className="caption-prefs__group">
@@ -88,13 +117,16 @@ export function CaptionPreferences({
         <div className="caption-prefs__frame">
           <CaptionBox
             box={prefs.design.box}
-            onChange={(box) => setPrefs((p) => ({ ...p, design: { ...p.design, box } }))}
+            onChange={(box) => editPrefs((p) => ({ ...p, design: { ...p.design, box } }))}
           >
             <span
-              className="caption-prefs__sample"
-              style={{ color: visual.activeColor, fontFamily: visual.fontFamily }}
+              className={`caption-prefs__sample${none ? ' caption-prefs__sample--none' : ''}`}
+              style={{
+                color: none ? undefined : visual.activeColor,
+                fontFamily: visual.fontFamily,
+              }}
             >
-              {isNoCaption(prefs.design.style) ? 'No captions' : 'Aa'}
+              {none ? 'No captions' : 'Aa'}
             </span>
           </CaptionBox>
         </div>
@@ -104,7 +136,7 @@ export function CaptionPreferences({
         <h3>Default style</h3>
         <CaptionStylePicker
           value={prefs.design.style}
-          onChange={(style) => setPrefs((p) => ({ ...p, design: { ...p.design, style } }))}
+          onChange={(style) => editPrefs((p) => ({ ...p, design: { ...p.design, style } }))}
         />
       </div>
 
@@ -115,7 +147,7 @@ export function CaptionPreferences({
           aria-label="Default subtitle delivery"
           value={prefs.subtitleMode}
           onChange={(e) =>
-            setPrefs((p) => ({ ...p, subtitleMode: e.target.value as SubtitleMode }))
+            editPrefs((p) => ({ ...p, subtitleMode: e.target.value as SubtitleMode }))
           }
         >
           {SUBTITLE_MODES.map((mode) => (
@@ -132,18 +164,27 @@ export function CaptionPreferences({
           value={prefs.language}
           includeAuto={false}
           label="Default language"
-          onChange={(code) => setPrefs((p) => ({ ...p, language: code }))}
+          onChange={(code) => editPrefs((p) => ({ ...p, language: code }))}
         />
       </div>
 
-      <div className="caption-prefs__group">
-        <h3>Caption quality</h3>
+      <div
+        className="caption-prefs__group"
+        role="group"
+        aria-labelledby={QUALITY_LABEL_ID}
+        aria-describedby={QUALITY_SCOPE_ID}
+      >
+        <h3 id={QUALITY_LABEL_ID}>Caption quality</h3>
+        <p className="caption-prefs__scope" id={QUALITY_SCOPE_ID}>
+          Applies to captions generated on the Caption, Subtitles and Recipes screens — not to the
+          Make Shorts export, where captions are tuned per clip in the caption editor.
+        </p>
         <label className="caption-prefs__toggle" htmlFor="prefs-caption-polish">
           <input
             id="prefs-caption-polish"
             type="checkbox"
             checked={prefs.captionPolish}
-            onChange={(e) => setPrefs((p) => ({ ...p, captionPolish: e.target.checked }))}
+            onChange={(e) => editPrefs((p) => ({ ...p, captionPolish: e.target.checked }))}
           />
           <span className="caption-prefs__toggle-text">
             Polish captions
@@ -155,7 +196,7 @@ export function CaptionPreferences({
             id="prefs-caption-speakers"
             type="checkbox"
             checked={prefs.captionSpeakerLabels}
-            onChange={(e) => setPrefs((p) => ({ ...p, captionSpeakerLabels: e.target.checked }))}
+            onChange={(e) => editPrefs((p) => ({ ...p, captionSpeakerLabels: e.target.checked }))}
           />
           <span className="caption-prefs__toggle-text">
             Speaker labels

--- a/app/renderer/src/components/SavePresetsControls.test.tsx
+++ b/app/renderer/src/components/SavePresetsControls.test.tsx
@@ -5,7 +5,10 @@
 // acceptance: list renders rows with the active one tagged; Apply calls
 // `savePresets.apply` + `onApply(bundle)` + marks active; Save upserts the live
 // autosave/exportDefaults under the typed name and refreshes; Remove drops a row;
-// empty/error states render; whitespace name is a no-op.
+// empty/error states render; Save is DISABLED on a blank/whitespace name (Enter is
+// the ungated route and still no-ops); and every in-flight mutation carries a busy
+// affordance (aria-busy + the owning button's verb + one neutral live region) while
+// the whole surface stays locked.
 //
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -156,14 +159,55 @@ describe('<SavePresetsControls />', () => {
     expect((container.querySelector('#save-presets-name') as HTMLInputElement).value).toBe('');
   });
 
-  it('trims the name and ignores a whitespace-only save (no RPC)', async () => {
+  it('disables Save while the typed name is blank or whitespace-only', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const saveBtn = container.querySelector('.save-presets__save') as HTMLButtonElement;
+    expect(saveBtn.disabled).toBe(true); // A: pristine empty field
+    const input = container.querySelector('#save-presets-name') as HTMLInputElement;
+    typeInto(input, '   ');
+    expect(saveBtn.disabled).toBe(true); // B: whitespace-only
+    typeInto(input, 'My preset');
+    expect(saveBtn.disabled).toBe(false); // C: anti-overfit control
+  });
+
+  it('Enter on a whitespace-only name hits the canSave guard (no RPC)', async () => {
     const rpc = makeRpc();
     await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
     const input = container.querySelector('#save-presets-name') as HTMLInputElement;
     typeInto(input, '   ');
-    const saveBtn = container.querySelector('.save-presets__save') as HTMLButtonElement;
-    // The handler trims and no-ops on a blank name — no RPC fires.
-    await act(async () => saveBtn.click());
+    // The Save BUTTON is disabled for a blank name, so Enter is the only route
+    // that still reaches (and therefore covers) the `if (!canSave) return;` guard.
+    await act(async () =>
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })),
+    );
+    await flush();
+    expect(rpc.upsert).not.toHaveBeenCalled();
+  });
+
+  it('Enter submits the trimmed name', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const input = container.querySelector('#save-presets-name') as HTMLInputElement;
+    typeInto(input, '  My preset  ');
+    await act(async () =>
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true })),
+    );
+    await flush();
+    expect(rpc.upsert).toHaveBeenCalledWith('My preset', {
+      autosave: AUTOSAVE,
+      exportDefaults: EXPORT_DEFAULTS,
+    });
+  });
+
+  it('a non-Enter keydown does not submit', async () => {
+    const rpc = makeRpc();
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const input = container.querySelector('#save-presets-name') as HTMLInputElement;
+    typeInto(input, 'My preset');
+    await act(async () =>
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true })),
+    );
     await flush();
     expect(rpc.upsert).not.toHaveBeenCalled();
   });
@@ -220,5 +264,108 @@ describe('<SavePresetsControls />', () => {
     );
     await flush();
     expect(container.querySelector('.save-presets__error')?.textContent).toBe('remove boom');
+  });
+
+  // ---- busy affordance (F50) ----------------------------------------------
+  // Every mutation blanks the WHOLE surface (deliberately — see the lost-update
+  // guard test at the end). Each of the three actions must therefore say so:
+  // `aria-busy` on the control the user pressed, its own verb on the Save button,
+  // and ONE action-NEUTRAL live region (a shared region must never claim
+  // "Saving…" while an apply or a remove is what is actually running).
+  function gated<T>(value: () => T): { fn: () => Promise<T>; release: () => void } {
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = () => resolve();
+    });
+    return {
+      fn: async () => {
+        await gate;
+        return value();
+      },
+      release: () => release(),
+    };
+  }
+
+  it('announces an in-flight save: aria-busy, a Saving… label, and a neutral status region', async () => {
+    const gate = gated(() => ({ presets: block().presets }));
+    const rpc = makeRpc({ upsert: vi.fn().mockImplementation(gate.fn) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    typeInto(container.querySelector('#save-presets-name') as HTMLInputElement, 'X');
+    const saveBtn = (): HTMLButtonElement =>
+      container.querySelector('.save-presets__save') as HTMLButtonElement;
+    await act(async () => saveBtn().click());
+    expect(saveBtn().disabled).toBe(true); // control: already true today
+    expect(saveBtn().getAttribute('aria-busy')).toBe('true');
+    expect(saveBtn().textContent).toBe('Saving…');
+    expect(container.querySelector('[role="status"]')?.textContent).toBe('Working…');
+    gate.release();
+    await flush();
+    expect(saveBtn().getAttribute('aria-busy')).toBe('false');
+    expect(saveBtn().textContent).toBe('Save');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('announces an in-flight apply on the row that owns it (aria-busy + title)', async () => {
+    const gate = gated(() => ({ active: 'Slow', savePreset: preset() }));
+    const rpc = makeRpc({ apply: vi.fn().mockImplementation(gate.fn) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const applyBtn = (): HTMLButtonElement =>
+      container.querySelector('[data-preset="Slow"] .save-presets__apply') as HTMLButtonElement;
+    await act(async () => applyBtn().click());
+    expect(applyBtn().disabled).toBe(true); // control: already true today
+    expect(applyBtn().getAttribute('aria-busy')).toBe('true');
+    expect(applyBtn().title).not.toBe('');
+    expect(container.querySelector('[role="status"]')?.textContent).toBe('Working…');
+    gate.release();
+    await flush();
+    expect(applyBtn().getAttribute('aria-busy')).toBe('false');
+    expect(applyBtn().title).toBe('');
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('announces an in-flight remove without ever claiming a save is running', async () => {
+    const gate = gated(() => ({ presets: { Slow: preset() }, active: '' }));
+    const rpc = makeRpc({ remove: vi.fn().mockImplementation(gate.fn) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    const removeBtn = (): HTMLButtonElement =>
+      container.querySelector('[data-preset="Fast"] .save-presets__remove') as HTMLButtonElement;
+    await act(async () => removeBtn().click());
+    expect(removeBtn().disabled).toBe(true); // control: already true today
+    expect(removeBtn().getAttribute('aria-busy')).toBe('true');
+    expect(removeBtn().title).not.toBe('');
+    // The shared region stays action-neutral and Save keeps its own verb: a remove
+    // must not announce "Saving…" — that would describe the wrong operation.
+    expect(container.querySelector('[role="status"]')?.textContent).toBe('Working…');
+    expect((container.querySelector('.save-presets__save') as HTMLButtonElement).textContent).toBe(
+      'Save',
+    );
+    gate.release();
+    await flush();
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it('locks the WHOLE surface while one mutation is in flight (lost-update guard)', async () => {
+    const gate = gated(() => ({ active: 'Fast', savePreset: preset() }));
+    const rpc = makeRpc({ apply: vi.fn().mockImplementation(gate.fn) });
+    await mount({ rpc, autosave: AUTOSAVE, exportDefaults: EXPORT_DEFAULTS });
+    await act(async () =>
+      (
+        container.querySelector('[data-preset="Fast"] .save-presets__apply') as HTMLButtonElement
+      ).click(),
+    );
+    // All three sidecar handlers read-modify-WRITE the whole `savePresets` block
+    // (providers_ops.py:388-396 — `settings.set` is a shallow top-level replace), so
+    // two concurrent mutations would lose an update. The coarse whole-surface lock is
+    // deliberate; this pins it so a later per-row "improvement" cannot regress it.
+    for (const selector of [
+      '[data-preset="Slow"] .save-presets__apply',
+      '[data-preset="Slow"] .save-presets__remove',
+      '#save-presets-name',
+    ]) {
+      const el = container.querySelector(selector) as HTMLButtonElement | HTMLInputElement;
+      expect(el.disabled).toBe(true);
+    }
+    gate.release();
+    await flush();
   });
 });

--- a/app/renderer/src/components/SavePresetsControls.tsx
+++ b/app/renderer/src/components/SavePresetsControls.tsx
@@ -7,8 +7,15 @@
 //     `aria-current` (text "Active", not color alone — WCAG 1.4.1);
 //   * APPLIES a bundle — marks it active server-side AND calls `onApply` so the
 //     parent can pre-fill export dialogs from the bundle's `exportDefaults`;
-//   * SAVES the live `autosave` + `exportDefaults` under a typed name (upsert);
+//   * SAVES the live `autosave` + `exportDefaults` under a typed name (upsert) —
+//     Save is disabled until the trimmed name is non-empty, and Enter in the name
+//     field submits (the repo convention, AddKeyRow.tsx:38-48);
 //   * REMOVES a bundle.
+//
+// Any mutation locks the WHOLE surface (all three sidecar handlers read-modify-write
+// the entire `savePresets` block, so concurrent mutations would lose an update) and
+// says so: `aria-busy` on every control, the verb on the button that owns it, and one
+// action-neutral "Working…" live region.
 //
 // Self-fetching (mirrors JobQueue's load-on-mount + error state) but with the RPC
 // surface INJECTED (mirrors useVideoThumbnail) so it unit-tests against a fake
@@ -45,6 +52,19 @@ function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
+/**
+ * Which mutation is in flight, or `null` when idle.
+ *
+ * This replaces a bare `busy` boolean ONLY so the busy COPY can be truthful: one
+ * flag shared by three mutations would relabel Save to "Saving…" (and announce it)
+ * while a remove or an apply is what is actually running. The disable SCOPE is
+ * unchanged — every control still locks on the derived `busy`, because all three
+ * sidecar handlers read-modify-write the WHOLE `savePresets` block
+ * (`providers_ops.py:388-396`; `settings.set` is a shallow top-level replace), so
+ * per-row unlocking would let two concurrent mutations lose an update.
+ */
+type PendingAction = 'apply' | 'remove' | 'save' | null;
+
 export function SavePresetsControls({
   rpc,
   autosave,
@@ -54,7 +74,15 @@ export function SavePresetsControls({
   const [block, setBlock] = useState<SavePresetsBlock>({ presets: {}, active: '' });
   const [error, setError] = useState<string | null>(null);
   const [name, setName] = useState<string>('');
-  const [busy, setBusy] = useState<boolean>(false);
+  const [pending, setPending] = useState<PendingAction>(null);
+
+  // The whole surface locks for ANY mutation (see PendingAction above).
+  const busy = pending !== null;
+
+  // Save is disabled while the trimmed name is empty (the repo-wide convention —
+  // AddKeyRow.tsx:20-21, ProviderKeyRow, DirectorPanel, Dub). Derived, not state.
+  const trimmed = name.trim();
+  const canSave = trimmed.length > 0;
 
   const refresh = useCallback(async () => {
     try {
@@ -72,7 +100,7 @@ export function SavePresetsControls({
 
   const handleApply = useCallback(
     async (presetName: string) => {
-      setBusy(true);
+      setPending('apply');
       try {
         const result = await rpc.apply(presetName);
         setBlock((prev) => ({ ...prev, active: result.active }));
@@ -81,16 +109,15 @@ export function SavePresetsControls({
       } catch (err) {
         setError(errText(err));
       } finally {
-        setBusy(false);
+        setPending(null);
       }
     },
     [rpc, onApply],
   );
 
   const handleSave = useCallback(async () => {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setBusy(true);
+    if (!canSave) return;
+    setPending('save');
     try {
       await rpc.upsert(trimmed, { autosave, exportDefaults });
       setName('');
@@ -99,13 +126,13 @@ export function SavePresetsControls({
     } catch (err) {
       setError(errText(err));
     } finally {
-      setBusy(false);
+      setPending(null);
     }
-  }, [name, rpc, autosave, exportDefaults, refresh]);
+  }, [canSave, trimmed, rpc, autosave, exportDefaults, refresh]);
 
   const handleRemove = useCallback(
     async (presetName: string) => {
-      setBusy(true);
+      setPending('remove');
       try {
         const result = await rpc.remove(presetName);
         setBlock({ presets: result.presets, active: result.active });
@@ -113,7 +140,7 @@ export function SavePresetsControls({
       } catch (err) {
         setError(errText(err));
       } finally {
-        setBusy(false);
+        setPending(null);
       }
     },
     [rpc],
@@ -129,6 +156,15 @@ export function SavePresetsControls({
         <div className="save-presets__error" role="alert">
           {error}
         </div>
+      ) : null}
+
+      {/* ONE live region for all three mutations, so it must stay action-NEUTRAL:
+       * the specific verb belongs on the control that owns it (Save, below).
+       * Precedent for the markup shape: CaptionPreferences.tsx:173-177. */}
+      {busy ? (
+        <p className="save-presets__status" role="status">
+          Working…
+        </p>
       ) : null}
 
       {names.length === 0 ? (
@@ -152,6 +188,8 @@ export function SavePresetsControls({
                     className="save-presets__apply"
                     aria-label={`Apply ${presetName}`}
                     disabled={busy}
+                    aria-busy={busy}
+                    title={busy ? 'Working…' : undefined}
                     onClick={() => void handleApply(presetName)}
                   >
                     Apply
@@ -161,6 +199,8 @@ export function SavePresetsControls({
                     className="save-presets__remove"
                     aria-label={`Remove ${presetName}`}
                     disabled={busy}
+                    aria-busy={busy}
+                    title={busy ? 'Working…' : undefined}
                     onClick={() => void handleRemove(presetName)}
                   >
                     Remove
@@ -182,14 +222,22 @@ export function SavePresetsControls({
           value={name}
           disabled={busy}
           onChange={(e) => setName(e.target.value)}
+          onKeyDown={(e) => {
+            // Enter submits (and exercises the canSave guard for a blank field —
+            // the Save button is disabled when blank, but Enter is not gated by it).
+            if (e.key === 'Enter') void handleSave();
+          }}
         />
         <button
           type="button"
           className="save-presets__save"
-          disabled={busy}
+          disabled={busy || !canSave}
+          aria-busy={busy}
           onClick={() => void handleSave()}
         >
-          Save
+          {/* The verb is only truthful while the SAVE is the in-flight action —
+           * `busy` alone is also true for apply/remove (see PendingAction). */}
+          {pending === 'save' ? 'Saving…' : 'Save'}
         </button>
       </div>
     </div>

--- a/app/renderer/src/components/captionPreferences.css
+++ b/app/renderer/src/components/captionPreferences.css
@@ -22,6 +22,14 @@
   gap: 8px;
 }
 
+/* Per-group scope disclosure (aria-describedby target) — quieter than the group
+   heading, same treatment as the panel hint. */
+.caption-prefs__scope {
+  margin: 0;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+}
+
 .caption-prefs__group h3 {
   margin: 0;
   font-size: 0.95rem;
@@ -68,6 +76,14 @@
   font-weight: 800;
   font-size: 18px;
   text-shadow: 0 1px 3px rgba(0, 0, 0, 0.9);
+}
+
+/* "No captions" is explanatory COPY, not a type sample, so it carries no
+   template fill (the none template's activeColor is `transparent`) and inherits
+   --text-primary. Quieter weight than a real sample; NO colour override here, so
+   contrast against the frame gradient stays that of the primary text token. */
+.caption-prefs__sample--none {
+  font-weight: 600;
 }
 
 .caption-prefs__actions {

--- a/app/renderer/src/components/savePresetsControls.css
+++ b/app/renderer/src/components/savePresetsControls.css
@@ -20,6 +20,14 @@
   font-size: var(--type-caption-size);
 }
 
+/* Quiet, action-neutral "Working…" live region shown while a mutation is in
+ * flight (the whole surface is locked for it). Existing tokens only. */
+.save-presets__status {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+}
+
 .save-presets__list {
   list-style: none;
   margin: 0;
@@ -106,4 +114,13 @@
   background: var(--surface-raised);
   color: var(--text-primary);
   padding: var(--space-1) var(--space-2);
+}
+
+/* Without this the input looked fully editable while swallowing keystrokes: the
+ * author declarations above beat Chromium's UA `input:disabled` colours, and the
+ * global `.feature-panel button:disabled` rule never reaches `.settings__panel`.
+ * Mirrors `spendCap.css:226` (`.spend-cap__input:disabled`). */
+.save-presets__name-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
 }

--- a/app/renderer/src/features/ExportPresetsPanel.test.tsx
+++ b/app/renderer/src/features/ExportPresetsPanel.test.tsx
@@ -77,6 +77,32 @@ function clickText(text: string): void {
   act(() => btn.dispatchEvent(new MouseEvent('click', { bubbles: true })));
 }
 
+/** The (single) input carrying `aria-label`, re-queried so a re-render is seen. */
+function field(label: string): HTMLInputElement {
+  return container.querySelector(`input[aria-label="${label}"]`) as HTMLInputElement;
+}
+
+/** Type into a controlled input the way a browser does (native setter + `input`). */
+function type(label: string, value: string): void {
+  const el = field(label);
+  const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+/** Append one character to a field's CURRENT value (models a real keystroke). */
+function typeMore(label: string, char: string): void {
+  type(label, `${field(label).value}${char}`);
+}
+
+/** Commit a field — React's `onBlur` is the bubbling native `focusout`. */
+function blur(label: string): void {
+  const el = field(label);
+  act(() => el.dispatchEvent(new FocusEvent('focusout', { bubbles: true })));
+}
+
 describe('ExportPresetsPanel', () => {
   it('loads and renders the preset rows', async () => {
     await render();
@@ -96,20 +122,65 @@ describe('ExportPresetsPanel', () => {
     expect(ids).not.toContain('__nope__');
   });
 
-  it('clamps an over-max duration in the maxSec input', async () => {
+  // F12 — the clamp must NOT run on every keystroke. Typing digit-by-digit toward
+  // an in-window value has to be possible; the clamp fires at the COMMIT points.
+  it('does not clamp mid-typing: consecutive keystrokes land in the field', async () => {
     await render();
-    const maxInput = container.querySelector(
-      'input[aria-label="Maximum seconds"]',
-    ) as HTMLInputElement;
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
-        .set!;
-      setter.call(maxInput, '600');
-      maxInput.dispatchEvent(new Event('input', { bubbles: true }));
+    type('Minimum seconds', '4');
+    expect(field('Minimum seconds').value).toBe('4');
+    typeMore('Minimum seconds', '5');
+    expect(field('Minimum seconds').value).toBe('45');
+  });
+
+  // F12 — the §7/§10.5 invariant (no out-of-window preset is authorable) still
+  // holds, just at blur + save instead of per keystroke.
+  it('clamps an over-max duration at the commit points (blur, then save)', async () => {
+    await render();
+    type('Maximum seconds', '600');
+    expect(field('Maximum seconds').value).toBe('600');
+    blur('Maximum seconds');
+    expect(field('Maximum seconds').value).toBe('60');
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
     });
-    expect(
-      (container.querySelector('input[aria-label="Maximum seconds"]') as HTMLInputElement).value,
-    ).toBe('60');
+    expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ maxSec: 60 }));
+  });
+
+  // F27 — the two duration cells are independent today, so `{minSec:60,maxSec:20}`
+  // is authorable and POSTed verbatim: a window NEITHER the renderer's nor the
+  // sidecar's policy permits.
+  it('never commits an inverted window (Max edited last wins)', async () => {
+    await render();
+    type('Minimum seconds', '60');
+    type('Maximum seconds', '20');
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
+    });
+    expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ minSec: 20, maxSec: 20 }));
+  });
+
+  // F27 — direction-aware coupling: the field just edited wins. A symmetric
+  // `max := min` rule would make Max un-lowerable (40-60 could never narrow).
+  it('lowering Max below Min pulls Min down, not Max back up', async () => {
+    await render();
+    type('Minimum seconds', '40');
+    blur('Minimum seconds');
+    type('Maximum seconds', '30');
+    blur('Maximum seconds');
+    expect(field('Maximum seconds').value).toBe('30');
+    expect(field('Minimum seconds').value).toBe('30');
+  });
+
+  it('raising Min above Max pushes Max up, not Min back down', async () => {
+    await render();
+    type('Maximum seconds', '30');
+    blur('Maximum seconds');
+    type('Minimum seconds', '50');
+    blur('Minimum seconds');
+    expect(field('Minimum seconds').value).toBe('50');
+    expect(field('Maximum seconds').value).toBe('50');
   });
 
   it('floors the count at 1 (and on non-numeric)', async () => {
@@ -181,7 +252,58 @@ describe('ExportPresetsPanel', () => {
     );
   });
 
+  // F26 — the draft-resync effect was keyed on the `preset` OBJECT IDENTITY, and
+  // every reload crosses IPC + a JSON re-read in the sidecar, so each row got a
+  // fresh identity and the effect wiped sibling rows' unsaved keystrokes.
+  it("keeps a sibling row's unsaved edits when another row is saved", async () => {
+    const TWO: ExportPreset[] = [SEED[0], { ...SEED[0], id: 'reels', label: 'Reels', count: 3 }];
+    // Faithful to the wire: `list()` yields brand-new identities on EVERY call.
+    // The shared-identity fixture used elsewhere in this file hides the defect.
+    listMock.mockImplementation(() => Promise.resolve({ presets: TWO.map((p) => ({ ...p })) }));
+    await render();
+    const labels = (): HTMLInputElement[] =>
+      [...container.querySelectorAll('input[aria-label="Preset label"]')] as HTMLInputElement[];
+    expect(labels()).toHaveLength(2); // guard: both rows mounted
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')!
+      .set!;
+    act(() => {
+      setter.call(labels()[1], 'KEEP-ME');
+      labels()[1].dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    expect(labels()[1].value).toBe('KEEP-ME'); // guard: the keystroke reached row 2
+    await act(async () => {
+      clickText('Save'); // the FIRST Save button — row 1's
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve(); // drain save -> reload -> setPresets
+    });
+    // guard: the save that ran targeted the OTHER row
+    expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'tiktok' }));
+    expect(labels()[1].value).toBe('KEEP-ME');
+  });
+
+  // F26 companion — a value fingerprint ALONE breaks the acted-on row: the sidecar
+  // strips whitespace (`_require_str`, export_presets.py:75-79), so this save stores
+  // a row byte-identical to the one already on disk. The fingerprint never changes,
+  // so only the per-row sync nonce can pull the rejected text back to the truth.
+  it('re-displays the server value after a normalisation-only save', async () => {
+    await render();
+    type('Preset label', 'TikTok  ');
+    expect(field('Preset label').value).toBe('TikTok  ');
+    await act(async () => {
+      clickText('Save');
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(saveMock).toHaveBeenCalledWith(expect.objectContaining({ label: 'TikTok  ' }));
+    expect(field('Preset label').value).toBe('TikTok');
+  });
+
   it('deletes a preset', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await render();
     await act(async () => {
       clickText('Delete');
@@ -200,12 +322,39 @@ describe('ExportPresetsPanel', () => {
   });
 
   it('resets to defaults', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await render();
     await act(async () => {
       clickText('Reset to defaults');
       await Promise.resolve();
     });
     expect(resetMock).toHaveBeenCalledTimes(1);
+  });
+
+  // F13 — Reset overwrites the whole catalog (`PresetStore.reset` re-seeds and
+  // `_write` keeps no prior copy, so there is no restore path) and per-row Delete
+  // is equally final. Both were one-click, against the project's own standard
+  // ("never a silent one-click destructive action", KeepCopyControl.tsx:21).
+  it('does not reset when the confirm is declined', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await render();
+    await act(async () => {
+      clickText('Reset to defaults');
+      await Promise.resolve();
+    });
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(resetMock).not.toHaveBeenCalled();
+  });
+
+  it('does not delete when the confirm is declined', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    await render();
+    await act(async () => {
+      clickText('Delete');
+      await Promise.resolve();
+    });
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(deleteMock).not.toHaveBeenCalled();
   });
 
   it('shows an error when load fails', async () => {
@@ -223,6 +372,7 @@ describe('ExportPresetsPanel', () => {
   });
 
   it('surfaces save / delete / reset failures', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await render();
     saveMock.mockRejectedValueOnce('x');
     await act(async () => {
@@ -247,6 +397,7 @@ describe('ExportPresetsPanel', () => {
   });
 
   it('surfaces Error-typed save/delete/reset messages (instanceof arm)', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await render();
     saveMock.mockRejectedValueOnce(new Error('save-e'));
     await act(async () => {
@@ -271,6 +422,7 @@ describe('ExportPresetsPanel', () => {
   });
 
   it('notifies onChanged after a successful save / delete / reset', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     await render();
     await act(async () => {
       clickText('Save');

--- a/app/renderer/src/features/ExportPresetsPanel.tsx
+++ b/app/renderer/src/features/ExportPresetsPanel.tsx
@@ -3,7 +3,9 @@
 // `captionStyle` is a CLOSED select of valid ids (so an invalid id is
 // unselectable — the sidecar save-time validation is a defense-in-depth backstop,
 // §7/§10.5) and whose duration fields are clamped into the hard 20-60 s window
-// (so the user cannot author a preset the pipeline would silently correct).
+// AND coupled so `minSec <= maxSec` (so the user cannot author a preset the
+// pipeline would silently correct). Both run at the COMMIT points — blur and Save
+// — never per keystroke, or an in-window value like 45 is untypeable.
 //
 // Driven through the canonical client (`client.exportPresets.*`). Reset restores
 // the seeds. CRUD is direct-return (no jobs).
@@ -11,29 +13,86 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { client, type ExportPreset } from '../lib/rpc';
 import {
   CAPTION_STYLE_OPTIONS,
+  MAX_WINDOW_SEC,
+  MIN_WINDOW_SEC,
   REFRAME_ENGINE_OPTIONS,
+  type WindowEdge,
   blankPreset,
-  clampWindowSec,
+  clampWindowPair,
 } from './repurposeLogic';
 import './panels.css';
 
+/**
+ * VALUE fingerprint of a server row. Sorted keys make it order-independent and
+ * `Object.keys` makes it complete, so a future `ExportPreset` field cannot
+ * silently drop out of the comparison.
+ */
+function presetKey(preset: ExportPreset): string {
+  return JSON.stringify(preset, Object.keys(preset).sort());
+}
+
 interface RowProps {
   preset: ExportPreset;
+  /**
+   * Bumped for THIS row only, when its own save (or a Reset) makes the server
+   * copy authoritative again. Distinct from the value fingerprint because a
+   * normalisation-only save leaves the fingerprint unchanged.
+   */
+  syncNonce: number;
   onSave: (preset: ExportPreset) => void;
   onDelete: (id: string) => void;
 }
 
-function PresetRow({ preset, onSave, onDelete }: RowProps): React.ReactElement {
+function PresetRow({ preset, syncNonce, onSave, onDelete }: RowProps): React.ReactElement {
   const [draft, setDraft] = useState<ExportPreset>(preset);
+  // The two duration cells are string MIRRORS, so `onChange` only records what
+  // was typed and never rewrites the field mid-entry. Clamping per keystroke made
+  // an in-window value unreachable: the first digit of "45" clamped to 20, then
+  // the second appended to *that* and overshot to 60.
+  const [minText, setMinText] = useState(String(preset.minSec));
+  const [maxText, setMaxText] = useState(String(preset.maxSec));
+  // Which duration cell was touched last. Consulted ONLY when the pair inverts,
+  // and a freshly loaded row cannot invert (the sidecar persists minSec <=
+  // maxSec), so the seed value is inert until the user edits something.
+  const [editedEdge, setEditedEdge] = useState<WindowEdge>('max');
 
-  // Keep the row in sync if the parent reloads the list (e.g. after reset).
+  const serverKey = presetKey(preset);
+
+  // Re-sync this row when the server row's VALUES change, or when its own save (or
+  // a Reset) bumps its nonce.
+  //
+  // The dep used to be the `preset` OBJECT IDENTITY. Every `exportPresets.list()`
+  // crosses `ipcRenderer.invoke` and is re-read from JSON in the sidecar, so each
+  // reload handed EVERY row a brand-new identity and this effect overwrote sibling
+  // rows' unsaved keystrokes with the server copy — silently, with no dirty marker.
+  //
+  // A value fingerprint ALONE is not enough either: when the sidecar normalises the
+  // submitted draft back onto the values already on disk (whitespace strip,
+  // `9x16` -> `9:16`, window de-inversion) the fingerprint is unchanged, the effect
+  // never fires, and the row the user acted on keeps displaying a value the server
+  // rejected. Hence fingerprint AND a PER-ROW nonce — a reload-wide nonce would
+  // reinstate the sibling-wipe.
   useEffect(() => {
     setDraft(preset);
-  }, [preset]);
+    setMinText(String(preset.minSec));
+    setMaxText(String(preset.maxSec));
+  }, [serverKey, syncNonce]);
 
   const setField = useCallback(<K extends keyof ExportPreset>(key: K, value: ExportPreset[K]) => {
     setDraft((prev) => ({ ...prev, [key]: value }));
   }, []);
+
+  // The ONE commit value for the window: both ends clamped into [20, 60] and the
+  // pair de-inverted, derived from the MIRRORS rather than from `draft`. Blur
+  // shows the correction; Save reads the same value, so a field the user typed
+  // into but never blurred commits what they typed instead of silently reverting.
+  const windowPair = clampWindowPair(Number(minText), Number(maxText), editedEdge);
+
+  const commitWindow = (): void => {
+    setMinText(String(windowPair.minSec));
+    setMaxText(String(windowPair.maxSec));
+    setDraft((prev) => ({ ...prev, ...windowPair }));
+  };
 
   return (
     <tr className="export-presets__row">
@@ -55,16 +114,30 @@ function PresetRow({ preset, onSave, onDelete }: RowProps): React.ReactElement {
         <input
           type="number"
           aria-label="Minimum seconds"
-          value={draft.minSec}
-          onChange={(e) => setField('minSec', clampWindowSec(Number(e.target.value)))}
+          min={MIN_WINDOW_SEC}
+          max={MAX_WINDOW_SEC}
+          step={1}
+          value={minText}
+          onChange={(e) => {
+            setMinText(e.target.value);
+            setEditedEdge('min');
+          }}
+          onBlur={commitWindow}
         />
       </td>
       <td>
         <input
           type="number"
           aria-label="Maximum seconds"
-          value={draft.maxSec}
-          onChange={(e) => setField('maxSec', clampWindowSec(Number(e.target.value)))}
+          min={MIN_WINDOW_SEC}
+          max={MAX_WINDOW_SEC}
+          step={1}
+          value={maxText}
+          onChange={(e) => {
+            setMaxText(e.target.value);
+            setEditedEdge('max');
+          }}
+          onBlur={commitWindow}
         />
       </td>
       <td>
@@ -102,7 +175,7 @@ function PresetRow({ preset, onSave, onDelete }: RowProps): React.ReactElement {
         </select>
       </td>
       <td>
-        <button type="button" onClick={() => onSave(draft)}>
+        <button type="button" onClick={() => onSave({ ...draft, ...windowPair })}>
           Save
         </button>
         <button type="button" onClick={() => onDelete(draft.id)}>
@@ -122,6 +195,16 @@ export interface ExportPresetsPanelProps {
 export function ExportPresetsPanel({ onChanged }: ExportPresetsPanelProps): React.ReactElement {
   const [presets, setPresets] = useState<ExportPreset[]>([]);
   const [error, setError] = useState('');
+  /** Per-preset-id resync counter (see `RowProps.syncNonce`). */
+  const [syncNonces, setSyncNonces] = useState<Record<string, number>>({});
+
+  const bumpSync = useCallback((ids: readonly string[]) => {
+    setSyncNonces((prev) => {
+      const next = { ...prev };
+      for (const id of ids) next[id] = (next[id] ?? 0) + 1;
+      return next;
+    });
+  }, []);
 
   const reload = useCallback(async () => {
     try {
@@ -140,18 +223,28 @@ export function ExportPresetsPanel({ onChanged }: ExportPresetsPanelProps): Reac
   const handleSave = useCallback(
     async (preset: ExportPreset) => {
       try {
-        await client.exportPresets.save(preset);
+        // The save RPC returns the STORED record, so its id is the one row whose
+        // draft must yield to the server copy (even if the values did not move).
+        const { preset: saved } = await client.exportPresets.save(preset);
         await reload();
+        bumpSync([saved.id]);
         onChanged?.();
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Save failed');
       }
     },
-    [reload, onChanged],
+    [reload, onChanged, bumpSync],
   );
 
   const handleDelete = useCallback(
     async (id: string) => {
+      // Confirm before any destructive call (the in-repo idiom — Library.tsx:461,
+      // Shorts.tsx:147, useShortsGallery.ts:99 — and the standard this panel was
+      // violating: "never a silent one-click destructive action").
+      const ok = (globalThis as { confirm?: (m: string) => boolean }).confirm?.(
+        `Delete preset "${id}"?\n\nThis removes the preset; templates targeting it will fail to expand.`,
+      );
+      if (!ok) return;
       try {
         await client.exportPresets.delete(id);
         await reload();
@@ -168,15 +261,24 @@ export function ExportPresetsPanel({ onChanged }: ExportPresetsPanelProps): Reac
   }, [handleSave]);
 
   const handleReset = useCallback(async () => {
+    // Reset re-seeds the WHOLE catalog and nothing retains the prior copy, so this
+    // is irreversible — the loudest confirm in the panel.
+    const ok = (globalThis as { confirm?: (m: string) => boolean }).confirm?.(
+      'Reset export presets to defaults?\n\nThis replaces the whole catalog with TikTok / Reels / Shorts and discards every custom preset.',
+    );
+    if (!ok) return;
     try {
       const { presets: list } = await client.exportPresets.reset();
       setPresets(list);
+      // Reset is catalog-wide: every surviving row must drop its draft, including
+      // one whose persisted values happen to equal the seeds already.
+      bumpSync(list.map((p) => p.id));
       setError('');
       onChanged?.();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Reset failed');
     }
-  }, [onChanged]);
+  }, [onChanged, bumpSync]);
 
   return (
     <section className="export-presets" aria-label="Export presets">
@@ -187,7 +289,9 @@ export function ExportPresetsPanel({ onChanged }: ExportPresetsPanelProps): Reac
         <button type="button" onClick={() => void handleReset()}>
           Reset to defaults
         </button>
-        <span className="export-presets__hint">Durations are clamped to 20-60 s.</span>
+        <span className="export-presets__hint">
+          Durations are clamped to 20-60 s, and Min is kept at or below Max.
+        </span>
       </div>
 
       {error !== '' ? (
@@ -214,6 +318,7 @@ export function ExportPresetsPanel({ onChanged }: ExportPresetsPanelProps): Reac
             <PresetRow
               key={preset.id}
               preset={preset}
+              syncNonce={syncNonces[preset.id] ?? 0}
               onSave={(p) => void handleSave(p)}
               onDelete={(id) => void handleDelete(id)}
             />

--- a/app/renderer/src/features/Tracks.test.tsx
+++ b/app/renderer/src/features/Tracks.test.tsx
@@ -3,8 +3,9 @@
 // The panel consumes the FROZEN window.api bridge via getApi(), so we install a
 // fake on globalThis.api. Covers: list (empty + populated + error), rename/
 // relabel-on-blur (incl. the no-op guards), add/remove/burn/strip ops (success +
-// error), the burn long-job progress + job.done path, the available-tracks add,
-// and refresh.
+// error), Remove's destructive confirm (cancel = no-op, approve = removes, and the
+// raw-manifest row with no `cues` field), the burn long-job progress + job.done
+// path, the available-tracks add, and refresh.
 
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -161,12 +162,83 @@ describe('<Tracks />', () => {
     expect(container.querySelector('.status')?.textContent).toContain('Relabelled');
   });
 
+  it('Remove CONFIRMS first and is a no-op when the user cancels', async () => {
+    // tracks.remove drops the whole soft-track ROW from the project manifest
+    // (sidecar/media_studio/features/tracks.py:135) and project.save() overwrites
+    // the manifest with no history. Cues live INLINE on that row, and there is no
+    // import RPC, so every hand correction / translation / caption-polish layered
+    // on the track dies with it — the transcript-derived base can be regenerated,
+    // the edit delta cannot. This is the same class as the already-guarded
+    // shorts.delete sites (views/Shorts.tsx:147, views/Library.tsx:461,
+    // features/useShortsGallery.ts:99) and KeepCopyControl.tsx:21's standard:
+    // "never a silent one-click destructive action".
+    const fake = makeFakeApi({
+      tracks: [track({ cues: [{ index: 1, start: 0, end: 1, text: 'hand-edited' }] })],
+    });
+    await mount(fake);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const removeBtn = [...container.querySelectorAll('.track-row button')].find(
+      (b) => b.textContent === 'Remove',
+    ) as HTMLButtonElement;
+
+    await act(async () => {
+      removeBtn.click();
+      await Promise.resolve();
+    });
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(fake.calls.find((c) => c.method === 'tracks.remove')).toBeUndefined();
+    // The prompt names the track AND the real loss (its cue count).
+    expect(confirmSpy.mock.calls[0][0]).toContain('English');
+    expect(confirmSpy.mock.calls[0][0]).toContain('1 cue');
+
+    // Approving the same click removes for real (the guard must not break the
+    // happy path).
+    confirmSpy.mockReturnValue(true);
+    await act(async () => {
+      removeBtn.click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'tracks.remove')?.params).toEqual({
+      videoId: 'v1',
+      trackId: 't1',
+    });
+  });
+
+  it('the Remove prompt reads 0 cues for a legacy row with no cues field', async () => {
+    // tracks.list returns manifest rows RAW — list_tracks is `list(_tracks_of(project))`
+    // (sidecar/media_studio/features/tracks.py:104-106) and normalization runs only on
+    // WRITE (normalize_track, :157-180). So a legacy / hand-edited project.json row can
+    // reach the renderer with no `cues` key at all, and an unguarded `t.cues.length`
+    // inside the click handler would throw — turning "Remove has no confirmation" into
+    // "Remove is a dead button". Timeline.tsx:136 guards the same field for the same
+    // reason.
+    const legacy = { id: 't1', lang: 'en', name: 'English', format: 'srt', kind: 'soft' };
+    const fake = makeFakeApi({ tracks: [legacy as unknown as SubtitleTrack] });
+    await mount(fake);
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const removeBtn = [...container.querySelectorAll('.track-row button')].find(
+      (b) => b.textContent === 'Remove',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      removeBtn.click();
+      await Promise.resolve();
+    });
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(confirmSpy.mock.calls[0][0]).toContain('0 cue');
+    expect(fake.calls.find((c) => c.method === 'tracks.remove')?.params).toEqual({
+      videoId: 'v1',
+      trackId: 't1',
+    });
+  });
+
   it('Add (from the available section) / Remove (row) call the right method', async () => {
     // Attached rows no longer carry an `Add` button (re-adding an already-listed
     // track just persists a duplicate), so Add is exercised via the available
     // section and Remove via the row.
     const fake = makeFakeApi({ tracks: [track()] });
     await mount(fake, { availableTracks: [track({ id: 'avail-1' })] });
+    // Remove now confirms first (see the CONFIRM test above); approve it.
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
 
     const addBtn = container.querySelector('.available-tracks button') as HTMLButtonElement;
     await act(async () => {
@@ -201,6 +273,7 @@ describe('<Tracks />', () => {
   it('surfaces an error when a mutation op rejects', async () => {
     const fake = makeFakeApi({ tracks: [track()] });
     await mount(fake);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('remove failed'));
     const removeBtn = [...container.querySelectorAll('.track-row button')].find(
       (b) => b.textContent === 'Remove',
@@ -409,6 +482,7 @@ describe('<Tracks />', () => {
   it('uses String(err) when a mutation op rejects with a non-Error value', async () => {
     const fake = makeFakeApi({ tracks: [track()] });
     await mount(fake);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce('plain remove error');
     const removeBtn = [...container.querySelectorAll('.track-row button')].find(
       (b) => b.textContent === 'Remove',
@@ -471,6 +545,7 @@ describe('<Tracks />', () => {
   it('shows the in-flight op label (…) while a mutation op is running', async () => {
     const fake = makeFakeApi({ tracks: [track()] });
     await mount(fake);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     // Hang the next op so the busy label renders.
     let release: (v: unknown) => void = () => undefined;
     (fake.api.rpc as ReturnType<typeof vi.fn>).mockImplementationOnce(
@@ -495,6 +570,7 @@ describe('<Tracks />', () => {
   it('shows the … label on the Remove button while a remove op is running', async () => {
     const fake = makeFakeApi({ tracks: [track()] });
     await mount(fake);
+    vi.spyOn(window, 'confirm').mockReturnValue(true);
     let release: (v: unknown) => void = () => undefined;
     (fake.api.rpc as ReturnType<typeof vi.fn>).mockImplementationOnce(
       () => new Promise((res) => (release = res)),

--- a/app/renderer/src/features/Tracks.tsx
+++ b/app/renderer/src/features/Tracks.tsx
@@ -109,7 +109,33 @@ export function Tracks({ videoId, availableTracks = [] }: TracksProps): React.Re
   );
 
   const remove = useCallback(
-    (trackId: string) => runOp(trackId, 'remove', 'tracks.remove', { videoId, trackId }, 'Removed'),
+    async (t: SubtitleTrack) => {
+      // CONFIRM before the destructive call. `tracks.remove` drops the whole soft
+      // track ROW from the project manifest (features/tracks.py:135) and the save
+      // overwrites it with no history — and the row carries its `cues` INLINE, so
+      // every hand correction, translation and caption-polish layered on the track
+      // dies with it (the machine transcript can be regenerated; the edit delta
+      // cannot). Same shape as the other destructive sites — views/Shorts.tsx:147,
+      // views/Library.tsx:461, features/useShortsGallery.ts:99 — per
+      // KeepCopyControl.tsx:21: "never a silent one-click destructive action".
+      //
+      // `cues` is read defensively: tracks.list returns manifest rows RAW
+      // (features/tracks.py:104-106; normalisation happens only on write at
+      // :157-180), so a legacy row can arrive with no `cues` key and an unguarded
+      // deref here would turn "no confirmation" into a dead button. Timeline.tsx:136
+      // guards the same field for the same reason.
+      //
+      // Wording is deliberately neutral about the outcome: a `kind:"hard"` row's
+      // Remove is enabled and merely rejects with HardSubtitleError
+      // (features/tracks.py:132-133), so the prompt must not promise a deletion.
+      const ok = (globalThis as { confirm?: (m: string) => boolean }).confirm?.(
+        `Remove the subtitle track "${t.name}" (${t.id})?\n\n` +
+          `${t.cues?.length ?? 0} cue(s) would be dropped from this project. Hand edits, ` +
+          `translations and caption polish on this track cannot be recovered.`,
+      );
+      if (!ok) return;
+      await runOp(t.id, 'remove', 'tracks.remove', { videoId, trackId: t.id }, 'Removed');
+    },
     [runOp, videoId],
   );
 
@@ -232,7 +258,7 @@ export function Tracks({ videoId, availableTracks = [] }: TracksProps): React.Re
                     attached tracks, so re-adding them just persists a duplicate
                     (media_ops mints a fresh id, dodging add_track's dedupe). Add
                     lives only in the available-tracks section below. */}
-                <button type="button" disabled={isBusy} onClick={() => void remove(t.id)}>
+                <button type="button" disabled={isBusy} onClick={() => void remove(t)}>
                   {opOn(t.id, 'remove') ? '…' : 'Remove'}
                 </button>
                 <button type="button" disabled={isBusy} onClick={() => void burn(t.id)}>

--- a/app/renderer/src/features/caption/CaptionClipLane.test.tsx
+++ b/app/renderer/src/features/caption/CaptionClipLane.test.tsx
@@ -22,6 +22,28 @@ const cue = (index: number, start: number, end: number, text: string): Cue => ({
 const CUES: Cue[] = [cue(1, 2, 3, 'Alpha'), cue(2, 6, 7, 'Beta'), cue(3, 10, 11, 'Gamma')];
 const SEED: EditorSeed = { video: { videoId: 'v1', window: { start: 0, end: 20 } }, cues: CUES };
 
+// The cue shape `captions.cues` ACTUALLY emits: faster-whisper derives a word's
+// `end` and the next word's `start` from the same `jump_times` element
+// (transcribe.py:1745-1746) and cues.py:86-93 flattens words without padding, so
+// within-segment neighbours ABUT with gap exactly 0. This — not the well-spaced
+// CUES above — is the normal case every keyboard nudge meets.
+const WORD_CUES: Cue[] = [
+  cue(1, 1.0, 1.3, 'Alpha'),
+  cue(2, 1.3, 1.6, 'Beta'),
+  cue(3, 1.6, 1.9, 'Gamma'),
+];
+const WORD_SEED: EditorSeed = {
+  video: { videoId: 'v1', window: { start: 0, end: 20 } },
+  cues: WORD_CUES,
+};
+
+// A GAPPED pair — the anti-overfit control: a nudge with real room must still
+// translate BOTH edges, so "refuse every move" cannot pass as the fix.
+const GAPPED_SEED: EditorSeed = {
+  video: { videoId: 'v1', window: { start: 0, end: 20 } },
+  cues: [cue(1, 1.0, 1.3, 'Alpha'), cue(2, 2.0, 2.3, 'Beta')],
+};
+
 function Probe(): React.ReactElement {
   const { state } = useEditor();
   return (
@@ -31,6 +53,7 @@ function Probe(): React.ReactElement {
       <span data-testid="c0start">{state.cues[0]?.start}</span>
       <span data-testid="c0end">{state.cues[0]?.end}</span>
       <span data-testid="c1start">{state.cues[1]?.start}</span>
+      <span data-testid="c1end">{state.cues[1]?.end}</span>
     </div>
   );
 }
@@ -127,5 +150,72 @@ describe('CaptionClipLane', () => {
     keyClip(0, 'Home');
     expect(num('c0start')).toBe(2);
     expect(num('playhead')).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// F21 — a "move" must MOVE, never silently shrink (abutting word cues)
+// ---------------------------------------------------------------------------
+
+describe('CaptionClipLane — moving a clip against an abutting neighbour', () => {
+  const dur = (): number => num('c1end') - num('c1start');
+
+  it('ArrowRight preserves the clip duration (never trades it for the move)', () => {
+    render(WORD_SEED);
+    expect(dur()).toBeCloseTo(0.3, 10);
+    keyClip(1, 'ArrowRight');
+    expect(dur()).toBeCloseTo(0.3, 10);
+  });
+
+  it('ArrowLeft preserves the clip duration (the symmetric half)', () => {
+    render(WORD_SEED);
+    keyClip(1, 'ArrowLeft');
+    expect(dur()).toBeCloseTo(0.3, 10);
+  });
+
+  it('still translates BOTH edges when the neighbour gap has room', () => {
+    render(GAPPED_SEED);
+    keyClip(0, 'ArrowRight');
+    expect(num('c0start')).toBeCloseTo(1.1, 10);
+    expect(num('c0end')).toBeCloseTo(1.4, 10);
+  });
+
+  it('announces the refusal instead of being a silent dead key (later)', () => {
+    render(WORD_SEED);
+    // The live region is mounted while EMPTY so the announcement is heard.
+    const region = q('.caption-clip-lane__status');
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute('role')).toBe('status');
+    expect(region?.getAttribute('aria-live')).toBe('polite');
+    expect(region?.textContent).toBe('');
+    keyClip(1, 'ArrowRight');
+    expect(q('.caption-clip-lane__status')?.textContent).toBe(
+      'Caption 2 has no room to move later.',
+    );
+  });
+
+  it('announces the refusal in the other direction too (earlier)', () => {
+    render(WORD_SEED);
+    keyClip(1, 'ArrowLeft');
+    expect(q('.caption-clip-lane__status')?.textContent).toBe(
+      'Caption 2 has no room to move earlier.',
+    );
+  });
+
+  it('clears a stale refusal once an edit lands (resize has room)', () => {
+    render(WORD_SEED);
+    keyClip(1, 'ArrowRight');
+    expect(q('.caption-clip-lane__status')?.textContent).not.toBe('');
+    keyClip(1, 'ArrowRight', true);
+    expect(q('.caption-clip-lane__status')?.textContent).toBe('');
+  });
+
+  it('clears a stale refusal once a move lands', () => {
+    render(WORD_SEED);
+    keyClip(1, 'ArrowRight'); // boxed in on both sides — refused
+    expect(q('.caption-clip-lane__status')?.textContent).not.toBe('');
+    keyClip(0, 'ArrowLeft'); // the FIRST clip still has room down to 0
+    expect(q('.caption-clip-lane__status')?.textContent).toBe('');
+    expect(num('c0start')).toBeCloseTo(0.9, 10);
   });
 });

--- a/app/renderer/src/features/caption/CaptionClipLane.tsx
+++ b/app/renderer/src/features/caption/CaptionClipLane.tsx
@@ -8,11 +8,22 @@
 //   * Enter / Space  — seek the shared playhead to the clip start (and select it);
 //   * Arrow Left/Right — MOVE the whole clip earlier/later (neighbor-clamped);
 //   * Shift+Arrow      — RESIZE the clip's out-point (neighbor-clamped).
-// All cue math is the shipped, unit-tested `timelineOps` (retimeAt/dragEdge) — the
+// All cue math is the shipped, unit-tested `timelineOps` (nudgeAt/dragEdge) — the
 // same neighbor-clamping the mouse Timeline uses, reused, not rewritten.
+//
+// SCOPE OF THE MOVE (read before "fixing" a silent arrow key). A move preserves
+// duration, so a clip whose neighbor ABUTS it has zero legal room — and real word
+// cues abut exactly (the sidecar emits a word's end and the next word's start from
+// one array element). Moving such a clip necessarily RETIMES a neighbor, i.e. a
+// ripple / overwrite / swap semantics, and picking one is a product decision that
+// is deliberately NOT implemented here: this lane only ever edits the ONE focused
+// cue. What is implemented is that the refusal is never silent — the boundary is
+// announced through the polite live region below, so the key has a defined,
+// perceivable outcome instead of doing nothing. Until ripple ships, "arrow keys
+// move a clip" means "within its own gap".
 
 import React from 'react';
-import { type Cue, MIN_CUE_SEC, dragEdge, retimeAt } from '../../lib/timelineOps';
+import { type Cue, MIN_CUE_SEC, dragEdge, nudgeAt } from '../../lib/timelineOps';
 import { useEditor } from '../EditorContext';
 import './captionClipLane.css';
 
@@ -26,6 +37,8 @@ function pct(value: number): number {
 
 export function CaptionClipLane(): React.ReactElement {
   const { state, dispatch } = useEditor();
+  // Declared BEFORE the empty-cues early return so hook order is unconditional.
+  const [notice, setNotice] = React.useState('');
   const { cues, video, playhead, selection } = state;
   const { start: winStart, end: winEnd } = video.window;
   const span = Math.max(winEnd - winStart, MIN_CUE_SEC);
@@ -53,11 +66,18 @@ export function CaptionClipLane(): React.ReactElement {
       if (dir === 0) return;
       e.preventDefault();
       const delta = dir * CLIP_NUDGE_SEC;
-      // Shift = resize the out-point; plain arrow = move the whole clip. Both are
-      // neighbor-clamped by the shipped timelineOps helpers.
+      // Shift = resize the out-point; plain arrow = TRANSLATE the whole clip
+      // (duration-preserving). Both are neighbor-clamped by timelineOps.
       const next = e.shiftKey
         ? dragEdge(cues, pos, 'end', cue.end + delta)
-        : retimeAt(cues, pos, cue.start + delta, cue.end + delta);
+        : nudgeAt(cues, pos, delta);
+      if (next === cues) {
+        // Nothing legal to do (see SCOPE OF THE MOVE above). Announce it and bail
+        // BEFORE dispatching, so a no-room press does not rebuild editor state.
+        setNotice(`Caption ${pos + 1} has no room to move ${dir > 0 ? 'later' : 'earlier'}.`);
+        return;
+      }
+      setNotice('');
       dispatch({ type: 'setCues', cues: next });
     };
 
@@ -94,6 +114,12 @@ export function CaptionClipLane(): React.ReactElement {
           data-testid="clip-playhead"
           style={{ left: `${pct(((playhead - winStart) / span) * 100)}%` }}
         />
+      </div>
+      {/* Mounted while EMPTY (a region inserted with its text is not reliably
+          announced) and a <div>, which has no default margin — so an empty
+          notice costs no layout and the lane needs no extra CSS. */}
+      <div className="caption-clip-lane__status" role="status" aria-live="polite">
+        {notice}
       </div>
     </div>
   );

--- a/app/renderer/src/features/repurposeLogic.test.ts
+++ b/app/renderer/src/features/repurposeLogic.test.ts
@@ -8,6 +8,7 @@ import {
   MIN_WINDOW_SEC,
   MAX_WINDOW_SEC,
   clampWindowSec,
+  clampWindowPair,
   isValidCaptionStyle,
   statusToken,
   isTerminalItem,
@@ -56,6 +57,27 @@ describe('clampWindowSec', () => {
   });
   it('treats NaN as the min', () => {
     expect(clampWindowSec(Number.NaN)).toBe(MIN_WINDOW_SEC);
+  });
+});
+
+describe('clampWindowPair (direction-aware min<=max coupling)', () => {
+  it('passes a non-inverted pair through untouched', () => {
+    expect(clampWindowPair(30, 50, 'min')).toEqual({ minSec: 30, maxSec: 50 });
+  });
+
+  it('clamps both ends into the [20, 60] window', () => {
+    expect(clampWindowPair(5, 600, 'max')).toEqual({
+      minSec: MIN_WINDOW_SEC,
+      maxSec: MAX_WINDOW_SEC,
+    });
+  });
+
+  it('pushes Max UP when Min is the edited field', () => {
+    expect(clampWindowPair(60, 20, 'min')).toEqual({ minSec: 60, maxSec: 60 });
+  });
+
+  it('pulls Min DOWN when Max is the edited field (Max stays lowerable)', () => {
+    expect(clampWindowPair(60, 20, 'max')).toEqual({ minSec: 20, maxSec: 20 });
   });
 });
 

--- a/app/renderer/src/features/repurposeLogic.ts
+++ b/app/renderer/src/features/repurposeLogic.ts
@@ -70,6 +70,34 @@ export function clampWindowSec(sec: number): number {
   return sec;
 }
 
+/** Which end of the duration window the user just edited (it wins a conflict). */
+export type WindowEdge = 'min' | 'max';
+
+/**
+ * Clamp BOTH ends of a duration window into [20, 60] AND de-invert the pair, so
+ * `minSec <= maxSec` always holds. `clampWindowSec` alone is per-scalar and has
+ * no notion of a sibling, which is how `{minSec:60, maxSec:20}` — a window
+ * neither the UI nor the sidecar permits — reached the wire.
+ *
+ * The coupling is DIRECTION-AWARE: the field just edited wins and the sibling
+ * yields. A symmetric `max := min` would make Max un-lowerable (narrowing a
+ * 40-60 preset to 20-30 would snap Max back UP to 40), and the sidecar's own
+ * `min := max` backstop (`export_presets.normalize_preset`) is direction-blind
+ * because it never sees which field was touched — so the renderer must pass the
+ * edited axis rather than copy either fixed policy.
+ */
+export function clampWindowPair(
+  minSec: number,
+  maxSec: number,
+  edited: WindowEdge,
+): { minSec: number; maxSec: number } {
+  const min = clampWindowSec(minSec);
+  const max = clampWindowSec(maxSec);
+  if (min <= max) return { minSec: min, maxSec: max };
+  if (edited === 'min') return { minSec: min, maxSec: min };
+  return { minSec: max, maxSec: max };
+}
+
 /** True when `id` is a selectable caption style (closed-set guard). */
 export function isValidCaptionStyle(id: string): boolean {
   return CAPTION_STYLE_OPTIONS.includes(id);

--- a/app/renderer/src/lib/captionPreferences.ts
+++ b/app/renderer/src/lib/captionPreferences.ts
@@ -1,12 +1,21 @@
 // captionPreferences.ts — persisted caption + output DEFAULTS (P4 §4 Preferences).
 //
-// The Preferences/Settings area lets a user set the defaults every new short
-// starts from: the caption style + on-frame position, the subtitle delivery
-// mode, the default language, and two caption-quality toggles (transcript
-// polish + speaker labels). They are stored in the free-form settings store
-// (C12: settings.get/set, like the brand kit) under FROZEN keys, so the Make
-// Shorts flow + the Output Tray seed from one place instead of every surface
-// re-choosing. Pure read/write helpers only — unit-tested.
+// The Preferences/Settings area lets a user set two DIFFERENT-SCOPED groups of
+// defaults, stored together in the free-form settings store (C12:
+// settings.get/set, like the brand kit) under FROZEN keys so no surface
+// re-chooses them. Pure read/write helpers only — unit-tested.
+//
+//  1. Seeds every NEW SHORT (read by the Make Shorts flow + the Output Tray):
+//     the caption style + on-frame position, the subtitle delivery mode, and the
+//     default language.
+//  2. Applies to GENERATED CAPTIONS only (read by the sidecar's
+//     subtitles.generate, i.e. the Caption / Subtitles / Recipes surfaces —
+//     NOT the shorts export): the two caption-quality toggles, transcript
+//     polish + speaker labels.
+//
+// Do not describe group 2 as seeding shorts: the shorts export path never reads
+// those two keys, so a panel-wide "seeds every new short" promise is false for
+// them (see CaptionPreferences.tsx, which discloses the split in the UI).
 //
 // CONTRACT-NOTE: `captionPolish` + `captionSpeakerLabels` are the EXACT keys the
 // sidecar reads in handlers/media_ops.py subtitles_generate (settings.get). This

--- a/app/renderer/src/lib/timelineOps.property.test.ts
+++ b/app/renderer/src/lib/timelineOps.property.test.ts
@@ -28,6 +28,7 @@ import {
   dragEdge,
   type History,
   mergeAt,
+  nudgeAt,
   pushHistory,
   redo,
   renumber,
@@ -193,6 +194,50 @@ describe('dragEdge / retimeAt (property)', () => {
 });
 
 // ---------------------------------------------------------------------------
+// nudgeAt — a TRANSLATE, so duration is invariant (F21)
+// ---------------------------------------------------------------------------
+
+describe('nudgeAt (property)', () => {
+  it('preserves duration and stays inside the neighbor gap for any delta', () => {
+    fc.assert(
+      fc.property(
+        cueList.filter((c) => c.length > 0),
+        fc.nat(),
+        fc.double({ min: -6, max: 6, noNaN: true }),
+        (cues, posSeed, delta) => {
+          const pos = posSeed % cues.length;
+          const out = nudgeAt(cues, pos, delta);
+          // no legal room -> the SAME reference, so callers can ===-check
+          if (out === cues) return;
+          const before = cues[pos];
+          const after = out[pos];
+          expect(after.end - after.start).toBeCloseTo(before.end - before.start, 9);
+          expect(after.start).toBeGreaterThanOrEqual(-1e-9);
+          if (pos > 0) expect(after.start).toBeGreaterThanOrEqual(cues[pos - 1].end - 1e-9);
+          if (pos + 1 < cues.length)
+            expect(after.end).toBeLessThanOrEqual(cues[pos + 1].start + 1e-9);
+          // Never travels AGAINST the requested direction. Not strict: a denormal
+          // delta (the generator reaches 7e-323) is a non-zero `room` whose
+          // addition is unobservable at this magnitude, so `start` can be equal.
+          if (delta > 0) expect(after.start).toBeGreaterThanOrEqual(before.start);
+          else expect(after.start).toBeLessThanOrEqual(before.start);
+        },
+      ),
+    );
+  });
+
+  it('a zero delta and an out-of-range position both return the SAME array', () => {
+    fc.assert(
+      fc.property(cueList, fc.integer({ min: -5, max: 20 }), (cues, pos) => {
+        expect(nudgeAt(cues, pos, 0)).toBe(cues);
+        if (pos >= 0 && pos < cues.length) return;
+        expect(nudgeAt(cues, pos, 0.5)).toBe(cues);
+      }),
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
 // view helpers
 // ---------------------------------------------------------------------------
 
@@ -327,6 +372,16 @@ const DragCmd = (
   toString: () => `drag(${pos},${edge},${t})`,
 });
 
+const NudgeCmd = (pos: number, delta: number): fc.Command<Model, TimelineModel> => ({
+  check: () => true,
+  run: (_m, r) => {
+    const p = r.cues.length === 0 ? 0 : pos % r.cues.length;
+    if (r.cues.length > 0) r.apply(nudgeAt(r.cues, p, delta));
+    assertWellFormed(r.cues);
+  },
+  toString: () => `nudge(${pos},${delta})`,
+});
+
 const UndoCmd: fc.Command<Model, TimelineModel> = {
   check: () => true,
   run: (_m, r) => {
@@ -352,6 +407,9 @@ describe('timeline edit sequences (model-based)', () => {
             fc.double({ min: -5, max: 50, noNaN: true }),
           )
           .map(([p, e, t]) => DragCmd(p, e, t)),
+        fc
+          .tuple(fc.nat(), fc.double({ min: -4, max: 4, noNaN: true }))
+          .map(([p, d]) => NudgeCmd(p, d)),
         fc.constant(UndoCmd),
       ],
       { maxCommands: 20 },

--- a/app/renderer/src/lib/timelineOps.test.ts
+++ b/app/renderer/src/lib/timelineOps.test.ts
@@ -14,6 +14,7 @@ import {
   dragEdge,
   mergeAt,
   mergeCues,
+  nudgeAt,
   pushHistory,
   redo,
   renumber,
@@ -231,6 +232,82 @@ describe('retimeAt', () => {
   it('returns the SAME array for an invalid position', () => {
     const input = threeCues();
     expect(retimeAt(input, 5, 0, 1)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// nudgeAt — the duration-PRESERVING translate (F21)
+// ---------------------------------------------------------------------------
+
+describe('nudgeAt', () => {
+  /** Three ABUTTING cues — the shape real word cues have (gap exactly 0). */
+  const abutting = (): Cue[] => [cue(1, 0, 1, 'a'), cue(2, 1, 2, 'b'), cue(3, 2, 3, 'c')];
+  /** A hand-built OVERLAPPING pair: cue 0 ends after cue 1 starts. */
+  const overlapping = (): Cue[] => [cue(1, 0, 2, 'a'), cue(2, 1, 3, 'b')];
+  const span = (c: Cue): number => c.end - c.start;
+
+  it('translates BOTH edges forward, preserving duration and other cue identity', () => {
+    const input = threeCues();
+    const out = nudgeAt(input, 1, 0.5);
+    expect(out[1].start).toBeCloseTo(3.5, 10);
+    expect(out[1].end).toBeCloseTo(5.5, 10);
+    expect(span(out[1])).toBeCloseTo(span(input[1]), 10);
+    expect(out[0]).toBe(input[0]); // untouched cues keep their identity
+    expect(out[2]).toBe(input[2]);
+  });
+
+  it('translates BOTH edges backward, preserving duration', () => {
+    const out = nudgeAt(threeCues(), 1, -0.5);
+    expect(out[1].start).toBeCloseTo(2.5, 10);
+    expect(out[1].end).toBeCloseTo(4.5, 10);
+    expect(span(out[1])).toBeCloseTo(2, 10);
+  });
+
+  it('returns the SAME array against an abutting neighbour (no legal room)', () => {
+    const later = abutting();
+    expect(nudgeAt(later, 1, 0.1)).toBe(later);
+    const earlier = abutting();
+    expect(nudgeAt(earlier, 1, -0.1)).toBe(earlier);
+  });
+
+  it('returns the SAME array for an invalid position', () => {
+    const input = threeCues();
+    expect(nudgeAt(input, -1, 0.1)).toBe(input);
+    expect(nudgeAt(input, 99, 0.1)).toBe(input);
+    expect(nudgeAt(input, 1.5, 0.1)).toBe(input);
+  });
+
+  it('returns the SAME array for a zero delta (no dedicated guard needed)', () => {
+    const input = threeCues();
+    expect(nudgeAt(input, 1, 0)).toBe(input);
+  });
+
+  it('moves the LAST cue freely (its upper bound is unbounded)', () => {
+    const out = nudgeAt(threeCues(), 2, 5); // [6,8] -> [11,13]
+    expect(out[2].start).toBe(11);
+    expect(out[2].end).toBe(13);
+  });
+
+  it('floors the FIRST cue exactly at 0, keeping its duration', () => {
+    const out = nudgeAt([cue(1, 1, 2, 'a'), cue(2, 5, 6, 'b')], 0, -5);
+    expect(out[0].start).toBe(0);
+    expect(out[0].end).toBe(1);
+  });
+
+  it('caps a move PARTIALLY when the gap is smaller than the delta', () => {
+    const out = nudgeAt([cue(1, 0, 1, 'a'), cue(2, 1.04, 3, 'b')], 0, 0.1);
+    expect(out[0].end).toBe(1.04); // pinned exactly to next.start, not one ulp past
+    expect(span(out[0])).toBeCloseTo(1, 10);
+  });
+
+  it('never moves BACKWARD on a forward nudge over a pre-existing overlap', () => {
+    const input = overlapping();
+    expect(nudgeAt(input, 0, 0.1)).toBe(input);
+  });
+
+  it('never moves FORWARD on a backward nudge over a pre-existing overlap', () => {
+    const input = overlapping();
+    expect(nudgeAt(input, 1, -0.1)).toBe(input);
   });
 });
 

--- a/app/renderer/src/lib/timelineOps.ts
+++ b/app/renderer/src/lib/timelineOps.ts
@@ -144,6 +144,46 @@ export function retimeAt(cues: readonly Cue[], pos: number, start: number, end: 
 }
 
 /**
+ * TRANSLATE the cue at `pos` by up to `delta` seconds, PRESERVING its duration.
+ * This is the "move the whole clip" primitive; `retimeAt` is deliberately NOT it
+ * — that one clamps the two edges INDEPENDENTLY into `[prev.end, next.start]`,
+ * which is right for a numeric retime but silently trades duration for travel
+ * when a move meets an abutting neighbor.
+ *
+ * The cue moves by the largest legal amount not exceeding `|delta|` in the
+ * requested direction and never crosses a neighbor. When there is NO room the
+ * INPUT array reference is returned, per the module's `===` convention (:11-13)
+ * so `pushHistory` no-ops and callers can detect "nothing happened".
+ *
+ * Note there is no `delta === 0` special case: with delta 0 the room expression
+ * already evaluates to 0 and the `room === 0` guard returns the same reference.
+ *
+ * The outer `Math.max(0, …)` / `Math.min(0, …)` are a direction guard, not
+ * noise: on a PRE-EXISTING overlap (`hi < cue.end`) the inner term is negative
+ * and would otherwise move the clip BACKWARD on a forward nudge. The fast-check
+ * `cueList` generator cannot build such a list (it walks a cursor with
+ * `gap >= 0`, so cues abut but never overlap), so that guard is covered by a
+ * hand-built fixture in timelineOps.test.ts — not by the property suite.
+ */
+export function nudgeAt(cues: readonly Cue[], pos: number, delta: number): Cue[] {
+  if (!validPos(cues, pos)) return cues as Cue[];
+  const cue = cues[pos];
+  const { lo, hi } = neighborBounds(cues, pos);
+  // `hi === +Infinity` for the last cue and `lo === 0` for the first, so both
+  // list ends fall out of the same expression with no special case.
+  const room =
+    delta > 0
+      ? Math.max(0, Math.min(delta, hi - cue.end))
+      : Math.min(0, Math.max(delta, lo - cue.start));
+  if (room === 0) return cues as Cue[];
+  // Re-clamp to the bounds `room` was derived from: `x + (bound - x)` can land
+  // one ulp past `bound` in floating point, and the neighbor invariant is exact.
+  return cues.map((c, i) =>
+    i === pos ? { ...c, start: Math.max(c.start + room, lo), end: Math.min(c.end + room, hi) } : c,
+  );
+}
+
+/**
  * Drag one edge of the cue at `pos` to time `t`, clamping so the cue (a) never
  * crosses its neighbor on that side and (b) keeps >= MIN_CUE_SEC against its
  * own other edge. Returns a new list (untouched cues keep their identity).

--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -417,6 +417,18 @@ describe('Library', () => {
     );
   });
 
+  it('does not claim the library is empty when library.list failed', async () => {
+    // F03: a failed listing left `videos === []`, so the first-run "No videos yet"
+    // poster rendered UNDER the error alert — the app told the user their library
+    // was empty when it had simply failed to read it.
+    rpcMock.mockRejectedValueOnce(new Error('database is locked'));
+    await renderLibrary();
+
+    // Precondition guard: the rejection really reached `refresh` (not a mock slip).
+    expect(container.querySelector('.library__error')?.textContent).toContain('database is locked');
+    expect(container.textContent).not.toContain('No videos yet');
+  });
+
   it('emits a typed error toast when library.add returns no video', async () => {
     rpcMock.mockResolvedValueOnce({ videos: [] });
     await renderLibrary();
@@ -583,6 +595,96 @@ describe('Library', () => {
     // optimistic removal rolled back -> the video is back
     expect(container.textContent).toContain('Talk');
     expect(container.querySelector('.library__error')?.textContent).toContain('delete failed');
+  });
+
+  it('a failed remove does not resurrect a video whose own remove succeeded', async () => {
+    // F02 CASE 1: the rollback restored a whole-list SNAPSHOT captured at click
+    // time, so a reject on Alpha wrote Beta back onto the grid even though the
+    // sidecar had already deleted Beta's row and unlinked its manifest + poster
+    // (library_ops.py:160-161). A phantom card that opens into failing RPCs.
+    rpcMock.mockResolvedValueOnce({
+      videos: [
+        makeVideo({ id: 'a', title: 'Alpha', path: '/movies/a.mp4' }),
+        makeVideo({ id: 'b', title: 'Beta', path: '/movies/b.mp4' }),
+      ],
+    });
+    await renderLibrary();
+
+    // Alpha's remove stays in flight (controllable rejection); Beta's succeeds.
+    let rejectAlpha: (e: Error) => void = () => {};
+    rpcMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((_res, rej) => {
+            rejectAlpha = rej;
+          }),
+      )
+      .mockResolvedValueOnce({ ok: true });
+
+    await act(async () => {
+      (container.querySelectorAll('.library__remove-btn')[0] as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    await flush();
+
+    // Alpha is optimistically gone, so the sole remaining button is Beta's.
+    await act(async () => {
+      (container.querySelector('.library__remove-btn') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    await flush();
+
+    await act(async () => {
+      rejectAlpha(new Error('refusing to destroy the only surviving copy'));
+    });
+    await flush();
+
+    // Alpha comes back (its remove FAILED) ...
+    expect(container.textContent).toContain('Alpha');
+    // ... and Beta stays gone (its remove SUCCEEDED).
+    expect(container.textContent).not.toContain('Beta');
+  });
+
+  it('a failed remove does not erase a video added while it was in flight', async () => {
+    // F02 CASE 2: the same snapshot rollback also wiped a concurrent import off
+    // the grid while it WAS in the library DB. This case is load-bearing for the
+    // 100% `functions` gate: it is the only one where `prev` is non-empty at
+    // rollback time, so the restore's de-duplication predicate is invoked.
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    await renderLibrary();
+
+    let rejectRemove: (e: Error) => void = () => {};
+    rpcMock.mockImplementationOnce(
+      () =>
+        new Promise((_res, rej) => {
+          rejectRemove = rej;
+        }),
+    );
+    await act(async () => {
+      (container.querySelector('button.library__remove-btn') as HTMLButtonElement).dispatchEvent(
+        new MouseEvent('click', { bubbles: true }),
+      );
+    });
+    await flush();
+
+    // A drag-drop import lands while the remove RPC is still pending.
+    pathForFileMock.mockReturnValue('/movies/new.mp4');
+    rpcMock.mockResolvedValueOnce({
+      video: makeVideo({ id: 'x', title: 'Xray', path: '/movies/new.mp4' }),
+    });
+    await dropFiles([new File(['x'], 'new.mp4')]);
+    expect(container.textContent).toContain('Xray');
+
+    await act(async () => {
+      rejectRemove(new Error('delete failed'));
+    });
+    await flush();
+
+    // The rollback restores ONLY the removed video; the import survives.
+    expect(container.textContent).toContain('Talk');
+    expect(container.textContent).toContain('Xray');
   });
 
   it('exposes the open affordance as a real, labelled <button> (keyboard-native)', async () => {

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -369,15 +369,34 @@ export function Library({
     async (id: string, event: React.MouseEvent) => {
       event.stopPropagation();
       setError(null);
-      // Optimistic removal; restore on failure.
-      const snapshot = videos;
+      // Optimistic removal; on failure restore ONLY this video, at its original
+      // index, through a FUNCTIONAL update.
+      //
+      // A whole-list snapshot (`const snapshot = videos` + `setVideos(snapshot)`)
+      // clobbered every state change that landed while this RPC was in flight: it
+      // resurrected a video whose OWN remove had succeeded — a phantom card whose
+      // manifest and poster the sidecar had already unlinked (library_ops.py:160-161)
+      // and which opens into failing path-resolving RPCs — and it erased a
+      // just-dropped import that WAS in the library DB.
+      //
+      // Deliberately BRANCH-FREE, for the same 100%-branch-coverage reason spelled
+      // out in removeSelected below: with `at === -1` (the id already gone),
+      // `slice(-1, 0)` is `[]` and the reassembly `slice(0, -1) + [] + slice(-1)`
+      // reconstitutes the list exactly, so the unreachable not-found case needs no
+      // conditional and mints no uncovered branch.
+      const at = videos.findIndex((v) => v.id === id);
+      const removed = videos.slice(at, at + 1);
       setVideos((prev) => prev.filter((v) => v.id !== id));
       unselect(id);
       try {
         await rpc<{ ok: boolean }>('library.remove', { id });
       } catch (err) {
         setError(errText(err));
-        setVideos(snapshot);
+        setVideos((prev) => {
+          // Re-filter first so a double-fire cannot duplicate the restored card.
+          const without = prev.filter((v) => v.id !== id);
+          return [...without.slice(0, at), ...removed, ...without.slice(at)];
+        });
       }
     },
     [videos, unselect],
@@ -586,16 +605,28 @@ export function Library({
           </ul>
         </div>
       ) : videos.length === 0 ? (
-        <div className="library__empty">
-          <div className="library__empty-poster" aria-hidden="true">
-            <span className="library__empty-glyph">▶</span>
-            <span className="library__empty-timecode">--:--</span>
+        // A FAILED `library.list` also lands here with `videos === []`, so the
+        // first-run poster used to render UNDER the error alert and tell the user
+        // their library was empty when we had merely failed to read it. SUPPRESS
+        // the poster then; the single `.library__error` alert above stays the one
+        // error surface (restating the message would duplicate it on screen, once
+        // inside a role="alert").
+        //
+        // The `error` test must live strictly INSIDE this arm: hoisting it above
+        // `videos.length === 0` would also suppress the LIST, and a failed
+        // `library.remove` legitimately renders error != null WITH videos > 0.
+        error ? null : (
+          <div className="library__empty">
+            <div className="library__empty-poster" aria-hidden="true">
+              <span className="library__empty-glyph">▶</span>
+              <span className="library__empty-timecode">--:--</span>
+            </div>
+            <p className="library__empty-title">No videos yet</p>
+            <p className="library__empty-hint">
+              Click “Add videos” or drop video files anywhere here.
+            </p>
           </div>
-          <p className="library__empty-title">No videos yet</p>
-          <p className="library__empty-hint">
-            Click “Add videos” or drop video files anywhere here.
-          </p>
-        </div>
+        )
       ) : visible.length === 0 ? (
         <div className="library__empty library__empty--filtered">
           <p className="library__empty-title">No matches</p>

--- a/app/renderer/src/views/Shorts.test.tsx
+++ b/app/renderer/src/views/Shorts.test.tsx
@@ -454,9 +454,59 @@ describe('Shorts view', () => {
     await flush();
 
     // refresh returns early -> no shorts.list call, loading cleared, empty state.
+    // ALSO the anti-overfit control for F09: this path leaves `error` null, so the
+    // empty state (and the count) MUST survive the failed-listing suppression —
+    // gating on `error` alone would break here.
     expect(listMock).not.toHaveBeenCalled();
     expect(container.querySelector('.shorts__loading')).toBeNull();
     expect(container.querySelector('.shorts__empty')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Shorts count"]')).not.toBeNull();
+  });
+
+  // F09: a rejected `shorts.list` used to render the red banner AND the
+  // "No shorts yet" empty state AND a "0 clips" chip together — three surfaces
+  // asserting an empty library when the truth is "we could not find out".
+  it('does not claim "No shorts yet" (or "0 clips") when the listing failed', async () => {
+    listMock.mockRejectedValue(new Error('sidecar is not running'));
+
+    await act(async () => {
+      root.render(<Shorts />);
+    });
+    await flush();
+
+    // Control FIRST: the harness really did reach refresh's catch, so the two
+    // assertions below fail for the defect (an ungated zero-state), never for a
+    // setup artifact.
+    expect(container.querySelector('.shorts__error')).not.toBeNull();
+    expect(container.textContent).toContain('sidecar is not running');
+    // The listing is UNKNOWN, not empty: neither false-zero surface may render.
+    expect(container.querySelector('.shorts__empty')).toBeNull();
+    expect(container.querySelector('[aria-label="Shorts count"]')).toBeNull();
+  });
+
+  it('offers a header Reload that re-runs shorts.list after a failure', async () => {
+    listMock
+      .mockRejectedValueOnce(new Error('sidecar is not running'))
+      .mockResolvedValueOnce({ shorts: [makeShort({ path: '/exports/shorts-v1/a.mp4' })] });
+
+    await act(async () => {
+      root.render(<Shorts />);
+    });
+    await flush();
+
+    // The recovery path: before F09 NOTHING in the view re-ran the fetch, so a
+    // sidecar that came back stayed invisible until the view was remounted.
+    const reload = container.querySelector<HTMLButtonElement>('.shorts__reload');
+    expect(reload).not.toBeNull();
+
+    await act(async () => {
+      reload!.click();
+    });
+    await flush();
+
+    expect(listMock).toHaveBeenCalledTimes(2);
+    expect(container.querySelector('.shorts__error')).toBeNull();
+    expect(container.querySelectorAll('.shorts__card').length).toBe(1);
   });
 
   it('shows an error when Open folder has no preload bridge wired', async () => {

--- a/app/renderer/src/views/Shorts.tsx
+++ b/app/renderer/src/views/Shorts.tsx
@@ -93,6 +93,15 @@ export function Shorts({ onReexport }: ShortsProps): React.ReactElement {
   // P4 §7: apply the chosen sort for display (never mutates the stored list).
   const sortedShorts = useMemo(() => sortShorts(shorts, sortMode), [shorts, sortMode]);
 
+  // F09: with a visible error and nothing listed, the library is UNKNOWN — not
+  // empty. "No shorts yet" and "0 clips" would both assert a zero we never
+  // measured, so suppress them and leave the banner + Reload as the only story.
+  // Deliberately NOT gated on `error` alone: when the preload bridge is absent
+  // `refresh` bails out with `error` still null (:75-78), and that genuinely IS
+  // an empty gallery. Coupled to the banner's own truthiness so a suppressed
+  // zero-state always has a visible explanation beside it.
+  const listUnknown = Boolean(error) && shorts.length === 0;
+
   useEffect(() => {
     void refresh();
   }, [refresh]);
@@ -163,9 +172,23 @@ export function Shorts({ onReexport }: ShortsProps): React.ReactElement {
     <div className="shorts">
       <header className="shorts__header">
         <h1 className="shorts__title">Shorts</h1>
-        <span className="shorts__count" aria-label="Shorts count">
-          {shorts.length} clip{shorts.length === 1 ? '' : 's'}
-        </span>
+        {listUnknown ? null : (
+          <span className="shorts__count" aria-label="Shorts count">
+            {shorts.length} clip{shorts.length === 1 ? '' : 's'}
+          </span>
+        )}
+        {/* F09: the ONLY way to re-run `shorts.list` — before this, a sidecar that
+            crashed and came back stayed invisible until the view was remounted.
+            Deliberately a header control labelled for what it actually does, NOT a
+            "Retry" inside the error banner: that banner is the shared sink for five
+            producers (the listing, open-folder, re-export, package, delete), so a
+            "Retry" there would claim to redo an action it never touches — and
+            `refresh`'s setError(null) would silently wipe the message it replaced.
+            Placed BEFORE the sort group, whose `margin-left:auto` keeps its own
+            right-edge position unchanged. */}
+        <button type="button" className="shorts__reload" onClick={() => void refresh()}>
+          Reload shorts
+        </button>
         {/* P4 §7: sort the gallery by recency or virality. */}
         {shorts.length > 0 ? (
           <div className="shorts__sort" role="group" aria-label="Sort shorts">
@@ -222,15 +245,19 @@ export function Shorts({ onReexport }: ShortsProps): React.ReactElement {
           </ul>
         </div>
       ) : shorts.length === 0 ? (
-        <div className="shorts__empty">
-          <div className="shorts__empty-poster" aria-hidden="true">
-            <span className="shorts__empty-glyph">▶</span>
+        // F09: suppressed when the listing itself failed — the grid below still
+        // renders a stale-but-real list when a later refresh rejects.
+        listUnknown ? null : (
+          <div className="shorts__empty">
+            <div className="shorts__empty-poster" aria-hidden="true">
+              <span className="shorts__empty-glyph">▶</span>
+            </div>
+            <p className="shorts__empty-title">No shorts yet</p>
+            <p className="shorts__empty-hint">
+              Open a video, run the Short-maker, and export clips — they show up here.
+            </p>
           </div>
-          <p className="shorts__empty-title">No shorts yet</p>
-          <p className="shorts__empty-hint">
-            Open a video, run the Short-maker, and export clips — they show up here.
-          </p>
-        </div>
+        )
       ) : (
         <ul className="shorts__grid">
           {sortedShorts.map((short) => (

--- a/app/renderer/src/views/ShortsGalleryModal.test.tsx
+++ b/app/renderer/src/views/ShortsGalleryModal.test.tsx
@@ -196,4 +196,51 @@ describe('ShortsGalleryModal', () => {
     renderModal();
     expect(container.querySelector('[data-testid="edit-s1"]')).toBeNull();
   });
+
+  // F04 — the one role="dialog" in the renderer that never adopted the shared
+  // useFocusTrap. Both cases carry setup guards so a red result cannot be
+  // mistaken for a harness error.
+  describe('focus trap', () => {
+    it('restores focus to the opener when the dialog unmounts', () => {
+      const opener = document.createElement('button');
+      opener.type = 'button';
+      document.body.appendChild(opener);
+      opener.focus();
+      // Guard: the opener really holds focus before the dialog mounts.
+      expect(document.activeElement).toBe(opener);
+
+      renderModal();
+      // Guard: the dialog mounted and pulled focus onto its close control.
+      expect(document.activeElement).toBe(container.querySelector('.shorts-modal__close'));
+
+      act(() => root.unmount());
+      // The defect: nothing captures/restores the pre-open focus, so removing
+      // the close button drops document.activeElement to <body>.
+      expect(document.activeElement).toBe(opener);
+      opener.remove();
+    });
+
+    it('traps Tab inside the dialog, wrapping the last control back to the first', () => {
+      renderModal({
+        shorts: [makeShort({ id: 's1' }), makeShort({ id: 's2', path: '/out/s2.mp4' })],
+      });
+      const focusables = Array.from(dialog().querySelectorAll('button'));
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      // Guard: there really is more than one focusable to wrap between.
+      expect(last).not.toBe(first);
+      act(() => last.focus());
+      // Guard: focus really moved to the last control.
+      expect(document.activeElement).toBe(last);
+
+      const ev = new KeyboardEvent('keydown', { key: 'Tab', bubbles: true, cancelable: true });
+      act(() => {
+        last.dispatchEvent(ev);
+      });
+      // The defect: nothing listens for Tab, so the event is not prevented and
+      // the browser walks focus out of the dialog into the Library grid behind it.
+      expect(ev.defaultPrevented).toBe(true);
+      expect(document.activeElement).toBe(first);
+    });
+  });
 });

--- a/app/renderer/src/views/ShortsGalleryModal.tsx
+++ b/app/renderer/src/views/ShortsGalleryModal.tsx
@@ -8,10 +8,18 @@
 //
 // Presentational + controlled: the parent (Library) owns which video's gallery is
 // open and the shorts list; this owns only the inline-play state + the dialog
-// shell (backdrop-close, Escape, focus-on-open). Motion is neutralised by the
-// global prefers-reduced-motion rule in shell.css.
+// shell (backdrop-close). Motion is neutralised by the global
+// prefers-reduced-motion rule in shell.css.
+//
+// F04: keyboard focus management is delegated to the shared useFocusTrap (Lane 0
+// F4 / R-M10), matching the renderer's three other role="dialog" surfaces
+// (FirstRunChooser, ModelsOnboarding, DirectorOnboarding). The hook moves focus
+// to the close control on mount, traps Tab/Shift+Tab inside the dialog, maps
+// Escape to onClose, and restores focus to the Library card's "N shorts" opener
+// on unmount — which a local onKeyDown + focus-on-open ref could not do.
 import React, { useCallback, useMemo, useState } from 'react';
 
+import { useFocusTrap } from '../hooks/useFocusTrap';
 import { ProducedShorts } from '../features/ProducedShorts';
 import type { ShortInfo } from '../lib/rpc';
 import '../components/library-shell.css';
@@ -40,11 +48,12 @@ export function ShortsGalleryModal({
 }: ShortsGalleryModalProps): React.ReactElement {
   const [playingShortPath, setPlayingShortPath] = useState('');
 
-  // Focus the close control on open (and release cleanly on unmount) via a
-  // callback ref — both the mount (node) and unmount (null) paths run.
-  const focusOnOpen = useCallback((node: HTMLButtonElement | null) => {
-    node?.focus();
-  }, []);
+  // Trap focus inside the dialog: initial focus on the close control, Tab cycles
+  // within, Escape dismisses, focus returns to the opener on unmount.
+  const trapRef = useFocusTrap<HTMLDivElement>({
+    onEscape: onClose,
+    initialFocus: '.shorts-modal__close',
+  });
 
   const play = useCallback((path: string) => {
     setPlayingShortPath((cur) => (cur === path ? '' : path));
@@ -60,29 +69,22 @@ export function ShortsGalleryModal({
       }
     : undefined;
 
-  const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
-    if (event.key === 'Escape') {
-      event.stopPropagation();
-      onClose();
-    }
-  };
-
   return (
     <div className="shorts-modal__backdrop" onClick={onClose}>
       {/* The dialog stops backdrop-close on inner clicks; it is dismissed by the
-          close button or Escape, so it is not itself an interactive control. */}
+          close button or Escape (via the focus trap), so it is not itself an
+          interactive control. */}
       <div
+        ref={trapRef}
         className="shorts-modal"
         role="dialog"
         aria-modal="true"
         aria-label={`Produced shorts for ${title}`}
         onClick={(event) => event.stopPropagation()}
-        onKeyDown={onKeyDown}
       >
         <header className="shorts-modal__head">
           <h2 className="shorts-modal__title">{title}</h2>
           <button
-            ref={focusOnOpen}
             type="button"
             className="shorts-modal__close"
             aria-label="Close produced shorts"

--- a/app/renderer/src/views/shorts.css
+++ b/app/renderer/src/views/shorts.css
@@ -384,6 +384,42 @@
   color: var(--status-error);
 }
 
+/* ---- F09: the gallery's only re-fetch control ----------------------------- */
+
+/* Same quiet pill voice as the sort toggle, so it reads as a header control and
+   not a primary action. It is the ONLY path back from a rejected `shorts.list`. */
+.shorts__reload {
+  appearance: none;
+  border: none;
+  padding: 4px 12px;
+  border-radius: var(--radius-pill);
+  background: var(--surface-deep);
+  color: var(--text-muted);
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition:
+    background var(--dur-fast) var(--ease-out),
+    color var(--dur-fast) var(--ease-out);
+}
+
+.shorts__reload:hover {
+  color: var(--text-primary);
+  background: var(--surface-hover);
+}
+
+/* A REAL focus ring, on a class selector (0,2,0) so nothing in the cascade can
+   tie it — deliberately NOT wrapped in `:where()`, whose zero specificity is what
+   silently killed focus rings across this codebase before (see shell.css:59-63).
+   An `outline` rather than only a box-shadow, because Chromium force-clears
+   box-shadow under `forced-colors: active` and substitutes a system color for an
+   outline — so the ring survives Windows High Contrast. */
+.shorts__reload:focus-visible {
+  outline: 2px solid var(--accent-edge);
+  outline-offset: 2px;
+}
+
 /* ---- P4 §7: gallery sort toggle (recency ↔ virality) ---------------------- */
 
 .shorts__sort {


### PR DESCRIPTION
Integration PR **C of 4** for the 50-finding audit programme — the **renderer leaf panels**. Eight single-component batches with a mechanically-verified zero-file overlap, unit-tested only. Kept as one PR because a vitest failure here names its own component, so cross-batch masking is not a practical risk and a coverage dip is attributable by file.

## Attribution

| batch | branch | findings | what it fixes |
|---|---|---|---|
| B02 | `fix/export-presets-inputs` | F12, F27, F26, F13 | the preset-row input contract |
| B04 | `fix/caption-preferences-copy` | F46, F47, F48 | scope disclosure for caption defaults; a stale "saved" confirmation; "No captions" painted transparent |
| B11 | `fix/library-rollback-and-empty` | F02, F03 | whole-list snapshot rollback **resurrected a video whose files were already unlinked**; a failed listing claimed the library was empty |
| B13 | `fix/shortsgallery-focus` | F04 | the shorts gallery modal now uses the shared focus trap |
| B17 | `fix/tracks-remove-confirm` | F20 | confirm before the irreversible subtitle-track Remove |
| B18 | `fix/timelineops-nudge` | F21 | arrow "move clip" was a **retime that shrank the cue** |
| B21 | `fix/shorts-error-state` | F09 | stopped asserting an empty gallery when the listing failed |
| B24 | `fix/save-presets-affordance` | F49, F50 | Save was enabled on a blank name → silent dead click |

Merged with `--no-ff`, so each batch commit survives and any one batch stays revertable.

## Two of these are data-loss adjacent, not cosmetic

- **B11/F02** — `setVideos(snapshot)` restored the *whole* pre-removal list on a single failed remove, resurrecting a card for a video whose manifest and poster `library_ops.py:160-161` had already unlinked. The UI then showed a library entry that could not be opened. Now rolls back per entry.
- **B18/F21** — the arrow-key "move clip" affordance moved only one edge, so pressing it *shortened the cue* instead of shifting it. The user's caption text got clipped by an action labelled "move".

## Honest residuals (carried forward, not silently dropped)

Each is disclosed inline in the code and re-stated here because none is closed by this PR:

1. **B02** — a cleared duration field now commits `20` (`Number('') === 0` → clamp), a visible change from today's snap-on-keystroke. The three-way inversion policy stays inconsistent: `shortMakerLogic.ts:339-342` still does `max := min` (B06's file — lands in PR-D). `export_presets.py:136`'s comment now misdescribes the renderer policy.
2. **B04** — F48 legibility is **INFERRED, not measured**: jsdom applies no stylesheet, and the settling probe is a screenshot of `Settings → Caption defaults`, a sub-tab with **no visual baseline at all**. The shipped copy also under-claims — Repurpose additionally issues `subtitles.generate`.
3. **B11** — removes the false "No videos yet" but adds **no recovery path**: after a successful sidecar [Restart] the Library stays stale until the user round-trips a tab. `Remove` still has no per-card in-flight `disabled`.
4. **B13** — **part 1 only.** The delete-orphaned-focus hole is still live: `Library.tsx:467-474` rebuilds the list, focus falls to `<body>`, and Escape then reaches no handler (`useFocusTrap.ts:103` binds to the container). `useFocusTrap.ts` was deliberately untouched, so the same fix for FirstRunChooser / ModelsOnboarding / DirectorOnboarding / FirstRunSetup remains **owner-less**.
5. **B17** — confirm-only. Remove still renders identically to its non-destructive siblings; the destructive styling needs `shell.css` or `panels.css`, neither of which is in any batch's declared scope.
6. **B18** — the affordance still cannot move a clip on a real transcript (word cues abut with gap 0); it now *explains* the refusal via new English-only announcements no copy review has seen. Stryker was not run against `nudgeAt` (the 91.35% `timelineOps` mutation baseline predates it).
7. **B21** — `Reload shorts` renders unconditionally, so under `hasApi() === false` it is a dead click — the exact F49 class B24 fixes elsewhere in this same PR.
8. **B24** — the new `:disabled` CSS rule is **asserted by nothing** (jsdom applies no stylesheet), and the inserted live region shifts the preset list down one caption line while a mutation runs. No baseline or axe test covers `Settings → Export presets`. Sidecar `_shared.py:_require_str` still admits whitespace-only names, so the renderer is now the *only* guard.

Items 4, 5 and 7 are the ones worth filing as follow-ups; the rest are scope statements.

## Local gate (on the merged tree, rebuilt on `710c0186`)

- `uvx pre-commit run --all-files` → ruff lint, ruff format, oxlint, biome 2.5.0, gitleaks — **all Passed**
- `node app/node_modules/typescript/bin/tsc --noEmit` → **exit 0** *(local binary deliberately — a bare `npx tsc` in a tree without `node_modules` resolves a same-named public package that prints "This is not the tsc command you are looking for" and exits 0, so a clean exit there proves nothing)*
- `npx vitest run --coverage` → **100% statements / branches / functions / lines** (19598 stmts, 6514 branches, 1153 fns)
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **100%, 6084 passed** (unchanged by this PR — it is renderer-only; the count rose because #318's sidecar tests are now on main)

Note on verification method: total-branch counts are **not** a fingerprint — identical runs measured 6354 vs 6352 on B13 and 6369 vs 6365 on B18. The verdict is the four 100% results plus exit 0, never the denominator.
