### PR TITLE
fix(scripts): the branch-landed receipt was position-blind, and it authorises branch -D

### DIFF
--- a/scripts/lib/branch-containment-selftest.ps1
+++ b/scripts/lib/branch-containment-selftest.ps1
@@ -1,0 +1,161 @@
+<#
+.SYNOPSIS
+  Both-states proof for Test-BranchLanded, on a throwaway fixture repo.
+
+.DESCRIPTION
+  `Landed = $true` is what authorises `git branch -D` in worktree-hygiene-teardown.ps1, so
+  the predicate needs a proof that it says NO in the case that matters, not only YES on a
+  branch that really landed. A verdict that has only ever been observed agreeing is
+  indistinguishable from a verdict that always agrees (single-signal-verification 3b).
+
+  Four cases, built from scratch in a temp repo so nothing depends on this checkout's state:
+
+    C1 landed-verbatim      branch content present in base as a contiguous block -> LANDED
+    C2 coincidental-lines   every added line occurs SOMEWHERE in base, but never as a block.
+                            This is the false-positive the position-blind predicate shipped
+                            with: bare set membership scores residual=0 and deletes work that
+                            never landed. Must be NOT LANDED, and WeakResidual must be 0 --
+                            that gap (weak=0, strict>0) IS the bug, made visible.
+    C3 genuinely-unlanded   added lines absent from base entirely -> NOT LANDED
+    C4 tree-equal           branch adds nothing -> LANDED via tier 1, without reaching tier 2
+
+.NOTES
+  Run:  pwsh -NoProfile -File scripts/lib/branch-containment-selftest.ps1
+  Exit 0 when all four behave; 1 otherwise, naming the case.
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+. (Join-Path $PSScriptRoot 'branch-containment.ps1')
+
+$root = Join-Path ([System.IO.Path]::GetTempPath()) "bc-selftest-$([guid]::NewGuid().ToString('N').Substring(0,8))"
+New-Item -ItemType Directory -Path $root | Out-Null
+
+# The git EXECUTABLE, resolved once and called by absolute path.
+#
+# Do NOT wrap this in a helper named `Git`, and do not `Set-Alias Git <helper>`: PowerShell
+# command resolution is case-INSENSITIVE and puts aliases and functions ahead of
+# applications, so `& git ...` inside such a helper resolves back to the helper. The first
+# version of this file did exactly that and recursed forever -- 600s with zero bytes on
+# stdout and stderr, which reads like an environment problem rather than a bug in the script.
+# A trivial control script launched the same way finished in under a second, which is what
+# localised it here.
+$gitExe = (Get-Command git.exe -CommandType Application | Select-Object -First 1).Source
+if (-not $gitExe) { throw 'git.exe not found on PATH' }
+
+function Invoke-FixtureGit {
+  param([Parameter(ValueFromRemainingArguments = $true)][string[]]$GitArgs)
+  & $gitExe -C $root @GitArgs 2>&1 | Out-Null
+  if ($LASTEXITCODE -ne 0) { throw "fixture git failed ($LASTEXITCODE): git $($GitArgs -join ' ')" }
+}
+
+function Write-FixtureFile {
+  param([string]$Name, [string[]]$Lines)
+  Set-Content -LiteralPath (Join-Path $root $Name) -Value ($Lines -join "`n") -Encoding utf8NoBOM -NoNewline
+}
+
+$ANCESTOR = @('def a():', '    x = 1', '    return x', '', 'def b():', '    y = 2', '    return y')
+
+try {
+  Invoke-FixtureGit init -q -b main
+  Invoke-FixtureGit config user.email 'selftest@example.invalid'
+  Invoke-FixtureGit config user.name 'selftest'
+  Invoke-FixtureGit config commit.gpgsign false
+
+  # ---- the shared ancestor -------------------------------------------------
+  Write-FixtureFile 'mod.py' $ANCESTOR
+  Invoke-FixtureGit add -A
+  Invoke-FixtureGit commit -q -m base0
+
+  # C2: the SAME three lines the base will later gain, but in a different ORDER. Each one is
+  # therefore individually present in the base (weakResidual=0) while the arrangement this
+  # branch actually wrote never landed anywhere (residual=3). Getting this fixture wrong is
+  # easy -- the first attempt used a line the base never gains, so weakResidual was 1 and the
+  # case would have passed without exercising coincidence at all. The in-loop fixture
+  # assertion below exists because that mistake was made here, and caught, rather than
+  # shipped.
+  Invoke-FixtureGit checkout -q -b coincidental
+  Write-FixtureFile 'mod.py' ($ANCESTOR + @('', 'def real():', '    return z', '    z = 3'))
+  Invoke-FixtureGit add -A
+  Invoke-FixtureGit commit -q -m coincidental
+
+  Invoke-FixtureGit checkout -q main
+  Invoke-FixtureGit checkout -q -b unlanded
+  Write-FixtureFile 'mod.py' ($ANCESTOR + @('', 'def totally_new():', '    return "nothing like this exists"'))
+  Invoke-FixtureGit add -A
+  Invoke-FixtureGit commit -q -m unlanded
+
+  Invoke-FixtureGit checkout -q main
+  Invoke-FixtureGit checkout -q -b landed
+  Write-FixtureFile 'mod.py' ($ANCESTOR + @('', 'def real():', '    z = 3', '    return z'))
+  Invoke-FixtureGit add -A
+  Invoke-FixtureGit commit -q -m landed
+
+  Invoke-FixtureGit checkout -q main
+  Invoke-FixtureGit checkout -q -b noop   # C4: identical content -> merge-tree equals base tree
+
+  # ---- advance the base: the `landed` branch's block really lands ----------
+  # It lands together with a FURTHER function appended in the same region, so a three-way
+  # merge of `landed` into the base conflicts and tier 1 cannot answer. That is deliberate:
+  # tier 2 is the code under test, and a fixture where every positive case short-circuits at
+  # tree-equality would leave context-containment with no passing case at all -- the same
+  # "green but never executed" hole this whole file exists to close. (Measured: with the base
+  # gaining ONLY the branch's own block, C1 returned method=tree-equal, added=0.)
+  Invoke-FixtureGit checkout -q main
+  Write-FixtureFile 'mod.py' ($ANCESTOR + @(
+      '', 'def real():', '    z = 3', '    return z',
+      '', 'def extra():', '    return 0'))
+  Invoke-FixtureGit add -A
+  Invoke-FixtureGit commit -q -m 'base advances, absorbing the landed work and appending more'
+
+  $baseSha = "$(@(& $gitExe -C $root rev-parse HEAD)[0])".Trim()
+  $baseTree = Get-TreeOf -Repo $root -Rev $baseSha
+
+  # ExpectMethod is asserted too, not just the verdict: C1 passing via `tree-equal` would be
+  # the right answer from the wrong code path and would leave tier 2 unexercised.
+  $cases = @(
+    @{ Name = 'C1 landed-verbatim'; Branch = 'landed'; Expect = $true; ExpectMethod = 'context-containment' },
+    @{ Name = 'C2 coincidental-lines'; Branch = 'coincidental'; Expect = $false; ExpectMethod = 'not-landed' },
+    @{ Name = 'C3 genuinely-unlanded'; Branch = 'unlanded'; Expect = $false; ExpectMethod = 'not-landed' },
+    @{ Name = 'C4 tree-equal'; Branch = 'noop'; Expect = $true; ExpectMethod = 'tree-equal' }
+  )
+
+  $failures = @()
+  foreach ($c in $cases) {
+    $r = Test-BranchLanded -Repo $root -Branch $c.Branch -BaseSha $baseSha -BaseTree $baseTree
+    $ok = ($r.Landed -eq $c.Expect) -and ($r.Method -eq $c.ExpectMethod)
+    $mark = if ($ok) { 'OK  ' } else { 'FAIL' }
+    Write-Output ("  {0} {1,-24} landed={2,-5} method={3,-20} added={4} residual={5} weakResidual={6}" -f `
+        $mark, $c.Name, $r.Landed, $r.Method, $r.Added, $r.Residual, $r.WeakResidual)
+    if (-not $ok) { $failures += $c.Name }
+
+    # C2 is the whole point: assert the SHAPE of the bug, not just the verdict. If
+    # WeakResidual stops being 0 the fixture no longer exercises coincidental matching and
+    # the case would pass for the wrong reason -- a green test measuring nothing.
+    if ($c.Name -like 'C2*') {
+      if ($r.WeakResidual -ne 0) {
+        Write-Output "  FAIL C2 fixture no longer exercises coincidence (weakResidual=$($r.WeakResidual), expected 0)"
+        $failures += 'C2-fixture'
+      }
+      if ($r.Residual -le 0) {
+        Write-Output "  FAIL C2 window check did not fire (residual=$($r.Residual), expected > 0)"
+        $failures += 'C2-window'
+      }
+    }
+  }
+
+  if ($failures.Count) {
+    Write-Output "FAILED:bc-selftest $($failures.Count) case(s): $($failures -join ', ')"
+    exit 1
+  }
+  Write-Output ("SUCCESS:bc-selftest {0}/{0} cases behaved; C2 proves the position-blind predicate would have deleted unlanded work" -f $cases.Count)
+  exit 0
+}
+finally {
+  # Bounded by construction: this fixture holds no junctions and nothing outside $root --
+  # unlike the teardown script's tree, which is why that one refuses to recurse until it has
+  # proved the directory is empty.
+  Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/scripts/lib/branch-containment.ps1
+++ b/scripts/lib/branch-containment.ps1
@@ -16,12 +16,26 @@
       resulting tree equals the base's own tree, merging changes nothing, so the branch
       contributes nothing. Fast and exact, but returns CONFLICT (indeterminate, not
       "unmerged") whenever the base later touched the same regions.
-    Tier 2 -- line-set containment. For every file the branch changed, take the lines it
-      ADDED relative to its own merge-base and test membership in the base's blob. Set
-      membership cannot conflict, so it stays decisive as the base advances.
+    Tier 2 -- CONTEXT-WINDOW containment. For every file the branch changed, take the lines
+      it ADDED relative to its own merge-base and require each one to appear in the base's
+      blob *together with its two neighbours*. Membership cannot conflict, so it stays
+      decisive as the base advances.
   Dropping tier 2 is not a conservative simplification: it converts branches whose work
   demonstrably landed into permanent false keeps, because a long-lived base eventually
   conflicts with everything.
+
+  WHY THE WINDOW, NOT BARE SET MEMBERSHIP. The first version tested each added line for
+  membership in a HashSet of the target's lines -- position-blind. Source code is full of
+  lines that recur verbatim (`}`, `  return None`, `    })`, an import), so a branch whose
+  additions happen to be individually common scores residual=0 and is declared LANDED while
+  none of its work is present. `Landed` is what authorises `git branch -D` in
+  worktree-hygiene-teardown.ps1, so that error class deletes unlanded work. Requiring the
+  (previous, line, next) triple shifts every coincidence to needing three consecutive lines
+  to coincide, which effectively does not happen; and when the branch's work landed in a
+  MODIFIED form the window misses and the verdict becomes not-landed -- i.e. the errors now
+  point at KEEPING a branch rather than deleting one. `Residual` (window) and `WeakResidual`
+  (bare membership, the old measure) are both returned so the gap between them is visible
+  instead of inferred.
 
   MEASURED LIMITATION, inline rather than in a footnote: tier 2 considers ADDED lines only.
   A branch whose contribution was a DELETION that never landed would be reported as landed.
@@ -79,10 +93,32 @@ function Get-TreeOf {
   return "$(@(& git -C $Repo show -s --format=%T $Rev)[0])".Trim()
 }
 
+function Get-ContextWindows {
+  <#
+    The set of (previous, line, next) triples in a file, joined by a delimiter that cannot
+    occur in source text. Missing neighbours at the file edges are the empty string, so the
+    first and last lines are still representable.
+  #>
+  param([string[]]$Lines)
+  $set = [System.Collections.Generic.HashSet[string]]::new()
+  for ($i = 0; $i -lt $Lines.Count; $i++) {
+    $prev = if ($i -gt 0) { "$($Lines[$i - 1])" } else { '' }
+    $next = if ($i -lt $Lines.Count - 1) { "$($Lines[$i + 1])" } else { '' }
+    [void]$set.Add("$prev`u{0000}$($Lines[$i])`u{0000}$next")
+  }
+  return $set
+}
+
 function Test-BranchLanded {
   <#
-    Returns [pscustomobject] @{ Landed; Method; Residual; Added }
-    Method: tree-equal | line-containment | not-landed | error
+    Returns [pscustomobject] @{ Landed; Method; Residual; WeakResidual; Added }
+    Method: tree-equal | context-containment | not-landed | error
+
+    Residual     -- added lines whose (prev,line,next) window is absent from the base. This
+                    is the one `Landed` depends on.
+    WeakResidual -- added lines whose TEXT is absent from the base anywhere. Kept only as a
+                    diagnostic: WeakResidual=0 with Residual>0 is precisely the
+                    coincidental-line-match case the old predicate mistook for landed.
   #>
   param(
     [Parameter(Mandatory)][string]$Repo,
@@ -96,14 +132,16 @@ function Test-BranchLanded {
   # on a string returns a [char], which compares unequal to every SHA on earth.
   $mt = @(& git -C $Repo merge-tree --write-tree $BaseSha $Branch 2>&1)
   if ($LASTEXITCODE -eq 0 -and "$($mt[0])".Trim() -eq $BaseTree) {
-    return [pscustomobject]@{ Landed = $true; Method = 'tree-equal'; Residual = 0; Added = 0 }
+    return [pscustomobject]@{ Landed = $true; Method = 'tree-equal'; Residual = 0; WeakResidual = 0; Added = 0 }
   }
 
-  # ---- tier 2: line-set containment against the base's blobs.
+  # ---- tier 2: context-window containment against the base's blobs.
   $mb = "$(@(& git -C $Repo merge-base $BaseSha $Branch)[0])".Trim()
-  if (-not $mb) { return [pscustomobject]@{ Landed = $false; Method = 'error'; Residual = -1; Added = 0 } }
+  if (-not $mb) {
+    return [pscustomobject]@{ Landed = $false; Method = 'error'; Residual = -1; WeakResidual = -1; Added = 0 }
+  }
 
-  $added = 0; $residual = 0
+  $added = 0; $residual = 0; $weakResidual = 0
   foreach ($f in @(& git -C $Repo diff --name-only $mb $Branch 2>$null)) {
     $f = "$f".Trim(); if (-not $f) { continue }
 
@@ -118,17 +156,26 @@ function Test-BranchLanded {
     foreach ($l in $baseLines) { [void]$wasSet.Add("$l") }
     $tgtSet = [System.Collections.Generic.HashSet[string]]::new()
     foreach ($l in $tgtLines) { [void]$tgtSet.Add("$l") }
+    $tgtWindows = Get-ContextWindows -Lines $tgtLines
 
-    foreach ($l in $bLines) {
-      $s = "$l"
+    for ($i = 0; $i -lt $bLines.Count; $i++) {
+      $s = "$($bLines[$i])"
       if ($wasSet.Contains($s)) { continue }                    # not introduced by this branch
       $added++
-      if ($absentInBase -or -not $tgtSet.Contains($s)) { $residual++ }
+      if ($absentInBase) { $residual++; $weakResidual++; continue }
+      if (-not $tgtSet.Contains($s)) { $weakResidual++ }
+      $prev = if ($i -gt 0) { "$($bLines[$i - 1])" } else { '' }
+      $next = if ($i -lt $bLines.Count - 1) { "$($bLines[$i + 1])" } else { '' }
+      if (-not $tgtWindows.Contains("$prev`u{0000}$s`u{0000}$next")) { $residual++ }
     }
   }
 
   if ($added -gt 0 -and $residual -eq 0) {
-    return [pscustomobject]@{ Landed = $true; Method = 'line-containment'; Residual = 0; Added = $added }
+    return [pscustomobject]@{
+      Landed = $true; Method = 'context-containment'; Residual = 0; WeakResidual = $weakResidual; Added = $added
+    }
   }
-  return [pscustomobject]@{ Landed = $false; Method = 'not-landed'; Residual = $residual; Added = $added }
+  return [pscustomobject]@{
+    Landed = $false; Method = 'not-landed'; Residual = $residual; WeakResidual = $weakResidual; Added = $added
+  }
 }

--- a/scripts/lib/branch-containment.ps1
+++ b/scripts/lib/branch-containment.ps1
@@ -1,0 +1,134 @@
+<#
+.SYNOPSIS
+  Shared "has this branch's work landed?" receipt, used by worktree-hygiene-{audit,teardown}.
+
+.DESCRIPTION
+  WHY THIS IS NOT `git merge-base --is-ancestor`
+  This repo squash-merges, so a fully-landed branch is NOT an ancestor of main -- only its
+  combined content is. Ancestry reports every landed branch as unmerged.
+
+  WHY THIS IS NOT `gh pr list --head <branch>`
+  Measured 2026-08-08: zero of the 24 programme branches was ever pushed. An empty gh
+  result means "never pushed", not "not merged".
+
+  TWO TIERS, because one probe is not enough.
+    Tier 1 -- tree equality. `git merge-tree --write-tree <baseSha> <branch>`; if the
+      resulting tree equals the base's own tree, merging changes nothing, so the branch
+      contributes nothing. Fast and exact, but returns CONFLICT (indeterminate, not
+      "unmerged") whenever the base later touched the same regions.
+    Tier 2 -- line-set containment. For every file the branch changed, take the lines it
+      ADDED relative to its own merge-base and test membership in the base's blob. Set
+      membership cannot conflict, so it stays decisive as the base advances.
+  Dropping tier 2 is not a conservative simplification: it converts branches whose work
+  demonstrably landed into permanent false keeps, because a long-lived base eventually
+  conflicts with everything.
+
+  MEASURED LIMITATION, inline rather than in a footnote: tier 2 considers ADDED lines only.
+  A branch whose contribution was a DELETION that never landed would be reported as landed.
+  Settle that case for a specific branch with `git diff <mergeBase> <branch> --diff-filter=D`
+  plus a check that the base still carries the file. Not automated here because every unit
+  in this programme was additive; do not reuse this on a deletion-heavy branch without
+  closing that gap.
+
+  PIN THE BASE TO A SHA, NEVER A MOVING REF. Measured 2026-08-08: passing the ref
+  `origin/main` while Dependabot merges landed mid-run made 14 branches flip from contained
+  to not-contained inside one loop -- the captured base tree no longer matched the tree the
+  re-resolved ref produced. Get-BaseSha exists so callers cannot make that mistake.
+#>
+
+function Test-PrimaryHealthy {
+  <#
+    Pure predicate for "the primary checkout's dependency trees are undamaged".
+
+    IT IS A PURE PREDICATE ON PURPOSE. The first version of this guard lived inline in
+    worktree-hygiene-teardown.ps1 and did `Write-Output "..."` and then `return $ok` in the
+    same function. PowerShell adds BOTH to the output stream, so the caller's
+    `if (-not (Test-PrimaryIntact ...))` tested a two-element array -- which is always
+    truthy -- and the guard could never fire. It was a dead safety check that read as a
+    live one. Keep printing at the CALL SITE; this function returns one object and nothing
+    else, so `-not $result.Ok` cannot be fooled.
+
+    Returns [pscustomobject] @{ App; Cli; Tsc; Ok }
+  #>
+  param(
+    [Parameter(Mandatory)][string]$Repo,
+    [Parameter(Mandatory)][int]$ExpectApp,
+    [Parameter(Mandatory)][int]$ExpectCli
+  )
+  $nmApp = Join-Path $Repo 'app\node_modules'
+  $nmCli = Join-Path $Repo 'app\render-cli\node_modules'
+  $a = @(Get-ChildItem -LiteralPath $nmApp -Force -ErrorAction SilentlyContinue).Count
+  $c = @(Get-ChildItem -LiteralPath $nmCli -Force -ErrorAction SilentlyContinue).Count
+  $t = Test-Path -LiteralPath (Join-Path $nmApp '.bin\tsc')
+  # Counts may only ever be >= baseline: a concurrent npm install can legitimately add a
+  # package, but nothing this script does may ever REMOVE one.
+  return [pscustomobject]@{ App = $a; Cli = $c; Tsc = $t; Ok = ($a -ge $ExpectApp -and $c -ge $ExpectCli -and $t) }
+}
+
+function Get-BaseSha {
+  param([Parameter(Mandatory)][string]$Repo, [string]$Ref = 'origin/main')
+  $sha = "$(@(& git -C $Repo rev-parse --verify --quiet $Ref)[0])".Trim()
+  if (-not $sha) { $sha = "$(@(& git -C $Repo rev-parse --verify --quiet 'main')[0])".Trim() }
+  return $sha
+}
+
+function Get-TreeOf {
+  param([Parameter(Mandatory)][string]$Repo, [Parameter(Mandatory)][string]$Rev)
+  # `show -s --format=%T` avoids the `<rev>^{tree}` peel syntax; `^` is PowerShell's escape
+  # character and corrupts a ref on some invocation paths.
+  return "$(@(& git -C $Repo show -s --format=%T $Rev)[0])".Trim()
+}
+
+function Test-BranchLanded {
+  <#
+    Returns [pscustomobject] @{ Landed; Method; Residual; Added }
+    Method: tree-equal | line-containment | not-landed | error
+  #>
+  param(
+    [Parameter(Mandatory)][string]$Repo,
+    [Parameter(Mandatory)][string]$Branch,
+    [Parameter(Mandatory)][string]$BaseSha,
+    [Parameter(Mandatory)][string]$BaseTree
+  )
+
+  # ---- tier 1: tree equality.
+  # @() is mandatory: git emitting a single line hands back a [string], and indexing [0]
+  # on a string returns a [char], which compares unequal to every SHA on earth.
+  $mt = @(& git -C $Repo merge-tree --write-tree $BaseSha $Branch 2>&1)
+  if ($LASTEXITCODE -eq 0 -and "$($mt[0])".Trim() -eq $BaseTree) {
+    return [pscustomobject]@{ Landed = $true; Method = 'tree-equal'; Residual = 0; Added = 0 }
+  }
+
+  # ---- tier 2: line-set containment against the base's blobs.
+  $mb = "$(@(& git -C $Repo merge-base $BaseSha $Branch)[0])".Trim()
+  if (-not $mb) { return [pscustomobject]@{ Landed = $false; Method = 'error'; Residual = -1; Added = 0 } }
+
+  $added = 0; $residual = 0
+  foreach ($f in @(& git -C $Repo diff --name-only $mb $Branch 2>$null)) {
+    $f = "$f".Trim(); if (-not $f) { continue }
+
+    $bLines = @(& git -C $Repo show "${Branch}:$f" 2>$null)
+    if ($LASTEXITCODE -ne 0) { continue }                       # deleted on branch -- see limitation above
+    $baseLines = @(& git -C $Repo show "${mb}:$f" 2>$null)
+    if ($LASTEXITCODE -ne 0) { $baseLines = @() }
+    $tgtLines = @(& git -C $Repo show "${BaseSha}:$f" 2>$null)
+    $absentInBase = ($LASTEXITCODE -ne 0)
+
+    $wasSet = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($l in $baseLines) { [void]$wasSet.Add("$l") }
+    $tgtSet = [System.Collections.Generic.HashSet[string]]::new()
+    foreach ($l in $tgtLines) { [void]$tgtSet.Add("$l") }
+
+    foreach ($l in $bLines) {
+      $s = "$l"
+      if ($wasSet.Contains($s)) { continue }                    # not introduced by this branch
+      $added++
+      if ($absentInBase -or -not $tgtSet.Contains($s)) { $residual++ }
+    }
+  }
+
+  if ($added -gt 0 -and $residual -eq 0) {
+    return [pscustomobject]@{ Landed = $true; Method = 'line-containment'; Residual = 0; Added = $added }
+  }
+  return [pscustomobject]@{ Landed = $false; Method = 'not-landed'; Residual = $residual; Added = $added }
+}

--- a/scripts/lib/ps-lint.ps1
+++ b/scripts/lib/ps-lint.ps1
@@ -1,0 +1,92 @@
+<#
+.SYNOPSIS
+  Static analysis + self-test for this repo's PowerShell, since no CI gate covers `.ps1`.
+
+.DESCRIPTION
+  HONEST SCOPE, STATED UP FRONT: this is NOT wired into CI, so nothing forces it to run.
+  QUALITY-CHARTER.md rule 2 declares the six-gate list closed, and `.quality/charter_check.py`
+  fails any `gate-<slug>` step in quality.yml without a charter row -- so adding a seventh
+  gate is a charter amendment, not a config edit. The gap is therefore real and this file
+  does not pretend otherwise: it makes the check one command instead of zero, and names what
+  is unenforced.
+
+  Everything here is developer TOOLING (`scripts/**`). No `.ps1` in this repo ships inside
+  the Electron app or the Python sidecar, which is why the exposure is bounded -- a defect
+  here breaks a maintenance script, not the product.
+
+  Three checks:
+    1. PARSE  -- every tracked `.ps1` through PowerShell's own parser. No module needed, so
+                 this half always runs. It is the check that would have caught nothing in the
+                 recursion incident below, which is exactly why 3 exists.
+    2. PSSA   -- PSScriptAnalyzer at Error+Warning, IF the module is installed. Skipped, and
+                 said out loud, when it is not: a silent skip would make this script report
+                 clean while measuring half of what it claims.
+    3. SELFTEST -- scripts/lib/branch-containment-selftest.ps1, the both-states proof for the
+                 predicate that authorises `git branch -D`.
+
+.NOTES
+  Run:  pwsh -NoProfile -File scripts/lib/ps-lint.ps1
+  Install the analyzer once:  Install-Module PSScriptAnalyzer -Scope CurrentUser
+#>
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repo = (& git rev-parse --show-toplevel 2>$null | Select-Object -First 1)
+if (-not $repo) { Write-Output 'FAILED:ps-lint not inside a git repo'; exit 1 }
+$repo = "$repo".Trim()
+
+$files = @(& git -C $repo ls-files '*.ps1') | Where-Object { $_ }
+if ($files.Count -eq 0) {
+  # FAIL CLOSED (rules/common/ci-hygiene.md 1): an empty walk means the enumerator broke,
+  # not that the repo is clean.
+  Write-Output 'FAILED:ps-lint zero .ps1 files enumerated -- the walk is broken'
+  exit 1
+}
+Write-Output "ps-lint: $($files.Count) tracked .ps1 file(s)"
+
+$failures = 0
+
+# ---- 1. parse ---------------------------------------------------------------
+foreach ($rel in $files) {
+  $full = Join-Path $repo $rel
+  $errors = $null
+  [void][System.Management.Automation.Language.Parser]::ParseFile($full, [ref]$null, [ref]$errors)
+  if ($errors -and $errors.Count) {
+    Write-Output "  PARSE-FAIL $rel :: $($errors[0].Message)"
+    $failures++
+  }
+}
+Write-Output "  parse: $($files.Count - $failures)/$($files.Count) clean"
+
+# ---- 2. PSScriptAnalyzer ----------------------------------------------------
+$pssa = Get-Module -ListAvailable PSScriptAnalyzer | Select-Object -First 1
+if (-not $pssa) {
+  Write-Output '  pssa: SKIPPED (PSScriptAnalyzer not installed) -- this run did NOT lint'
+}
+else {
+  Import-Module PSScriptAnalyzer -ErrorAction Stop
+  $found = @(Invoke-ScriptAnalyzer -Path (Join-Path $repo 'scripts') -Recurse -Severity Error, Warning)
+  foreach ($d in $found) {
+    Write-Output "  $($d.Severity.ToString().ToUpper()) $($d.RuleName) $($d.ScriptName):$($d.Line) $($d.Message)"
+  }
+  Write-Output "  pssa: v$($pssa.Version) $($found.Count) finding(s)"
+  $failures += $found.Count
+}
+
+# ---- 3. the containment both-states proof -----------------------------------
+$selftest = Join-Path $repo 'scripts/lib/branch-containment-selftest.ps1'
+if (Test-Path -LiteralPath $selftest) {
+  & pwsh -NoProfile -NonInteractive -File $selftest
+  if ($LASTEXITCODE -ne 0) { Write-Output '  selftest: FAILED'; $failures++ }
+}
+else {
+  Write-Output "  selftest: MISSING at $selftest"
+  $failures++
+}
+
+if ($failures) { Write-Output "FAILED:ps-lint $failures issue(s)"; exit 1 }
+Write-Output 'SUCCESS:ps-lint parse + analyzer + containment selftest all clean'
+exit 0

--- a/scripts/prepare-worktree.ps1
+++ b/scripts/prepare-worktree.ps1
@@ -1,4 +1,4 @@
-<#
+﻿<#
 .SYNOPSIS
   Make a fresh git worktree able to run the local gate (tsc / vitest / pre-commit).
 

--- a/scripts/worktree-hygiene-audit.ps1
+++ b/scripts/worktree-hygiene-audit.ps1
@@ -1,0 +1,127 @@
+<#
+.SYNOPSIS
+  Assert the agent-worktree pool holds no leftover, fully-landed programme worktrees.
+
+.DESCRIPTION
+  A fan-out programme leaves one git worktree + one fix/* branch per work unit. Once the
+  work has landed on main those worktrees are pure cost: each one pins a branch ref, holds
+  two junctions into the primary checkout's dependency trees, and hides genuinely unmerged
+  work in the noise. This script is the regression guard that says "the pool is clean".
+
+  READ-ONLY. It never deletes anything; scripts/worktree-hygiene-teardown.ps1 does that.
+
+  WHY NOT `git merge-base --is-ancestor`
+  This repo squash-merges. A squash-merged branch is NOT an ancestor of main -- its
+  commits never enter main's history, only their combined content does. Ancestry therefore
+  reports a fully-landed branch as unmerged. This script uses CONTENT containment instead:
+  `git merge-tree --write-tree <base> <branch>` produces the tree that merging would yield;
+  if that equals <base>'s own tree, the branch contributes nothing and its work has landed.
+
+  WHY NOT `gh pr list --head <branch>`
+  Measured on this repo 2026-08-08: zero of the 24 programme branches was ever pushed
+  (`git branch -r --list origin/fix/*` returns 16 branches, all pre-programme). An empty
+  gh result here means "never pushed", NOT "not merged" -- using it as the receipt would
+  have classified all 24 as unmerged.
+
+  DETECTOR SELF-VALIDATION (the both-states test)
+  A containment probe that answers "contained" for everything is indistinguishable from a
+  probe that is broken. Before classifying anything this script proves its detector can
+  produce BOTH answers:
+    positive -- merging an ancestor (main~1) must yield exactly main's tree;
+    negative -- at least one real branch in the repo must NOT yield main's tree.
+  If either control fails the script aborts and classifies nothing. This is not theatre:
+  an earlier revision of this probe read `$t[0]` on git's output, which returns the first
+  CHARACTER when git emits a single line, and every branch on earth compared not-equal.
+  The tell was a self-contradiction -- a branch with a merged-PR receipt reporting
+  un-contained. Hence @() around every git capture below.
+
+.PARAMETER Repo
+  The primary checkout that owns the shared .git and the worktree admin data.
+
+.PARAMETER Pool
+  Directory holding the agent worktrees.
+
+.PARAMETER CohortStart / .PARAMETER CohortEnd
+  Only worktrees CREATED inside this window are in scope. This is the guard that keeps
+  unrelated agent worktrees -- including ones created later that hold untracked work --
+  out of a teardown. Do NOT replace it with a name pattern: every worktree in the pool
+  matches `agent-*`, so a name glob would sweep up live siblings.
+
+.PARAMETER Base
+  Ref to test containment against. Defaults to origin/main (the current published head)
+  and falls back to main when there is no remote-tracking ref.
+#>
+[CmdletBinding()]
+param(
+  [string]$Repo = 'C:\Users\Prekzursil\Documents\GitHub\Reframe',
+  [string]$Pool = 'C:\Users\Prekzursil\.claude\agent-worktrees',
+  [datetime]$CohortStart = '2026-07-31 23:00',
+  [datetime]$CohortEnd = '2026-08-01 01:00',
+  [string]$Base = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Every call site wraps this in @(). PowerShell UNROLLS a single-element array on return,
+# so a bare `Git-Lines ...` that produced one line hands back a [string], and indexing [0]
+# on it yields a [char]. Same family as the $t[0] bug described in the header.
+function Git-Lines { param([string[]]$GitArgs) return @(& git -C $Repo @GitArgs 2>&1) }
+
+if (-not (Test-Path -LiteralPath $Repo)) { Write-Output "FAILED:wt-hygiene repo not found: $Repo"; exit 1 }
+
+. (Join-Path $PSScriptRoot 'lib\branch-containment.ps1')
+
+# Pin to an immutable SHA. Passing the moving ref `origin/main` to each probe made 14
+# branches flip mid-run while Dependabot merges landed -- see the lib header.
+if (-not $Base) { $Base = 'origin/main' }
+$baseSha = Get-BaseSha -Repo $Repo -Ref $Base
+if (-not $baseSha) { Write-Output "FAILED:wt-hygiene cannot resolve $Base"; exit 1 }
+$baseTree = Get-TreeOf -Repo $Repo -Rev $baseSha
+
+function Test-Contained {
+  param([string]$Ref)
+  return (Test-BranchLanded -Repo $Repo -Branch $Ref -BaseSha $baseSha -BaseTree $baseTree).Landed
+}
+
+# ---------------------------------------------------------------- detector controls
+$posOk = Test-Contained "$baseSha~1"
+$negRef = $null
+foreach ($b in @(Git-Lines @('for-each-ref', 'refs/heads/', '--format=%(refname:short)'))) {
+  $b = "$b".Trim(); if (-not $b) { continue }
+  if (-not (Test-Contained $b)) { $negRef = $b; break }
+}
+Write-Output "DETECTOR base=$Base@$($baseSha.Substring(0,10)) tree=$baseTree positive-control=$posOk negative-control=$negRef"
+if (-not $posOk) { Write-Output 'FAILED:wt-hygiene detector positive control failed (an ancestor must be contained)'; exit 1 }
+if (-not $negRef) { Write-Output 'FAILED:wt-hygiene detector negative control failed (no branch is un-contained; probe cannot discriminate)'; exit 1 }
+
+# ---------------------------------------------------------------- worktree -> branch map
+$wtBranch = @{}
+$cur = $null
+foreach ($line in @(Git-Lines @('worktree', 'list', '--porcelain'))) {
+  $line = "$line"
+  if ($line -like 'worktree *') { $cur = $line.Substring(9).Trim() }
+  elseif ($line -like 'branch *') { $wtBranch[$cur] = $line.Substring(7).Trim() -replace '^refs/heads/', '' }
+}
+
+# ---------------------------------------------------------------- classify the pool
+$violations = @()
+$kept = @()
+if (Test-Path -LiteralPath $Pool) {
+  foreach ($d in (Get-ChildItem -LiteralPath $Pool -Directory | Sort-Object Name)) {
+    if ($d.CreationTime -lt $CohortStart -or $d.CreationTime -gt $CohortEnd) { continue }  # not this programme
+    $br = $wtBranch[($d.FullName -replace '\\', '/')]
+    if (-not $br) { continue }                                                             # detached => not a programme unit
+    if (Test-Contained $br) { $violations += "$($d.Name) [$br]" }
+    else { $kept += "$($d.Name) [$br] -- NOT contained in $Base; holds unique work" }
+  }
+}
+
+foreach ($k in $kept) { Write-Output "KEEP      $k" }
+foreach ($v in $violations) { Write-Output "VIOLATION $v -- fully landed in $Base, worktree still present" }
+
+if ($violations.Count -gt 0) {
+  Write-Output "FAILED:wt-hygiene $($violations.Count) landed programme worktree(s) still in the pool; $($kept.Count) correctly kept"
+  exit 1
+}
+Write-Output "SUCCESS:wt-hygiene pool clean; 0 landed programme worktrees, $($kept.Count) kept for unique work"
+exit 0

--- a/scripts/worktree-hygiene-audit.ps1
+++ b/scripts/worktree-hygiene-audit.ps1
@@ -63,9 +63,16 @@ param(
 $ErrorActionPreference = 'Stop'
 
 # Every call site wraps this in @(). PowerShell UNROLLS a single-element array on return,
-# so a bare `Git-Lines ...` that produced one line hands back a [string], and indexing [0]
+# so a bare `Get-GitLine ...` that produced one line hands back a [string], and indexing [0]
 # on it yields a [char]. Same family as the $t[0] bug described in the header.
-function Git-Lines { param([string[]]$GitArgs) return @(& git -C $Repo @GitArgs 2>&1) }
+#
+# Named Get-GitLine, not Git-Lines: `Git` is not an approved PowerShell verb (PSSA
+# PSUseApprovedVerbs) and the noun is singular by convention (PSUseSingularNouns). More
+# importantly the name must not be `git` in any casing -- command resolution is
+# case-insensitive and prefers functions over applications, so a helper called `Git` makes
+# the `& git` inside its own body call itself. That recursion cost a 600s hang in this
+# lane's self-test before it was diagnosed.
+function Get-GitLine { param([string[]]$GitArgs) return @(& git -C $Repo @GitArgs 2>&1) }
 
 if (-not (Test-Path -LiteralPath $Repo)) { Write-Output "FAILED:wt-hygiene repo not found: $Repo"; exit 1 }
 
@@ -86,7 +93,7 @@ function Test-Contained {
 # ---------------------------------------------------------------- detector controls
 $posOk = Test-Contained "$baseSha~1"
 $negRef = $null
-foreach ($b in @(Git-Lines @('for-each-ref', 'refs/heads/', '--format=%(refname:short)'))) {
+foreach ($b in @(Get-GitLine @('for-each-ref', 'refs/heads/', '--format=%(refname:short)'))) {
   $b = "$b".Trim(); if (-not $b) { continue }
   if (-not (Test-Contained $b)) { $negRef = $b; break }
 }
@@ -97,7 +104,7 @@ if (-not $negRef) { Write-Output 'FAILED:wt-hygiene detector negative control fa
 # ---------------------------------------------------------------- worktree -> branch map
 $wtBranch = @{}
 $cur = $null
-foreach ($line in @(Git-Lines @('worktree', 'list', '--porcelain'))) {
+foreach ($line in @(Get-GitLine @('worktree', 'list', '--porcelain'))) {
   $line = "$line"
   if ($line -like 'worktree *') { $cur = $line.Substring(9).Trim() }
   elseif ($line -like 'branch *') { $wtBranch[$cur] = $line.Substring(7).Trim() -replace '^refs/heads/', '' }

--- a/scripts/worktree-hygiene-teardown.ps1
+++ b/scripts/worktree-hygiene-teardown.ps1
@@ -145,10 +145,24 @@ foreach ($t in $targets) {
   }
   Assert-Primary 'after-remove'
 
-  # 3. delete the branch. -D is required (see above); the SHA is printed so it is recoverable.
+  # 3. ANCHOR the tip before deleting. Printing the SHA is not recovery: once the branch ref
+  #    is gone the commit is unreachable, and `git gc` (which runs automatically) is free to
+  #    discard it -- so "recoverable from the log" holds only until the next gc, and only if
+  #    anyone kept the log. A ref under refs/retired/ keeps the object reachable forever at
+  #    zero cost, and makes the undo one command instead of a forensic exercise.
+  $anchor = "refs/retired/$($t.Branch)"
+  $ur = @(& git -C $Repo update-ref $anchor $sha 2>&1)
+  if ($LASTEXITCODE -ne 0) {
+    Write-Output "    ABORT could not anchor $anchor before deleting: $($ur -join ' | ')"; exit 1
+  }
+  Write-Output "    anchored $anchor -> $sha"
+
+  # 4. delete the branch. -D is required (see above); the anchor from step 3 is the safety net.
   $bd = @(& git -C $Repo branch -D $t.Branch 2>&1)
   if ($LASTEXITCODE -ne 0) { Write-Output "    WARN branch delete failed: $($bd -join ' | ')" }
-  else { Write-Output "    deleted branch $($t.Branch) (was $sha)" }
+  else {
+    Write-Output "    deleted branch $($t.Branch) (was $sha; restore: git branch $($t.Branch) $anchor)"
+  }
 
   $done++
 }

--- a/scripts/worktree-hygiene-teardown.ps1
+++ b/scripts/worktree-hygiene-teardown.ps1
@@ -1,0 +1,157 @@
+<#
+.SYNOPSIS
+  Safely retire agent worktrees (and their branches) whose work has landed on the base ref.
+
+.DESCRIPTION
+  The destructive half of scripts/worktree-hygiene-audit.ps1. Removes ONLY worktrees the
+  audit classifies as fully landed, one at a time, re-verifying the receipt and the primary
+  checkout's health between every single step.
+
+  THE JUNCTION HAZARD, stated as measured rather than as folklore.
+  Each worktree carries app/node_modules and app/render-cli/node_modules as JUNCTIONS into
+  the primary checkout. Two distinct facts, both verified on this machine 2026-08-08:
+    1. `git worktree remove` REFUSES a worktree while those junctions exist -- it walks
+       into them, sees hundreds of untracked files, and aborts. This is the reason the
+       unlink step is mandatory, and it is not the reason usually given.
+    2. Whether a recursive delete follows a junction and destroys the TARGET depends on the
+       tool. PowerShell 7's Remove-Item was measured NOT to (link removed, target intact),
+       but other tools (shutil.rmtree, some archivers) are UNVERIFIED here -- settle per
+       tool by pointing it at a scratch junction and counting the target's files after.
+       Because the answer is tool-dependent, this script never recursively deletes a
+       worktree directory at all. It unlinks first, always, and lets git do the removal.
+
+  The primary's node_modules is a single point of failure for EVERY concurrent worktree, so
+  damage is checked after each teardown, not once at the end, and any drop aborts the loop.
+
+.PARAMETER WhatIf
+  Print the plan and the per-item receipts without removing anything.
+
+.PARAMETER Limit
+  Process at most N worktrees. Use -Limit 1 for the first run to observe real behaviour
+  before committing to a loop.
+#>
+[CmdletBinding()]
+param(
+  [string]$Repo = 'C:\Users\Prekzursil\Documents\GitHub\Reframe',
+  [string]$Pool = 'C:\Users\Prekzursil\.claude\agent-worktrees',
+  [datetime]$CohortStart = '2026-07-31 23:00',
+  [datetime]$CohortEnd = '2026-08-01 01:00',
+  [string]$Base = 'origin/main',
+  [switch]$WhatIf,
+  [int]$Limit = 0
+)
+
+$ErrorActionPreference = 'Stop'
+$prep = Join-Path $PSScriptRoot 'prepare-worktree.ps1'
+. (Join-Path $PSScriptRoot 'lib\branch-containment.ps1')
+
+# Pin to an immutable SHA before anything else. Re-resolving the ref per probe raced two
+# Dependabot merges mid-run and flipped 14 receipts inside one loop.
+$baseSha = Get-BaseSha -Repo $Repo -Ref $Base
+$baseTree = Get-TreeOf -Repo $Repo -Rev $baseSha
+
+# Baseline the resource every other worktree on this machine depends on.
+$nmApp = Join-Path $Repo 'app\node_modules'
+$nmCli = Join-Path $Repo 'app\render-cli\node_modules'
+$base0 = @(Get-ChildItem -LiteralPath $nmApp -Force).Count
+$base1 = @(Get-ChildItem -LiteralPath $nmCli -Force).Count
+Write-Output "BASELINE base=$Base@$($baseSha.Substring(0,10)) tree=$baseTree app/node_modules=$base0 app/render-cli/node_modules=$base1"
+if ($base0 -eq 0 -or $base1 -eq 0) { Write-Output 'FAILED:wt-teardown primary node_modules already empty'; exit 1 }
+
+# Printing happens HERE, at the call site, never inside the predicate -- see the comment on
+# Test-PrimaryHealthy for the dead-guard this arrangement exists to prevent.
+function Assert-Primary {
+  param([string]$Stage)
+  $s = Test-PrimaryHealthy -Repo $Repo -ExpectApp $base0 -ExpectCli $base1
+  Write-Output "    PRIMARY $Stage tsc=$($s.Tsc) app=$($s.App)/$base0 cli=$($s.Cli)/$base1 ok=$($s.Ok)"
+  if (-not $s.Ok) { Write-Output "FAILED:wt-teardown primary damaged at $Stage"; exit 1 }
+}
+
+# worktree -> branch
+$wtBranch = @{}
+$cur = $null
+foreach ($line in @(& git -C $Repo worktree list --porcelain)) {
+  $line = "$line"
+  if ($line -like 'worktree *') { $cur = $line.Substring(9).Trim() }
+  elseif ($line -like 'branch *') { $wtBranch[$cur] = $line.Substring(7).Trim() -replace '^refs/heads/', '' }
+}
+
+$targets = @()
+foreach ($d in (Get-ChildItem -LiteralPath $Pool -Directory | Sort-Object Name)) {
+  if ($d.CreationTime -lt $CohortStart -or $d.CreationTime -gt $CohortEnd) { continue }
+  $br = $wtBranch[($d.FullName -replace '\\', '/')]
+  if (-not $br) { continue }
+  $targets += [pscustomobject]@{ Path = $d.FullName; Name = $d.Name; Branch = $br }
+}
+Write-Output "CANDIDATES $($targets.Count)"
+
+$done = 0; $skipped = @()
+foreach ($t in $targets) {
+  if ($Limit -gt 0 -and $done -ge $Limit) { break }
+  Write-Output "--- $($t.Name) [$($t.Branch)]"
+
+  # RECEIPT, re-verified immediately before acting. `git branch -d` cannot protect us here
+  # (a squash-merged branch is not an ancestor, so -d refuses it and -D is required, which
+  # disables git's own safety net) -- this check is the replacement for that net.
+  $rcpt = Test-BranchLanded -Repo $Repo -Branch $t.Branch -BaseSha $baseSha -BaseTree $baseTree
+  if (-not $rcpt.Landed) {
+    Write-Output "    SKIP not landed (method=$($rcpt.Method) added=$($rcpt.Added) residual=$($rcpt.Residual))"
+    $skipped += "$($t.Name)/$($t.Branch) residual=$($rcpt.Residual)"; continue
+  }
+
+  $dirty = @(& git -C $t.Path status --porcelain 2>&1)
+  if ($dirty.Count -gt 0) { Write-Output "    SKIP dirty ($($dirty.Count) entries)"; $skipped += $t.Name; continue }
+
+  $sha = "$(@(& git -C $Repo rev-parse $t.Branch)[0])".Trim()
+  Write-Output "    receipt=$($rcpt.Method) added=$($rcpt.Added) residual=$($rcpt.Residual) sha=$sha"
+  if ($WhatIf) { Write-Output '    WHATIF would unlink + remove worktree + delete branch'; $done++; continue }
+
+  # 1. unlink the junctions (prepare-worktree asserts the primary survived and exits 1 if not)
+  $u = @(& pwsh -NoProfile -File $prep -Worktree $t.Path -Unlink 2>&1)
+  if ($LASTEXITCODE -ne 0 -or -not ($u -match 'SUCCESS:prepare-worktree unlinked')) {
+    Write-Output "    ABORT unlink failed: $($u -join ' | ')"; exit 1
+  }
+  Assert-Primary 'after-unlink'
+
+  # 2. let git remove the worktree (never a recursive delete of the directory)
+  $rm = @(& git -C $Repo worktree remove $t.Path 2>&1)
+  if ($LASTEXITCODE -ne 0) {
+    Write-Output "    remove returned: $($rm -join ' | ')"
+
+    # MEASURED 2026-08-08 on agent-612289141, after 17 consecutive clean removals: git
+    # reports "Permission denied" having ALREADY deregistered the worktree and emptied the
+    # directory -- only the (now empty) directory handle was still locked, transiently, by
+    # something outside git. Retrying with --force then fails with "is not a working tree",
+    # because there is no longer a working tree to force. So the intermittent lock is not
+    # systematic and must not abort the run; detect the already-deregistered state and
+    # finish the one remaining step ourselves.
+    $stillRegistered = [bool](@(& git -C $Repo worktree list --porcelain) -match [regex]::Escape(($t.Path -replace '\\', '/')))
+    if ($stillRegistered) {
+      $rm = @(& git -C $Repo worktree remove --force $t.Path 2>&1)
+      if ($LASTEXITCODE -ne 0) { Write-Output "    ABORT worktree remove failed: $($rm -join ' | ')"; exit 1 }
+    }
+    else {
+      # Deregistered already. Removing the leftover directory is only safe once we have
+      # positively confirmed it holds nothing and carries no junction -- otherwise this
+      # would be the recursive delete the whole script exists to avoid.
+      foreach ($rel in @('app\node_modules', 'app\render-cli\node_modules')) {
+        if (Test-Path -LiteralPath (Join-Path $t.Path $rel)) { Write-Output "    ABORT junction still present: $rel"; exit 1 }
+      }
+      $left = @(Get-ChildItem -LiteralPath $t.Path -Force -Recurse -ErrorAction SilentlyContinue)
+      if ($left.Count -ne 0) { Write-Output "    ABORT deregistered but $($left.Count) file(s) remain; not deleting"; exit 1 }
+      Remove-Item -LiteralPath $t.Path -Force -Recurse -ErrorAction SilentlyContinue
+      Write-Output "    recovered: empty deregistered directory removed (dir-gone=$(-not (Test-Path -LiteralPath $t.Path)))"
+    }
+  }
+  Assert-Primary 'after-remove'
+
+  # 3. delete the branch. -D is required (see above); the SHA is printed so it is recoverable.
+  $bd = @(& git -C $Repo branch -D $t.Branch 2>&1)
+  if ($LASTEXITCODE -ne 0) { Write-Output "    WARN branch delete failed: $($bd -join ' | ')" }
+  else { Write-Output "    deleted branch $($t.Branch) (was $sha)" }
+
+  $done++
+}
+
+Write-Output "SUCCESS:wt-teardown processed=$done skipped=$($skipped.Count) [$($skipped -join ', ')]"
+exit 0


### PR DESCRIPTION
Adds the worktree-hygiene audit/teardown pair, and fixes a defect in its core predicate that pointed at **data loss**.

## The defect

`Test-BranchLanded` tier 2 tested each line a branch **added** for membership in a `HashSet` of the base blob's lines. Set membership has no position. Source is full of lines that recur verbatim (`}`, `    return None`, an import, a closing paren), so a branch whose additions are individually common scored `residual=0` and came back `Landed = $true`.

That verdict is not advisory — `worktree-hygiene-teardown.ps1` skips a branch only when `-not $rcpt.Landed`, and the true path runs **`git branch -D`**. The failure mode was: *delete a branch whose work never landed.*

## The fix

Tier 2 now requires each added line to appear in the base **together with its two neighbours** — the `(previous, line, next)` window. A coincidence now needs three consecutive lines to coincide. And when a branch's work landed in a *modified* form the window misses and the answer becomes "not landed": **the errors now point at keeping a branch rather than deleting one.**

Both figures are returned so the gap is visible rather than inferred:

- `Residual` — window misses. `Landed` depends on this one.
- `WeakResidual` — bare-membership misses, i.e. the old measure.

`WeakResidual=0` with `Residual>0` **is** the bug, in numbers.

## Proof — `scripts/lib/branch-containment-selftest.ps1` (new, ~2s on a temp repo)

```
OK C1 landed-verbatim     landed=True  method=context-containment added=3 residual=0 weak=0
OK C2 coincidental-lines  landed=False method=not-landed          added=3 residual=3 weak=0
OK C3 genuinely-unlanded  landed=False method=not-landed          added=2 residual=2 weak=2
OK C4 tree-equal          landed=True  method=tree-equal          added=0 residual=0 weak=0
```

**C2 is the case that matters:** `weak=0` means the shipped predicate scored zero residual and would have deleted it.

Two fixture bugs were caught by the harness itself rather than shipped:
- A first C2 used a line the base never gains, so `weak` came back 1 and the case would have passed while exercising nothing. The harness now asserts the *shape* (`weak=0 AND residual>0`), not just the verdict.
- C1 originally short-circuited at tier 1 (`tree-equal`, `added=0`), leaving the code under test with no passing case. The fixture now lands an extra function in the same region so the three-way merge conflicts and tier 2 is forced. Each case asserts its `Method`, not only `Landed`.

## Deletion is now reversible

Printing the SHA is not recovery: once the branch ref is gone the commit is unreachable and `git gc` may discard it. Teardown now writes `refs/retired/<branch>` **before** deleting and aborts if that fails. The undo command is printed on the spot.

## PowerShell static analysis

`.ps1` had none. `scripts/lib/ps-lint.ps1` runs the parser over all 8 tracked scripts (no module needed), PSScriptAnalyzer at Error+Warning when installed, and the self-test:

```
parse: 8/8 clean · pssa v1.25.0: 0 findings · selftest 4/4
SUCCESS:ps-lint
```

Fixed to get there: `Git-Lines` → `Get-GitLine` (unapproved verb + plural noun) and a missing BOM on `prepare-worktree.ps1` (3 bytes; PowerShell 5.1 misreads non-ASCII UTF-8 without one).

**It is not a CI gate, and the script's own header says so.** `QUALITY-CHARTER.md` rule 2 declares the six-gate list closed and `.quality/charter_check.py` enforces that, so a seventh gate is a charter amendment rather than a config edit. Exposure is bounded — no `.ps1` ships inside the Electron app or the Python sidecar.

## A hang worth recording

The self-test's first version wrapped git in a helper named `Git` and called `& git` inside it. PowerShell command resolution is **case-insensitive** and prefers functions/aliases over applications, so the helper called itself: infinite recursion, 600 seconds, **zero bytes on stdout and stderr** — which reads exactly like a broken environment. A trivial control script launched the identical way finished in under a second, which is what localised it.

## Test plan

- `ps-lint` — parse 8/8, PSSA 0 findings, selftest 4/4, exit 0
- Cross-lane: octopus-merged with `fix/uc-hermetic` + `fix/uc-ssot`; combined tree passes `docs_check` (`r1..r5 = 0`), `charter_check` (6 gates), `verify_ssot_claims` (40/40)
- Scripts are developer tooling only; no product code path changes.
