### PR TITLE
fix(sidecar): unblock main — 14 tests were silently downloading get-pip.py; make them hermetic + rotate the pin

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -540,9 +540,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/asar/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -839,9 +839,9 @@
       "license": "MIT"
     },
     "node_modules/@electron/universal/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2916,9 +2916,9 @@
       "optional": true
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3523,9 +3523,9 @@
       "license": "MIT"
     },
     "node_modules/dir-compare/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4238,9 +4238,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -4290,9 +4290,9 @@
       "license": "MIT"
     },
     "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4483,9 +4483,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4951,9 +4951,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -5337,9 +5337,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {
@@ -6653,9 +6653,9 @@
       "license": "MIT"
     },
     "node_modules/test-exclude/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6892,9 +6892,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.27.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
-      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "version": "6.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.28.0.tgz",
+      "integrity": "sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/app/package.json
+++ b/app/package.json
@@ -32,12 +32,16 @@
     "react-dom": "^18.3.1"
   },
   "overrides": {
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@2": "2.1.4",
+    "brace-expansion@5": "5.0.9",
     "esbuild": "^0.28.1",
-    "fast-uri": "^3.1.4",
-    "js-yaml": "^4.3.0",
+    "fast-uri": "^3.1.5",
+    "js-yaml": "^4.3.1",
+    "nanoid": "^3.3.17",
     "postcss": "^8.5.18",
     "tar": "^7.5.21",
-    "undici": "^6.27.0"
+    "undici": "^6.28.0"
   },
   "devDependencies": {
     "@axe-core/playwright": "^4.12.1",

--- a/app/render-cli/package-lock.json
+++ b/app/render-cli/package-lock.json
@@ -1887,9 +1887,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "dev": true,
       "funding": [
         {
@@ -2158,9 +2158,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/app/render-cli/package.json
+++ b/app/render-cli/package.json
@@ -25,7 +25,11 @@
     "typescript": "5.9.3"
   },
   "overrides": {
-    "fast-uri": "^3.1.4",
+    "brace-expansion@1": "1.1.18",
+    "brace-expansion@2": "2.1.4",
+    "brace-expansion@5": "5.0.9",
+    "fast-uri": "^3.1.5",
+    "nanoid": "^3.3.17",
     "postcss": "^8.5.18",
     "ws": "^8.21.0"
   }

--- a/build/python-embed-setup.ps1
+++ b/build/python-embed-setup.ps1
@@ -93,7 +93,7 @@ param(
     # a341e1a4...7055 (2,226,848 B) started failing closed. Current: 2,230,427 B, pip 26.2.
     # Provenance + its limits are documented at the runtime site, which is the SSOT —
     # see sidecar/media_studio/assets/manager.py::GET_PIP_SHA256. Keep the two in lockstep.
-    [string]$ExpectedGetPipSha256 = '25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8',
+    [string]$ExpectedGetPipSha256 = 'fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6',
     # Fail-closed bootstrap escape hatch: fetch every artifact, PRINT its sha256,
     # delete it, stage NOTHING, exit non-zero. The only way to obtain a pin you
     # do not have yet — it can never produce a build.

--- a/sidecar/media_studio/assets/manager.py
+++ b/sidecar/media_studio/assets/manager.py
@@ -64,26 +64,35 @@ PINNED_PIP = "pip==25.2"
 # .part stage (sha mismatch in _finalize), never run. The seam
 # (AssetManager(get_pip_sha256=...)) lets ops/tests override without a code edit.
 #
-# ROTATED 2026-07-30. pypa republished the rolling URL at Last-Modified
-# "Wed, 29 Jul 2026 22:35:44 GMT", so the previous pin
-# (a341e1a43e38001c551a1508a73ff23636a11970b61d901d9a1cad2a18f57055, 2,226,848 B,
-# recorded 2026-06-28) began failing closed — correctly. 14 sidecar tests and the
-# Windows packaged-runtime staging step went red on the mismatch; that is the pin
-# working, not breaking.
+# ROTATED 2026-08-07 (second rotation in 8 days). pypa republished the rolling URL at
+# Last-Modified "Tue, 04 Aug 2026 23:11:14 GMT", so the previous pin
+# (25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8, 2,230,427 B,
+# recorded 2026-07-30) began failing closed — correctly.
 #
-# Current: https://bootstrap.pypa.io/get-pip.py, 2,230,427 B, bundles pip 26.2.
+# Current: https://bootstrap.pypa.io/get-pip.py, 2,230,488 B.
 # EVIDENCE, and its LIMIT — pypa publishes NO checksum for this file, so unlike the
 # embeddable-CPython pins (cross-checked against python.org's per-row MD5) this
 # rotation rests only on: two independent TLS fetches agreeing on the digest, a
-# Last-Modified consistent with a fresh publish, a +3,579 B size delta consistent
-# with a content update rather than truncation, and the payload being the canonical
-# base85-zip bootstrapper ("Hi There!" header, declares pip 26.2). That is
+# Last-Modified consistent with a fresh publish, a +61 B size delta consistent with a
+# content update rather than truncation, and the payload being the canonical
+# base85-zip bootstrapper (shebang + "Hi There!" header + base85/zip markers). That is
 # provenance, NOT authenticity — treat it as weaker than a vendor-checksummed pin.
-# The durable fix is unavailable: pypa's versioned URLs
+# Re-run `.audit/verify_getpip_rotation.py` to reproduce all four checks.
+#
+# The durable fix is still unavailable: pypa's versioned URLs
 # (https://bootstrap.pypa.io/pip/<ver>/get-pip.py) 404 for 3.12/3.14, they exist only
 # for EOL Pythons, so there is no non-rolling artifact to pin. Vendoring get-pip.py
 # into the tree is the only way to stop trusting a mutable URL.
-GET_PIP_SHA256 = "25b5c39ade96bab5eabe6404ce83cab6da2deb5fe3c07d9881f43803edb6f9c8"
+#
+# WHAT CHANGED THIS TIME: the previous rotation's note said "14 sidecar tests ... went
+# red on the mismatch; that is the pin working, not breaking." Half of that was wrong.
+# Those 14 tests do not exercise the pin at all — they pre-stage a dummy cached
+# get-pip.py and mean to skip the download entirely. Cache re-verification discarded
+# the dummy and made them SILENTLY REFETCH OVER THE NETWORK, so a rolling-URL rotation
+# reached tests that had no business touching it and took the blocking gate down with
+# it. They now inject their staged digest through the `get_pip_sha256=` seam below and
+# pass with egress blocked. Re-pinning is maintenance; that was a defect.
+GET_PIP_SHA256 = "fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6"
 #: success sentinel written into an env dir after a full install
 ENV_SENTINEL = ".media-studio-env.json"
 

--- a/sidecar/tests/test_assets.py
+++ b/sidecar/tests/test_assets.py
@@ -132,6 +132,16 @@ def make_manager(
 # building entries; tests that exercise the verify path still pass an explicit one.
 _DUMMY_SHA256 = "a" * 64
 
+#: The dummy get-pip.py body the env-installer tests pre-stage into <root>/tools,
+#: and its digest. Staging alone is NOT enough: `_install_env` RE-VERIFIES a cached
+#: get-pip.py against the manager's pin, so a fixture whose sha does not match is
+#: discarded and silently REFETCHED FROM THE NETWORK. Injecting this through the
+#: documented `AssetManager(get_pip_sha256=...)` seam is what actually makes these
+#: tests hermetic -- otherwise every upstream rotation of the rolling
+#: https://bootstrap.pypa.io/get-pip.py turns the blocking gate red.
+STAGED_GET_PIP = b"# get-pip"
+STAGED_GET_PIP_SHA256 = "93273d4007915e76636bbdfd82cc515939157dd57b4efccee2cbbfc923a45058"
+
 
 def sha_of(*parts: bytes) -> str:
     """sha256 of concatenated body parts (lets download tests pin the served bytes)."""
@@ -879,7 +889,12 @@ class TestEnvInstaller:
         (tmp_path / "tools" / "get-pip.py").write_text("# get-pip", encoding="utf-8")
 
         entry = env_entry()
-        mgr = make_manager(tmp_path, run_cmd=run_cmd, python_exe="C:/embed/python.exe")
+        mgr = make_manager(
+            tmp_path,
+            run_cmd=run_cmd,
+            python_exe="C:/embed/python.exe",
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
+        )
         mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
 
         env_dir = tmp_path / "envs" / "tts-env"
@@ -920,6 +935,7 @@ class TestEnvInstaller:
             chatterbox_python=lambda: "C:/py314/python.exe",
             usage=big_free_usage,
             env_vars={},
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
         )
         mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
         assert calls and calls[0][0] == "C:/py314/python.exe"
@@ -951,6 +967,7 @@ class TestEnvInstaller:
             python_exe="C:/host/python.exe",
             usage=big_free_usage,
             env_vars={},
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
         )
         with pytest.raises(JobCancelled):
             mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: state["cancel"])
@@ -980,6 +997,7 @@ class TestEnvInstaller:
             chatterbox_python=lambda: None,  # py3.14 embed not staged
             usage=big_free_usage,
             env_vars={},
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
         )
         mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
         assert calls and calls[0][0] == "C:/host/python.exe"
@@ -1002,6 +1020,7 @@ class TestEnvInstaller:
             chatterbox_python=lambda: pytest.fail("host-kind must not consult chatterbox_python"),
             usage=big_free_usage,
             env_vars={},
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
         )
         mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
         assert calls and calls[0][0] == "C:/host/python.exe"
@@ -1028,7 +1047,13 @@ class TestEnvInstaller:
             requirements=("torch==2.10.0+cu128",),
             python_kind="chatterbox",
         )
-        mgr = AssetManager(root=tmp_path, run_cmd=run_cmd, usage=big_free_usage, env_vars={})
+        mgr = AssetManager(
+            root=tmp_path,
+            run_cmd=run_cmd,
+            usage=big_free_usage,
+            env_vars={},
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
+        )
         mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
         assert calls and calls[0][0] == "C:/auto314/python.exe"
 
@@ -1039,7 +1064,7 @@ class TestEnvInstaller:
         (tmp_path / "tools").mkdir(parents=True)
         (tmp_path / "tools" / "get-pip.py").write_text("# get-pip", encoding="utf-8")
         entry = env_entry("bad-env")
-        mgr = make_manager(tmp_path, run_cmd=run_cmd)
+        mgr = make_manager(tmp_path, run_cmd=run_cmd, get_pip_sha256=STAGED_GET_PIP_SHA256)
         with pytest.raises(AssetError, match="no matching distribution"):
             mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: False)
         assert not env_sentinel_path(tmp_path / "envs" / "bad-env").exists()
@@ -1203,6 +1228,7 @@ class TestEnsureJob:
             http_factory=boom_factory,
             usage=big_free_usage,
             env_vars={},
+            get_pip_sha256=STAGED_GET_PIP_SHA256,
         )
         dest = mgr.resolve_dest(entry)
         dest.parent.mkdir(parents=True)

--- a/sidecar/tests/test_assets_extra.py
+++ b/sidecar/tests/test_assets_extra.py
@@ -82,7 +82,16 @@ def big_free_usage(_path: str) -> SimpleNamespace:
     return SimpleNamespace(total=10**13, used=0, free=10**13)
 
 
-def make_manager(tmp_path, *, client=None, run_cmd=None, hf_fetch=None, usage=big_free_usage):
+#: sha256(b"# get-pip") — the dummy body the env-installer tests pre-stage. Injecting
+#: it through the `get_pip_sha256=` seam is what makes "pre-staged, so no download"
+#: actually TRUE: `_install_env` re-verifies a cached get-pip.py against the pin, so an
+#: un-injected dummy is discarded and SILENTLY REFETCHED over the network — which is how
+#: a rotation of the rolling https://bootstrap.pypa.io/get-pip.py reaches tests that
+#: never meant to touch it. Verified: with egress blocked, these now pass.
+STAGED_GET_PIP_SHA256 = "93273d4007915e76636bbdfd82cc515939157dd57b4efccee2cbbfc923a45058"
+
+
+def make_manager(tmp_path, *, client=None, run_cmd=None, hf_fetch=None, usage=big_free_usage, get_pip_sha256=None):
     return AssetManager(
         root=tmp_path,
         http_factory=(lambda: client) if client is not None else None,
@@ -91,6 +100,7 @@ def make_manager(tmp_path, *, client=None, run_cmd=None, hf_fetch=None, usage=bi
         python_exe="C:/embed/python.exe",
         usage=usage,
         env_vars={},
+        get_pip_sha256=get_pip_sha256,
     )
 
 
@@ -412,7 +422,7 @@ def test_env_install_cancelled_between_steps(tmp_path):
         installer="env",
         requirements=("numpy==2.1.0",),
     )
-    mgr = make_manager(tmp_path, run_cmd=run_cmd)
+    mgr = make_manager(tmp_path, run_cmd=run_cmd, get_pip_sha256=STAGED_GET_PIP_SHA256)
     with pytest.raises(JobCancelled):
         mgr._install(entry, on_frac=lambda f, m="": None, should_cancel=lambda: True)
     assert run_calls["n"] == 0

--- a/sidecar/tests/test_env_lockfile.py
+++ b/sidecar/tests/test_env_lockfile.py
@@ -177,8 +177,14 @@ class _StubMgr:
     def make(tmp_path: Path):
         from media_studio.assets.manager import AssetManager
 
-        mgr = AssetManager(root=tmp_path / "root")
-        # get-pip already staged so _install_env never downloads.
+        # get-pip pre-staged AND its digest injected through the documented
+        # `AssetManager(get_pip_sha256=...)` seam. The injection is what makes
+        # 'never downloads' TRUE: `_install_env` re-verifies a cached get-pip.py
+        # against the pin, so without it this dummy is discarded and the manager
+        # silently refetches from the network -- which is how an upstream rotation
+        # of the rolling get-pip.py URL turned this file red.
+        gp_sha = "8153d63a9c9aa82b8751e206360a47ac82a56eac21edcc3ae6b121bc72de2cf0"  # sha256(b"# gp")
+        mgr = AssetManager(root=tmp_path / "root", get_pip_sha256=gp_sha)
         gp = tmp_path / "root" / "tools" / "get-pip.py"
         gp.parent.mkdir(parents=True, exist_ok=True)
         gp.write_text("# gp", encoding="utf-8")

--- a/sidecar/tests/test_supply_chain_pins.py
+++ b/sidecar/tests/test_supply_chain_pins.py
@@ -43,10 +43,19 @@ EMBED_SETUP_PS1 = REPO_ROOT / "build" / "python-embed-setup.ps1"
 
 
 def _recording_manager(root: Path, **kwargs: object) -> tuple[AssetManager, list[list[str]]]:
-    """An AssetManager with get-pip pre-staged and a recording run_cmd (no pip)."""
+    """An AssetManager with get-pip pre-staged and a recording run_cmd (no pip).
+
+    "no pip" requires INJECTING the staged digest, not merely writing the file:
+    `_install_env` re-verifies a cached get-pip.py against the manager's pin, so an
+    un-injected dummy is discarded and silently refetched over the network. That is
+    how an upstream rotation of the rolling get-pip.py URL turned this file red.
+    """
     gp = root / "tools" / "get-pip.py"
     gp.parent.mkdir(parents=True, exist_ok=True)
     gp.write_text("# gp", encoding="utf-8")
+    kwargs.setdefault(
+        "get_pip_sha256", "8153d63a9c9aa82b8751e206360a47ac82a56eac21edcc3ae6b121bc72de2cf0"
+    )  # sha256(b"# gp")
     calls: list[list[str]] = []
 
     def fake_run(argv, extra_env=None):  # noqa: ANN001, ANN202 - test seam


### PR DESCRIPTION
**`main` has been red since `49171746`** (green at `a455946e`): `14 failed, 6099 passed`, coverage 99.92%, failing step `gate-tests-coverage pytest`. This fixes it — and the interesting part is that re-pinning alone would not have.

## Two defects, one of them latent for weeks

### The latent one — the blocking gate was not hermetic

Fourteen tests pre-stage a dummy cached `get-pip.py` and say exactly what they intend:

> `# get-pip already staged so _install_env never downloads.` — `test_env_lockfile.py:181`
> `"""An AssetManager with get-pip pre-staged and a recording run_cmd (no pip)."""` — `test_supply_chain_pins.py:46`

**Both comments were false.** `_install_env` re-verifies a cached `get-pip.py` against the manager's pinned sha256. The dummy body doesn't match, so the cache is discarded and the manager **silently refetches the real 2.2 MB artifact over the network** — `cached get-pip.py failed sha256 re-verification; refetching`. Those tests have been network-dependent since re-verification landed, and passed only while the live rolling file happened to match the pin.

Proven rather than inferred: the live `https://bootstrap.pypa.io/get-pip.py` hashes to `fb24e693bab954209a063d90953621412ccad4a500905a726286e038f508ddf6` (2,230,488 B) — **byte-for-byte the `got` digest in the CI failure**. A fixture mismatch cannot produce the live file's hash.

The fix injects the seam the manager already documents for this (`AssetManager(get_pip_sha256=...)`, `manager.py:65`) at 10 call sites across 4 files. `make_manager`'s default deliberately stays `None`: `test_get_pip_sha256_defaults_to_pinned_constant` asserts the un-injected default **is** the module pin, and the two real verify-path tests already pass their own sha. Neither is touched.

| check | result |
|---|---|
| suite with **egress blocked** (`socket.socket`/`create_connection`/`getaddrinfo` raising) | **150 passed** |
| runtime before → after | 13.7 s → **3.8 s** (that delta was the download) |

Probe committed as `.audit/hermetic_probe.py` so this is re-findable in one command.

### The maintenance one — pin rotation, second in 8 days

pypa republished the rolling URL at `Last-Modified: Tue, 04 Aug 2026 23:11:14 GMT`. Rotated in lockstep across `manager.py` and `build/python-embed-setup.ps1` (a test asserts they match). Provenance per the standard `manager.py` sets for itself, reproducible via `.audit/verify_getpip_rotation.py`:

| check | result |
|---|---|
| two independent TLS fetches agree | `fb24e693…`, 2,230,488 B — both |
| Last-Modified | `Tue, 04 Aug 2026 23:11:14 GMT` |
| size delta vs previous pin | **+61 B** — content update, not truncation |
| payload sanity | shebang + `Hi There!` + base85/zip markers |

That is **provenance, not authenticity** — pypa publishes no checksum for this file. The durable fix remains unavailable (versioned URLs 404 for 3.12/3.14); vendoring is the only way to stop trusting a mutable URL.

## Correcting the previous rotation note

The 2026-07-30 note said *"14 sidecar tests … went red on the mismatch; that is the pin working, not breaking."* **Half of that was wrong.** Those 14 don't exercise the pin — they mean to skip the download entirely. The pin working is the two dedicated verify-path tests. The 14 were a non-hermetic gate reaching the network, and re-pinning alone would have left that live to fire again on the next rotation. It has now fired twice in eight days.

## Residual — disclosed, not fixed here

The egress probe finds **8 further network-reaching tests** in the default suite:

- `test_tts_engines.py::TestEdgeTts` (4)
- `test_e2e_ai2_director_text_consent.py` (3) — which despite the name are **not** marked `@pytest.mark.e2e`, so they run in the fast gate
- `test_director_golden_plans.py::test_example2_drops_the_injected_destructive_op` (1)

None currently breaks CI (CI has network), so they are latent risk of exactly this class, not a present failure. I've deliberately left them out of this fix rather than widening it — they're being handled in a separate lane, and one caveat matters: blocking `getaddrinfo` is aggressive and can trip code that never egresses, so each of the 8 needs classifying as real-egress vs probe-artifact before anyone rewrites it.
