### PR TITLE
docs(validation): track the two reusable probes from the main-unblock work

### DIFF
--- a/docs/validation/tools/hermetic_probe.py
+++ b/docs/validation/tools/hermetic_probe.py
@@ -1,0 +1,63 @@
+"""Run the DEFAULT (non-e2e) sidecar suite with network egress BLOCKED.
+
+ci-hygiene.md 2: "Hermetic CI = block egress + verify a committed snapshot store."
+The get-pip.py incident showed the suite silently reaching the network: 14 tests
+pre-staged a dummy cache, the manager re-verified it, discarded it, and REFETCHED
+the real 2.2 MB rolling artifact -- so an upstream rotation turned the blocking
+gate red. Nothing detected that the suite was non-hermetic.
+
+This blocks socket creation at the stdlib seam and runs the suite. Every failure it
+reports is a test that reaches the network and would break the gate the next time
+that endpoint moves, rate-limits, or goes down.
+
+Usage:  python .audit/hermetic_probe.py [extra pytest args...]
+"""
+
+from __future__ import annotations
+
+import socket
+import sys
+from pathlib import Path
+
+
+def _find_root() -> Path:
+    """Walk up to the repo root rather than assuming a fixed depth.
+
+    Authored at `.audit/` where `parent.parent` IS the root; it now lives at
+    `docs/validation/tools/`, where that same expression resolves to
+    `docs/validation/`. This is the SECOND tool in this directory to hit that, so it
+    is anchored on markers that exist only at the root instead.
+    """
+    here = Path(__file__).resolve()
+    for cand in (here.parent, *here.parents):
+        if (cand / ".git").exists() and (cand / "sidecar/pyproject.toml").is_file():
+            return cand
+    raise SystemExit(f"FAILED:hermetic-probe cannot locate the repo root from {here}")
+
+
+SIDECAR = _find_root() / "sidecar"
+
+
+class _BlockedSocket(socket.socket):
+    def __init__(self, *a: object, **k: object) -> None:  # noqa: D107
+        raise OSError("EGRESS BLOCKED (hermetic_probe): this test reaches the network")
+
+
+def _blocked(*_a: object, **_k: object) -> object:
+    raise OSError("EGRESS BLOCKED (hermetic_probe): this test reaches the network")
+
+
+def main() -> int:
+    sys.path.insert(0, str(SIDECAR))
+    socket.socket = _BlockedSocket  # type: ignore[misc,assignment]
+    socket.create_connection = _blocked  # type: ignore[assignment]
+    socket.getaddrinfo = _blocked  # type: ignore[assignment]
+
+    import pytest
+
+    args = sys.argv[1:] or ["tests", "-q", "--no-header", "-p", "no:cacheprovider"]
+    return int(pytest.main(args))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/validation/tools/verify_getpip_rotation.py
+++ b/docs/validation/tools/verify_getpip_rotation.py
@@ -1,0 +1,114 @@
+"""Provenance check for a get-pip.py pin rotation.
+
+`manager.py` documents the standard this rotation must meet, and its LIMIT: pypa
+publishes NO checksum for the rolling URL, so a rotation rests only on
+  * two INDEPENDENT TLS fetches agreeing on the digest,
+  * a Last-Modified consistent with a fresh publish,
+  * a size delta consistent with a content update rather than truncation, and
+  * the payload being the canonical base85-zip bootstrapper.
+That is PROVENANCE, NOT AUTHENTICITY -- weaker than a vendor-checksummed pin.
+
+This runs those four checks and prints the new pin, so the rotation is evidenced
+rather than pasted.
+
+Usage:  python .audit/verify_getpip_rotation.py
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+import urllib.request
+from pathlib import Path
+
+URL = "https://bootstrap.pypa.io/get-pip.py"
+
+
+def _find_root() -> Path:
+    """Walk up to the repo root rather than assuming a fixed depth (see hermetic_probe)."""
+    here = Path(__file__).resolve()
+    for cand in (here.parent, *here.parents):
+        if (cand / ".git").exists() and (cand / "sidecar/pyproject.toml").is_file():
+            return cand
+    raise SystemExit(f"FAILED:getpip-rotation cannot locate the repo root from {here}")
+
+
+ROOT = _find_root()
+
+# Read the CURRENT pin out of the source of truth instead of hardcoding it. A hardcoded
+# "previous pin" goes stale the moment a rotation lands, and this tool would then compare
+# against a value nothing uses — reporting a rotation that already happened.
+_MANAGER = ROOT / "sidecar/media_studio/assets/manager.py"
+_m = re.search(r'GET_PIP_SHA256\s*=\s*"([0-9a-f]{64})"', _MANAGER.read_text(encoding="utf-8"))
+OLD_SHA = _m.group(1) if _m else "(could not read GET_PIP_SHA256 from manager.py)"
+# Size of the currently-pinned artifact, for the truncation check. Parsed from the same
+# comment block so it travels with the pin.
+_s = re.search(r"Current: https://bootstrap\.pypa\.io/get-pip\.py, ([\d,]+) B", _MANAGER.read_text(encoding="utf-8"))
+OLD_SIZE = int(_s.group(1).replace(",", "")) if _s else 0
+
+
+def fetch() -> tuple[bytes, dict[str, str]]:
+    req = urllib.request.Request(URL, headers={"User-Agent": "reframe-pin-check"})
+    with urllib.request.urlopen(req, timeout=120) as r:  # noqa: S310 - pinned https literal
+        return r.read(), {k.lower(): v for k, v in r.headers.items()}
+
+
+print(f"URL: {URL}\n")
+
+b1, h1 = fetch()
+b2, h2 = fetch()
+s1, s2 = hashlib.sha256(b1).hexdigest(), hashlib.sha256(b2).hexdigest()
+
+print("1. TWO INDEPENDENT FETCHES")
+print(f"     fetch A: {len(b1):,} B  sha256={s1}")
+print(f"     fetch B: {len(b2):,} B  sha256={s2}")
+agree = s1 == s2
+print(f"     agree: {agree}")
+
+print("\n2. LAST-MODIFIED")
+print(f"     A: {h1.get('last-modified', '(none)')}")
+print(f"     B: {h2.get('last-modified', '(none)')}")
+
+print("\n3. SIZE DELTA vs the previous pin")
+delta = len(b1) - OLD_SIZE
+print(f"     previous: {OLD_SIZE:,} B   current: {len(b1):,} B   delta: {delta:+,} B")
+grew = delta > 0
+print(f"     consistent with a content update (not truncation): {grew}")
+
+print("\n4. PAYLOAD SANITY (canonical base85-zip bootstrapper)")
+head = b1[:400].decode("utf-8", "replace")
+has_hi = "Hi There!" in head
+m = re.search(rb"pip==?([0-9][0-9.]*)", b1[:8000]) or re.search(rb"pip[- ]([0-9]+\.[0-9]+)", b1[:8000])
+declared = m.group(1).decode() if m else "(not found in header)"
+is_b85 = b"base64" in b1[:8000] or b"b85decode" in b1[:8000] or b"zipfile" in b1[:8000]
+print(f"     '#!/usr/bin/env python' header: {b1[:30].startswith(b'#!')}")
+print(f"     'Hi There!' marker: {has_hi}")
+print(f"     declares pip: {declared}")
+print(f"     base85/zip bootstrapper markers: {is_b85}")
+
+print("\n--- VERDICT ---")
+print(f"  pinned in manager.py: {OLD_SHA}")
+print(f"  live upstream:        {s1}")
+
+# THREE outcomes, not two. An earlier version had only pass/fail and gated on `delta > 0`,
+# which made the HEALTHY state (pin == live, delta 0) report FAILED — a detector that
+# cries wolf every time someone runs it is worse than no detector, because the next reader
+# learns to ignore it.
+if s1 == OLD_SHA:
+    print("SUCCESS:getpip-rotation NO ROTATION NEEDED — the pin already matches upstream")
+    raise SystemExit(0)
+
+# A rotation HAS happened. Now the provenance standard applies. `grew` is a truncation
+# check, so it is only meaningful against a real previous size.
+sane_size = len(b1) > 1_000_000 and (OLD_SIZE == 0 or delta > 0)
+ok = agree and sane_size
+if ok:
+    print("  ROTATION DETECTED and provenance-checked. To adopt it, update BOTH:")
+    print("    sidecar/media_studio/assets/manager.py  GET_PIP_SHA256")
+    print("    build/python-embed-setup.ps1            $ExpectedGetPipSha256")
+    print("  (a test asserts those two match; rotating one alone fails the gate)")
+    print("SUCCESS:getpip-rotation rotation evidenced (PROVENANCE, not authenticity)")
+    raise SystemExit(0)
+
+print("FAILED:getpip-rotation a rotation is present but did NOT pass provenance -- do NOT re-pin")
+raise SystemExit(1)


### PR DESCRIPTION
docs(validation): track the two reusable probes from the main-unblock work

`.audit/` is gitignored and declared disposable — `git clean -xfd` is meant to be safe
there. Two of the probes written while unblocking main are NOT disposable: they answer
questions that will be asked again, and leaving them in a directory designed to be
deleted is the exact "regeneration recipe inside the disposable tree" trap the SSOT pass
fixed for the audit-ledger tools.

  hermetic_probe.py          runs the default sidecar suite with egress BLOCKED, so a
                             test that reaches the network is named instead of waiting
                             to break the gate the next time an endpoint moves. This is
                             what found the 14 get-pip downloaders and 8 more besides.
  verify_getpip_rotation.py  the four provenance checks manager.py sets as the standard
                             for adopting a get-pip.py pin rotation. That URL is rolling
                             and has rotated twice in eight days, so this WILL be needed
                             again.

Both needed real fixes to survive the move — the same defect, twice:

  ROOT DISCOVERY. Both hardcoded `Path(__file__).resolve().parent.parent`, correct at
  `.audit/` and resolving to `docs/validation/` here. `verify_ssot_claims.py` already hit
  this and reported 26 of 36 claims mismatched, blaming the repo for its own relocation.
  Both now walk up to markers that exist only at the root, verified from two different
  cwds.

  verify_getpip_rotation.py additionally had TWO defects of its own:

  * It hardcoded the "previous" pin and size. Those went stale the moment the rotation
    landed, so it would have compared against a value nothing uses. It now reads
    GET_PIP_SHA256 and the recorded size out of manager.py — the source of truth.

  * It had only pass/fail and gated on `delta > 0`, which made the HEALTHY state (pin
    already matches upstream, delta 0) report FAILED. A detector that cries wolf every
    time it runs is worse than no detector, because the next reader learns to ignore it.
    Three outcomes now: NO ROTATION NEEDED / rotation evidenced / rotation present but
    provenance failed. On a real rotation it also names BOTH files that must move
    together, since a test asserts they match and rotating one alone fails the gate.

Verified in the healthy state: "NO ROTATION NEEDED — the pin already matches upstream",
exit 0.

The rest of `.audit/` stays untracked on purpose — those are one-shot migration and
bump scripts for this programme, and tracking them would be the bloat this directory
exists to avoid.
