### PR TITLE
fix(e2e): unblock both failing e2e jobs + make the visual-baseline regen actually reachable

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -282,8 +282,21 @@ jobs:
       # exits 0 after writing), so this run is non-blocking by design; the regenerated
       # PNGs are uploaded below for the maintainer to download + commit. Never runs on
       # the schedule (input is '' there), so the nightly gate stays a real diff.
+      # `always()` is load-bearing and was MISSING: without it this step inherits the
+      # implicit "all previous steps succeeded" gate, so any failure in the Playwright
+      # step above SKIPS the regen — while the upload step below already carries
+      # `always()` and therefore uploads the OLD baselines under the name
+      # `updated-visual-baselines`. That is worse than no artifact: it looks like a
+      # successful regen. Measured on run 30612141716: the Playwright step failed on
+      # golden-journey's beforeAll, so a dispatch with the box checked could not have
+      # produced a new baseline no matter how many times it was re-run.
+      #
+      # A baseline REGEN is an explicitly-requested maintainer action, not a gate, and
+      # `--update-snapshots` makes Playwright exit 0 after writing — so running it
+      # regardless of an unrelated earlier failure is correct. The BLOCKING diff path
+      # at the step above deliberately does NOT get `always()`; it must stay a real gate.
       - name: E2E GUI — VISUAL baseline REGEN (--update-snapshots) [Windows only, on demand]
-        if: runner.os == 'Windows' && github.event.inputs.update_visual_baselines == 'true'
+        if: always() && runner.os == 'Windows' && github.event.inputs.update_visual_baselines == 'true'
         working-directory: app
         env:
           RF_PY: ${{ steps.setup-python.outputs.python-path }}

--- a/app/e2e/golden-journey.spec.ts
+++ b/app/e2e/golden-journey.spec.ts
@@ -127,6 +127,22 @@ async function pollForFinalShort(
 }
 
 test.beforeAll(async () => {
+  // A beforeAll hook does NOT inherit the `test.setTimeout(240_000)` at :194 — per
+  // Playwright, beforeAll/afterAll "have their own separate timeout value" seeded
+  // from the config `timeout` and "do not share time with any test", and it can only
+  // be changed by calling `test.setTimeout` INSIDE the hook (`test.slow()` is not
+  // allowed here). So this hook ran on `playwright.config.ts:23`'s 120_000 while
+  // `provisionAssets` below sets its OWN 300_000 ceiling for the YuNet download —
+  // the hook was killed 3 minutes before its heaviest step was even allowed to give
+  // up, with the anonymous '"beforeAll" hook timeout of 120000ms exceeded' as the
+  // only evidence. Measured on CI run 30612141716 (windows-latest): exactly this
+  // hook, exactly that message, 1 failed / 1 skipped of 14.
+  //
+  // 420s = provisionAssets' own 300s ceiling + headroom for the Electron launch and
+  // first paint. Deliberately ABOVE the inner timeout so the inner one fires first:
+  // it rejects with `provisionAssets(...) timed out\n${stderr}`, which names the
+  // failing asset and carries the sidecar's stderr. The hook timeout carries nothing.
+  test.setTimeout(420_000);
   // macOS is a NON-SHIPPING platform: electron-builder ships a `win:` target only
   // (packaged.spec + build/python-embed-setup.ps1 are Windows-only). golden-journey
   // runs the FULL export pipeline through the libass caption stage, and brew-ffmpeg

--- a/sidecar/tests/test_e2e_ai2_intel_repurpose.py
+++ b/sidecar/tests/test_e2e_ai2_intel_repurpose.py
@@ -199,10 +199,33 @@ def _ffprobe_dims(path: str) -> tuple[int, int]:
 # settings + project helpers
 # --------------------------------------------------------------------------- #
 def _cloud_settings(base_url: str, *, capabilities: list[str], model: str = "mock-model") -> dict[str, Any]:
-    """A provider entry pointed at the mock, fully consented + routed (no budget gate)."""
+    """A provider entry pointed at the mock, fully consented + routed (no budget gate).
+
+    ``routingPolicy`` is load-bearing and used to be MISSING, which is why this
+    helper did not actually live up to "fully ... routed". The M3 cross-cutting
+    RoutingPolicy is **authoritative over ``routing.perFunction``** — a deliberate
+    GATE-2 privacy fix, so that a user who flips the global toggle to Local can never
+    egress despite a stale per-function cloud entry
+    (``providers_ops.py:_provider_for_function`` / ``_translator_for_function``). It
+    is also fail-CLOSED: absent from settings, ``resolve_route`` returns ``local``
+    (``routing_policy.DEFAULT_GLOBAL``) and a LOCAL-ONLY pool is built in which "NO
+    cloud entry is built" — so the mock below was unreachable no matter what
+    ``routing.perFunction`` said.
+
+    That silently degraded two e2e tests into asserting against a local llama.cpp
+    server which CI has no GGUF for, producing ``provider pool exhausted (text):
+    local (local): local model server failed to start: no GGUF model configured``
+    and then the misleading ``never reached the mock`` assertion (measured: CI run
+    30612141716, ``2 failed, 45 passed``).
+
+    The guard is CORRECT and is not touched here. Declaring ``global: 'cloud'`` is
+    what a user who deliberately chose a cloud route has, i.e. the state these tests
+    already intend — the per-entry text/frame consent gates below still apply.
+    """
     return {
         "confirmCloudBudget": False,
         "cloudModel": model,
+        "routingPolicy": {"global": "cloud", "overrides": {}},
         "providers": [
             {
                 "id": "mock",


### PR DESCRIPTION
The e2e suite has been red on `main` for at least three runs. This fixes **both** failing jobs and unblocks the visual-baseline regen path, which PR-D (#321) needs and which currently cannot produce a baseline at all.

## 1. `e2e-gui (windows-latest)` — a hook killed 3 minutes before its own step was allowed to give up

`golden-journey.spec.ts` failed with the anonymous `"beforeAll" hook timeout of 120000ms exceeded` (run [30612141716](https://github.com/Prekzursil/Reframe/actions/runs/30612141716): 14 tests, **1 failed, 1 skipped**, the rest green).

The `beforeAll` at `:129` does the heaviest work in the file — `provisionAssets(...)` downloads the YuNet model, then Electron launches — and `provisionAssets` sets its **own 300 000 ms ceiling** for that download. But the hook itself ran on `playwright.config.ts:23`'s `timeout: 120_000`.

Per the Playwright docs, `beforeAll`/`afterAll` *"have their own separate timeout value"*, seeded from the config `timeout`, and *"do not share time with any test"* — so the `test.setTimeout(240_000)` the author correctly added at `:194` never applied to the hook. `test.slow()` is explicitly not allowed in these hooks; `test.setTimeout` **inside** the hook is the documented mechanism. There was no in-repo precedent for it (checked: zero specs set a timeout inside a `beforeAll`), which is why the gap survived.

Now `test.setTimeout(420_000)` as the hook's first statement. 420 s is deliberately **above** `provisionAssets`' own 300 s so the inner timeout is the one that fires: it rejects with `provisionAssets(...) timed out\n${stderr}`, naming the failing asset and carrying the sidecar's stderr. The hook timeout carries nothing.

## 2. `e2e-sidecar` — a stale fixture silently stopped testing the thing it claimed to test

```
ProviderError: provider pool exhausted (text): local (local): local model server
failed to start: no GGUF model configured (set settings.ggufPath or settings.modelsDir)
→ FAILED test_intel_director_plan_real_chat_editplan_over_http
    AssertionError: director.plan never reached the mock /v1/chat/completions — assert 0 >= 1
→ FAILED test_intel_bestframe_thumbnail_real_jpg
    AssertionError: thumbnail.select never reached the mock vision endpoint — assert 0 >= 1
  2 failed, 45 passed, 4 skipped, 6076 deselected
```

The `_cloud_settings` fixture describes itself as *"fully consented + routed"* but sets only the legacy `routing.perFunction` map. It never set `routingPolicy`.

The M3 cross-cutting `RoutingPolicy` is **authoritative over `routing.perFunction`** — that precedence is a deliberate GATE-2 privacy fix, so a user who flips the global toggle to Local can never egress despite a stale per-function cloud entry (`providers_ops.py:_provider_for_function`, `_translator_for_function`: *"a Local-policy user with a cloud perFunction route slipped past it"*). And it is **fail-closed**: absent from settings, `resolve_route` returns `local` and a LOCAL-ONLY pool is built in which, per the docstring, *"NO cloud entry is built"*.

So the mock provider was never in the pool. The tests degraded into asserting against a local llama.cpp server that CI has no GGUF for, and the `never reached the mock` message was the symptom, not the cause.

**The guard is correct and is untouched.** The fixture now declares `routingPolicy: {global: 'cloud', overrides: {}}` — the state a user who deliberately chose a cloud route actually has, i.e. what these tests already intended. The per-entry text/frame consent gates still apply.

Both-states check, so this is not a CI-only guess:

| state | result |
|---|---|
| without the fixture fix, **locally** | `2 failed, 6 passed` — the same two tests, same names |
| with the fixture fix | `8 passed` |

## 3. The baseline REGEN step could never have run

`e2e.yml`'s regen step lacked `if: always()`, so it inherited the implicit "all previous steps succeeded" gate — and the step before it is the Playwright run that was failing. Meanwhile the **upload** step already had `always()`, with `path: app/e2e/visual/**/*-win32.png`.

The combination is worse than no artifact: the regen is skipped, and the upload publishes the **existing committed baselines** under the name `updated-visual-baselines`. A maintainer downloading that artifact would be looking at the old PNGs while believing they had regenerated them.

Fixed by adding `always()` to the regen step only. `--update-snapshots` makes Playwright exit 0 after writing, and a regen is an explicitly-requested maintainer action rather than a gate. **The blocking diff path immediately above deliberately does NOT get `always()`** — it must stay a real gate.

## What this does not fix

- The `workspace-preview-win32.png` baseline is still the one captured from the broken state, and was measured **50% flaky at HEAD** (2 pass / 2 fail over 4 runs, failing delta 130 743 px = 13% against a 1% tolerance). Re-recording it is now *possible*; it still has to be done on the CI Windows runner and the mask box verified as 1016×280 before the artifact is accepted.
- `Export` remains off-viewport at 1280 px (x=1268 vs 1264) even with the Advanced cluster collapsed — a separate open finding.
- The `<video>` poster race in `_visualSetup.ts` that causes that flake is still un-owned.

## Local gate

- `uvx pre-commit run --all-files` → **all Passed**
- `tsc --noEmit` (app) → **exit 0**
- `tsc --noEmit -p tsconfig.e2e.json` → **exit 0** — the gate added in #321, which is what typechecks the `golden-journey.spec.ts` edit above
- `npx vitest run --coverage` → **100% / 100% / 100% / 100%** (19657 stmts, 6545 branches, 1156 fns)
- `pytest --cov=media_studio --cov-branch --cov-fail-under=100` → **100%, 6084 passed**
- `pytest tests/test_e2e_ai2_intel_repurpose.py -m e2e` → **8 passed** (was 2 failed / 6 passed)
