### PR TITLE
fix(quality): qualify the two ambiguous doc citations, and report the rest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,7 +67,7 @@ repos:
   - repo: local
     hooks:
       - id: docs-check
-        name: docs-check (SSOT anti-drift R1-R4)
+        name: docs-check (SSOT anti-drift R1-R5)
         entry: python .quality/docs_check.py
         language: system
         pass_filenames: false

--- a/.quality/docs_check.py
+++ b/.quality/docs_check.py
@@ -267,6 +267,54 @@ def subdir_docs_by_basename(files: list[str]) -> dict[str, str]:
     return {name: paths[0] for name, paths in seen.items() if len(paths) == 1}
 
 
+def count_ambiguous_citations(files: list[str], ambiguous: dict[str, list[str]]) -> int:
+    """Bare citations r5 cannot judge, because the basename matches several docs.
+
+    REPORTED, never enforced. r5 skips these deliberately: with 7 tracked `DESIGN.md`
+    files it cannot name the correct fix, and a rule whose message has to guess is worse
+    than silence. But silence hid the residual entirely -- a reader following
+    `see PLAN.md` has six candidates and no way to choose.
+
+    Emitting the count keeps the number generated rather than hand-written (the same
+    reasoning as `waivers-applied`), so tightening this later starts from a measurement
+    instead of an estimate. A sibling reference from inside a candidate's own directory
+    is unambiguous in context and is not counted.
+    """
+    n = 0
+    for rel in files:
+        if Path(rel).suffix not in CITING_SUFFIXES:
+            continue
+        lines = read_lines(rel)
+        if lines is None:
+            continue
+        here = Path(rel).parent.as_posix()
+        for line in lines:
+            if WAIVER_RE.search(line):
+                continue
+            for m in BARE_DOC_RE.finditer(line):
+                cands = ambiguous.get(m.group(1))
+                if not cands:
+                    continue
+                if any(Path(c).parent.as_posix() == here for c in cands):
+                    continue
+                n += 1
+    return n
+
+
+def ambiguous_docs_by_basename(files: list[str]) -> dict[str, list[str]]:
+    """Basenames that match MORE THAN ONE subdirectory doc (r5's blind spot)."""
+    root_names = {f for f in files if "/" not in f}
+    seen: dict[str, list[str]] = {}
+    for rel in files:
+        if not rel.endswith(".md") or "/" not in rel or not is_authority_doc(rel):
+            continue
+        name = Path(rel).name
+        if name in root_names:
+            continue
+        seen.setdefault(name, []).append(rel)
+    return {name: paths for name, paths in seen.items() if len(paths) > 1}
+
+
 def check_r5(files: list[str], subdir_docs: dict[str, str]) -> list[str]:
     """Flag `see FOO.md` when FOO.md actually lives at `some/dir/FOO.md`."""
     bad = []
@@ -353,9 +401,10 @@ def main() -> int:
     # direction, because `git grep -c ssot-allow:` also counts the regex literal and
     # the docstring that explains the idiom — use-vs-mention. A generated number
     # cannot drift from the thing it counts.
+    ambiguous = count_ambiguous_citations(files, ambiguous_docs_by_basename(files))
     print(
         f"docscheck: authority-docs={len(docs)} citing-files-scanned={scanned} "
-        f"waivers-applied={waivers} "
+        f"waivers-applied={waivers} ambiguous-bare={ambiguous} "
         f"r1={counts['r1']} r2={counts['r2']} r3={counts['r3']} r4={counts['r4']} "
         f"r5={counts['r5']}"
     )

--- a/docs/validation/tools/verify_ssot_claims.py
+++ b/docs/validation/tools/verify_ssot_claims.py
@@ -252,7 +252,7 @@ for var, truth, doc_claim in PALETTE:
         f"C8:{var}",
         True,
         tok_ok and doc_wrong,
-        f"tokens.css has {truth}={tok_ok}; DESIGN-DIRECTION.md still has {doc_claim}={doc_wrong}",
+        f"tokens.css has {truth}={tok_ok}; docs/build/DESIGN-DIRECTION.md still has {doc_claim}={doc_wrong}",
     )
 
 # ---------------------------------------------------- C9 keystore / consent gate

--- a/sidecar/media_studio/features/apply_engine.py
+++ b/sidecar/media_studio/features/apply_engine.py
@@ -1,5 +1,6 @@
 """The applyEngine: walk an EditPlan over a project COPY, recording an inverse
-(DESIGN §5, GAP-1, PLAN.md §WU-apply — build FIRST, "unretrofittable").
+(docs/plans/_archive/prompt-driven-editing/DESIGN.md §5, GAP-1, and that plan's
+PLAN.md §WU-apply — build FIRST, "unretrofittable").
 
 This is the reversibility layer the in-place handlers lack. Today every handler
 mutates ``project.data`` in place and ``project.save()``s with **no undo**


### PR DESCRIPTION
r5 skips a bare basename matching several tracked docs — with 7 tracked `DESIGN.md` files any suggested fix would be a guess. Correct for a gate, but the residual then went unreported: a reader following `see PLAN.md` has six candidates and no way to choose.

## Two were resolvable from evidence, and both are code

- **`verify_ssot_claims.py`** built a failure message naming a bare `DESIGN-DIRECTION.md` while the same function reads `docs/build/DESIGN-DIRECTION.md` three lines up — so the message pointed at two files, one of which it was not using.
- **`apply_engine.py`** cites `DESIGN §5` / `PLAN.md §WU-apply`. Both live in `docs/plans/_archive/prompt-driven-editing/` — i.e. live production code pointing at a plan that has since been **archived**. Qualifying it records where the design actually is instead of implying a live plan.

## The rest are now counted, not enforced

`docs_check.py` emits `ambiguous-bare=N` beside `waivers-applied`. Same reasoning as that field: three prose claims about waiver counts were wrong **in three different directions** because they were hand-written. A generated number means tightening this later starts from a measurement rather than an estimate.

A sibling reference from inside a candidate's own directory is unambiguous in context and is not counted — that is how a plan directory refers to its own `DESIGN.md`.

Also: the pre-commit hook still announced itself as `R1-R4` after r5 shipped. A gate whose own label is stale is a poor advertisement for an anti-drift gate.

## Test plan

```
docscheck   authority-docs=85 citing-files-scanned=981 waivers-applied=9
            ambiguous-bare=10 r1=0 r2=0 r3=0 r4=0 r5=0   SUCCESS
mutations   7/7 behaved, all reverted clean
ssot-verify total=40 as-predicted=40 mismatched=0
sidecar     130 passed (apply/apply_engine selection)
ruff        0.15.17 lint + format clean
```
