### PR TITLE
fix(e2e-coupled): four nightly-validated audit batches + typecheck the e2e harness (PR-D of 4)

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -99,6 +99,15 @@ jobs:
       - name: gate-types tsc render-cli
         working-directory: app/render-cli
         run: npx tsc -p . --noEmit
+      # `app/tsconfig.json` deliberately EXCLUDES e2e/** so Playwright types never
+      # reach the renderer build, and the pre-commit `files:` regexes are scoped to
+      # main|renderer/src|render-cli/src — so before this step nothing in CI read
+      # app/e2e/** at all. The `typecheck:e2e` script existed but no workflow ever
+      # called it. Verified both states: clean tree exits 0; a planted `const x:
+      # number = 'str'` in e2e/overlay-hittest.spec.ts exits 2 naming the line.
+      - name: gate-types tsc e2e harness
+        working-directory: app
+        run: npx tsc --noEmit -p tsconfig.e2e.json
       - name: gate-types basedpyright
         run: basedpyright
 

--- a/app/e2e/overlay-hittest.spec.ts
+++ b/app/e2e/overlay-hittest.spec.ts
@@ -1,0 +1,262 @@
+// overlay-hittest.spec.ts — REAL-Chromium POINTER HIT-TEST gate for the caption
+// overlay (audit F22).
+//
+// WHY THIS IS A PLAYWRIGHT SPEC AND NOT A VITEST TEST: the defect is purely a
+// hit-testing fact. jsdom performs no layout and does not implement
+// `pointer-events`, and the renderer's own CaptionBox unit suite dispatches
+// MouseEvents straight AT `.caption-box-frame` (CaptionBox.test.tsx), so it can
+// never observe that the frame is stealing the <video>'s clicks. Only a real
+// Chromium `document.elementFromPoint` can answer "which element would actually
+// receive a click here", which is exactly the question F22 asks.
+//
+// THE DEFECT: `.caption-box-frame` is `position:absolute; inset:0; z-index:3`
+// over the plain in-flow `<video controls>` the Player emits, with no
+// `pointer-events: none` (captionBox.css). It therefore swallows every pointer
+// event inside the 9:16 stage — including the native control bar at its bottom —
+// so a mouse-only user has no play/pause/seek on the Caption surface (which
+// renders no transport of its own; CaptionClipLane's mouse path only selects a
+// cue, CaptionClipLane.tsx). The same `<Player controls /> + <CaptionBox>`
+// sibling pattern is also live in components/CaptionDesigner.tsx (mounted from
+// views/MakeShorts.tsx), so ONE stylesheet governs two shipped surfaces.
+//
+// SPEC LOCATION IS LOAD-BEARING: this file sits at `e2e/` (NOT `e2e/audit/`),
+// because playwright.config.ts `testIgnore: ['visual/**', 'audit/**']` would
+// exclude an audit/** spec from every CI job, and there is no audit npm script.
+// Here it is matched by `testMatch: '**/*.spec.ts'` and runs in the 4-OS
+// `e2e-gui` matrix (`npm run test:e2e`), and is type-checked by
+// `npm run typecheck:e2e` (tsconfig.e2e.json includes e2e/**). Importing the
+// launch helpers from ./visual/_visualSetup.ts is safe — that file is a helper
+// module, not a spec, so it is not itself collected here.
+
+import { test, expect, type Page } from '@playwright/test';
+import {
+  launchSeededApp,
+  prepareWindow,
+  openTopTab,
+  openVideo,
+  type LaunchedApp,
+} from './visual/_visualSetup';
+
+let launched: LaunchedApp;
+let win: Page;
+
+test.beforeAll(async () => {
+  launched = await launchSeededApp();
+  win = await prepareWindow(launched.app);
+});
+
+test.afterAll(async () => {
+  await launched?.app.close();
+});
+
+/** What `document.elementFromPoint` reports at a viewport point. */
+interface HitInfo {
+  tag: string;
+  /** The raw class attribute — for diagnostics in failure messages only. */
+  cls: string;
+  /**
+   * The class list as EXACT tokens. Every assertion below matches on these, never
+   * on `cls` substrings: `'caption-box-frame'` CONTAINS the substring
+   * `'caption-box'`, so a substring assertion could not tell the dead overlay from
+   * the live draggable box and would pass spuriously.
+   */
+  classes: string[];
+  /** Whether the sampled point was inside the viewport at all (see hitTest). */
+  inView: boolean;
+}
+
+/**
+ * Ask CHROMIUM ITSELF which element would receive a click at (x, y). This is the
+ * oracle: it honours stacking order AND `pointer-events`, unlike a "what is
+ * painted on top" heuristic. `className` is read defensively because it is an
+ * SVGAnimatedString (not a string) on SVG elements.
+ *
+ * SELF-VALIDATING: `elementFromPoint` returns null for a point OUTSIDE the
+ * viewport, and Playwright's `toBeVisible()` does NOT imply in-viewport (it only
+ * requires a non-empty box), so a below-the-fold target silently yields `(none)`
+ * in every state — a probe that is equally dead before and after a fix, i.e. one
+ * that measures nothing. The `inView` assertion converts that into a named setup
+ * failure instead of a mystery verdict. (Measured: the MakeShorts designer probe
+ * did exactly this until `scrollIntoViewIfNeeded` was added.)
+ */
+async function hitTest(page: Page, x: number, y: number): Promise<HitInfo> {
+  const hit = await page.evaluate(([px, py]) => {
+    const el = document.elementFromPoint(px, py);
+    const cls = typeof el?.className === 'string' ? el.className : '';
+    return {
+      tag: el?.tagName ?? '(none)',
+      cls,
+      classes: [...(el?.classList ?? [])],
+      inView: px >= 0 && py >= 0 && px < window.innerWidth && py < window.innerHeight,
+    };
+  }, [x, y] as const);
+  expect(
+    hit.inView,
+    `probe point (${Math.round(x)}, ${Math.round(y)}) is OUTSIDE the viewport — ` +
+      'elementFromPoint cannot answer there, so this run measured nothing',
+  ).toBe(true);
+  return hit;
+}
+
+/** The laid-out box of `selector`, failing loudly rather than returning null. */
+async function boxOf(
+  page: Page,
+  selector: string,
+): Promise<{ x: number; y: number; width: number; height: number }> {
+  const rect = await page.locator(selector).boundingBox();
+  expect(rect, `boundingBox(${selector}) — element must be laid out`).not.toBeNull();
+  return rect as { x: number; y: number; width: number; height: number };
+}
+
+/**
+ * Hit-test the native control bar of the <video> at `videoSelector`.
+ *
+ * Samples 16px up from the video's bottom edge — inside Chromium's control bar —
+ * in the LEFT third, near play/pause. The left-third x and the 16px depth both
+ * keep the probe clear of the default caption box's s/sw/se resize handles, which
+ * sit at `bottom: -12px` with a 24px hit area (captionBox.css) and so end
+ * (0.08 * H - 12)px above the bottom edge for the default box (y+h = 0.92).
+ *
+ * NOTE this deliberately does NOT depend on the control bar being *visible*:
+ * Chromium's media controls live in the <video>'s closed shadow DOM, so
+ * `elementFromPoint` reports the <video> host either way. Reaching the host IS
+ * the necessary and sufficient condition for those controls to be clickable —
+ * which is exactly what the overlay was preventing.
+ */
+async function probeControlBar(page: Page, videoSelector: string): Promise<HitInfo> {
+  // MANDATORY before measuring: `boundingBox()` does not scroll, and the
+  // MakeShorts designer sits below the fold, so without this the probe point
+  // lands outside the viewport and elementFromPoint returns null in EVERY state.
+  await page.locator(videoSelector).scrollIntoViewIfNeeded();
+  const r = await boxOf(page, videoSelector);
+  return hitTest(page, r.x + r.width * 0.15, r.y + r.height - 16);
+}
+
+/**
+ * Drive the app to a mounted Caption stage, from ANY starting route.
+ *
+ * Every stage test calls this rather than relying on the previous test's route:
+ * Playwright discards the worker process after a failed test and starts a fresh
+ * one, which re-runs `beforeAll` and lands the app back on the Library. A test
+ * that assumed the earlier navigation then fails with "element not found" — a
+ * FIXTURE error that proves nothing about the defect.
+ *
+ * Caption.tsx renders an "Open a video to caption" EMPTY STATE (no stage, no
+ * overlay) when `editVideo` is null, so the video must be opened first.
+ */
+async function openCaptionStage(page: Page): Promise<void> {
+  await openTopTab(page, 'Caption');
+  // Settle on ONE of Caption's two states before branching, so the count() below
+  // cannot race the route's first render.
+  await page
+    .locator('.caption-stage__frame, .caption-view--empty')
+    .first()
+    .waitFor({ state: 'visible' });
+  if ((await page.locator('.caption-stage__frame').count()) === 0) {
+    // Empty state => no video open yet. Open one, then come back. This branch is
+    // taken exactly once per launched app: `openVideo` is NOT idempotent (the
+    // Task Hub's "Advanced" escape is a one-time step, so a second call would
+    // hang on `button.task-hub__advanced`), which is why re-entry must go through
+    // the tab switch above instead of re-opening the video.
+    await openTopTab(page, 'Library');
+    await openVideo(page, 'sample');
+    await openTopTab(page, 'Caption');
+  }
+  await expect(page.locator('.caption-stage__frame')).toBeVisible();
+}
+
+// ---------------------------------------------------------------------------
+// 1. DETECTOR CONTROL — run FIRST, so a broken oracle fails before any claim.
+// ---------------------------------------------------------------------------
+// A silence/verdict from `elementFromPoint` is only evidence if the oracle
+// actually respects `pointer-events`. `.library__thumb-img` is an ALREADY-CORRECT
+// site in this same app: a full-bleed <img> over the card poster that carries
+// `pointer-events: none` precisely so "the click target is the card, never the
+// media element" (library-cards.css `.library__thumb-img`). If the oracle still
+// named the <img> here, then its "caption-box-frame" answer below would prove
+// nothing about clicks — it would just be reporting the topmost painted box.
+test('detector control — elementFromPoint sees THROUGH a pointer-events:none layer', async () => {
+  await expect(win.locator('.library__title')).toBeVisible();
+  const img = win.locator('.library__thumb-img').first();
+  await expect(img).toBeVisible();
+  await img.scrollIntoViewIfNeeded();
+  const r = await boxOf(win, '.library__thumb-img');
+  // Centre of the poster: clear of the bottom-right duration badge (z-index 1).
+  const hit = await hitTest(win, r.x + r.width / 2, r.y + r.height / 2);
+  expect(
+    hit.classes,
+    `oracle named the pointer-events:none <img> itself (${hit.tag}.${hit.cls}) — ` +
+      'it is reporting paint order, not hit-testing; do not trust its verdicts below',
+  ).not.toContain('library__thumb-img');
+  expect(hit.tag, `hit at the poster centre: ${hit.tag}.${hit.cls}`).not.toBe('IMG');
+});
+
+// ---------------------------------------------------------------------------
+// 2. THE DEFECT (F22) — the caption frame must not eat the video's controls.
+// ---------------------------------------------------------------------------
+test('the caption overlay does NOT swallow the video native controls', async () => {
+  await openCaptionStage(win);
+  const video = win.locator('.caption-stage__frame video');
+  await expect(video).toHaveCount(1);
+
+  const hit = await probeControlBar(win, '.caption-stage__frame video');
+
+  expect(
+    hit.classes,
+    `the caption overlay is intercepting the control bar: elementFromPoint → ${hit.tag}.${hit.cls}`,
+  ).not.toContain('caption-box-frame');
+  expect(
+    hit.tag,
+    `a click on the native control bar must reach the <video>, got ${hit.tag}.${hit.cls}`,
+  ).toBe('VIDEO');
+});
+
+// ---------------------------------------------------------------------------
+// 3. OVER-CORRECTION GUARD — passes BEFORE and AFTER the fix.
+// ---------------------------------------------------------------------------
+// `pointer-events` INHERITS, so `pointer-events: none` on `.caption-box-frame`
+// alone would also kill the draggable box and its resize handles — trading one
+// broken control for another. This case pins that the box body still hit-tests
+// to itself, which is what proves the companion `.caption-box { pointer-events:
+// auto }` half of the fix was not forgotten.
+test('the draggable caption box still receives its own pointer events', async () => {
+  await openCaptionStage(win);
+  await win.locator('.caption-stage__frame .caption-box').scrollIntoViewIfNeeded();
+  const r = await boxOf(win, '.caption-stage__frame .caption-box');
+  const hit = await hitTest(win, r.x + r.width / 2, r.y + r.height / 2);
+  // EXACT token: `.caption-box`, not `.caption-box-frame` (which is now the dead
+  // hit layer). A substring check would accept the frame and pass spuriously.
+  expect(
+    hit.classes,
+    `the caption box must stay draggable; elementFromPoint → ${hit.tag}.${hit.cls}`,
+  ).toContain('caption-box');
+});
+
+// ---------------------------------------------------------------------------
+// 4. THE SECOND SHIPPED SURFACE — one stylesheet, two surfaces.
+// ---------------------------------------------------------------------------
+// `components/CaptionDesigner.tsx` renders the SAME `<Player controls />` +
+// `<CaptionBox>` sibling pair inside `.caption-designer__phone` (also
+// `position: relative`, also 9:16), and is mounted in the shipped app from
+// `views/MakeShorts.tsx` once a source video is picked. MakeShorts likewise has
+// no play/pause/seek of its own. This case MEASURES the second surface rather
+// than inferring it from the shared stylesheet.
+test('the same fix reaches the MakeShorts caption designer', async () => {
+  await openTopTab(win, 'Make Shorts');
+  await expect(win.locator('.make-shorts')).toBeVisible();
+  // The designer only mounts once a source video is selected (MakeShorts.tsx).
+  await win.locator('select[aria-label="Source video"]').selectOption({ label: 'sample' });
+  await expect(win.locator('.caption-designer__phone')).toBeVisible();
+  const video = win.locator('.caption-designer__phone video');
+  await expect(video).toHaveCount(1);
+
+  const hit = await probeControlBar(win, '.caption-designer__phone video');
+  expect(
+    hit.classes,
+    `the designer overlay is intercepting the control bar: elementFromPoint → ${hit.tag}.${hit.cls}`,
+  ).not.toContain('caption-box-frame');
+  expect(
+    hit.tag,
+    `a click on the designer's control bar must reach the <video>, got ${hit.tag}.${hit.cls}`,
+  ).toBe('VIDEO');
+});

--- a/app/e2e/preview.spec.ts
+++ b/app/e2e/preview.spec.ts
@@ -148,6 +148,66 @@ test('preview <video> PLAYS the imported sample (real playback)', async () => {
   expect(advanced, 'currentTime after play()').toBeGreaterThan(0.2);
 });
 
+test('Advanced disclosure actually COLLAPSES the Deliver cluster (F17)', async () => {
+  const win = await app.firstWindow();
+  // Workspace is already open from the playback test, in its DEFAULT view:
+  // Workspace.tsx seeds `advancedOpen = false`, and nothing on the route in
+  // (library card -> task-hub "Advanced / all tools") ever opens the cluster.
+  await expect(win.locator('.workspace')).toBeVisible();
+
+  const toggle = win.locator('.tabbar__advanced-toggle');
+  const panel = win.locator('.tabbar__advanced-panel');
+  const deliverTab = win.locator('.tab[data-tab-id="tracks"]');
+
+  // DETECTOR CONTROL (same element, mechanically independent of layout): the
+  // panel EXISTS and React really wrote the `hidden` attribute onto it. So a
+  // failure of the layout assertions below cannot come from a typo'd selector,
+  // an unmounted panel, or React skipping `hidden` — the only remaining cause
+  // is the CSS cascade. This is what makes the red below name the defect.
+  await expect(panel).toHaveCount(1);
+  await expect(panel).toHaveAttribute('hidden', '');
+
+  // The disclosure REPORTS collapsed...
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  // ...so the cluster it owns must not paint. It does today: the author-origin
+  // `display: flex` on `.tabbar--grouped .tabbar__advanced-panel` outranks the
+  // UA `[hidden] { display: none }`, and no `[hidden]` selector anywhere under
+  // app/ restores it — so all 13 tabs paint instead of 8 and `aria-expanded`
+  // lies about what is on screen.
+  await expect(panel).toBeHidden();
+  await expect(deliverTab).toBeHidden();
+  // The user-visible consequence: the default view paints the 8 primary tabs,
+  // not all 13. (`.tab` is exclusive to this strip — measured 13 total.)
+  await expect(win.locator('.tab')).toHaveCount(13);
+  await expect(win.locator('.tab:visible')).toHaveCount(8);
+  // ...and the disclosure's own toggle is reachable WITHOUT horizontally
+  // scrolling `.workspace .tabbar` (workspace.css `overflow-x: auto`). With the
+  // cluster always painted the strip overflowed its 1064px track by 587px and
+  // pushed the toggle out of the window entirely, so the only control that could
+  // collapse the cluster was itself off-screen.
+  await expect(toggle).toBeInViewport();
+  // Deliberately NOT asserted: `.tabbar__export` in-viewport. Measured on the
+  // live app at the default window (innerWidth 1264), collapsing the cluster
+  // cuts the strip's overflow from 587px to 94px — which restores the toggle
+  // (x 1175..1268) but still leaves Export starting at x=1268, 4px past the
+  // right edge. Export needs a separate layout change that this rule does not
+  // govern, so asserting it here would pin a promise this fix does not keep.
+
+  // The disclosure still REVEALS when asked — pins that the fix scopes the rule
+  // rather than deleting the cluster (passes before AND after the fix).
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  await expect(panel).toBeVisible();
+  await expect(deliverTab).toBeVisible();
+
+  // RESTORE the collapsed default. playwright.config.ts runs `fullyParallel:
+  // false, workers: 1` against ONE app launched in `beforeAll`, so leaving the
+  // cluster open would leak `advancedOpen === true` into the tests below and
+  // hide whether THEY reveal it themselves.
+  await toggle.click();
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+});
+
 test('Workspace tabs mount, including SemanticSearch', async () => {
   const win = await app.firstWindow();
   // Workspace is already open from the playback test.
@@ -161,6 +221,12 @@ test('Workspace tabs mount, including SemanticSearch', async () => {
   await expect(win.locator('section.semantic-search-panel h2')).toHaveText('Search the transcript');
   await expect(win.locator('input[aria-label="Search the transcript"]')).toBeVisible();
 
+  // "Timeline export" (tab id `nle`) lives in the Deliver cluster, which is
+  // collapsed by default — so REVEAL it first or Playwright's actionability gate
+  // cannot click a `display:none` button. Use `.tabbar__export` (Workspace
+  // handleExport → `setAdvancedOpen(true)`), which is IDEMPOTENT; the
+  // `.tabbar__advanced-toggle` would flip the cluster shut on a second caller.
+  await win.locator('.tabbar__export').click();
   // Switch to Timeline export and assert the NleExport panel ITSELF mounted.
   await win.locator('button', { hasText: 'Timeline export' }).first().click();
   await expect(win.locator('section.nle-panel')).toBeVisible();
@@ -174,6 +240,9 @@ test('export action yields a real file (NLE timeline export, real button)', asyn
   // Drive the REAL "Export timeline" button in the mounted NleExport panel (it
   // calls nle.export through the live preload bridge -> live sidecar). Then read
   // the saved path the panel renders and assert the file exists on disk.
+  // Reveal the Deliver cluster first (see the note above): this test must not
+  // depend on a sibling test having left it open.
+  await win.locator('.tabbar__export').click();
   await win.locator('button', { hasText: 'Timeline export' }).first().click();
   await expect(win.locator('section.nle-panel')).toBeVisible();
   await win.locator('section.nle-panel button', { hasText: 'Export timeline' }).click();

--- a/app/renderer/src/components/captionBox.css
+++ b/app/renderer/src/components/captionBox.css
@@ -1,15 +1,34 @@
 /* CaptionBox — draggable/resizable caption region overlay (P4 §4). */
 
+/* Audit F22: this frame is a full-bleed (inset:0, z-index:3) sibling painted OVER
+   the in-flow `<video controls>` the Player emits, so with hit-testing enabled it
+   swallowed EVERY click inside the 9:16 stage — including the native control bar
+   at its bottom. That left the Caption surface and MakeShorts/CaptionDesigner
+   (both `<Player controls /> + <CaptionBox>`) with no mouse play/pause/seek at
+   all. The frame is a geometry/event-plumbing layer, never a click target, so it
+   opts out of hit-testing; `.caption-box` opts BACK IN below. Pinned by the real
+   Chromium hit-test in e2e/overlay-hittest.spec.ts. */
 .caption-box-frame {
   position: absolute;
   inset: 0;
   z-index: 3;
+  pointer-events: none;
   touch-action: none;
 }
 
 .caption-box {
   position: absolute;
   box-sizing: border-box;
+  /* MANDATORY companion to the frame's `pointer-events: none` — the property
+     INHERITS, so without this the draggable box and its resize handles (which
+     inherit `auto` from here) would go dead too, trading one broken control for
+     another. */
+  pointer-events: auto;
+  /* Declared here as well as on the frame: touch-action is resolved by
+     intersecting the hit element with its ancestors, and the box is now the hit
+     element for a touch drag, so stating it locally keeps the drag from being
+     claimed as a browser pan even if the frame rule ever moves. */
+  touch-action: none;
   border: 1.5px dashed rgba(255, 255, 255, 0.85);
   border-radius: 6px;
   /* Bug-sweep: token-driven amber tint (was an off-theme blue wash). */

--- a/app/renderer/src/features/NleExport.test.tsx
+++ b/app/renderer/src/features/NleExport.test.tsx
@@ -9,11 +9,24 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+// The panel now resolves promises inside effects, so the multi-generation
+// `settle()` below needs a real act environment (house pattern — see
+// panels/ModelsSystemPanel.test.tsx, panels/DirectorPanel.test.tsx).
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
 const exportMock = vi.fn();
+const settingsGetMock = vi.fn();
+const settingsSetMock = vi.fn();
 let apiAvailable = true;
 
 vi.mock('../lib/rpc', () => ({
-  client: { nle: { export: (...a: unknown[]) => exportMock(...a) } },
+  client: {
+    nle: { export: (...a: unknown[]) => exportMock(...a) },
+    settings: {
+      get: (...a: unknown[]) => settingsGetMock(...a),
+      set: (...a: unknown[]) => settingsSetMock(...a),
+    },
+  },
   hasApi: () => apiAvailable,
 }));
 
@@ -27,6 +40,12 @@ beforeEach(() => {
   document.body.appendChild(container);
   root = createRoot(container);
   exportMock.mockReset();
+  settingsGetMock.mockReset();
+  settingsSetMock.mockReset();
+  // Default: a persisted store with no `exportDefaults` slice at all, so the
+  // panel keeps its built-in edl/30 and the pre-existing tests are unaffected.
+  settingsGetMock.mockResolvedValue({});
+  settingsSetMock.mockResolvedValue({});
   apiAvailable = true;
 });
 
@@ -38,6 +57,33 @@ afterEach(() => {
 async function flush(): Promise<void> {
   await act(async () => {
     await Promise.resolve();
+  });
+}
+
+/**
+ * Drain a multi-await chain (mount seed -> export -> re-read -> persist). One
+ * `flush()` only advances a single microtask generation.
+ */
+async function settle(): Promise<void> {
+  await flush();
+  await flush();
+  await flush();
+}
+
+function selects(): { fmt: HTMLSelectElement; fps: HTMLSelectElement } {
+  return {
+    fmt: container.querySelector('#nle-format') as HTMLSelectElement,
+    fps: container.querySelector('#nle-fps') as HTMLSelectElement,
+  };
+}
+
+function pick(format: string, fps: string): void {
+  const { fmt, fps: fpsEl } = selects();
+  act(() => {
+    fmt.value = format;
+    fmt.dispatchEvent(new Event('change', { bubbles: true }));
+    fpsEl.value = fps;
+    fpsEl.dispatchEvent(new Event('change', { bubbles: true }));
   });
 }
 
@@ -134,5 +180,197 @@ describe('NleExport', () => {
       'sidecar bridge is not available',
     );
     expect(exportMock).not.toHaveBeenCalled();
+  });
+
+  // ---- F28: the persisted `exportDefaults` slice is read at mount + written ----
+
+  it('seeds the format + fps selects from the persisted exportDefaults', async () => {
+    settingsGetMock.mockResolvedValue({
+      exportDefaults: { subtitleFormat: 'srt', nleFormat: 'csv', nleFps: 24 },
+    });
+    render();
+    await settle();
+    const { fmt, fps } = selects();
+    expect(fmt.value).toBe('csv');
+    expect(fps.value).toBe('24');
+  });
+
+  it('persists the picked format + fps after a successful export, re-reading first', async () => {
+    // Mount reads `subtitleFormat: 'vtt'`; ANOTHER surface then writes 'ass'
+    // before the export lands. The persisted payload must carry 'ass' — a
+    // mount-time snapshot would clobber it, because the sidecar `settings.set`
+    // is a SHALLOW top-level merge (settings_store.py:508-528).
+    settingsGetMock
+      .mockResolvedValueOnce({
+        exportDefaults: { subtitleFormat: 'vtt', nleFormat: 'edl', nleFps: 30 },
+      })
+      .mockResolvedValueOnce({
+        exportDefaults: { subtitleFormat: 'ass', nleFormat: 'edl', nleFps: 30 },
+      });
+    exportMock.mockResolvedValue({ path: '/exports/v1-timeline.csv', clipCount: 2 });
+    render();
+    await settle();
+    pick('csv', '25');
+    click('Export timeline');
+    await settle();
+    expect(settingsSetMock).toHaveBeenCalledWith({
+      exportDefaults: { subtitleFormat: 'ass', nleFormat: 'csv', nleFps: 25 },
+    });
+  });
+
+  it('falls back to edl/30 for a persisted format + fps the panel does not offer', async () => {
+    // `nleFormat` is a bare `string` on the wire and the sidecar documents
+    // `fcpxml` as legal; an unmatched <select> value would render BLANK.
+    settingsGetMock.mockResolvedValue({
+      exportDefaults: { subtitleFormat: 'srt', nleFormat: 'fcpxml', nleFps: 99 },
+    });
+    render();
+    await settle();
+    const { fmt, fps } = selects();
+    expect(fmt.value).toBe('edl');
+    expect(fps.value).toBe('30');
+  });
+
+  it('treats a non-object exportDefaults as absent, on both the read and the write', async () => {
+    // A corrupt scalar must not be spread into the persisted payload — spreading
+    // a string would write index keys ({0:'c',1:'o',…}) into the slice.
+    settingsGetMock.mockResolvedValue({ exportDefaults: 'corrupt' });
+    exportMock.mockResolvedValue({ path: '/exports/v1-timeline.edl', clipCount: 1 });
+    render();
+    await settle();
+    const { fmt, fps } = selects();
+    expect(fmt.value).toBe('edl');
+    expect(fps.value).toBe('30');
+    click('Export timeline');
+    await settle();
+    expect(settingsSetMock).toHaveBeenCalledWith({
+      exportDefaults: { nleFormat: 'edl', nleFps: 30 },
+    });
+  });
+
+  it('keeps the built-in defaults when the settings read rejects', async () => {
+    settingsGetMock.mockRejectedValue(new Error('settings unreadable'));
+    render();
+    await settle();
+    const { fmt, fps } = selects();
+    expect(fmt.value).toBe('edl');
+    expect(fps.value).toBe('30');
+    // A failed preference read is not an error the user is shown.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('never touches client.settings when there is no bridge', async () => {
+    // `client.settings.get` throws SYNCHRONOUSLY without a preload, so the mount
+    // effect must return on `hasApi()` BEFORE reaching the client.
+    apiAvailable = false;
+    render();
+    await settle();
+    expect(settingsGetMock).not.toHaveBeenCalled();
+    expect(container.querySelector('#nle-format')).toBeTruthy();
+  });
+
+  it('does not let a late settings resolve clobber a pick the user already made', async () => {
+    let resolveGet: (value: Record<string, unknown>) => void = () => undefined;
+    settingsGetMock.mockReturnValue(
+      new Promise<Record<string, unknown>>((res) => {
+        resolveGet = res;
+      }),
+    );
+    render();
+    pick('csv', '30');
+    await act(async () => {
+      resolveGet({ exportDefaults: { subtitleFormat: 'srt', nleFormat: 'edl', nleFps: 60 } });
+    });
+    await settle();
+    const { fmt, fps } = selects();
+    expect(fmt.value).toBe('csv');
+    expect(fps.value).toBe('30');
+  });
+
+  it('ignores a settings resolve that lands after unmount', async () => {
+    let resolveGet: (value: Record<string, unknown>) => void = () => undefined;
+    settingsGetMock.mockReturnValue(
+      new Promise<Record<string, unknown>>((res) => {
+        resolveGet = res;
+      }),
+    );
+    render();
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    act(() => root.unmount());
+    await act(async () => {
+      resolveGet({ exportDefaults: { subtitleFormat: 'srt', nleFormat: 'csv', nleFps: 24 } });
+    });
+    // The cleanup flag suppressed the seed: no update on an unmounted tree.
+    expect(errors).not.toHaveBeenCalled();
+    errors.mockRestore();
+    // Hand afterEach a fresh, never-rendered root (this one is already unmounted).
+    root = createRoot(container);
+  });
+
+  it('does not surface a failed preference write as an export error', async () => {
+    exportMock.mockResolvedValue({ path: '/exports/v1-timeline.edl', clipCount: 4 });
+    settingsSetMock.mockRejectedValue(new Error('settings read-only'));
+    render();
+    await settle();
+    click('Export timeline');
+    await settle();
+    expect(settingsSetMock).toHaveBeenCalled();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('.status')?.textContent).toContain('Exported 4 clips');
+  });
+
+  // ---- F29: the success outcome + saved path are announced -------------------
+
+  it('announces the export outcome and the saved path in a polite live region', async () => {
+    exportMock.mockResolvedValue({ path: '/exports/v1-timeline.edl', clipCount: 3 });
+    render();
+    await settle();
+    // Mounted-while-empty (components/ToastHost.tsx): a region inserted together
+    // with its text is not reliably announced, so it must exist BEFORE the action.
+    const live = container.querySelector('[role="status"][aria-live="polite"]');
+    expect(live).toBeTruthy();
+    click('Export timeline');
+    await settle();
+    expect(live?.textContent).toContain('Exported 3 clips');
+    expect(live?.textContent).toContain('/exports/v1-timeline.edl');
+  });
+
+  it('announces the empty-timeline outcome inside the live region', async () => {
+    // clipCount>0 needs persisted approved clips, so this is the string real
+    // users hear today — it must land in the region too, not just beside it.
+    exportMock.mockResolvedValue({ path: '/exports/v1-timeline.edl', clipCount: 0 });
+    render();
+    await settle();
+    const live = container.querySelector('[role="status"][aria-live="polite"]');
+    click('Export timeline');
+    await settle();
+    expect(live?.textContent).toContain('no approved clips');
+    expect(live?.textContent).toContain('/exports/v1-timeline.edl');
+  });
+
+  it('keeps the failure alert OUT of the polite region', async () => {
+    exportMock.mockRejectedValue(new Error('disk full'));
+    render();
+    await settle();
+    click('Export timeline');
+    await settle();
+    const live = container.querySelector('[role="status"][aria-live="polite"]');
+    expect(live).toBeTruthy();
+    expect(live?.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('disk full');
+  });
+
+  it('drops the previous saved path when a later export fails', async () => {
+    exportMock.mockResolvedValueOnce({ path: '/exports/v1-timeline.edl', clipCount: 2 });
+    render();
+    await settle();
+    click('Export timeline');
+    await settle();
+    expect(container.querySelector('.export-path')).toBeTruthy();
+    // A stale success path must not sit in the live region beside the alert.
+    exportMock.mockRejectedValueOnce(new Error('disk full'));
+    click('Export timeline');
+    await settle();
+    expect(container.querySelector('.export-path')).toBeNull();
   });
 });

--- a/app/renderer/src/features/NleExport.tsx
+++ b/app/renderer/src/features/NleExport.tsx
@@ -7,7 +7,12 @@
 //
 // Calls `nle.export({videoId, format, fps})` -> {path, clipCount} (direct-return,
 // no job). Consumes the canonical typed client (lib/rpc.ts).
-import React, { useCallback, useState } from 'react';
+//
+// The two picks round-trip through the persisted `exportDefaults` slice
+// ({subtitleFormat, nleFormat, nleFps}) so they survive leaving the tab — both
+// mount sites are conditional renders (views/Deliver.tsx, views/Workspace.tsx),
+// so the panel genuinely unmounts and un-persisted state is lost every visit.
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import './panels.css';
 import { client, hasApi, type NleFormat, type NleFps } from '../lib/rpc';
 
@@ -22,18 +27,107 @@ const FORMATS: Array<{ value: NleFormat; label: string }> = [
 
 const FPS_CHOICES: NleFps[] = [24, 25, 30, 60];
 
+const DEFAULT_FORMAT: NleFormat = 'edl';
+const DEFAULT_FPS: NleFps = 30;
+
+/**
+ * The persisted `exportDefaults` slice as it arrives on the wire: every field is
+ * `unknown` on purpose. `ExportDefaults.nleFormat` is declared a bare `string`
+ * (lib/rpc/schemas.ts) and the sidecar documents `fcpxml` as legal
+ * (settings_store.py exportDefaults default), so a stored value may name a
+ * format this panel does not offer — an unmatched `<select>` value renders blank.
+ */
+interface RawExportDefaults {
+  readonly nleFormat?: unknown;
+  readonly nleFps?: unknown;
+}
+
+/**
+ * Pull the `exportDefaults` sub-object out of a `settings.get()` payload.
+ *
+ * Object-only — `null` is deliberately allowed through because it is harmless
+ * (an optional-chain read short-circuits and spreading it yields `{}`), whereas a
+ * corrupt SCALAR must not reach the write path: spreading a string there would
+ * persist index keys ({0:'c',1:'o',…}) into the slice.
+ */
+function rawExportDefaults(
+  settings: Record<string, unknown>,
+): RawExportDefaults | null | undefined {
+  const slice = settings.exportDefaults;
+  return typeof slice === 'object' ? (slice as RawExportDefaults | null) : undefined;
+}
+
+/** Narrow a persisted `nleFormat` to a format this panel offers, else the default. */
+function narrowFormat(raw: unknown): NleFormat {
+  return FORMATS.find((f) => f.value === raw)?.value ?? DEFAULT_FORMAT;
+}
+
+/** Narrow a persisted `nleFps` to a frame rate this panel offers, else the default. */
+function narrowFps(raw: unknown): NleFps {
+  return FPS_CHOICES.find((f) => f === raw) ?? DEFAULT_FPS;
+}
+
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
 }
 
 export function NleExport({ videoId }: NleExportProps): React.ReactElement {
-  const [format, setFormat] = useState<NleFormat>('edl');
-  const [fps, setFps] = useState<NleFps>(30);
+  const [format, setFormat] = useState<NleFormat>(DEFAULT_FORMAT);
+  const [fps, setFps] = useState<NleFps>(DEFAULT_FPS);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState('');
   const [status, setStatus] = useState('');
   const [lastPath, setLastPath] = useState('');
   const [clipCount, setClipCount] = useState<number | null>(null);
+  // Set as soon as the user touches either select: a pick always beats a
+  // settings read that resolves after it.
+  const picked = useRef(false);
+
+  // Seed the two selects from the persisted `exportDefaults`. `hasApi()` is
+  // checked FIRST and returns before `client` is touched: `client.settings.get`
+  // -> `rpc()` -> `bridge()` THROWS SYNCHRONOUSLY without a preload
+  // (lib/rpc/client.ts), so no promise would exist for `.catch()` to attach to
+  // and the throw would escape this effect at commit — turning the graceful
+  // no-bridge degrade below into a mount-time crash. Best-effort throughout: an
+  // absent slice, an unreadable store, or an unrecognised stored value all keep
+  // the built-in edl + 30 fps.
+  useEffect(() => {
+    if (!hasApi()) return;
+    let cancelled = false;
+    void client.settings
+      .get()
+      .then((settings) => {
+        // `cancelled` covers unmount-during-fetch (both mount sites are
+        // conditional renders); `picked` covers a late resolve after a pick.
+        if (cancelled || picked.current) return;
+        const slice = rawExportDefaults(settings);
+        setFormat(narrowFormat(slice?.nleFormat));
+        setFps(narrowFps(slice?.nleFps));
+      })
+      .catch(() => {
+        // An unreadable settings store keeps the built-in defaults.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Write side. RE-READS immediately before writing: the sidecar `settings.set`
+  // is a SHALLOW top-level merge, so it REPLACES the whole `exportDefaults`
+  // object — writing a mount-time snapshot would silently revert a
+  // `subtitleFormat` another surface persisted meanwhile. Best-effort: neither
+  // the read nor the write may ever surface as an export error.
+  const persistDefaults = useCallback(async (): Promise<void> => {
+    try {
+      const slice = rawExportDefaults(await client.settings.get());
+      await client.settings.set({
+        exportDefaults: { ...slice, nleFormat: format, nleFps: fps },
+      });
+    } catch {
+      // The export itself succeeded; a failed preference write is not an export
+      // failure and must never reach the error banner.
+    }
+  }, [format, fps]);
 
   const runExport = useCallback(async () => {
     if (!hasApi()) {
@@ -42,6 +136,11 @@ export function NleExport({ videoId }: NleExportProps): React.ReactElement {
     }
     setBusy(true);
     setError('');
+    // Drop the previous outcome up front: now that the saved path lives inside
+    // the polite region, a later failure would otherwise leave a stale success
+    // path being announced right beside the error alert.
+    setLastPath('');
+    setClipCount(null);
     setStatus(`Exporting ${format.toUpperCase()} at ${fps} fps…`);
     try {
       const res = await client.nle.export(videoId, { format, fps });
@@ -52,13 +151,14 @@ export function NleExport({ videoId }: NleExportProps): React.ReactElement {
           ? `Exported ${res.clipCount} clip${res.clipCount === 1 ? '' : 's'}`
           : 'Exported an empty timeline (no approved clips yet)',
       );
+      await persistDefaults();
     } catch (err) {
       setError(errText(err));
       setStatus('');
     } finally {
       setBusy(false);
     }
-  }, [videoId, format, fps]);
+  }, [videoId, format, fps, persistDefaults]);
 
   // The "N clip(s) " prefix for the saved-path line. clipCount is always set
   // alongside lastPath by runExport, so the null arm is defensive only.
@@ -80,7 +180,10 @@ export function NleExport({ videoId }: NleExportProps): React.ReactElement {
           id="nle-format"
           value={format}
           disabled={busy}
-          onChange={(e) => setFormat(e.target.value as NleFormat)}
+          onChange={(e) => {
+            picked.current = true;
+            setFormat(e.target.value as NleFormat);
+          }}
         >
           {FORMATS.map((f) => (
             <option key={f.value} value={f.value}>
@@ -96,7 +199,10 @@ export function NleExport({ videoId }: NleExportProps): React.ReactElement {
           id="nle-fps"
           value={fps}
           disabled={busy}
-          onChange={(e) => setFps(Number(e.target.value) as NleFps)}
+          onChange={(e) => {
+            picked.current = true;
+            setFps(Number(e.target.value) as NleFps);
+          }}
         >
           {FPS_CHOICES.map((f) => (
             <option key={f} value={f}>
@@ -112,12 +218,25 @@ export function NleExport({ videoId }: NleExportProps): React.ReactElement {
         </button>
       </div>
 
-      {status && !error && <p className="status">{status}</p>}
-      {lastPath && (
-        <p className="export-path">
-          Saved {savedClipPrefix}to <code>{lastPath}</code>
-        </p>
-      )}
+      {/*
+        Always mounted, even while empty: a live region inserted together with
+        its text is not reliably announced (components/ToastHost.tsx). Both class
+        names are load-bearing — the unit tests and the e2e locator
+        `.export-path code` (app/e2e/preview.spec.ts) select them. No CSS is
+        needed: `.feature-panel .status` / `.feature-panel .export-path` are
+        DESCENDANT selectors (components/shell.css) and `.feature-panel` is plain
+        block flow with no `gap`, so an empty wrapper adds nothing.
+      */}
+      <div className="nle-live" role="status" aria-live="polite">
+        {status && !error && <p className="status">{status}</p>}
+        {lastPath && (
+          <p className="export-path">
+            Saved {savedClipPrefix}to <code>{lastPath}</code>
+          </p>
+        )}
+      </div>
+      {/* The failure branch stays OUTSIDE: `role="alert"` is assertive, and
+          nesting it here would announce one failure twice. */}
       {error && (
         <p className="error" role="alert">
           {error}

--- a/app/renderer/src/features/ShortMaker.test.tsx
+++ b/app/renderer/src/features/ShortMaker.test.tsx
@@ -1675,6 +1675,81 @@ describe('<ShortMaker /> component', () => {
     );
   });
 
+  // -------------------------------------------------------------------------
+  // F45 — the host surface's caption POSITION / subtitle DELIVERY / OVERRIDE.
+  // Both export call sites (review + unattended batch) have their own
+  // useCallback, so each one is pinned separately: forwarding at only one seam
+  // was the shape of the original defect.
+  // -------------------------------------------------------------------------
+
+  const OUTPUT_SLICE = {
+    captionPosition: { x: 0.1, y: 0.06, w: 0.8, h: 0.16 },
+    subtitleMode: 'sidecar' as const,
+    captionOverride: { uppercase: true },
+  };
+
+  it('forwards the host `output` slice into the REVIEW-path export params (F45)', async () => {
+    const rpc = rpcFake({
+      'tracks.audio.list': { audioTracks: [] },
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': { clips: [{ path: '/out/1.mp4' }] },
+    });
+    render(<ShortMaker videoId="v1" api={makeApi({ rpc })} output={OUTPUT_SLICE} />);
+    await submitForm();
+
+    const row = container.querySelector('.sm-candidate[data-id="1@97"]')!;
+    act(() => (row.querySelector('[aria-label="Approve"]') as HTMLButtonElement).click());
+    const exportBtn = [...container.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Export approved',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      exportBtn.click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(rpc).toHaveBeenCalledWith(
+      'shortmaker.export',
+      expect.objectContaining({
+        videoId: 'v1',
+        captionPosition: OUTPUT_SLICE.captionPosition,
+        subtitleMode: 'sidecar',
+        captionOverride: { uppercase: true },
+      }),
+    );
+  });
+
+  it('forwards the host `output` slice into the BATCH export params too (F45)', async () => {
+    const rpc = rpcFake({
+      'tracks.audio.list': { audioTracks: [] },
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': { clips: [{ path: '/out/1.mp4' }] },
+    });
+    render(
+      <ShortMaker
+        videoId="v1"
+        api={makeApi({ rpc })}
+        initialControls={{ count: 1 }}
+        output={OUTPUT_SLICE}
+      />,
+    );
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+
+    expect(rpc).toHaveBeenCalledWith(
+      'shortmaker.export',
+      expect.objectContaining({
+        videoId: 'v1',
+        captionPosition: OUTPUT_SLICE.captionPosition,
+        subtitleMode: 'sidecar',
+        captionOverride: { uppercase: true },
+      }),
+    );
+  });
+
   it('seeds the emphasis control from the per-style default when the caption style changes (P4 §8a)', async () => {
     const rpc = rpcFake({
       'tracks.audio.list': { audioTracks: [] },

--- a/app/renderer/src/features/ShortMaker.tsx
+++ b/app/renderer/src/features/ShortMaker.tsx
@@ -99,6 +99,7 @@ import {
   type PlatformPreset,
   type PlatformPresetId,
   type BrandSettings,
+  type ExportOutputOptions,
   PLATFORM_PRESETS,
   PLATFORM_PRESET_IDS,
   EMPTY_BRAND_SETTINGS,
@@ -120,6 +121,7 @@ export {
   type PlatformPreset,
   type PlatformPresetId,
   type BrandSettings,
+  type ExportOutputOptions,
   PLATFORM_PRESETS,
   PLATFORM_PRESET_IDS,
   EMPTY_BRAND_SETTINGS,
@@ -145,6 +147,15 @@ export interface ShortMakerProps {
    * re-opens the Short-maker primed. Optional — absent in standalone tests.
    */
   onReexport?: (hint: ShortReexportHint) => void;
+  /**
+   * F45 / P4 §4 — the caption POSITION box + the subtitle DELIVERY mode + the
+   * V1.1 caption OVERRIDE chosen on the HOST surface (Make Shorts' caption editor
+   * and Output Tray). Forwarded verbatim to `buildExportParams` at BOTH export
+   * call sites (review and unattended batch). Read at export time, not at mount,
+   * so a mid-session change is honoured. Omitted (standalone/tests) => the export
+   * payload carries none of those keys, exactly as before.
+   */
+  output?: ExportOutputOptions;
 }
 
 type Phase = 'idle' | 'selecting' | 'reviewing' | 'exporting';
@@ -154,6 +165,9 @@ export function ShortMaker({
   api,
   initialControls,
   onReexport,
+  // NOT defaulted to `{}` on purpose: `buildExportParams`'s own `output = {}`
+  // default already tolerates `undefined`, so leaving it undefined adds no branch.
+  output,
 }: ShortMakerProps): React.JSX.Element {
   const resolvedApi: Api = api ?? (resolveWindowApi() as Api);
 
@@ -648,7 +662,9 @@ export function ShortMaker({
       // captionStyle/reframeEngine already do (frozen P3 mini-contract).
       const res = await resolvedApi.rpc<ExportResult | JobHandle>(
         'shortmaker.export',
-        buildExportParams(videoId, approvedCandidates(items), clean, audioTrackId),
+        // F45: `output` carries the host surface's caption position + subtitle
+        // delivery + override. Without it the AI path silently dropped all three.
+        buildExportParams(videoId, approvedCandidates(items), clean, audioTrackId, output),
       );
       let clips = extractClips(res);
       if (clips === null && isJobHandle(res)) {
@@ -690,7 +706,7 @@ export function ShortMaker({
       abortRef.current = null;
       setProgress(null);
     }
-  }, [resolvedApi, busy, items, videoId, controls, audioTrackId, reloadVideoShorts]);
+  }, [resolvedApi, busy, items, videoId, controls, audioTrackId, output, reloadVideoShorts]);
 
   // ---- P4 §8c: unattended batch "Make N" ----------------------------------
   // Runs the existing RPC flow end-to-end with no manual review:
@@ -743,7 +759,8 @@ export function ShortMaker({
       setProgress({ jobId: '', pct: 0, message: `Exporting ${top.length} clips…` });
       const expRes = await resolvedApi.rpc<ExportResult | JobHandle>(
         'shortmaker.export',
-        buildExportParams(videoId, top, clean, audioTrackId),
+        // F45: same `output` slice as the review path (see runExport).
+        buildExportParams(videoId, top, clean, audioTrackId, output),
       );
       const clips = await resolveJobResult(
         resolvedApi,
@@ -770,7 +787,7 @@ export function ShortMaker({
       abortRef.current = null;
       setProgress(null);
     }
-  }, [resolvedApi, busy, videoId, prompt, controls, audioTrackId, reloadVideoShorts]);
+  }, [resolvedApi, busy, videoId, prompt, controls, audioTrackId, output, reloadVideoShorts]);
 
   // F2: abort any in-flight job.done wait (cancel/unmount) so the wait rejects
   // with JobAbortedError and its subscription/timer tear down instead of leaking.

--- a/app/renderer/src/features/manualIntervalLogic.test.ts
+++ b/app/renderer/src/features/manualIntervalLogic.test.ts
@@ -60,6 +60,16 @@ describe('intervalToCandidate', () => {
     expect(c.end).toBe(250);
     expect(c.durationSec).toBe(167);
   });
+
+  // F05: a NON-EMPTY hook is BURNED into the exported pixels by the sidecar
+  // caption stage (shortmaker.py `hook_title = hook_text or None` -> caption.py
+  // HookCard for ranks 1-10 / plain HookTitle otherwise) AND is persisted as the
+  // clip's gallery label in <clip>.json. A raw time range has no user-authored
+  // headline, so the manual path must emit NO hook text — never a placeholder.
+  it('emits NO hook text for a manual range (a non-empty hook is burned into the pixels)', () => {
+    expect(intervalToCandidate(10, 40, 1).hook).toBe('');
+    expect(intervalToCandidate(83, 250, 2).hook).toBe('');
+  });
 });
 
 describe('buildManualCandidates', () => {
@@ -74,5 +84,14 @@ describe('buildManualCandidates', () => {
 
   it('returns an empty list for no ranges', () => {
     expect(buildManualCandidates([])).toEqual([]);
+  });
+
+  // F05: every manual candidate, at every rank, carries an empty hook.
+  it('emits an empty hook for every ranked range', () => {
+    const cands = buildManualCandidates([
+      { start: 10, end: 40 },
+      { start: 60, end: 90 },
+    ]);
+    expect(cands.map((c) => c.hook)).toEqual(['', '']);
   });
 });

--- a/app/renderer/src/features/manualIntervalLogic.ts
+++ b/app/renderer/src/features/manualIntervalLogic.ts
@@ -46,7 +46,20 @@ export function formatTimecode(sec: number): string {
   return `${m}:${ss}`;
 }
 
-/** Build one export Candidate for a manual range (source-anchored, given rank). */
+/**
+ * Build one export Candidate for a manual range (source-anchored, given rank).
+ *
+ * F05 — `hook` MUST stay EMPTY on this path. A non-empty hook is not renderer
+ * metadata: it is BURNED into the exported pixels by the sidecar caption stage
+ * (`shortmaker.py` `hook_title = hook_text or None` -> `caption.py`, as the
+ * OpusClip HookCard for ranks 1-10 and as the plain HookTitle headline
+ * otherwise) and it is persisted as the clip's gallery label in `<clip>.json`.
+ * A raw time range carries no user-authored headline, so the manual path must
+ * emit NO hook text — a placeholder like "Manual clip 1" would be hard-burned
+ * into the delivered short with no control on this surface to suppress it.
+ * Empty makes `hook_title` falsy sidecar-side, which drops BOTH the card and
+ * the headline. `why` is renderer-only and never burned.
+ */
 export function intervalToCandidate(start: number, end: number, rank: number): Candidate {
   return {
     rank,
@@ -54,7 +67,7 @@ export function intervalToCandidate(start: number, end: number, rank: number): C
     end,
     durationSec: end - start,
     sourceStart: start,
-    hook: `Manual clip ${rank}`,
+    hook: '',
     why: 'Manual interval',
     score: 0,
   };

--- a/app/renderer/src/views/MakeShorts.aiCaptionDefaults.ce.test.tsx
+++ b/app/renderer/src/views/MakeShorts.aiCaptionDefaults.ce.test.tsx
@@ -1,0 +1,243 @@
+// @vitest-environment jsdom
+//
+// F45 — the AI moment-pick export must carry the caption POSITION, the subtitle
+// DELIVERY mode and the V1.1 caption OVERRIDE, exactly like the manual path.
+//
+// Why a SEPARATE file: `MakeShorts.test.tsx` mocks `../features/ShortMaker`
+// module-wide, so it cannot see what the real AI flow actually puts on the wire.
+// Here ShortMaker is REAL — only `../lib/rpc` and `../components/CaptionDesigner`
+// are mocked — so the assertions are made at the `shortmaker.export` RPC boundary
+// that the sidecar reads. MakeShorts passes no `api` prop, so ShortMaker resolves
+// the bridge through `resolveWindowApi()`; the `window.api` stub below is that
+// bridge.
+//
+// CONTRACT-NOTE (deliberate behaviour change, pinned by the third test):
+// `captionDesignWire` ALWAYS emits `captionPosition`, so after the fix EVERY AI
+// export sends a box — including the DEFAULT bottom band for a user who never
+// opened the caption editor. Sidecar-side that moves the libass margins from the
+// `position=None` defaults (alignment 2 / 40,40,115) to the default-box values
+// via `caption_position_fields`, which narrows the usable text width and can
+// change line wrapping. That is accepted deliberately: it converges the AI path
+// onto the manual path (which already sends the default box). AI-flow caption
+// visual baselines are expected to move.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Candidate, Video } from '../lib/rpc';
+import { DEFAULT_CAPTION_BOX, boxToWire } from '../lib/captionPosition';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const libraryListMock = vi.fn();
+const settingsGetMock = vi.fn();
+const exportMock = vi.fn();
+
+vi.mock('../lib/rpc', () => ({
+  hasApi: () => true,
+  client: {
+    library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    shortmaker: { export: (...a: unknown[]) => exportMock(...a) },
+    settings: { get: (...a: unknown[]) => settingsGetMock(...a) },
+  },
+}));
+
+vi.mock('../components/CaptionDesigner', () => ({
+  CaptionDesigner: ({ design }: { design: { style: string } }) => (
+    <div data-testid="caption-designer" data-style={design.style} />
+  ),
+}));
+
+import { MakeShorts } from './MakeShorts';
+
+/** A TOP band + a non-burn delivery — both DIFFERENT from the shipped defaults, so
+ *  the assertions cannot pass by coincidence. */
+const TOP_BAND = { x: 0.1, y: 0.06, w: 0.8, h: 0.16 };
+
+const AI_CANDIDATES: Candidate[] = [
+  {
+    rank: 1,
+    start: 10,
+    end: 40,
+    durationSec: 30,
+    sourceStart: 10,
+    hook: 'A real model-authored hook',
+    why: 'strong opener',
+    score: 0.9,
+    viralityPct: 95,
+  },
+  {
+    rank: 2,
+    start: 60,
+    end: 90,
+    durationSec: 30,
+    sourceStart: 60,
+    hook: 'Another hook',
+    why: 'punchline',
+    score: 0.5,
+    viralityPct: 40,
+  },
+];
+
+let container: HTMLDivElement;
+let root: Root;
+let rpc: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  libraryListMock.mockReset();
+  libraryListMock.mockResolvedValue({
+    videos: [
+      {
+        id: 'v1',
+        path: '/m/a.mp4',
+        title: 'Alpha',
+        addedAt: '2026-06-27T00:00:00Z',
+        durationSec: 100,
+        hasTranscript: false,
+      } satisfies Video,
+    ],
+  });
+  settingsGetMock.mockReset();
+  settingsGetMock.mockResolvedValue({});
+  exportMock.mockReset();
+  exportMock.mockResolvedValue({ clips: [] });
+
+  // Method-aware bridge fake: ShortMaker's mount fires tracks.audio.list,
+  // feedback.stats, settings.get (brand kit) and shorts.list, so an order-based
+  // mock would misfire — route by method name.
+  rpc = vi.fn(async (method: string) => {
+    if (method === 'tracks.audio.list') return { audioTracks: [] };
+    if (method === 'shortmaker.select') return { candidates: AI_CANDIDATES };
+    if (method === 'shortmaker.export') return { clips: [{ path: '/out/1.mp4' }] };
+    return {};
+  });
+  (globalThis as { window: { api?: unknown } }).window.api = {
+    rpc,
+    onProgress: () => () => {},
+  };
+
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+  delete (globalThis as { window: { api?: unknown } }).window.api;
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Mount MakeShorts, pick the source video, and await the preferences read so
+ *  the AI section (gated on `prefsLoaded`) is mounted with the seeded design. */
+async function mountWithVideo(): Promise<void> {
+  await act(async () => {
+    root.render(<MakeShorts />);
+  });
+  await flush();
+  const sel = container.querySelector('select[aria-label="Source video"]') as HTMLSelectElement;
+  await act(async () => {
+    sel.value = 'v1';
+    sel.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+  await flush();
+}
+
+function exportParams(): Record<string, unknown> {
+  const call = rpc.mock.calls.find((c) => c[0] === 'shortmaker.export');
+  if (!call) throw new Error('shortmaker.export was never called');
+  return call[1] as Record<string, unknown>;
+}
+
+/** Find clips -> approve rank 1 -> Export approved (the review call site). */
+async function driveApproveExport(): Promise<void> {
+  const form = container.querySelector('form') as HTMLFormElement;
+  await act(async () => {
+    form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    await Promise.resolve();
+  });
+  await flush();
+  const row = container.querySelector('.sm-candidate[data-id="1@10"]') as HTMLElement;
+  act(() => (row.querySelector('[aria-label="Approve"]') as HTMLButtonElement).click());
+  const exportBtn = [...container.querySelectorAll('button')].find(
+    (b) => b.textContent === 'Export approved',
+  ) as HTMLButtonElement;
+  await act(async () => {
+    exportBtn.click();
+    await Promise.resolve();
+  });
+  await flush();
+}
+
+/** "Make N shorts" — the unattended batch call site (a separate useCallback). */
+async function driveBatch(): Promise<void> {
+  const batchBtn = container.querySelector('[aria-label="Make N shorts"]') as HTMLButtonElement;
+  await act(async () => {
+    batchBtn.click();
+    await Promise.resolve();
+  });
+  await flush();
+}
+
+describe('<MakeShorts /> AI export caption defaults (F45)', () => {
+  it('threads the caption position + subtitle delivery into the review-path AI export', async () => {
+    settingsGetMock.mockResolvedValue({
+      defaultCaptionBox: TOP_BAND,
+      defaultSubtitleMode: 'sidecar',
+    });
+    await mountWithVideo();
+    await driveApproveExport();
+
+    // SETUP GUARD — passes TODAY, proving the harness reached the right RPC with
+    // the right video. A failure below is therefore the defect, not a fixture.
+    expect(rpc).toHaveBeenCalledWith(
+      'shortmaker.export',
+      expect.objectContaining({ videoId: 'v1', captionStyle: expect.any(String) }),
+    );
+
+    // THE RED ASSERTIONS — neither key is present before the fix.
+    expect(exportParams()).toMatchObject({
+      subtitleMode: 'sidecar',
+      captionPosition: boxToWire(TOP_BAND),
+    });
+  });
+
+  it('threads them into the unattended batch AI export too (the second call site)', async () => {
+    settingsGetMock.mockResolvedValue({
+      defaultCaptionBox: TOP_BAND,
+      defaultSubtitleMode: 'sidecar',
+    });
+    await mountWithVideo();
+    await driveBatch();
+
+    expect(rpc).toHaveBeenCalledWith(
+      'shortmaker.export',
+      expect.objectContaining({ videoId: 'v1', captionStyle: expect.any(String) }),
+    );
+    expect(exportParams()).toMatchObject({
+      subtitleMode: 'sidecar',
+      captionPosition: boxToWire(TOP_BAND),
+    });
+  });
+
+  it('sends the DEFAULT caption box on an out-of-box AI export (an explicit layout change)', async () => {
+    // Nothing persisted: the built-in defaults. This pins the deliberate
+    // behaviour change described in the CONTRACT-NOTE above — the AI path now
+    // sends the default bottom band instead of omitting the position entirely,
+    // which converges it onto the manual path.
+    settingsGetMock.mockResolvedValue({});
+    await mountWithVideo();
+    await driveApproveExport();
+
+    expect(exportParams()).toMatchObject({
+      subtitleMode: 'burn',
+      captionPosition: boxToWire(DEFAULT_CAPTION_BOX),
+    });
+  });
+});

--- a/app/renderer/src/views/MakeShorts.manualHook.test.tsx
+++ b/app/renderer/src/views/MakeShorts.manualHook.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+//
+// F05 regression at the REAL IPC boundary — the manual path must never send a
+// fabricated hook.
+//
+// Why a SEPARATE file: `MakeShorts.test.tsx` mocks `../features/ManualInterval`
+// module-wide and its mock hardcodes `hook: ''`, so that suite stays green even
+// if the placeholder were reintroduced in `manualIntervalLogic.ts`. This file
+// deliberately does NOT mock ManualInterval — it drives the real control (type a
+// range, Add range, Make shorts from ranges) so the candidates that reach
+// `client.shortmaker.export` are the ones `buildManualCandidates` actually built.
+//
+// A non-empty `hook` is BURNED into the exported pixels by the sidecar caption
+// stage (`shortmaker.py` `hook_title = hook_text or None` -> `caption.py`
+// HookCard for ranks 1-10 / plain HookTitle otherwise) and is persisted as the
+// clip's gallery label in `<clip>.json`. The remaining five child mocks are
+// re-declared here so the real CaptionDesigner/Player tree is not pulled into
+// jsdom.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import type { Candidate, Video } from '../lib/rpc';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const libraryListMock = vi.fn();
+const exportMock = vi.fn();
+const settingsGetMock = vi.fn();
+
+vi.mock('../lib/rpc', () => ({
+  hasApi: () => true,
+  client: {
+    library: { list: (...a: unknown[]) => libraryListMock(...a) },
+    shortmaker: { export: (...a: unknown[]) => exportMock(...a) },
+    settings: { get: (...a: unknown[]) => settingsGetMock(...a) },
+  },
+}));
+
+vi.mock('../components/CaptionDesigner', () => ({
+  CaptionDesigner: ({ design }: { design: { style: string } }) => (
+    <div data-testid="caption-designer" data-style={design.style} />
+  ),
+}));
+
+vi.mock('./Shorts', () => ({
+  Shorts: () => <div data-testid="shorts" />,
+}));
+
+vi.mock('./Repurpose', () => ({
+  Repurpose: () => <div data-testid="repurpose" />,
+}));
+
+vi.mock('../features/ShortMaker', () => ({
+  ShortMaker: ({ videoId }: { videoId: string }) => (
+    <div data-testid="shortmaker" data-video-id={videoId} />
+  ),
+}));
+
+vi.mock('../components/OutputTray', () => {
+  // Self-contained (vi.mock is hoisted — no top-level refs allowed).
+  const seed = {
+    caption: true,
+    translate: false,
+    reframe: true,
+    subtitleMode: 'burn',
+    language: 'en',
+  };
+  return {
+    DEFAULT_OUTPUT_TRAY: seed,
+    OutputTray: () => <div data-testid="output-tray" />,
+  };
+});
+
+// NOTE: `../features/ManualInterval` is deliberately NOT mocked.
+import { MakeShorts } from './MakeShorts';
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  libraryListMock.mockReset();
+  libraryListMock.mockResolvedValue({
+    videos: [
+      {
+        id: 'v1',
+        path: '/m/a.mp4',
+        title: 'Alpha',
+        addedAt: '2026-06-27T00:00:00Z',
+        durationSec: 100,
+        hasTranscript: false,
+      } satisfies Video,
+    ],
+  });
+  exportMock.mockReset();
+  exportMock.mockResolvedValue({ clips: [{ path: '/out/1.mp4' }] });
+  settingsGetMock.mockReset();
+  settingsGetMock.mockResolvedValue({});
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+  vi.restoreAllMocks();
+});
+
+async function flush(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function button(text: string): HTMLButtonElement {
+  const found = [...container.querySelectorAll('button')].find((b) => b.textContent === text);
+  if (!found) throw new Error(`button "${text}" not found`);
+  return found;
+}
+
+function typeInto(label: string, value: string): void {
+  const el = container.querySelector(`input[aria-label="${label}"]`) as HTMLInputElement;
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+  act(() => {
+    setter.call(el, value);
+    el.dispatchEvent(new Event('input', { bubbles: true }));
+  });
+}
+
+async function addRange(start: string, end: string): Promise<void> {
+  typeInto('Range start', start);
+  typeInto('Range end', end);
+  await act(async () => {
+    button('Add range').click();
+  });
+}
+
+describe('<MakeShorts /> manual export — real ManualInterval (F05)', () => {
+  async function driveTwoRanges(): Promise<void> {
+    await act(async () => {
+      root.render(<MakeShorts />);
+    });
+    await flush();
+    const sel = container.querySelector('select[aria-label="Source video"]') as HTMLSelectElement;
+    await act(async () => {
+      sel.value = 'v1';
+      sel.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+    await addRange('0:10', '0:40');
+    await addRange('1:00', '1:30');
+    await act(async () => {
+      button('Make shorts from ranges').click();
+      await Promise.resolve();
+    });
+    await flush();
+  }
+
+  it('sends NO hook text for manual ranges (a non-empty hook is burned into the pixels)', async () => {
+    await driveTwoRanges();
+
+    // SETUP GUARD — proves the harness actually reached the export RPC with the
+    // real control's candidates. This passes both before and after the fix, so a
+    // failure below is the defect and not a broken fixture.
+    expect(exportMock).toHaveBeenCalledTimes(1);
+    const [videoId, ids, params] = exportMock.mock.calls[0] as [
+      string,
+      string[],
+      { candidates: Candidate[] },
+    ];
+    expect(videoId).toBe('v1');
+    expect(ids).toEqual(['1@10', '2@60']);
+    expect(params.candidates).toHaveLength(2);
+
+    // THE ASSERTION — no candidate may carry a fabricated headline.
+    expect(params.candidates.map((c) => c.hook)).toEqual(['', '']);
+  });
+
+  it('keeps the manual ranges themselves intact (source-anchored, ranked)', async () => {
+    await driveTwoRanges();
+    const [, , params] = exportMock.mock.calls[0] as [
+      string,
+      string[],
+      { candidates: Candidate[] },
+    ];
+    expect(params.candidates.map((c) => [c.rank, c.sourceStart, c.end])).toEqual([
+      [1, 10, 40],
+      [2, 60, 90],
+    ]);
+  });
+});

--- a/app/renderer/src/views/MakeShorts.test.tsx
+++ b/app/renderer/src/views/MakeShorts.test.tsx
@@ -150,6 +150,19 @@ vi.mock('../components/OutputTray', () => {
         <button type="button" onClick={() => onChange({ ...seed, translate: true })}>
           tray-change
         </button>
+        {/* F08: mirrors what the REAL OutputTray emits when the "Caption"
+            checkbox is unchecked — `caption: false` with `subtitleMode` LEFT at
+            'burn' (OutputTray.tsx flips only the named key and simultaneously
+            hides the "Subtitle delivery" select). */}
+        <button type="button" onClick={() => onChange({ ...seed, caption: false })}>
+          tray-uncaption
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange({ ...seed, caption: true, subtitleMode: 'sidecar' })}
+        >
+          tray-recaption-sidecar
+        </button>
         <button type="button" onClick={() => onSaveShort?.()}>
           tray-save-short
         </button>
@@ -557,6 +570,50 @@ describe('<MakeShorts />', () => {
     expect(container.querySelector('.make-shorts__note')?.textContent).toContain(
       'Saved the SRT sidecar',
     );
+  });
+
+  // F08: the tray's "Caption" checkbox is the COARSE switch. Unchecking it must
+  // reach the export payload — 'none' is already a first-class subtitle mode the
+  // sidecar honours by skipping the whole caption stage. Before the fix
+  // `subtitleMode: tray.subtitleMode` was forwarded unconditionally, so the next
+  // export still HARD-BURNED captions into the pixels.
+  it('honours the tray Caption toggle on the NEXT manual export', async () => {
+    await mount();
+    await selectVideo('v1');
+    await clickManualSubmit();
+    // PRECONDITION GUARD: the harness reaches the payload correctly today.
+    expect(exportMock).toHaveBeenCalledTimes(1);
+    expect(exportMock.mock.calls[0][2].subtitleMode).toBe('burn');
+
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'tray-uncaption',
+        ) as HTMLButtonElement
+      ).click();
+    });
+    await clickManualSubmit();
+
+    expect(exportMock).toHaveBeenCalledTimes(2);
+    expect(exportMock.mock.calls[1][2].subtitleMode).toBe('none');
+  });
+
+  // The true branch of the same expression: with Caption ON, a real delivery
+  // choice must still flow through untouched (the coarse switch must not clobber
+  // the fine-grained select).
+  it('keeps a real subtitle delivery choice when Caption stays checked', async () => {
+    await mount();
+    await selectVideo('v1');
+    await clickManualSubmit();
+    await act(async () => {
+      (
+        [...container.querySelectorAll('button')].find(
+          (b) => b.textContent === 'tray-recaption-sidecar',
+        ) as HTMLButtonElement
+      ).click();
+    });
+    await clickManualSubmit();
+    expect(exportMock.mock.calls[1][2].subtitleMode).toBe('sidecar');
   });
 
   it('swallows a library.list rejection (best-effort) and stays usable', async () => {

--- a/app/renderer/src/views/MakeShorts.tsx
+++ b/app/renderer/src/views/MakeShorts.tsx
@@ -12,7 +12,7 @@
 // Re-export from the gallery jumps to Make primed with the source video. The
 // heavy children own their own tests; this view owns the section routing +
 // video selection + the manual-export wiring.
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { TabBar, tabId, tabPanelId, type TabDef } from '../components/TabBar';
 import { Shorts } from './Shorts';
 import { Repurpose } from './Repurpose';
@@ -20,7 +20,7 @@ import { ShortMaker } from '../features/ShortMaker';
 import { ManualInterval } from '../features/ManualInterval';
 import { OutputTray, DEFAULT_OUTPUT_TRAY, type OutputTrayState } from '../components/OutputTray';
 import { CaptionDesigner } from '../components/CaptionDesigner';
-import { buildExportParams } from '../features/shortMakerPresets';
+import { buildExportParams, type ExportOutputOptions } from '../features/shortMakerPresets';
 import {
   candidateId,
   sanitizeControls,
@@ -145,6 +145,39 @@ export function MakeShorts({ resumeId, videoId }: MakeShortsProps): React.ReactE
   const handleSaveShort = useCallback(() => setManualNote('Saved the short.'), []);
   const handleSaveSrt = useCallback(() => setManualNote('Saved the SRT sidecar.'), []);
 
+  // The caption design's export slice (style id + wire-rounded position box +
+  // the optional V1.1 tuning patch), computed ONCE for every consumer: the
+  // manual export payload, the AI flow's `output` prop, and the AI flow's
+  // mount-time style seed. Recomputed only when the design changes.
+  const wire = useMemo(() => captionDesignWire(design), [design]);
+
+  // F08 — the Output Tray's "Caption" checkbox is the COARSE switch: unchecking
+  // it means "no captions at all", which the contract already expresses as the
+  // 'none' delivery mode (the sidecar skips the whole caption stage). The tray's
+  // own onChange flips only `caption` and hides the delivery select, so nothing
+  // else translates the intent — without this gate an explicit "captions off"
+  // was silently discarded and the next export HARD-BURNED them into the pixels.
+  //
+  // H6/F45 — this is deliberately ONE expression shared by BOTH export paths
+  // (the manual `buildExportParams` call below AND the AI flow's `output` prop).
+  // Gating only the manual path would leave the identical defect one seam over.
+  const subtitleMode = tray.caption ? tray.subtitleMode : 'none';
+
+  // F45 — the caption POSITION, the subtitle DELIVERY mode and the V1.1 caption
+  // OVERRIDE the user chose in this section. Both export paths send them; before
+  // this the AI/batch call sites omitted the whole slice, so a top/centre box, a
+  // soft-track/sidecar delivery and any override were dropped on the floor.
+  // Memoised so the AI flow's export/batch callbacks are not re-created on every
+  // render by a fresh object literal.
+  const exportOutput = useMemo<ExportOutputOptions>(
+    () => ({
+      captionPosition: wire.captionPosition,
+      subtitleMode,
+      captionOverride: wire.captionOverride,
+    }),
+    [wire, subtitleMode],
+  );
+
   // Manual export runs only from the ManualInterval control, which is rendered
   // ONLY once a video is selected (so `selectedId` is always set here, and the
   // video list is populated only when the preload bridge is present — no extra
@@ -158,16 +191,11 @@ export function MakeShorts({ resumeId, videoId }: MakeShortsProps): React.ReactE
       setTrayOpen(false);
       setManualBusy(true);
       try {
-        const wire = captionDesignWire(design);
         // The design's style flows via controls.captionStyle; the position +
         // subtitle delivery + the V1.1 within-template tuning patch flow via the
         // export output options (P4 §4 / V1.1 CaptionOverride).
         const controls = sanitizeControls({ captionStyle: wire.captionStyle });
-        const params = buildExportParams(selectedId, candidates, controls, '', {
-          captionPosition: wire.captionPosition,
-          subtitleMode: tray.subtitleMode,
-          captionOverride: wire.captionOverride,
-        });
+        const params = buildExportParams(selectedId, candidates, controls, '', exportOutput);
         const res = await client.shortmaker.export(selectedId, candidates.map(candidateId), params);
         // shortmaker.export is a DEFERRED job: the immediate resolution carries
         // only {jobId}; the exported clips (or a job.done ERROR) arrive later.
@@ -192,7 +220,13 @@ export function MakeShorts({ resumeId, videoId }: MakeShortsProps): React.ReactE
         setManualBusy(false);
       }
     },
-    [selectedId, design, tray.subtitleMode],
+    // `wire` + `exportOutput` are memoised, so listing them (rather than
+    // `design`/`tray.*`) keeps the callback fresh across a design change AND a
+    // tray Caption/delivery change. MANDATORY: `react-hooks/exhaustive-deps` is
+    // off in app/.oxlintrc.json, so a missing dep here is caught only by tests —
+    // and it would silently make the F08 gate above a no-op (the memoised
+    // callback would keep the pre-toggle binding).
+    [selectedId, wire, exportOutput],
   );
 
   return (
@@ -236,14 +270,19 @@ export function MakeShorts({ resumeId, videoId }: MakeShortsProps): React.ReactE
                     <h2 className="make-shorts__heading">AI moment-pick</h2>
                     {/* Seed the AI flow from the SAME persisted caption/language
                         default the manual path uses, so both agree (P4 §4). The
-                        wired caption-style value matches the manual export's. */}
+                        wired caption-style value matches the manual export's.
+                        F45: `output` carries the caption position + subtitle
+                        delivery + override into BOTH AI export call sites (review
+                        and unattended batch) — the same slice the manual path
+                        sends, so the two paths cannot diverge again. */}
                     <ShortMaker
                       videoId={selectedId}
                       onReexport={handleReexport}
                       initialControls={{
-                        captionStyle: captionDesignWire(design).captionStyle,
+                        captionStyle: wire.captionStyle,
                         language: tray.language,
                       }}
+                      output={exportOutput}
                     />
                   </section>
                 ) : null}

--- a/app/renderer/src/views/workspace.css
+++ b/app/renderer/src/views/workspace.css
@@ -145,7 +145,12 @@
   transform: rotate(90deg);
 }
 
-.tabbar--grouped .tabbar__advanced-panel {
+/* `:not([hidden])` is load-bearing, not cosmetic. TabBar renders this panel as
+   `<div className="tabbar__advanced-panel" hidden={!advancedOpen}>`, and an
+   author-origin `display` outranks the UA `[hidden] { display: none }` rule — so
+   an unscoped `display: flex` here keeps the collapsed cluster painted, making
+   the "Advanced" disclosure a no-op that also pushes Export off the strip. */
+.tabbar--grouped .tabbar__advanced-panel:not([hidden]) {
   display: flex;
   align-items: center;
   gap: var(--space-2);


### PR DESCRIPTION
Integration PR **D of 4** — the last one, and the group whose real validation is the **nightly e2e**, not this gate. Landing these four together makes exactly one nightly delta to interpret and keeps B20's CSS+spec pair atomic.

> **This PR must be followed by a manual `e2e.yml` dispatch.** Two of its batches change the behaviour of a single Playwright test, and one of them owns a visual-baseline re-record decision. Merging without the dispatch leaves the actual verdict unmeasured. Details in §"What the nightly must answer" below.

## Attribution

| batch | branch | findings | what it fixes |
|---|---|---|---|
| B19 | `fix/nle-export-defaults` | F28, F29 | the persisted `exportDefaults` were written but never read back; the outcome was never announced |
| B06 | `fix/shortmaker-export-params` | F05, F08, F45 | a **fabricated "Manual clip N" hook was burned into the pixels**; the Caption checkbox was ignored; caption output never reached the AI export |
| B08 | `fix/captionbox-pointer-events` | F22 | the caption frame swallowed the video's own controls |
| B20 | `fix/workspace-advanced-cluster` | F17 | the Advanced-cluster `display` rule was unscoped, so the disclosure **could never collapse** |

Merged `--no-ff` in that exact order — it is load-bearing, not cosmetic. B20 is last because it owns the baseline decision, and B19 must precede it because B20 rewrites the body of the same spec B19 changes the runtime behaviour of.

## B06/F05 is the most user-visible defect in the whole programme

Manual clip mode synthesised a hook string — literally `"Manual clip 1"` — and the export **burned it into the video**. Not a label in the UI: rasterised into the delivered file. `intervalToCandidate` now returns `hook: ''`, and the export honours the Caption checkbox instead of always burning.

## Plus one CI gate that was missing entirely

`app/tsconfig.json` deliberately excludes `e2e/**` (so Playwright types stay out of the renderer build) and the pre-commit `files:` regexes cover only `main|renderer/src|render-cli/src`. Net effect: **no blocking gate read `app/e2e/**` at all.** `app/package.json:20` already defined `typecheck:e2e`, and `git grep tsconfig.e2e` across `.github/` and both package.json files returned exactly one hit — the definition itself. Nothing invoked it.

Now wired as a blocking `gate-types tsc e2e harness` step, validated in **both** states first (a probe that is silent in the broken state measures nothing):

| state | result |
|---|---|
| clean tree | exit 0 |
| planted `const x: number = 'str'` in `e2e/overlay-hittest.spec.ts` | **exit 2**, `TS2322` at `264,7` |

This PR is the right home for it: B08 adds a spec and B20 edits one, so its own two files are the first the new gate covers.

## What the nightly must answer (and the two facts you should read before dispatching)

Both were measured, not inferred:

1. **The committed `workspace-preview-win32.png` baseline was captured from the broken state and is 50% flaky at HEAD** — 2 pass / 2 fail over 4 runs, failing delta 130,743 px = 13% against a `maxDiffPixelRatio: 0.01` tolerance. Six local `--update-snapshots=all` attempts under fan-out load *all* captured the degraded 1016×150 video box. **Do the re-record on the CI Windows runner, not this machine**, and verify the mask box reads 1016×**280** before accepting the artifact. Local font rasterisation and DPI differ from `windows-latest`.
2. **`Export` remains off-viewport at 1280 px** (x=1268 vs 1264) even with the cluster collapsed. B20 fixes the collapse; it does not fix the overflow. That is a separate, still-open finding.

Sequence for the dispatch: `gh run list` first (`e2e.yml` has `concurrency: cancel-in-progress: true`, so a second dispatch **kills** the first) → dispatch with `-f update_visual_baselines=true` → download the `updated-visual-baselines` artifact → check the mask geometry → commit.

## Honest residuals (disclosed, not closed)

1. **B19** — adds a live `settings.get` + `settings.set` to the currently-*passing* `preview.spec.ts:172`. The values written equal what is already on disk so it should be a no-op, but that is **UNVERIFIED**, and it is a new live write inside a spec B20 simultaneously rewrites. `busy` now stays true across two extra RPCs, so the button reads "Exporting…" slightly longer.
2. **B06** — position/override land for the **libass engine only**; the 14 Remotion styles ignore both and always burn, so `subtitleMode: 'softmux'` still degrades there. Unchecking "Caption" in the Output Tray now also sets the AI export's delivery to `'none'` (a deliberate coupling). Two sidecar characterisation tests were correctly *not* written — `sidecar/tests/test_caption.py` is in no batch's declared scope — which means a future sidecar change re-introducing a fallback headline would pass every test B06 ships. None of the 8 committed baselines captures burned captions, so the real exposure here is the golden journey, not a snapshot.
3. **B08** — cross-OS geometry (a 16 px sample point vs the resize-handle clearance) is **UNVERIFIED off Windows**; I'd put it at 75–85% likely to hold. The narrow fallback if it fails is dropping the single `toBeInViewport()` assertion. Adds ~50 s and one more Electron launch to a step that already exhibits relaunch flake.
4. **B20** — the two facts above. Also: the `workspace-preview` flake traces to an unwaited `<video>` poster race in `_visualSetup.ts`/`surfaces.visual.spec.ts`, a **pre-existing defect that no batch owns**.

## Local gate (on the merged tree)

- `uvx pre-commit run --all-files` → ruff lint, ruff format, oxlint, biome 2.5.0, gitleaks — **all Passed**
- `node app/node_modules/typescript/bin/tsc --noEmit` → **exit 0** *(local binary deliberately — a bare `npx tsc` in a tree without `node_modules` resolves a same-named public package that prints "This is not the tsc command you are looking for" and exits 0, so a clean exit there proves nothing)*
- `node app/node_modules/typescript/bin/tsc --noEmit -p tsconfig.e2e.json` → **exit 0** (the new gate)
- `npx vitest run --coverage` → **100% statements / branches / functions / lines** (19532 stmts, 6484 branches, 1151 fns)
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **100%, 6084 passed**
