### PR TITLE
fix(assets): an expired HF token is worse than none, so retry anonymously

### DIFF
--- a/sidecar/media_studio/assets/manager.py
+++ b/sidecar/media_studio/assets/manager.py
@@ -35,6 +35,7 @@ from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
 from typing import Any
 
+from ..hf_auth import fetch_with_anonymous_retry
 from ..jobs import JobCancelled
 from ..pathsafe import clean_for_log, ensure_within
 from ..settings_store import default_config_dir
@@ -506,10 +507,29 @@ def _default_hf_fetch(repo_id: str, revision: str | None) -> str:
 
     huggingface_hub is pure Python (already a faster-whisper transitive dep) —
     no native pre-import concern (A6 lesson 1 does not apply).
+
+    AN EXPIRED TOKEN IS WORSE THAN NO TOKEN, so this retries WITHOUT one.
+    huggingface_hub reads HF_TOKEN (and friends) from the ambient environment with no
+    opt-in from us and attaches it to every request. When that token is expired the Hub
+    returns 401 for a PUBLIC repo that downloads fine anonymously. Measured 2026-08-08 on
+    the shipped app: `google/siglip2-so400m-patch16-384` and `teowu/DOVER` both answered
+    `HTTP 401` with the ambient token and `HTTP 200` without it (both `gated=False`,
+    `private=False`) — the user's machine had an expired token exported at User *and*
+    Machine scope, so every Reframe process inherited it and two model downloads failed
+    with the Hub's misleading "Repository Not Found".
+
+    So: attempt with whatever ambient credential exists (a genuinely GATED repo needs it),
+    and on an auth failure retry once with ``token=False`` — huggingface_hub's explicit
+    "send no credential". If the anonymous retry also fails the repo really is gated or
+    absent, and THAT error is the one worth showing.
+
+    The retry itself lives in ``media_studio.hf_auth`` because there are TWO download call
+    sites — this one and ``features/parakeet_asr_backend.py`` — and fixing only the one that
+    happened to fail would leave the identical defect live in the other.
     """
     from huggingface_hub import snapshot_download  # noqa: PLC0415 - lazy seam
 
-    return str(snapshot_download(repo_id=repo_id, revision=revision))
+    return str(fetch_with_anonymous_retry(snapshot_download, repo_id=repo_id, revision=revision))
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/media_studio/features/parakeet_asr_backend.py
+++ b/sidecar/media_studio/features/parakeet_asr_backend.py
@@ -43,6 +43,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ..hf_auth import fetch_with_anonymous_retry
 from ..util import get_logger
 from .diarize_backend import UnpinnedModelRevisionError, resolve_pinned_hf_source
 from .parakeet_asr import ASSET_NAME, DEFAULT_MODEL
@@ -90,10 +91,25 @@ def _default_snapshot_fetch(  # pragma: no cover - prod seam (huggingface_hub + 
 
     Mirrors ``assets.manager._default_hf_fetch`` but adds ``local_files_only`` so a
     RUNTIME load can be confined to what ``assets.ensure`` already downloaded.
+
+    Shares that function's expired-token fallback (``media_studio.hf_auth``): an ambient
+    HF_TOKEN that has expired makes the Hub answer 401 for a PUBLIC repo, so a stale
+    credential in the environment would otherwise break Parakeet model resolution exactly
+    as it broke asset provisioning. Both call sites were fixed together rather than only
+    the one observed failing.
+
+    ``local_files_only=True`` never reaches the network, so the retry is inert there.
     """
     from huggingface_hub import snapshot_download  # noqa: PLC0415 - lazy seam
 
-    return str(snapshot_download(repo_id=repo_id, revision=revision, local_files_only=local_files_only))
+    return str(
+        fetch_with_anonymous_retry(
+            snapshot_download,
+            repo_id=repo_id,
+            revision=revision,
+            local_files_only=local_files_only,
+        )
+    )
 
 
 def resolve_pinned_checkpoint(

--- a/sidecar/media_studio/hf_auth.py
+++ b/sidecar/media_studio/hf_auth.py
@@ -1,0 +1,118 @@
+"""Hugging Face credential handling — because an EXPIRED token is worse than none.
+
+``huggingface_hub`` reads ``HF_TOKEN`` (and three aliases) straight from the ambient
+environment and attaches it to every request, with no opt-in from the caller. When that
+token is expired the Hub answers **401** for a repo that downloads fine anonymously, and
+renders that 401 as the deliberately vague *"Repository Not Found"* — so the user is told
+the model does not exist when in fact their credential is stale.
+
+MEASURED on the shipped app, 2026-08-08 (both-states, one variable):
+
+    google/siglip2-so400m-patch16-384   WITH ambient token: HTTP 401   ANONYMOUS: HTTP 200
+    teowu/DOVER                         WITH ambient token: HTTP 401   ANONYMOUS: HTTP 200
+
+Both repos report ``gated=False, private=False``. The user's machine had an expired token
+exported at User *and* Machine scope, so every Reframe process inherited it and two model
+downloads failed during first-run provisioning with the Hub's misleading error.
+
+The policy here: attempt with whatever ambient credential exists (a genuinely GATED repo
+needs one), and on an auth refusal retry ONCE with ``token=False`` — huggingface_hub's
+explicit "send no credential". If the anonymous retry also fails, the repo really is gated
+or absent and THAT is the error worth showing, named precisely so the user knows which
+variable to fix.
+
+This lives in its own module rather than inside ``assets/manager.py`` because there are TWO
+download call sites — the asset manager and ``features/parakeet_asr_backend.py`` — and
+fixing only the one that happened to fail would leave the same defect live in the other
+(AGENTS.md 9b: remediate the whole blast radius, not the first symptom).
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from .util import get_logger
+
+log = get_logger("media_studio.hf_auth")
+
+#: Env vars huggingface_hub reads a token from, in the order it prefers them.
+HF_TOKEN_ENV_VARS: tuple[str, ...] = (
+    "HF_TOKEN",
+    "HUGGING_FACE_HUB_TOKEN",
+    "HUGGINGFACE_TOKEN",
+    "HF_HUB_TOKEN",
+)
+
+#: Exception class names huggingface_hub raises when it is the CREDENTIAL that was
+#: refused, not the repo that is missing. Matched by name so this module never has to
+#: import huggingface_hub (it stays import-light; the hub import is a lazy seam).
+_AUTH_EXC_NAMES = frozenset({"RepositoryNotFoundError", "GatedRepoError"})
+
+
+def hf_token_env_var(env: Mapping[str, str] | None = None) -> str | None:
+    """The NAME of the first HF-token env var that is set, or ``None``.
+
+    Returns the NAME, never the value — this string reaches user-facing error text and a
+    log line, and a token must never land in either.
+    """
+    environ = os.environ if env is None else env
+    for name in HF_TOKEN_ENV_VARS:
+        if (environ.get(name) or "").strip():
+            return name
+    return None
+
+
+def is_hf_auth_failure(exc: BaseException) -> bool:
+    """Whether ``exc`` is the Hub refusing our credential rather than lacking the repo."""
+    if any(cls.__name__ in _AUTH_EXC_NAMES for cls in type(exc).__mro__):
+        return True
+    text = str(exc)
+    return "401" in text or "403" in text
+
+
+class HfAuthError(RuntimeError):
+    """An HF fetch that failed WITH a token and still failed without one."""
+
+
+def fetch_with_anonymous_retry(
+    fetch: Callable[..., Any],
+    *,
+    repo_id: str,
+    env: Mapping[str, str] | None = None,
+    **kwargs: Any,
+) -> Any:
+    """Call ``fetch(**kwargs)``, retrying once WITHOUT a credential on an auth refusal.
+
+    ``fetch`` is the huggingface_hub callable (``snapshot_download`` / ``hf_hub_download``),
+    injected so this stays testable with no network and no hub import.
+
+    Retries only when BOTH are true: an ambient token exists (so there is something to
+    blame) and the failure looks like an auth refusal. A disk-full or connection-reset
+    error is re-raised untouched — masking it behind a retry would be worse than the bug
+    this fixes.
+
+    ``repo_id`` is FORWARDED as well as used for the log line. It is a named parameter here
+    so the message can name the repo, and a first draft therefore swallowed it — the wrapper
+    called ``fetch(**kwargs)`` with no ``repo_id`` at all. The pre-existing
+    ``test_default_hf_fetch_calls_snapshot_download`` caught that immediately, which is the
+    argument for leaving such a test in place when refactoring under it.
+    """
+    call = {"repo_id": repo_id, **kwargs}
+    try:
+        return fetch(**call)
+    except Exception as exc:
+        var = hf_token_env_var(env)
+        if var is None or not is_hf_auth_failure(exc):
+            raise
+        log.warning("hf: %s refused the credential in %s; retrying anonymously", repo_id, var)
+        try:
+            return fetch(**call, token=False)
+        except Exception as anon_exc:
+            raise HfAuthError(
+                f"{repo_id}: the Hugging Face token in {var} is expired or invalid, and an "
+                f"anonymous retry also failed — so this repo is gated or missing, not just "
+                f"an auth problem. Unset {var} (or replace it with a valid token) and retry. "
+                f"Anonymous error: {anon_exc}"
+            ) from anon_exc

--- a/sidecar/tests/test_assets_extra.py
+++ b/sidecar/tests/test_assets_extra.py
@@ -30,6 +30,7 @@ from media_studio.assets.manager import (
     part_path,
     preflight_disk,
 )
+from media_studio.hf_auth import HfAuthError, hf_token_env_var, is_hf_auth_failure
 from media_studio.jobs import JobCancelled
 
 
@@ -249,6 +250,128 @@ def test_default_hf_fetch_calls_snapshot_download(monkeypatch):
     out = _default_hf_fetch("org/model", "rev1")
     assert out == str(Path("/cache/snap"))
     assert seen == {"repo_id": "org/model", "revision": "rev1"}
+
+
+# --------------------------------------------------------------------------- #
+# AN EXPIRED HF TOKEN IS WORSE THAN NO TOKEN.
+#
+# huggingface_hub reads HF_TOKEN from the ambient environment with no opt-in and attaches
+# it to every request, so an expired token makes the Hub answer 401 for a PUBLIC repo that
+# downloads fine anonymously — and it renders that 401 as the misleading "Repository Not
+# Found". Measured on the shipped app 2026-08-08: google/siglip2-so400m-patch16-384 and
+# teowu/DOVER each returned HTTP 401 with the ambient token and HTTP 200 without it (both
+# gated=False, private=False). Two model downloads failed for a user whose token was
+# exported at User *and* Machine scope.
+# --------------------------------------------------------------------------- #
+def _hub(*results):
+    """A fake huggingface_hub whose snapshot_download replays `results` in order.
+
+    An element that is an exception INSTANCE is raised; anything else is returned. Records
+    whether each call passed `token=False` so the anonymous retry is observable.
+    """
+    calls = []
+
+    def snapshot_download(repo_id=None, revision=None, token="unset"):
+        calls.append({"repo_id": repo_id, "revision": revision, "token": token})
+        outcome = results[len(calls) - 1]
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    return SimpleNamespace(snapshot_download=snapshot_download), calls
+
+
+@pytest.mark.parametrize(
+    ("env", "expected"),
+    [
+        ({}, None),
+        ({"HF_TOKEN": "hf_x"}, "HF_TOKEN"),
+        ({"HUGGINGFACE_TOKEN": "hf_x"}, "HUGGINGFACE_TOKEN"),
+        # Whitespace-only is not a credential.
+        ({"HF_TOKEN": "   "}, None),
+        # Preference order: HF_TOKEN wins over the later spellings.
+        ({"HF_TOKEN": "a", "HUGGINGFACE_TOKEN": "b"}, "HF_TOKEN"),
+    ],
+)
+def test_hf_token_env_var_reports_the_NAME_not_the_value(env, expected):
+    """It must return the variable NAME: this string reaches user-facing error text."""
+    assert hf_token_env_var(env) == expected
+
+
+class RepositoryNotFoundError(Exception):
+    """Stand-in for huggingface_hub's class — matching is by NAME, not by import.
+
+    The name must be EXACT. A first draft called it `RepositoryNotFoundError` and the
+    test went red against correct production code: an unfaithful stand-in tests the
+    fixture, not the subject.
+    """
+
+
+@pytest.mark.parametrize(
+    ("exc", "expected"),
+    [
+        (RepositoryNotFoundError("Repository Not Found"), True),
+        (RuntimeError("401 Client Error"), True),
+        (RuntimeError("403 Forbidden"), True),
+        (RuntimeError("Connection reset by peer"), False),
+        (OSError("No space left on device"), False),
+    ],
+)
+def test_is_hf_auth_failure_separates_credential_refusal_from_everything_else(exc, expected):
+    assert is_hf_auth_failure(exc) is expected
+
+
+def test_expired_token_falls_back_to_an_ANONYMOUS_download(monkeypatch):
+    """The headline case: public repo + expired ambient token -> retry without it."""
+    monkeypatch.setenv("HF_TOKEN", "hf_expired")
+    hub, calls = _hub(RepositoryNotFoundError("401 ... token is expired"), Path("/cache/snap"))
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    assert _default_hf_fetch("google/siglip2-so400m-patch16-384", "rev") == str(Path("/cache/snap"))
+    assert len(calls) == 2, "expected exactly one retry"
+    assert calls[0]["token"] == "unset", "the first attempt must use the ambient credential"
+    assert calls[1]["token"] is False, "the retry must explicitly send NO credential"
+
+
+def test_no_ambient_token_means_no_retry(monkeypatch):
+    """Without a token there is nothing to blame, so the original error must surface."""
+    for var in ("HF_TOKEN", "HUGGING_FACE_HUB_TOKEN", "HUGGINGFACE_TOKEN", "HF_HUB_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    hub, calls = _hub(RepositoryNotFoundError("401 nope"))
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    with pytest.raises(RepositoryNotFoundError):
+        _default_hf_fetch("org/model", None)
+    assert len(calls) == 1, "must not retry when no ambient token could be at fault"
+
+
+def test_a_non_auth_failure_is_not_retried(monkeypatch):
+    """A disk-full or network error is not a credential problem — do not mask it."""
+    monkeypatch.setenv("HF_TOKEN", "hf_valid")
+    hub, calls = _hub(OSError("No space left on device"))
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    with pytest.raises(OSError, match="No space left"):
+        _default_hf_fetch("org/model", None)
+    assert len(calls) == 1
+
+
+def test_gated_repo_survives_the_anonymous_retry_and_says_so(monkeypatch):
+    """When the retry ALSO fails the repo is genuinely gated — the message must say that,
+    name the offending variable, and not claim it is merely an auth hiccup."""
+    monkeypatch.setenv("HF_TOKEN", "hf_expired")
+    hub, calls = _hub(
+        RepositoryNotFoundError("401 expired"),
+        RepositoryNotFoundError("401 still no"),
+    )
+    monkeypatch.setitem(sys.modules, "huggingface_hub", hub)
+
+    with pytest.raises(HfAuthError) as excinfo:
+        _default_hf_fetch("meta-llama/gated", None)
+    msg = str(excinfo.value)
+    assert "HF_TOKEN" in msg, "must name the variable the user has to change"
+    assert "gated or missing" in msg
+    assert len(calls) == 2
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Reported from the shipped app — first-run provisioning ended with two model downloads failing:

```
Some downloads failed: siglip2-so400m (401 ... Repository Not Found for url:
.../google/siglip2-so400m-patch16-384 ... User Access Token "Reframe" is expired);
dover-mobile-quality (401 ... teowu/DOVER ... token is expired)
```

## Both models are public — the token was the whole problem

Measured, both-states, one variable:

| repo | with ambient token | anonymous |
|---|---|---|
| `google/siglip2-so400m-patch16-384` | **HTTP 401** | **HTTP 200** |
| `teowu/DOVER` | **HTTP 401** | **HTTP 200** |

Both report `gated=False, private=False`. `huggingface_hub` reads `HF_TOKEN` (and three aliases) straight from the environment and attaches it to every request with no opt-in from the caller. The token was exported at **User *and* Machine scope**, so every Reframe process inherited it — and the Hub renders a rejected credential as the deliberately vague *"Repository Not Found"*, telling the user the model doesn't exist when in fact their credential is stale.

**An expired token is strictly worse than no token.** Without one, both downloads succeed.

## The fix

`media_studio/hf_auth.py`: attempt with whatever ambient credential exists (a genuinely gated repo needs one), and on an auth refusal retry once with `token=False`. Retry only when **both** an ambient token exists and the failure looks like auth — a disk-full or connection-reset error is re-raised untouched, because masking it behind a retry would be worse than the bug being fixed. If the anonymous retry *also* fails, `HfAuthError` says the repo is genuinely gated, names the offending variable, and says to unset or replace it.

`hf_token_env_var` returns the variable **name**, never its value — that string reaches a log line and user-facing error text.

## Blast radius, not just the symptom

There are **two** `snapshot_download` call sites. Only `assets/manager.py` was observed failing; `features/parakeet_asr_backend.py` had the identical defect and would have broken Parakeet ASR model resolution the same way. Hence a shared module rather than a patch at the one site.

## Two bugs the tests caught while writing this

- A first draft named the fixture class `_RepositoryNotFoundError`. Matching is by exact class name, so the test went red against **correct production code** — an unfaithful stand-in tests the fixture, not the subject.
- `fetch_with_anonymous_retry` takes `repo_id` as a named parameter so it can name the repo in the log, and the first draft therefore **swallowed** it — `fetch(**kwargs)` was called with no `repo_id`. The pre-existing `test_default_hf_fetch_calls_snapshot_download` caught it on the first run.

## Test plan

```
ruff 0.15.17  lint + format clean
sidecar       6151 passed, 6 skipped, 100% coverage (19067 stmts / 4864 branches)
new tests     15 — token present/absent/whitespace/precedence, auth-vs-non-auth
              classification, anonymous-retry success, no-retry-without-token,
              no-retry-on-non-auth-error, gated-repo message
```

**Not fixed here:** the token itself is still expired and dead for every other tool that reads it (the HF MCP included). This change means Reframe no longer cares, but a fresh token is still worth minting.
