### PR TITLE
test(sidecar): arm an always-on egress guard, and fix the arm that could never fire

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -89,6 +89,17 @@ jobs:
 
       - name: E2E sidecar — pytest -m e2e (AI2 hub/director + intel/repurpose + nasty inputs)
         working-directory: sidecar
+        env:
+          # sidecar/tests/conftest.py installs the hermetic egress guard
+          # (tests/_hermetic.py) for EVERY pytest invocation, including this one.
+          # That guard exists to keep the BLOCKING gate (quality.yml) independent
+          # of third-party endpoints — the get-pip.py rotation took main red twice.
+          # This opt-in suite is the opposite contract by design: it is the heavy
+          # leg that is ALLOWED real fetches (it installs huggingface_hub +
+          # faster-whisper precisely so the reframe/ASD flows can provision real
+          # model weights). Blocking egress here would be a scope error, not
+          # hardening, so the guard is explicitly stood down for this step only.
+          REFRAME_ALLOW_EGRESS: "1"
         run: python -m pytest -m e2e -v
 
       - name: E2E sidecar — real short-making pipeline smoke (real ffmpeg + tiny whisper)

--- a/sidecar/tests/_hermetic.py
+++ b/sidecar/tests/_hermetic.py
@@ -1,0 +1,365 @@
+"""Destination-aware network-egress guard for the sidecar test suite.
+
+WHY THIS EXISTS
+---------------
+``main`` went red twice in eight days for a reason unrelated to any code change:
+14 tests pre-staged a dummy cached ``get-pip.py``, the runtime-setup manager
+re-verified it, discarded it, and SILENTLY REFETCHED the real rolling artifact
+from ``https://bootstrap.pypa.io/get-pip.py``. When pypa rotated that file the
+blocking gate failed. Nothing in the gate could see that the suite was reaching
+the network at all -- and a suite whose green depends on a third party's CDN is
+not a gate, it is a coin flip (``ci-hygiene.md`` 2: "Hermetic CI = block egress +
+verify a committed snapshot store").
+
+This module is the missing detector. It rides inside the existing
+``gate-tests-coverage`` pytest step (installed from ``tests/conftest.py``), so it
+costs no extra CI minutes, needs no new charter gate slug, and cannot drift out
+of step with the suite it guards.
+
+WHY IT IS DESTINATION-AWARE, NOT A BLANKET BLOCK
+------------------------------------------------
+The obvious implementation -- replace ``socket.socket`` wholesale -- is WRONG.
+``socket.socketpair()`` goes through that constructor, and it is how *every*
+asyncio event loop builds its self-pipe (Proactor on Windows, Selector on POSIX);
+so does every ``("127.0.0.1", 0)`` bind. A blanket block therefore breaks
+``asyncio.run(...)`` and every loopback test server while detecting nothing that
+actually leaves the machine. That is not hypothetical: an earlier constructor-
+replacing probe reported 8 sidecar tests as "network-reaching", and a follow-up
+with four independent instruments measured ZERO off-box attempts from any of
+them. All 8 were artifacts of the detector's shape.
+
+So the predicate here is the DESTINATION, not the syscall: loopback and
+unspecified addresses (and the ``localhost`` family of names) pass through
+untouched; anything else raises :class:`HermeticEgressError` naming where it was
+going, before a single byte is sent.
+
+WHAT IS AND IS NOT COVERED (measured 2026-08-08 on win32 / CPython 3.14.6)
+--------------------------------------------------------------------------
+Guarded: ``socket.getaddrinfo``, ``socket.gethostbyname``,
+``socket.gethostbyname_ex``, ``socket.create_connection``,
+``socket.socket.connect``, ``socket.socket.connect_ex``, ``socket.socket.sendto``,
+``socket.socket.sendmsg`` (POSIX only -- Windows has no such method) and
+``asyncio.proactor_events.BaseProactorEventLoop.sock_connect``.
+
+``sendto``/``sendmsg`` matter because UDP to a hardcoded IP needs neither a
+``connect`` nor a DNS lookup. The asyncio Proactor entry matters for the same
+reason one level up, and it is NOT redundant with the ``socket.socket.connect``
+patch: on Windows, ``asyncio.open_connection("203.0.113.1", 9)`` skips
+``getaddrinfo`` (the host is already numeric) and connects via
+``_overlapped.ConnectEx``, never touching ``socket.socket.connect``. Measured
+before the patch existed: that call was neither logged nor raised -- it simply
+timed out after 3s. The POSIX Selector loop needs no equivalent patch because
+its ``sock_connect`` calls ``sock.connect(address)``, which is already guarded.
+
+Two honest limits, stated here so nobody has to rediscover them:
+
+* **A subprocess is out of scope.** This patches this interpreter's ``socket``
+  module. A test that shells out to ``curl``/``pip``/``git`` reaches the network
+  in a process that never imported this module. Egress from a child process is
+  the job of a sandbox or a network namespace, not of this guard.
+* **``HermeticEgressError`` subclasses ``OSError``, so callers can swallow it.**
+  Measured: ``urllib.request.urlopen("http://example.invalid/")`` IS caught (the
+  attempt is logged and the raise happens), but urllib catches ``OSError`` and
+  re-raises it as ``URLError`` -- so an assertion on the exception TYPE will miss
+  it while the attempt log still shows it. That is why :func:`attempts` exists and
+  why any report should read the log, not the traceback. Subclassing ``OSError``
+  is nevertheless deliberate: a test that legitimately handles "the network is
+  down" should keep working.
+
+NOT under ``--cov=media_studio``: this is test support, so it carries no coverage
+burden. Opt out for a deliberately-live run with ``REFRAME_ALLOW_EGRESS=1``.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import socket
+from typing import Any, NamedTuple
+
+__all__ = [
+    "Attempt",
+    "HermeticEgressError",
+    "attempts",
+    "clear_attempts",
+    "install",
+    "is_installed",
+    "is_local_destination",
+    "real_getaddrinfo",
+    "restore_attempts",
+    "uninstall",
+]
+
+#: Hostnames that resolve to this machine without leaving it. ``""``/``None`` are
+#: the "any/unspecified" spellings ``getaddrinfo`` accepts when binding.
+_LOCAL_NAMES = frozenset(
+    {
+        "",
+        "localhost",
+        "localhost.localdomain",
+        "ip6-localhost",
+        "ip6-loopback",
+        "broadcasthost",
+    }
+)
+
+_ENV_OPT_OUT = "REFRAME_ALLOW_EGRESS"
+
+
+class HermeticEgressError(OSError):
+    """Raised instead of letting a test reach a destination off this machine."""
+
+
+class Attempt(NamedTuple):
+    """One blocked egress attempt, kept so a failure says WHERE it was going."""
+
+    api: str
+    host: str
+    address: str
+
+
+_ATTEMPTS: list[Attempt] = []
+
+# The pristine stdlib callables, captured at import time -- before anything in the
+# suite has had a chance to shadow them.
+real_getaddrinfo = socket.getaddrinfo
+real_gethostbyname = socket.gethostbyname
+real_gethostbyname_ex = socket.gethostbyname_ex
+real_create_connection = socket.create_connection
+real_connect = socket.socket.connect
+real_connect_ex = socket.socket.connect_ex
+real_sendto = socket.socket.sendto
+real_sendmsg = getattr(socket.socket, "sendmsg", None)
+
+try:
+    import asyncio.proactor_events as _proactor_events
+except ImportError:  # a stripped-down asyncio; nothing to patch
+    _proactor_events = None  # type: ignore[assignment]
+
+_proactor_loop_cls = getattr(_proactor_events, "BaseProactorEventLoop", None)
+
+#: Present on every platform (``proactor_events`` is pure Python and imports
+#: cleanly on POSIX), but only ever *instantiated* on Windows.
+real_proactor_sock_connect = getattr(_proactor_loop_cls, "sock_connect", None)
+
+_installed = False
+
+
+def is_installed() -> bool:
+    """Whether the guard is currently armed."""
+    return _installed
+
+
+def attempts() -> tuple[Attempt, ...]:
+    """Every egress attempt blocked since the last :func:`clear_attempts`."""
+    return tuple(_ATTEMPTS)
+
+
+def clear_attempts() -> None:
+    """Reset the recorded-attempt log.
+
+    Process-wide. A test module that trips the guard on purpose should
+    :func:`restore_attempts` to a snapshot instead, so it removes only its own
+    synthetic entries and cannot discard a real finding recorded by a sibling.
+    """
+    _ATTEMPTS.clear()
+
+
+def restore_attempts(snapshot: tuple[Attempt, ...]) -> None:
+    """Roll the attempt log back to ``snapshot`` (see :func:`clear_attempts`)."""
+    _ATTEMPTS[:] = list(snapshot)
+
+
+def _as_text(host: object) -> str:
+    if isinstance(host, (bytes, bytearray)):
+        return host.decode("utf-8", "replace")
+    return "" if host is None else str(host)
+
+
+def is_local_destination(host: object) -> bool:
+    """True when ``host`` cannot leave this machine.
+
+    Accepts what the socket APIs accept: a name, an IPv4/IPv6 literal (with or
+    without a ``%zone`` suffix), bytes, ``None``, or a non-string address
+    component (AF_UNIX path, AF_PACKET tuple member) which is not IP egress.
+    """
+    if host is None:
+        return True
+    if isinstance(host, (bytes, bytearray)):
+        host = _as_text(host)
+    if not isinstance(host, str):
+        # A non-string address component: AF_UNIX path object, AF_BLUETOOTH
+        # channel, ... none of which is an IP destination.
+        return True
+    text = host.strip()
+    if text.lower() in _LOCAL_NAMES:
+        return True
+    try:
+        parsed = ipaddress.ip_address(text.split("%", 1)[0])
+    except ValueError:
+        # A real DNS name. Resolving it is itself a query that leaves the box.
+        return False
+    return bool(parsed.is_loopback or parsed.is_unspecified)
+
+
+def _host_of(address: object) -> object:
+    """The host component of a socket address, or ``None`` when there is none."""
+    if isinstance(address, (tuple, list)) and address:
+        return address[0]
+    return None
+
+
+def sendto_address(args: tuple[Any, ...]) -> object:
+    """The ``address`` positional of ``sendto(data[, flags], address)``.
+
+    ``data`` is a named parameter on the guard, so ``args`` is either
+    ``(address,)`` or ``(flags, address)`` -- the address is LAST either way.
+    Extracted as a pure function so the argument arithmetic is unit-testable on
+    a platform basis, rather than only via a live socket.
+    """
+    return args[-1] if args else None
+
+
+def sendmsg_address(args: tuple[Any, ...]) -> object:
+    """The ``address`` positional of ``sendmsg(buffers[, ancdata[, flags[, address]]])``.
+
+    ``buffers`` is a NAMED parameter on the guard, so ``args`` starts at
+    ``ancdata`` and the address is ``args[2]``.
+
+    This was ``args[3]`` in the first revision -- off by one, which made the arm
+    UNREACHABLE: a real ``sock.sendmsg([b"x"], [], 0, (host, port))`` passes three
+    positionals, ``len(args) > 3`` is False, and the guard checked ``None`` (which
+    :func:`is_local_destination` calls local) and waved the packet through. It
+    survived review because Windows has no ``sendmsg`` at all, so no test on the
+    authoring machine could ever have executed this line. Hence the pure helper
+    and :func:`test_sendmsg_address_is_the_third_positional`, which fails on every
+    platform if the index regresses.
+    """
+    return args[2] if len(args) > 2 else None
+
+
+def _reject(api: str, address: object, host: object) -> None:
+    attempt = Attempt(api=api, host=_as_text(host), address=repr(address))
+    _ATTEMPTS.append(attempt)
+    raise HermeticEgressError(
+        f"HERMETIC GUARD: {api} -> {attempt.host!r} is OFF-BOX network egress. "
+        "The default sidecar suite must be hermetic: a test that fetches a "
+        "remote artifact goes red when that artifact rotates, rate-limits, or "
+        "goes down (this is exactly how get-pip.py took main red twice). Inject "
+        "the seam and assert against a committed fixture instead. For a "
+        f"deliberately live run, set {_ENV_OPT_OUT}=1. Destination: {attempt.address}"
+    )
+
+
+def _check(api: str, address: object) -> None:
+    host = _host_of(address)
+    if not is_local_destination(host):
+        _reject(api, address, host)
+
+
+def _guarded_getaddrinfo(host: Any, port: Any, *args: Any, **kwargs: Any) -> Any:
+    if not is_local_destination(host):
+        _reject("socket.getaddrinfo", (host, port), host)
+    return real_getaddrinfo(host, port, *args, **kwargs)
+
+
+def _guarded_gethostbyname(hostname: Any) -> Any:
+    if not is_local_destination(hostname):
+        _reject("socket.gethostbyname", hostname, hostname)
+    return real_gethostbyname(hostname)
+
+
+def _guarded_gethostbyname_ex(hostname: Any) -> Any:
+    if not is_local_destination(hostname):
+        _reject("socket.gethostbyname_ex", hostname, hostname)
+    return real_gethostbyname_ex(hostname)
+
+
+def _guarded_create_connection(address: Any, *args: Any, **kwargs: Any) -> Any:
+    _check("socket.create_connection", address)
+    return real_create_connection(address, *args, **kwargs)
+
+
+def _guarded_connect(self: socket.socket, address: Any) -> Any:
+    _check("socket.socket.connect", address)
+    return real_connect(self, address)
+
+
+def _guarded_connect_ex(self: socket.socket, address: Any) -> Any:
+    _check("socket.socket.connect_ex", address)
+    return real_connect_ex(self, address)
+
+
+def _guarded_sendto(self: socket.socket, data: Any, *args: Any) -> Any:
+    _check("socket.socket.sendto", sendto_address(args))
+    return real_sendto(self, data, *args)
+
+
+def _guarded_sendmsg(self: socket.socket, buffers: Any, *args: Any) -> Any:
+    _check("socket.socket.sendmsg", sendmsg_address(args))
+    return real_sendmsg(self, buffers, *args)  # type: ignore[misc]
+
+
+async def _guarded_proactor_sock_connect(self: Any, sock: Any, address: Any) -> Any:
+    # Windows' Proactor loop reaches ConnectEx without going through
+    # socket.socket.connect; see the module docstring's measurement.
+    _check("asyncio.BaseProactorEventLoop.sock_connect", address)
+    return await real_proactor_sock_connect(self, sock, address)  # type: ignore[misc]
+
+
+#: ``(owner, attribute name, guarded callable, pristine callable)``. Everything
+#: patched here lives on the ``socket`` module, the ``socket.socket`` class, or
+#: asyncio's Proactor loop -- no filesystem, subprocess or os-level behaviour is
+#: touched.
+_PATCHES: tuple[tuple[Any, str, Any, Any], ...] = (
+    (socket, "getaddrinfo", _guarded_getaddrinfo, real_getaddrinfo),
+    (socket, "gethostbyname", _guarded_gethostbyname, real_gethostbyname),
+    (socket, "gethostbyname_ex", _guarded_gethostbyname_ex, real_gethostbyname_ex),
+    (socket, "create_connection", _guarded_create_connection, real_create_connection),
+    (socket.socket, "connect", _guarded_connect, real_connect),
+    (socket.socket, "connect_ex", _guarded_connect_ex, real_connect_ex),
+    (socket.socket, "sendto", _guarded_sendto, real_sendto),
+    # sendmsg is POSIX-only; the Proactor loop only exists where asyncio ships it.
+    *(((socket.socket, "sendmsg", _guarded_sendmsg, real_sendmsg),) if real_sendmsg is not None else ()),
+    *(
+        (
+            (
+                _proactor_loop_cls,
+                "sock_connect",
+                _guarded_proactor_sock_connect,
+                real_proactor_sock_connect,
+            ),
+        )
+        if real_proactor_sock_connect is not None
+        else ()
+    ),
+)
+
+
+def install(env: dict[str, str] | None = None) -> str:
+    """Arm the guard. Returns ``installed`` / ``already-installed`` / ``disabled``.
+
+    ``env`` defaults to :data:`os.environ`; it is injectable so the opt-out path
+    is testable without mutating the process environment.
+    """
+    global _installed
+    environ = os.environ if env is None else env
+    if environ.get(_ENV_OPT_OUT):
+        return "disabled"
+    if _installed:
+        return "already-installed"
+    for owner, name, guarded, _original in _PATCHES:
+        setattr(owner, name, guarded)
+    _installed = True
+    return "installed"
+
+
+def uninstall() -> str:
+    """Disarm the guard. Returns ``uninstalled`` / ``not-installed``."""
+    global _installed
+    if not _installed:
+        return "not-installed"
+    for owner, name, _guarded, original in _PATCHES:
+        setattr(owner, name, original)
+    _installed = False
+    return "uninstalled"

--- a/sidecar/tests/conftest.py
+++ b/sidecar/tests/conftest.py
@@ -15,6 +15,25 @@ from hypothesis import HealthCheck, settings
 from media_studio import protocol
 from media_studio.jobs import JobRegistry
 
+from tests import _hermetic
+
+# --- Hermetic egress guard (ALWAYS ON) -------------------------------------
+# Installed at MODULE scope, not in a fixture, so it is armed before any test
+# module is imported (import-time network calls are exactly the class this
+# catches). ci-hygiene.md 2: "Hermetic CI = block egress + verify a committed
+# snapshot store."
+#
+# The get-pip.py incident took the blocking gate red TWICE in eight days: 14
+# tests pre-staged a dummy cache, the manager re-verified it, discarded it, and
+# silently refetched the real rolling artifact -- so an upstream rotation, not a
+# code change, decided whether CI was green. Riding inside this existing pytest
+# step costs no extra CI minutes and cannot drift out of sync with the suite.
+#
+# It is DESTINATION-aware: loopback/unspecified addresses pass through, so the
+# asyncio self-pipe and every ("127.0.0.1", 0) test server keep working. Opt out
+# for a deliberately live run with REFRAME_ALLOW_EGRESS=1.
+_hermetic.install()
+
 # --- Hypothesis: a deterministic, bounded CI profile -----------------------
 # WU-B property/fuzz layer. The default Hypothesis profile is non-deterministic
 # (random seed) and enforces a 200ms per-example deadline — both flake the

--- a/sidecar/tests/test_ce_sidecar_media_studio_handlers_director_ops_py.py
+++ b/sidecar/tests/test_ce_sidecar_media_studio_handlers_director_ops_py.py
@@ -256,3 +256,49 @@ def test_editplan_injected_provider_short_circuits_before_routing(tmp_path: Path
     svc.settings.set(_cloud_editplan_settings("local"))
 
     assert svc._editplan_provider_or_refuse() is sentinel
+
+
+# --------------------------------------------------------------------------- #
+# TEXT-consent REFUSAL — the privacy gate, covered WITHOUT ffmpeg or a socket
+#
+# This refusal (``director_ops.py`` `_editplan_provider_or_refuse`, the
+# `raise _invalid(...)` when the RAW routed pool has a cloud target but the
+# TEXT-consent-filtered pool has none) is the single line that stops
+# ``director.plan`` shipping the transcript to a provider the user revoked text
+# consent for. Until now its ONLY coverage in the blocking gate came from
+# ``test_e2e_ai2_director_text_consent.py``, which is `skipif`-gated on
+# `shutil.which("ffmpeg")` and stands up a real loopback HTTP model server.
+#
+# That made a privacy gate's coverage depend on `apt-get install ffmpeg`
+# succeeding on the runner (quality.yml): if ffmpeg ever failed to install, the
+# module would silently skip and the 100%-coverage gate would fail with a
+# confusing 99.99% error instead of a clear missing-dependency one. Measured:
+# ignoring that module drops the sidecar to `19032 1 4856 1 99%` with this line
+# as the sole miss. This test covers the same refusal with no ffmpeg, no
+# subprocess and no socket, so the coverage no longer rides on a system package.
+# --------------------------------------------------------------------------- #
+def _text_revoked_cloud_settings() -> dict[str, Any]:
+    """A cloud-routed editPlan target whose per-provider TEXT consent is REVOKED."""
+    settings = _cloud_editplan_settings("cloud")
+    settings["consent"] = {"perProvider": {"Groq": {"text": False}}}
+    # Pin offline OFF so the sibling OfflineError branch cannot fire first and
+    # mask the consent refusal (is_offline falls back to MEDIA_STUDIO_OFFLINE
+    # when the setting is absent — an ambient env var must not steer this test).
+    settings["offline"] = False
+    return settings
+
+
+def test_editplan_refuses_when_every_cloud_target_has_text_consent_revoked(tmp_path: Path) -> None:
+    """Cloud route + revoked TEXT consent -> typed refusal, before any chat egress."""
+    svc = Services(data_dir=tmp_path / "data")  # provider=None -> routing resolves
+    svc.settings.set(_text_revoked_cloud_settings())
+
+    with pytest.raises(RpcError) as excinfo:
+        svc._editplan_provider_or_refuse()
+
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    message = str(excinfo.value)
+    assert "TEXT consent is revoked" in message
+    # The message must name the setting the user has to change, or the refusal
+    # is a dead end for whoever hits it.
+    assert "consent.perProvider" in message

--- a/sidecar/tests/test_hermetic_guard.py
+++ b/sidecar/tests/test_hermetic_guard.py
@@ -1,0 +1,356 @@
+"""The egress guard's own both-states matrix (ci-hygiene.md 2: hermetic CI).
+
+The get-pip incident took ``main`` red twice in eight days: 14 tests pre-staged a
+dummy cache, the manager re-verified it, discarded it, and SILENTLY REFETCHED the
+real rolling artifact from the network. Nothing in the blocking gate noticed the
+suite was non-hermetic. :mod:`tests._hermetic` is the detector that would have.
+
+A detector is only trustworthy in BOTH states, so this file is deliberately two
+halves that pull in opposite directions:
+
+* FALSE-POSITIVE direction -- purely-local work (``socketpair``, ``asyncio.run``,
+  a ``127.0.0.1`` bind + round-trip) MUST be left alone. A guard that replaces
+  ``socket.socket`` wholesale fails every one of these while proving nothing: the
+  Windows Proactor / POSIX Selector event loop builds its self-pipe through that
+  constructor, and so does every loopback server.
+* ANTI-GUTTING direction -- real off-box destinations MUST still raise. These are
+  the cases that stop a future reader from "fixing" a false positive by loosening
+  the destination check until the guard blocks nothing at all. All the addresses
+  used are reserved-and-unroutable (RFC 5737 TEST-NET, RFC 6761 ``.invalid``), so
+  even an unguarded run cannot actually leak.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import socket
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+
+import pytest
+
+from tests import _hermetic
+
+# RFC 5737 TEST-NET-1/2/3 and RFC 6761 .invalid: reserved, globally unroutable,
+# guaranteed never to resolve. Safe to name in an assertion.
+_OFF_BOX_TCP = ("192.0.2.1", 80)
+_OFF_BOX_UDP = ("198.51.100.1", 9)
+_OFF_BOX_RAW = ("203.0.113.1", 80)
+_OFF_BOX_HOST = "example.invalid"
+
+
+@pytest.fixture(autouse=True)
+def _guard():
+    """Arm the guard for every case here, and leave the attempt log CLEAN.
+
+    The anti-gutting cases below deliberately trip the guard. Without the
+    teardown their synthetic destinations survive in the process-wide log, and
+    any reporter that prints ``_hermetic.attempts()`` at the end of a run (e.g.
+    ``docs/validation/tools/hermetic_probe.py``) then announces an off-box attempt
+    that no production code ever made -- a detector reporting its own negative
+    controls as findings. Measured: a full-suite probe run reported
+    ``OFF-BOX EGRESS ATTEMPTS RECORDED: 1 -> example.invalid`` for exactly this
+    reason.
+
+    ``env={}`` is deliberate: this file TESTS the guard, it is not protected by
+    it, so it must arm regardless of the ``REFRAME_ALLOW_EGRESS`` opt-out that
+    .github/workflows/e2e.yml sets for the heavy suite. Without that, a run with
+    the opt-out exported would leave the guard down and send
+    ``test_guard_blocks_non_local_dns`` at a REAL resolver.
+
+    The teardown restores whatever state the session was in, so forcing the
+    guard on HERE cannot silently re-arm it for every module that runs after
+    this one -- which would defeat the opt-out for whoever set it.
+
+    It SNAPSHOTS-and-restores the log rather than clearing it. ``_ATTEMPTS`` is
+    process-wide, so a bare ``clear_attempts()`` here would also discard a
+    genuine off-box attempt recorded by a test module that ran earlier in the
+    same session -- this file would be silently destroying the very evidence the
+    guard exists to collect. Restoring the snapshot removes exactly the synthetic
+    entries these cases create and nothing else.
+    """
+    was_installed = _hermetic.is_installed()
+    prior_attempts = _hermetic.attempts()
+    _hermetic.install(env={})
+    yield
+    _hermetic.restore_attempts(prior_attempts)
+    if not was_installed:
+        _hermetic.uninstall()
+
+
+# --------------------------------------------------------------------------- #
+# FALSE-POSITIVE direction: local-only work must survive untouched
+# --------------------------------------------------------------------------- #
+def test_guard_allows_socketpair():
+    left, right = socket.socketpair()
+    try:
+        left.sendall(b"ping")
+        assert right.recv(4) == b"ping"
+    finally:
+        left.close()
+        right.close()
+
+
+def test_guard_allows_asyncio_run():
+    async def _answer() -> int:
+        await asyncio.sleep(0)
+        return 42
+
+    assert asyncio.run(_answer()) == 42
+
+
+def test_guard_allows_loopback_http_roundtrip():
+    class _Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802 - BaseHTTPRequestHandler's required spelling
+            body = b"loopback-ok"
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *args):
+            """Silence the per-request stderr line."""
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        # No-proxy opener: a configured http_proxy would turn a loopback GET into
+        # a genuine off-box hop, which the guard is right to block.
+        opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+        with opener.open(f"http://127.0.0.1:{port}/", timeout=5) as resp:
+            assert resp.status == 200
+            assert resp.read() == b"loopback-ok"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1", "", None])
+def test_guard_allows_local_name_resolution(host):
+    assert _hermetic.is_local_destination(host) is True
+
+
+# --------------------------------------------------------------------------- #
+# ANTI-GUTTING direction: off-box destinations must still raise, and say where
+# --------------------------------------------------------------------------- #
+def test_guard_blocks_off_box_create_connection():
+    with pytest.raises(_hermetic.HermeticEgressError) as excinfo:
+        socket.create_connection(_OFF_BOX_TCP, timeout=0.05)
+    assert _OFF_BOX_TCP[0] in str(excinfo.value)
+
+
+def test_guard_blocks_off_box_socket_connect():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(_hermetic.HermeticEgressError) as excinfo:
+            sock.connect(_OFF_BOX_RAW)
+    finally:
+        sock.close()
+    assert _OFF_BOX_RAW[0] in str(excinfo.value)
+
+
+def test_guard_blocks_off_box_connect_ex():
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    try:
+        with pytest.raises(_hermetic.HermeticEgressError):
+            sock.connect_ex(_OFF_BOX_RAW)
+    finally:
+        sock.close()
+
+
+def test_guard_blocks_off_box_sendto():
+    """UDP to a hardcoded IP needs neither connect() nor DNS -- guard it too."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        with pytest.raises(_hermetic.HermeticEgressError) as excinfo:
+            sock.sendto(b"x", _OFF_BOX_UDP)
+    finally:
+        sock.close()
+    assert _OFF_BOX_UDP[0] in str(excinfo.value)
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        ((_OFF_BOX_UDP,), _OFF_BOX_UDP),  # sendto(data, address)
+        ((0, _OFF_BOX_UDP), _OFF_BOX_UDP),  # sendto(data, flags, address)
+        ((), None),  # malformed; must not IndexError
+    ],
+)
+def test_sendto_address_is_the_last_positional(args, expected):
+    assert _hermetic.sendto_address(args) is expected
+
+
+@pytest.mark.parametrize(
+    ("args", "expected"),
+    [
+        (([], 0, _OFF_BOX_UDP), _OFF_BOX_UDP),  # sendmsg(buffers, ancdata, flags, address)
+        (([], 0), None),  # no address supplied -- a connected socket
+        ((), None),  # malformed; must not IndexError
+    ],
+)
+def test_sendmsg_address_is_the_third_positional(args, expected):
+    """The index arithmetic, provable on EVERY platform including Windows.
+
+    ``sendmsg`` does not exist on Windows, so the live-socket case below skips
+    there -- which is exactly how this shipped wrong the first time, as
+    ``args[3]``. That index makes the guard's ``sendmsg`` arm unreachable: a real
+    four-arg call passes three positionals after the named ``buffers``, so
+    ``len(args) > 3`` is False and the destination read as ``None`` (which counts
+    as local) while the packet went out. This parametrisation fails on any
+    platform if the index regresses.
+    """
+    assert _hermetic.sendmsg_address(args) is expected
+
+
+@pytest.mark.skipif(_hermetic.real_sendmsg is None, reason="socket.socket.sendmsg is POSIX-only")
+def test_guard_blocks_off_box_sendmsg():
+    """The live-socket half of the arm above -- runs on the Linux CI leg."""
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        with pytest.raises(_hermetic.HermeticEgressError) as excinfo:
+            sock.sendmsg([b"x"], [], 0, _OFF_BOX_UDP)
+    finally:
+        sock.close()
+    assert _OFF_BOX_UDP[0] in str(excinfo.value)
+
+
+def test_guard_blocks_non_local_dns():
+    with pytest.raises(_hermetic.HermeticEgressError) as excinfo:
+        socket.getaddrinfo(_OFF_BOX_HOST, 443)
+    assert _OFF_BOX_HOST in str(excinfo.value)
+
+
+def test_guard_blocks_asyncio_connect_to_a_numeric_off_box_ip():
+    """asyncio + a NUMERIC host is the one shape the socket-level patches miss.
+
+    A numeric host skips ``getaddrinfo`` entirely, and on Windows the Proactor
+    loop then reaches ``_overlapped.ConnectEx`` without ever calling
+    ``socket.socket.connect``. Measured before the ``sock_connect`` patch existed:
+    this call was neither logged nor raised -- it just timed out after 3s, so the
+    guard would have waved through any hardcoded-IP asyncio egress. On POSIX the
+    Selector loop routes through ``sock.connect``, so this passes there via a
+    different patch; asserting the OUTCOME keeps one test honest on both.
+    """
+
+    async def _reach() -> None:
+        await asyncio.wait_for(asyncio.open_connection(*_OFF_BOX_RAW), timeout=5)
+
+    with pytest.raises(_hermetic.HermeticEgressError) as excinfo:
+        asyncio.run(_reach())
+    assert _OFF_BOX_RAW[0] in str(excinfo.value)
+
+
+def test_restore_attempts_rolls_back_only_the_new_entries():
+    """UNIT scope: the semantics of :func:`restore_attempts` itself.
+
+    This does NOT prove the autouse fixture uses it correctly -- measured: with
+    the teardown mutated back to ``clear_attempts()`` this test still passed,
+    because its own assertions run before any teardown. The fixture's behaviour
+    is covered by the module-scoped sentinel at the bottom of this file, which
+    that mutation does kill. Two different claims, two different tests.
+    """
+    sibling = _hermetic.Attempt(api="socket.getaddrinfo", host="sibling.invalid", address="()")
+    _hermetic.restore_attempts((sibling,))
+    with pytest.raises(_hermetic.HermeticEgressError):
+        socket.getaddrinfo(_OFF_BOX_HOST, 443)
+    assert len(_hermetic.attempts()) == 2
+
+    _hermetic.restore_attempts((sibling,))
+    assert _hermetic.attempts() == (sibling,)
+
+
+def test_blocked_attempt_is_recorded_with_its_destination():
+    # Measure the DELTA rather than calling clear_attempts(): the log is
+    # process-wide, so clearing it here would destroy an off-box attempt
+    # recorded by an earlier test module -- the same defect the module-scoped
+    # sentinel at the bottom of this file guards against.
+    before = len(_hermetic.attempts())
+    with pytest.raises(_hermetic.HermeticEgressError):
+        socket.getaddrinfo(_OFF_BOX_HOST, 443)
+    recorded = _hermetic.attempts()[before:]
+    assert len(recorded) == 1
+    assert recorded[0].host == _OFF_BOX_HOST
+    assert recorded[0].api == "socket.getaddrinfo"
+
+
+def test_error_is_an_oserror_so_callers_see_a_network_failure():
+    assert issubclass(_hermetic.HermeticEgressError, OSError)
+
+
+# --------------------------------------------------------------------------- #
+# The guard itself: idempotent, reversible, and demonstrably load-bearing
+# --------------------------------------------------------------------------- #
+def test_install_is_idempotent():
+    first = socket.getaddrinfo
+    assert _hermetic.install(env={}) == "already-installed"
+    assert socket.getaddrinfo is first
+
+
+def test_uninstall_restores_the_stdlib_and_is_what_blocks():
+    """Both-states: with the guard OFF the same call is NOT a HermeticEgressError."""
+    assert _hermetic.uninstall() == "uninstalled"
+    try:
+        assert socket.getaddrinfo is _hermetic.real_getaddrinfo
+        with pytest.raises(OSError) as excinfo:
+            socket.create_connection(_OFF_BOX_TCP, timeout=0.05)
+        assert not isinstance(excinfo.value, _hermetic.HermeticEgressError)
+    finally:
+        assert _hermetic.install(env={}) == "installed"
+    assert socket.getaddrinfo is not _hermetic.real_getaddrinfo
+
+
+def test_install_is_a_no_op_when_the_opt_out_env_is_set():
+    assert _hermetic.uninstall() == "uninstalled"
+    try:
+        assert _hermetic.install(env={"REFRAME_ALLOW_EGRESS": "1"}) == "disabled"
+        assert socket.getaddrinfo is _hermetic.real_getaddrinfo
+    finally:
+        assert _hermetic.install(env={}) == "installed"
+
+
+def test_uninstall_is_idempotent():
+    assert _hermetic.uninstall() == "uninstalled"
+    try:
+        assert _hermetic.uninstall() == "not-installed"
+    finally:
+        _hermetic.install(env={})
+
+
+# --------------------------------------------------------------------------- #
+# The teardown's OWN both-states case -- must stay LAST in this file
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module", autouse=True)
+def _sibling_finding():
+    """A stand-in for an off-box attempt recorded by an EARLIER test module.
+
+    ``_ATTEMPTS`` is process-wide and this file trips the guard a dozen times on
+    purpose, so its per-test teardown has to remove ONLY its own synthetic
+    entries. Seeding a sentinel before the first case and asserting it is still
+    there after the last one is the only way to measure that: a unit test of
+    :func:`_hermetic.restore_attempts` cannot see a teardown, and measurably did
+    not -- mutating the teardown to ``clear_attempts()`` left that test green.
+    """
+    sentinel = _hermetic.Attempt(api="socket.getaddrinfo", host="earlier-module.invalid", address="()")
+    before = _hermetic.attempts()
+    _hermetic.restore_attempts((*before, sentinel))
+    yield sentinel
+    _hermetic.restore_attempts(before)
+
+
+def test_zz_an_earlier_modules_finding_survives_every_teardown_in_this_file(
+    _sibling_finding,
+):
+    """Defined LAST on purpose: pytest runs a module in definition order, so by
+    here every guard-tripping case above has set up and torn down at least once.
+    If the teardown clears instead of restoring, the sentinel is gone and this
+    goes red -- which is exactly what a mutation run confirms.
+    """
+    assert _sibling_finding in _hermetic.attempts(), (
+        "a teardown in this file destroyed an attempt it did not create; the "
+        "guard's log is process-wide, so that would discard a real finding"
+    )


### PR DESCRIPTION
Arms an always-on, destination-aware egress guard for the sidecar suite, and fixes a defect in it that **could never have fired**.

## The defect

```python
_check("socket.socket.sendmsg", args[3] if len(args) > 3 else None)
```

`_guarded_sendmsg(self, buffers, *args)` names `buffers`, so `args` starts at `ancdata` and the address is `args[2]`. A real four-argument `sendmsg` passes three positionals → `len(args) > 3` is False → the destination read as `None` (which counts as local) → the packet went out. It survived review because **Windows has no `sendmsg`**, so no test on the authoring machine could execute that line.

Both index computations are now pure functions with parametrised tests that fail on **every** platform if the index regresses, plus a `skipif`-guarded live-socket case for the Linux leg.

## A second hole, found by measuring rather than reading

On Windows, `asyncio.open_connection("203.0.113.1", 9)` skips `getaddrinfo` (numeric host) and connects via `_overlapped.ConnectEx`, never touching `socket.socket.connect`. Measured before the fix: **neither logged nor raised** — it just timed out after 3s, so any hardcoded-IP asyncio egress walked straight through. Now guarded at `BaseProactorEventLoop.sock_connect`. POSIX needs no equivalent (its Selector loop routes through `sock.connect`, already covered).

## Mutation matrix — both-states, because a test that only ever passes proves nothing

| | mutation | result |
|---|---|---|
| M1 | sendmsg index off-by-one (the shipped defect) | KILLED |
| M2 | drop the asyncio Proactor patch | KILLED |
| M3 | teardown clears process-wide instead of restoring | KILLED |
| M3b | clear the log mid-file — **equivalent mutant, must survive** | SURVIVED (as designed) |
| M4 | sendto index (the sibling arm) | KILLED |
| M5 | destination check accepts any name (gut the guard) | KILLED |

M3b is kept deliberately: the fixture repairs a mid-test clear, so that mutation is genuinely harmless. Forcing it red would assert a behaviour the design does not have.

## Two limits stated in the module, not left to be rediscovered

- **A subprocess is out of scope** — this patches one interpreter's socket module.
- **`HermeticEgressError` subclasses `OSError`, so callers can swallow it.** Measured: `urlopen("http://example.invalid/")` *is* caught, but urllib re-raises it as `URLError`, so an assertion on exception **type** misses it while the attempt log still shows it. Read `attempts()`, not the traceback. My own first probe misclassified that row for exactly this reason.

## Test plan

- `tests/test_hermetic_guard.py` — 28 passed, 1 skipped (the POSIX-only `sendmsg` live case)
- Full sidecar — **6137 passed, 6 skipped, 100% coverage** (19032 stmts / 4856 branches), 205s
- `ruff 0.15.17` lint + format clean
- Cross-lane: octopus-merged with `fix/uc-ssot` + `fix/uc-hygiene`; combined tree passes `docs_check` (`r1..r5 = 0`), `charter_check` (6 gates), `verify_ssot_claims` (40/40)

Also carried: a `director_ops` TEXT-consent refusal test that covers the privacy gate **without** ffmpeg, a subprocess or a socket. Its only prior coverage was a module `skipif`-gated on `shutil.which("ffmpeg")`, so an `apt-get` failure on the runner would have turned a privacy gate's coverage into a confusing 99.99% error.
