### PR TITLE
fix(e2e): scroll the video's bottom into view before probing its control bar (last Windows GUI failure)

### DIFF
--- a/app/e2e/overlay-hittest.spec.ts
+++ b/app/e2e/overlay-hittest.spec.ts
@@ -127,8 +127,27 @@ async function probeControlBar(page: Page, videoSelector: string): Promise<HitIn
   // MANDATORY before measuring: `boundingBox()` does not scroll, and the
   // MakeShorts designer sits below the fold, so without this the probe point
   // lands outside the viewport and elementFromPoint returns null in EVERY state.
+  //
+  // `scrollIntoViewIfNeeded()` alone is NOT enough, and this cost a red Windows CI
+  // leg: it scrolls the MINIMUM needed to make an element visible, so for an element
+  // taller than the remaining space it can stop with the TOP in view and the BOTTOM
+  // still below the fold. This probe samples the bottom edge, which is exactly the
+  // edge that stayed off-screen. Measured on run 31222301375 (windows-latest): the
+  // guard in `hitTest` fired with "probe point (641, 837) is OUTSIDE the viewport"
+  // against an 820px-tall window — the video's bottom edge was at y=853.
+  //
+  // `scrollIntoView({ block: 'end' })` aligns the element's BOTTOM with the
+  // scrollport's bottom, and acts on the nearest scrollable ANCESTOR rather than only
+  // the window — which matters here because the app shell scrolls inner containers,
+  // so a `window.scrollBy` would have been a no-op.
   await page.locator(videoSelector).scrollIntoViewIfNeeded();
+  await page
+    .locator(videoSelector)
+    .evaluate((el) => el.scrollIntoView({ block: 'end', inline: 'nearest' }));
   const r = await boxOf(page, videoSelector);
+  // The self-validating guard in `hitTest` stays the authority: if the point is STILL
+  // outside after this, the run genuinely measured nothing and must fail loudly rather
+  // than report a null hit as a passing "no interception".
   return hitTest(page, r.x + r.width * 0.15, r.y + r.height - 16);
 }
 


### PR DESCRIPTION
fix(e2e): scroll the video's BOTTOM into view before probing its control bar

The last Windows GUI failure on main. e2e run 31222301375 (c4ac93f1): 1 failed,
18 passed, with the spec's own guard firing:

  Error: probe point (641, 837) is OUTSIDE the viewport — elementFromPoint cannot
         answer there, so this run measured nothing

The window is 820px tall (main.ts createWindow), so the video's bottom edge was at
y=853 — 33px below the fold — and the probe samples 16px above that edge.

`scrollIntoViewIfNeeded()` was doing its job and was still the wrong tool: it scrolls
the MINIMUM needed to make an element visible, so for an element taller than the
remaining space it can stop with the TOP in view and the BOTTOM still below the fold.
This probe measures the bottom edge, which is exactly the edge that stayed off-screen.

Fixed by additionally aligning the bottom edge with `scrollIntoView({ block: 'end' })`,
which also acts on the nearest scrollable ANCESTOR rather than only the window — that
matters here because the app shell scrolls inner containers, so a `window.scrollBy`
would have been a no-op.

The self-validating guard is deliberately left as the authority. If the point is still
outside after this, the run genuinely measured nothing and must fail loudly rather than
report a null hit as a passing "no interception". That guard is why this surfaced as a
precise coordinate instead of a silent false green, and it is worth keeping exactly as
strict as it is.

Predicted at 75-85% by the integration report when B08 landed ("cross-OS geometry ...
UNVERIFIED off Windows"), so this is a disclosed risk coming due, not a surprise.

Typechecked by `gate-types tsc e2e harness` (exit 0) — the gate added in #321, which is
what makes changes to app/e2e/** visible to CI at all.
