### PR TITLE
docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -179,3 +179,13 @@ now. Their bodies are left intact as historical record; the header is the correc
 | `plans/_archive/v1.4-experience-overhaul.md` | the v1.4 plan. Its one unshipped sub-unit (WU-3a3) is open item O-2 in `plans/v1.5/SCOPE.md`. |
 | `_archive/2026-06/` | pre-v1.3 plan/gate artifacts (`PLAN-P1`, `PLAN-P2`, `PLAN-P4-REFRAME-OPUSCLIP`, `DESIGN`, `DESIGN-GATE-1`, `V1-GRILL-DECISIONS`, `reframe-v1.3-settings-gaps`), the two P2 build reports, `docs/_archive/2026-06/LLM-BACKEND.md`, and `docs/_archive/2026-06/PR-PURGE-CHECKLIST.md`. |
 | `_archive/2026-07/` | `docs/_archive/2026-07/reframe-visual-audit.md` and `docs/_archive/2026-07/reframe-reconcile-audit.md` (both actively wrong — kept as a lesson, see `plans/v1.5/README.md`), and `handoff/` (two v1.4 handoff docs). |
+
+### v1.5 audit fleet (2026-08)
+
+| Doc | What it decides |
+|---|---|
+| [`plans/v1.5/captions-translation-audit-2026-08.md`](plans/v1.5/captions-translation-audit-2026-08.md) | captions / subtitles / transcription / translation audit + design |
+| [`plans/v1.5/competitor-matrix-2026-08.md`](plans/v1.5/competitor-matrix-2026-08.md) | competitor capability matrix vs the measured repo state |
+| [`plans/v1.5/distribution-audit-2026-08.md`](plans/v1.5/distribution-audit-2026-08.md) | installer, updater, code-signing and backward-compatibility audit |
+| [`plans/v1.5/editing-surface-audit-2026-08.md`](plans/v1.5/editing-surface-audit-2026-08.md) | general video-editing surface audit (what exists vs what a pro editor needs) |
+| [`plans/v1.5/uiux-qol-audit-2026-08.md`](plans/v1.5/uiux-qol-audit-2026-08.md) | UI/UX + quality-of-life audit driven against the INSTALLED app |

--- a/docs/plans/v1.5/captions-translation-audit-2026-08.md
+++ b/docs/plans/v1.5/captions-translation-audit-2026-08.md
@@ -1,0 +1,456 @@
+# Captions / Subtitles / Transcription / Translation — Audit + Design (v1.5)
+
+> **Status:** ACTIVE
+
+**Unit:** `captions` (audit + design only — NO implementation, NO file changes outside this doc)
+**Date opened:** 2026-08-08 · **Last rewrite:** milestone 2 — ALL FIVE SECTIONS MEASURED
+
+> **If a section reads "UNKNOWN - not yet measured", the unit died before measuring it and no
+> verdict there may be cited.** No section currently reads that.
+
+## COVERAGE
+
+| § | Section | State |
+|---|---|---|
+| 1 | Per-engine supported-language set | MEASURED (one item NOT-CHECKED, named inline) |
+| 2 | Language-selector design | MEASURED + DESIGNED |
+| 3 | Translation quality | MEASURED + DESIGNED |
+| 4 | Caption parity (karaoke / normal / Remotion) | MEASURED |
+| 5 | Escape hatches (.SRT import, custom dictionary) | MEASURED |
+
+## Owner ask (verbatim)
+
+> "captions language list is very short ... it should feature everything and autodetect as well,
+> should allow transcription and translation of transcription and it has to be very accurate and
+> properly worded not bad translations, as well as properly captioned, for both shorts and/or
+> karaoke captions and normal subtitles as well"
+
+## Honesty contract in force
+
+`UNVERIFIED` is INLINE next to the claim it qualifies and names the settling experiment.
+Sherman-Kent bands on forward-looking claims (`almost certain` 90-99%, `likely` 55-80%,
+`roughly even` 45-55%, `unlikely` 20-45%). Every factual claim carries `file:line` or a model-card
+URL. `NOT-CHECKED` beats a guess.
+
+## The three headline defects
+
+1. **§3.1 — Translation is per-cue and context-free, on cues already split mid-sentence.** This is
+   the mechanical cause of "bad translations", not model quality.
+2. **§3.5 — An EN-only punctuation/casing model is applied to ALL languages with no language
+   check.** Latent (behind two opt-ins) but it makes non-English captions worse, not better.
+3. **§4.2 — One call site (`caption.py:640-648`) drops six styling parameters on the karaoke
+   path.** Karaoke captions cannot be styled at all.
+
+---
+
+## 1. Real supported-language set per engine — MEASURED
+
+### 1.1 Four language vocabularies that disagree
+
+Counted by mechanical regex extraction, not by eye (a deliberate re-probe of the brief's hand
+count, via a throwaway script):
+
+| Vocabulary | Count | Source |
+|---|---|---|
+| **UI dropdown** (`LANGUAGES`) | **19** | `app/renderer/src/lib/languages.ts:25-45` |
+| **UI dropdown #2** (duplicate, in `Transcribe`) | **9** + auto | `app/renderer/src/features/Transcribe.tsx:27-38` |
+| MT local tier1 (TranslateGemma-4B) | 40 | `sidecar/media_studio/models/translation.py:104-147` |
+| MT local tier2 (TranslateGemma-12B, `SLOW`) | 12 | `sidecar/media_studio/models/translation.py:148` |
+| MT local total (tier1 ∪ tier2) | **52** | derived; `ROUTING_TABLE` at `translation.py:150-153` |
+| MT hosted (tier3) | unbounded | `DEFAULT_TIER = TIER_HOSTED`, `translation.py:157` |
+
+The 19 UI codes: `en es pt fr de it nl pl ru uk tr ar hi id vi th ja ko zh`.
+
+**Every UI code is inside the local MT table**, so the UI is a strict SUBSET and **33
+locally-supported languages are unreachable from the UI**: `bg bn ca cs da el et fa fi gu he hr hu
+is kn lt lv ml mr ms nb no pa ro sk sl sr sv sw ta te ur zu`.
+
+> Self-check on my own probe: it printed `local MT codes NOT offered in UI: 52`. That number is
+> WRONG — an operator-precedence bug in my script (`set(t1)|set(t2) - ui` binds `-` first). The
+> enumerated list is correct with **33** members (52 − 19 = 33, consistent). A self-contradicting
+> output is a detector failure, not a finding: the list is the signal, the count was not.
+
+**`ro` (Romanian) is absent from the UI's 19** — while Parakeet's docstring names Romanian
+(`features/parakeet_asr.py:4-5`) and `ro` is a tier1 MT language (`translation.py:135`). A
+Romanian user cannot select their own language even though both ASR and MT cover it.
+
+**`languages.ts:6-9` claims to be "the SINGLE source of truth ... so every surface reads one
+vocabulary". That claim is false as written** — `Transcribe.tsx:27-38` declares its own 9-language
+array and never imports the module. It also uses a **different auto sentinel**: `code: ''`
+(`Transcribe.tsx:28`) versus `AUTO_DETECT = 'auto'` (`languages.ts:18`).
+
+### 1.2 ASR engines — what is actually wired
+
+| Engine | Model | Language set | Citation |
+|---|---|---|---|
+| **whisper** (default) | `large-v3-turbo` GPU / `small` CPU | Whisper's full set | `features/transcribe.py:74`, `:82` |
+| **parakeet** (opt-in) | `nvidia/parakeet-tdt-0.6b-v3` | **25 European**, CC-BY-4.0 | `features/parakeet_asr.py:4-5`, `:48` |
+
+Engine choice: `settings["asrEngine"]` (`transcribe.py:385`); resolved by `selected_asr_engine`
+(`:399-411`) — anything not `"parakeet"` → whisper. Live call path is
+`transcribe_with_engine` at `handlers/media_ops.py:425`.
+
+**Neither engine's language set exists in machine-readable form anywhere in the repo.** This is
+the crux of the owner's complaint and it is structural:
+
+- Parakeet's "25 European languages incl. Romanian" is a **docstring only** (`:4-5`). There is no
+  `PARAKEET_LANGS` constant. Nothing in the app can warn that a chosen language is outside it.
+  *NOT-CHECKED: the exact membership of the 25. Settling experiment: fetch
+  `https://huggingface.co/nvidia/parakeet-tdt-0.6b-v3` at the pinned revision
+  `575de92b31b2f60855bca9b70968bde5afb069ba` (`parakeet_asr.py:420`) and read its language table.*
+- Whisper's set is likewise not enumerated; `language=` is passed straight through
+  (`transcribe.py:348-352`). *NOT-CHECKED: the exact count. I attempted a direct enumeration —
+  `from faster_whisper.tokenizer import _LANGUAGE_CODES` — and it failed with
+  `ModuleNotFoundError` (not installed in the ambient Python), so I am NOT asserting "99". The
+  pin is `faster-whisper==1.2.1` (`sidecar/requirements.lock.txt:52`). Settling experiment: run
+  that import inside the sidecar venv, or read `faster_whisper/tokenizer.py` at tag 1.2.1.*
+
+**Consequence (measured, not inferred):** with `asrEngine="parakeet"` and an out-of-set language,
+the only guard is the empty-transcript degrade at `transcribe.py:474-483`, which falls back to
+whisper **only when `segments` is empty** — never when the output is wrong-language garbage.
+
+### 1.3 Auto-detect: the engine supports it; the persistence layer forbids it
+
+- Engine: `transcribe_file(language=None)` → faster-whisper auto-detects, detected code returned
+  in `Transcript.language` (`transcribe.py:330-331`, `:355`, `:374-378`).
+- Parakeet: `language` forwarded per chunk (`parakeet_asr.py:377`); detected code read from
+  `info.language` (`:300`) with a fallback to the requested language (`:384-385`).
+- `AUTO_DETECT = 'auto'` exported, documented "surfaces prepend it when they offer auto-detect"
+  (`languages.ts:18`, `:20-24`).
+
+The brief's screenshot claim is **CONFIRMED by an independent method** (reading source, not
+pixels) — and the real mechanism is worse than a missing option. See §2.1.
+
+---
+
+## 2. Language-selector design — MEASURED + DESIGNED
+
+### 2.1 Current state: five surfaces, three inconsistent
+
+| Surface | Auto-detect? | Vocabulary | Citation |
+|---|---|---|---|
+| `components/LanguageSelect.tsx` (shared) | default **YES** | 19 | `:31`, `:49` |
+| `features/ShortMakerControls.tsx` | YES (default) | 19 | `:145` |
+| `components/OutputTray.tsx` (translation target) | **NO** — `includeAuto={false}` | 19 | `:124-126` |
+| **`components/CaptionPreferences.tsx`** ("Default language") | **NO** — `includeAuto={false}` | 19 | `:162-168` |
+| **`features/Transcribe.tsx`** | YES, but sentinel `''` | **9** (own array) | `:27-38`, `:167` |
+
+`OutputTray`'s `includeAuto={false}` is **correct** — a translation *target* cannot be
+auto-detected. `CaptionPreferences`' is not: a caption default language is a transcription
+*source* hint, where auto-detect is exactly the meaningful choice.
+
+**The deeper defect: auto-detect is not even representable in persisted state.**
+
+```ts
+// captionPreferences.ts:73-76
+export function coerceLanguage(raw: unknown): string {
+  const v = typeof raw === 'string' ? raw.trim() : '';
+  return LANGUAGES.some((l) => l.code === v) ? v : DEFAULT_LANGUAGE;   // DEFAULT_LANGUAGE = 'en'
+}
+```
+
+`LANGUAGES` deliberately excludes the auto sentinel (`languages.ts:20-24`), so
+`coerceLanguage('auto')` returns `'en'`. **Even if the dropdown offered Auto-detect, saving it
+would silently rewrite it to English.** Flipping `includeAuto` alone would produce a control that
+appears to work and does not — fix both or neither.
+
+### 2.2 Proposed design
+
+**D1 — Two-level vocabulary: a full ISO set for display, a per-engine capability map for
+warnings.** Replace the flat 19 with the complete set the engines actually cover, and keep the
+current 19 as a "Common" ordering group at the top of the list (this preserves the V1-GRILL §h
+intent — fast access to creator languages — while satisfying "should feature everything").
+
+**D2 — Auto-detect first, always, on every SOURCE surface.** Target-language surfaces
+(`OutputTray`) keep `includeAuto={false}`.
+
+**D3 — Searchable, still not free-typed.** V1-GRILL §h banned free-typing to prevent invalid
+codes (`languages.ts:3-5`). A filtering combobox over a fixed list satisfies both: you type to
+filter, but can only commit a listed option. With ~100 entries a plain `<select>` is unusable, so
+this is required, not cosmetic.
+
+**D4 — Engine-capability signal.** When the chosen language is outside the chosen ASR engine's
+set, show an inline warning and name the fix ("Parakeet does not support Thai — switch to Whisper
+in Settings ▸ Models, or pick a supported language"). Reuse the existing advice-note affordance
+(`LanguageSelect.tsx:57-62`, `role="note"`) rather than inventing a new pattern.
+
+**D5 — Mirror the vocabulary sidecar-side with a conformance test.** The repo already has this
+exact pattern for caption templates — a three-way mirror conformance-tested by
+`app/renderer/src/lib/captionTemplates.conformance.test.ts` (cited at
+`caption_remotion.py:69-72`). Reuse it so the renderer list and the sidecar validator cannot
+drift.
+
+### 2.3 Exactly which files change
+
+| File | Change |
+|---|---|
+| `app/renderer/src/lib/languages.ts` | Expand `LANGUAGES` to the full set; add `COMMON_CODES` for the top group; add `ENGINE_LANGS = {whisper, parakeet}` + `mtTier(code)`; add `supportsLanguage(engine, code)` |
+| **NEW** `sidecar/media_studio/features/languages.py` | `WHISPER_LANGS`, `PARAKEET_LANGS` as real frozensets; re-export `translation.TIER1_LANGS/TIER2_LANGS`; the sidecar-side validation half of D5 |
+| `app/renderer/src/components/LanguageSelect.tsx` | `<select>` → filtering combobox; add `engine?: string` prop; render the D4 warning |
+| `app/renderer/src/components/CaptionPreferences.tsx:165` | `includeAuto={false}` → `true` (delete the prop) |
+| `app/renderer/src/lib/captionPreferences.ts:73-76` | `coerceLanguage` must accept `AUTO_DETECT` — **required, or D2 is cosmetic** |
+| `app/renderer/src/features/Transcribe.tsx:27-38` | DELETE the duplicate array; use `LanguageSelect`; unify the `''` sentinel onto `AUTO_DETECT` |
+| `app/renderer/src/components/OutputTray.tsx:126` | **No change** — `includeAuto={false}` is correct for a target |
+| `app/renderer/src/lib/captionTemplates.conformance.test.ts` (or a sibling) | Extend to assert the renderer↔sidecar language mirror |
+
+**Migration hazard (flagging, not solving):** `Transcribe.tsx` sends `''` for auto and the
+contract note at `:25-26` says "empty = auto-detect (sent as undefined, not "")". Unifying on
+`'auto'` means the wire value must still arrive as `undefined`, since the sidecar validates
+`language` as "a string when given" (`transcribe.py:533-534`) and would treat the literal string
+`"auto"` as a language code. **`'auto'` must be translated to `undefined` at the RPC boundary, not
+forwarded.** Confidence that forwarding `"auto"` raw would degrade transcription: **almost
+certain** (90-99%) — it would be passed straight to faster-whisper as a language id
+(`transcribe.py:348-352`).
+
+---
+
+## 3. Translation quality — MEASURED + DESIGNED
+
+Local/hosted split: tier1 40 languages local-fast, tier2 12 local-slow, everything else hosted
+(`translation.py:104-157`). That split is sound. The quality problems are **not** in the tiering.
+
+### 3.1 Root cause #1 — per-cue, context-free translation (the big one)
+
+`_translate_with_tier` loops one cue at a time (`translation.py:419-437`); `_chat_one` sends only
+that cue's text (`:490-493`); `build_messages` builds a 2-message chat with no neighbours and no
+document context (`:222-230`). The same shape exists in the older seam
+(`subtitles.make_provider_translator`, `subtitles.py:321-340`).
+
+### 3.2 Root cause #2 — the cues are already split mid-sentence
+
+`cues_from_transcript` splits any segment over `max_chars=84` **or** `max_duration=7.0` on word
+boundaries (`subtitles.py:142-143`, split at `:160-161`, packer at `:167-207`). Translation then
+runs on that split track (`subtitles.translate`, `:343-382`; `TieredTranslator.translate_track`,
+`translation.py:334-358`).
+
+**So a sentence spanning three cues is translated as three independent fragments.** For
+verb-final or different-word-order targets (de, ja, ko, tr, hi — all in the UI's 19) a fragment
+cannot be translated correctly in isolation: the model has to guess the clause it belongs to.
+Confidence this is a **primary** contributor to the owner's "bad translations": **likely** (55-80%)
+— the mechanism is certain from the code; its share of observed badness versus model quality is
+not measured. *Settling experiment: translate one transcript twice — once per-cue as today, once
+by joining cues into sentences first — and have a fluent speaker rank the two outputs blind.*
+
+### 3.3 Root cause #3 — routing is TARGET-only
+
+`route(target_lang)` (`translation.py:293-295`, called at `:326`); `source_lang` only appends one
+sentence to the system prompt (`:226-227`). So `ro→en` routes **tier1** because `en` is tier1,
+ignoring that the source is lower-resource. The heavier tier2 model is unreachable for exactly
+the direction that needs it.
+
+### 3.4 Root cause #4 — no glossary, no do-not-translate list
+
+See §5.2 — nothing exists.
+
+### 3.5 Root cause #5 — an EN-only punctuation/casing model runs on ALL languages
+
+`polish_cues` applies the punctuation backend with **no language check**:
+
+```python
+# caption_polish.py:449-452
+for cue in cues:
+    text = str(cue.get("text", "") or "")
+    if punct_backend is not None:
+        text = punct_backend.restore(text)
+```
+
+The model is unambiguously English-only: `PUNCT_ASSET_NAME = "sherpa-onnx-punct-en"` (`:114`),
+`PUNCT_HF_REPO = "lorneluo/sherpa-onnx-online-punct-en-2024-08-06"` (`:522`), label
+`"sherpa-onnx punctuation + casing (EN, Apache-2.0)"` (`:543`).
+
+**`_is_english` exists (`:75-77`) but gates only the CPS reading-speed limit (`:102`) — it is NOT
+wired to the punctuation stage.** I initially assumed it gated the backend and was wrong; reading
+the call site corrected it.
+
+Latency of harm: gated behind two opt-ins — `captionPolish` defaults `false`
+(`captionPreferences.ts:57`) and the asset must be installed (`:475-480`). Confidence the model
+is EN-only: **almost certain** (90-99%, three independent naming signals). Confidence it actively
+CORRUPTS non-English text rather than no-op'ing: **likely** (55-80%). *Settling experiment: run
+`polish_cues` with the real backend on a Romanian and a Japanese cue and diff against input.*
+
+### 3.6 Proposed changes, highest value first
+
+**T1 — Translate at sentence level, then re-split (the keystone).** Reassemble cues into
+sentences, translate with context, then re-segment using the machinery that already exists —
+`caption_polish.enforce_cps_cpl` (`:238`) + `wrap_two_lines` (`:184`) + `enforce_min_gap`
+(`:331`). Timings redistribute proportionally across the re-split. This reuses shipped, tested
+code and addresses §3.1 and §3.2 together.
+
+**T2 — Sliding context window (cheaper interim).** Keep per-cue calls but pass N previous and N
+next cues as context in `build_messages` (`translation.py:222-230`), instructing the model to
+return ONLY the target cue's translation. Lower risk than T1, lower payoff; a reasonable first
+increment if T1 is too large for one work unit.
+
+**T3 — Glossary / do-not-translate.** A `settings["translationGlossary"]` of `{source, target}`
+pairs plus a proper-noun list, injected into **both** `build_messages` (`translation.py:222-230`)
+and whisper's `initial_prompt` (`transcribe.py:348-352`). One feature fixes both ASR proper-noun
+errors and translation drift.
+
+**T4 — Route on the language PAIR.** `route(target)` → `route_pair(source, target)` selecting the
+heavier of the two tiers, so a low-resource source escalates.
+
+**T5 — Gate the punctuation stage on language.** Pass the track language into `polish_cues` and
+skip the EN-only restorer for non-`en`. Whisper already emits punctuation natively, so skipping is
+a safe default; a multilingual restorer is a later upgrade. **This is the cheapest of the five and
+prevents an active regression.**
+
+**T6 — Preserve the ASS/SRT escape contract across translation.** `subtitles.py:619-635` and
+`caption.py:80-100` implement *different* escape schemes (`{` → `\(` vs `{` → `\{`). Translated
+text re-enters the caption builders, so a model that emits a brace changes which path is safe.
+*UNVERIFIED that this is exploitable or visible today; settling experiment: translate a cue whose
+text contains `{` and `}` and inspect both the ASS and SRT outputs.*
+
+*NOT-CHECKED: whether `captionPolish` runs BEFORE or AFTER `subtitles.translate` in the handler.
+If polish runs first, `wrap_two_lines` (`caption_polish.py:184`) will have inserted hard newlines
+into cue text before the model sees it, adding a fourth root cause. Settling experiment: read the
+`subtitles_generate` / `subtitles.translate` bodies in `handlers/media_ops.py` (near `:179`) and
+record the stage order.*
+
+---
+
+## 4. Caption parity — MEASURED. THREE engines, not two; the asymmetries are real
+
+### 4.1 The router
+
+`features/shortmaker.py:366-448` (`_lazy_caption`) picks the engine from
+`settings["captionStyle"]`:
+
+| `captionStyle` | Engine | Line |
+|---|---|---|
+| `"none"` / captions not embedded | skip entirely (pass-through) | `:399-400` |
+| any of the **14** Remotion styles | `RemotionCaptionEngine` | `:405-422` |
+| `"opusclip-karaoke"` | libass **karaoke** ASS | `:443` → `caption.py:640-648` |
+| anything else / unset | libass **normal** ASS | `:428-448` |
+
+The 14 Remotion styles (`caption_remotion.py:75+`, extracted mechanically): `bold, karaoke, clean,
+bounce, hormozi, neon, tiktok, gradient, impact, mrbeast, pop, serif, fire, subtitle`.
+
+**Trap: TWO different karaoke implementations behind two different style ids.** `"karaoke"` is in
+`Remotion.STYLES` and the Remotion check runs FIRST (`:405`), so `captionStyle="karaoke"` →
+**Remotion**; only the distinct id `"opusclip-karaoke"` reaches the libass word-by-word preset.
+Nothing cross-references them, and `caption_karaoke.py:48-50` notes the id is deliberately "NOT a
+member of `caption_remotion.STYLES`" — so the collision of the *word* "karaoke" across two
+namespaces is by construction, undocumented at the router.
+
+### 4.2 The parity matrix (each cell measured)
+
+| Capability | libass NORMAL | libass KARAOKE | Remotion |
+|---|---|---|---|
+| `fontFamily` override | YES `caption_override.py:193-195` | **NO** — hardcoded `Anton` `caption_karaoke.py:75` | **NO** — not passed `shortmaker.py:407-422` |
+| `sizeScale` | YES `caption.py:346` | **NO** — fixed `play_y*0.05` `caption_karaoke.py:258` | **NO** |
+| `textColor` → Primary | YES `caption_override.py:197-200` | **NO** — fixed `KARAOKE_FILL` `:62` | **NO** |
+| `activeColor` → Secondary | YES `caption_override.py:201` | **NO** — fixed yellow/green alternation `:68` | **NO** |
+| `box` / `outline` (BorderStyle) | YES `caption_override.py:164-178` | **NO** — fixed `1/4/2` `:77-79` | **NO** |
+| `uppercase` | YES `caption.py:450` | param EXISTS `caption_karaoke.py:237`, **not passed** → locked `True` | **NO** |
+| `positionBand` | YES `caption.py:360-361` | param EXISTS `caption_karaoke.py:236`, **not passed** → locked `"bottom"` | **NO** |
+| `captionPosition` box `{x,y,w,h}` | YES `caption.py:352-354` | **NO param at all** | **NO** — not passed |
+| `hook_title` headline | YES `caption.py:373-387` | **NO param** | YES `shortmaker.py:416` |
+| `hook_card` (OpusClip white card) | YES `caption.py:376`, `:417-422` | **NO param** | **NO** — not passed |
+| `total_sec` (title span) | YES `caption.py:424-432` | **NO param** | YES `shortmaker.py:421` |
+| `emphasis` spans → bold | YES `caption.py:190-206` | **NO** — `build_line_text` ignores it `caption_karaoke.py:187-206` | NOT-CHECKED |
+| trailing `emoji` | YES `caption.py:207-209` | **NO** | NOT-CHECKED |
+| **word-by-word reveal + scale-pop** | **NO** | **YES** `caption_karaoke.py:290-301` | YES (own `karaoke` style) |
+| burn AND soft-mux | YES `caption.py:670-673` | YES — same path `caption.py:663-673` | YES `shortmaker.py:412` |
+
+**The root cause is one call site** — `caption.py:640-648`:
+
+```python
+if karaoke:
+    from . import caption_karaoke as _karaoke
+    ass_doc = _karaoke.build_karaoke_ass(
+        cues, width=width, height=height, source_start=source_start,
+    )
+```
+
+`override`, `hook_title`, `position`, `total_sec`, `hook_card`, `hook_card_sec` are all in scope
+and all dropped. Two of them (`position_band`, `uppercase`) are **already accepted** by
+`build_karaoke_ass` and cost one line each.
+
+The docstring at `caption.py:637-638` declares this deliberate ("its look is fixed by the
+teardown"), so it is a **decision to revisit with evidence, not a bug to silently overturn** —
+but the owner's ask ("properly captioned, for both shorts and/or karaoke captions and normal
+subtitles") is precisely a request to revisit it.
+
+**Answer to the brief's question:** No. Styling/timing capability is NOT available to all three
+paths. libass-normal is the only full-featured path; karaoke is style-locked; Remotion gets
+neither the override, nor the position box, nor the hook card.
+
+**Suggested minimal fix, in cost order:** (a) thread `position_band` + `uppercase` into
+`build_karaoke_ass` — two lines, zero new API; (b) give `build_karaoke_ass` a
+`ResolvedCaptionStyle` for font/size/colours, keeping the alternating-accent and scale-pop as
+karaoke-only; (c) pass `position` and `override` to `RemotionCaptionEngine.render`, which needs a
+schema change in the vendored composition and is the largest of the three.
+
+### 4.3 What IS shared (parity that already holds)
+
+- Cue re-basing to clip-local time: one helper `rebase_cue_time` (`caption.py:122-129`), imported
+  by `caption_karaoke.py:42` and used at `caption_remotion.py:426`.
+- ASS override-injection escaping: `escape_ass_text` shared (`caption.py:80-100` →
+  `caption_karaoke.py:42`). Note `subtitles.py:619-635` is an INDEPENDENT second implementation
+  with a different scheme (see §3.6 T6).
+- The Netflix CPS/CPL/min-gap timing gate runs at cue GENERATION
+  (`subtitles.generate_polished:264-294` → `caption_polish.polish_cues:404`), i.e. **upstream of
+  all three engines** — so timing polish is genuinely shared.
+
+---
+
+## 5. Escape hatches — MEASURED
+
+### 5.1 Custom `.SRT` import — engine BUILT, RPC + UI **MISSING**
+
+Parsing/loading is complete and tested:
+
+| Piece | Location |
+|---|---|
+| `read_srt` (tolerant of CRLF, BOM, missing indices) | `features/subtitles.py:535-554` |
+| `read_vtt` / `read_ass` | `:576-597` / `:682-706` |
+| `parse(text, fmt)` dispatch | `:768-771` |
+| `load(path, fmt=None)` — ext-inferred | `:786-790` |
+| **`track_from_file(path, lang=…)` → full SubtitleTrack** | **`:793-812`** |
+
+**But the RPC surface has exactly four `subtitles.*` methods** — `generate`, `edit`, `translate`,
+`export` — registered at `handlers/composition.py:128-131`, mirrored client-side at
+`app/renderer/src/lib/rpc/client.ts:197-208`. There is **no** `subtitles.import`.
+
+Second, independent signal: `track_from_file` and `read_srt` have **no production caller** —
+every hit outside `subtitles.py` is a test (`tests/test_subtitles.py:494`, `:505`, `:321-350`;
+`tests/e2e/test_nasty_inputs.py:320-384`; `tests/test_subtitles_property.py:148-159`).
+
+**Verdict: MISSING at the user-reachable boundary; ~90% of the work already exists.** Shipping it
+is a handler + a client method + a file picker, not a parser.
+
+*Governance note: `translation.py:39-41` states "A2's method names are frozen". Adding
+`subtitles.import` therefore needs an explicit contract amendment, not a silent addition. Flagging
+as a decision for the owner, not resolving it here.*
+
+### 5.2 Custom dictionary / glossary for proper nouns & jargon — **MISSING** (nothing at all)
+
+A repo-wide case-insensitive search for
+`glossary|dictionary|custom_words|hotword|initial_prompt|proper_noun` returns **zero**
+implementation hits. Only occurrences:
+
+- `docs/plans/v1.5/competitor-research.md:22` — item 13 names exactly this gap: "Caption-accuracy
+  escape hatches: custom .SRT import + custom dictionary (fixes #1 caption complaint: proper
+  nouns/jargon/accents) — S."
+- `app/renderer/src/lib/rpc.property.test.ts:198` — `fc.dictionary`, an unrelated generator.
+
+**faster-whisper's `initial_prompt` — the standard zero-cost way to bias ASR toward proper nouns —
+is not passed.** `transcribe_file` calls
+`whisper_model.transcribe(audio_path, language=…, word_timestamps=True)` and nothing else
+(`transcribe.py:348-352`). That is the cheapest accuracy lever available and it is unused.
+Confidence it measurably improves proper-noun accuracy: **likely** (55-80%) — documented upstream
+behaviour, not benchmarked here. *Settling experiment: transcribe one clip containing 5 known
+proper nouns with and without `initial_prompt`; diff token-level errors.*
+
+---
+
+## Appendix — corrections made during this audit
+
+Recorded so the dead ends are not re-walked:
+
+1. I suspected `is_karaoke_style` had **no** production caller (a truncated grep). Re-probing with
+   a script found `shortmaker.py:425` and `:443`. The karaoke preset **is** reachable.
+2. I assumed `_is_english` (`caption_polish.py:75`) gated the punctuation backend. It gates only
+   the CPS limit (`:102`). The real finding is worse — §3.5.
+3. My language-diff script printed a count of `52` that contradicted its own 33-item list
+   (operator precedence). The list was correct.

--- a/docs/plans/v1.5/competitor-matrix-2026-08.md
+++ b/docs/plans/v1.5/competitor-matrix-2026-08.md
@@ -1,0 +1,345 @@
+# Reframe v1.5 — Competitor Capability Matrix (2026-08)
+
+> **Status:** ACTIVE (audit complete at milestone 3).
+> **COVERAGE:** Reframe-side state is **MEASURED** for all 52 capability rows (mechanical
+> wire-surface extraction, two independent probes — see §1). Competitor-side is **researched with
+> URLs for 15 of 16**: Vidnoz, CapCut, Submagic, OpusClip, Descript (§2.1); Kapwing, VEED, Vizard,
+> Klap, HeyGen, Captions.ai (§2.2); AetherCut, Reelify, Bitcut (§2.3). **One cell is still
+> inherited** — Diffusion Studio — and **Riverside returned no usable feature results** in the one
+> search that targeted it, so its column is `?` rather than measured. Both are named in §7.
+
+## Provenance and honesty contract
+
+- Competitor capability claims carry a **URL**. Reframe state claims carry a **`file:line`**.
+- `UNVERIFIED` is inline on the sentence it qualifies and names the settling experiment.
+- Sherman-Kent bands: almost-certain 90-99% / likely 55-80% / roughly-even 45-55% /
+  unlikely 20-45% / remote 1-20%.
+- This **extends** `docs/plans/v1.5/competitor-research.md`, whose own stated gap was *"did NOT
+  read the repo (web-only)"*. Closing that gap is this document's primary contribution, and it
+  **materially refutes that doc's #1 recommendation** (§4.1).
+
+---
+
+## 1. Method — what I actually measured
+
+**Reframe side (mechanical, not judgement).** Per `fan-out-contract.md` §C4, classification that an
+exact algorithm can answer was answered by an algorithm, not by reading and guessing:
+
+1. **Engine layer** — enumerated every `*.py` under `sidecar/media_studio/features/` (91 modules)
+   and, for each candidate capability, ran a literal keyword probe over the whole sidecar tree
+   excluding `__pycache__` / `site-packages`.
+2. **RPC layer** — extracted every registered wire method by regexing `@method("…")`,
+   `register…("…"`, and `reg("…"` across the sidecar. Verified against the composition root
+   `sidecar/media_studio/handlers/composition.py:90-93` (`reg()` wraps `protocol.register`), which
+   confirmed the extraction matches the real registry. Result: **~150 dotted RPC methods**.
+3. **UI layer** — extracted every method string reachable from `app/` non-test code.
+   **My first detector here was incomplete and I corrected it**: a `rpc\('literal'\)` regex missed
+   `system.recommend` and `diarize.rename`, which reach the UI as `api.system.recommend(...)`
+   (`app/renderer/src/panels/ModelsSystemPanel.tsx:450`). The corrected detector matches any
+   quoted dotted literal in `app/**/*.{ts,tsx,js,mjs,cjs,html}`.
+4. **Gap confirmation (second independent probe)** — for each method the regex said was unwired, I
+   re-ran a `-SimpleMatch` literal search across **all** app file types **including tests**. Both
+   probes agreed on all 7 (§4.2). Per `single-signal-verification.md`, one probe would not have
+   been evidence.
+
+**PARTIAL is split by half**: `engine` (feature module exists) / `rpc` (registered on the wire) /
+`ui` (reachable from the renderer). A module existing is *not* evidence it is wired; a doc claiming
+a feature is *not* evidence at all.
+
+**Competitor side.** WebSearch per vendor, 2026 feature pages + independent reviews. Where a
+vendor's own marketing number is the only source (accuracy %, virality-score efficacy) I say so.
+
+---
+
+## 2. Competitor inventories
+
+### 2.1 Deep-researched by me (2026-08)
+
+| Vendor | Capability highlights | Source |
+|---|---|---|
+| **Vidnoz** | 1,900+ AI avatars; dual-avatar conversation scenes; 2,000+ voices / 140+ languages; voice cloning; **talking photo** (still image → lip-synced speaker, 100+ languages); AI face swap (photo+video, multi-face); video translator with lip-sync preserved ("fully operational for the top 10 languages"); 2,800+ templates. Starter $26.99/mo (15 credits), Business $74.99/mo (+voice clone, +translation). | [vidnoz.com](https://www.vidnoz.com/), [talking-head](https://www.vidnoz.com/talking-head.html), [unite.ai review](https://www.unite.ai/vidnoz-review/), [creatorstackclub](https://www.creatorstackclub.com/software/vidnoz-ai) |
+| **CapCut** | AI Auto-Edit; instant captions **130+ languages** (55+ for auto-caption per one source — the two numbers disagree, see note); sound-effect captions `(applause)`; AI Script-to-Video; long-video→multi-shorts with highlight detect + auto-format; AI avatars; TTS 269 voices + voice cloning; background removal; auto-translate captions; upscaling; Seedream 5.0 image gen + Dreamina Seedance 2.0 video gen; Gemini-driven conversational editing. | [capcut.com](https://www.capcut.com/), [solidaitech 2026 guide](https://www.solidaitech.com/2026/05/capcut.html), [freeacademy.ai](https://freeacademy.ai/blog/capcut-ai-features-complete-guide-review-2026) |
+| **Submagic** | 150+ caption templates; claimed **99% accuracy / 123 languages** (vendor number, unverifiable); AI B-roll from Storyblocks; Magic Zoom (fast/crash/smooth/expo/linear); **eye-contact correction**; AI Auto-Edit = captions + silence + filler + B-roll + zoom + SFX-on-emphasis + hook title in one pass; AI Avatar Studio; Clean Audio (1-click denoise); translation 100+ languages; auto-reframe→9:16; ThumbMagic thumbnails. | [submagic.co](https://www.submagic.co/), [b-roll](https://www.submagic.co/features/b-roll), [ai-caption](https://www.submagic.co/ai-caption) |
+| **OpusClip** | ClipAnything (visual+audio+expression+narrative analysis in parallel); **virality score 0-99**; ReframeAnything object/active-speaker tracking → 9:16 / 1:1 / 16:9; AI B-roll (generated *or* stock); brand templates applied across a batch. | [opus-clip.com](https://opus-clip.com/), [BIGVU test](https://bigvu.tv/blog/opus-clip-tested-2026-where-ai-wins-40-percent-discard/), [theplanettools](https://theplanettools.ai/tools/opusclip) |
+| **Descript** | Underlord = **agentic** multi-step co-editor ("remove filler, tighten pauses, add captions, pull three vertical clips"); eye-contact correction incl. glasses/extreme angles; Studio Sound 4.0 (stem-separates voice/background/music, de-reverb); Overdub 3.0 voice clone from 3 min + emotional intonation; filler removal; **generative** B-roll via diffusion; script drafting, summaries, show notes, viral-clip ID. | [descript.com/underlord](https://www.descript.com/underlord), [aitoolsdevpro guide](https://aitoolsdevpro.com/ai-tools/descript-guide/) |
+
+**Note on CapCut's caption-language count:** two 2026 sources give **55+** and **130+**. I did not
+resolve which is current — UNVERIFIED; settled by opening CapCut's own auto-caption language picker
+in the current build. It does not change any matrix cell (Reframe's own count is what matters).
+
+### 2.2 Also researched by me (2026-08) — cloud majors
+
+| Vendor | Capability highlights | Source |
+|---|---|---|
+| **Kapwing** | Prompt-to-video; script generator; TTS + **dubbing 40+ languages**; auto-subtitles; **Clean Audio** noise removal; **Smart Cut** silence removal; **B-Roll Generator**; Clip Maker; Repurpose Studio; real-time collaboration. | [kapwing vs veed](https://www.kapwing.com/resources/kapwing-vs-veed-comparison-for-video-creators-in-2026/), [ngram](https://www.ngram.com/blog/kapwing-vs-veed) |
+| **VEED** | Fast auto-subtitles; dubbing (many languages); **text-to-video + image-to-video** via own Fabric model *plus* third-party Sora/Veo; AI avatars; AI voice generator; background removal; **eye-contact correction**. | [ngram](https://www.ngram.com/blog/kapwing-vs-veed), [videoai.me](https://videoai.me/compare/kapwing-vs-veed) |
+| **Vizard** | Team-oriented repurposing: AI highlight detection → clips, plus collaborative edit/review/approve. | [ngram vizard alternatives](https://www.ngram.com/blog/vizard-alternatives-tested) |
+| **Klap** | Premium *visual* positioning — cleaner crops, **4K export**, brand-consistent output; wins head-to-head when "looks like us" beats clip volume. | [uxerwave](https://uxerwave.com/video-audio/opus-clip-vs-vizard-vs-kapwing/), [klap.app](https://klap.app/blog/veed-alternatives) |
+| **HeyGen** | **Avatar V** from a 15-second recording (multi-angle stability, long-form); Seedance 2.0 cinematic gen + digital twin interacting with up to 2 others; podcast → social clips in **175+ languages**; new AI Studio (no timeline). | [heygen.com](https://www.heygen.com/), [April 2026 release](https://www.heygen.com/blog/heygen-april-2026-release), [AI Studio](https://help.heygen.com/en/articles/11049655-overview-our-new-ai-studio) |
+| **Captions.ai** | AI captions; **AI Twins** (avatar cloned from your own recordings); **AI eye contact** (look at camera while reading a script); AI shorts (auto best-moment → clips for IG/YT/TikTok/LinkedIn). | [fahimai comparison](https://www.fahimai.com/heygen-vs-captions-ai) |
+
+### 2.3 The local-first rivals — the segment Reframe actually competes in
+
+| Vendor | Position | Source |
+|---|---|---|
+| **AetherCut** | Browser-based, "**nothing uploads — verifiable in DevTools**", **51 AI tools**, 5× realtime export, no signup, 4K, no watermark. Explicit anti-surveillance marketing. | [aethercut.app](https://aethercut.app/), [no-account](https://aethercut.app/free-video-editor-no-account) |
+| **Reelify AI** | **Mac / Apple Silicon only.** On-device Edge AI; no frames/audio/metadata leave the Mac ("the pipeline was never designed to send it anywhere"); 1-hour video analysed in **under 90 s**; 5-10× faster than cloud. | [local-ai-video-editor](https://reelifyclips.com/local-ai-video-editor), [no-upload](https://reelifyclips.com/private-video-editing-no-upload) |
+| **Bitcut** | **iOS App Store app.** Long → Shorts, AI subtitles with word-level transcription, face-tracking reframe, beat-synchronised editing. | [App Store](https://apps.apple.com/us/app/bitcut-ai-video-editor/id6759696573) |
+| **Diffusion Studio** | Not re-measured this pass — the only remaining inherited cell. `[prior]` | `competitor-research.md:5` |
+
+**Strategic read (this changes the competitive framing).** Reframe's platform position is
+*better than the prior doc implies*, on two measured grounds:
+
+- **Reelify is Mac-only and Bitcut is iOS-only.** Neither competes with Reframe on Windows at all.
+  Confidence: **almost certain (90-99%)** — both vendors state the platform restriction themselves.
+- **AetherCut runs in a browser.** That caps it at WebGPU/WASM-class inference, whereas Reframe
+  runs a WSL2 GPU path with full PyTorch models (LightASD, TransNetV2, pyannote, Qwen3-VL). Its
+  "51 AI tools" count therefore does not imply parity of *model depth*. Confidence that AetherCut
+  cannot match Reframe's heaviest local models in-browser: **likely (55-80%)** — inferred from the
+  browser runtime constraint, **UNVERIFIED**; settled by loading AetherCut and inspecting whether it
+  ships an ONNX/WebGPU bundle or calls a server, which its own DevTools claim invites.
+
+**Correction to the prior research.** `competitor-research.md:11,33` states AetherCut markets an
+"AI Director by Claude". I did **not** find that phrase on aethercut.app in this pass; what I found
+is "51 AI tools" and anti-surveillance framing. I am **not** claiming the prior doc is wrong — the
+site may have changed, or the claim may sit on a page I did not fetch. **UNVERIFIED both ways**;
+settled by fetching aethercut.app's feature/pricing pages directly.
+
+---
+
+## 3. THE MATRIX
+
+**Legend.** Competitor columns: `Y` = has it (URL in §2), `-` = does not / not marketed,
+`?` = unknown. Reframe: **BUILT** (engine+rpc+ui) · **PARTIAL(x)** (the missing half is named) ·
+**MISSING**. Effort S/M/L/XL is *incremental over what already exists*, calibrated against the
+measured code. `Cap`=CapCut, `Opus`=OpusClip, `Vid`=Vidnoz, `Desc`=Descript, `Sub`=Submagic;
+`Others` covers Kapwing/VEED/Vizard/Klap/HeyGen/Captions.ai and the local-first trio.
+
+**A `-` is weaker evidence than a `Y`.** A `Y` rests on a vendor feature page; a `-` rests on the
+capability being absent from the pages I read, which is not proof of absence. Read `-` as
+"not marketed as a headline feature", **not** as "cannot do it".
+
+| # | Capability | Cap | Opus | Vid | Desc | Sub | Others | Reframe state (file:line) | Effort |
+|---|---|---|---|---|---|---|---|---|---|
+| 1 | Auto clip-finding: long → ranked shorts | Y | Y | - | Y | Y | Klap/Vizard/Veed Y | **BUILT** `features/select.py`, `shortmaker.select` @ `handlers/composition.py:144` | — |
+| 2 | Candidate ranking / score | ? | Y (0-99) | - | Y | Y | Vizard Y | **BUILT** `features/ranker.py`, `features/scorer.py`; honest-score design in `features/director_eval.py` | — |
+| 3 | Virality *prediction* score | - | **Y** | - | - | - | Vizard Y | **MISSING** — deliberate: prior doc argues users distrust it | S |
+| 4 | Auto-reframe 16:9→9:16 subject track | Y | Y | - | Y | Y | most Y | **BUILT** `features/reframe.py`; mediapipe face track (26 hits incl. `reframe.py`) | — |
+| 5 | **Active-speaker detection (ASD)** | ? | Y | - | ? | Y | AetherCut Y | **BUILT** `features/_lightasd_infer.py` (20 KB), `features/_lightasd/`; engine selectable in UI @ `app/renderer/src/features/shortMakerLogic.ts:261,270` | — |
+| 6 | **Multi-speaker split / composite layout** | - | - | - | - | - | ? | **BUILT** `features/reframe_multispeaker.py:382` `decide_layout()` → single/split/composite; debounce `:97,402` | — |
+| 7 | Shot / scene detection | Y | Y | - | Y | Y | most Y | **BUILT** `features/scene_transnet.py` (TransNetV2) + `_transnetv2/` | — |
+| 8 | Speaker diarization | - | ? | - | Y | ? | Riverside Y | **BUILT** `features/diarize.py`, `pyannote_backend.py`; `diarize.start`/`diarize.rename` + UI `features/Diarize.tsx` | — |
+| 9 | Word-level karaoke captions | Y | Y | - | Y | Y | most Y | **BUILT** `features/caption_karaoke.py` (14 KB) | — |
+| 10 | Caption template **gallery** (many presets) | Y | Y | - | Y | **Y 150+** | most Y | **PARTIAL(ui)** — engine `features/templates.py`, `templates.list/save/apply` wired; but count/visual gallery ≠ 150 presets. Needs preset *content*, not plumbing | M |
+| 11 | Auto-emphasis (power-word styling) | ? | Y | - | ? | Y | ? | **BUILT** `features/emphasis.py` (12 KB), consumed by `caption.py`, `caption_polish.py`, `caption_remotion.py`, `zoom.py` (11 importers) | — |
+| 12 | Auto-emoji in captions | Y | Y | - | ? | Y | ? | **BUILT** — 81 `emoji` hits across `caption.py`, `caption_polish.py`, `caption_remotion.py`, `emphasis.py` | — |
+| 13 | Caption polish (CPS/CPL/gaps) | ? | ? | - | ? | ? | ? | **BUILT** `features/caption_polish.py` (25 KB), 8 importers | — |
+| 14 | Caption translation / multilang | Y | Y | Y | Y | Y | most Y | **BUILT** `subtitles.translate` + `models/translation.py` | — |
+| 15 | Custom dictionary / SRT import | - | ? | - | Y | ? | ? | **PARTIAL(ui)** `subtitles.edit` exists; no dictionary module found (0 hits) | S |
+| 16 | Burn-in / soft-mux subtitle tracks | Y | Y | - | Y | Y | most Y | **BUILT** `features/subtitles.py`, `tracks.burn`, `tracks.strip` | — |
+| 17 | Auto-zoom / punch-in | Y | ? | - | ? | **Y** | ? | **PARTIAL(rpc+ui)** engine `features/zoom.py` exists but has **exactly 1 importer** (`shortmaker.py`) — no standalone RPC, no UI control | S-M |
+| 18 | Filler-word removal | Y | Y | - | **Y** | Y | most Y | **BUILT** `features/fillers.py` — **18 importers** (`refine.py`, `silencetrim.py`, `director_op_engines.py`, `emphasis.py`, `shortmaker.py`) | — |
+| 19 | Silence / dead-air removal | Y | Y | - | Y | Y | Kapwing **Smart Cut** Y | **PARTIAL(ui)** engine `features/silencetrim.py` (18 KB) + `silence.trim` RPC registered — **ZERO UI references** (§4.2) | S |
+| 20 | Bad-take detection | - | ? | - | Y | Y | ? | **PARTIAL(engine)** `features/refine.py` + `refine.apply`/`refine.preview` wired; explicit take-selection unverified | M |
+| 21 | Text-based (transcript) editing | Y | - | - | **Y** | - | ? | **PARTIAL(ui)** word-aligned transcript BUILT (`features/ctc_align.py`, `transcribe.py`); delete-word→cut-video UI not found | L |
+| 22 | B-roll from **stock** library | Y | Y | Y | **Y** | Y | most Y | **MISSING** — 0 hits for any stock provider. Conflicts with offline-first; deliberate | M (needs cloud) |
+| 23 | **B-roll from user's OWN library** (semantic) | - | - | - | - | - | - | **PARTIAL(ui)** `features/semantic_index.py` + `index.build/search/status/plan` wired; *insertion into the edit* not found | M |
+| 24 | **Generative** B-roll (diffusion) | Y | Y | Y | **Y** | - | **VEED (Fabric+Sora/Veo), Kapwing, HeyGen (Seedance 2.0)** | **MISSING** — 0 hits for any diffusion/T2V model | L-XL |
+| 25 | Hook title / hook card | ? | Y | - | ? | **Y** | ? | **PARTIAL(engine)** renderer BUILT `features/hook_card.py` (4 importers); **LLM text generation** for it not found | S |
+| 26 | Thumbnail generation | Y | ? | - | ? | Y (ThumbMagic) | ? | **PARTIAL(engine)** `thumbnail.select` + `features/best_frame.py` (6 importers) = best-frame pick, not *generated* thumbnail | M |
+| 27 | Brand kit (fonts/colors/logo) | Y | Y | Y | Y | Y | most Y | **BUILT** `features/brandkit.py`, imported by `shortmaker.py` | — |
+| 28 | Batch processing | Y | Y | Y | ? | Y | most Y | **BUILT** `features/batch.py` (52 KB); full `batch.*` RPC set + UI | — |
+| 29 | Multi-aspect export matrix | Y | Y | ? | Y | Y | most Y | **BUILT** `features/aspect.py`, `features/export_presets.py` (7 importers), `exportPresets.*` wired | — |
+| 30 | AI dubbing (translated TTS VO) | Y | ? | **Y** | ? | Y | Kapwing 40+ langs, VEED Y | **BUILT** `features/tts/dub.py` (`run_dub_pipeline`), registered `tts.dub.start` @ `features/tts/__init__.py:105`; engines `tts/kokoro.py`, `tts/chatterbox.py`; mux via `features/tracks_audio.py:600` | — |
+| 31 | Voice cloning | Y | - | **Y** | **Y** | - | ? | **BUILT** `tts.sample.add`, `tts.voices`, `features/tts/chatterbox.py` (zero-shot clone) | — |
+| 32 | **Lip-sync to the dub** | - | **Y** | **Y** | - | - | HeyGen Y | **MISSING** — 0 hits for `lipsync`/`latentsync`/`wav2lip` | L |
+| 33 | **AI avatars / talking photo** | **Y** | - | **Y** | - | **Y** | **HeyGen Avatar V, Captions.ai AI Twins, VEED Y** | **MISSING** — 0 hits for `avatar` (the 2 keyword hits were `_scheduled`, a use-vs-mention false positive) | XL |
+| 34 | **Eye-contact / gaze correction** | - | - | - | **Y** | **Y** | **VEED Y, Captions.ai Y** | **MISSING** — 0 hits for `gaze`/`eye contact` | L |
+| 35 | Face swap | - | - | **Y** | - | - | ? | **MISSING** — 0 hits (`insightface` 0) | L |
+| 36 | Background removal / greenscreen | **Y** | ? | Y | ? | ? | most Y | **MISSING** — 0 hits (`rembg`, `background remov`) | M |
+| 37 | Denoise / "studio sound" | Y | ? | ? | **Y** | **Y** | Kapwing **Clean Audio** Y | **MISSING** — 0 hits (`denoise`, `DeepFilter`) | M |
+| 38 | Stem separation (voice/music/bg) | ? | - | - | **Y** | - | ? | **MISSING** — 0 hits (`demucs`) | M |
+| 39 | Loudness normalization (LUFS) | ? | ? | - | ? | ? | ? | **PARTIAL(ui)** `features/audiomix.py` has `loudnorm` (35 hits) + `audiomix.normalize` RPC — **ZERO UI** (§4.2) | S |
+| 40 | Music bed + auto-ducking | Y | ? | - | Y | ? | most Y | **PARTIAL(ui)** `audiomix.py` `sidechaincompress` (6 hits) + `audiomix.merge` RPC — **ZERO UI** (§4.2) | S |
+| 41 | SFX on emphasis words | - | - | - | - | **Y** | ? | **MISSING** — 0 hits (`sfx`, `sound effect`) | S-M |
+| 42 | Multi audio-track management | ? | - | - | Y | - | ? | **BUILT** `features/tracks_audio.py` (27 KB); `tracks.audio.{list,mux,replace,strip}` + UI | — |
+| 43 | Stabilization | Y | - | - | ? | - | ? | **PARTIAL(ui)** `features/stabilize.py` (21 KB) + `stabilize.run` RPC — **ZERO UI** (§4.2) | S |
+| 44 | Upscaling / enhance | **Y** | - | ? | ? | ? | most Y | **MISSING** — 0 hits (`upscal`, `esrgan`) | M |
+| 45 | Watermark removal | ? | - | ? | - | - | ? | **MISSING in sidecar** — 0 hits for `ProPainter`. A `video-watermark-removal` skill exists in the *harness*, so the tooling may live outside this tree — UNVERIFIED; settled by `grep -ri propainter` over the whole repo incl. WSL scripts | M |
+| 46 | Agentic AI director (1 prompt → N steps) | Y (Gemini) | - | **Y** | - | Y (Auto-Edit) | AetherCut Y | **BUILT** `features/director.py`, `director_op_engines.py` (39 KB), `director_eval.py`; `director.{plan,previewCost,apply,undo,evaluate}` + UI `Director.tsx` — and **reversible**, which no competitor offers | — |
+| 47 | Script → video | **Y** | - | Y | Y | - | ? | **MISSING** (needs #24) | L |
+| 48 | NLE handoff (FCPXML/EDL) | - | - | - | ? | - | ? | **BUILT** `features/nle_export.py`, `nle.export` RPC + client | — |
+| 49 | Social scheduling / publish | Y | ? | ? | Y | Y | most Y | **MISSING** — 0 hits (`oauth`, `publish to`; `schedul` hits were `_scheduled` job-pool, use-vs-mention) | M (needs cloud) |
+| 50 | Screen recording | Y | - | - | **Y** | - | Riverside Y | **MISSING** — 2 hits, both in `test_director_golden_plans.py` (fixture text) | M |
+| 51 | Collaboration / team review | Y | Y | Y | Y | Y | most Y | **MISSING** — architecturally out of scope (offline-first) | XL |
+| 52 | **100% offline / no upload** | **-** | **-** | **-** | **-** | **-** | AetherCut Y (browser), Reelify Y (**Mac only**), Bitcut Y (**iOS only**) | **BUILT** — `features/offline.py`; the whole sidecar is local. **Only Windows-native local-first entrant found** | — |
+
+---
+
+## 4. What the repo audit actually changed
+
+### 4.1 The prior doc's #1 recommendation is already built — REFUTED
+
+`competitor-research.md:8` ranks **"Active-speaker detection + multi-speaker split/switch layouts
+(L)"** as the single highest-value thing to steal, and proposes sourcing it from an NVIDIA ASD NIM.
+**It is already in the tree and already reachable from the UI:**
+
+- ASD engine: `sidecar/media_studio/features/_lightasd_infer.py` (20,210 bytes) + `features/_lightasd/`
+- Fusion + layout: `sidecar/media_studio/features/reframe_multispeaker.py` (68,571 bytes), with
+  `decide_layout()` at `:382` returning `single` / `split` (50-50 vertical) / `composite`
+  (host top + guests bottom), and anti-flicker debounce at `:97` (`LAYOUT_MIN_DWELL_SEC = 0.5`)
+  and `:402` (`debounce_layouts`)
+- UI: selectable engine `'reframe_multispeaker'` at `app/renderer/src/features/shortMakerLogic.ts:261`,
+  labelled `'Multi-speaker (hybrid, WSL/GPU)'` at `:270`, also in `features/repurposeLogic.ts:55`
+
+Building it again would be **pure waste**. Confidence it is genuinely wired end-to-end:
+**likely (55-80%)** — I verified engine + UI-selectable engine name, and did *not* execute a job,
+so I have not proven it produces correct output. **UNVERIFIED: whether a multispeaker export
+actually renders a split layout.** Settling experiment: run `shortmaker.export` with
+`engine=reframe_multispeaker` on a 2-speaker clip and `ffprobe` + eyeball the result — the
+`packaged-artifact-smoke` skill's postcondition-probe pattern is the right shape.
+
+Items 11 (auto-emphasis) and 12 (auto-emoji) were also listed as things to *add*
+(`competitor-research.md:9`, "auto-emphasis + auto-emoji"). Both are **BUILT**
+(`features/emphasis.py`, 11 importers; 81 `emoji` hits across four caption modules). The prior
+doc's stated gap — *"auto-zoom/emoji status unknown"* — resolves as: **emoji built, zoom half-built**.
+
+### 4.2 Seven capabilities are fully built and registered but have NO UI
+
+This is the highest-yield finding in the audit: **engine + RPC exist and are wired to
+`protocol.METHODS`, but zero references exist anywhere in `app/`** — including tests, main process,
+and preload. Verified by two mechanically independent probes (regex extraction, then literal
+`-SimpleMatch` across all app file types).
+
+| RPC method | Engine | Competitor pressure |
+|---|---|---|
+| `silence.trim` | `features/silencetrim.py` (18 KB) | Submagic + Descript + OpusClip + CapCut all ship it |
+| `audiomix.normalize` | `features/audiomix.py` — `loudnorm`, 35 hits | platform LUFS targets |
+| `audiomix.merge` | `features/audiomix.py` — `sidechaincompress`, 6 hits | music bed + ducking, market-standard |
+| `stabilize.run` | `features/stabilize.py` (21 KB) | CapCut |
+| `reframe.eval` | `features/reframe_eval.py` (23 KB) | internal quality signal |
+| `phase8.signals` | `handlers` → `svc.phase8_signals` | internal |
+| `assets.plan` | `assets/` | internal |
+
+The first four are **user-visible competitive features already paid for in engine cost**. Exposing
+them is an **S** each — a panel + a typed client wrapper in
+`app/renderer/src/lib/rpc/client.ts` (the file already holds 123 wrappers, so the pattern is
+established). This is the cheapest capability-per-effort work in the whole plan.
+
+Also measured: `features/scroll_regen.py` (12,131 bytes) has **zero importers**. Likely dead code
+— **UNVERIFIED**, since my probe cannot see a dynamic/string-keyed import. Settling experiment:
+`grep -rn "scroll_regen" sidecar/` including string literals, then delete-and-test.
+
+### 4.3 Reframe's genuine differentiators (not just "offline")
+
+Beyond row 52, two are architecturally distinctive and worth marketing, not just keeping:
+
+- **Reversible AI director.** `director.undo` is registered (`handlers/composition.py:216`) and
+  `director.apply` records an inverse over a fresh copy (`:208-216`). Descript's Underlord and
+  CapCut's Gemini mode are both fire-and-forget. Confidence no major competitor ships a
+  transactional undo of an agentic edit: **likely (55-80%)**, from the absence of any such claim in
+  the 6 vendors I researched — absence of a marketing claim is weak evidence, so not higher.
+- **Honest scoring instead of a virality oracle.** `features/director_eval.py` +
+  `features/feedback.py` (`feedback.record`/`feedback.stats`) is a measured-feedback loop, versus
+  OpusClip's 0-99 score. Independent creator data does report 80+ clips outperforming
+  ([BIGVU](https://bigvu.tv/blog/opus-clip-tested-2026-where-ai-wins-40-percent-discard/)), so the
+  prior doc's "decorative" framing is **too strong** — the score has *some* signal; what is
+  unverifiable is the vendor's implied causality.
+
+---
+
+## 5. Local feasibility + licence gate for the MISSING rows
+
+**Licence rule applied:** MIT / Apache-2.0 / BSD only for anything shipping commercially.
+**Every licence below is from my training knowledge, NOT from opening the licence file** — flagged
+inline. **UNVERIFIED (all rows): the licence as stated.** Settling experiment per row: open the HF
+model card + the repo `LICENSE`, and for gated weights confirm whether the *weights* carry the
+code's licence (they frequently do not — this is the trap that bites).
+
+| Row | Capability | Candidate open-weights model | Licence (claimed) | Verdict |
+|---|---|---|---|---|
+| 32 | Lip-sync | **MuseTalk** | MIT | **GO** — best licence/quality ratio |
+| 32 | Lip-sync | LatentSync | Apache-2.0 code; weights unclear | CHECK WEIGHTS |
+| 32 | Lip-sync | Wav2Lip | **research/non-commercial** | **BLOCKED** |
+| 33 | Avatar / talking photo | LivePortrait | MIT code; weights unclear | CHECK WEIGHTS |
+| 33 | Avatar | SadTalker | Apache-2.0 code, restrictive ckpts | CHECK WEIGHTS |
+| 34 | Eye contact | MediaPipe FaceMesh + custom pupil warp | Apache-2.0 | **GO** — and mediapipe is *already a dependency* (26 hits) |
+| 35 | Face swap | InsightFace / inswapper | **non-commercial** | **BLOCKED** |
+| 36 | Background removal | RMBG-2.0 | non-commercial | **BLOCKED** |
+| 36 | Background removal | BiRefNet / `rembg` (u2net) | MIT / Apache-2.0 | **GO** |
+| 37 | Denoise | DeepFilterNet3 | MIT/Apache-2.0 | **GO** |
+| 38 | Stem separation | Demucs v4 (htdemucs) | MIT | **GO** |
+| 44 | Upscaling | Real-ESRGAN | BSD-3-Clause | **GO** |
+| 45 | Watermark inpaint | big-LAMA | Apache-2.0 | **GO** |
+| 45 | Watermark inpaint | ProPainter | **S-Lab non-commercial** | **BLOCKED for commercial** |
+| 24 | Generative B-roll (image) | FLUX.1-**schnell** | Apache-2.0 | **GO** |
+| 24 | Generative B-roll (image) | FLUX.1-dev / SDXL | NC / OpenRAIL++ restrictions | **BLOCKED / CHECK** |
+| 24 | Generative B-roll (video) | Wan 2.x | Apache-2.0 | **GO** (heavy VRAM) |
+| 24 | Generative B-roll (video) | LTX-Video | custom LTXV licence | **CHECK** |
+
+**Already-licensed-and-present stack** (no new licence risk): Parakeet ASR
+(`features/parakeet_asr.py`), Whisper/CTC align (`features/ctc_align.py`), TransNetV2
+(`features/_transnetv2/`), LightASD (`features/_lightasd/`), pyannote
+(`features/pyannote_backend.py`), SmolVLM2 (`features/smolvlm2.py`), Qwen3-VL
+(`features/qwen3vl_backend.py`), EdgeTAM (`features/reframe_edgetam_backend.py`), Kokoro +
+Chatterbox TTS (`features/tts/`), PANNs (`features/audio_saliency.py`).
+
+**Note on gated weights:** `sidecar/media_studio/hf_auth.py` exists, so the project already has a
+Hugging Face auth path — meaning gated-but-permissive models are *operationally* reachable. That
+does not make an NC licence usable.
+
+---
+
+## 6. Ranked build order — the 10 to do first
+
+Score = (market prevalence across the 6 measured majors × user value) ÷ effort, then re-ordered so
+the near-free wins land first. Effort is incremental over measured code.
+
+| # | Build | Why now | Effort |
+|---|---|---|---|
+| 1 | **Expose `silence.trim` in the UI** | Engine done, RPC done, 4/6 majors ship it, zero engine cost | **S** |
+| 2 | **Expose `audiomix.merge` + `audiomix.normalize`** | Music bed + ducking + per-platform LUFS; engine done | **S** |
+| 3 | **Auto-zoom / punch-in control** | `features/zoom.py` exists with 1 importer; Submagic's Magic Zoom is a headline feature; emphasis timing already available from `emphasis.py` | **S-M** |
+| 4 | **Caption template gallery content** (target 20-30, not 150) | Plumbing (`templates.*`) already wired; captions are the #1 loved feature market-wide; this is asset authoring not engineering | **M** |
+| 5 | **Hook-title LLM generation** | Renderer exists (`hook_card.py`); only the text-gen step is missing; Submagic + OpusClip both ship it | **S** |
+| 6 | **Denoise / "clean audio"** | DeepFilterNet3 MIT; Submagic + Descript both headline it; single-model add | **M** |
+| 7 | **Own-library B-roll insertion** | `semantic_index.py` + `index.search` already wired — only the *insert into edit* step is missing. This is the strongest local-only differentiator: on-brand B-roll no cloud tool can match | **M** |
+| 8 | **Expose `stabilize.run`** | Engine done (21 KB); rounds out the "does it replace CapCut" story | **S** |
+| 9 | **Eye-contact correction** | **4 of the measured majors ship it** (Submagic, Descript, VEED, Captions.ai) and none of the local-first trio does — a clean differentiation win; mediapipe is *already* a dependency (26 hits); Apache-2.0 path | **L** |
+| 10 | **Lip-sync for the existing dub** (MuseTalk, MIT) | Dub + voice-clone already BUILT — lip-sync is the missing last mile that makes dubbing shippable; biggest reach multiplier per prior research | **L** |
+
+**Deliberately NOT in the top 10:**
+- **AI avatars / talking photo (row 33, XL).** Vidnoz's core product, and the owner named Vidnoz.
+  But it is a *different product category* (synthetic presenter) from repurposing real footage, and
+  it is the single largest build here. Recommend as an explicit **v1.6 scope decision**, not a v1.5
+  gap-close. **This is a judgement call that contradicts a literal reading of "all capabilities of
+  Vidnoz" — flagging it for the owner rather than silently dropping it.**
+- **Generative B-roll (24), script→video (47)** — XL, and both push against offline-first (VRAM).
+- **Stock B-roll (22), social publish (49), collaboration (51)** — all require cloud, which
+  contradicts row 52, the product's actual moat.
+- **Virality score (3)** — cheap (S) but the prior doc's user-distrust argument stands; ship the
+  honest `director_eval` score instead.
+
+---
+
+## 7. Residual gaps and what would settle them
+
+1. **Two of sixteen competitor columns are not measured.** **Riverside** — the one search that
+   targeted it returned no usable feature results, so its cells are `?`, and I did not retry with a
+   narrower query. **Diffusion Studio** — inherited from `competitor-research.md:5`, never fetched.
+   Settle: two targeted WebSearch/WebFetch passes against each vendor's own feature page.
+   Confidence this changes the top-10: **remote (1-20%)** — Riverside is a recording/studio product
+   and Diffusion Studio is a library, so neither adds a capability row the measured 14 lack.
+2. **No capability was executed.** Every Reframe verdict is *static* (module exists, method
+   registered, string referenced). A BUILT row could still be broken at runtime. Settle:
+   `packaged-artifact-smoke` golden journeys with `ffprobe` postconditions on the produced file.
+3. **All 18 licence rows in §5 are from memory, not from a licence file.** This is the single
+   highest-risk section for a commercial build. Settle: open each HF model card + repo `LICENSE`,
+   and separately confirm the *weights* licence.
+4. **"PARTIAL(ui)" does not distinguish "no UI" from "UI exists under a name I did not match."**
+   For the 7 in §4.2 the second probe covered all app file types, so those are solid; for rows
+   marked PARTIAL on judgement (20, 21, 23, 25, 26) the classification is weaker. Settle: drive the
+   built app with `ui-drive` and try to reach each feature.
+5. **Effort grades are my estimates**, not decomposed plans. Treat S/M/L/XL as ordinal, not
+   as hours.
+6. **CapCut caption-language count unresolved** (55+ vs 130+) — see §2.1 note. Immaterial.

--- a/docs/plans/v1.5/distribution-audit-2026-08.md
+++ b/docs/plans/v1.5/distribution-audit-2026-08.md
@@ -1,0 +1,970 @@
+# Reframe Distribution Posture Audit — installer · updater · code-signing · backward compatibility
+
+> **Status:** ACTIVE
+
+- **Date of audit:** 2026-08-08. Every external price / CA rule below was looked up on **2026-08-08**;
+  prices and CA requirements change, so re-check before purchase.
+- **Scope:** AUDIT + DESIGN only. This lane does **not** edit `electron-builder.yml`; the installer
+  implementation is owned by a separate lane.
+- **Honesty contract:** `UNVERIFIED` is attached INLINE to the sentence it qualifies and names the
+  settling experiment. Forward-looking claims carry a Sherman-Kent band
+  (*almost certain* ≈ 90-99% · *likely* ≈ 55-80% · *roughly even* ≈ 40-60% · *unlikely* ≈ 20-45%).
+  External facts carry a URL; repo facts carry `file:line`.
+
+## COVERAGE
+
+| § | Section | State |
+|---|---------|-------|
+| 0 | Measured baseline + 3 live defects in the existing pipeline | MEASURED |
+| 1 | Code-signing options, 2026 prices, recommendation | MEASURED (external, URL-cited) |
+| 2 | NSIS component-page design | DESIGNED — hooks + inclusion path measured in the pinned tool; the `.nsh` is **not compiled** (§2.9) |
+| 3 | Backward-compatibility test plan | DESIGNED — every path measured to `file:line`; **no sequence executed** |
+| 4 | Gap register, ranked by value/effort | MEASURED + ranked |
+
+One claim in an earlier draft of this document was **REFUTED** during self-review and is corrected
+in place, with the refutation left visible rather than deleted — see the boxed correction in §0.3/D3.
+
+## ⚠ RECONCILIATION WITH EXISTING v1.5 DOCS — read this before acting on §0.3 or §4
+
+An earlier draft of this audit was written **without first enumerating `docs/plans/v1.5/`**. That was
+a process failure on my part and it produced one actively harmful recommendation. Two sibling
+documents, both dated 2026-08-08 07:13, already cover part of this ground:
+
+- **`docs/plans/v1.5/signed-release-ci.md`** (36 KB) — a complete two-phase release-signing runbook:
+  CI builds → SLSA `actions/attest-build-provenance` → publish to a **DRAFT** release → human
+  downloads the exact CI bytes, `gh attestation verify`s them, signs offline with
+  `build/sign-release.mjs`, uploads the `.sig`, **then** un-drafts (`:15-16`, `:61-74`, `:267-290`).
+- **`docs/plans/v1.5/signed-release-trust-options.md`** (24 KB) — the trust-model options analysis.
+- **`docs/plans/v1.5/GRILL-DECISION-QUEUE.md`** — the owner's open decision queue.
+
+### RETRACTED: "un-draft a release" (was G3)
+
+**Do not do this.** `signed-release-ci.md:249` states: *"Draft is the safety interlock. Draft assets
+are not served at the public `/releases/download` URL. `updateVerify.ts` fetches the `.sig` from that
+public URL, which only resolves after un-draft — so **no client can auto-update to an unsigned
+draft.**"* v1.4.1's draft state is therefore **deliberate**, not an oversight. Un-drafting it without
+first uploading a `.sig` would ship an unsigned release and defeat the interlock the sibling lane
+designed. My original G3 had this as a top-three "~0 d, DO FIRST" action. It was wrong. Retracted.
+
+### D1 and D3 re-framed — the measurements stand, the framing did not
+
+What I verified independently and still stands: no release carries a `.sig`; `dist/` holds 8
+installers and zero `*.sig`; `/releases/latest` resolves to v1.4.0; `updateVerify.ts` is absent from
+the `v1.4.0` and `v1.4.1` tags. Those are measured facts.
+
+What was overclaimed: the heading "found by this audit" and the framing as undiscovered defects.
+`signed-release-ci.md:89` already names the exact failure mode — *"Fail-closed on a missing
+signature… **Auto-update stays dark until a real `.sig` is published** — which is why the
+draft-then-sign-then-publish ordering is mandatory, not stylistic"* — and `:345` already records the
+PoC-key blocker. So **D1/D2 are known and have a designed remediation; D3 is intentional.** The
+residual value of §0.3 is the *state* evidence (the runbook has never been executed end-to-end, and
+the dry-run at `signed-release-ci.md:325` has not been run), not the diagnosis.
+
+My audit also **omitted SLSA build provenance** entirely, which the sibling design treats as a
+first-class complementary layer. Defer to `signed-release-ci.md` on that.
+
+### The Authenticode conflict — surfaced, not silently resolved
+
+`signed-release-ci.md:32` and `§8` put Authenticode explicitly **out of scope** ("stays unsigned",
+"no action needed"), and `GRILL-DECISION-QUEUE.md:146` records *"**Signing** stays NONE (already by
+design). No SmartScreen concern to solve."*
+
+Per AGENTS.md §10 I surface this rather than pick a side — but the record needs two corrections:
+
+1. **The queue item is OPEN, not decided.** `GRILL-DECISION-QUEUE.md:63` reads
+   `[ ] **B-2** Unsigned installer — confirm (memory says signing = NONE by design)` — an unchecked
+   box awaiting owner confirmation. §1 is therefore *input to an open decision*, not an override of a
+   closed one.
+2. **The stated rationale is factually outdated.** "No SmartScreen concern to solve" does not
+   address **Smart App Control**, which on Windows 11 *"will block execution of unsigned files unless
+   the file has a positive reputation"* and *"applies to all executable files, not just those
+   downloaded from the Internet"* ([Microsoft, SmartScreen reputation](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation),
+   read 2026-08-08). That is a **block**, not a warning. Nor does it address the compounding cost for
+   an auto-updating app: *"Unsigned files must build reputation anew with every update."*
+   The Ed25519 gate and Authenticode answer **different questions** — feed authenticity vs. OS
+   execution trust — exactly as `signed-release-ci.md:106-108` argues provenance and the `.sig` are
+   orthogonal and must coexist. The same reasoning applies one layer out.
+
+So §1 stands as a real gap, re-scoped to: *evidence for owner decision B-2*, not a unilateral "DO".
+
+---
+
+## 0. Measured baseline
+
+### 0.1 What ships today
+
+| Fact | Evidence |
+|---|---|
+| Targets: NSIS installer + portable zip, **x64 only** | `electron-builder.yml:132-136` |
+| `productName: Reframe`, `appId: local.media-studio`, package name `media-studio` | `electron-builder.yml:24-25`, `app/package.json:2-4` |
+| Current version **1.4.2** | `app/package.json:4` |
+| Installer size **223.3 MB**, zip **295.7 MB** (measured on disk, `dist/`, built 2026-08-08 07:22) | `dist/media-studio-1.4.2-win-x64.exe` |
+| electron-builder **^26.15.3**, electron-updater **^6.8.9**, electron **^43.3.0** | `app/package.json` devDependencies/dependencies |
+| Publish provider: GitHub Releases, `Prekzursil/Reframe` | `electron-builder.yml:39-42` |
+| Repo is **PUBLIC** but has **no LICENSE file** and `"license": "UNLICENSED"` | `gh repo view` → `{"isPrivate":false,"licenseInfo":null}`; `app/package.json:10` |
+| NSIS config is 6 keys only — no component page, no custom `include`/`script` | `electron-builder.yml:139-150` |
+
+NSIS block verbatim (`electron-builder.yml:139-150`): `oneClick: false`, `perMachine: false`,
+`allowToChangeInstallationDirectory: true`, `installerIcon`, `uninstallerIcon`,
+`deleteAppDataOnUninstall: false`, `shortcutName: Reframe`. There is **no** `build/installer.nsh`
+in the tree (measured: `build/` contains only `check-python.ps1`, `make-portable.ps1`,
+`python-embed-setup.ps1`, `sign-release.mjs`, two `wsl-verthor-bootstrap.*`, and the
+`ffmpeg`/`icon`/`icons`/`python-embed`/`python-embed-314` directories).
+
+### 0.2 The updater — already built, and better than most
+
+This is genuinely good work and should not be rebuilt. Measured:
+
+- `electron-updater` wired to the GitHub feed; `latest.yml` + NSIS `.blockmap` (delta downloads)
+  emitted by the `publish` block — `electron-builder.yml:26-38`.
+- Launch check deferred until the renderer has loaded so it can observe the status stream —
+  `app/main/main.ts:845-852`.
+- `autoDownload = false` and `autoInstallOnAppQuit = false`: the user confirms every download and
+  nothing installs outside the gate — `app/main/updater.ts:163-164`.
+- **Ed25519 authenticity gate** over `reframe:update:v1 ‖ version ‖ sha512(installer)`, verified
+  against embedded public keys with a two-key rotation window — `app/main/updateVerify.ts:36`,
+  `:52-61`, `:98-100`, `:119-136`.
+- **Downgrade-replay guard** (a validly-signed *older* release is refused) —
+  `app/main/updateVerify.ts:185-187`, called at `:223-225`.
+- Signature URL is a fixed `github.com` release path with both segments percent-encoded, so a
+  hostile feed value cannot redirect the host — `app/main/updateVerify.ts:103-111`.
+- Re-verification immediately before `quitAndInstall()`, closing the TOCTOU window —
+  `app/main/updater.ts:14-16`, `:245-262`.
+- Fail-closed by construction: the verifier never throws, every failure is a typed
+  `{ok:false, reason}` — `app/main/updateVerify.ts:66-67`, `:195-198`.
+
+### 0.3 THREE live defects in the release pipeline (found by this audit)
+
+**D1 — the Ed25519 gate has never been exercised, and no release carries a `.sig`.** The gate will
+reject 100% of updates the moment it ships, unless `.sig` publication is added to the release
+runbook.
+
+Two mechanically independent signals:
+1. `gh release view --repo Prekzursil/Reframe` on the **Latest** release (`v1.4.0`) returns exactly
+   three assets: `latest.yml`, `media-studio-1.4.0-win-x64.exe`, `…exe.blockmap`. **No `.sig`.**
+2. `dist/` on disk holds 8 built installers (1.0.0 → 1.4.2) and **zero** `*.sig` files —
+   `build/sign-release.mjs` has never been run.
+
+Failure path if shipped as-is: `fetchUpdateSignature` (`app/main/main.ts:797-805`) gets HTTP 404 →
+throws → `verifyDownloadedUpdate` rejects with `cannot fetch update signature`
+(`app/main/updateVerify.ts:238-241`) **after the full 223 MB download completes**. Confidence
+*almost certain* (the code path is unconditional and fail-closed).
+
+Mitigating detail that changes the severity — **the gate is not in any shipped build yet.** Measured:
+`git ls-tree v1.4.0:app/main/` and `v1.4.1:app/main/` list `updater.ts` but **not**
+`updateVerify.ts`; `git ls-tree v1.4.0:build/` does **not** list `sign-release.mjs`. So the gate
+lives only on `main` and will ship first in the next release. Consequence: the v1.4.0 → next-release
+upgrade is performed by **v1.4.0's un-gated updater**, so the gate protects N+1 → N+2, not
+N → N+1. That is normal for a first-signed release, but it must be stated rather than assumed away.
+
+**D2 — the embedded update keypair is a proof-of-concept key and is a hard release blocker.**
+`app/main/updateVerify.ts:46-51` says so in its own words: *"these two keys were generated for this
+proof-of-concept PR. Before the first PRODUCTION signed release, regenerate a fresh keypair on an
+offline machine … whose private half has NEVER touched a shared/agent environment."* Both embedded
+keys (`:54-60`) are therefore untrusted. Shipping them would mean the authenticity claim is
+cosmetic. Settling action (not a check — a task): generate offline, replace both entries, re-run the
+`updateVerify.test.ts` pins.
+
+**Third, mechanically independent signal that no signed release has ever been possible:** the
+production keypair **does not exist yet**. `signed-release-ci.md:278` documents reading it from
+`C:\offline\reframe-ed25519.pem`; measured 2026-08-08, `C:\offline\reframe-ed25519.pem` is absent,
+as are `C:\offline` and `%USERPROFILE%\offline`. So the D1/D2 cluster now rests on three independent
+probes — release assets (`gh release view`), built artifacts (`dist/` has zero `*.sig`), and the
+signing key's own absence on disk.
+
+**Minor hygiene finding while verifying the above (low severity, cheap fix).**
+`docs/plans/v1.5/signed-release-ci.md` is **committed** (`git log` → `6ae972c1`, clean working-tree
+status) in a **public** repo, and line 278 names the intended on-disk location of the offline
+update-signing private key. That key is the highest-authority secret in the entire distribution
+chain — it authorizes *silent* auto-updates on every installed copy. Right now the disclosure is
+inert (the file does not exist), so this is **not** an exposure and there is nothing to rotate. But it
+is a pre-committed instruction telling any future local foothold exactly where to look. When G2
+generates the real key: (a) do not place it at the documented path, (b) genericise that line to
+`<offline-key-path>` or an env-var reference, and (c) prefer a removable/encrypted volume over a
+plain `C:\` directory. Confidence *high* that this is worth doing and *high* that it is not urgent.
+
+**D3 — v1.4.0 users currently have no update path at all.** `gh release list` shows `v1.4.1` in
+state **Draft** and `v1.4.2` built (`dist/`, 2026-08-08) but never released.
+
+Mechanism, measured in the pinned provider — not inferred. `allowPrerelease` is not set anywhere in
+this repo, so `GitHubProvider.getLatestVersion()` takes the `else` branch at
+`app/node_modules/electron-updater/out/providers/GitHubProvider.js:92-93` and resolves the tag via
+`getLatestTagName()`, which for `github.com` hits `<repo>/releases/latest`
+(`GitHubProvider.js:158-163`). The Atom feed is fetched only to locate the matching entry for release
+notes (`:94-104`) — it does **not** select the tag on this path.
+
+Second independent signal: `https://github.com/Prekzursil/Reframe/releases/latest` measurably
+resolves to **v1.4.0** (read 2026-08-08). So every installed copy reports "no update available".
+Confidence *almost certain*.
+
+> **Correction to an earlier draft of this document.** An earlier version asserted the mechanism was
+> "the Atom feed excludes drafts". That is **REFUTED**: fetching
+> `https://github.com/Prekzursil/Reframe/releases.atom` lists `v1.4.1` as its newest entry, because
+> that feed enumerates **tags** (the tag `v1.4.1` exists — `git tag --list "v1.4*"` → `v1.4.0`,
+> `v1.4.1`) regardless of whether a release is published. The conclusion survives; the reasoning did
+> not. Worth keeping visible because it also flags a latent hazard: **if `allowPrerelease: true` is
+> ever set for a beta channel (§4, G7), the code path switches to the Atom feed and can select a tag
+> whose release is a draft or has no assets** (`GitHubProvider.js:51-58` takes the first entry
+> outright when the current version is stable and no channel is set). Any G7 work must test that
+> case explicitly.
+
+Asset-count reconciliation, so the D1 evidence is not misread: the v1.4.0 release *page* reports
+"Assets 5" while `gh release view` returns 3. The difference is GitHub's two auto-generated source
+archives, which `gh` does not list. There are still **no `.sig` assets**.
+
+### 0.4 Where user state lives (the backward-compatibility surface)
+
+Two roots, and the distinction is the whole ballgame:
+
+- **`$INSTDIR`** (`%LOCALAPPDATA%\Programs\Reframe` by default at `perMachine:false`) — **replaced
+  wholesale by electron-updater's in-place NSIS upgrade.** Anything here is destroyed on update.
+- **`<userData>`** = `app.getPath('userData')` — survives.
+- **`<dataRoot>`** = `%APPDATA%/media-studio` by default — survives. Relocatable.
+
+| Artifact | Path | Evidence | Survives update? |
+|---|---|---|---|
+| Encrypted provider keys (DPAPI) | `<userData>/secure-keys.json` | `app/main/keystore.ts:37`, `:905` | YES |
+| Settings — incl. `savePresets`, `routing`, `firstRunChoiceMade` | `<dataRoot>/settings.json` | `sidecar/media_studio/handlers/_services.py:75`, `settings_store.py:159`, `:163` | YES |
+| Library database | `<dataRoot>/library.db` | `sidecar/media_studio/library.py:131`, `handlers/library_ops.py:395` | YES |
+| Project manifests | `<dataRoot>/projects/<videoId>.json` | `_services.py:73`, `library_ops.py:60` | YES |
+| Exports | `<dataRoot>/exports` | `_services.py:74` | YES |
+| Export-preset catalog | `<dataRoot>/export-presets.json` | `handlers/composition.py:436-441` | YES |
+| Thumbnails / posters | `<dataRoot>/thumbnails/<id>.jpg` | `library_ops.py:144` | YES |
+| Keep-a-copy managed store | `<dataRoot>/managed-copies` (cap 20 GiB) | `sidecar/media_studio/keepcopy.py:54-59` | YES |
+| Models / tools / pip envs | `<dataRoot>/{models,tools,envs}` | `electron-builder.yml:147-148`; `bootstrap.py` | YES |
+| First-run markers | `<dataRoot>/.first-run-complete.json`, `.first-run-requirements.json`, `.first-run-profile.json` | `bootstrap.py:618`; `firstRunGate.ts:41`; `installProfiles.ts:242` | YES |
+| Data-root pointer (stable) | `<userData>/data-dir.txt` | `dataRootIo.ts:59-65`, `dataRoot.ts:19` | YES |
+| Data-root pointer (legacy) | `<exeDir>/data-dir.txt` | `dataRootIo.ts:43-54` | **NO** — but forward-migrated into the stable copy on read (`dataRootIo.ts:131-141`) |
+| Embeddable-python activation | `<resources>/python/python3XX._pth` | `main.ts:692-719` | **NO** — destroyed by design, rewritten every packaged launch by `ensurePthActivated()` |
+
+`deleteAppDataOnUninstall: false` (`electron-builder.yml:149`) means an **uninstall** also keeps
+`<dataRoot>`, so a reinstall needs no re-download. That is deliberate and correct.
+
+The two mechanisms that make an upgrade non-destructive already exist and were built for exactly
+this: `dataRootPlan.ts:1-24` documents the historical `<exeDir>/data` regression (a default install's
+`library.db` + multi-GB envs *were* wiped by the very auto-update v1.4 relies on) and the
+migrate-out-of-`$INSTDIR` fix; `dataRootIo.ts:114-141` documents the legacy-marker forward write.
+
+### 0.5 Install profiles today (the input to §2)
+
+The Default/Full/Custom concept **already exists in the app**, with a single source of truth:
+
+- Four profile ids — `minimum` · `default` · `full` · `custom` — `app/main/installProfiles.ts:24`.
+- A **core floor** present in every profile including Minimum: `yunet-face-detection` +
+  `lightasd-asd` (`installProfiles.ts:44`). Skipping it is the trap the completion marker guards:
+  without those weights the engine silently centre-crops (`installProfiles.ts:16-21`).
+- Exactly **two** optional bundles — `transcription` (Whisper large-v3-turbo) and `ai-director`
+  (Qwen3-4B GGUF + three llama-server builds) — `installProfiles.ts:60`, `:72-85`.
+- Fixed mapping: minimum `[]` · default `[transcription]` · full `[transcription, ai-director]` —
+  `installProfiles.ts:92-98`.
+- Sizes for the picker come from the same map (`ASSET_SIZES_MB`, `installProfiles.ts:47-55`), so the
+  number shown can never drift from what is installed.
+- Choice → `installProfile.choose` IPC → validate → persist → spawn `bootstrap.py --assets …` —
+  `app/main/installProfileIpc.ts:17`, `:60-81`.
+- Persisted as `{profile, bundles}` at `<dataRoot>/.first-run-profile.json` —
+  `installProfiles.ts:242-248`, written by `main.ts:654-665`, replayed by `main.ts:675-689`.
+- The picker is shown **only** on a first-ever run (`firstRunKind === 'first-ever'`), never on a
+  silent re-bootstrap — `app/main/main.ts:1206-1216`.
+
+**Everything else is on-demand, at point of use, not an install-time pack.** Measured asset universe
+beyond the two bundles: `all-minilm-l6-v2-onnx`, `hsemotion-onnx`, `rapidocr-onnx`,
+`edgetam-video-tracker`, `kokoro-v1.0-onnx`, `sherpa-onnx-punct-en`, `speechbrain-vad-crdnn`,
+`speechbrain-ecapa-voxceleb`, `ctc-forced-aligner-wav2vec2`, `ctc-forced-aligner-romanian`,
+`dover-mobile-quality`, `pyannote-speaker-diarization-31`, `pyannote-segmentation-30`, `qwen3vl-4b`,
+`qwen3vl-8b`, `siglip2-so400m` (grep of `*_ASSET_NAME` across `sidecar/media_studio`).
+
+`ModelsSystemPanel.tsx` is **not** a static pack list — it renders whatever `assets.list` returns
+from the sidecar at runtime and downloads via `assets.ensure`
+(`app/renderer/src/panels/ModelsSystemPanel.tsx:446`, `:629`, `:678-685`). So the installer's pack
+list must be derived from `installProfiles.ts`, not from that panel. Trying to mirror the panel into
+NSIS would create a second, drifting source of truth.
+
+---
+
+## 1. Code signing
+
+### 1.1 Two market changes that invalidate most advice you will find
+
+**(a) EV certificates no longer bypass SmartScreen.** Microsoft's own docs, twice:
+
+> "EV certificates no longer bypass SmartScreen. Years ago, signing files with an Extended
+> Validation (EV) code signing certificate would result in positive SmartScreen reputation by
+> default, but this behavior no longer exists. … Paying a premium for EV solely to avoid SmartScreen
+> warnings is no longer justified."
+> — [SmartScreen reputation for Windows app developers](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/smartscreen-reputation) (page `ms.date` 2026-05-04; read 2026-08-08)
+
+The comparison table on the sibling page marks EV as *"Same as OV since 2024 — no longer instant
+bypass"* and *"No longer recommended specifically for SmartScreen bypass"* —
+[Code signing options for Windows app developers](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options)
+(page `ms.date` 2026-04-20; read 2026-08-08). **Any recommendation to buy EV for SmartScreen is
+obsolete.** This is the single most consequential finding in this section.
+
+**(b) Certificate lifetimes just collapsed.** CA/Browser Forum **Ballot CSC-31** passed 2025-10-13
+and cuts the maximum validity of publicly-trusted code-signing certificates **from 39 months to 460
+days, effective 2026-03-01** —
+[cabforum.org/2025/11/17/ballot-csc-31-maximum-validity-reduction](https://cabforum.org/2025/11/17/ballot-csc-31-maximum-validity-reduction/)
+(read 2026-08-08). Practical effect: multi-year OV orders are now re-issued inside the term, and the
+"buy 3 years to amortise the token" strategy is dead. Budget as an annual cost.
+
+**(c) HSM/token has been mandatory since June 2023.** *"As of June 2023, the CA/Browser Forum
+requires private keys for OV certificates to be stored on a hardware security module (HSM) or
+hardware token."* — Microsoft, code-signing-options page (above). Cloud-HSM services (DigiCert
+KeyLocker, Sectigo cloud signing, SSL.com eSigner) satisfy this without a shipped USB stick, which
+is what makes CI signing possible at all.
+
+### 1.2 Options, with 2026 prices
+
+| Option | Cost | Availability | SmartScreen | Token/HSM | Source |
+|---|---|---|---|---|---|
+| **Azure Artifact Signing** (formerly Trusted Signing) | **~$9.99/mo** Basic (5,000 signatures/mo), $99.99/mo Premium (100,000) | Orgs: US, CA, EU, UK (+AU, NZ, JP, KR, SG, CH, NO, IL for Public Trust). **Individuals: US and Canada only** | Reputation builds over time. Explicitly **not** instant trust | **None required**; native GitHub Actions / Azure DevOps integration | [code-signing-options](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options); [Artifact Signing quickstart](https://learn.microsoft.com/en-us/azure/artifact-signing/quickstart) |
+| **OV cert, Sectigo/Comodo via reseller** | **$219/yr** | Worldwide. **Individual Validation (IV) offered to solo devs with no registered company** | Same as Artifact Signing | USB token or HSM | [SSL Dragon code signing](https://www.ssldragon.com/ssl-certificates/code-signing/) |
+| OV cert, GoGetSSL | $289/yr | Worldwide, IV available | Same | Token or HSM | same |
+| OV cert, DigiCert | $400/yr | Worldwide, **no IV** | Same | Token, HSM, or **KeyLocker cloud** | same |
+| EV cert | $287 (Sectigo) – $685 (DigiCert)/yr | Worldwide, **no IV** | **Same as OV** | Token or HSM | same + Microsoft docs |
+| Microsoft Store (MSIX) | Free | Worldwide | **No warnings at all** — Microsoft re-signs | n/a | [code-signing-options](https://learn.microsoft.com/en-us/windows/apps/package-and-deploy/code-signing-options) |
+| SignPath Foundation (OSS) | Free | OSS only | OV-level | managed | [signpath.org/terms](https://signpath.org/terms) |
+| Self-signed / unsigned | Free | — | Blocks / strong warning | — | Microsoft docs |
+
+The $9.99/$99.99 figures are **UNVERIFIED against a Microsoft-hosted price page** — the official
+[Artifact Signing pricing page](https://azure.microsoft.com/en-us/pricing/details/artifact-signing/)
+renders its price cells empty to unauthenticated fetches (measured 2026-08-08: it returned `$-` for
+both tiers while still showing the 5,000 / 100,000 quotas and "1 of each Certificate Profile type" /
+"10 of each"). Microsoft's own docs pages independently corroborate the magnitude
+("Approximately $9.99/month", "Approximately $10/month"), which is why the number is stated at all.
+**Settling experiment:** sign in to the Azure pricing calculator (or `az` a test account) and read
+the Basic SKU rate for the target region. Do this before committing a budget line.
+
+### 1.3 Eligibility analysis for *this* developer
+
+Microsoft's geographic restriction is unambiguous and it is the deciding constraint. Verbatim from
+the Artifact Signing quickstart prerequisites (read 2026-08-08):
+
+> "Public Trust certificates are available to organizations in the United States, Canada, the
+> European Union, the United Kingdom, Australia, New Zealand, Japan, South Korea, Singapore,
+> Switzerland, Norway, and Israel. **Individual developers must be located in the United States or
+> Canada.** These geographic restrictions do not apply to Private Trust certificates."
+
+The owner is in **Romania (EU)**. Therefore:
+
+- **As an individual / sole developer → NOT eligible** for Azure Artifact Signing. Confidence *almost
+  certain* (primary-source restriction, stated twice across two Microsoft pages).
+- **As a registered EU legal entity (SRL / PFA with a business identifier and a matching website
+  domain) → eligible**, at ~$9.99/mo. The organization path requires: legal business entity name,
+  a website URL belonging to that entity, a business identifier, the business address, and an
+  individual representative who completes government-ID verification — quickstart, Organization tab.
+  Processing time is stated as **"from 1 to 20 business days"**.
+- Additional constraint for the individual path that also bites the org path: identity details are
+  **auto-sourced from the Azure billing account**, and *"the billing account type must match the
+  identity validation type"* — an Individual billing account cannot validate an Organization
+  identity or vice versa. So an existing personal Azure subscription cannot be reused to validate a
+  company.
+
+**SignPath Foundation free OSS signing: NO-GO.** It requires *"an OSI-approved Open Source license"*
+with *"no commercial dual-licensing"* and the project *"may not contain any proprietary, non
+open-source component"* ([signpath.org/terms](https://signpath.org/terms), read 2026-08-08).
+Reframe is public-source but carries **no LICENSE file** and `"license": "UNLICENSED"`
+(`app/package.json:10`) — i.e. all-rights-reserved, not open source — and it bundles ViNet-S under
+**CC-BY-NC-SA 4.0** (`NOTICE`, "NON-COMMERCIAL NOTICE"), which is not an OSI license. Two
+independent disqualifiers. Confidence *almost certain*.
+
+### 1.4 Recommendation
+
+**Buy a Sectigo (or Comodo) OV code-signing certificate with Individual Validation, ~$219/year,
+with a cloud-HSM signing option rather than a shipped USB token.**
+
+- **Cost:** ~$219/yr (+ any cloud-signing fee the reseller charges separately — **UNVERIFIED**: the
+  `signmycode.com` OV page returned HTTP 403 to automated fetch on 2026-08-08, so the cloud-HSM
+  line-item price was not read. Settling experiment: open the chosen reseller's OV product page in a
+  browser and read the eSigner / cloud-signing add-on price before ordering).
+- **Lead time:** *"1–7 days"* issuance per the reseller, on top of your own document-gathering.
+  Plan **two weeks** wall-clock. Confidence *likely*.
+- **Why not Azure Artifact Signing**, despite being 2.2× cheaper and CI-native: the owner is an
+  individual in Romania and individuals are restricted to US/Canada. It becomes the better choice
+  **the moment a Romanian legal entity exists** — at which point migrating is a config change, but
+  note Microsoft's own warning that *"changing your signing certificate affects the publisher trust
+  signal"*, so any accumulated reputation resets.
+- **Why not EV** at any price: §1.1(a). It buys enterprise-procurement optics, nothing for
+  SmartScreen.
+- **Why not the Microsoft Store**, which would eliminate warnings entirely: Reframe ships an
+  NSIS/EXE installer that spawns an embeddable CPython, writes to `%APPDATA%`, and downloads
+  multi-GB models on demand. An MSIX repackage is a large, separate programme, and the Store's
+  MSI/EXE path still requires you to sign the installer yourself (*"Microsoft does not re-sign your
+  installer"*). Worth a v2 evaluation, not a v1.5 decision.
+
+### 1.5 What signing actually buys — set expectations honestly
+
+Signing does **not** remove the first-download warning. *"newly created binary could still show a
+SmartScreen warning until its hash or publisher certificate accumulates sufficient evidence of
+positive reputation"* and *"There is no exact threshold, but it can take several weeks and hundreds
+of clean installs from a wide audience"* (SmartScreen page). There is also *"no need (or mechanism)
+to manually submit a file for SmartScreen reputation review for consumer endpoints."*
+
+What it does buy, concretely:
+
+1. **The publisher name is displayed** in the warning instead of "Unknown publisher" — the single
+   biggest trust delta for a user deciding whether to click through.
+2. **Reputation carries across versions.** *"Signing files using a trusted certificate can allow
+   certificate reputation to build, potentially avoiding warnings on new files signed by the same
+   trusted certificate. Unsigned files must build reputation anew with every update."* For an app
+   that auto-updates, this compounds — every unsigned release restarts at zero.
+3. **Smart App Control.** *"On Windows 11 devices, the Smart App Control feature may supersede
+   SmartScreen Application Reputation. Smart App Control will block execution of unsigned files
+   unless the file has a positive reputation."* This is a **block**, not a warning, and it applies to
+   all executables, not just downloaded ones. For a Windows-11-targeted app this is the strongest
+   argument for signing.
+4. **Enterprise deployability** — unsigned installers are commonly blocked outright by policy.
+
+Two operational rules from the same page that interact with Reframe's build: *"Avoid modifying files
+after signing as doing so can break the signature"* — the Ed25519 `.sig` step (`build/sign-release.mjs`)
+computes a detached signature over the file and does **not** modify it, so the ordering
+Authenticode-sign → then Ed25519-sign is safe. Confidence *high* (detached signature by construction,
+`updateVerify.ts:88-100`). And *"Use a consistent signing identity"* — do not rotate CAs casually.
+
+### 1.6 Wiring it in (design only — this lane does not edit the config)
+
+`electron-builder.yml:31-38` currently documents the absence of signing. The change is confined to
+the `win` block plus CI secrets:
+
+- Cloud-HSM path (recommended): set `win.signtoolOptions.sign` to a custom script, or use the CA's
+  signing CLI as electron-builder's `sign` hook. Do **not** put a `.pfx` + password in CI — the
+  CA/B HSM rule makes an exportable `.pfx` non-compliant for a publicly-trusted OV cert anyway.
+- Add `win.signtoolOptions.rfc3161TimeStampServer` (the CA's timestamp URL). **Timestamping is
+  what keeps already-shipped binaries valid after the 460-day certificate expiry** (§1.1(b)) — with
+  the new short lifetimes this is no longer optional hygiene.
+- **Sign order — CORRECTED.** An earlier draft of this section said "build → Authenticode-sign →
+  regenerate `latest.yml`/`.blockmap` from the signed bytes → `sign-release.mjs`". For the Ed25519
+  step that is **wrong**, and `signed-release-ci.md:136` explains why: *"a local rebuild would produce
+  different bytes (electron-builder/NSIS Windows builds embed timestamps and are not bit-reproducible),
+  breaking both the provenance digest match and the users' download."* The owner must sign **the exact
+  CI-built bytes downloaded from the draft release**, never a local rebuild.
+
+  Authenticode therefore has to happen **inside the CI build**, before `--publish always` computes
+  `latest.yml` + `.blockmap` — so that the bytes CI attests, the bytes the human downloads and
+  Ed25519-signs, and the bytes users receive are all one and the same signed artifact. Concretely the
+  Phase A step in `signed-release-ci.md:61` gains the signing credential and drops
+  `CSC_IDENTITY_AUTO_DISCOVERY: "false"`; Phase B is unchanged. Getting this wrong is the classic
+  self-inflicted wound — Authenticode-signing *after* the blockmap is computed invalidates every
+  sha512 in `latest.yml`.
+
+  **UNVERIFIED** that electron-builder orders its internal sign → blockmap correctly for this
+  config; settling experiment: build once with signing enabled, then assert `sha512` in
+  `dist/latest.yml` equals `sha512` of the signed `dist/*.exe` on disk.
+
+  Note the trade-off this forces, which the sibling lane deliberately avoided: putting a signing
+  credential in CI reintroduces a long-lived secret, the very thing `signed-release-ci.md:104` argues
+  against for the *Ed25519* key. A cloud-HSM OV credential is narrower in blast radius than the
+  update-signing key (it cannot forge a silent auto-update, only an installer signature), but it is
+  not zero. This is a real cost of G4 and belongs in decision B-2.
+
+---
+
+## 2. NSIS component page design
+
+### 2.1 The constraint that shapes the entire design
+
+electron-builder's NSIS installer extracts **one 7z app package in one `Section`**
+(`app/node_modules/app-builder-lib/templates/nsis/installSection.nsh:66` `installApplicationFiles`,
+with `setSpaceRequired` targeting a single section id in `common.nsh:19-45`). There is **no**
+`MUI_PAGE_COMPONENTS` anywhere in the template set (measured: 24 files under
+`app-builder-lib/templates/nsis/`; the assisted page order is `assistedInstaller.nsh:9-64` and
+contains welcome → license → install-mode → directory → `customPageAfterChangeDir` → instfiles →
+finish).
+
+Therefore: **a real NSIS components page that selects payload subsets is not achievable without
+restructuring the whole build.** And it is not wanted — the owner's decision is that models keep
+downloading on demand (`electron-builder.yml:3-7` documents the slim-artifact contract and the NSIS
+~2 GB ceiling; bundling `transcription` alone would add ~1.6 GB per `ASSET_SIZES_MB`).
+
+So the correct design is a **choice-recording page**: an `nsDialogs` page that captures
+Default/Full/Custom/Minimum and writes it into the existing `.first-run-profile.json` contract. The
+installer decides *what the app will fetch on first launch*; it does not change what the installer
+extracts. This is exactly what the owner already decided, and it is also the only thing the platform
+allows cheaply.
+
+### 2.2 The pack list (derived, not invented)
+
+Straight from `app/main/installProfiles.ts` — no new names:
+
+| Radio option | id | Bundles added on top of the core floor | Approx first-run download |
+|---|---|---|---|
+| Minimum | `minimum` | — | ~4 MB |
+| **Default (pre-selected)** | `default` | `transcription` | ~1.6 GB |
+| Full | `full` | `transcription`, `ai-director` | ~4.9 GB |
+| Custom | `custom` | user-checked subset | computed |
+
+Custom checkboxes (exactly the two that exist — `installProfiles.ts:72-85`):
+
+- **Transcription & subtitles** — *"Whisper speech-to-text for captions, subtitles and search."*
+  (`whisper-large-v3-turbo`)
+- **AI Director** — *"The local LLM (plus its llama-server builds) that powers prompt-driven
+  editing."* (`qwen3-4b-gguf`, `llama-server-cuda`, `llama-server-cuda-cudart`, `llama-server-cpu`)
+
+Labels, descriptions and the `recommended` flag on Default are already authored in
+`installProfiles.ts:111-140` and `:72-85`; **copy those strings verbatim** so the installer and the
+in-app picker read identically. Size labels must come from the same map (`formatSize`,
+`installProfiles.ts:220-225`) — hardcoding "~1.6 GB" in the `.nsh` creates the drift the TS module
+exists to prevent. Recommendation: have the build emit a tiny generated `.nsh` fragment of
+`!define`s from `installProfiles.ts` rather than hand-typing numbers.
+
+The core floor (`yunet-face-detection`, `lightasd-asd`) must **not** be a checkbox. It is the
+no-silent-centre-crop invariant (`installProfiles.ts:16-21`, `firstRunGate.ts:43-50`); making it
+optional re-opens the exact bug the completion marker was built to catch.
+
+### 2.3 Where the page goes (measured hook)
+
+`assistedInstaller.nsh:41-44`:
+
+```nsis
+  # after change installation directory and before install start, you can show custom page here.
+  !ifmacrodef customPageAfterChangeDir
+    !insertmacro customPageAfterChangeDir
+  !endif
+```
+
+That is the hook — after the directory page, before `MUI_PAGE_INSTFILES`. Two adjacent measured
+facts that the design must respect:
+
+- The license and directory pages are wrapped in `skipPageIfUpdated` (`assistedInstaller.nsh:14`,
+  `:25`), which `Abort`s the page when `${isUpdated}` (`common.nsh:110-121`). **The component page
+  must do the same**, or electron-updater's silent in-place upgrade becomes an interactive prompt and
+  auto-update breaks. This is the highest-risk detail in §2.
+- `${Silent}` is already handled throughout (`installSection.nsh:5-7`, `:106-109`), and
+  `/allusers` + `/currentuser` are parsed at `assistedInstaller.nsh:122-133`. A silent install must
+  skip the page and take the profile from the command line (§4, G6).
+
+### 2.4 The `.nsh`
+
+`build/installer.nsh` (new file; electron-builder auto-detects this exact path — see §2.5):
+
+```nsis
+; build/installer.nsh — Reframe installer customisation.
+; Included by electron-builder into BOTH the installer and the uninstaller build,
+; so every Function is defined INSIDE a macro that is only inserted on the
+; installer side. Never define a bare top-level Function here.
+
+; Sizes/labels are generated from app/main/installProfiles.ts at build time into
+; build/installProfiles.generated.nsh (single source of truth -- see §2.2).
+!include /NONFATAL "installProfiles.generated.nsh"
+!ifndef REFRAME_SIZE_DEFAULT
+  ; Fallback keeps a hand build compiling, but the generator is the contract.
+  !define REFRAME_SIZE_MINIMUM "~4 MB"
+  !define REFRAME_SIZE_DEFAULT "~1.6 GB"
+  !define REFRAME_SIZE_FULL    "~4.9 GB"
+!endif
+
+!macro customPageAfterChangeDir
+  Var /GLOBAL ReframeProfile        ; minimum | default | full | custom
+  Var /GLOBAL ReframeWantWhisper    ; "1" | "0"
+  Var /GLOBAL ReframeWantDirector   ; "1" | "0"
+  Var /GLOBAL RfDialog
+  Var /GLOBAL RfRbMinimum
+  Var /GLOBAL RfRbDefault
+  Var /GLOBAL RfRbFull
+  Var /GLOBAL RfRbCustom
+  Var /GLOBAL RfCbWhisper
+  Var /GLOBAL RfCbDirector
+  Var /GLOBAL RfState
+
+  Page custom RfComponentsCreate RfComponentsLeave
+
+  Function RfComponentsCreate
+    ; 1. An in-place auto-update MUST NOT prompt. Mirrors skipPageIfUpdated
+    ;    (common.nsh:110-121) -- the same guard the license/directory pages use.
+    ${If} ${isUpdated}
+      Abort
+    ${EndIf}
+    ; 2. Unattended install: take /PROFILE= + /PACKS= and never draw a dialog.
+    ${If} ${Silent}
+      Abort
+    ${EndIf}
+
+    !insertmacro MUI_HEADER_TEXT "Choose what to set up" \
+      "Reframe downloads its AI models on first launch. Pick how much to fetch now -- you can add the rest later in Models & System."
+
+    nsDialogs::Create 1018
+    Pop $RfDialog
+    ${If} $RfDialog == error
+      Abort
+    ${EndIf}
+
+    ${NSD_CreateRadioButton} 0 0u 100% 12u "Minimum -- app plus subject tracking (${REFRAME_SIZE_MINIMUM})"
+    Pop $RfRbMinimum
+    ${NSD_CreateLabel} 12u 13u 96% 18u "Everything else downloads the first time you use it. Smallest first-run download."
+    Pop $RfState
+
+    ${NSD_CreateRadioButton} 0 34u 100% 12u "Default (recommended) -- adds offline transcription (${REFRAME_SIZE_DEFAULT})"
+    Pop $RfRbDefault
+    ${NSD_CreateLabel} 12u 47u 96% 18u "Captions, subtitles and search work out of the box. The balanced choice for most people."
+    Pop $RfState
+
+    ${NSD_CreateRadioButton} 0 68u 100% 12u "Full -- everything up front (${REFRAME_SIZE_FULL})"
+    Pop $RfRbFull
+    ${NSD_CreateLabel} 12u 81u 96% 18u "Also installs the local AI Director model so nothing downloads later. Best for offline use."
+    Pop $RfState
+
+    ${NSD_CreateRadioButton} 0 102u 100% 12u "Custom -- choose feature packs"
+    Pop $RfRbCustom
+    ${NSD_OnClick} $RfRbCustom RfSyncCustom
+    ${NSD_OnClick} $RfRbMinimum RfSyncCustom
+    ${NSD_OnClick} $RfRbDefault RfSyncCustom
+    ${NSD_OnClick} $RfRbFull RfSyncCustom
+
+    ${NSD_CreateCheckBox} 12u 116u 96% 12u "Transcription && subtitles -- Whisper speech-to-text"
+    Pop $RfCbWhisper
+    ${NSD_CreateCheckBox} 12u 130u 96% 12u "AI Director -- local LLM for prompt-driven editing"
+    Pop $RfCbDirector
+
+    ; Default is the pre-selected recommendation (installProfiles.ts:111-140).
+    ${NSD_Check} $RfRbDefault
+    Call RfSyncCustom
+    nsDialogs::Show
+  FunctionEnd
+
+  ; Custom checkboxes are only live when Custom is selected.
+  Function RfSyncCustom
+    ${NSD_GetState} $RfRbCustom $RfState
+    ${If} $RfState == ${BST_CHECKED}
+      EnableWindow $RfCbWhisper 1
+      EnableWindow $RfCbDirector 1
+    ${Else}
+      EnableWindow $RfCbWhisper 0
+      EnableWindow $RfCbDirector 0
+    ${EndIf}
+  FunctionEnd
+
+  Function RfComponentsLeave
+    StrCpy $ReframeWantWhisper "0"
+    StrCpy $ReframeWantDirector "0"
+    ${NSD_GetState} $RfRbMinimum $RfState
+    ${If} $RfState == ${BST_CHECKED}
+      StrCpy $ReframeProfile "minimum"
+      Return
+    ${EndIf}
+    ${NSD_GetState} $RfRbFull $RfState
+    ${If} $RfState == ${BST_CHECKED}
+      StrCpy $ReframeProfile "full"
+      StrCpy $ReframeWantWhisper "1"
+      StrCpy $ReframeWantDirector "1"
+      Return
+    ${EndIf}
+    ${NSD_GetState} $RfRbCustom $RfState
+    ${If} $RfState == ${BST_CHECKED}
+      StrCpy $ReframeProfile "custom"
+      ${NSD_GetState} $RfCbWhisper $RfState
+      ${If} $RfState == ${BST_CHECKED}
+        StrCpy $ReframeWantWhisper "1"
+      ${EndIf}
+      ${NSD_GetState} $RfCbDirector $RfState
+      ${If} $RfState == ${BST_CHECKED}
+        StrCpy $ReframeWantDirector "1"
+      ${EndIf}
+      Return
+    ${EndIf}
+    StrCpy $ReframeProfile "default"
+    StrCpy $ReframeWantWhisper "1"
+  FunctionEnd
+!macroend
+
+; Runs inside the install Section, AFTER installApplicationFiles +
+; registryAddInstallInfo + shortcuts (installSection.nsh:66-83).
+!macro customInstall
+  ; An in-place update must not touch the user's recorded choice.
+  ${If} ${isUpdated}
+    Goto rfSkipProfile
+  ${EndIf}
+
+  ; Unattended default resolution: /PROFILE=<id> [/PACKS=transcription,ai-director]
+  ${If} ${Silent}
+    ${GetParameters} $R0
+    ${GetOptions} $R0 "/PROFILE=" $R1
+    ${IfNot} ${Errors}
+      StrCpy $ReframeProfile $R1
+    ${EndIf}
+    ${If} $ReframeProfile == ""
+      StrCpy $ReframeProfile "default"
+      StrCpy $ReframeWantWhisper "1"
+    ${EndIf}
+    ${GetOptions} $R0 "/PACKS=" $R1
+    ${IfNot} ${Errors}
+      ${StrContains} $0 "transcription" $R1
+      ${If} $0 != ""
+        StrCpy $ReframeWantWhisper "1"
+      ${EndIf}
+      ${StrContains} $0 "ai-director" $R1
+      ${If} $0 != ""
+        StrCpy $ReframeWantDirector "1"
+      ${EndIf}
+    ${EndIf}
+  ${EndIf}
+
+  ; Build the bundles array in the EXACT shape parsePersistedInstallProfile reads
+  ; (installProfiles.ts:257-267): {"profile": "...", "bundles": [...]}.
+  StrCpy $R2 ""
+  ${If} $ReframeWantWhisper == "1"
+    StrCpy $R2 '"transcription"'
+  ${EndIf}
+  ${If} $ReframeWantDirector == "1"
+    ${If} $R2 != ""
+      StrCpy $R2 '$R2, '
+    ${EndIf}
+    StrCpy $R2 '$R2"ai-director"'
+  ${EndIf}
+
+  ; STAGING handoff -- see §2.6 for why this is NOT written to %APPDATA% directly.
+  ClearErrors
+  FileOpen $R3 "$INSTDIR\.install-profile.json" w
+  ${IfNot} ${Errors}
+    FileWrite $R3 '{$\n'
+    FileWrite $R3 '  "profile": "$ReframeProfile",$\n'
+    FileWrite $R3 '  "bundles": [$R2]$\n'
+    FileWrite $R3 '}$\n'
+    FileClose $R3
+  ${EndIf}
+  rfSkipProfile:
+!macroend
+```
+
+Notes on correctness: `${StrContains}` is available because `assistedInstaller.nsh:23` includes
+`StrContains.nsh` when `allowToChangeInstallationDirectory` is defined — which it is
+(`electron-builder.yml:142`). `&&` in the checkbox label is the NSIS escape for a literal ampersand.
+`$\n` is the NSIS newline escape. `${isUpdated}`, `${Silent}`, `${GetParameters}`, `${GetOptions}`
+are all already in scope in the generated script.
+
+### 2.5 How electron-builder picks it up
+
+Zero config needed, and this is measured from the pinned build tool rather than from docs:
+`app/node_modules/app-builder-lib/out/targets/nsis/NsisTarget.js:600-603` reads
+`await packager.getResource(this.options.include, "installer.nsh")` and, when non-null, does
+`addIncludeDir(packager.info.buildResourcesDir)` + `include(customInclude)`. With
+`directories.buildResources: ../build` (`electron-builder.yml:46`), dropping the file at
+`build/installer.nsh` is therefore sufficient. Making it explicit is still preferable for
+grep-ability:
+
+```yaml
+nsis:
+  # ... existing keys unchanged ...
+  include: installer.nsh          # relative to buildResources (= ../build)
+  warningsAsErrors: true          # a typo'd macro name otherwise compiles silently
+```
+
+`warningsAsErrors: true` is the important one — an `!ifmacrodef` hook whose macro name is misspelled
+is simply never inserted, and the page silently does not appear. That failure mode is invisible
+without it. **UNVERIFIED** that `warningsAsErrors` catches *that specific* class (a never-inserted
+`!ifmacrodef` may not emit a makensis warning at all); settling experiment: rename the macro to
+`customPageAfterChangeDirXX`, build, and confirm the build fails rather than producing an installer
+with no component page. This is precisely the both-states test — do not trust the page's appearance
+in the good state as proof the guard works.
+
+### 2.6 Writing the choice into the existing `.first-run-profile.json` contract
+
+Three candidate designs. The recommendation is (C).
+
+**(A) Installer writes `%APPDATA%\media-studio\.first-run-profile.json` directly.** Rejected. Three
+defects: (1) it duplicates the data-root precedence logic — `MEDIA_STUDIO_CONFIG_DIR` env >
+`<userData>/data-dir.txt` > legacy `<exeDir>/data-dir.txt` > `%APPDATA%` (`dataRootPlan.ts:67-84`,
+`dataRootIo.ts:114-141`) — inside NSIS, creating a second source of truth that will drift; (2) it
+cannot see a data root the user relocated to `D:/Reframe/data`; (3) if `perMachine` is ever enabled
+(§4, G4), the elevated inner UAC instance's `$APPDATA` is the **administrator's** profile, not the
+installing user's, so the file lands in the wrong place — silently. Confidence *likely* for (3)
+(standard NSIS/UAC behaviour; **settling experiment:** add `perMachine: true` in a scratch build and
+`MessageBox` `$APPDATA` from the elevated section).
+
+**(B) Registry handoff** (`HKCU\Software\Reframe\InstallProfile`). Works, and dodges (1)/(2). But it
+adds a new persistence mechanism and a new uninstall-cleanup obligation for a value consumed exactly
+once.
+
+**(C) `$INSTDIR` staging file, consumed once on first launch — RECOMMENDED.** The installer writes
+`$INSTDIR\.install-profile.json`; the app adopts it on the first-ever launch and writes the real
+`.first-run-profile.json` through the code that already owns that file.
+
+Why the `$INSTDIR` wipe-on-update is a *feature* here: the staging file must **not** survive an
+update (an update must never re-offer or re-apply a profile), and it *should* be re-created by a
+fresh re-install. The lifetime matches exactly.
+
+App-side change (one function, ~20 lines, in the file that already does this work):
+
+1. In `main.ts`, beside `readPersistedInstallAssets()` (`app/main/main.ts:675-689`), add
+   `adoptStagedInstallProfile(): ResolvedInstallChoice | null` — if `<dataRoot>/.first-run-profile.json`
+   is **absent** and `<exeDir>/.install-profile.json` exists, parse it with the *existing*
+   `parsePersistedInstallProfile` (`installProfiles.ts:257-267`), resolve with the *existing*
+   `resolveInstallChoice`, and return it. Never overwrite an existing data-root profile — a returning
+   user's choice always wins.
+2. At the gate (`main.ts:1206-1216`), when `firstRunKind === 'first-ever'` **and** a staged profile
+   was adopted: `persistInstallProfile(choice)` (`main.ts:654-665`), set `awaitingProfile = false`,
+   and go straight to `beginBootstrap(choice.assets)`. The user picked in the installer; do not ask
+   twice.
+3. Delete the staging file after a successful adopt (best-effort, fail-open — same posture as
+   `persistInstallProfile`'s logged-not-fatal write).
+4. Fall through to today's behaviour on any parse failure: no staged file, or a corrupt one, ⇒ show
+   the ProfilePicker. `parsePersistedInstallProfile` already returns `null` on garbage and drops
+   unknown bundle ids defensively (`installProfiles.ts:250-267`), so a hostile/garbled staging file
+   degrades to a prompt, never to a wrong install.
+
+This keeps **one** writer of `.first-run-profile.json` and **one** validator, adds no new schema, and
+reuses the module whose entire reason for existing is that there is exactly one map
+(`installProfiles.ts:1-14`).
+
+### 2.7 Test obligations this design creates
+
+`installProfiles.test.ts` already pins the TS↔Python conformance and "Default is the sole recommended
+profile" (`installProfiles.ts:27-31`). Add:
+
+- A cross-file test asserting the `.nsh` (or the generated `installProfiles.generated.nsh`) contains
+  exactly the ids in `INSTALL_PROFILE_IDS` and exactly the bundle ids in `BUNDLE_IDS` — the same
+  read-the-other-file pattern `firstRunGate.test.ts` uses against `bootstrap.py`.
+- A unit test for `adoptStagedInstallProfile` covering: absent staging file · valid staging file ·
+  corrupt JSON · unknown bundle id · **staging file present but data-root profile already exists**
+  (must be ignored). That last case is the data-loss-adjacent one.
+- The both-states test from §2.5 for the `!ifmacrodef` hook.
+
+### 2.8 What this design deliberately does *not* do
+
+Bundle models into the installer. `electron-builder.yml:3-7` sets the slim contract and notes NSIS's
+~2 GB ceiling; `transcription` alone is ~1.6 GB and `full` ~4.9 GB (`ASSET_SIZES_MB`,
+`installProfiles.ts:47-55`). A "Full" *installer* is not physically available at NSIS; a "Full"
+*profile* is. The page therefore chooses download policy, not payload — and the UI copy must say so
+("Reframe downloads its AI models on first launch"), or the size labels will read as a lie.
+
+### 2.9 Honest status of §2
+
+This is a **design**, not a verified implementation. The `.nsh` above has **not been compiled by
+makensis** and has not been run. Expect at least one iteration on nsDialogs coordinates and on
+`Var /GLOBAL` placement inside a macro. **Settling experiment:** `npx electron-builder --win` with the
+file in place, then (a) confirm the page appears on a fresh install, (b) confirm it is skipped on an
+electron-updater-driven upgrade, (c) confirm `$INSTDIR\.install-profile.json` matches the selection,
+(d) confirm `/S /PROFILE=full` produces `{"profile":"full","bundles":["transcription","ai-director"]}`.
+
+---
+
+## 3. Backward compatibility — as a test plan, not a promise
+
+### 3.1 What "backward compatible" has to mean here
+
+Four distinct upgrade shapes, and they fail differently:
+
+1. **In-place auto-update** (electron-updater → NSIS `/S`): `$INSTDIR` replaced, `<userData>` and
+   `<dataRoot>` retained.
+2. **Manual re-install over an existing install** (user double-clicks the new `.exe`): same, plus the
+   interactive pages appear (and must not re-prompt for a profile if one already exists).
+3. **Uninstall → install** (`deleteAppDataOnUninstall: false`, `electron-builder.yml:149`):
+   `<dataRoot>` retained, so the app must open already-provisioned.
+4. **Sidecar-requirements change across versions**: handled by the fingerprint file — a silent
+   re-bootstrap, no picker (`firstRunGate.ts:23-41`, `main.ts:1196-1209`).
+
+Shape 4 is the one most likely to regress silently, because a "successful" upgrade that quietly
+re-downloads 1.6 GB looks identical to one that does not, unless you measure.
+
+### 3.2 The matrix
+
+**Two baselines are required, not one.**
+
+- **Baseline A — the published old build:** v1.4.0 from
+  `https://github.com/Prekzursil/Reframe/releases/download/v1.4.0/media-studio-1.4.0-win-x64.exe`
+  (the current `/releases/latest`). This is what a real user upgrades *from*.
+- **Baseline B — the owner's actual installed state:** **v1.4.1 at `D:\Program Files\Reframe`, with
+  an `/allusers` uninstaller requiring elevation** (`GRILL-DECISION-QUEUE.md:24`). This is a
+  per-machine-shaped, non-default install path, so it exercises the elevated-`$APPDATA` hazard
+  (§2.6 defect 3), a non-`%LOCALAPPDATA%` `$INSTDIR`, and a version that never shipped publicly.
+  An earlier draft of this matrix used Baseline A alone; that would have tested a configuration the
+  owner is not running.
+
+Then install the candidate over it. Every row is *install-old → mutate → install-new → assert*, and
+rows B10/B12/B13/B15 must be run against **both** baselines.
+
+| # | Artifact | Mutate on old build | Assert on new build |
+|---|---|---|---|
+| B1 | Provider keys | Add an OpenRouter key via Models & System; record `sha256` of `<userData>/secure-keys.json` | File present, `sha256` unchanged, key still listed in the UI, a `providers.testKey` ping still succeeds (proves DPAPI still decrypts — file bytes alone do not) |
+| B2 | Settings | Set a non-default in Models & System; note `firstRunChoiceMade: true` and one `savePresets` entry in `<dataRoot>/settings.json` | Both values byte-identical; the first-run local-vs-cloud chooser (`FirstRunChooser.tsx`) does **not** reappear |
+| B3 | Library DB | Import 3 videos; record row count + `sha256` of `<dataRoot>/library.db` | Same row count; all 3 visible in Library; no migration error in the sidecar log |
+| B4 | Projects | Edit one project (creates `<dataRoot>/projects/<id>.json`); record its `sha256` | File unchanged; project opens with the same edits |
+| B5 | Export presets | Save a named export preset → `<dataRoot>/export-presets.json` | Preset present and applies |
+| B6 | Thumbnails | Note `<dataRoot>/thumbnails/*.jpg` count | Same count; no black posters in Library |
+| B7 | Keep-a-copy store | Enable keep-a-copy on one video → `<dataRoot>/managed-copies/`; record byte total | Byte total unchanged; `managed store status` reports the same used/cap |
+| B8 | **Models — the expensive one** | Record `<dataRoot>/models` byte total + mtimes | Byte total unchanged **and no `assets.ensure` job runs on first launch**. A re-download is the silent failure: assert on *no download*, not just on final presence |
+| B9 | pip env | Record `<dataRoot>/envs/sidecar` byte total + `.media-studio-env.json` | Unchanged if `requirements-sidecar.lock.txt` is unchanged between the two versions; if it *did* change, assert exactly one silent re-bootstrap and **no ProfilePicker** |
+| B10 | Install profile | Note `<dataRoot>/.first-run-profile.json` | Unchanged. With §2 shipped: also assert `$INSTDIR\.install-profile.json` was **not** written by the update (the `${isUpdated}` guard) |
+| B11 | First-run markers | Note `.first-run-complete.json` + `.first-run-requirements.json` | Present; app opens straight to the shell with **no** provisioning screen |
+| B12 | **Relocated data root** | On old build, use Change… to move the data root to `D:\ReframeData`; confirm `<userData>/data-dir.txt` | New build resolves to `D:\ReframeData`, not `%APPDATA%`. This is the scenario `dataRootIo.ts:114-141` exists for — test the *legacy-marker-only* variant too by deleting the `<userData>` copy and leaving `<exeDir>/data-dir.txt`, then asserting it is forward-migrated |
+| B13 | Legacy `<exeDir>/data` | Simulate a pre-fix install: create `<exeDir>\data` with a sentinel file and no markers | Migrated to `%APPDATA%/media-studio` with the sentinel intact, **or** left untouched with a loud warning if `%APPDATA%` is occupied — never a partial move (`dataRootPlan.ts:15-19`) |
+| B14 | Python `._pth` | Note `<resources>/python/python3*._pth` contents | Recreated by `ensurePthActivated()` (`main.ts:708-719`); sidecar starts; `import media_studio` succeeds. This one is *expected* to be destroyed — the test proves the repair, not the survival |
+| B15 | Shortcuts | Rename the desktop shortcut, then update | Not duplicated (`installSection.nsh:40-50` `KeepShortcuts` path) |
+| B16 | Downgrade refusal | Point a test feed at an older version | Update rejected with `refusing downgrade` (`updateVerify.ts:223-225`) |
+| B17 | **Signature gate** | Publish a candidate **without** a `.sig` | Update rejected with `cannot fetch update signature` — i.e. prove D1 fires, then publish the `.sig` and prove it passes. Both states, per §2.5 |
+
+### 3.3 Make it a harness, not a ritual
+
+Rows B1-B14 are all "hash/count a known path before and after", which is an exact algorithm — write
+it as a script, do not eyeball it. Concretely: a PowerShell probe that emits a JSON snapshot
+(`{path, exists, sha256|byteTotal|rowCount}`) for every path in §0.4, run before and after, then a
+diff with an expected-change allowlist (only `$INSTDIR` contents and `._pth` may differ). Anything
+else that differs is a finding. `packaged-artifact-smoke` and the existing e2e Electron harness are
+the natural hosts; the postcondition style matches what already runs in this repo.
+
+Rows B8/B9 need a *negative* assertion (no download happened), which a snapshot diff cannot express.
+Get it from the sidecar log or by blocking egress for the first launch after the upgrade — the
+hermetic-probe pattern used in `docs/validation/tools/hermetic_probe.py` is the right instrument.
+
+Honest limits of this plan: it is **not executed**. It is a design over measured paths. Rows B12/B13
+in particular depend on `dataRootPlan.ts` behaviour I read but did not run.
+
+---
+
+## 4. Gap register — everything else professional installers do
+
+Ranked by value ÷ effort. "Value" is user-visible or risk-reducing; "effort" is engineering days,
+*roughly even* confidence on each estimate.
+
+| # | Gap | Value | Effort | Verdict |
+|---|---|---|---|---|
+| **G1** | **Publish the `.sig` asset in the release runbook** (D1). Without it the shipped Ed25519 gate rejects every update after a full 223 MB download | Critical — the difference between a working and a dead updater | ~0.5 d (runbook + a CI step; `electron-builder.yml:14-19` already documents the command) | **DO FIRST.** Add a release-gate check that asserts a `.sig` exists for every `.exe` before the release leaves draft |
+| **G2** | **Regenerate the update keypair offline** (D2) | Critical — the authenticity claim is otherwise cosmetic | ~0.5 d, mostly process | **DO FIRST**, blocks the first signed release |
+| ~~**G3**~~ | ~~Un-draft a release~~ | — | — | **RETRACTED — do not do this.** Draft state is a deliberate safety interlock (`signed-release-ci.md:249`); un-drafting without a `.sig` ships an unsigned release. See the Reconciliation section. The real action is *execute the runbook* (G1), which ends in un-drafting |
+| **G4** | **Authenticode signing** (§1) | High — publisher name in the warning, reputation carries across versions, and Smart App Control *blocks* unsigned binaries on Win 11 | ~1-2 d + ~$219/yr + ~2 wk lead + a CI signing credential (§1.6) | **OWNER DECISION B-2** — `GRILL-DECISION-QUEUE.md:63` is an open, unchecked item. §1 is the evidence for it, and it rebuts the recorded "No SmartScreen concern to solve" rationale (`:146`). Not a unilateral DO |
+| **G5** | **RFC-3161 timestamping** alongside G4 | High — with the 460-day cap (§1.1b) untimestamped binaries stop validating fast | ~0 d (one config key, with G4) | **DO with G4** |
+| **G6** | **Silent/unattended flags documented** — `/S`, `/D=`, `/allusers`, `/currentuser` already work (`assistedInstaller.nsh:122-133`, `installSection.nsh:5-7`); add `/PROFILE=` + `/PACKS=` (§2.4) and *document* them | Medium-high — the entry ticket for any IT deployment, and it is nearly free | ~0.5 d | **DO** with §2 |
+| **G7** | **Release channels (stable/beta)** — `allowPrerelease` + `channel` are already supported by the pinned provider (`GitHubProvider.js:51-89`, `:132-138`); needs a UI toggle and a settings key. **Carries the D3 hazard**: setting `allowPrerelease: true` switches tag resolution from `/releases/latest` to the Atom feed, which enumerates *tags* — so a stale tag with a draft or asset-less release can be selected (`GitHubProvider.js:51-58`). Must be tested against a feed that contains exactly that (this repo currently does) | Medium-high — lets you test an installer change on volunteers before it reaches everyone | ~1-2 d | **DO**, with that specific test — cheapest risk reduction available for installer work specifically |
+| **G8** | **Rollback on failed update.** Today `quitAndInstall()` replaces `$INSTDIR` with no retained previous version. A bad release is only recoverable by manually installing an older `.exe` | Medium-high | ~3-5 d (keep N-1 payload, or a repair-from-last-good path) | **CONSIDER** — cost is real; G7 plus a canary mitigates most of the exposure for less |
+| **G9** | **Portable mode is built but undocumented.** `zip` target ships (`electron-builder.yml:135-136`) and `build/make-portable.ps1` exists, but there is no user-facing portable story and no statement about where a portable copy stores data | Medium | ~1 d (docs + assert the data root lands beside the exe or in `%APPDATA%`, deliberately) | **DO** — mostly writing down what exists |
+| **G10** | **Uninstall cleanup choice.** `deleteAppDataOnUninstall: false` keeps multi-GB models forever with no way to reclaim them from the uninstaller | Medium — a user who uninstalls and does not know about `%APPDATA%/media-studio` silently loses GBs of disk | ~1 d (a `customUnInstall` checkbox; the hook exists in the template set) | **DO** — small, visible, and a genuine disk-space courtesy |
+| **G11** | **winget manifest.** Reaches `winget install` users; the manifest is YAML pointing at the GitHub release; requires a stable installer URL + sha256 | Medium | ~1-2 d, and it **wants G4 first** (winget's validation and user trust both favour signed installers) | **DO after G4** |
+| **G12** | **Staged rollout.** electron-builder supports a `stagingPercentage` in `latest.yml` | Low-medium — meaningful at thousands of users, not at tens | ~0.5 d | **DEFER** until install base justifies it |
+| **G13** | **`perMachine` / elevated install — ALREADY LIVE IN THE FIELD, not hypothetical.** `GRILL-DECISION-QUEUE.md:24` records the owner's installed app as *"Reframe **1.4.1**, `D:\Program Files\Reframe`, uninstaller `/allusers` (needs elevation)"* — i.e. a per-machine-shaped install exists despite `perMachine: false` (`electron-builder.yml:141`), presumably via `/D=` into Program Files and/or `/allusers` (`assistedInstaller.nsh:122-133`) | Medium — this makes §2.6 defect 3 (elevated `$APPDATA` = the **admin's** profile) a live hazard for the component page, not a future one | ~1 d to test; ~2-3 d to support properly | **TEST BEFORE §2 SHIPS.** The staging-file design (§2.6C) is what makes this safe — it writes to `$INSTDIR`, which is correct under elevation. Re-confirm on an elevated Program Files install |
+| **G14** | **MSI / Chocolatey.** MSI needs a different toolchain (WiX) and loses electron-updater's delta path; Chocolatey is a community-maintained wrapper around the same `.exe` | Low for a consumer video tool | MSI ~5+ d | **DECLINE** MSI. Chocolatey only if a user asks |
+| **G15** | **Uninstall survey.** Opens a URL on uninstall | Low, and it conflicts with the local-first/privacy posture the app leads with (`FirstRunChooser.tsx:63-65`) | ~0.5 d | **DECLINE** |
+| **G16** | **ARM64 build.** `target.arch: [x64]` only (`electron-builder.yml:134`) | Low today, rising | High — the embeddable CPython, ffmpeg, and the Remotion native compositor all need ARM64 variants | **DEFER**, revisit when a user asks |
+
+### 4.1 The ordering that matters
+
+**G1 + G2 first** — execute the `signed-release-ci.md` runbook end-to-end, including its own
+unexercised dry-run (`signed-release-ci.md:325`), and replace the PoC keypair. These are the
+difference between an updater that works and one that does not. Shipping a component page onto a
+release pipeline that has never completed a signed release would be the classic inversion: the
+visible work lands, the load-bearing work does not.
+
+**Then G13's test** — before the §2 component page ships, confirm the staging-file handoff behaves on
+an elevated `D:\Program Files` install, because that is what the owner actually runs.
+
+**Then G6/G7** (cheap; G7 de-risks everything after it, but must be tested against the
+`allowPrerelease` Atom-feed hazard), then G9/G10.
+
+**G4/G5 (Authenticode) is not in this sequence — it is owner decision B-2.** It is the gap the owner
+asked about and §1 is the evidence, but it carries a cost the sibling lane deliberately avoided (a
+signing credential in CI, §1.6) and it contradicts a recorded — though unconfirmed — scope decision.
+That belongs to the owner, not to this lane.
+
+---
+
+## Residual uncertainties (consolidated)
+
+| Claim | Status | Settling experiment |
+|---|---|---|
+| Azure Artifact Signing is $9.99/mo Basic | Corroborated by two Microsoft doc pages; **not** read off a Microsoft price page (that page renders `$-` unauthenticated) | Azure pricing calculator, signed in, Basic SKU, target region |
+| Reseller cloud-HSM add-on price | **UNVERIFIED** — `signmycode.com` returned HTTP 403 to automated fetch | Open the chosen reseller's OV page in a browser before ordering |
+| `warningsAsErrors` catches a misspelled `!ifmacrodef` hook | **UNVERIFIED** | Rename the macro, build, expect failure (both-states test) |
+| electron-builder recomputes `latest.yml` sha512 from the *signed* exe | **UNVERIFIED** for this repo's two-stage signing | Build with signing on; assert `dist/latest.yml` sha512 == sha512 of the signed `dist/*.exe` |
+| Elevated `$APPDATA` is the admin's profile under `perMachine` | *likely* (standard NSIS/UAC) | `MessageBox $APPDATA` from an elevated scratch build |
+| The `.nsh` in §2.4 compiles | **UNVERIFIED — not compiled** | `npx electron-builder --win` with the file in place |
+| §3 matrix outcomes | **UNVERIFIED — designed, not executed** | Run the matrix against v1.4.0 → candidate |
+| ~~GitHub's Atom feed excludes drafts~~ | **REFUTED and retired** — the feed lists tags, and `v1.4.1` is present. D3's conclusion now rests on `/releases/latest`, measured directly | done: `releases.atom` shows v1.4.1; `/releases/latest` shows v1.4.0 |
+| `nsis.include` defaults to `<buildResources>/installer.nsh` | **MEASURED** in the pinned tool (`NsisTarget.js:600-603`) | done |
+| With `allowPrerelease: true`, the Atom-feed path can select a draft/asset-less tag | *likely* — inferred from `GitHubProvider.js:51-58` taking the first entry outright; not executed | Set `allowPrerelease: true` in a scratch build against this repo's feed and observe which tag is chosen |

--- a/docs/plans/v1.5/editing-surface-audit-2026-08.md
+++ b/docs/plans/v1.5/editing-surface-audit-2026-08.md
@@ -1,0 +1,332 @@
+# Reframe general-video-editing surface audit — 2026-08
+
+> **Status:** ACTIVE
+
+**Status: MEASURED.** 27 of 27 primitive rows measured against source (the brief's 24 named
+primitives, split where one row held two distinct verdicts). Sections 2-4 written.
+**COVERAGE:** engine + RPC columns measured by direct source read for every row. The **UI**
+column is measured for the Workspace/Edit/Director/Timeline surfaces (the rail destinations);
+per-row UI absence is inferred from the tab inventory at `app/renderer/src/views/Workspace.tsx:53-66`
+plus the view files, not from an exhaustive component-by-component sweep — flagged inline where
+that distinction changes a verdict.
+
+Audit only. No code modified.
+
+Owner's ask, verbatim: *"apart from shorts themselves, it should also allow general video
+editing stuff subtitles and so more professional app regarding most stuff"*.
+
+## Honesty contract in force
+
+`UNVERIFIED` sits inline beside the claim it qualifies and names the settling experiment.
+Every capability claim carries a `file:line`. `NOT-CHECKED` where not measured. Sherman-Kent
+bands on forward-looking claims (*likely* 55-80%, *almost certain* 90-99%).
+
+---
+
+## 0. The headline
+
+Reframe has a **large, genuinely good set of clip-level operations** and **no editor**.
+
+Three measured facts carry that claim:
+
+1. **The tab labelled "Timeline" is a subtitle-cue editor, not a video timeline.**
+   `app/renderer/src/features/Timeline.tsx:1-8` — *"timeline subtitle editor (P2 T1). Waveform
+   strip (from `timeline.peaks`) + a cue lane of draggable rects"*. Its split/merge/retime ops
+   act on `Cue` objects (`app/renderer/src/lib/timelineOps.ts:57-83`), i.e. subtitle cues.
+   `sidecar/media_studio/features/timeline.py:324` registers exactly one method,
+   `timeline.peaks`, which returns `{sampleRate, peaks}` — a waveform, nothing more.
+
+2. **There is no direct-manipulation edit surface at all.** `app/renderer/src/views/Edit.tsx`
+   is a 192-line *router*: it renders either `TaskHub` or `Workspace` (`Edit.tsx:153-163`).
+   Its own empty state promises *"trim, cut, join, reframe, caption, and more — every edit tool
+   lives here"* (`Edit.tsx:183-185`), but the Workspace tab list
+   (`Workspace.tsx:53-66`) is `transcribe, search, subtitles, diarize, refine, tracks, convert,
+   shortmaker, timeline, dub, nle, recipes, assets` — **no trim, no cut, no join tab**. The
+   `trim`/`cut`/`join` engines are real (§1) and are reachable only through
+   `director.apply` — i.e. behind an **AI prompt** (`app/renderer/src/views/Director.tsx:3,57`
+   — *"prompt-driven AI editing… One prompt in. A reviewable plan out"*) — or implicitly via
+   shorts candidate selection. A user cannot drag a cut.
+
+3. **The render model is a linear destructive re-render chain, not a sequence model.**
+   Each applied op reads the current source, renders a **whole new mp4** into the copy folder
+   (`sidecar/media_studio/features/director_op_engines.py:148-157`), then re-points the manifest
+   at it (`:160-175`). N ops = N full re-encodes. Undo is a *re-point to the previous file*
+   (`RESTORE_KEY`, `:62,178-189`), never a re-render. This is elegant and safe, and it
+   structurally cannot express two clips existing at the same time.
+
+The multi-clip gap is not an oversight — it is **named and deliberately deferred in the source**:
+`DEFERRED_SUBSYSTEMS["reorder"] = "the timeline clip-reorder engine (multi-clip permutation)"`
+(`director_op_engines.py:116`), with the comment *"`reorder` is a multi-clip timeline permutation
+outside the single-clip render scope of these adapters"* (`:103-104`).
+
+**Standing defect, independently re-probed and CONFIRMED (not taken on faith):** `libx264` is
+hardcoded in **9 non-test `media_studio` modules** — `brandkit.py`, `media_compat.py`,
+`director_op_engines.py` (3 sites: `:360,:689,:912`), `fillers.py`, `reframe_claudeshorts.py`,
+`reframe_multispeaker.py`, `shortmaker.py` (7 sites), `stabilize.py`, `zoom.py` (grep count by
+file, a different probe than the brief's). **A second casualty of the same packaging defect that
+the brief did not mention:** stabilisation needs GPL `libvidstab`, and the source says so —
+*"`vidstabdetect`/`vidstabtransform` exist only when ffmpeg was compiled `--enable-libvidstab`
+(GPL) … a stripped/LGPL bundle would NOT [have it]"* (`stabilize.py:25-27`). So the pinned GPL
+rebuild is load-bearing for **stabilise** as well as H.264 export. Treat every "BUILT" verdict
+below as *"built in source, blocked on the shipped binary"*.
+
+---
+
+## 1. Editing-primitive inventory
+
+Legend — **BUILT**: engine + RPC + a user-reachable UI. **PARTIAL**: says which half is missing.
+**MISSING**: no implementation found. "Director-only" = reachable solely by AI prompt.
+
+| # | Primitive | Verdict | Evidence |
+|---|-----------|---------|----------|
+| 1 | **Trim** | PARTIAL — engine BUILT, RPC via `director.apply` only, **UI MISSING** | `director_op_engines.py:79` (`"trim"` in `WIRED_KINDS`), `:748`; no trim tab in `Workspace.tsx:53-66` |
+| 2 | **Cut** (delete span, ripple) | PARTIAL — engine BUILT, Director-only, **UI MISSING** | `director_op_engines.py:80`; `:269` *"head + tail concatenated"* |
+| 3 | **Split at playhead** | PARTIAL — **cues only**; video split MISSING | `timelineOps.ts:57-67` `splitCue` operates on `Cue`; no video-split op kind in `WIRED_KINDS` (`:78-92`) |
+| 4 | **Multi-clip timeline** | **MISSING** — explicitly deferred | `director_op_engines.py:105-120`; `reorder` -> *"the timeline clip-reorder engine (multi-clip permutation)"* (`:116`). `join` is **append-only** — extra clips go *"AFTER the COPY source"* (`:318`) |
+| 5 | **Transitions** | **MISSING** | zero `xfade` in `sidecar/media_studio` (grep, 0 hits) |
+| 6 | **Speed ramp / slow-mo** | PARTIAL — **constant** factor BUILT, **ramp MISSING**, Director-only | `retime` wired `:87`; `build_retime_argv` `:665-689` = `setpts=(1/factor)*PTS` + `atempo` chain `:640-673`. One scalar `factor`; no keyframed curve |
+| 7 | **Crop / pan / zoom keyframes** | PARTIAL — **auto** punch-in BUILT, **user keyframes MISSING** | `zoom.py:5` *"pure ffmpeg `zoompan` expression"*, `:168-194` *"the auto punch-in zoom"*; `zoomPan` wired `:86`. Per-shot crop override exists (`reframe.applyOverrides`, `reframe_override.py:433`) but is reframe-scoped, not a general keyframe editor |
+| 8 | **Colour correction** | **MISSING** | zero `eq=`, `curves`, `colorbalance`, `colorchannelmixer`, `hue=` (grep, 0 hits) |
+| 9 | **LUTs** | **MISSING** | zero `lut3d` (grep, 0 hits) |
+| 10 | **Audio mixing** | PARTIAL — **2-input only**; N-track mixer MISSING | `audiomix.py:150` `amix=inputs=2` — foreground + exactly one bed |
+| 11 | **Ducking** | BUILT (engine + RPC) — UI NOT-CHECKED per-row | `audiomix.py:149` `sidechaincompress`; RPC `audiomix.merge` (`:408`) |
+| 12 | **Loudness normalisation** | BUILT (engine + RPC) — EBU R128 | `audiomix.py:151,225` `loudnorm=I=…:TP=…:LRA=…`; RPC `audiomix.normalize` (`:409`) |
+| 13 | **Multi-track audio** | PARTIAL — **container-level only**, no mix timeline | `tracks_audio.py:670-673` = `tracks.audio.list/mux/replace/strip` (stream add/replace/remove). No per-track level/pan/automation |
+| 14 | **Titles / lower-thirds** | PARTIAL — engine BUILT but **un-styleable**, Director-only | `build_drawtext_argv` `:699-722`; hardcoded `fontcolor=white`, `fontsize=h/18` (overlay) / `h/12` (lower third). No font, colour, position, or timing params. **UNVERIFIED:** `:711-712` relies on *"fontconfig's default face (no `fontfile` needed where fontconfig is present)"* — Windows ffmpeg builds frequently ship without fontconfig, which would make every title render fail or fall back silently. Settling experiment: run `build_drawtext_argv` against the packaged `ffmpeg.exe` and check exit code + a pixel-diff of the output frame |
+| 15 | **Image / B-roll overlay** | PARTIAL — **static brand logo only**; B-roll MISSING | `brandkit.py:68-115` `build_logo_overlay_argv` — one image, corner-inset, whole-clip duration. No timed insert, no video-over-video. (`docs/plans/v1.5/flagship-auto-broll.md` is a plan, not an implementation) |
+| 16 | **Freeze frame** | **MISSING** | zero `tpad`, `loop=`, `framestep` editing hits (grep) |
+| 17 | **Reverse** | **MISSING** | zero `areverse`; every `reverse` hit in the tree is Python `reversed()`/`sort(reverse=True)` — a use-vs-mention false positive, individually checked (`jobs.py:376`, `catalog.py:412`, `fillers.py:109`, etc.) |
+| 18 | **Stabilisation** | BUILT engine + RPC — **blocked on the LGPL binary** | `stabilize.py:1-6` vidstab 2-pass; RPC `stabilize.run` (`:496`); GPL requirement `:25-27` |
+| 19 | **Masking** | **MISSING** | zero `maskedmerge`, `alphamerge` (grep, 0 hits) |
+| 20 | **Chroma key** | **MISSING** | zero `colorkey`, `chromakey`, `despill` (grep, 0 hits) |
+| 21 | **Motion tracking** | PARTIAL — tracking exists but **only drives auto-crop** | `reframe_edgetam_backend.py`, `reframe_multispeaker.py`, `saliency.py`. Not attachable to a user effect or overlay |
+| 22 | **Proxy / optimised media** | BUILT — playback-compat scoped | `media_compat.py:245-269` h264 720p `scale=-2:720`; RPC `media.proxy.start` (`:487`). Note `:21` — *"proxy plays, all operations … keep using the ORIGINAL"* (correct conform behaviour) |
+| 23 | **Markers / chapters** | **MISSING** | zero editing hits; all `marker` hits are release-tag markers (`tools_resolver.py:276-337`) and redacted-secret markers (`settings_store.py:102,315`) — use-vs-mention, individually checked |
+| 24 | **Project save / load** | BUILT | `library.py:521-582` `Project.new/open/save`, manifest v1 `{video, tracks, clips, audioTracks, settings}` (`:526-527`); RPC `project.open/save/consolidate` (`composition.py:116-118`). `consolidate` rewrites refs relative for portability (`:529-532`) |
+| 25 | **Undo / redo** | PARTIAL — **two disjoint mechanisms, no app-wide stack** | (a) `director.undo` (`composition.py:216`) walks recorded inverse ops by *re-pointing*, not re-rendering (`apply_engine.py:139`, `director_op_engines.py:178-189`); (b) a 100-entry linear history for **subtitle cues only**, in-component (`timelineOps.ts:23` `MAX_HISTORY = 100`) |
+| 26 | **Render queue** | BUILT for batch-of-sources; **heterogeneous queue MISSING** | `batch.py:96` statuses `queued/running/done/error/cancelled/skipped`, durable resume `:471`; RPCs `batch.create/start/plan/status/list/cancel/resume/delete` (`:1083-1090`). One pipeline applied to many sources — not a queue of differing export jobs |
+| 27 | **NLE interchange** | PARTIAL — **EDL + CSV only**; FCPXML/AAF/OTIO MISSING | `nle_export.py:50` `FORMATS = ("edl", "csv")`; CMX3600 builder `:204-234`. **And the EDL is not a user timeline:** `clips_to_events` lays every clip **back-to-back** on the record side (`:162,175-177`), deriving a contiguous rough cut from approved *shorts candidates* (`_clip_window` reads `sourceStart`/`end` off the candidate, `:128-148`). Single track, no transitions, no effects |
+
+### Scorecard
+
+- **BUILT (engine + RPC + reachable UI): 6** — ducking, loudness, stabilisation (binary-blocked),
+  proxy, project save/load, batch queue.
+- **PARTIAL: 12** — of which **6 are "engine exists, no UI"** (trim, cut, retime, zoomPan,
+  titles, and split-for-video), all gated behind the AI Director.
+- **MISSING: 9** — transitions, colour, LUTs, freeze, reverse, masking, chroma key,
+  markers/chapters, multi-clip timeline.
+
+The distribution is the story: Reframe's gap is **less about missing engines than about missing
+direct manipulation**. Six real, tested, working ffmpeg engines have no user-facing control.
+
+---
+
+## 2. The architectural ceiling
+
+### What the substrate actually is
+
+Two engines, measured:
+
+- **ffmpeg filtergraph**, driven by pure argv builders (`build_*_argv` throughout `features/`),
+  one subprocess per op, output to a new file.
+- **Remotion**, and this is the finding that changes the roadmap: it is **already vendored and
+  already a compositor**. `vendor/remotion-captions/src/` holds a real Remotion project
+  (`Root.tsx`, `CaptionedClip.tsx`, four caption styles, `HookTitle.tsx`), rendered head-
+  lessly via `@remotion/renderer`'s `selectComposition` + `renderMedia`
+  (`app/render-cli/src/render.ts:33,168`). **But it is used for exactly one thing.**
+  `CaptionedClip.tsx:37-38` is a single `<OffthreadVideo src={videoSrc}>` inside an
+  `<AbsoluteFill>` with caption overlays — **no `<Sequence>`, no second video, no `<Img>`, no
+  `<Audio>`.** Reframe ships a multi-layer compositing timeline engine and drives it as a
+  single-clip caption burner.
+
+### Where the ceiling is
+
+The ceiling is **not** ffmpeg. ffmpeg can do every missing primitive in §1. The ceiling is the
+**data model**: there is no sequence. Concretely:
+
+- `Project.clips` is `[{candidate, path}]` (`library.py:527`) — a **bag of rendered shorts**,
+  each an independently exported file. It has no track index, no record position, no effect
+  stack, no transition. `nle_export.py` has to *synthesize* an order by butting clips together
+  (`:175-177`) precisely because none is stored.
+- The op model is a **mutation chain over one clip**: source -> render -> re-point
+  (`director_op_engines.py:148-175`). A "project state" is just *which file the manifest points
+  at right now*.
+
+That model makes four things structurally impossible, not merely unimplemented:
+
+1. **Anything requiring two clips at the same instant** — transitions, video-over-video B-roll,
+   picture-in-picture, compositing. `xfade` needs an overlap; an append-only `join` (`:318`)
+   cannot produce one.
+2. **Arbitrary time reordering** — the deferred `reorder` op. Ripple/roll/slip/slide edits all
+   need positions the model does not hold.
+3. **Non-destructive parameter tweaking.** Changing a title's colour today means re-running the
+   whole chain. A sequence model re-renders a preview; a mutation chain re-encodes generations.
+4. **Real-time preview / scrubbing of an edit.** The current preview *is* the last rendered file.
+
+There is also a quality cost that compounds silently: **N ops = N H.264 re-encodes**, each
+generational loss. No `-crf` continuity or intermediate-codec discipline was found in the
+Director path — `:360,:689` pass bare `-c:v libx264` with no rate-control flags. Corroborated by
+a second, independent probe: grepping `director_op_engines.py` for `crf|-preset|-b:v|-pix_fmt`
+returns **zero** hits (only `-c:a` at `:361,582,631,690,734`), so every op re-encodes at
+x264's default CRF 23 with no quality floor carried between generations. **UNVERIFIED:**
+I did not measure actual quality degradation over a chain. Settling experiment: apply 6 Director
+ops to one clip and compare VMAF/SSIM of the result against a single-pass filtergraph doing the
+same work.
+
+### The honest split — cheap vs. needs new architecture
+
+**Cheap on today's substrate** (one more entry in `WIRED_KINDS` + one argv builder + a UI
+control; no model change). Confidence *almost certain* (90-99%) for the render side, since each
+is a single ffmpeg filter over one clip, which is exactly the shape the existing 13 engines have:
+
+| Primitive | Filter | Note |
+|---|---|---|
+| Colour correction | `eq`, `curves`, `colorbalance` | pure per-frame, no state |
+| LUTs | `lut3d=file=x.cube` | + a `.cube` asset path |
+| Reverse | `reverse,areverse` | **caveat:** `reverse` buffers the whole clip in RAM — must chunk or cap duration |
+| Freeze frame | `tpad` / `trim`+`loop` | changes duration; cue re-timing needed (`silencetrim` already does this) |
+| Chroma key | `colorkey`+`despill` | keyable, but only useful once you can put something *behind* it — see below |
+| Markers / chapters | none — **pure metadata** | zero render. Cheapest item in this document |
+| FCPXML export | none — **pure serialization** | `nle_export.py` already has the timecode math (`:151-193`) |
+| Title styling | existing `drawtext` | just thread params through `build_drawtext_argv` |
+
+**Needs a real sequence/compositing model.** Confidence that these cannot be done well by
+extending the mutation chain: *high* — the deferral comment at `:103-104` is the codebase
+reaching the same conclusion independently.
+
+- Multi-clip timeline with reorder / ripple
+- Transitions
+- B-roll / PiP / multi-track video
+- Masking, and motion tracking bound to an effect (needs per-frame animated parameters)
+- N-track audio mixing with automation
+- Non-destructive editing and real-time preview
+
+**The leverage:** the sequence model does not have to be built from nothing. Remotion already
+*is* the compositor — `<Sequence from={} durationInFrames={}>` over N `<OffthreadVideo>` layers
+is precisely a multi-track timeline, and the headless render path is already wired and shipping
+(`render.ts:168`). The missing piece is a **sequence document** (ordered clips with
+in/out/track/position/effects) that both Remotion (preview + composite render) and ffmpeg
+(fast flatten) can consume. That is a real piece of architecture — but it is *additive* and it
+reuses two engines already in the tree, which is a materially cheaper position than "rewrite the
+renderer".
+
+---
+
+## 3. Staged plan
+
+### Stage 1 — "a credible editor" with **no new architecture**
+
+Thesis: the fastest credibility win is **not** new capability, it is **exposing the six engines
+that already work** and giving them a manual surface. Everything here fits the existing
+single-clip mutation model.
+
+**S1.1 — A manual edit surface (the keystone).**
+New view `app/renderer/src/views/Trim.tsx` (or a `cut` tab in `WORKSPACE_TABS`,
+`Workspace.tsx:53-66`), reusing the **existing** waveform (`timeline.peaks`) and the existing
+lane/drag math (`timelineOps.ts` — `timeFromClientX`, `dragEdge`, `cueRectStyle` are already
+generic over a time axis). Emits a hand-built `EditPlan` and calls the **existing**
+`director.apply`. No new RPC. This alone converts trim/cut/join/retime/zoomPan/overlayText from
+Director-only to user-driven.
+- Modules: `app/renderer/src/views/` (new), `app/renderer/src/lib/timelineOps.ts` (extend to
+  generic spans), `sidecar/media_studio/models/edit_plan.py` (already models `EditOp`/`EditPlan`,
+  `:81,:106` — likely no change).
+- RPCs: **none new.** `director.apply` + `director.undo` already accept and invert plans.
+
+**S1.2 — Title styling params.** Thread `font`, `size`, `colour`, `position`, `start/end` through
+`build_drawtext_argv` (`director_op_engines.py:699-722`) and add `enable=between(t,s,e)` for
+timing. Resolve the fontconfig risk (row 14) at the same time by bundling a font and passing
+`fontfile=` explicitly.
+
+**S1.3 — Colour + LUT ops.** Add `colour` and `lut` to `WIRED_KINDS` (`:78-92`) with
+`build_color_argv` / `build_lut3d_argv` beside the existing builders. Same engine-factory shape
+as `make_overlay_text_engine` (`:940`).
+
+**S1.4 — Markers / chapters.** Add a `markers: []` array to the project manifest
+(`library.py:559-566` already backfills unknown fields, so this is schema-compatible) + new RPCs
+`markers.list` / `markers.set`. Zero render work. Export chapters into the mp4 container and
+into the EDL.
+
+**S1.5 — FCPXML + freeze + reverse.** Add `"fcpxml"` to `nle_export.FORMATS` (`:50`) reusing
+`clips_to_events`; add `freeze` and `reverse` op kinds (with the RAM cap noted above).
+
+**S1.6 — Fix the binary.** Ship the pinned GPL ffmpeg. Nothing in stage 1 is demonstrable
+without it, and it unblocks stabilisation too (`stabilize.py:25-27`).
+
+Stage-1 outcome: a user can open a video, see a waveform, drag trims, cut, join, retime, colour-
+grade, LUT, title, marker, and export — plus everything Reframe already does. That is a credible
+lightweight editor. **Estimated confidence it lands without touching the render model: *likely*
+(55-80%)** — the main risk is S1.1's plan-building UI proving to want positions the model lacks
+the moment a user tries to reorder two cuts, which is exactly the stage-2 trigger.
+
+### Stage 2 — the sequence model
+
+Introduce a **sequence document** as the source of truth: ordered `clips[{sourceId, inSec,
+outSec, trackIndex, recordSec, effects[]}]`. Store it in the existing project manifest
+(additive — `Project.open` already tolerates new keys, `library.py:559-566`). Two renderers over
+one document:
+- **Remotion** for preview + composited render (extend `vendor/remotion-captions/` from one
+  `<OffthreadVideo>` to `<Sequence>`-mapped layers — the engine and headless driver already
+  exist).
+- **ffmpeg** for a fast flatten of the simple single-track case (reuse the concat-filter path,
+  `:339-360`).
+
+Unlocks multi-clip reorder (retiring the deferred `reorder`), transitions (`xfade` becomes
+expressible), B-roll/PiP, and a real app-wide undo over document edits rather than file
+re-points. NLE export stops being synthesized and becomes a faithful serialization.
+
+### Stage 3 — depth
+
+Masking + motion tracking bound to effects (reuse the existing `reframe_edgetam_backend` tracker
+as the tracking source), N-track audio mixing with automation curves, chroma key composite
+(needs stage 2 to have something behind the key), speed *ramps* via piecewise `setpts` with
+segment-wise audio resampling, and proxy-based editing performance.
+
+---
+
+## 4. What Reframe should NOT try to be
+
+**Not DaVinci Resolve / Premiere.** No node-based colour grading, no Fairlight-class audio, no
+Fusion-class VFX, no collaborative/multi-user project locking, no broadcast deliverable
+compliance (AAF round-trip with an audio post house, closed-caption standards conformance). The
+reason is not ambition, it is measured: Reframe's differentiators are the AI ones — active-speaker
+reframing (`reframe_multispeaker.py`), moment-finding (`select.py`, `ranker.py`), dub
+(`dub.py`), Director planning. Every hour spent chasing a scope/waveform/curve editor is an hour
+not spent there, and it competes on the axis where two free incumbents are 20 years ahead.
+
+**Not a real-time NLE.** The mutation-chain heritage and per-op subprocess model mean Reframe's
+honest posture is *plan -> render -> review*, not *scrub -> instant feedback*. Even with stage 2,
+Remotion preview is frame-serving, not GPU timeline playback. Promising real-time scrubbing
+would be an overclaim.
+
+**Not a colour-managed finishing tool.** No ACES, no HDR tonemapping pipeline, no scopes. It
+should do *corrective* colour (§S1.3), and hand off to Resolve via FCPXML (§S1.5) for finishing.
+The interchange path is the honest answer to "professional", and it is cheap.
+
+**The scope that IS defensible:** *the best AI-first shorts and social editor that also handles
+ordinary cuts, titles, colour, and subtitles competently, and hands off cleanly to a real NLE
+when the job outgrows it.* That framing makes the missing primitives a finite list (§1) rather
+than an open-ended chase, and it is honest about the handoff instead of pretending it never
+happens.
+
+One caution on the owner's ask: *"professional app regarding most stuff"* is the phrasing most
+likely to lead to stage-2-and-3 scope with stage-1 resourcing. The measured recommendation is to
+ship stage 1 whole — six engines already exist and are invisible, which is the highest
+value-per-hour work available in this repo — and let stage 1's friction decide whether stage 2
+is warranted, rather than committing to the sequence model up front.
+
+---
+
+## Residual gaps in this audit (disclosed, not blocking)
+
+- **UI column granularity.** Measured at rail/tab level (`Workspace.tsx:53-66` + the view
+  files), not by a per-component sweep. A control could exist inside a panel I did not open.
+  Settling experiment: drive the built app with the `ui-audit` skill and enumerate every
+  interactive control per tab.
+- **Runtime behaviour NOT-CHECKED.** Every verdict is from source. I did not launch Reframe or
+  execute a single ffmpeg command; given the LGPL/libx264 defect, several "BUILT" rows are
+  *likely* (55-80%) to fail at runtime on the installed build. Settling experiment:
+  `packaged-artifact-smoke` golden journeys against the packaged binary with ffprobe
+  postconditions.
+- **Test coverage of the deferred paths NOT-CHECKED.** I did not check whether the `DEFERRED_KINDS`
+  degradation path (per-op `failed` + auto-rollback, claimed at `director_op_engines.py:94-97`)
+  is actually exercised by a test.

--- a/docs/plans/v1.5/uiux-qol-audit-2026-08.md
+++ b/docs/plans/v1.5/uiux-qol-audit-2026-08.md
@@ -1,0 +1,306 @@
+# Reframe UI/UX + QOL Audit — 2026-08-08
+
+> **Status:** ACTIVE
+
+**Auditor:** uiux subagent (Opus 5). **Mode:** READ-ONLY on app source — drove + inspected, never edited.
+**Target:** `D:\Program Files\Reframe\Reframe.exe` launched with `--force-renderer-accessibility`, pid 17292.
+**Method:** Windows UI Automation (`AutomationElement.FromHandle`) for the control tree + actuation;
+`PrintWindow(flag=2)` window-scoped screenshots with a distinct-colour assert for pixels; repo source read
+for corroboration. **Every rail destination and every Settings sub-tab was ACTUATED, not merely read.**
+
+**Honesty contract:** UNVERIFIED is inline next to the claim it qualifies, naming the settling experiment.
+Sherman-Kent bands on forward-looking claims. A control never actuated is `NOT-CHECKED`, never "works".
+
+## COVERAGE
+
+| Section | Status |
+|---|---|
+| 0. Ground truth / instrument corrections | MEASURED |
+| 1. Rail destinations (8/8 actuated) | MEASURED |
+| 2. Settings sub-sections (8/8 actuated) | MEASURED |
+| 3. Design-direction conformance | MEASURED (static + pixel; no computed-style access) |
+| 4. QOL sweep | PARTIAL — menus/shortcuts MEASURED; undo/redo, drag-drop, job cancel/resume from source read |
+| 5. Ranked findings | MEASURED |
+| 6. Evidence anchors | MEASURED |
+
+## 0. Ground truth and instrument corrections
+
+Two premises in my brief were wrong; correcting them because they change what the evidence means.
+
+1. **The app was NOT running when I started.** `Get-Process -Name Reframe` and
+   `Get-CimInstance Win32_Process -Filter "Name='Reframe.exe'"` both returned empty (two mechanically
+   independent probes). I launched it myself with `--force-renderer-accessibility`.
+2. **`docs/build/DESIGN-DIRECTION.md` is stale.** Its own line 3 reads
+   *"Status: SUPERSEDED BY docs/design-system.md (2026-08-08)"*, it is titled "media-studio" not Reframe,
+   and `app/renderer/src/styles/tokens.css:103` explicitly calls its `system-ui`/`Georgia` font values
+   and its `#08090b` surface ladder **stale**. I therefore judged the app against
+   `docs/design-system.md` (Status: ACTIVE) and used DESIGN-DIRECTION.md only where the newer doc
+   restates the same intent.
+
+**Instrument correction (recorded so no one cites my first pass).** My initial rail sweep reported that
+"Make Shorts" rendered the Library panel — an apparent routing bug. It was **my detector, not the app**:
+Chromium updates the UIA accessibility tree asynchronously, and a 1400 ms settle returned the previous
+panel's nodes. The screenshot taken moments later showed Make Shorts rendering correctly. I rewrote the
+dumper (`uia_dump2.ps1`) to block until the expected `tabpanel-*` node is live, and re-ran everything;
+observed settle times were 319–856 ms once the wait was correct. **No routing bug exists.**
+
+**Second instrument correction.** UIA menu enumeration failed twice (no `InvokePattern`; then no popup
+items surfaced). Rather than attempt a third variant I pivoted to two independent methods — a
+desktop-region screen capture with the menu open, and a source read — which agreed.
+
+## 1. Rail destinations — all 8 actuated
+
+| Destination | Empty state | CTA offered | Notes |
+|---|---|---|---|
+| Library | ghost-poster + "No videos yet" | **Add videos** (amber) | Search + Sort render live on an empty library |
+| Make Shorts | ghost-poster + "No video selected" | `Select a video…` combo | 3 sub-tabs: MAKE / PRODUCED SHORTS / BATCH & TEMPLATES |
+| Edit | "No video open" + prose | **none** | dead end — no way forward from the screen |
+| Caption | "Open a video to caption" | `← Library` | |
+| Export | "Open a video to export" | `← Library` | |
+| Deliver | per-section prose | `← Library` | 3 sub-tabs; unstyled `fieldset`; 23×20 px native `select` |
+| Director | ghost-poster in a card | **Choose a video** + `What is Director?` | title set in the editorial serif (see §3) |
+| Settings | n/a | n/a | 8 sub-tabs, all actuated |
+
+Library is empty, so every media-dependent flow is `NOT-CHECKED` end-to-end. I did **not** add media —
+that would mutate the owner's library. **The single most valuable follow-up is a first-run walkthrough
+with one real video**; nothing below substitutes for it.
+
+**Four different CTA treatments for the same "you need media" state** (amber button / combo / nothing /
+`← Library`). Edit offering *nothing* is the worst case.
+
+## 2. Settings sub-sections — all 8 actuated
+
+All 8 actuated against the real preload bridge; each panel's own `tabpanel-*` node verified live
+(settle 319–856 ms). No degraded or error state observed.
+
+MODELS & SYSTEM · SETUP · PROVIDERS & KEYS · STORAGE · CAPTION DEFAULTS · SYSTEM HEALTH · LICENSES ·
+EXPORT PRESETS.
+
+**Best-executed surfaces:** SETUP (green summary banner + 5 PASS rows with left-rail status) and
+SYSTEM HEALTH (tracked-caps section labels, consistent rows, semantic green). These match the design
+system closely and should be the template for the others.
+
+**Content taller than the 673 px viewport, with primary actions below the fold:**
+CAPTION DEFAULTS is 952 px tall and its **`Save defaults` button sits at y=1198** — the panel's only
+commit action is unreachable without scrolling, with no sticky footer. SYSTEM HEALTH (887 px) and
+PROVIDERS & KEYS both push content offscreen too.
+
+## 3. Design-direction conformance (vs `docs/design-system.md`, Status: ACTIVE)
+
+### 3.1 The editorial serif has spread to 15 sites (documented limit: 1)
+
+`docs/design-system.md:49` — "Georgia editorial serif (ShortMaker hook pull-quotes **ONLY**)". The superseded
+doc was blunter: *"ONE place only … It is the editorial signature; **do not spread it**."*
+
+`--font-editorial` is referenced in **15** stylesheets. The clearest violation is visible on screen:
+`app/renderer/src/views/director.css:48-56` sets `.director-view__title` to `--font-editorial` at
+`--type-display-size` (30 px) — a **view title**, not a 15 px italic pull-quote. The code comment at
+`director.css:47` calls it "the editorial moment", so the spread is deliberate in code and simply never
+reconciled with the design SSOT. Other sites: `caption.css:96`, `export.css:94`,
+`features/export/export.css:277,454`, `features/caption/captionStage.css:88`, `captionInspector.css:24`,
+`captionGallery.css:29`, `components/library-shell.css:232`, `components/firstRunSetup.css:40`,
+`components/profilePicker.css:31`, `components/shell.css:1480`, `features/lineage.css:71`,
+`features/director/directorHandoff.css:21`, plus the sanctioned `views/shorts.css:336`.
+
+`docs/design-system.md:6` says `tokens.conformance.test.ts` guards "one-accent discipline" — it evidently does
+**not** guard serif rationing. **Fix:** either add a conformance test capping `--font-editorial` usage, or
+amend the doc to describe the real intent. Right now doc and code disagree and nothing detects it.
+
+### 3.2 Accent rationing is exceeded on every screen
+
+`docs/design-system.md:30` — "Rationed: **at most one accent touchpoint per surface**." Counted from pixels on
+Settings › MODELS & SYSTEM: brand tick, `AI MODEL: Local` ring, `WHERE JOBS RUN: Local` ring, Settings
+rail item, active sub-tab underline + text, `Analyze my system` fill, and the `Privacy / offline` card
+border + `ACTIVE` chip ≈ **7**.
+
+UNVERIFIED — whether "surface" means *screen* or *region*: under a per-region reading the header alone
+still carries 2 (both toggle groups), so the rule is exceeded either way, but the severity depends on the
+reading. Settling experiment: have the design owner state the unit, then encode it as a conformance test
+counting accent-valued declarations per component.
+
+### 3.3 Two label voices coexist, sometimes on one screen
+
+`docs/design-system.md:43` defines caption 11 px/600 tracked CAPS as *the* label voice. Honoured on Library
+(`SORT`), the header (`AI MODEL`), and most Settings headings — but Deliver renders `Sources` and
+`Template` as sentence-case body text, Make Shorts renders `Video`, EXPORT PRESETS renders
+`Save current settings as`, and MODELS & SYSTEM mixes a sentence-case `OpenRouter spend` heading among
+tracked-caps siblings.
+
+### 3.4 Native form controls leak through the design system
+
+Measured from live bounding boxes — a clean discriminator, since styled controls render 32–33 px tall and
+raw native ones 20 px:
+
+- **Styled (8):** `Sort videos` 132×33 · `#asr-engine` 452×32 · `#diarize-backend` 452×32 ·
+  `#fn-select` / `#fn-subtitles` / `#fn-translation` / `#fn-vision` / `#fn-editPlan` 389×33.
+- **Raw native (3):** Deliver `Template` **23×20** · `#prefs-subtitle-mode` 98×20 ·
+  `#:r1:` Default language 94×20.
+
+Deliver's `Template` at **23 px wide** is the worst: it renders as a bare caret with no room for a value.
+Root cause is structural — there is no global `select` rule; `app/renderer/src/views/makeShorts.css:34`
+styles `.make-shorts__picker select` with `appearance:none` and a hand-drawn caret, and every other select
+is styled ad hoc or not at all. This is the same feature-namespaced-selector debt
+`docs/design-system.md:65-66` already admits for buttons, unacknowledged for selects.
+
+Deliver also renders an **unstyled `<fieldset>`** ("Sources") with a default notched legend and a
+full-strength grey border — directly against "depth via TONE … borders almost eliminated"
+(`docs/design-system.md:13`, anti-template gate #3).
+
+Checkboxes split the same way: `COMMERCIAL USE` 23×17 and `#spend-cap-enforce` 22×17 vs
+`#prefs-caption-polish` and `#prefs-caption-speakers` at **13×14**. All are under the WCAG 2.5.8 AA
+24×24 target minimum. UNVERIFIED whether the associated label extends the hit target (which would satisfy
+the exception) — settling experiment: click the label text, not the box, and observe the toggle.
+
+### 3.5 What the design system gets right
+
+Genuinely strong and worth protecting: the shared ghost-poster empty state (deep 16:9 well, play glyph,
+mono `--:--` timecode) on Library / Make Shorts / Director; the surface ladder and near-total absence of
+borders on Library, Settings and Health; the mono tabular voice for versions, paths and timecodes; the
+double focus ring, which rendered visibly on every rail item I actuated; the SETUP and SYSTEM HEALTH
+status treatments; and 17 caption-style presets with visual `Aa` previews.
+
+## 4. QOL sweep
+
+### 4.1 The app ships Electron's stock menu — no application shortcuts
+
+Two independent signals: (a) `app/main/main.ts:13` imports `app, BrowserWindow, ipcMain, net, safeStorage,
+session, shell` — **no `Menu`**, and no `setApplicationMenu` / `buildFromTemplate` / `accelerator` appears
+anywhere under `app/`; (b) a desktop capture of the open menus shows exactly the Electron defaults.
+
+- **View:** Reload `Ctrl+R` · Force Reload `Ctrl+Shift+R` · **Toggle Developer Tools `Ctrl+Shift+I`** ·
+  Actual Size `Ctrl+0` · Zoom In/Out · Toggle Full Screen `F11`.
+- **Edit:** Undo `Ctrl+Z` · Redo `Ctrl+Y` · Cut/Copy/Paste · Delete · Select All.
+
+Consequences:
+1. **DevTools and Force Reload are exposed in a production consumer build.** `Ctrl+R` mid-job hard-reloads
+   the renderer. UNVERIFIED whether a running job survives it — settling experiment: start a long export,
+   press `Ctrl+R`, observe whether the job continues and whether the UI recovers its progress.
+2. **`Edit ▸ Undo (Ctrl+Z)` is a text-field role, not an edit-history undo.** In an app whose rail has a
+   dedicated **Edit** destination for trimming and cutting, a top-level Undo that cannot undo a trim is
+   actively misleading.
+3. **No app shortcut exists for any core action** — no `Ctrl+O` add-videos, no `Space` play/pause, no
+   `I`/`O` in/out, no `Ctrl+E` export, no `Ctrl+,` settings. For a video tool this is the single largest
+   QOL gap.
+
+Positive: CAPTION DEFAULTS' caption-region widget is keyboard-operable — its accessible name is
+*"Caption region — arrow keys move; Tab to a handle then arrow keys to resize"*, with 8 named resize
+handles as real buttons. That pattern should be generalised, not left as an island.
+
+### 4.2 Controls that are live but cannot do anything
+
+- Library **Search videos** and **Sort videos** render enabled with 0 items.
+- Deliver **Template** select is empty and 23 px wide; **Run batch** is correctly `[DISABLED]`, but the
+  screen stacks *three* separate blocked-state messages ("Add videos in your Library first." / "Save a
+  template first." / "Select at least one source and a template to run a batch.").
+- EXPORT PRESETS offers **"Save current settings as"** with no indication of *which* settings are
+  captured — the panel shows no export setting at all, and the name field stretches ~810 px for a short
+  string with placeholder-as-label.
+
+### 4.3 Unexplained jargon with no help affordance
+
+`Capabilities: 10 of 11 installed` (Library) names neither the missing capability nor whether it blocks
+anything. `Lineage view`, `PRO HANDOFF`, `DIARIZATION BACKEND`, `Instant numeric`, `Video-LLM re-rank`,
+`dover-mobile-quality` all appear with no tooltip. `What is Director?` is the only explicit help
+affordance I found in the whole app.
+
+### 4.4 Aggregate health verdicts contradict their own detail
+
+SYSTEM HEALTH prints **"Setup OK"** and `ML BACKENDS (7/8)` while listing `kokoro (TTS) not installed`,
+and reports `llama-server available` under ENGINES while `llama (CUDA)` and `llama (CPU)` both read
+`empty` under MODEL & CACHE PATHS on the same page. UNVERIFIED whether those are genuinely optional —
+settling experiment: run a TTS/dub job and a local-LLM job and see whether either fails against a page
+that said OK.
+
+SETUP and SYSTEM HEALTH also substantially duplicate each other (both answer "is my install OK", with
+different data and different wording).
+
+## 5. Ranked findings
+
+Ranking is by user impact. "Screen · control" then the concrete fix.
+
+### CRITICAL — blocks a task
+
+**C1. Settings ▸ MODELS & SYSTEM opens scrolled ~503 px down, hiding its own title and the entire
+capability list.** Reproduced on two independent fresh entries (Library→Settings, and HEALTH→MODELS):
+the `Models & System` heading reports `y = -258` both times, while the control panel SYSTEM HEALTH reports
+its heading at `y = +269`. Everything above the fold is lost, including `WHAT WORKS RIGHT NOW` and the
+**only** `Download the Multimodal (visual + audio + transcript) model` button — the one control a new user
+needs to enable multimodal moment-finding. This is the default Settings tab, so it is the first thing
+seen. Fix: `app/renderer/src/panels/ModelsSystemPanel.tsx` — find the mount-time `scrollIntoView`/`focus()`
+that pulls the panel down and scope it, or reset `scrollTop` on tab activation.
+UNVERIFIED — the exact triggering call; I inferred it from the reproducible offset and did not read the
+mount effect. Settling experiment: `Ctrl+Shift+I` and log `scrollTop` on the panel's scroll container.
+
+**C2. `Edit ▸ Undo (Ctrl+Z)` promises an undo the app does not have.** Stock Electron text-field role in
+an app with a dedicated Edit destination. Fix: `app/main/main.ts` — install a real
+`Menu.setApplicationMenu` and either wire Undo to a genuine edit-history stack or remove the item.
+
+### HIGH
+
+**H1. DevTools + Force Reload shipped to end users.** `View ▸ Toggle Developer Tools (Ctrl+Shift+I)`,
+`Reload (Ctrl+R)`, `Force Reload (Ctrl+Shift+R)`. Fix: same custom menu in `app/main/main.ts`; gate the
+dev items behind `!app.isPackaged`.
+
+**H2. No application keyboard shortcuts at all** (§4.1). Fix: a custom menu with `Ctrl+O` (Add videos),
+`Ctrl+,` (Settings), `Ctrl+E` (Export), and renderer bindings for `Space` play/pause and `I`/`O` in/out.
+
+**H3. Two identical `Analyze my system` buttons on one panel.** `ModelsSystemPanel.tsx:799-804` (toolbar,
+label cycles `Analyzing…`/`Re-analyze`) and `:842-847` (`empty-state__cta`, always "Analyze my system"),
+both calling the same `analyze()`. Measured live at `552,161` **and** `576,326`. C1 currently hides the
+first one, so **the two defects mask each other** — fixing C1 alone will make the duplicate visible.
+Fix: render the empty-state CTA only when the toolbar button is not visible, or drop one.
+
+**H4. `Capabilities: 10 of 11 installed` names neither the gap nor its consequence.** Fix: name the
+missing capability inline and say what it blocks, with a direct action to install it.
+
+**H5. Deliver leaks unstyled native HTML** — a raw `<fieldset>`/legend and a **23×20 px** `Template`
+select (§3.4). Fix: add a global `select` rule to the token layer; replace the fieldset with a raised
+card.
+
+**H6. `EXPORT PRESETS ▸ Save current settings as` gives no idea what will be saved.** Fix: list the
+captured settings, cap the input width, and use a real label instead of a placeholder.
+
+**H7. The editorial serif is used in 15 places against a documented limit of 1** (§3.1), undetected by the
+conformance suite that already guards the accent.
+
+### MEDIUM
+
+**M1. Primary actions below the fold with no sticky footer** — CAPTION DEFAULTS' `Save defaults` at
+y=1198 in a 673 px viewport (§2).
+**M2. `Edit`'s empty state offers no action at all** — the only one of 8 destinations with no way forward.
+**M3. Four different CTA treatments for the same "you need media" state** (§1).
+**M4. Accent rationing exceeded on every screen** (§3.2).
+**M5. Two label voices, sometimes on one screen** (§3.3).
+**M6. Search + Sort live on an empty Library** (§4.2).
+**M7. Three stacked blocked-state messages on Deliver ▸ BATCH PUBLISH** (§4.2).
+**M8. SETUP and SYSTEM HEALTH duplicate each other** (§4.4).
+**M9. `AI MODEL` and `WHERE JOBS RUN` remain near-identical twins** — same Local/Cloud vocabulary, same
+visual treatment, adjacent. `docs/design-system.md:78-81` records this as already "disambiguated (v1.4)" via a
+seam divider and distinct scope labels; the seam is present, but they still read as one duplicated
+control. Fix: distinguish by form, not only by label.
+**M10. `last checked 575m ago`** — raw minutes instead of a humanised interval.
+**M11. Health verdicts contradict their own detail rows** (§4.4).
+
+### LOW
+
+**L1. Checkbox hit targets 13×14 px** (§3.4), under the WCAG 2.5.8 AA 24×24 minimum; label-extension
+unverified.
+**L2. `REQ LIMITS` meter renders a full-width green bar for `0 req`** — a full bar reads as 100%, and per
+`docs/design-system.md:28` progress should be accent-amber while green means done. UNVERIFIED whether the
+element is a fill or a track; settling experiment: inspect the `<meter>` value/max in DevTools.
+**L3. Placeholder-as-label** on the preset-name field.
+**L4. `← Library` back buttons on sibling rail destinations** mix a hierarchical affordance into a flat
+rail.
+
+## 6. Evidence anchors
+
+1. **Screen · control:** Settings ▸ MODELS & SYSTEM, `Models & System` heading — UIA reports
+   `y = -258` on two fresh entries; SYSTEM HEALTH control reports `y = +269`. (C1)
+2. `app/renderer/src/panels/ModelsSystemPanel.tsx:799-804` and `:842-847` — two buttons, one `analyze()`.
+3. `app/renderer/src/views/director.css:48-56` — `.director-view__title` uses `--font-editorial` at
+   `--type-display-size`; `docs/design-system.md:49` says pull-quotes ONLY.
+4. `app/main/main.ts:13` — electron import list contains no `Menu`; no `setApplicationMenu` under `app/`.
+   Corroborated by a desktop capture of `View` showing `Toggle Developer Tools  Ctrl+Shift+I`.
+5. **Screen · control:** Deliver ▸ BATCH PUBLISH, `Template` select — live bounding box **23×20 px**
+   vs styled peers at 32–33 px; no global `select` rule exists
+   (`app/renderer/src/views/makeShorts.css:34` styles only `.make-shorts__picker select`).


### PR DESCRIPTION
docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it

Five parallel audit units, each writing as it went so a death mid-run would leave a truthful
partial rather than nothing. All five landed. They answer the owner's standing question --
is Reframe working, usable, and is every option working -- with measurements rather than
opinion, and several findings are the MECHANICAL CAUSE of symptoms reported from the app.

WHAT THEY FOUND (headline per lane; the docs carry the evidence)

captions-translation-audit
  * Translation is per-cue and CONTEXT-FREE, on cues already split mid-sentence. That is the
    mechanical cause of "bad translations" -- not model quality.
  * An EN-only punctuation/casing model is applied to ALL languages with no language check,
    so it makes non-English captions worse rather than better.
  * caption.py:640-648 drops six styling parameters on the karaoke path: karaoke captions
    cannot be styled at all.
  * FOUR language vocabularies that disagree -- 19 in languages.ts, a duplicate 9-entry
    dropdown in Transcribe.tsx, 40 in the local MT tier, and the ASR's own set.

editing-surface-audit
  * "Reframe has a large, genuinely good set of clip-level operations and no editor."
  * The tab labelled Timeline is a SUBTITLE-CUE editor; timeline.py registers exactly one
    method, timeline.peaks, returning a waveform.
  * Edit.tsx's empty state promises "trim, cut, join, reframe, caption, and more" that the
    Workspace tab list does not deliver.

uiux-qol-audit (driven against the INSTALLED app, not the dev tree)
  * CRITICAL: Settings > MODELS & SYSTEM opens scrolled ~503 px down, hiding its own title and
    the ONLY "Download the Multimodal model" button -- on the DEFAULT tab, so it is the first
    thing a new user sees. Reproduced on two independent entries.
  * CRITICAL: Edit > Undo (Ctrl+Z) promises an undo the app does not have.

competitor-matrix (16 competitors, every capability cross-checked against real file:line --
closing the prior research's own admitted "did NOT read the repo" gap)
  * FOUR of the top-ten gaps are S-effort UI EXPOSURE of engines that already exist and work:
    silence.trim, audiomix.merge/normalize, hook-title generation, stabilize.run.
  * Own-library B-roll needs only the INSERT step; semantic_index.py + index.search are wired.

distribution-audit
  * Auto-update is already stronger than most commercial tools (Ed25519 over version||sha512).
    The real gap is OS code-signing -- no CSC, so SmartScreen warns.

THE GATE CAUGHT THIS COMMIT

Staging these five files produced 18 violations from .quality/docs_check.py: 5 missing R2 status
lines, 5 unlinked from docs/INDEX.md, and 8 bare `design-system.md` citations. On documents
written MINUTES earlier. That is the anti-drift gate (#338/#339) doing its job on fresh content
instead of the drift being discovered months later, and it is the most direct evidence so far
that r1/r3/r5 earn their place.

Fixed mechanically, driven by the rule rather than by hand: status lines inserted at line 3,
an INDEX.md section added, citations qualified. One residual needed a judgement call --
competitor-matrix.md declared `Status: COMPLETE`, which is not in the gate's closed vocabulary
(DRAFT|ACTIVE|SHIPPED|SUPERSEDED BY|ARCHIVED); rewritten as ACTIVE while preserving the
milestone note, rather than widening the vocabulary to fit one file.

VERIFIED
  docscheck  authority-docs=90 citing-files-scanned=987 waivers-applied=9 ambiguous-bare=10
             r1=0 r2=0 r3=0 r4=0 r5=0  SUCCESS
  charter    6 gates consistent

SCOPE: documentation only. No code changes, no fixes applied. Every finding above is a CLAIM
carrying its own evidence anchor, not a verified repair -- the repairs are separate lanes.
