### PR TITLE
fix(models,export): re-land the two rejected batches with their one defect each fixed (PR-E)

### DIFF
--- a/app/renderer/src/components/ReadinessBadge.tsx
+++ b/app/renderer/src/components/ReadinessBadge.tsx
@@ -25,6 +25,13 @@ export interface ReadinessBadgeProps {
   action?: ReadinessAction | null;
   /** Fired with the action when the fix button is clicked. */
   onAction?: (action: ReadinessAction) => void;
+  /**
+   * F36: the fix action is in flight. Disables the button (so a repeat click
+   * cannot stack a second multi-GB download job) and announces `aria-busy`. The
+   * accessible NAME is deliberately unchanged so the existing
+   * `readinessActionLabel` contract still holds while busy.
+   */
+  busy?: boolean;
 }
 
 export function ReadinessBadge({
@@ -33,6 +40,7 @@ export function ReadinessBadge({
   blockedBy,
   action,
   onAction,
+  busy,
 }: ReadinessBadgeProps): React.ReactElement {
   const title = [readinessHint(status), blockedBy].filter(Boolean).join(' ');
   return (
@@ -50,6 +58,8 @@ export function ReadinessBadge({
           type="button"
           className="readiness-badge__action"
           aria-label={readinessActionLabel(action, capabilityLabel)}
+          disabled={busy}
+          aria-busy={busy}
           onClick={() => onAction?.(action)}
         >
           {readinessActionLabel(action, capabilityLabel)}

--- a/app/renderer/src/components/ReadinessRollup.test.tsx
+++ b/app/renderer/src/components/ReadinessRollup.test.tsx
@@ -230,6 +230,180 @@ describe('<ReadinessRollup /> — WU-14 wiring', () => {
     expect(container.querySelector('.jobqueue__empty')).toBeNull();
   });
 
+  // ---- F36: the roll-up must re-read after its OWN fix action ---------------
+
+  it('disables + marks the action busy while the parent action is in flight (F36)', async () => {
+    const items = [
+      makeItem({
+        capability: 'vis',
+        label: 'Vision',
+        status: 'needsDownload',
+        action: { kind: 'assets.ensure', assets: ['saliency'] },
+      }),
+    ];
+    const rpcClient = makeClient(() => Promise.resolve({ items }));
+    await act(async () => {
+      // A never-settling parent promise keeps the action in flight.
+      root.render(
+        <ReadinessRollup rpcClient={rpcClient} onAction={() => new Promise<void>(() => {})} />,
+      );
+    });
+    await flush();
+    const btn = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    await act(async () => {
+      btn.click();
+    });
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute('aria-busy')).toBe('true');
+  });
+
+  it('re-reads readiness.summary after its own fix action resolves (F36)', async () => {
+    let call = 0;
+    const rpcClient = makeClient(() => {
+      call += 1;
+      return Promise.resolve({
+        items: [
+          makeItem({
+            capability: 'vis',
+            label: 'Vision',
+            status: call === 1 ? 'needsDownload' : 'ready',
+            action: call === 1 ? { kind: 'assets.ensure', assets: ['saliency'] } : null,
+          }),
+        ],
+      });
+    });
+    await act(async () => {
+      root.render(<ReadinessRollup rpcClient={rpcClient} onAction={() => Promise.resolve()} />);
+    });
+    await flush();
+    expect(container.querySelector('[data-readiness]')?.getAttribute('data-readiness')).toBe(
+      'needsDownload',
+    );
+    const btn = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    await flush();
+    // The badge reflects the POST-fix truth without leaving + re-entering the tab.
+    expect(container.querySelector('[data-readiness]')?.getAttribute('data-readiness')).toBe(
+      'ready',
+    );
+    expect(call).toBe(2);
+  });
+
+  it('clears busy and still re-reads when the parent action REJECTS (F36)', async () => {
+    let call = 0;
+    const rpcClient = makeClient(() => {
+      call += 1;
+      return Promise.resolve({
+        items: [
+          makeItem({
+            capability: 'vis',
+            label: 'Vision',
+            status: 'needsDownload',
+            action: { kind: 'assets.ensure', assets: ['saliency'] },
+          }),
+        ],
+      });
+    });
+    await act(async () => {
+      root.render(
+        <ReadinessRollup
+          rpcClient={rpcClient}
+          onAction={() => Promise.reject(new Error('ensure blew up'))}
+        />,
+      );
+    });
+    await flush();
+    const btn = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    await flush();
+    const after = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    expect(after.disabled).toBe(false);
+    expect(after.getAttribute('aria-busy')).toBe('false');
+    // The parent owns its own error surface; the roll-up must not invent one.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(call).toBe(2);
+  });
+
+  it('does NOT busy-flash or re-read for navigation-only action kinds (F36)', async () => {
+    let call = 0;
+    const kinds: ReadinessAction[] = [{ kind: 'openProviders' }, { kind: 'setConsent' }];
+    for (const action of kinds) {
+      const rpcClient = makeClient(() => {
+        call += 1;
+        return Promise.resolve({
+          items: [makeItem({ capability: 'x', label: 'Translation', status: 'needsKey', action })],
+        });
+      });
+      const seen: ReadinessAction[] = [];
+      await act(async () => {
+        root.render(<ReadinessRollup rpcClient={rpcClient} onAction={(a) => void seen.push(a)} />);
+      });
+      await flush();
+      const before = call;
+      const btn = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+      await act(async () => {
+        btn.click();
+      });
+      await flush();
+      // Forwarded, but these NAVIGATE AWAY (Settings.goTo unmounts this tree) —
+      // a refresh there is a wasted RPC on a dying tree, and the busy flash lies.
+      expect(seen).toEqual([action]);
+      expect(call).toBe(before);
+      expect(btn.disabled).toBe(false);
+      await act(async () => {
+        root.unmount();
+      });
+      root = createRoot(container);
+    }
+  });
+
+  it('drops a post-action refresh after unmount (no setState on a dead tree)', async () => {
+    let release: (() => void) | undefined;
+    let call = 0;
+    const rpcClient = makeClient(() => {
+      call += 1;
+      return Promise.resolve({
+        items: [
+          makeItem({
+            capability: 'vis',
+            label: 'Vision',
+            status: 'needsDownload',
+            action: { kind: 'assets.ensure', assets: ['saliency'] },
+          }),
+        ],
+      });
+    });
+    await act(async () => {
+      root.render(
+        <ReadinessRollup
+          rpcClient={rpcClient}
+          onAction={() => new Promise<void>((res) => void (release = () => res()))}
+        />,
+      );
+    });
+    await flush();
+    const btn = container.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+    });
+    const callsAtUnmount = call;
+    await act(async () => {
+      root.unmount();
+    });
+    await act(async () => {
+      release?.();
+      await Promise.resolve();
+    });
+    // The alive guard drops both the setPending and the refetch.
+    expect(call).toBe(callsAtUnmount);
+    root = createRoot(container);
+  });
+
   it('ignores a late resolve after unmount (no state update warning)', async () => {
     let resolve: (v: { items: ReadinessItem[] }) => void = () => {};
     const rpcClient = makeClient(

--- a/app/renderer/src/components/ReadinessRollup.tsx
+++ b/app/renderer/src/components/ReadinessRollup.tsx
@@ -11,7 +11,7 @@
 // inline alert — it never blocks the host panel. Actions are forwarded to the
 // parent via `onAction` (the parent owns navigation to the providers/assets
 // flows), keeping this component a thin, side-effect-free consumer.
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { client, type ReadinessAction, type ReadinessItem } from '../lib/rpc';
 import { ReadinessBadge } from './ReadinessBadge';
 import './readinessBadge.css';
@@ -26,8 +26,26 @@ export interface ReadinessRollupProps {
   rpcClient?: Pick<typeof client, 'readiness'>;
   /** Section heading; defaults to a neutral label both hosts can reuse. */
   title?: string;
-  /** Fired when a badge's fix action is clicked (parent owns the routing). */
-  onAction?: (action: ReadinessAction) => void;
+  /**
+   * Fired when a badge's fix action is clicked (parent owns the routing).
+   *
+   * F36: may return a Promise. When it does, the roll-up marks that capability's
+   * button busy for the whole action and RE-READS `readiness.summary` when it
+   * settles — otherwise the badge kept displaying the pre-fix status for the rest
+   * of the mount (the only cure was leaving and re-entering the sub-tab).
+   */
+  onAction?: (action: ReadinessAction) => void | Promise<void>;
+}
+
+/**
+ * F36: action kinds that NAVIGATE AWAY instead of fixing anything in place.
+ * `ModelsSystemPanel.handleReadinessAction` returns early for these and calls
+ * `onOpenProviders()`, which routes to another Settings section and UNMOUNTS this
+ * tree — so a busy flash and a post-action refetch there would be a lie plus a
+ * wasted RPC on a dying tree.
+ */
+function navigatesAway(action: ReadinessAction): boolean {
+  return action.kind === 'openProviders' || action.kind === 'setConsent';
 }
 
 export function ReadinessRollup({
@@ -39,11 +57,17 @@ export function ReadinessRollup({
   const api = rpcClient ?? client;
   const [items, setItems] = useState<ReadinessItem[] | null>(null);
   const [error, setError] = useState<string>('');
+  // F36: the capability whose fix action is in flight (drives the badge's busy).
+  const [pending, setPending] = useState<string | null>(null);
+  // F36: liveness as a REF, not the mount effect's closure — the post-action
+  // refresh outlives that closure (an `assets.ensure` job can run for minutes),
+  // so it needs a guard the unmount actually flips for it too.
+  const aliveRef = useRef<boolean>(true);
 
-  useEffect(() => {
-    let alive = true;
-    setError('');
-    setItems(null);
+  // F36: extracted so BOTH the mount effect and the post-action path re-read it.
+  // It deliberately does NOT reset `items` to null — keeping the previous rows
+  // visible stops the refresh flashing the "Checking what's ready…" skeleton.
+  const load = useCallback((): void => {
     // WU2 resilience: the bridge access is EAGER — `api.readiness.summary()`
     // reaches through the preload bridge, which throws SYNCHRONOUSLY when
     // window.api is missing (before Promise.resolve can wrap it, so `.catch`
@@ -52,18 +76,49 @@ export function ReadinessRollup({
     try {
       Promise.resolve(api.readiness.summary())
         .then((res) => {
-          if (alive) setItems(Array.isArray(res?.items) ? res.items : []);
+          if (aliveRef.current) setItems(Array.isArray(res?.items) ? res.items : []);
         })
         .catch((err: unknown) => {
-          if (alive) setError(errText(err));
+          if (aliveRef.current) setError(errText(err));
         });
     } catch (err) {
       setError(errText(err));
     }
-    return () => {
-      alive = false;
-    };
   }, [api]);
+
+  useEffect(() => {
+    aliveRef.current = true;
+    setError('');
+    setItems(null);
+    load();
+    return () => {
+      aliveRef.current = false;
+    };
+  }, [load]);
+
+  // F36: forward the action, hold the button busy for its whole duration, then
+  // re-read the summary so the badge shows the POST-fix truth in place.
+  const runAction = useCallback(
+    (action: ReadinessAction, capability: string): void => {
+      if (navigatesAway(action)) {
+        onAction?.(action);
+        return;
+      }
+      setPending(capability);
+      Promise.resolve(onAction?.(action))
+        // The PARENT owns the failure surface (it sets its own `error`); the
+        // roll-up must not invent a second one. It still refreshes, because a
+        // partially-successful ensure can legitimately change readiness.
+        .catch(() => undefined)
+        .finally(() => {
+          if (aliveRef.current) {
+            setPending(null);
+            load();
+          }
+        });
+    },
+    [load, onAction],
+  );
 
   return (
     <section className="readiness-rollup" aria-label={title}>
@@ -90,7 +145,8 @@ export function ReadinessRollup({
                 capabilityLabel={item.label}
                 blockedBy={item.blockedBy || undefined}
                 action={item.action}
-                onAction={onAction}
+                onAction={(action) => runAction(action, item.capability)}
+                busy={pending === item.capability}
               />
             </li>
           ))}

--- a/app/renderer/src/components/RoutingOverrideTable.test.tsx
+++ b/app/renderer/src/components/RoutingOverrideTable.test.tsx
@@ -54,18 +54,22 @@ describe('RoutingOverrideTable', () => {
     expect(sel('select').value).toBe('cloud');
   });
 
-  it('persists a concrete override with the current global preserved', () => {
+  it('persists ONLY the overrides half (never its own global)', () => {
     const onApply = vi.fn();
     mount({ policy: { global: 'auto', overrides: {} }, onApply });
     setValue(sel('select'), 'cloud');
-    expect(onApply).toHaveBeenCalledWith({ global: 'auto', overrides: { select: 'cloud' } });
+    // F35: `policy.global` here is the PANEL's snapshot, written only by analyze()
+    // and by this table's own write — the header toggle is separate state, so the
+    // snapshot goes stale the moment the user clicks it. Re-sending it made every
+    // row edit revert the header. The table owns `overrides` and sends that alone.
+    expect(onApply).toHaveBeenCalledWith({ overrides: { select: 'cloud' } });
   });
 
-  it('inherit removes the override (sends the trimmed map)', () => {
+  it('inherit removes the override (sends the trimmed map, still no global)', () => {
     const onApply = vi.fn();
     mount({ policy: { global: 'local', overrides: { select: 'cloud' } }, onApply });
     setValue(sel('select'), 'inherit');
-    expect(onApply).toHaveBeenCalledWith({ global: 'local', overrides: {} });
+    expect(onApply).toHaveBeenCalledWith({ overrides: {} });
   });
 
   it('shows an egress badge only for cloud/auto rows', () => {

--- a/app/renderer/src/components/RoutingOverrideTable.tsx
+++ b/app/renderer/src/components/RoutingOverrideTable.tsx
@@ -3,10 +3,19 @@
 // The per-function half of the single `RoutingPolicy` (DESIGN §2.1/§2.4): the
 // header `RoutingToggle` sets `global`; this table sets `overrides[fn]`. Each row
 // is a `<select>` of Global default / Local / Cloud / Auto. Choosing "Global
-// default" REMOVES the override (the function inherits the global mode). On any
-// change it persists the WHOLE policy ({global, overrides}) via `onApply` — the
-// sidecar `setRoutingPolicy` write is a full replace, so we always send `global`
-// too (never clobber it to the local default).
+// default" REMOVES the override (the function inherits the global mode).
+//
+// F35: on change it persists ONLY the `overrides` half via `onApply` — never its
+// own `global`. The `policy` prop is the PANEL's snapshot (written by analyze()
+// and by this table's own write); the header toggle is separate App state, so the
+// snapshot is stale the moment the user clicks the header, and re-sending it
+// silently reverted the header on every row edit. The sidecar write is now a
+// per-half PATCH (`routing_policy.merge_routing_policy`), so an omitted `global`
+// INHERITS the persisted value instead of clamping to the local default.
+//
+// RESIDUAL (F35, disclosed): this cures the PERSISTENCE clobber, not the DISPLAY
+// staleness. `policy.global` still only refreshes when the panel writes, so the
+// intro line below can keep naming the pre-click mode until the next row edit.
 import React from 'react';
 import type { RoutingMode, RoutingPolicy } from '../lib/rpc';
 import {
@@ -23,8 +32,8 @@ import {
 export interface RoutingOverrideTableProps {
   /** The current persisted policy (from `models.overview` -> routingPolicy). */
   policy: RoutingPolicy;
-  /** Persist the FULL edited policy ({global, overrides}); the parent writes it. */
-  onApply: (policy: RoutingPolicy) => void;
+  /** Persist the `overrides` half ONLY (F35); the sidecar patches it per half. */
+  onApply: (patch: { overrides: Record<string, RoutingMode> }) => void;
   /** Disable every control while a write is in flight. */
   busy?: boolean;
 }
@@ -37,7 +46,7 @@ export function RoutingOverrideTable({
   const overrides: Record<string, RoutingMode> = policy.overrides ?? {};
 
   const change = (fn: AiFunction, choice: OverrideChoice): void => {
-    onApply({ global: policy.global, overrides: applyOverrideChoice(overrides, fn, choice) });
+    onApply({ overrides: applyOverrideChoice(overrides, fn, choice) });
   };
 
   return (

--- a/app/renderer/src/features/export/ExportResult.test.tsx
+++ b/app/renderer/src/features/export/ExportResult.test.tsx
@@ -86,12 +86,15 @@ describe('ExportResult', () => {
     expect(onExportAgain).toHaveBeenCalledTimes(1);
   });
 
-  it('CANCEL states plainly that no file was written and announces via role=status', () => {
+  it('CANCEL warns that a partial file may remain and announces via role=status', () => {
     render({ outcome: 'cancelled' });
     expect(q('.export-result')?.className).toContain('is-cancelled');
     expect(q('.export-result__title')?.textContent).toBe('Export cancelled');
     const blurb = q('.export-result__blurb');
-    expect(blurb?.textContent).toBe('No file was written.');
+    // ffmpeg runs with `-y` (sidecar/media_studio/ffmpeg.py:160) and is killed
+    // mid-write on cancel (:320-322) with nothing unlinking the partial, so
+    // promising a clean no-op would be false.
+    expect(blurb?.textContent).toBe('Cancelled mid-render — a partial file may remain.');
     // The terminal cancel reaches SR users through a polite live region (not just visually).
     expect(blurb?.getAttribute('role')).toBe('status');
     expect(q('.export-result__error')).toBeNull();

--- a/app/renderer/src/features/export/ExportResult.tsx
+++ b/app/renderer/src/features/export/ExportResult.tsx
@@ -7,6 +7,11 @@
 // and CANCEL announce their terminal outcome through a polite `role="status"` live
 // region so completion reaches SR users too. Status is text + a green/amber/red
 // edge, never hue alone. Controlled + presentational.
+//
+// CANCEL deliberately does NOT promise a clean no-op: ffmpeg is spawned with `-y`
+// (`sidecar/media_studio/ffmpeg.py:160`) and killed mid-write on cancel (`:320-322`),
+// and nothing in `convert.py`/`jobs.py` unlinks the partial output — so a partial
+// file remains and anything previously at that path was already truncated.
 
 import React from 'react';
 import './export.css';
@@ -84,7 +89,7 @@ export function ExportResult({
         </p>
       ) : (
         <p className="export-result__blurb" role="status">
-          No file was written.
+          Cancelled mid-render — a partial file may remain.
         </p>
       )}
       <div className="export-result__actions">

--- a/app/renderer/src/features/export/ExportStage.test.tsx
+++ b/app/renderer/src/features/export/ExportStage.test.tsx
@@ -54,7 +54,8 @@ describe('ExportStage', () => {
     expect(q('.export-stage')).not.toBeNull();
     expect(q('video')).not.toBeNull();
     expect(labelValue('Length')).toBe('0:45');
-    expect(labelValue('Captions')).toBe('2 captions');
+    // WORD-level cues, so the value counts words (see exportModel.captionSummary).
+    expect(labelValue('Captions')).toBe('2 words');
     // Framing reads "Reframed" — never the raw engine id.
     expect(labelValue('Framing')).toBe('Reframed');
     expect(q('.export-stage')?.textContent).not.toContain('verthor');

--- a/app/renderer/src/features/export/ExportStage.tsx
+++ b/app/renderer/src/features/export/ExportStage.tsx
@@ -2,9 +2,11 @@
 //
 // The one video surface the Export inspector talks about: a THIN CONSUMER of the
 // shared editor state (`useEditor`) that previews the exact clip being exported and
-// summarizes what is BAKED into it — its length, its captions (from the cues), and
-// its framing (reframed vs original, read from the cross-phase cropPlan WITHOUT
-// leaking the engine id). It owns no export controls; those live in the inspector.
+// summarizes what is BAKED into it — its length, its transcript size (a WORD count,
+// because `captions.cues` emits one cue per spoken word — see
+// `exportModel.captionSummary`), and its framing (reframed vs original, read from
+// the cross-phase cropPlan WITHOUT leaking the engine id). It owns no export
+// controls; those live in the inspector.
 
 import React from 'react';
 import { Player } from '../../components/Player';

--- a/app/renderer/src/features/export/exportModel.test.ts
+++ b/app/renderer/src/features/export/exportModel.test.ts
@@ -148,11 +148,23 @@ describe('captionSummary', () => {
   it('reports no captions', () => {
     expect(captionSummary(stateWith({ cues: [] }))).toBe('No captions');
   });
-  it('reports one caption (singular)', () => {
-    expect(captionSummary(stateWith({ cues: [cue(1)] }))).toBe('1 caption');
+  it('reports one word (singular)', () => {
+    expect(captionSummary(stateWith({ cues: [cue(1)] }))).toBe('1 word');
   });
-  it('reports many captions (plural)', () => {
-    expect(captionSummary(stateWith({ cues: [cue(1), cue(2)] }))).toBe('2 captions');
+  it('reports many words (plural)', () => {
+    expect(captionSummary(stateWith({ cues: [cue(1), cue(2)] }))).toBe('2 words');
+  });
+  it('labels WORD-level cues as words, not captions', () => {
+    // `captions.cues` returns ONE cue PER WORD (lib/rpc/client.ts:298-299;
+    // sidecar cues.py:59-94 `word_cues`). These six word cues are ONE rendered
+    // caption line — proved by sidecar/tests/test_caption_karaoke_flatten.py:14-24.
+    const cues = ['hello', 'there', 'how', 'are', 'you', 'today'].map((text, i) => ({
+      index: i + 1,
+      start: i,
+      end: i + 0.5,
+      text,
+    }));
+    expect(captionSummary(stateWith({ cues }))).toBe('6 words');
   });
 });
 

--- a/app/renderer/src/features/export/exportModel.ts
+++ b/app/renderer/src/features/export/exportModel.ts
@@ -192,11 +192,23 @@ export function buildPreflight(state: EditorState, preset: PlatformPreset): Pref
   };
 }
 
-/** Plain-language caption summary for the bake preview (never color-only). */
+/**
+ * Plain-language caption summary for the bake preview (never color-only).
+ *
+ * Counts the transcript's WORD-level cues, NOT rendered caption lines:
+ * `captions.cues` emits one cue PER SPOKEN WORD (`lib/rpc/client.ts:298-299`,
+ * sidecar `cues.py::word_cues`), and many words group into one on-screen line
+ * (`sidecar/tests/test_caption_karaoke_flatten.py`). Hence "148 words", matching
+ * `lib/directorHandoff.ts:107,119`, which reads the identical `state.cues.length`
+ * off the same EditorState and calls it `wordCount`.
+ */
 export function captionSummary(state: EditorState): string {
   const count = state.cues.length;
+  // The zero case stays phrased in CAPTION terms on purpose: "no cues" really does
+  // mean "no captions", and it reads better than "No words". Do NOT "tidy" this to
+  // match the plural branch — it is a deliberate split, not an oversight.
   if (count === 0) return 'No captions';
-  return `${count} caption${count === 1 ? '' : 's'}`;
+  return `${count} word${count === 1 ? '' : 's'}`;
 }
 
 /**

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -10,7 +10,10 @@ import { createRoot, type Root } from 'react-dom/client';
 import {
   ModelsSystemPanel,
   applyOutcomeText,
+  defaultJobBridge,
+  ensureFailureText,
   errText,
+  extractEnsureDone,
   indexAssets,
   ingestRenderable,
   isInstalled,
@@ -341,6 +344,47 @@ describe('renderable-shape guards', () => {
       /unexpected data \(system report, models overview\)/,
     );
   });
+
+  // ---- F34: the assets.ensure job.done payload readers --------------------
+
+  it('extractEnsureDone reads the real sidecar payload (manager.py:749)', () => {
+    expect(
+      extractEnsureDone({
+        installed: ['smolvlm2-2.2b'],
+        failed: [{ name: 'x', error: 'boom' }],
+        assets: assetList,
+      }),
+    ).toEqual({ failed: [{ name: 'x', error: 'boom' }], assets: assetList });
+  });
+
+  it('extractEnsureDone shape-checks every field of an UNTRUSTED payload', () => {
+    // A non-object result — including the `null` waitForJobDone resolves when the
+    // host exposes no job.done bridge (_api.ts:236-238).
+    expect(extractEnsureDone(null)).toBeNull();
+    expect(extractEnsureDone('done')).toBeNull();
+    // Present but wrong-typed fields normalise instead of throwing downstream.
+    expect(extractEnsureDone({ failed: 'nope', assets: 7 })).toEqual({
+      failed: [],
+      assets: null,
+    });
+    expect(extractEnsureDone({})).toEqual({ failed: [], assets: null });
+  });
+
+  it('ensureFailureText names every failed item and its reason', () => {
+    expect(
+      ensureFailureText([
+        { name: 'smolvlm2-2.2b', error: 'disk full' },
+        { name: 'saliency', error: 'sha256 mismatch' },
+      ]),
+    ).toBe('Some downloads failed: smolvlm2-2.2b (disk full); saliency (sha256 mismatch)');
+  });
+
+  it('defaultJobBridge degrades to a bridgeless stub with no window.api', () => {
+    // The whole point of the seam: `onJobDone` THROWS through bridge() without a
+    // preload bridge, so the default must NOT hand it to waitForJobDone here.
+    expect((globalThis as { window?: { api?: unknown } }).window?.api).toBeUndefined();
+    expect(defaultJobBridge().onJobDone).toBeUndefined();
+  });
 });
 
 // ---- component tests -------------------------------------------------------
@@ -532,13 +576,61 @@ afterEach(async () => {
   vi.restoreAllMocks();
 });
 
-async function mount(c: FakeClient, onOpenProviders?: () => void): Promise<void> {
+/**
+ * F34/F36: a `job.done` bridge stub. The panel's job-wait seam takes an injected
+ * bridge because these tests never install `window.api`; this captures the
+ * subscription so a test can emit the terminal payload on demand.
+ */
+function makeJobBridge() {
+  const subs: ((ev: { jobId: string; result?: unknown }) => void)[] = [];
+  return {
+    bridge: {
+      onJobDone: (cb: (ev: { jobId: string; result?: unknown }) => void): (() => void) => {
+        subs.push(cb);
+        return () => void subs.splice(subs.indexOf(cb), 1);
+      },
+    },
+    emit(ev: { jobId: string; result?: unknown }): void {
+      for (const cb of [...subs]) cb(ev);
+    },
+    subscriptions: (): number => subs.length,
+  };
+}
+
+/** The REAL `assets.ensure` job.done payload shape (assets/manager.py:749). */
+function ensureDone(over: Partial<Record<string, unknown>> = {}): Record<string, unknown> {
+  return { installed: ['smolvlm2-2.2b'], failed: [], assets: assetList, ...over };
+}
+
+async function mount(
+  c: FakeClient,
+  onOpenProviders?: () => void,
+  jobBridge?: { onJobDone?: (cb: (ev: { jobId: string; result?: unknown }) => void) => () => void },
+): Promise<void> {
   await act(async () => {
-    root.render(<ModelsSystemPanel rpcClient={c.client} onOpenProviders={onOpenProviders} />);
+    root.render(
+      <ModelsSystemPanel
+        rpcClient={c.client}
+        onOpenProviders={onOpenProviders}
+        jobBridge={jobBridge}
+      />,
+    );
   });
   await act(async () => {
     await Promise.resolve();
   });
+}
+
+async function settle(turns = 4): Promise<void> {
+  await act(async () => {
+    for (let i = 0; i < turns; i += 1) await Promise.resolve();
+  });
+}
+
+function downloadBtn(model: string): HTMLButtonElement {
+  return container.querySelector(
+    `.model-card[data-model="${model}"] button[data-action="download"]`,
+  ) as HTMLButtonElement;
 }
 
 async function analyze(): Promise<void> {
@@ -777,7 +869,7 @@ describe('<ModelsSystemPanel />', () => {
     expect(container.querySelector('select[data-action="route-select"]')).not.toBeNull();
   });
 
-  it('persists a per-function override via setRoutingPolicy with global preserved (M5)', async () => {
+  it('persists a per-function override as an overrides-ONLY patch (M5/F35)', async () => {
     const c = makeClient({
       initialSettings: { modelsOnboardingSeen: true },
       overview: modelsOverview({ routingPolicy: { global: 'auto', overrides: {} } }),
@@ -791,7 +883,9 @@ describe('<ModelsSystemPanel />', () => {
       await Promise.resolve();
     });
     const call = c.calls.find((x) => x.method === 'models.setRoutingPolicy');
-    expect(call?.args[0]).toEqual({ global: 'auto', overrides: { select: 'cloud' } });
+    // F35: the table must NOT re-send its (possibly stale) `global` snapshot —
+    // the sidecar patches per half, so an omitted `global` inherits from disk.
+    expect(call?.args[0]).toEqual({ overrides: { select: 'cloud' } });
     // overview reflects the persisted policy (the row now reads cloud).
     expect(
       (container.querySelector('select[data-action="route-select"]') as HTMLSelectElement).value,
@@ -907,6 +1001,241 @@ describe('<ModelsSystemPanel />', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+  });
+
+  // ---- F34: the panel must await job.done, not the ENQUEUE -----------------
+
+  it('keeps Download busy until job.done arrives, not at enqueue (F34)', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    // The enqueue resolved (so this is NOT a broken fixture) …
+    expect(c.calls.filter((x) => x.method === 'assets.ensure').length).toBe(1);
+    // … but the multi-GB job has NOT finished, so the button must still say so.
+    expect(downloadBtn('smolvlm2').dataset.state).toBe('downloading');
+    expect(downloadBtn('smolvlm2').disabled).toBe(true);
+    await act(async () => jb.emit({ jobId: 'job-1', result: ensureDone() }));
+    await settle();
+  });
+
+  it('flips the card to Installed from the job.done payload (F34)', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    const listsBefore = c.calls.filter((x) => x.method === 'assets.list').length;
+    // The REAL sidecar payload carries the refreshed asset rows (manager.py:749).
+    await act(async () =>
+      jb.emit({
+        jobId: 'job-1',
+        result: ensureDone({
+          assets: assetList.map((a) =>
+            a.name === 'smolvlm2-2.2b' ? { ...a, installed: true } : a,
+          ),
+        }),
+      }),
+    );
+    await settle();
+    // No manual "Re-analyze" needed, and no redundant assets.list round-trip.
+    expect(downloadBtn('smolvlm2').dataset.state).toBe('installed');
+    expect(c.calls.filter((x) => x.method === 'assets.list').length).toBe(listsBefore);
+  });
+
+  it('re-lists when a job.done payload carries no asset rows (F34)', async () => {
+    // `job.done` is untrusted wire data (an older sidecar, or a shape change),
+    // so a payload without usable `assets` must degrade to an explicit re-list
+    // rather than blanking the grid.
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    const listsBefore = c.calls.filter((x) => x.method === 'assets.list').length;
+    await act(async () =>
+      jb.emit({ jobId: 'job-1', result: { installed: ['smolvlm2-2.2b'], failed: [] } }),
+    );
+    await settle();
+    expect(c.calls.filter((x) => x.method === 'assets.list').length).toBe(listsBefore + 1);
+    expect(container.querySelector('.error')).toBeNull();
+  });
+
+  it('surfaces a FAILED download that only job.done carries (F34)', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    await act(async () =>
+      jb.emit({
+        jobId: 'job-1',
+        result: { error: { message: 'sha256 mismatch for smolvlm2-2.2b', type: 'AssetError' } },
+      }),
+    );
+    await settle();
+    expect(container.querySelector('.error')?.textContent).toContain('sha256 mismatch');
+    // The button is released so the user can retry.
+    expect(downloadBtn('smolvlm2').disabled).toBe(false);
+  });
+
+  it('surfaces a PARTIAL failure that job.done reports as success (F34)', async () => {
+    // manager.py:744 raises only when NOTHING installed; a partial failure is a
+    // SUCCESS payload carrying `failed:[…]`, which would otherwise stay silent.
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    await act(async () =>
+      jb.emit({
+        jobId: 'job-1',
+        result: ensureDone({
+          installed: ['siglip2-so400m'],
+          failed: [{ name: 'smolvlm2-2.2b', error: 'disk full' }],
+        }),
+      }),
+    );
+    await settle();
+    expect(container.querySelector('.error')?.textContent).toContain('smolvlm2-2.2b');
+    expect(container.querySelector('.error')?.textContent).toContain('disk full');
+  });
+
+  it('treats an unmount mid-download as a clean abort, not an error (F34)', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    expect(jb.subscriptions()).toBe(1);
+    await act(async () => root.unmount());
+    await settle();
+    // The wait tore its subscription down instead of leaking to the 35-min ceiling.
+    expect(jb.subscriptions()).toBe(0);
+    root = createRoot(container);
+  });
+
+  it('holds only the DOWNLOADING model busy, never every other card (F34)', async () => {
+    // The old panel-global `downloading` guard made every other Download button
+    // look enabled but do nothing for the whole multi-GB job (a dead click).
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true }, assets: [] });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    expect(downloadBtn('smolvlm2').disabled).toBe(true);
+    const other = downloadBtn('vlm_backbone');
+    expect(other.disabled).toBe(false);
+    await act(async () => other.click());
+    await settle();
+    expect(c.calls.filter((x) => x.method === 'assets.ensure').length).toBe(2);
+    expect(downloadBtn('vlm_backbone').dataset.state).toBe('downloading');
+    await act(async () => jb.emit({ jobId: 'job-1', result: ensureDone() }));
+    await settle();
+  });
+
+  it('falls back to assets.list when no job bridge is available (F34 degraded)', async () => {
+    // Default `jobBridge` in a bridgeless host: `waitForJobDone` resolves null at
+    // once (_api.ts:236-238), so the panel must keep TODAY's list-refresh, never
+    // hang and never claim success it cannot see.
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    await mount(c);
+    await analyze();
+    const listsBefore = c.calls.filter((x) => x.method === 'assets.list').length;
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+    expect(c.calls.filter((x) => x.method === 'assets.list').length).toBe(listsBefore + 1);
+    expect(downloadBtn('smolvlm2').disabled).toBe(false);
+    expect(container.querySelector('.error')).toBeNull();
+  });
+
+  // ---- F36: the roll-up action awaits the job and then re-reads -------------
+
+  it('the readiness action awaits job.done before the roll-up re-reads (F36)', async () => {
+    let summaries = 0;
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          action: { kind: 'assets.ensure', assets: ['smolvlm2-2.2b'] },
+        },
+      ],
+    });
+    (c.client.readiness.summary as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      summaries += 1;
+      c.calls.push({ method: 'readiness.summary', args: [] });
+      return {
+        items: [
+          {
+            capability: 'vis',
+            label: 'Vision',
+            status: summaries === 1 ? 'needsDownload' : 'ready',
+            blockedBy: '',
+            action: summaries === 1 ? { kind: 'assets.ensure', assets: ['smolvlm2-2.2b'] } : null,
+          },
+        ],
+      };
+    });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await settle();
+    const rollup = container.querySelector('.readiness-rollup') as HTMLElement;
+    expect(rollup.querySelector('[data-readiness]')?.getAttribute('data-readiness')).toBe(
+      'needsDownload',
+    );
+    const btn = rollup.querySelector('button.readiness-badge__action') as HTMLButtonElement;
+    await act(async () => btn.click());
+    await settle();
+    // Mid-job: busy, and NOT yet re-read (a refresh here would read pre-download
+    // state — F36's refresh is inert without F34's wait).
+    expect(btn.disabled).toBe(true);
+    expect(summaries).toBe(1);
+    await act(async () => jb.emit({ jobId: 'job-1', result: ensureDone() }));
+    await settle();
+    expect(summaries).toBe(2);
+    expect(
+      container.querySelector('.readiness-rollup [data-readiness]')?.getAttribute('data-readiness'),
+    ).toBe('ready');
+  });
+
+  it('a second roll-up click cannot stack a duplicate download job (F36)', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, firstRunChoiceMade: true },
+      readiness: [
+        {
+          capability: 'vis',
+          label: 'Vision',
+          status: 'needsDownload',
+          blockedBy: '',
+          action: { kind: 'assets.ensure', assets: ['smolvlm2-2.2b'] },
+        },
+      ],
+    });
+    const jb = makeJobBridge();
+    await mount(c, undefined, jb.bridge);
+    await settle();
+    const btn = container.querySelector(
+      '.readiness-rollup button.readiness-badge__action',
+    ) as HTMLButtonElement;
+    await act(async () => btn.click());
+    await settle();
+    await act(async () => btn.click());
+    await settle();
+    expect(c.calls.filter((x) => x.method === 'assets.ensure').length).toBe(1);
+    await act(async () => jb.emit({ jobId: 'job-1', result: ensureDone() }));
+    await settle();
   });
 
   it('does not show the tour when modelsOnboardingSeen is already set', async () => {

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -4,7 +4,7 @@
 
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act } from 'react';
+import { act, StrictMode } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import {
@@ -621,6 +621,31 @@ async function mount(
   });
 }
 
+/**
+ * F34, StrictMode variant. `app/renderer/src/main.tsx:19` wraps the real app in
+ * `<React.StrictMode>`, so in `npm run dev` every effect runs setup -> cleanup ->
+ * setup. The panel's unmount-abort effect therefore fires a cleanup while the
+ * panel is still very much mounted; anything that captured a value at SETUP time
+ * (rather than reading it at cleanup time) is destroyed by that first pass.
+ *
+ * `mount()` above renders bare, so it cannot see this class of defect at all.
+ */
+async function mountStrict(
+  c: FakeClient,
+  jobBridge?: { onJobDone?: (cb: (ev: { jobId: string; result?: unknown }) => void) => () => void },
+): Promise<void> {
+  await act(async () => {
+    root.render(
+      <StrictMode>
+        <ModelsSystemPanel rpcClient={c.client} jobBridge={jobBridge} />
+      </StrictMode>,
+    );
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
 async function settle(turns = 4): Promise<void> {
   await act(async () => {
     for (let i = 0; i < turns; i += 1) await Promise.resolve();
@@ -1019,6 +1044,51 @@ describe('<ModelsSystemPanel />', () => {
     expect(downloadBtn('smolvlm2').disabled).toBe(true);
     await act(async () => jb.emit({ jobId: 'job-1', result: ensureDone() }));
     await settle();
+  });
+
+  // F34 — the download must survive StrictMode's double-invoked effects. This is
+  // the one environment (`npm run dev`, where `main.tsx:19` wraps the app in
+  // StrictMode) in which a human would hand-verify a multi-GB download, and it was
+  // exactly where the abort effect destroyed the only controller the panel had:
+  // `waitForJobDone` short-circuits on `signal?.aborted` (`_api.ts:266-269`) and
+  // `surfaceJobError` swallows `JobAbortedError`, so the job was enqueued and then
+  // silently no-op'd with the error path muted. Measured on the broken code:
+  // effect setups=2, cleanups=1, `signal.aborted` at click time = true.
+  //
+  // Both assertions matter and they fail differently:
+  //  * still 'downloading' before job.done — an aborted signal resolves null
+  //    immediately, so the button snaps back to 'download' while bytes are moving.
+  //  * 'installed' after job.done — proves the payload was actually consumed
+  //    rather than the wait having already been thrown away.
+  it('completes a download under StrictMode double-invoked effects (F34)', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    const jb = makeJobBridge();
+    await mountStrict(c, jb.bridge);
+    await analyze();
+    await act(async () => downloadBtn('smolvlm2').click());
+    await settle();
+
+    // The enqueue happened (not a broken fixture) and the wait is genuinely live.
+    expect(c.calls.filter((x) => x.method === 'assets.ensure').length).toBe(1);
+    expect(downloadBtn('smolvlm2').dataset.state).toBe('downloading');
+
+    const listsBefore = c.calls.filter((x) => x.method === 'assets.list').length;
+    await act(async () =>
+      jb.emit({
+        jobId: 'job-1',
+        result: ensureDone({
+          assets: assetList.map((a) =>
+            a.name === 'smolvlm2-2.2b' ? { ...a, installed: true } : a,
+          ),
+        }),
+      }),
+    );
+    await settle();
+
+    expect(downloadBtn('smolvlm2').dataset.state).toBe('installed');
+    // The payload's rows were used — no fallback re-list, which is what an
+    // abandoned wait (`done === null`) would have forced.
+    expect(c.calls.filter((x) => x.method === 'assets.list').length).toBe(listsBefore);
   });
 
   it('flips the card to Installed from the job.done payload (F34)', async () => {

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -14,11 +14,13 @@
 //
 // Consumes the FROZEN window.api bridge through the typed `client`/`rpc` from
 // lib/rpc. All settings flow through settings.get/set — no new store.
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import '../features/panels.css';
 import './modelsSystem.css';
 import {
   client,
+  hasApi,
+  onJobDone,
   type AdvisorReport,
   type AsrEngine,
   type AssetInfo,
@@ -53,6 +55,12 @@ import { PresetPicker } from '../components/PresetPicker';
 import { FirstRunChooser } from '../components/FirstRunChooser';
 import { ReadinessRollup } from '../components/ReadinessRollup';
 import type { ReadinessAction } from '../lib/rpc';
+import {
+  DEFAULT_JOB_TIMEOUT_MS,
+  JobAbortedError,
+  waitForJobDone,
+  type JobDoneCapable,
+} from '../features/_api';
 
 // --- pure helpers (exported for tests) -------------------------------------
 
@@ -84,6 +92,61 @@ export function qualityFraction(componentName: string, report: AdvisorReport): n
   const owning = report.tiers.find((t) => t.components.includes(componentName));
   if (!owning) return 0.5;
   return owning.tier / maxTier;
+}
+
+/**
+ * F34: the terminal `assets.ensure` job payload, normalised. The sidecar returns
+ * `{installed, failed, assets}` (`assets/manager.py:749`) — `assets` is the SAME
+ * `list_assets()` rows `assets.list` serves, so a successful job already carries
+ * the refreshed state and needs no second round-trip. Both fields are normalised
+ * to a non-optional shape here so the caller has no per-field nullish branches.
+ */
+export interface EnsureDone {
+  /** Per-item failures a SUCCESS payload can still carry (partial failure). */
+  failed: { name: string; error: string }[];
+  /** The refreshed asset rows, or null when the payload did not carry them. */
+  assets: AssetInfo[] | null;
+}
+
+/**
+ * Read the `assets.ensure` terminal payload off a `job.done` result.
+ *
+ * `job.done` is UNTRUSTED wire data, so every field is shape-checked (the same
+ * `Array.isArray` discipline the panel's other ingest points use). Returns null
+ * for a non-object result — including the `null` `waitForJobDone` resolves when
+ * the host exposes no `job.done` bridge (`_api.ts:236-238`).
+ */
+export function extractEnsureDone(result: unknown): EnsureDone | null {
+  if (!result || typeof result !== 'object') return null;
+  const raw = result as { failed?: unknown; assets?: unknown };
+  return {
+    failed: Array.isArray(raw.failed) ? (raw.failed as EnsureDone['failed']) : [],
+    assets: Array.isArray(raw.assets) ? (raw.assets as AssetInfo[]) : null,
+  };
+}
+
+/**
+ * F34: announce the per-item failures a SUCCESS ensure payload carries.
+ * `manager.py:744` raises only when NOTHING installed, so a partial failure
+ * arrives as a successful `job.done` with `failed:[…]` — silent without this.
+ */
+export function ensureFailureText(failed: EnsureDone['failed']): string {
+  return `Some downloads failed: ${failed.map((f) => `${f.name} (${f.error})`).join('; ')}`;
+}
+
+/**
+ * F34: the real `job.done` bridge, or an inert stub when no preload bridge exists.
+ *
+ * `onJobDone` reaches through `bridge()`, which THROWS without `window.api`, so
+ * handing it to `waitForJobDone` unguarded would turn every bridgeless host (and
+ * every test in this file) into a REJECTED wait instead of the intended degraded
+ * arm. `hasApi()` keeps that arm reachable: an empty object has no `onJobDone`,
+ * so `waitForJobDone` resolves null at once (`_api.ts:236-238`) and the caller
+ * falls back to a plain `assets.list` refresh.
+ */
+export function defaultJobBridge(): JobDoneCapable {
+  /* v8 ignore next -- hasApi() is TRUE only in the packaged app with a real preload bridge; this jsdom host and every test run bridgeless and take the `{}` arm. */
+  return hasApi() ? { onJobDone } : {};
 }
 
 /** Map asset name -> AssetInfo for O(1) size/installed lookup. */
@@ -229,6 +292,15 @@ export interface ModelsSystemPanelProps {
    * key/consent actions no-op (the host did not wire navigation).
    */
   onOpenProviders?: () => void;
+  /**
+   * F34/F36: the `job.done` bridge the asset-download wait subscribes to.
+   * Injected because `assets.ensure` is a LONG job — its rpc promise resolves at
+   * ENQUEUE with only `{jobId}`, so the terminal result is reachable only through
+   * this channel (`features/_api.ts:167-178`). Defaults to
+   * {@link defaultJobBridge}; tests inject a stub because they install no
+   * `window.api`.
+   */
+  jobBridge?: JobDoneCapable;
 }
 
 interface SettingsShape {
@@ -250,9 +322,11 @@ interface SettingsShape {
 export function ModelsSystemPanel({
   rpcClient,
   onOpenProviders,
+  jobBridge,
 }: ModelsSystemPanelProps): React.ReactElement {
   /* v8 ignore next -- the `?? client` default only runs in the real app; every test injects rpcClient. */
   const api = useMemo(() => rpcClient ?? client, [rpcClient]);
+  const jobs = useMemo<JobDoneCapable>(() => jobBridge ?? defaultJobBridge(), [jobBridge]);
 
   const [hardware, setHardware] = useState<HardwareInfo | null>(null);
   const [report, setReport] = useState<AdvisorReport | null>(null);
@@ -262,7 +336,10 @@ export function ModelsSystemPanel({
   const [analyzed, setAnalyzed] = useState<boolean>(false);
   const [busy, setBusy] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
-  const [downloading, setDownloading] = useState<string | null>(null);
+  // F34: a SET, not one name. The busy flag now spans the WHOLE download job
+  // (minutes, not the enqueue instant), and a panel-global lock would make every
+  // OTHER model's Download button look enabled while doing nothing — a dead click.
+  const [downloading, setDownloading] = useState<ReadonlySet<string>>(() => new Set<string>());
   const [showTour, setShowTour] = useState<boolean>(false);
   const [usage, setUsage] = useState<UsageRow[]>([]);
   // WU-models/device: local-runner plan (device-ranked whisper+LLM + runner advice)
@@ -284,6 +361,15 @@ export function ModelsSystemPanel({
   const [applyOutcome, setApplyOutcome] = useState<string>('');
 
   const byAsset = useMemo(() => indexAssets(assets), [assets]);
+
+  // F34: tear a pending job-wait down on unmount. Without it a Settings sub-tab
+  // switch mid-download leaves the `job.done` subscription and its timer alive to
+  // the DEFAULT_JOB_TIMEOUT_MS ceiling (~35 min).
+  const abortRef = useRef<AbortController>(new AbortController());
+  useEffect(() => {
+    const ctrl = abortRef.current;
+    return () => ctrl.abort();
+  }, []);
 
   // Load persisted settings up-front (cheap) so the tier/ASR/commercial controls
   // reflect saved choices even before the opt-in analysis runs.
@@ -424,13 +510,19 @@ export function ModelsSystemPanel({
     [patchSettings],
   );
 
-  // M5: persist the FULL routing policy ({global, overrides}) via the fail-closed
+  // M5: persist a PARTIAL routing-policy patch via the fail-closed
   // setRoutingPolicy write (NOT settings.set — the sidecar sanitises/clamps), then
   // reflect the policy the sidecar actually persisted back into the overview so the
   // override table + reason strip stay in sync. Best-effort: a failed write keeps
   // the prior overview policy.
+  //
+  // F35: the parameter is a PATCH, not a whole policy — the table sends only the
+  // `overrides` half it owns and the sidecar merges per half, so a row edit can no
+  // longer clobber the header's `global`. Folding the RETURNED policy back in also
+  // refreshes the panel's snapshot of `global` from disk — but only on the panel's
+  // OWN write, so a header click alone still leaves the table's intro text stale.
   const applyRoutingPolicy = useCallback(
-    async (policy: RoutingPolicy): Promise<void> => {
+    async (policy: Partial<RoutingPolicy>): Promise<void> => {
       try {
         const { routingPolicy } = await api.models.setRoutingPolicy(policy);
         setOverview((prev) => mergeOverviewRoutingPolicy(prev, routingPolicy));
@@ -554,32 +646,72 @@ export function ModelsSystemPanel({
     void patchSettings({ modelsOnboardingSeen: true });
   }, [patchSettings]);
 
-  // Download a single model (assets.ensure long job) then refresh asset state.
+  // F34: announce a job failure — EXCEPT a clean abort. `waitForJobDone` rejects
+  // with JobAbortedError on unmount/cancel, which is an idle reset, not a fault
+  // to show the user (precedent: Export.tsx:130-133).
+  const surfaceJobError = useCallback((err: unknown): void => {
+    if (!(err instanceof JobAbortedError)) setError(errText(err));
+  }, []);
+
+  // F34/F36 — the ONE shared "install assets and wait for the job to ACTUALLY
+  // finish" path, used by both the per-model Download and the readiness roll-up.
+  //
+  // `assets.ensure` is a LONG job: its rpc promise resolves at ENQUEUE with only
+  // `{jobId}` (`assets/rpc.py:91-92`), so the previous code reported completion it
+  // had never observed — the button reverted while bytes were still moving, the
+  // post-enqueue `assets.list` could not yet see `installed` (the download only
+  // renames `.part` -> dest at the very end, `manager.py:863-875`), and a FAILED
+  // download was invisible because the error only ever arrives on `job.done`.
+  const runAssetJob = useCallback(
+    async (assetNames: string[]): Promise<void> => {
+      const { jobId } = await api.assets.ensure(assetNames);
+      const done = await waitForJobDone<EnsureDone>(
+        jobs,
+        jobId,
+        extractEnsureDone,
+        DEFAULT_JOB_TIMEOUT_MS,
+        abortRef.current.signal,
+      );
+      // A SUCCESS payload can still carry per-item failures (manager.py:742-749
+      // raises only when NOTHING installed), so a partial failure must be shown.
+      const failed = done === null ? [] : done.failed;
+      if (failed.length > 0) setError(ensureFailureText(failed));
+      // The job payload already carries the refreshed rows; re-list only when it
+      // did not (a bridgeless host resolved null, or a partial payload).
+      const rows = done?.assets ?? (await api.assets.list()).assets;
+      setAssets(Array.isArray(rows) ? rows : []);
+      // Re-run the advisor so installed-state flips the verdicts/recommendation.
+      const rep = await api.system.advisor({ commercial: Boolean(settings.commercial) });
+      setReport(
+        ingestRenderable(rep, isRenderableReport, () =>
+          setError(malformedDataMessage(['system report'])),
+        ),
+      );
+    },
+    [api, jobs, settings.commercial],
+  );
+
+  // Download a single model: hold THIS card busy for the whole job, then refresh.
   const download = useCallback(
     async (componentName: string): Promise<void> => {
       const asset = componentAsset(componentName);
-      /* v8 ignore next -- defensive guard: floor components (no asset) render an "Installed", disabled button, and the Download button is disabled while downloading, so neither arm trips in tests. */
-      if (!asset || downloading) return;
-      setDownloading(componentName);
+      /* v8 ignore next -- defensive guard: floor components (no asset) render an "Installed", disabled button, and this card's Download button is disabled while it downloads, so neither arm trips in tests. */
+      if (!asset || downloading.has(componentName)) return;
+      setDownloading((prev) => new Set(prev).add(componentName));
       setError('');
       try {
-        await api.assets.ensure([asset]);
-        const res = await api.assets.list();
-        setAssets(Array.isArray(res?.assets) ? res.assets : []);
-        // Re-run the advisor so installed-state flips the verdicts/recommendation.
-        const rep = await api.system.advisor({ commercial: Boolean(settings.commercial) });
-        setReport(
-          ingestRenderable(rep, isRenderableReport, () =>
-            setError(malformedDataMessage(['system report'])),
-          ),
-        );
+        await runAssetJob([asset]);
       } catch (err) {
-        setError(errText(err));
+        surfaceJobError(err);
       } finally {
-        setDownloading(null);
+        setDownloading((prev) => {
+          const next = new Set(prev);
+          next.delete(componentName);
+          return next;
+        });
       }
     },
-    [api, downloading, settings.commercial],
+    [downloading, runAssetJob, surfaceJobError],
   );
 
   // WU-14 / WU-PROVIDERS: the readiness roll-up surfaces a fix action per
@@ -598,20 +730,16 @@ export function ModelsSystemPanel({
       if (!action.assets || action.assets.length === 0) return;
       setError('');
       try {
-        await api.assets.ensure(action.assets);
-        const res = await api.assets.list();
-        setAssets(Array.isArray(res?.assets) ? res.assets : []);
-        const rep = await api.system.advisor({ commercial: Boolean(settings.commercial) });
-        setReport(
-          ingestRenderable(rep, isRenderableReport, () =>
-            setError(malformedDataMessage(['system report'])),
-          ),
-        );
+        // F36: the SAME job-wait as the per-card Download — a refresh without it
+        // would re-read pre-download state, so the roll-up's badge would still be
+        // wrong. Returning the promise lets the roll-up hold the button busy and
+        // re-read `readiness.summary` only once the job has truly finished.
+        await runAssetJob(action.assets);
       } catch (err) {
-        setError(errText(err));
+        surfaceJobError(err);
       }
     },
-    [api, settings.commercial, onOpenProviders],
+    [runAssetJob, surfaceJobError, onOpenProviders],
   );
 
   const currentTier = settings.phase8Tier ?? 1;
@@ -643,7 +771,7 @@ export function ModelsSystemPanel({
       <ReadinessRollup
         rpcClient={api}
         title="What works right now"
-        onAction={(action) => void handleReadinessAction(action)}
+        onAction={handleReadinessAction}
       />
 
       <div className="actions">
@@ -909,7 +1037,7 @@ export function ModelsSystemPanel({
                 vramBudgetMb={report.vramBudgetMb}
                 installed={isInstalled(component, byAsset)}
                 sizeMb={sizeForComponent(component, byAsset)}
-                downloading={downloading === component.name}
+                downloading={downloading.has(component.name)}
                 onDownload={download}
               />
             ))}

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -365,11 +365,24 @@ export function ModelsSystemPanel({
   // F34: tear a pending job-wait down on unmount. Without it a Settings sub-tab
   // switch mid-download leaves the `job.done` subscription and its timer alive to
   // the DEFAULT_JOB_TIMEOUT_MS ceiling (~35 min).
+  //
+  // A live controller is always present and is REPLACED per job (`runAssetJob`),
+  // exactly the `views/Export.tsx:75,108` pattern. Two properties are load-bearing:
+  //
+  //  1. The cleanup must read `abortRef.current` AT CLEANUP TIME, not capture it at
+  //     setup time. `main.tsx` wraps the app in `React.StrictMode`, so in dev the
+  //     effect runs setup -> cleanup -> setup; a captured `ctrl` meant the cleanup
+  //     aborted the ONE controller the panel would ever use. `waitForJobDone`
+  //     short-circuits on `signal?.aborted` (`_api.ts:266-269`) and
+  //     `surfaceJobError` swallows `JobAbortedError`, so every Download and every
+  //     readiness fix action enqueued its multi-GB job and then silently no-op'd,
+  //     with the error path muted — in the exact environment where a human would
+  //     hand-verify this. Measured: effect setups=2, cleanups=1,
+  //     `signal.aborted` at click time = true.
+  //  2. Because the controller is replaced per job, the StrictMode cleanup aborts
+  //     only the initial controller, which nothing is ever awaiting.
   const abortRef = useRef<AbortController>(new AbortController());
-  useEffect(() => {
-    const ctrl = abortRef.current;
-    return () => ctrl.abort();
-  }, []);
+  useEffect(() => () => abortRef.current.abort(), []);
 
   // Load persisted settings up-front (cheap) so the tier/ASR/commercial controls
   // reflect saved choices even before the opt-in analysis runs.
@@ -664,13 +677,18 @@ export function ModelsSystemPanel({
   // download was invisible because the error only ever arrives on `job.done`.
   const runAssetJob = useCallback(
     async (assetNames: string[]): Promise<void> => {
+      // Fresh controller per job (see the `abortRef` note above): the mount-time
+      // one may already be aborted by StrictMode's double-invoke, and reusing an
+      // aborted signal makes `waitForJobDone` return null immediately.
+      const controller = new AbortController();
+      abortRef.current = controller;
       const { jobId } = await api.assets.ensure(assetNames);
       const done = await waitForJobDone<EnsureDone>(
         jobs,
         jobId,
         extractEnsureDone,
         DEFAULT_JOB_TIMEOUT_MS,
-        abortRef.current.signal,
+        controller.signal,
       );
       // A SUCCESS payload can still carry per-item failures (manager.py:742-749
       // raises only when NOTHING installed), so a partial failure must be shown.

--- a/app/renderer/src/views/Export.test.tsx
+++ b/app/renderer/src/views/Export.test.tsx
@@ -307,6 +307,7 @@ describe('Export view', () => {
     });
     expect(jobCancelMock).toHaveBeenCalledWith('late');
     // A cancelled job must NEVER render a terminal SUCCESS with "Show in folder".
+    // Mutation-proved: with the latch removed this renders `is-done`.
     expect(q('.export-result')?.className).toContain('is-cancelled');
     expect(q('.export-result__path')).toBeNull();
   });

--- a/app/renderer/src/views/Export.test.tsx
+++ b/app/renderer/src/views/Export.test.tsx
@@ -262,6 +262,45 @@ describe('Export view', () => {
     expect(q('.export-result')?.className).toContain('is-cancelled');
   });
 
+  // F23 — the cancel LATCH must not survive into the next export. `cancel` sets
+  // `cancelRequested.current = true` on every press and the drain at
+  // `Export.tsx:126` is TERMINAL: a stale latch makes the SECOND commit cancel a
+  // healthy job and paint "Export cancelled — a partial file may remain."
+  //
+  // This test exists because the behaviour was previously protected by exactly one
+  // unasserted line: deleting `onCommit`'s `cancelRequested.current = false` left
+  // all 3577 tests green. It is a mutation guard, so it is written against the
+  // OBSERVABLE contract (no cancel for the second id, real terminal success) rather
+  // than against either clearing site — either one alone must satisfy it.
+  it('does not carry a cancel latch into the next export (F23)', async () => {
+    convertStartMock.mockResolvedValue({ jobId: 'j1' });
+    render(VIDEO);
+    await flush();
+    await commit();
+    await act(async () => {
+      q<HTMLButtonElement>('.export-progress__cancel')?.click();
+      await flush();
+    });
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+    expect(jobCancelMock).toHaveBeenCalledWith('j1');
+
+    // "Export again" -> a second, healthy export carrying a FRESH jobId.
+    jobCancelMock.mockClear();
+    convertStartMock.mockResolvedValue({ jobId: 'j2' });
+    act(() => q<HTMLButtonElement>('.export-result__again')?.click());
+    await commit();
+    await act(async () => {
+      doneCb?.({ jobId: 'j2', result: { path: '/exports/second.mp4' } });
+      await flush();
+    });
+
+    // The stale latch must not have cancelled the second job...
+    expect(jobCancelMock).not.toHaveBeenCalled();
+    // ...and it must reach a genuine terminal success, not 'cancelled'.
+    expect(q('.export-result')?.className).toContain('is-done');
+    expect(q('.export-result__path')?.textContent).toBe('/exports/second.mp4');
+  });
+
   // A cancel pressed while `convert.start`'s round-trip is still in flight has no
   // jobId to cancel YET, but the sidecar has already started the job. The latch
   // must drain the moment the id lands, or the job is orphaned (F23).

--- a/app/renderer/src/views/Export.test.tsx
+++ b/app/renderer/src/views/Export.test.tsx
@@ -131,7 +131,7 @@ describe('Export view', () => {
     await flush();
     expect(cuesMock).toHaveBeenCalledWith('v1');
     expect(q('.export-view__title')?.textContent).toBe('My Clip');
-    expect(stageValue('Captions')).toBe('2 captions');
+    expect(stageValue('Captions')).toBe('2 words');
     // Idle: the guarded inspector is shown with a default fitting destination.
     expect(q('.export-inspector__primary')?.textContent).toBe('Export to TikTok');
   });

--- a/app/renderer/src/views/Export.test.tsx
+++ b/app/renderer/src/views/Export.test.tsx
@@ -262,7 +262,10 @@ describe('Export view', () => {
     expect(q('.export-result')?.className).toContain('is-cancelled');
   });
 
-  it('cancels before the job id resolves (abort settles the pending wait)', async () => {
+  // A cancel pressed while `convert.start`'s round-trip is still in flight has no
+  // jobId to cancel YET, but the sidecar has already started the job. The latch
+  // must drain the moment the id lands, or the job is orphaned (F23).
+  it('cancels the job once a late jobId arrives (pre-jobId cancel latch)', async () => {
     let resolveStart!: (value: { jobId: string }) => void;
     convertStartMock.mockReturnValue(
       new Promise<{ jobId: string }>((resolve) => {
@@ -273,14 +276,58 @@ describe('Export view', () => {
     await flush();
     await commit(); // convert.start is still pending here
     expect(q('.export-progress')).not.toBeNull();
-    // Cancel while there is no jobId yet: job.cancel is NOT called.
+    // Cancel while there is no jobId yet: nothing is on the wire to cancel.
     act(() => q<HTMLButtonElement>('.export-progress__cancel')?.click());
     expect(jobCancelMock).not.toHaveBeenCalled();
-    // Now the start resolves; the already-aborted wait settles to cancelled.
+    // The start resolves. The latch must now stop the job the sidecar DID start.
     await act(async () => {
       resolveStart({ jobId: 'late' });
       await flush();
     });
+    expect(jobCancelMock).toHaveBeenCalledWith('late');
+    // Setup discriminator: this assertion already passed pre-fix, so a failure
+    // HERE means the harness is wrong, not the product.
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+  });
+
+  it('keeps the late cancel terminal even when the start returns a path', async () => {
+    let resolveStart!: (value: { jobId: string; path: string }) => void;
+    convertStartMock.mockReturnValue(
+      new Promise<{ jobId: string; path: string }>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    render(VIDEO);
+    await flush();
+    await commit();
+    act(() => q<HTMLButtonElement>('.export-progress__cancel')?.click());
+    await act(async () => {
+      resolveStart({ jobId: 'late', path: '/exports/fast.mp4' });
+      await flush();
+    });
+    expect(jobCancelMock).toHaveBeenCalledWith('late');
+    // A cancelled job must NEVER render a terminal SUCCESS with "Show in folder".
+    expect(q('.export-result')?.className).toContain('is-cancelled');
+    expect(q('.export-result__path')).toBeNull();
+  });
+
+  it('swallows a rejected late cancel and still settles to cancelled', async () => {
+    jobCancelMock.mockRejectedValue(new Error('cancel boom'));
+    let resolveStart!: (value: { jobId: string }) => void;
+    convertStartMock.mockReturnValue(
+      new Promise<{ jobId: string }>((resolve) => {
+        resolveStart = resolve;
+      }),
+    );
+    render(VIDEO);
+    await flush();
+    await commit();
+    act(() => q<HTMLButtonElement>('.export-progress__cancel')?.click());
+    await act(async () => {
+      resolveStart({ jobId: 'late' });
+      await flush();
+    });
+    expect(jobCancelMock).toHaveBeenCalledWith('late');
     expect(q('.export-result')?.className).toContain('is-cancelled');
   });
 

--- a/app/renderer/src/views/Export.tsx
+++ b/app/renderer/src/views/Export.tsx
@@ -73,6 +73,14 @@ function ExportWorkspace({
   // A live controller is always present (replaced per commit) so `cancel` never
   // needs a null guard — a stale abort with nothing awaiting it is harmless.
   const abort = useRef<AbortController>(new AbortController());
+  // Cancel pressed BEFORE `convert.start` resolved, so there was no jobId to stop
+  // yet — but the sidecar had already started the job. Deliberately a LATCH rather
+  // than the sibling panels' `running && jobId` gating (`Convert.tsx:317`,
+  // `Refine.tsx:249`), diverging from a tested repo convention for two reasons:
+  // `jobId` here is a `useRef` (no re-render, so gating would need it promoted to
+  // state), and hiding Cancel would remove the escape hatch during exactly the
+  // slow-start window where the user most wants one.
+  const cancelRequested = useRef(false);
 
   // Best-effort: load the cues being exported so the stage can summarize them. The
   // export never REQUIRES captions, so a load failure is silently non-blocking.
@@ -89,6 +97,7 @@ function ExportWorkspace({
   const onCommit = useCallback(
     async (preset: PlatformPreset, options: ConvertOptions): Promise<void> => {
       if (!hasApi()) return;
+      cancelRequested.current = false;
       setPhase('running');
       setPct(0);
       setMessage('Starting…');
@@ -107,6 +116,20 @@ function ExportWorkspace({
           setPct(event.pct);
           setMessage(event.message);
         });
+        // Drain a cancel that landed before this id existed. TERMINAL, not
+        // advisory: the `res.path` fast path below skips `waitForJobDone`, so
+        // without the early return a cancelled job would render a terminal SUCCESS
+        // with a "Show in folder" reveal. Fire-and-forget preserves the
+        // abort-settles-the-UI-first ordering documented in `cancel` below — an
+        // awaited RPC on a queued stdio channel would strand the user on a stale
+        // "Exporting…" panel and invite a duplicate cancel.
+        if (cancelRequested.current) {
+          void client.job.cancel(id).catch(() => {
+            // best-effort: the UI is already settling to 'cancelled'.
+          });
+          setPhase('cancelled');
+          return;
+        }
         let outPath: string | null = res.path ?? null;
         if (!outPath) {
           outPath = await waitForJobDone(
@@ -142,6 +165,9 @@ function ExportWorkspace({
   );
 
   const cancel = useCallback(async (): Promise<void> => {
+    // Latch FIRST, so a cancel racing `convert.start`'s round-trip is still
+    // honoured once the jobId lands (drained in `onCommit`).
+    cancelRequested.current = true;
     // Abort the terminal wait (settles the UI to 'cancelled'), then stop the job.
     abort.current.abort();
     const id = jobId.current;

--- a/app/renderer/src/views/Export.tsx
+++ b/app/renderer/src/views/Export.tsx
@@ -179,7 +179,17 @@ function ExportWorkspace({
     }
   }, []);
 
-  const reset = useCallback(() => setPhase('idle'), []);
+  // "Export again" (F23). Clearing the latch here is belt-and-braces — `onCommit`
+  // already clears it at :100 — but it is the difference between a defect that is
+  // one line away and one that is a whole reachable state away: `cancel` latches on
+  // EVERY cancel, and before this the ONLY clearing point was inside the next
+  // `onCommit`. Deleting or hoisting that line left all 3577 tests green while, at
+  // runtime, the stale latch cancelled the user's NEXT export and painted
+  // "Export cancelled — a partial file may remain." over a healthy run.
+  const reset = useCallback(() => {
+    cancelRequested.current = false;
+    setPhase('idle');
+  }, []);
 
   const openFolder = openInFolderBridge();
   const reveal = openFolder

--- a/sidecar/media_studio/handlers/system_ops.py
+++ b/sidecar/media_studio/handlers/system_ops.py
@@ -245,12 +245,25 @@ def models_set_routing_policy(self: Services, params: dict[str, Any], ctx: RpcCo
 
     M3 — the WRITE half of the single ``RoutingPolicy`` store the M1a read
     (:func:`routing_policy.read_routing_policy`) surfaces. The header toggle sends
-    ``{global}``; the Advanced per-function table sends ``{overrides}``. The
-    incoming candidate is run through :func:`routing_policy.sanitize_routing_policy`
-    BEFORE persistence so the SAME fail-closed clamp protects the write as the
-    read: an out-of-enum (or corrupt) ``global`` / override mode is forced to
-    ``local`` (zero silent cloud egress, GATE-2) and a non-string override key is
-    dropped — the handler NEVER raises on a malformed body, it clamps.
+    ``{global}``; the Advanced per-function table sends ``{overrides}``.
+
+    The write is a PER-HALF PATCH (:func:`routing_policy.merge_routing_policy`),
+    NOT a whole-key replace: those two senders are disjoint UI owners of one
+    document, so a replace let each one silently ERASE the other's half (F33 — a
+    header flip wiped every per-function pin, including a ``translation:'local'``
+    pin whose only job is to stop transcript egress; F35 — a row edit re-clamped
+    ``global`` back to the default). A key ABSENT from the body now INHERITS the
+    persisted value.
+
+    Every PRESENT value still runs through the same
+    :func:`routing_policy.sanitize_routing_policy` clamp as the read, so the
+    fail-closed guarantee is unchanged: an out-of-enum (or corrupt) ``global`` /
+    override mode is forced to ``local`` (zero silent cloud egress, GATE-2), a
+    non-string override key is dropped, and the handler NEVER raises on a
+    malformed body — it clamps. GATE-2 additionally holds across the patch
+    because writing ``global:'local'`` SCRUBS any inherited ``cloud``/``auto``
+    pin, so a user who flipped the header to Local can still never egress
+    (the invariant ``providers_ops._translator_for_function`` documents).
 
     Persistence is the existing :class:`settings_store.SettingsStore` ``set`` (a
     partial top-level merge whose ``_write`` is an atomic temp-file +
@@ -262,7 +275,7 @@ def models_set_routing_policy(self: Services, params: dict[str, Any], ctx: RpcCo
     """
     from ..models import routing_policy as _routing_policy  # local: import-light pure
 
-    policy = _routing_policy.sanitize_routing_policy(params)
+    policy = _routing_policy.merge_routing_policy(self.settings.get().get("routingPolicy"), params)
     self.settings.set({"routingPolicy": policy})
     return {"routingPolicy": policy}
 
@@ -302,7 +315,7 @@ def system_self_test(self: Services, params: dict[str, Any], ctx: RpcContext) ->
     :func:`self_test.run` over the runtime services — the data-dir writability
     probe (write+read+delete under :attr:`data_dir`), the hardware probe seam
     (:class:`HardwareProbe`, the SAME one ``system.probe``/``advisor`` use), the
-    native-dependency import map (cv2/mediapipe for reframe + the faster-whisper
+    native-dependency import map (cv2 for reframe + the faster-whisper
     ASR backend, via ``importlib.find_spec`` — nothing heavy is imported), and
     the ffmpeg/ffprobe chain (:func:`tools_resolver.resolve_tool`). Every probe
     is fail-open: a failure becomes a reported problem + fix hint, never an

--- a/sidecar/media_studio/models/routing_policy.py
+++ b/sidecar/media_studio/models/routing_policy.py
@@ -17,6 +17,9 @@ I/O of its own — the bytes live in the §2 settings document under
   * :func:`sanitize_routing_policy` clamps any candidate ``{global, overrides}``
     shape to a valid, JSON-safe policy (the corrupt-load AND the write-validate
     path share it, so the fail-closed default is one constant).
+  * :func:`merge_routing_policy` PATCHES a partial ``{global?, overrides?}`` over
+    the persisted policy per half, because the two halves have two disjoint UI
+    owners (header toggle / Advanced table) that must not clobber each other.
   * :func:`read_routing_policy` reads the persisted policy from a settings dict.
   * :func:`resolve_route` is the PURE policy resolver M3 owns:
     ``resolve_route(fn) = overrides[fn] ?? {mode: global}`` with the SAME clamp
@@ -81,6 +84,47 @@ def sanitize_routing_policy(raw: Any) -> dict[str, Any]:
     return {"global": global_mode, "overrides": overrides}
 
 
+def merge_routing_policy(current: Any, patch: Any) -> dict[str, Any]:
+    """PATCH ``patch`` over the persisted ``current`` policy, per half (F33/F35).
+
+    One ``RoutingPolicy`` document has TWO disjoint UI owners: the header toggle
+    owns ``global`` and sends ``{global}``; the Advanced per-function table owns
+    ``overrides`` and sends ``{overrides}``. A whole-key REPLACE therefore let
+    each owner silently ERASE the other's half — a header flip wiped every
+    per-function pin (including a ``translation: local`` pin whose only job is to
+    stop transcript egress), and a row edit re-clamped ``global`` to the default.
+    So a key that is ABSENT from ``patch`` INHERITS the persisted value.
+
+    GATE-2 (Risk #3 — silent cloud egress) is preserved two independent ways:
+
+      * every PRESENT value still runs through :func:`sanitize_routing_policy`'s
+        clamp, so an absent key can never promote to cloud and a present
+        out-of-enum value is still forced to ``local``; and
+      * writing ``global:'local'`` — the header flipped to Local — additionally
+        SCRUBS any INHERITED ``cloud``/``auto`` pin, so "I clicked Local" can
+        never leave an egress path behind for
+        ``providers_ops._translator_for_function`` to find. An ``overrides`` map
+        supplied in the SAME patch is the caller's explicit instruction and is
+        honoured verbatim (unchanged from the pre-patch behaviour).
+
+    PURE: never raises, never mutates either input, opens no I/O. A non-dict
+    ``patch`` is a no-op; a non-dict ``current`` degrades to
+    :func:`default_routing_policy` first.
+    """
+    base = sanitize_routing_policy(current)
+    if not isinstance(patch, dict):
+        return base
+    has_global = "global" in patch
+    global_mode = _clamp_mode(patch["global"]) if has_global else base["global"]
+    if "overrides" in patch:
+        overrides = sanitize_routing_policy({"overrides": patch["overrides"]})["overrides"]
+    elif has_global and global_mode == DEFAULT_GLOBAL:
+        overrides = {fn: m for fn, m in base["overrides"].items() if m == DEFAULT_GLOBAL}
+    else:
+        overrides = dict(base["overrides"])
+    return {"global": global_mode, "overrides": overrides}
+
+
 def read_routing_policy(settings: dict[str, Any]) -> dict[str, Any]:
     """Read the persisted ``RoutingPolicy`` from ``settings``, failing CLOSED.
 
@@ -112,6 +156,7 @@ __all__ = [
     "DEFAULT_GLOBAL",
     "VALID_MODES",
     "default_routing_policy",
+    "merge_routing_policy",
     "read_routing_policy",
     "resolve_route",
     "sanitize_routing_policy",

--- a/sidecar/media_studio/models/routing_policy.py
+++ b/sidecar/media_studio/models/routing_policy.py
@@ -29,9 +29,11 @@ I/O of its own — the bytes live in the §2 settings document under
     two layers do not collide.
 
 The atomic ``models.setRoutingPolicy`` write lives in the system_ops handler; it
-persists the :func:`sanitize_routing_policy` output through the settings store,
-whose ``_write`` is an atomic temp-file + ``os.replace`` (mirrors
-``library._write_json``).
+persists the :func:`merge_routing_policy` output (``system_ops.py:278``) through
+the settings store, whose ``_write`` is an atomic temp-file + ``os.replace``
+(mirrors ``library._write_json``). It is NOT the :func:`sanitize_routing_policy`
+output — that distinction is the whole point of F33: a full-replace write let the
+header toggle and the Advanced override table clobber each other's half.
 """
 
 from __future__ import annotations

--- a/sidecar/tests/test_handlers_set_routing_policy.py
+++ b/sidecar/tests/test_handlers_set_routing_policy.py
@@ -6,9 +6,17 @@ persists a sanitised ``{global, overrides}`` through the atomic settings store
 out-of-enum mode is clamped to ``local`` BEFORE persistence, a non-string
 override key is dropped, and the handler NEVER raises on a malformed body. The
 DECISION §4 default (``global:'local'``, no auto-promote) means the toggle only
-ever moves on an explicit user write. These tests pin: registration, the
-round-trip persist+read-back, the fail-closed clamp on write, the partial-merge
-(other settings preserved), and that the returned policy is the sanitised one.
+ever moves on an explicit user write.
+
+The write is a PER-HALF PATCH, not a whole-key replace (F33/F35): the header
+toggle owns ``global`` and the Advanced table owns ``overrides``, so an ABSENT
+key inherits the persisted value instead of blanking it. Writing
+``global:'local'`` still scrubs inherited cloud/auto pins so GATE-2 holds.
+
+These tests pin: registration, the round-trip persist+read-back, the fail-closed
+clamp on write, the partial-merge (other settings preserved), the per-half patch
+in both directions + its egress consequence, and that the returned policy is the
+sanitised one.
 """
 
 from __future__ import annotations
@@ -111,9 +119,62 @@ def test_set_routing_policy_preserves_other_settings(tmp_path: Path) -> None:
     assert merged["routingPolicy"] == {"global": "cloud", "overrides": {}}
 
 
-def test_set_routing_policy_overwrites_previous_policy(tmp_path: Path) -> None:
-    """A second write replaces the first (the store holds exactly one policy)."""
+def test_set_routing_policy_header_local_scrubs_egress_pins(tmp_path: Path) -> None:
+    """GATE-2: a header flip to Local drops INHERITED cloud/auto pins.
+
+    F33 changed the write from a whole-key REPLACE to a per-half PATCH, so a
+    second write no longer blanks the half it omits. The one case that still
+    ends with ``overrides == {}`` is this GATE-2 scrub: writing
+    ``global:'local'`` cannot leave an inherited cloud pin behind, or a user who
+    clicked Local would still egress (``providers_ops._translator_for_function``).
+    """
     svc = _services(tmp_path)
     svc.models_set_routing_policy({"global": "cloud", "overrides": {"select": "cloud"}}, _direct())
     out = svc.models_set_routing_policy({"global": "local"}, _direct())
     assert out["routingPolicy"] == {"global": "local", "overrides": {}}
+
+
+# --------------------------------------------------------------------------- #
+# (e) F33/F35 — the write is a PER-HALF PATCH, not a whole-key replace
+# --------------------------------------------------------------------------- #
+def test_header_toggle_preserves_existing_overrides(tmp_path: Path) -> None:
+    """F33: a header-toggle {global} write must NOT erase the Advanced table's pins."""
+    svc = _services(tmp_path)
+    # The Advanced-table write (proven to land by ..._persists_and_returns above).
+    first = svc.models_set_routing_policy({"global": "auto", "overrides": {"translation": "local"}}, _direct())
+    assert first["routingPolicy"]["overrides"] == {"translation": "local"}
+    # The header-toggle body, byte-identical to what App.tsx sends.
+    out = svc.models_set_routing_policy({"global": "cloud"}, _direct())
+    assert out["routingPolicy"] == {"global": "cloud", "overrides": {"translation": "local"}}
+
+
+def test_header_toggle_preserves_the_local_egress_gate(tmp_path: Path) -> None:
+    """F33 EGRESS proof at the resolver ``providers_ops`` actually consults.
+
+    ``translation`` is used deliberately: it is one of the three functions with a
+    live ``resolve_route`` consumer, so a wiped pin is real cloud egress rather
+    than inert state loss.
+    """
+    svc = _services(tmp_path)
+    svc.models_set_routing_policy({"global": "auto", "overrides": {"translation": "local"}}, _direct())
+    svc.models_set_routing_policy({"global": "cloud"}, _direct())
+
+    from media_studio.models import routing_policy as rp
+
+    assert rp.resolve_route("translation", svc.settings.get()) == {"mode": "local"}
+
+
+def test_overrides_only_write_preserves_persisted_global(tmp_path: Path) -> None:
+    """F35: the table sends {overrides} only; the persisted global must SURVIVE."""
+    svc = _services(tmp_path)
+    svc.models_set_routing_policy({"global": "cloud"}, _direct())
+    out = svc.models_set_routing_policy({"overrides": {"select": "local"}}, _direct())
+    assert out["routingPolicy"] == {"global": "cloud", "overrides": {"select": "local"}}
+
+
+def test_empty_body_against_an_existing_policy_is_a_no_op(tmp_path: Path) -> None:
+    """An empty body patches nothing — it can neither promote NOR blank a policy."""
+    svc = _services(tmp_path)
+    svc.models_set_routing_policy({"global": "auto", "overrides": {"director": "cloud"}}, _direct())
+    out = svc.models_set_routing_policy({}, _direct())
+    assert out["routingPolicy"] == {"global": "auto", "overrides": {"director": "cloud"}}

--- a/sidecar/tests/test_routing_policy.py
+++ b/sidecar/tests/test_routing_policy.py
@@ -110,6 +110,95 @@ def test_sanitize_preserves_valid_policy() -> None:
     assert out == {"global": "auto", "overrides": {"director": "cloud"}}
 
 
+# --- merge_routing_policy (the PER-HALF patch the WRITE applies) --------------
+#
+# F33/F35: one RoutingPolicy document has TWO disjoint renderer owners (the header
+# toggle owns `global`, the Advanced table owns `overrides`). A whole-key REPLACE
+# let each owner silently erase the other's half, so the write is a PATCH: a key
+# that is ABSENT from the patch inherits the persisted value. GATE-2 is preserved
+# two ways — every PRESENT value still runs through the same fail-closed clamp,
+# and writing `global:'local'` (the header flipped to Local) additionally scrubs
+# any INHERITED cloud/auto pin so "I clicked Local" can never leave an egress path.
+
+
+@pytest.mark.parametrize("bad_patch", [None, "garbage", 42, [], 3.14])
+def test_merge_non_dict_patch_returns_sanitised_current(bad_patch: Any) -> None:
+    """A non-dict patch is a no-op: the persisted policy survives, sanitised."""
+    current = {"global": "cloud", "overrides": {"select": "auto"}}
+    assert rp.merge_routing_policy(current, bad_patch) == current
+
+
+@pytest.mark.parametrize("bad_current", [None, "garbage", 42, [], 3.14])
+def test_merge_non_dict_current_starts_from_default(bad_current: Any) -> None:
+    """A corrupt persisted policy degrades to the local default before merging."""
+    out = rp.merge_routing_policy(bad_current, {"overrides": {"select": "cloud"}})
+    assert out == {"global": "local", "overrides": {"select": "cloud"}}
+
+
+def test_merge_empty_patch_is_a_no_op() -> None:
+    """Neither key present -> the persisted policy is returned unchanged."""
+    current = {"global": "auto", "overrides": {"translation": "cloud"}}
+    assert rp.merge_routing_policy(current, {}) == current
+
+
+def test_merge_global_only_patch_inherits_overrides() -> None:
+    """The header toggle sends {global}: the persisted overrides are INHERITED."""
+    current = {"global": "local", "overrides": {"translation": "local", "select": "cloud"}}
+    out = rp.merge_routing_policy(current, {"global": "cloud"})
+    assert out == {"global": "cloud", "overrides": {"translation": "local", "select": "cloud"}}
+
+
+def test_merge_overrides_only_patch_inherits_global() -> None:
+    """The Advanced table sends {overrides}: the persisted global is INHERITED."""
+    out = rp.merge_routing_policy({"global": "cloud", "overrides": {}}, {"overrides": {"select": "local"}})
+    assert out == {"global": "cloud", "overrides": {"select": "local"}}
+
+
+def test_merge_writing_global_local_scrubs_inherited_egress_pins() -> None:
+    """GATE-2: flipping the header to Local drops INHERITED cloud/auto pins only."""
+    current = {"global": "cloud", "overrides": {"select": "cloud", "translation": "local"}}
+    out = rp.merge_routing_policy(current, {"global": "local"})
+    assert out == {"global": "local", "overrides": {"translation": "local"}}
+
+
+def test_merge_explicit_overrides_survive_an_explicit_local_global() -> None:
+    """Both keys present -> the caller owns BOTH halves verbatim (no scrub)."""
+    out = rp.merge_routing_policy(
+        {"global": "cloud", "overrides": {}},
+        {"global": "local", "overrides": {"select": "cloud"}},
+    )
+    assert out == {"global": "local", "overrides": {"select": "cloud"}}
+
+
+def test_merge_clamps_a_present_out_of_enum_global() -> None:
+    """A present but out-of-enum global still clamps to local (fail-closed)."""
+    out = rp.merge_routing_policy({"global": "cloud", "overrides": {}}, {"global": "sneaky"})
+    assert out["global"] == "local"
+
+
+def test_merge_clamps_present_overrides_and_drops_bad_keys() -> None:
+    """A present overrides map runs through the same clamp as the read path."""
+    out = rp.merge_routing_policy(
+        {"global": "auto", "overrides": {}},
+        {"overrides": {"select": "nope", "vision": "auto", 7: "cloud"}},
+    )
+    assert out == {"global": "auto", "overrides": {"select": "local", "vision": "auto"}}
+
+
+def test_merge_does_not_mutate_its_inputs() -> None:
+    """PURE: neither the current policy nor the patch is mutated."""
+    current = {"global": "cloud", "overrides": {"select": "cloud"}}
+    patch = {"global": "local"}
+    rp.merge_routing_policy(current, patch)
+    assert current == {"global": "cloud", "overrides": {"select": "cloud"}}
+    assert patch == {"global": "local"}
+
+
+def test_merge_is_exported() -> None:
+    """The merge is part of the module's public surface (export discipline)."""
+    assert "merge_routing_policy" in rp.__all__
+
+
 # --- resolve_route (the pure policy resolver M3 owns) -------------------------
 
 


### PR DESCRIPTION
Integration PR **E** — the two batches that adversarial review **rejected**, re-landed with their single defect each fixed. Recovers 6 findings (F33, F34, F35, F36, F23, F24) that would otherwise not land at all.

Neither was a drop or a re-scope. Both reviewers explicitly validated everything else on each batch — B03's per-half `merge_routing_policy`, the GATE-2 scrub scoping, the single `runAssetJob`/`jobBridge` seam, the Set-based per-card busy, the `aliveRef`, scope, coverage, security, minimality (reviewer 2 re-executed `merge_routing_policy` standalone 9/9 including 4 adversarial cases); and B12 was accepted on all four scope-and-gate axes with its RED proof validated on all three findings.

| batch | branch | findings | the one defect |
|---|---|---|---|
| B03 | `fix/models-routing-readiness` | F33, F34, F35, F36 | StrictMode aborted the only `AbortController` the panel would ever have |
| B12 | `fix/export-cancel-and-copy` | F23, F24 | the cancel latch's only clearing point was one unasserted line |

## B03 — a silent no-op in the exact environment a human would verify in

`ModelsSystemPanel.tsx` allocated one `AbortController` per mount and aborted it in an empty-dep cleanup that **captured it at setup time**. `main.tsx:19` wraps the app in `React.StrictMode`, so in `npm run dev` the effect runs setup → cleanup → setup and that cleanup destroyed the controller.

`waitForJobDone` short-circuits on `signal?.aborted` (`_api.ts:266-269`) and `surfaceJobError` swallows `JobAbortedError`, so every per-card Download and every readiness fix action **enqueued its multi-GB job and then silently no-op'd, with the error path muted.** Measured on the broken code: effect setups=2, cleanups=1, `signal.aborted` at click time = true.

Fixed with the in-repo precedent at `views/Export.tsx:75,108` — a fresh controller per job inside `runAssetJob`, and a cleanup that reads `abortRef.current` *at cleanup time*.

## B12 — correctness that rested on one line no test asserted

`cancel` latches `cancelRequested.current = true` on every press, and the drain at `Export.tsx:126` is **terminal**: it calls `job.cancel(id)` and sets `phase='cancelled'`. The only clearing point was one line inside `onCommit`. Deleting it left **all 3577 tests green** while, at runtime, the stale latch cancelled the user's *next* export and painted "Export cancelled — a partial file may remain." over a healthy run.

The deliverable here is the missing test, not the production change. The latch is now also cleared in `reset` as belt-and-braces.

## Both-states matrix

A test that cannot go red proves nothing, so each new test was run against the code it guards:

| mutation | expected | actual | what it proves |
|---|---|---|---|
| `b03-revert` | RED | **RED** | the new StrictMode test catches the defect |
| `b03-effect-only` | GREEN | **RED** ← | see below |
| `b12-neither` | RED | **RED** | the new test catches the stale latch |
| `b12-commit-only` | GREEN | **GREEN** | it guards the *pre-existing* `onCommit` line — the whole point |
| `b12-reset-only` | GREEN | **GREEN** | the new clear alone also suffices |

**I predicted `b03-effect-only` GREEN and it measured RED. The measurement is right and the conclusion is stronger than my prediction.** With a fresh controller per job but the effect still capturing at setup, the unmount cleanup aborts controller A while the live job holds controller B — so it fails the **pre-existing** `'treats an unmount mid-download as a clean abort, not an error (F34)'` test with `expected 1 to be +0`, not the new StrictMode one. Both halves of the B03 fix are therefore load-bearing, and each is guarded by a *different* test. No test-shaped gap.

Matrix script committed at `.audit/run_mutation_matrix.ps1` + `.audit/mutate_b03_b12.py` (currently gitignored; Phase 1 of the SSOT plan tracks them).

## Also: a docstring that contradicted itself

`routing_policy.py`'s module docstring claimed the `models.setRoutingPolicy` write persists `sanitize_routing_policy` output. It persists `merge_routing_policy` output (`system_ops.py:278`) — and the same docstring's own bullet list already said so. That distinction *is* F33: a full-replace write let the header toggle and the Advanced override table clobber each other's half.

The `cv2/mediapipe` → `cv2` docstring rider in `handlers/system_ops.py` (which B05 was forbidden to touch) is already applied by B03's own commit — verified against `origin/main`.

## Local gate

- `uvx pre-commit run --all-files` → **all Passed**
- `node app/node_modules/typescript/bin/tsc --noEmit` → **exit 0**
- `npx vitest run --coverage` → **100% / 100% / 100% / 100%** (19549 stmts, 6489 branches, 1152 fns)
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **100%, 6107 passed** (+23 from B03's sidecar cases)

## Residue to decide, not blocking

The Export row still reads "Captions / N words". `cues.py:78-85`'s segment-span fallback means a transcript with no word timing is counted as *segments* yet labelled "words", and the `exportModel.ts:195-201` doc comment does not say so.
