### PR TITLE
fix(build): ship the GPL ffmpeg, because the LGPL one cannot encode H.264

### DIFF
--- a/app/renderer/src/features/ThirdPartyNotices.test.tsx
+++ b/app/renderer/src/features/ThirdPartyNotices.test.tsx
@@ -14,6 +14,7 @@ import {
   THIRD_PARTY_NOTICES,
   FONT_NOTICES,
   FONT_LICENSE_FILE,
+  FFMPEG_NOTICE,
 } from './ThirdPartyNotices';
 
 let container: HTMLDivElement;
@@ -79,7 +80,11 @@ describe('ThirdPartyNotices', () => {
 
   it('points at the vendored LICENSE files for the two vendored networks', async () => {
     await mount();
-    const files = Array.from(container.querySelectorAll('.tpn__file code')).map(
+    // Scoped to the MODELS list (the section's own direct-child <ul>) so the
+    // "exactly two" invariant keeps meaning "two vendored NETWORKS". The bundled-
+    // programs section below ships its own LICENSE path (ffmpeg's GPL text), which
+    // is a different obligation and is asserted separately.
+    const files = Array.from(container.querySelectorAll('.tpn > .tpn__list .tpn__file code')).map(
       (c) => c.textContent,
     );
     expect(files).toContain('sidecar/media_studio/features/_vinet_s/LICENSE');
@@ -141,5 +146,55 @@ describe('ThirdPartyNotices — bundled fonts (WU-1.5 fonts)', () => {
     expect(FONT_NOTICES.map((f) => f.name)).toEqual(['Inter', 'Newsreader', 'IBM Plex Mono']);
     expect(FONT_NOTICES.every((f) => f.license === 'OFL-1.1')).toBe(true);
     expect(FONT_NOTICES.every((f) => f.commercial)).toBe(true);
+  });
+
+  // --- FFmpeg: a REDISTRIBUTED GPL BINARY, not a model -------------------------
+  // The models above are weights we load; ffmpeg.exe is a whole executable we ship
+  // inside the installer, and it is GPL-3.0-or-later because Reframe needs the
+  // GPL-only libx264 encoder. GPL redistribution obliges an offer of the
+  // CORRESPONDING SOURCE, so the notice must name the exact upstream revision — a
+  // generic "we use FFmpeg" credit does not discharge that.
+  it('names the exact FFmpeg build it redistributes', () => {
+    expect(FFMPEG_NOTICE.license).toBe('GPL-3.0-or-later');
+    expect(FFMPEG_NOTICE.version).toBe('n7.1.5-1-g7d0e842004');
+    expect(FFMPEG_NOTICE.buildTag).toBe('autobuild-2026-06-30-13-34');
+    expect(FFMPEG_NOTICE.asset).toBe('ffmpeg-n7.1.5-1-g7d0e842004-win64-gpl-7.1.zip');
+    // The one-letter difference that caused the defect. If this ever reads
+    // `-lgpl-` again the shipped binary cannot encode H.264 at all.
+    expect(FFMPEG_NOTICE.asset).toContain('-win64-gpl-');
+    expect(FFMPEG_NOTICE.asset).not.toContain('-win64-lgpl-');
+  });
+
+  it('offers the corresponding source at the pinned commit, not just a project link', async () => {
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).toContain('GPL-3.0-or-later');
+    // A source offer has to be reachable and revision-exact.
+    expect(FFMPEG_NOTICE.sourceUrl).toBe('https://github.com/FFmpeg/FFmpeg/tree/7d0e842004');
+    expect(text).toContain(FFMPEG_NOTICE.sourceUrl);
+    expect(text).toContain(FFMPEG_NOTICE.buildScriptsUrl);
+    // ...and the full licence text has to travel with the binary.
+    expect(FFMPEG_NOTICE.licenseFile).toBe('resources/bin/LICENSE.txt');
+    const binaryFiles = Array.from(
+      container.querySelectorAll('.tpn__binaries .tpn__file code'),
+    ).map((c) => c.textContent);
+    expect(binaryFiles).toEqual([FFMPEG_NOTICE.licenseFile]);
+  });
+
+  it('states that shipping GPL ffmpeg does not relicense Reframe, and why', async () => {
+    await mount();
+    const text = container.textContent ?? '';
+    expect(text).toContain('separate child process');
+    expect(FFMPEG_NOTICE.note).toContain('separate child process');
+  });
+
+  it('renders ffmpeg in its own section so the model chip counts are undisturbed', async () => {
+    await mount();
+    expect(container.querySelector('.tpn__binaries')).not.toBeNull();
+    // The pre-existing model/font chip counts are load-bearing assertions above;
+    // a GPL binary is neither "Commercial OK" nor OFL, so it gets its own chip.
+    expect(container.querySelectorAll('.tpn__chip--ok')).toHaveLength(4);
+    expect(container.querySelectorAll('.tpn__chip--ofl')).toHaveLength(3);
+    expect(container.querySelectorAll('.tpn__chip--copyleft')).toHaveLength(1);
   });
 });

--- a/app/renderer/src/features/ThirdPartyNotices.tsx
+++ b/app/renderer/src/features/ThirdPartyNotices.tsx
@@ -158,6 +158,70 @@ export const FONT_NOTICES: readonly FontNotice[] = [
   },
 ];
 
+/**
+ * A REDISTRIBUTED third-party BINARY (an executable shipped inside the installer),
+ * as opposed to a model's weights. Copyleft binaries carry a source-offer
+ * obligation, so this record is revision-exact where a model notice is not.
+ */
+export interface BinaryNotice {
+  /** Display name. */
+  name: string;
+  /** What it does in Reframe (one line). */
+  role: string;
+  /** SPDX license id. */
+  license: string;
+  /** Canonical URL of the license text. */
+  licenseUrl: string;
+  /** Upstream version string, as the binary itself reports it. */
+  version: string;
+  /** The prebuilt-release tag the shipped artifact came from. */
+  buildTag: string;
+  /** The exact release asset file name. */
+  asset: string;
+  /** SHA-256 of that asset (the pin enforced at build-prep time). */
+  sha256: string;
+  /** The corresponding SOURCE at the exact revision — the GPL offer. */
+  sourceUrl: string;
+  /** The build recipe that produced the binary from that source. */
+  buildScriptsUrl: string;
+  /** Where the full license text ships, relative to the install root. */
+  licenseFile: string;
+  /** The obligation/scope callout shown to the user. */
+  note: string;
+}
+
+/**
+ * FFmpeg — the one copyleft BINARY Reframe redistributes.
+ *
+ * Kept in lockstep with `build/python-embed-setup.ps1` ($FfmpegUrl +
+ * $ExpectedFfmpegSha256), `electron-builder.yml`, and the written offer in
+ * `docs/THIRD-PARTY-LICENSES.md`. Re-pinning ffmpeg means editing all four.
+ *
+ * WHY GPL AND NOT LGPL: the software H.264/H.265 encoders are GPL-only, and
+ * `libx264` is the encoder every Reframe export names. The LGPL build shipped
+ * previously was `--disable-libx264`, so every export failed outright. Correcting
+ * the pin to the GPL build is what makes the product work, and it brings the
+ * source-offer obligation this notice discharges.
+ */
+export const FFMPEG_NOTICE: BinaryNotice = {
+  name: 'FFmpeg',
+  role: 'media decode/encode — every import, reframe, caption burn and export',
+  license: 'GPL-3.0-or-later',
+  licenseUrl: 'https://www.gnu.org/licenses/gpl-3.0.html',
+  version: 'n7.1.5-1-g7d0e842004',
+  buildTag: 'autobuild-2026-06-30-13-34',
+  asset: 'ffmpeg-n7.1.5-1-g7d0e842004-win64-gpl-7.1.zip',
+  sha256: '405b190f746db40539eb453967f72c0e69d8bf260b10ceff36e0c2149a9ad22f',
+  sourceUrl: 'https://github.com/FFmpeg/FFmpeg/tree/7d0e842004',
+  buildScriptsUrl: 'https://github.com/BtbN/FFmpeg-Builds',
+  licenseFile: 'resources/bin/LICENSE.txt',
+  note:
+    'Reframe ships this FFmpeg build UNMODIFIED and runs it as a separate child process, ' +
+    'never as a linked library. Reframe’s own source is therefore not covered by the GPL. ' +
+    'You are entitled to the corresponding source for the binary itself, linked above at the ' +
+    'exact revision it was built from.',
+};
+
 /** The Settings → Licenses surface: bundled third-party model attributions. */
 export function ThirdPartyNotices(): React.ReactElement {
   return (
@@ -206,6 +270,52 @@ export function ThirdPartyNotices(): React.ReactElement {
           </li>
         ))}
       </ul>
+      <div className="tpn__binaries">
+        <h3 className="tpn__subtitle">Bundled programs</h3>
+        <p className="tpn__intro">
+          Reframe also ships a complete third-party program inside the installer. Because it is
+          copyleft-licensed, you are entitled to its source code — the exact revision is linked
+          below, and the full license text ships beside the executable.
+        </p>
+        <ul className="tpn__list">
+          <li className="tpn__item" data-license={FFMPEG_NOTICE.license}>
+            <header className="tpn__head">
+              <span className="tpn__name">{FFMPEG_NOTICE.name}</span>
+              <span className="tpn__chip tpn__chip--copyleft" data-commercial="yes">
+                {FFMPEG_NOTICE.license}
+              </span>
+            </header>
+            <p className="tpn__role">{FFMPEG_NOTICE.role}</p>
+            <p className="tpn__attr">
+              Version <code>{FFMPEG_NOTICE.version}</code> · build{' '}
+              <code>{FFMPEG_NOTICE.buildTag}</code>
+            </p>
+            <p className="tpn__license">
+              License:{' '}
+              <a href={FFMPEG_NOTICE.licenseUrl} target="_blank" rel="noreferrer">
+                {FFMPEG_NOTICE.license}
+              </a>{' '}
+              · Source (this exact revision):{' '}
+              <a href={FFMPEG_NOTICE.sourceUrl} target="_blank" rel="noreferrer">
+                {FFMPEG_NOTICE.sourceUrl}
+              </a>
+            </p>
+            <p className="tpn__license">
+              Build scripts:{' '}
+              <a href={FFMPEG_NOTICE.buildScriptsUrl} target="_blank" rel="noreferrer">
+                {FFMPEG_NOTICE.buildScriptsUrl}
+              </a>{' '}
+              · asset <code>{FFMPEG_NOTICE.asset}</code>
+            </p>
+            <p className="tpn__file">
+              Full license: <code>{FFMPEG_NOTICE.licenseFile}</code>
+            </p>
+            <p className="tpn__note" role="note">
+              {FFMPEG_NOTICE.note}
+            </p>
+          </li>
+        </ul>
+      </div>
       <div className="tpn__fonts">
         <h3 className="tpn__subtitle">Bundled fonts</h3>
         <p className="tpn__intro">

--- a/app/renderer/src/features/thirdPartyNotices.css
+++ b/app/renderer/src/features/thirdPartyNotices.css
@@ -99,6 +99,16 @@
   color: var(--status-success);
 }
 
+/* A redistributed COPYLEFT binary (ffmpeg, GPL-3.0-or-later). Deliberately not the
+ * error tint used for ViNet-S: this is not a non-commercial restriction, it is an
+ * obligation we have already discharged (source offer + shipped license text). The
+ * warning tint reads as "carries duties", and the license id is the visible text so
+ * the meaning never depends on hue alone. */
+.tpn__chip--copyleft {
+  background: var(--status-warn-soft);
+  color: var(--status-warn);
+}
+
 .tpn__role {
   margin: 0;
   color: var(--text-secondary);

--- a/build/python-embed-setup.ps1
+++ b/build/python-embed-setup.ps1
@@ -8,8 +8,11 @@
 #   build/python-embed-314/  embeddable CPython 3.14 (+ get-pip.py) — the DEDICATED
 #                            interpreter for the ISOLATED chatterbox voice-clone env
 #                            (torch 2.10 only resolves on py3.14; CONTRACTS.md A4)
-#   build/ffmpeg/win/        ffmpeg.exe + ffprobe.exe + LICENSE   (BtbN win64-LGPL,
-#                            with -WithFfmpeg; shipped to resources/bin/)
+#   build/ffmpeg/win/        ffmpeg.exe + ffprobe.exe + LICENSE   (BtbN win64-GPL,
+#                            with -WithFfmpeg; shipped to resources/bin/). GPL, not
+#                            LGPL: the LGPL build is --disable-libx264, which cannot
+#                            encode the H.264 the whole app asks for. See the
+#                            $FfmpegUrl block below for the full licence reasoning.
 #
 # Everything downloaded is PINNED by exact URL (A6 lesson 5) *and* by SHA-256.
 #
@@ -57,13 +60,38 @@ param(
     # failed here for a DIFFERENT reason than the empty pin. It is live now.
     [string]$ExpectedChatterboxPythonSha256 = '8d4d3590c10449d78aa4375f534e6d5f3027d67fdc362dd1a882279db6f90fdf',
     [switch]$WithFfmpeg,
-    # Pinned ffmpeg build (WU A3): BtbN win64-LGPL STATIC (~138 MB zip). BtbN is
-    # the only mainstream source with a redistribution-safe LGPL static Windows
-    # build (gyan.dev main builds are all --enable-gpl); an UNMODIFIED LGPL exe
-    # invoked as a separate child process is redistribution-safe in a closed-
-    # source app. FFmpeg n7.1.5 line. The extractor below also copies the zip's
-    # LICENSE.txt next to the exes (LGPL obligation: ship the license + record
-    # this exact source tag).
+    # Pinned ffmpeg build (WU A3): BtbN win64-**GPL** STATIC. FFmpeg n7.1.5 line.
+    #
+    # *** WHY GPL, NOT LGPL (corrected 2026-08-08 — the previous rationale shipped a
+    # BROKEN product). *** This pin used to read win64-**lgpl** with the argument that
+    # "an UNMODIFIED LGPL exe invoked as a separate child process is redistribution-safe
+    # in a closed-source app". The licence half of that sentence was fine; the
+    # FUNCTIONAL half was never checked. BtbN's LGPL build is configured
+    # `--disable-libx264 --disable-libx265` (read it off the shipped binary:
+    # `ffmpeg -version` prints the full `configuration:` line), so it CANNOT encode
+    # H.264 in software — while nine sidecar modules and the renderer default pass
+    # `-c:v libx264` as a literal argv element. Measured on the installed 1.5 build:
+    #   -c:v libx264     -> "Unknown encoder 'libx264'", exit 1, NO output file
+    #   -c:v libopenh264 -> output produced
+    # Every gate missed it because CI installs ffmpeg from apt/choco (a GPL build that
+    # HAS libx264) and the packaged e2e never exercised an export.
+    #
+    # The GPL analysis that replaces it: FFmpeg is LGPL-2.1+ by default and
+    # `--enable-gpl` (required for libx264/libx265) makes the resulting BINARY GPL-2+.
+    # Reframe does not link it — `media_studio/ffmpeg.py::resolve_binary` resolves an
+    # absolute path and `run()` spawns it as a SEPARATE CHILD PROCESS over an argv list
+    # (never a library call, never `shell=True`). That is aggregation, not a derived
+    # work, so shipping the unmodified GPL `ffmpeg.exe` does NOT relicense Reframe's own
+    # source. What it DOES oblige is a written offer of the CORRESPONDING SOURCE for the
+    # binary we redistribute: the exact upstream tag + asset + source URL are recorded
+    # here, in electron-builder.yml, and user-facing in the app's Settings -> Licenses
+    # surface (app/renderer/src/features/ThirdPartyNotices.tsx, FFMPEG_NOTICE).
+    #
+    # Deliberately a ONE-DIMENSION change: same BtbN release tag, same ffmpeg commit
+    # (g7d0e842004), same n7.1.5 line, same asset shape — only `-lgpl-` becomes `-gpl-`,
+    # so nothing but the licence/encoder set moves. The extractor below still copies the
+    # zip's LICENSE.txt next to the exes (now the GPL text, which is the stronger
+    # obligation: ship the licence + record this exact source tag).
     #
     # *** PIN A MONTH-END TAG ONLY. *** BtbN's retention is TWO-TIER, and getting
     # this wrong silently breaks the Windows build weeks later:
@@ -75,12 +103,17 @@ param(
     # every Windows CI run. Re-pinned 2026-07-26 to the 2026-06-30 month-end tag,
     # which carries the SAME asset (identical filename + ffmpeg commit
     # g7d0e842004) and is retained for years rather than days.
-    [string]$FfmpegUrl = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n7.1.5-1-g7d0e842004-win64-lgpl-7.1.zip',
+    [string]$FfmpegUrl = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/autobuild-2026-06-30-13-34/ffmpeg-n7.1.5-1-g7d0e842004-win64-gpl-7.1.zip',
     # REQUIRED (WU-S10) when -WithFfmpeg is used: empty => the download is
     # REFUSED. BtbN publishes no per-asset checksum file, so this is the digest of
-    # the exact pinned asset, recorded 2026-07-26 (132 MB; verified to contain
-    # bin/ffmpeg.exe, bin/ffprobe.exe and LICENSE.txt).
-    [string]$ExpectedFfmpegSha256 = 'ec1c6ae03fab10f316344973f83c549b4b662ec3d73f1658353ab1587f4cf727',
+    # the exact pinned asset. RE-RECORDED 2026-08-08 for the win64-GPL asset
+    # (verified to contain bin/ffmpeg.exe, bin/ffprobe.exe and LICENSE.txt, and to
+    # report `--enable-gpl --enable-libx264 --enable-libx265` in its own
+    # `ffmpeg -version` configuration line). The superseded LGPL digest was
+    # ec1c6ae03fab10f316344973f83c549b4b662ec3d73f1658353ab1587f4cf727 — recorded
+    # here so a future reader can tell the two assets apart rather than assuming
+    # the pin merely rotated.
+    [string]$ExpectedFfmpegSha256 = '405b190f746db40539eb453967f72c0e69d8bf260b10ceff36e0c2149a9ad22f',
     [string]$FfmpegDest = (Join-Path (Join-Path $PSScriptRoot 'ffmpeg') 'win'),
     [string]$GetPipUrl = 'https://bootstrap.pypa.io/get-pip.py',
     # get-pip.py is DOWNLOADED then EXECUTED, so it is the most important pin

--- a/build/python-embed-setup.ps1
+++ b/build/python-embed-setup.ps1
@@ -77,7 +77,12 @@ param(
     # HAS libx264) and the packaged e2e never exercised an export.
     #
     # The GPL analysis that replaces it: FFmpeg is LGPL-2.1+ by default and
-    # `--enable-gpl` (required for libx264/libx265) makes the resulting BINARY GPL-2+.
+    # `--enable-gpl` (required for libx264/libx265) makes the resulting BINARY GPL.
+    # This asset is BOTH `--enable-gpl` AND `--enable-version3`, so it is
+    # **GPL-3.0-or-later** specifically -- CHECKED, not inferred: the LICENSE.txt in
+    # the staged zip opens "GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007"
+    # (35,147 B), where the superseded LGPL asset's opened "GNU LESSER GENERAL
+    # PUBLIC LICENSE Version 3" (7,651 B).
     # Reframe does not link it — `media_studio/ffmpeg.py::resolve_binary` resolves an
     # absolute path and `run()` spawns it as a SEPARATE CHILD PROCESS over an argv list
     # (never a library call, never `shell=True`). That is aggregation, not a derived

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -80,6 +80,7 @@ The five facts that get contradicted most often, and the one place each is decid
 | [`CHANGELOG.md`](../CHANGELOG.md) | the only release history; every version in `app/package.json` has a heading. |
 | [`QUALITY-CHARTER.md`](../QUALITY-CHARTER.md) | the only place gate COMPOSITION and tool VERSION PINS are declared. |
 | [`SECURITY.md`](../SECURITY.md) | the only vuln-reporting policy. |
+| [`THIRD-PARTY-LICENSES.md`](THIRD-PARTY-LICENSES.md) | the only record of obligations for REDISTRIBUTED BINARIES, and the home of the GPL written source offer for the bundled FFmpeg. Models/fonts are the in-app Settings → Licenses surface instead. |
 | [`CONTRACTS.md`](../CONTRACTS.md) | DEMOTED. Historical P1/P2 build contract; decides nothing. The wire contract is [`rpc-contract-v2.md`](rpc-contract-v2.md). |
 
 ## Current program — v1.5

--- a/docs/THIRD-PARTY-LICENSES.md
+++ b/docs/THIRD-PARTY-LICENSES.md
@@ -1,0 +1,79 @@
+# Reframe — third-party redistributables and the FFmpeg written source offer
+
+> **Status:** ACTIVE. · **Date:** 2026-08-08
+> **Charter:** the only place Reframe's obligations for REDISTRIBUTED BINARIES are
+> recorded. Bundled ML **models** and **fonts** are a different surface and are owned
+> by `app/renderer/src/features/ThirdPartyNotices.tsx` (Settings → Licenses), which
+> renders them in-app; this file is the binary-redistribution half, and it is where
+> the GPL written offer lives because an offer has to be a durable, quotable text.
+
+## 1. FFmpeg — GPL-3.0-or-later (the written source offer)
+
+Reframe ships **unmodified** `ffmpeg.exe` and `ffprobe.exe` binaries inside the
+Windows installer at `resources/bin/`. They are prebuilt by the BtbN FFmpeg-Builds
+project, and the exact artifact is pinned by URL **and** SHA-256 in
+`build/python-embed-setup.ps1`:
+
+| field | value |
+|---|---|
+| project | [BtbN/FFmpeg-Builds](https://github.com/BtbN/FFmpeg-Builds) |
+| release tag | `autobuild-2026-06-30-13-34` |
+| asset | `ffmpeg-n7.1.5-1-g7d0e842004-win64-gpl-7.1.zip` |
+| asset SHA-256 | `405b190f746db40539eb453967f72c0e69d8bf260b10ceff36e0c2149a9ad22f` |
+| FFmpeg version | `n7.1.5-1-g7d0e842004` (upstream commit `7d0e842004`) |
+| licence | **GPL-3.0-or-later** (`--enable-gpl` **and** `--enable-version3`) |
+| licence text shipped | `resources/bin/LICENSE.txt` (verbatim GNU GPL v3) |
+
+**Written offer.** The corresponding source for these binaries is the FFmpeg source
+at the exact upstream commit above, together with the build recipe that produced
+them. Both are publicly available and permanently fetchable:
+
+- FFmpeg source, exact revision:
+  `https://github.com/FFmpeg/FFmpeg/tree/7d0e842004`
+  (equivalently `git clone https://git.ffmpeg.org/ffmpeg.git && git checkout 7d0e842004`)
+- Upstream project + release page: `https://ffmpeg.org/download.html`
+- The build scripts and Dockerfiles that produced this exact binary:
+  `https://github.com/BtbN/FFmpeg-Builds` at tag `autobuild-2026-06-30-13-34`
+- The GPL-licensed encoder libraries linked into it, notably
+  x264 (`https://code.videolan.org/videolan/x264`) and
+  x265 (`https://bitbucket.org/multicoreware/x265_git`).
+
+If you would prefer to receive the corresponding source on a physical medium rather
+than by download, contact the address in [`SECURITY.md`](../SECURITY.md) and it will
+be provided for no more than the cost of distribution.
+
+**Why GPL and not LGPL — and why that does not relicense Reframe.** FFmpeg is
+LGPL-2.1+ in its default configuration, but the software H.264/H.265 encoders
+(`libx264`, `libx265`) are GPL-only, so a build that has them is GPL. Reframe needs
+`libx264`: it is the encoder every export path names (see
+`media_studio.ffmpeg.H264_ENCODER`). The previously shipped LGPL build was
+configured `--disable-libx264`, which made **every export in the product fail** with
+`Unknown encoder 'libx264'`.
+
+Reframe does not link FFmpeg. The sidecar resolves an absolute path
+(`media_studio/ffmpeg.py::resolve_binary`) and spawns the executable as a **separate
+child process** over an argv list (`media_studio/ffmpeg.py::run`) — no library call,
+no `shell=True`, no FFmpeg code in Reframe's address space. That is aggregation of
+independent works, so the GPL does not extend to Reframe's own source. What it does
+require, and what this section discharges, is that anyone who receives the binary can
+get its corresponding source.
+
+**If you rebuild or re-pin.** Changing `$FfmpegUrl` in
+`build/python-embed-setup.ps1` changes what is redistributed, so the table above and
+the `FFMPEG_NOTICE` entry in `app/renderer/src/features/ThirdPartyNotices.tsx` must
+be updated in the same commit. `sidecar/tests/test_ffmpeg_encoders.py` fails the
+build if the pin drifts back to a `-win64-lgpl-` asset.
+
+## 2. Embeddable CPython — PSF-2.0
+
+`resources/python/` and `resources/python-chatterbox/` are the unmodified
+embeddable CPython distributions from python.org (3.12.10 and 3.14.0), pinned by URL
+and SHA-256 in the same script. The PSF licence text ships with each distribution as
+`LICENSE.txt`. It is a permissive licence with no source-offer obligation.
+
+## 3. Bundled models and fonts
+
+Owned by the in-app Settings → Licenses surface, not by this file:
+`app/renderer/src/features/ThirdPartyNotices.tsx`. It reproduces each model's
+attribution and carries the **non-commercial** callout for ViNet-S
+(CC-BY-NC-SA-4.0), plus the OFL-1.1 notices for the bundled type trio.

--- a/docs/plans/v1.5/techprep-dossier.md
+++ b/docs/plans/v1.5/techprep-dossier.md
@@ -28,10 +28,28 @@ const ffprobePath = path.join(ffmpegDir, 'ffprobe.exe');
 - `extraResources` lands the exes in `process.resourcesPath` — **outside `app.asar`** — so no `asarUnpack` gymnastics and no "can't exec from inside asar" failure. (If instead you use `ffmpeg-static`/`@ffmpeg-installer`, you MUST add `asarUnpack` and rewrite `app.asar` → `app.asar.unpacked` in the returned path.)
 
 ### Licensing / gotcha notes (load-bearing)
-- **LGPL vs GPL is the whole game.** FFmpeg is LGPL 2.1+ by default; `--enable-gpl` (needed for libx264/libx265/libxvid) flips the entire binary to GPL v2+. Invoking an **unmodified LGPL exe as a separate child process** is redistribution-safe in a proprietary app.
+
+> **CORRECTED 2026-08-08 — the LGPL recommendation below was FOLLOWED and it shipped a broken
+> product.** Reframe now pins BtbN's **win64-GPL** asset. Read the bullets below as the record of
+> what was decided and why it was wrong, not as guidance.
+>
+> The reasoning error is worth naming precisely, because the dossier was not missing information —
+> the "Functional cost of LGPL" bullet below states plainly that an LGPL build has **no software
+> `libx264`**. What was never checked is that the *codebase* passes `libx264` as a literal argv
+> element in nine sidecar modules and the renderer export default. The licence analysis and the
+> code were each correct in isolation and nobody joined them, so every export in the shipped 1.5
+> build failed with `Unknown encoder 'libx264'`. A documented cost that no one traced to a caller
+> is indistinguishable from an undocumented one.
+>
+> The bullet's suggested mitigation — "use `hevc_nvenc`/hardware instead rather than shipping GPL"
+> — is also not viable as written: hardware encoders are not present on every machine, so a
+> product that requires one is a product that fails on the machines without it. Current decision
+> and full reasoning: [`../../THIRD-PARTY-LICENSES.md`](../../THIRD-PARTY-LICENSES.md).
+
+- **LGPL vs GPL is the whole game.** FFmpeg is LGPL 2.1+ by default; `--enable-gpl` (needed for libx264/libx265/libxvid) flips the entire binary to GPL v2+. Invoking an **unmodified LGPL exe as a separate child process** is redistribution-safe in a proprietary app. *(Still true — and the same separate-child-process reasoning is exactly what makes shipping the GPL build safe for Reframe's own source. The child-process argument was never the LGPL-specific part.)*
 - **Never use `ffmpeg-static` (eugeneware)** — its package and binaries are GPL-3.0. `@ffmpeg-installer/ffmpeg` (LGPL-2.1) is cleaner but you lose control of the exact build/flags.
 - **LGPL obligations to satisfy:** (a) ship the `LICENSE`/`COPYING` file next to the binaries, (b) don't modify the binaries, (c) record the **exact BtbN release tag** so you can honor the source-availability obligation (a link to that tag suffices in practice).
-- **Functional cost of LGPL:** no software `libx264`/`libx265` encoders. Decoding H.264/H.265 still works. For encoding you get **OpenH264** and hardware encoders (`h264_nvenc`/`hevc_nvenc`/`h264_qsv`/`h264_amf`). If Reframe ever needs software x265, that path is GPL-only — use `hevc_nvenc`/hardware instead rather than shipping GPL.
+- **Functional cost of LGPL:** no software `libx264`/`libx265` encoders. Decoding H.264/H.265 still works. For encoding you get **OpenH264** and hardware encoders (`h264_nvenc`/`hevc_nvenc`/`h264_qsv`/`h264_amf`). If Reframe ever needs software x265, that path is GPL-only — use `hevc_nvenc`/hardware instead rather than shipping GPL. **← THIS IS THE BULLET THAT WAS RIGHT AND IGNORED.** Reframe needs software `libx264` (it is `media_studio.ffmpeg.H264_ENCODER`, hardcoded in nine modules), so the cost was not acceptable and the hardware-encoder mitigation is not portable. Decoding still working is precisely what made the failure invisible until an export was attempted: import, preview and probe all behaved normally.
 - **Patents are orthogonal.** H.264/H.265 carry MPEG-LA royalties independent of GPL/LGPL — confirm separately for commercial distribution.
 - **Size:** budget **~150 MB** for both full static exes; drop to an essentials/reduced LGPL build if the installer is too heavy. Prefer **static over shared** (single self-contained exe, no DLL path juggling).
 

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -81,16 +81,35 @@ extraResources:
   # ChatterboxEngine + bootstrap resolve <resources>/python-chatterbox/python.exe.
   - from: ../build/python-embed-314
     to: python-chatterbox
-  # Bundled ffmpeg/ffprobe (WU A3) — BtbN win64-LGPL STATIC exes, redistribution-
-  # safe in a closed-source app when invoked as a separate child process (LGPL,
-  # unmodified). PINNED release tag: autobuild-2026-07-03-13-21 / asset
-  # ffmpeg-n7.1.5-1-g7d0e842004-win64-lgpl-7.1.zip (staged into build/ffmpeg/win/
+  # Bundled ffmpeg/ffprobe (WU A3) — BtbN win64-**GPL** STATIC exes.
+  # PINNED release tag: autobuild-2026-06-30-13-34 / asset
+  # ffmpeg-n7.1.5-1-g7d0e842004-win64-gpl-7.1.zip (staged into build/ffmpeg/win/
   # by build/python-embed-setup.ps1 -WithFfmpeg). Ships OUTSIDE app.asar via
   # extraResources -> resources/bin/, resolved by ffmpeg.py's _BUNDLED_DIR and by
   # the MEDIA_STUDIO_FFMPEG/FFPROBE env the supervisor injects (WIRING-T5 §2 /
-  # sidecar.ts buildSidecarEnv). LGPL obligation: the BtbN LICENSE.txt is shipped
-  # alongside the exes (the "*.txt" filter below), and the exact source tag is
-  # recorded here + in python-embed-setup.ps1.
+  # sidecar.ts buildSidecarEnv).
+  #
+  # CORRECTED 2026-08-08. This block used to pin the win64-**LGPL** asset and call
+  # it "redistribution-safe in a closed-source app". The licence claim was true but
+  # irrelevant, because that build is configured --disable-libx264 and therefore
+  # CANNOT ENCODE H.264 — which the entire app hardcodes. Every export in the
+  # shipped build failed with "Unknown encoder 'libx264'". Correcting the pin to
+  # GPL is what makes the product work; the reasoning is corrected here rather than
+  # deleted so the trade-off is not silently re-litigated back to LGPL.
+  #
+  # GPL obligation, and why it does NOT reach Reframe's own source: the sidecar
+  # spawns these exes as SEPARATE CHILD PROCESSES over argv lists (media_studio/
+  # ffmpeg.py resolve_binary + run(); no linking, no shell). That is aggregation,
+  # so shipping the unmodified GPL ffmpeg does not relicense Reframe. It DOES
+  # oblige an offer of ffmpeg's corresponding source, discharged three ways:
+  #   1. the BtbN LICENSE.txt travels beside the exes — VERIFIED, not assumed: the
+  #      "*.txt" filter below matches it, and the staged dir contains exactly
+  #      ffmpeg.exe / ffprobe.exe / LICENSE.txt (35,147 B of GPL text; the old LGPL
+  #      asset's was 7,651 B, so this really is the stronger licence's text);
+  #   2. the exact tag + asset + upstream source URL are recorded in
+  #      build/python-embed-setup.ps1 and in the user-facing Settings -> Licenses
+  #      surface (app/renderer/src/features/ThirdPartyNotices.tsx, FFMPEG_NOTICE);
+  #   3. docs/THIRD-PARTY-LICENSES.md carries the written source offer verbatim.
   - from: ../build/ffmpeg/win
     to: bin
     filter:

--- a/sidecar/media_studio/features/self_test.py
+++ b/sidecar/media_studio/features/self_test.py
@@ -16,6 +16,16 @@ Checks (the wire ``id`` the panel keys on):
     ``NATIVE_MODULES_FOR_PREIMPORT`` is likewise ``("cv2",)``).
   * ``asr``    — the Whisper ASR backend (``faster_whisper``) importable.
   * ``ffmpeg`` — ffmpeg + ffprobe resolvable via :mod:`tools_resolver`.
+  * ``encoder`` — the resolved ffmpeg can actually ENCODE H.264
+    (:data:`media_studio.ffmpeg.H264_ENCODER`), not merely exist.
+
+WHY ``encoder`` IS A SEPARATE CHECK FROM ``ffmpeg``. Resolving a binary proves
+presence, not capability, and the 1.5 build shipped exactly that gap: the packaged
+ffmpeg was BtbN's win64-LGPL build (``--disable-libx264``), so this panel reported a
+fully GREEN "Media tools (FFmpeg): ok" on an install where every single export died
+with ``Unknown encoder 'libx264'`` and produced no file. A first-run diagnostic
+whose entire purpose is "never proceed into a broken render" was, for that defect,
+the thing reassuring the user it was fine. Presence alone is not a capability.
 
 Design mirrors :mod:`system_advisor`: PURE verdict builders + injectable probe
 seams (filesystem write, hardware detect, ``importlib.find_spec``, tool resolve).
@@ -27,10 +37,11 @@ from __future__ import annotations
 
 import importlib.util
 import shutil
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
+from .. import ffmpeg as _ffmpeg
 from ..util import get_logger
 
 log = get_logger("media_studio.features.self_test")
@@ -52,6 +63,12 @@ ASR_FIX = "The Whisper engine needs faster-whisper — reinstall the app or run 
 
 FFMPEG_LABEL = "Media tools (FFmpeg)"
 FFMPEG_FIX = "ffmpeg/ffprobe were not found — install FFmpeg and add it to PATH, or set its path in Settings."
+
+ENCODER_LABEL = "Video encoder (H.264)"
+ENCODER_FIX = (
+    "This FFmpeg build cannot encode H.264 — exports will fail. Install a build with libx264 "
+    "(the bundled one has it), or clear the custom FFmpeg path in Settings to fall back to it."
+)
 
 # Probe-key module names (a single import-availability family per dependency).
 #
@@ -172,6 +189,28 @@ def tool_check(
     return CheckResult(check_id, label, False, True, f"not found: {', '.join(missing)}", fix_hint)
 
 
+def encoder_check(*, encoders: Collection[str], error: str = "") -> CheckResult:
+    """Verdict for "can this ffmpeg encode H.264?" (REQUIRED — it blocks ``ok``).
+
+    REQUIRED, not informational, because the failure mode is total: with the
+    encoder missing, every export path in the app raises ``Unknown encoder`` and
+    writes nothing. There is no degraded-but-working state to warn about.
+
+    On failure the detail names the H.264 encoders the binary DOES advertise
+    (``libopenh264``, ``h264_nvenc``, ...). That list is what makes the report
+    actionable — it is the difference between "ffmpeg is broken" and "this build
+    dropped libx264 specifically", which is the actual diagnosis.
+    """
+    if error:
+        return CheckResult("encoder", ENCODER_LABEL, False, True, f"Encoder probe failed: {error}", ENCODER_FIX)
+    if _ffmpeg.H264_ENCODER in encoders:
+        return CheckResult("encoder", ENCODER_LABEL, True, True, f"{_ffmpeg.H264_ENCODER} available.", "")
+    alternatives = sorted(name for name in encoders if "264" in name)
+    found = f" This build offers: {', '.join(alternatives)}." if alternatives else ""
+    detail = f"This FFmpeg build has no {_ffmpeg.H264_ENCODER} encoder.{found}"
+    return CheckResult("encoder", ENCODER_LABEL, False, True, detail, ENCODER_FIX)
+
+
 def build_report(checks: Sequence[CheckResult]) -> SelfTestReport:
     """Roll a list of checks up to the report: ``ok`` iff all REQUIRED checks pass.
 
@@ -268,6 +307,36 @@ def _default_disk_usage(path: Path) -> object:
     return shutil.disk_usage(path)
 
 
+def probe_encoder_set(
+    ffmpeg_path: str | None,
+    *,
+    probe: Callable[[str], Collection[str]] | None = None,
+) -> tuple[frozenset[str], str]:
+    """Ask the RESOLVED ffmpeg what it can encode; return ``(encoders, error)``.
+
+    Takes the already-resolved path so the capability answer describes the SAME
+    binary :func:`tool_check` just reported — resolving again here could probe a
+    different ffmpeg than the one the panel names, which is the measurement error
+    that hid the original defect.
+
+    Fail-open like every other probe in this module: an unresolvable ffmpeg or a
+    probe that raises becomes a reported error string, never an exception.
+    """
+    if not ffmpeg_path:
+        return frozenset(), "ffmpeg was not found, so its encoders could not be probed"
+    probe_fn = probe or _default_encoder_probe
+    try:
+        return frozenset(probe_fn(ffmpeg_path)), ""
+    except Exception as exc:
+        log.debug("encoder probe failed during self-test", exc_info=True)
+        return frozenset(), str(exc)
+
+
+def _default_encoder_probe(ffmpeg_path: str) -> Collection[str]:
+    """Default capability probe: one bounded ``ffmpeg -encoders`` subprocess."""
+    return _ffmpeg.probe_encoders(ffmpeg_path)
+
+
 # --------------------------------------------------------------------------- #
 # end-to-end composition
 # --------------------------------------------------------------------------- #
@@ -279,6 +348,7 @@ def run(
     find_spec: Callable[[str], object] | None = None,
     probe_io: Callable[[Path], str] | None = None,
     disk_usage: Callable[[Path], object] | None = None,
+    probe_encoders: Callable[[str], Collection[str]] | None = None,
 ) -> SelfTestReport:
     """Probe everything and assemble the :class:`SelfTestReport`.
 
@@ -314,7 +384,11 @@ def run(
     tool_paths = {name: resolve_tool(name) for name in _FFMPEG_TOOLS}
     ffmpeg = tool_check("ffmpeg", FFMPEG_LABEL, FFMPEG_FIX, paths=tool_paths, names=_FFMPEG_TOOLS)
 
-    return build_report([data, device, cv2, asr, ffmpeg])
+    # Capability, not presence — probed on the binary `ffmpeg` above just named.
+    encoders, encoder_error = probe_encoder_set(tool_paths.get("ffmpeg"), probe=probe_encoders)
+    encoder = encoder_check(encoders=encoders, error=encoder_error)
+
+    return build_report([data, device, cv2, asr, ffmpeg, encoder])
 
 
 __all__ = [
@@ -324,9 +398,11 @@ __all__ = [
     "data_check",
     "dependency_check",
     "device_check",
+    "encoder_check",
     "probe_data_dir",
     "probe_dependencies",
     "probe_disk_free_mb",
+    "probe_encoder_set",
     "run",
     "tool_check",
 ]

--- a/sidecar/media_studio/ffmpeg.py
+++ b/sidecar/media_studio/ffmpeg.py
@@ -62,6 +62,27 @@ TERMINATE_TIMEOUT_SEC = 5.0
 TREE_KILL_TIMEOUT_SEC = 10.0
 
 
+#: The software H.264 encoder EVERY argv builder in this package hardcodes as a
+#: literal element (features/shortmaker, reframe_claudeshorts, reframe_multispeaker,
+#: stabilize, zoom, brandkit, fillers, media_compat, director_op_engines) and that
+#: the renderer's export/convert defaults request over the wire.
+#:
+#: It is a named constant rather than nine more string literals for ONE reason: a
+#: hardcoded encoder is only correct while the RESOLVED binary actually has it, and
+#: the shipped 1.5 build proved that is not a safe assumption. BtbN's win64-LGPL
+#: ffmpeg is built ``--disable-libx264``, so every export failed with
+#: ``Unknown encoder 'libx264'`` and wrote no file. This constant is the single
+#: place the capability probe below and the setup self-test agree on WHAT to check.
+#:
+#: DELIBERATELY NOT a runtime fallback chain. Substituting ``libopenh264`` (or a
+#: hardware encoder) when libx264 is absent would let an export "succeed" with
+#: silently different rate-control — OpenH264 ignores ``-crf`` entirely — so every
+#: caller's quality contract would change without anyone being told. A loud,
+#: early, actionable failure is the correct behaviour for a missing encoder; the
+#: substitution decision belongs to a human choosing a build, not to the encoder.
+H264_ENCODER = "libx264"
+
+
 class FfmpegNotFound(RuntimeError):
     """Raised when neither a bundled nor a PATH ffmpeg/ffprobe could be found."""
 
@@ -123,6 +144,77 @@ def ffmpeg_path(settings: Mapping[str, Any] | None = None) -> str:
 def ffprobe_path(settings: Mapping[str, Any] | None = None) -> str:
     """Absolute path to the ffprobe binary."""
     return resolve_binary("ffprobe", settings)
+
+
+# ---------------------------------------------------------------------------
+# encoder capability (a PURE parser + one thin, bounded subprocess seam)
+# ---------------------------------------------------------------------------
+def parse_encoders(text: str) -> frozenset[str]:
+    """Parse ``ffmpeg -encoders`` stdout into the set of advertised encoder names.
+
+    The output is a legend block, a ``------`` rule, then one row per encoder::
+
+        Encoders:
+         V..... = Video
+         ...
+         ------
+         V....D libx264              libx264 H.264 / AVC / ... (codec h264)
+
+    Only rows AFTER the rule are encoders, and only the second whitespace-separated
+    column is the name; the six-character flag column is what distinguishes a real
+    row from prose.
+
+    FAILS CLOSED. Unrecognisable input — no rule, a short row, a flag column of the
+    wrong width, empty text — contributes nothing, so a garbled read yields an EMPTY
+    set rather than a guess. That direction matters: the caller treats "encoder
+    absent" as a blocking problem, so a parser that guessed would invent capability
+    the binary may not have and re-open the exact hole this exists to close.
+    """
+    lines = text.splitlines()
+    body: list[str] | None = None
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped and set(stripped) == {"-"}:
+            body = lines[index + 1 :]
+            break
+    if body is None:
+        return frozenset()
+    names: set[str] = set()
+    for line in body:
+        parts = line.split()
+        # parts[0] is the flag column (`V....D`); anything else is not a row.
+        if len(parts) >= 2 and len(parts[0]) == 6:
+            names.add(parts[1])
+    return frozenset(names)
+
+
+def probe_encoders(
+    ffmpeg_bin: str,
+    *,
+    runner: Callable[..., Any] = subprocess.run,
+) -> frozenset[str]:
+    """Ask ONE SPECIFIC ffmpeg binary which encoders it advertises.
+
+    Takes the binary path explicitly rather than re-running :func:`resolve_binary`,
+    so a caller that has already resolved a path (the setup self-test) probes the
+    SAME binary it reported — never a different one that happens to be on PATH.
+    That distinction is the whole point: the defect this closes was invisible
+    precisely because the dev/CI PATH ffmpeg is a different artifact from the
+    packaged one.
+
+    argv list, no shell, bounded by :data:`PROBE_TIMEOUT_SEC`, and fail-closed on a
+    non-zero exit. ``runner`` is injectable so tests never spawn a real process.
+    """
+    result = runner(
+        [ffmpeg_bin, "-hide_banner", "-encoders"],
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=PROBE_TIMEOUT_SEC,
+    )
+    if getattr(result, "returncode", 1) != 0:
+        return frozenset()
+    return parse_encoders(getattr(result, "stdout", "") or "")
 
 
 # ---------------------------------------------------------------------------

--- a/sidecar/tests/fixtures/ffmpeg-encoders-btbn-win64-gpl.txt
+++ b/sidecar/tests/fixtures/ffmpeg-encoders-btbn-win64-gpl.txt
@@ -1,0 +1,238 @@
+Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ .F.... = Frame-level multithreading
+ ..S... = Slice-level multithreading
+ ...X.. = Codec is experimental
+ ....B. = Supports draw_horiz_band
+ .....D = Supports direct rendering method 1
+ ------
+ V....D a64multi             Multicolor charset for Commodore 64 (codec a64_multi)
+ V....D a64multi5            Multicolor charset for Commodore 64, extended with 5th color (colram) (codec a64_multi5)
+ V....D alias_pix            Alias/Wavefront PIX image
+ V..... amv                  AMV Video
+ V....D apng                 APNG (Animated Portable Network Graphics) image
+ V....D asv1                 ASUS V1
+ V....D asv2                 ASUS V2
+ V....D libaom-av1           libaom AV1 (codec av1)
+ V....D librav1e             librav1e AV1 (codec av1)
+ V..... libsvtav1            SVT-AV1(Scalable Video Technology for AV1) encoder (codec av1)
+ V..... av1_qsv              AV1 (Intel Quick Sync Video acceleration) (codec av1)
+ V....D av1_amf              AMD AMF AV1 encoder (codec av1)
+ V....D av1_vaapi            AV1 (VAAPI) (codec av1)
+ V....D avrp                 Avid 1:1 10-bit RGB Packer
+ V....D libxavs2             libxavs2 AVS2-P2/IEEE1857.4 (codec avs2)
+ V..X.D avui                 Avid Meridien Uncompressed
+ VF...D bitpacked            Bitpacked
+ V....D bmp                  BMP (Windows and OS/2 bitmap)
+ VF...D cfhd                 GoPro CineForm HD
+ V....D cinepak              Cinepak
+ V....D cljr                 Cirrus Logic AccuPak
+ V.S..D vc2                  SMPTE VC-2 (codec dirac)
+ VFS..D dnxhd                VC3/DNxHD
+ V....D dpx                  DPX (Digital Picture Exchange) image
+ VFS..D dvvideo              DV (Digital Video)
+ VFS..D dxv                  Resolume DXV
+ VF...D exr                  OpenEXR image
+ V.S..D ffv1                 FFmpeg video codec #1
+ VF...D ffvhuff              Huffyuv FFmpeg variant
+ V....D fits                 Flexible Image Transport System
+ V....D flashsv              Flash Screen Video
+ V....D flashsv2             Flash Screen Video Version 2
+ V..... flv                  FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
+ V....D gif                  GIF (Graphics Interchange Format)
+ V..... h261                 H.261
+ V..... h263                 H.263 / H.263-1996
+ V.S... h263p                H.263+ / H.263-1998 / H.263 version 2
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D libx264rgb           libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
+ V....D libopenh264          OpenH264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D h264_amf             AMD AMF H.264 Encoder (codec h264)
+ V....D h264_mf              H264 via MediaFoundation (codec h264)
+ V....D h264_nvenc           NVIDIA NVENC H.264 encoder (codec h264)
+ V..... h264_qsv             H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (Intel Quick Sync Video acceleration) (codec h264)
+ V....D h264_vaapi           H.264/AVC (VAAPI) (codec h264)
+ V....D h264_vulkan          H.264/AVC (Vulkan) (codec h264)
+ V.S..D hap                  Vidvox Hap
+ VF...D hdr                  HDR (Radiance RGBE format) image
+ V....D libx265              libx265 H.265 / HEVC (codec hevc)
+ V....D hevc_amf             AMD AMF HEVC encoder (codec hevc)
+ V....D hevc_d3d12va         D3D12VA hevc encoder (codec hevc)
+ V....D hevc_mf              HEVC via MediaFoundation (codec hevc)
+ V....D hevc_nvenc           NVIDIA NVENC hevc encoder (codec hevc)
+ V..... hevc_qsv             HEVC (Intel Quick Sync Video acceleration) (codec hevc)
+ V....D hevc_vaapi           H.265/HEVC (VAAPI) (codec hevc)
+ V....D hevc_vulkan          H.265/HEVC (Vulkan) (codec hevc)
+ V....D libkvazaar           libkvazaar H.265 / HEVC (codec hevc)
+ VF...D huffyuv              Huffyuv / HuffYUV
+ VF...D jpeg2000             JPEG 2000
+ VF.... libopenjpeg          OpenJPEG JPEG 2000 (codec jpeg2000)
+ VF...D jpegls               JPEG-LS
+ V....D libjxl               libjxl JPEG XL (codec jpegxl)
+ VF...D ljpeg                Lossless JPEG
+ VFS..D magicyuv             MagicYUV video
+ VFS... mjpeg                MJPEG (Motion JPEG)
+ V..... mjpeg_qsv            MJPEG (Intel Quick Sync Video acceleration) (codec mjpeg)
+ V....D mjpeg_vaapi          MJPEG (VAAPI) (codec mjpeg)
+ V.S... mpeg1video           MPEG-1 video
+ V.S... mpeg2video           MPEG-2 video
+ V..... mpeg2_qsv            MPEG-2 video (Intel Quick Sync Video acceleration) (codec mpeg2video)
+ V....D mpeg2_vaapi          MPEG-2 (VAAPI) (codec mpeg2video)
+ V.S... mpeg4                MPEG-4 part 2
+ V....D libxvid              libxvidcore MPEG-4 part 2 (codec mpeg4)
+ V..... msmpeg4v2            MPEG-4 part 2 Microsoft variant version 2
+ V..... msmpeg4              MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
+ V....D msrle                Microsoft RLE
+ V..... msvideo1             Microsoft Video-1
+ V....D pam                  PAM (Portable AnyMap) image
+ V....D pbm                  PBM (Portable BitMap) image
+ V....D pcx                  PC Paintbrush PCX image
+ V....D pfm                  PFM (Portable FloatMap) image
+ V....D pgm                  PGM (Portable GrayMap) image
+ V....D pgmyuv               PGMYUV (Portable GrayMap YUV) image
+ V....D phm                  PHM (Portable HalfFloatMap) image
+ VF...D png                  PNG (Portable Network Graphics) image
+ V....D ppm                  PPM (Portable PixelMap) image
+ VF...D prores               Apple ProRes
+ VF...D prores_aw            Apple ProRes (codec prores)
+ VFS... prores_ks            Apple ProRes (iCodec Pro) (codec prores)
+ VF...D qoi                  QOI (Quite OK Image format) image
+ V....D qtrle                QuickTime Animation (RLE) video
+ V....D r10k                 AJA Kona 10-bit RGB Codec
+ V....D r210                 Uncompressed RGB 10-bit
+ VF...D rawvideo             raw video
+ V....D roqvideo             id RoQ video (codec roq)
+ V....D rpza                 QuickTime video (RPZA)
+ V..... rv10                 RealVideo 1.0
+ V..... rv20                 RealVideo 2.0
+ V....D sgi                  SGI image
+ V....D smc                  QuickTime Graphics (SMC)
+ V....D snow                 Snow
+ V..... speedhq              NewTek SpeedHQ
+ V....D sunrast              Sun Rasterfile image
+ V....D svq1                 Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
+ V....D targa                Truevision Targa image
+ V....D libtheora            libtheora Theora (codec theora)
+ VF...D tiff                 TIFF image
+ VF...D utvideo              Ut Video
+ VF...D v210                 Uncompressed 4:2:2 10-bit
+ V....D v308                 Uncompressed packed 4:4:4
+ V....D v408                 Uncompressed packed QT 4:4:4:4
+ V....D v410                 Uncompressed 4:4:4 10-bit
+ V.S..D vbn                  Vizrt Binary Image
+ V..... vnull                null video
+ V....D libvpx               libvpx VP8 (codec vp8)
+ V....D vp8_vaapi            VP8 (VAAPI) (codec vp8)
+ V....D libvpx-vp9           libvpx VP9 (codec vp9)
+ V....D vp9_vaapi            VP9 (VAAPI) (codec vp9)
+ V..... vp9_qsv              VP9 video (Intel Quick Sync Video acceleration) (codec vp9)
+ V....D libvvenc             libvvenc H.266 / VVC (codec vvc)
+ VF...D wbmp                 WBMP (Wireless Application Protocol Bitmap) image
+ V....D libwebp_anim         libwebp WebP image (codec webp)
+ V....D libwebp              libwebp WebP image (codec webp)
+ V..... wmv1                 Windows Media Video 7
+ V..... wmv2                 Windows Media Video 8
+ V..... wrapped_avframe      AVFrame to AVPacket passthrough
+ V....D xbm                  XBM (X BitMap) image
+ V....D xface                X-face image
+ V....D xwd                  XWD (X Window Dump) image
+ V....D y41p                 Uncompressed YUV 4:1:1 12-bit
+ V....D yuv4                 Uncompressed packed 4:2:0
+ VF...D zlib                 LCL (LossLess Codec Library) ZLIB
+ V....D zmbv                 Zip Motion Blocks Video
+ A....D aac                  AAC (Advanced Audio Coding)
+ A....D aac_mf               AAC via MediaFoundation (codec aac)
+ A....D ac3                  ATSC A/52A (AC-3)
+ A....D ac3_fixed            ATSC A/52A (AC-3) (codec ac3)
+ A....D ac3_mf               AC3 via MediaFoundation (codec ac3)
+ A....D adpcm_adx            SEGA CRI ADX ADPCM
+ A....D adpcm_argo           ADPCM Argonaut Games
+ A....D g722                 G.722 ADPCM (codec adpcm_g722)
+ A....D g726                 G.726 ADPCM (codec adpcm_g726)
+ A....D g726le               G.726 little endian ADPCM ("right-justified") (codec adpcm_g726le)
+ A....D adpcm_ima_alp        ADPCM IMA High Voltage Software ALP
+ A....D adpcm_ima_amv        ADPCM IMA AMV
+ A....D adpcm_ima_apm        ADPCM IMA Ubisoft APM
+ A....D adpcm_ima_qt         ADPCM IMA QuickTime
+ A....D adpcm_ima_ssi        ADPCM IMA Simon & Schuster Interactive
+ A....D adpcm_ima_wav        ADPCM IMA WAV
+ A....D adpcm_ima_ws         ADPCM IMA Westwood
+ A....D adpcm_ms             ADPCM Microsoft
+ A....D adpcm_swf            ADPCM Shockwave Flash
+ A....D adpcm_yamaha         ADPCM Yamaha
+ A....D alac                 ALAC (Apple Lossless Audio Codec)
+ A....D libopencore_amrnb    OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
+ A..... anull                null audio
+ A....D aptx                 aptX (Audio Processing Technology for Bluetooth)
+ A....D aptx_hd              aptX HD (Audio Processing Technology for Bluetooth)
+ A....D comfortnoise         RFC 3389 comfort noise generator
+ A....D dfpwm                DFPWM1a audio
+ A..X.D dca                  DCA (DTS Coherent Acoustics) (codec dts)
+ A....D eac3                 ATSC A/52 E-AC-3
+ A....D flac                 FLAC (Free Lossless Audio Codec)
+ A....D g723_1               G.723.1
+ A..X.D mlp                  MLP (Meridian Lossless Packing)
+ A....D mp2                  MP2 (MPEG audio layer 2)
+ A....D mp2fixed             MP2 fixed point (MPEG audio layer 2) (codec mp2)
+ A....D libtwolame           libtwolame MP2 (MPEG audio layer 2) (codec mp2)
+ A....D libmp3lame           libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
+ A....D mp3_mf               MP3 via MediaFoundation (codec mp3)
+ A....D nellymoser           Nellymoser Asao
+ A..X.D opus                 Opus
+ A....D libopus              libopus Opus (codec opus)
+ A....D pcm_alaw             PCM A-law / G.711 A-law
+ A....D pcm_bluray           PCM signed 16|20|24-bit big-endian for Blu-ray media
+ A....D pcm_dvd              PCM signed 16|20|24-bit big-endian for DVD media
+ A....D pcm_f32be            PCM 32-bit floating point big-endian
+ A....D pcm_f32le            PCM 32-bit floating point little-endian
+ A....D pcm_f64be            PCM 64-bit floating point big-endian
+ A....D pcm_f64le            PCM 64-bit floating point little-endian
+ A....D pcm_mulaw            PCM mu-law / G.711 mu-law
+ A....D pcm_s16be            PCM signed 16-bit big-endian
+ A....D pcm_s16be_planar     PCM signed 16-bit big-endian planar
+ A....D pcm_s16le            PCM signed 16-bit little-endian
+ A....D pcm_s16le_planar     PCM signed 16-bit little-endian planar
+ A....D pcm_s24be            PCM signed 24-bit big-endian
+ A....D pcm_s24daud          PCM D-Cinema audio signed 24-bit
+ A....D pcm_s24le            PCM signed 24-bit little-endian
+ A....D pcm_s24le_planar     PCM signed 24-bit little-endian planar
+ A....D pcm_s32be            PCM signed 32-bit big-endian
+ A....D pcm_s32le            PCM signed 32-bit little-endian
+ A....D pcm_s32le_planar     PCM signed 32-bit little-endian planar
+ A....D pcm_s64be            PCM signed 64-bit big-endian
+ A....D pcm_s64le            PCM signed 64-bit little-endian
+ A....D pcm_s8               PCM signed 8-bit
+ A....D pcm_s8_planar        PCM signed 8-bit planar
+ A....D pcm_u16be            PCM unsigned 16-bit big-endian
+ A....D pcm_u16le            PCM unsigned 16-bit little-endian
+ A....D pcm_u24be            PCM unsigned 24-bit big-endian
+ A....D pcm_u24le            PCM unsigned 24-bit little-endian
+ A....D pcm_u32be            PCM unsigned 32-bit big-endian
+ A....D pcm_u32le            PCM unsigned 32-bit little-endian
+ A....D pcm_u8               PCM unsigned 8-bit
+ A....D pcm_vidc             PCM Archimedes VIDC
+ A....D real_144             RealAudio 1.0 (14.4K) (codec ra_144)
+ A....D roq_dpcm             id RoQ DPCM
+ A..X.D s302m                SMPTE 302M
+ A....D sbc                  SBC (low-complexity subband codec)
+ A..X.D sonic                Sonic
+ A..X.D sonicls              Sonic lossless
+ A..X.D truehd               TrueHD
+ A....D tta                  TTA (True Audio)
+ A..X.D vorbis               Vorbis
+ A....D libvorbis            libvorbis (codec vorbis)
+ A....D wavpack              WavPack
+ A....D wmav1                Windows Media Audio 1
+ A....D wmav2                Windows Media Audio 2
+ S..... ssa                  ASS (Advanced SubStation Alpha) subtitle (codec ass)
+ S..... ass                  ASS (Advanced SubStation Alpha) subtitle
+ S..... dvbsub               DVB subtitles (codec dvb_subtitle)
+ S..... dvdsub               DVD subtitles (codec dvd_subtitle)
+ S..... mov_text             3GPP Timed Text subtitle
+ S..... srt                  SubRip subtitle (codec subrip)
+ S..... subrip               SubRip subtitle
+ S..... text                 Raw text subtitle
+ S..... ttml                 TTML subtitle
+ S..... webvtt               WebVTT subtitle
+ S..... xsub                 DivX subtitles (XSUB)

--- a/sidecar/tests/fixtures/ffmpeg-encoders-btbn-win64-lgpl.txt
+++ b/sidecar/tests/fixtures/ffmpeg-encoders-btbn-win64-lgpl.txt
@@ -1,0 +1,233 @@
+Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ .F.... = Frame-level multithreading
+ ..S... = Slice-level multithreading
+ ...X.. = Codec is experimental
+ ....B. = Supports draw_horiz_band
+ .....D = Supports direct rendering method 1
+ ------
+ V....D a64multi             Multicolor charset for Commodore 64 (codec a64_multi)
+ V....D a64multi5            Multicolor charset for Commodore 64, extended with 5th color (colram) (codec a64_multi5)
+ V....D alias_pix            Alias/Wavefront PIX image
+ V..... amv                  AMV Video
+ V....D apng                 APNG (Animated Portable Network Graphics) image
+ V....D asv1                 ASUS V1
+ V....D asv2                 ASUS V2
+ V....D libaom-av1           libaom AV1 (codec av1)
+ V....D librav1e             librav1e AV1 (codec av1)
+ V..... libsvtav1            SVT-AV1(Scalable Video Technology for AV1) encoder (codec av1)
+ V..... av1_qsv              AV1 (Intel Quick Sync Video acceleration) (codec av1)
+ V....D av1_amf              AMD AMF AV1 encoder (codec av1)
+ V....D av1_vaapi            AV1 (VAAPI) (codec av1)
+ V....D avrp                 Avid 1:1 10-bit RGB Packer
+ V..X.D avui                 Avid Meridien Uncompressed
+ VF...D bitpacked            Bitpacked
+ V....D bmp                  BMP (Windows and OS/2 bitmap)
+ VF...D cfhd                 GoPro CineForm HD
+ V....D cinepak              Cinepak
+ V....D cljr                 Cirrus Logic AccuPak
+ V.S..D vc2                  SMPTE VC-2 (codec dirac)
+ VFS..D dnxhd                VC3/DNxHD
+ V....D dpx                  DPX (Digital Picture Exchange) image
+ VFS..D dvvideo              DV (Digital Video)
+ VFS..D dxv                  Resolume DXV
+ VF...D exr                  OpenEXR image
+ V.S..D ffv1                 FFmpeg video codec #1
+ VF...D ffvhuff              Huffyuv FFmpeg variant
+ V....D fits                 Flexible Image Transport System
+ V....D flashsv              Flash Screen Video
+ V....D flashsv2             Flash Screen Video Version 2
+ V..... flv                  FLV / Sorenson Spark / Sorenson H.263 (Flash Video) (codec flv1)
+ V....D gif                  GIF (Graphics Interchange Format)
+ V..... h261                 H.261
+ V..... h263                 H.263 / H.263-1996
+ V.S... h263p                H.263+ / H.263-1998 / H.263 version 2
+ V....D libopenh264          OpenH264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D h264_amf             AMD AMF H.264 Encoder (codec h264)
+ V....D h264_mf              H264 via MediaFoundation (codec h264)
+ V....D h264_nvenc           NVIDIA NVENC H.264 encoder (codec h264)
+ V..... h264_qsv             H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (Intel Quick Sync Video acceleration) (codec h264)
+ V....D h264_vaapi           H.264/AVC (VAAPI) (codec h264)
+ V....D h264_vulkan          H.264/AVC (Vulkan) (codec h264)
+ V.S..D hap                  Vidvox Hap
+ VF...D hdr                  HDR (Radiance RGBE format) image
+ V....D hevc_amf             AMD AMF HEVC encoder (codec hevc)
+ V....D hevc_d3d12va         D3D12VA hevc encoder (codec hevc)
+ V....D hevc_mf              HEVC via MediaFoundation (codec hevc)
+ V....D hevc_nvenc           NVIDIA NVENC hevc encoder (codec hevc)
+ V..... hevc_qsv             HEVC (Intel Quick Sync Video acceleration) (codec hevc)
+ V....D hevc_vaapi           H.265/HEVC (VAAPI) (codec hevc)
+ V....D hevc_vulkan          H.265/HEVC (Vulkan) (codec hevc)
+ V....D libkvazaar           libkvazaar H.265 / HEVC (codec hevc)
+ VF...D huffyuv              Huffyuv / HuffYUV
+ VF...D jpeg2000             JPEG 2000
+ VF.... libopenjpeg          OpenJPEG JPEG 2000 (codec jpeg2000)
+ VF...D jpegls               JPEG-LS
+ V....D libjxl               libjxl JPEG XL (codec jpegxl)
+ VF...D ljpeg                Lossless JPEG
+ VFS..D magicyuv             MagicYUV video
+ VFS... mjpeg                MJPEG (Motion JPEG)
+ V..... mjpeg_qsv            MJPEG (Intel Quick Sync Video acceleration) (codec mjpeg)
+ V....D mjpeg_vaapi          MJPEG (VAAPI) (codec mjpeg)
+ V.S... mpeg1video           MPEG-1 video
+ V.S... mpeg2video           MPEG-2 video
+ V..... mpeg2_qsv            MPEG-2 video (Intel Quick Sync Video acceleration) (codec mpeg2video)
+ V....D mpeg2_vaapi          MPEG-2 (VAAPI) (codec mpeg2video)
+ V.S... mpeg4                MPEG-4 part 2
+ V..... msmpeg4v2            MPEG-4 part 2 Microsoft variant version 2
+ V..... msmpeg4              MPEG-4 part 2 Microsoft variant version 3 (codec msmpeg4v3)
+ V....D msrle                Microsoft RLE
+ V..... msvideo1             Microsoft Video-1
+ V....D pam                  PAM (Portable AnyMap) image
+ V....D pbm                  PBM (Portable BitMap) image
+ V....D pcx                  PC Paintbrush PCX image
+ V....D pfm                  PFM (Portable FloatMap) image
+ V....D pgm                  PGM (Portable GrayMap) image
+ V....D pgmyuv               PGMYUV (Portable GrayMap YUV) image
+ V....D phm                  PHM (Portable HalfFloatMap) image
+ VF...D png                  PNG (Portable Network Graphics) image
+ V....D ppm                  PPM (Portable PixelMap) image
+ VF...D prores               Apple ProRes
+ VF...D prores_aw            Apple ProRes (codec prores)
+ VFS... prores_ks            Apple ProRes (iCodec Pro) (codec prores)
+ VF...D qoi                  QOI (Quite OK Image format) image
+ V....D qtrle                QuickTime Animation (RLE) video
+ V....D r10k                 AJA Kona 10-bit RGB Codec
+ V....D r210                 Uncompressed RGB 10-bit
+ VF...D rawvideo             raw video
+ V....D roqvideo             id RoQ video (codec roq)
+ V....D rpza                 QuickTime video (RPZA)
+ V..... rv10                 RealVideo 1.0
+ V..... rv20                 RealVideo 2.0
+ V....D sgi                  SGI image
+ V....D smc                  QuickTime Graphics (SMC)
+ V....D snow                 Snow
+ V..... speedhq              NewTek SpeedHQ
+ V....D sunrast              Sun Rasterfile image
+ V....D svq1                 Sorenson Vector Quantizer 1 / Sorenson Video 1 / SVQ1
+ V....D targa                Truevision Targa image
+ V....D libtheora            libtheora Theora (codec theora)
+ VF...D tiff                 TIFF image
+ VF...D utvideo              Ut Video
+ VF...D v210                 Uncompressed 4:2:2 10-bit
+ V....D v308                 Uncompressed packed 4:4:4
+ V....D v408                 Uncompressed packed QT 4:4:4:4
+ V....D v410                 Uncompressed 4:4:4 10-bit
+ V.S..D vbn                  Vizrt Binary Image
+ V..... vnull                null video
+ V....D libvpx               libvpx VP8 (codec vp8)
+ V....D vp8_vaapi            VP8 (VAAPI) (codec vp8)
+ V....D libvpx-vp9           libvpx VP9 (codec vp9)
+ V....D vp9_vaapi            VP9 (VAAPI) (codec vp9)
+ V..... vp9_qsv              VP9 video (Intel Quick Sync Video acceleration) (codec vp9)
+ V....D libvvenc             libvvenc H.266 / VVC (codec vvc)
+ VF...D wbmp                 WBMP (Wireless Application Protocol Bitmap) image
+ V....D libwebp_anim         libwebp WebP image (codec webp)
+ V....D libwebp              libwebp WebP image (codec webp)
+ V..... wmv1                 Windows Media Video 7
+ V..... wmv2                 Windows Media Video 8
+ V..... wrapped_avframe      AVFrame to AVPacket passthrough
+ V....D xbm                  XBM (X BitMap) image
+ V....D xface                X-face image
+ V....D xwd                  XWD (X Window Dump) image
+ V....D y41p                 Uncompressed YUV 4:1:1 12-bit
+ V....D yuv4                 Uncompressed packed 4:2:0
+ VF...D zlib                 LCL (LossLess Codec Library) ZLIB
+ V....D zmbv                 Zip Motion Blocks Video
+ A....D aac                  AAC (Advanced Audio Coding)
+ A....D aac_mf               AAC via MediaFoundation (codec aac)
+ A....D ac3                  ATSC A/52A (AC-3)
+ A....D ac3_fixed            ATSC A/52A (AC-3) (codec ac3)
+ A....D ac3_mf               AC3 via MediaFoundation (codec ac3)
+ A....D adpcm_adx            SEGA CRI ADX ADPCM
+ A....D adpcm_argo           ADPCM Argonaut Games
+ A....D g722                 G.722 ADPCM (codec adpcm_g722)
+ A....D g726                 G.726 ADPCM (codec adpcm_g726)
+ A....D g726le               G.726 little endian ADPCM ("right-justified") (codec adpcm_g726le)
+ A....D adpcm_ima_alp        ADPCM IMA High Voltage Software ALP
+ A....D adpcm_ima_amv        ADPCM IMA AMV
+ A....D adpcm_ima_apm        ADPCM IMA Ubisoft APM
+ A....D adpcm_ima_qt         ADPCM IMA QuickTime
+ A....D adpcm_ima_ssi        ADPCM IMA Simon & Schuster Interactive
+ A....D adpcm_ima_wav        ADPCM IMA WAV
+ A....D adpcm_ima_ws         ADPCM IMA Westwood
+ A....D adpcm_ms             ADPCM Microsoft
+ A....D adpcm_swf            ADPCM Shockwave Flash
+ A....D adpcm_yamaha         ADPCM Yamaha
+ A....D alac                 ALAC (Apple Lossless Audio Codec)
+ A....D libopencore_amrnb    OpenCORE AMR-NB (Adaptive Multi-Rate Narrow-Band) (codec amr_nb)
+ A..... anull                null audio
+ A....D aptx                 aptX (Audio Processing Technology for Bluetooth)
+ A....D aptx_hd              aptX HD (Audio Processing Technology for Bluetooth)
+ A....D comfortnoise         RFC 3389 comfort noise generator
+ A....D dfpwm                DFPWM1a audio
+ A..X.D dca                  DCA (DTS Coherent Acoustics) (codec dts)
+ A....D eac3                 ATSC A/52 E-AC-3
+ A....D flac                 FLAC (Free Lossless Audio Codec)
+ A....D g723_1               G.723.1
+ A..X.D mlp                  MLP (Meridian Lossless Packing)
+ A....D mp2                  MP2 (MPEG audio layer 2)
+ A....D mp2fixed             MP2 fixed point (MPEG audio layer 2) (codec mp2)
+ A....D libtwolame           libtwolame MP2 (MPEG audio layer 2) (codec mp2)
+ A....D libmp3lame           libmp3lame MP3 (MPEG audio layer 3) (codec mp3)
+ A....D mp3_mf               MP3 via MediaFoundation (codec mp3)
+ A....D nellymoser           Nellymoser Asao
+ A..X.D opus                 Opus
+ A....D libopus              libopus Opus (codec opus)
+ A....D pcm_alaw             PCM A-law / G.711 A-law
+ A....D pcm_bluray           PCM signed 16|20|24-bit big-endian for Blu-ray media
+ A....D pcm_dvd              PCM signed 16|20|24-bit big-endian for DVD media
+ A....D pcm_f32be            PCM 32-bit floating point big-endian
+ A....D pcm_f32le            PCM 32-bit floating point little-endian
+ A....D pcm_f64be            PCM 64-bit floating point big-endian
+ A....D pcm_f64le            PCM 64-bit floating point little-endian
+ A....D pcm_mulaw            PCM mu-law / G.711 mu-law
+ A....D pcm_s16be            PCM signed 16-bit big-endian
+ A....D pcm_s16be_planar     PCM signed 16-bit big-endian planar
+ A....D pcm_s16le            PCM signed 16-bit little-endian
+ A....D pcm_s16le_planar     PCM signed 16-bit little-endian planar
+ A....D pcm_s24be            PCM signed 24-bit big-endian
+ A....D pcm_s24daud          PCM D-Cinema audio signed 24-bit
+ A....D pcm_s24le            PCM signed 24-bit little-endian
+ A....D pcm_s24le_planar     PCM signed 24-bit little-endian planar
+ A....D pcm_s32be            PCM signed 32-bit big-endian
+ A....D pcm_s32le            PCM signed 32-bit little-endian
+ A....D pcm_s32le_planar     PCM signed 32-bit little-endian planar
+ A....D pcm_s64be            PCM signed 64-bit big-endian
+ A....D pcm_s64le            PCM signed 64-bit little-endian
+ A....D pcm_s8               PCM signed 8-bit
+ A....D pcm_s8_planar        PCM signed 8-bit planar
+ A....D pcm_u16be            PCM unsigned 16-bit big-endian
+ A....D pcm_u16le            PCM unsigned 16-bit little-endian
+ A....D pcm_u24be            PCM unsigned 24-bit big-endian
+ A....D pcm_u24le            PCM unsigned 24-bit little-endian
+ A....D pcm_u32be            PCM unsigned 32-bit big-endian
+ A....D pcm_u32le            PCM unsigned 32-bit little-endian
+ A....D pcm_u8               PCM unsigned 8-bit
+ A....D pcm_vidc             PCM Archimedes VIDC
+ A....D real_144             RealAudio 1.0 (14.4K) (codec ra_144)
+ A....D roq_dpcm             id RoQ DPCM
+ A..X.D s302m                SMPTE 302M
+ A....D sbc                  SBC (low-complexity subband codec)
+ A..X.D sonic                Sonic
+ A..X.D sonicls              Sonic lossless
+ A..X.D truehd               TrueHD
+ A....D tta                  TTA (True Audio)
+ A..X.D vorbis               Vorbis
+ A....D libvorbis            libvorbis (codec vorbis)
+ A....D wavpack              WavPack
+ A....D wmav1                Windows Media Audio 1
+ A....D wmav2                Windows Media Audio 2
+ S..... ssa                  ASS (Advanced SubStation Alpha) subtitle (codec ass)
+ S..... ass                  ASS (Advanced SubStation Alpha) subtitle
+ S..... dvbsub               DVB subtitles (codec dvb_subtitle)
+ S..... dvdsub               DVD subtitles (codec dvd_subtitle)
+ S..... mov_text             3GPP Timed Text subtitle
+ S..... srt                  SubRip subtitle (codec subrip)
+ S..... subrip               SubRip subtitle
+ S..... text                 Raw text subtitle
+ S..... ttml                 TTML subtitle
+ S..... webvtt               WebVTT subtitle
+ S..... xsub                 DivX subtitles (XSUB)

--- a/sidecar/tests/test_ffmpeg_encoders.py
+++ b/sidecar/tests/test_ffmpeg_encoders.py
@@ -1,0 +1,351 @@
+"""Encoder-capability regression: the bundled ffmpeg must be able to encode H.264.
+
+WHY THIS FILE EXISTS (the shipped defect it pins). Nine sidecar modules and the
+renderer's export default pass ``libx264`` as a LITERAL argv element, but the
+packaged ffmpeg was BtbN's win64-**LGPL** build, configured
+``--disable-libx264 --disable-libx265``. Every export in the shipped product died
+with ``Unknown encoder 'libx264'`` and produced no output file. The whole gate
+stack was green throughout, because CI installs ffmpeg from apt/choco (a GPL build
+that HAS libx264) while the packaged binary is a different artifact entirely.
+
+So a test that merely runs ``ffmpeg`` off PATH would have stayed green through the
+entire defect and proves nothing. The three layers below each close a different
+half of that blindness:
+
+  1. :func:`test_pin_names_a_gpl_asset` — a HERMETIC read of the build script's
+     own ffmpeg pin. Fails the moment the pin names an ``-lgpl-`` asset again.
+     This is the only layer the Linux CI gate can enforce, and it is the layer
+     that would have caught the original regression at review time.
+  2. The fixture-driven parser/verdict tests — replayed against the REAL captured
+     ``ffmpeg -encoders`` output of BOTH builds (``tests/fixtures/``). The LGPL
+     fixture is the KNOWN-BROKEN state: the detector MUST fire on it. A probe that
+     is silent in both states measures nothing.
+  3. :func:`test_bundled_binary_advertises_the_encoder_we_ask_for` — marked
+     ``e2e`` and pointed at the STAGED/BUNDLED binary specifically (never PATH).
+     Skips where that binary is not staged.
+
+RESIDUAL, stated inline: layer 3 only executes on a host that has actually staged
+``build/ffmpeg/win`` (i.e. the Windows packaging machine); the Linux CI gate skips
+it, so the bundled binary's real capability is NOT proven by CI. Layers 1 and 2 are
+what CI enforces. The settling experiment for closing that gap fully is a packaged
+smoke job that runs the built installer's own ``resources/bin/ffmpeg.exe`` — that
+is a CI-topology change and out of this fix's scope.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+
+import pytest
+from media_studio import ffmpeg
+from media_studio.features import self_test
+
+# tests/ -> sidecar/ -> repo root
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+#: Real captured `ffmpeg -hide_banner -encoders` stdout from the two BtbN builds
+#: of the SAME upstream commit (n7.1.5-1-g7d0e842004). Only the licence build
+#: differs, which is exactly what makes them a clean both-states pair.
+_LGPL_DUMP = _FIXTURES / "ffmpeg-encoders-btbn-win64-lgpl.txt"
+_GPL_DUMP = _FIXTURES / "ffmpeg-encoders-btbn-win64-gpl.txt"
+
+_SETUP_SCRIPT = _REPO_ROOT / "build" / "python-embed-setup.ps1"
+_STAGED_FFMPEG = _REPO_ROOT / "build" / "ffmpeg" / "win" / "ffmpeg.exe"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------- #
+# layer 1 — the pin itself (hermetic; the only layer Linux CI can enforce)
+# --------------------------------------------------------------------------- #
+def test_pin_names_a_gpl_asset() -> None:
+    """The staged ffmpeg pin must name BtbN's GPL asset, not the LGPL one.
+
+    BtbN publishes ``…-win64-lgpl-…zip`` and ``…-win64-gpl-…zip`` side by side and
+    the names differ by ONE letter, so this is a genuinely easy regression to
+    reintroduce. The LGPL asset cannot encode H.264 (``--disable-libx264``), which
+    is the whole defect, so the pin is the load-bearing line.
+    """
+    url_line = next(ln for ln in _read(_SETUP_SCRIPT).splitlines() if "$FfmpegUrl" in ln and "http" in ln)
+    assert "-win64-gpl-" in url_line, f"ffmpeg pin must be the GPL asset, got: {url_line.strip()}"
+    assert "-win64-lgpl-" not in url_line, (
+        "ffmpeg pin points at BtbN's LGPL build, which is --disable-libx264 and "
+        f"CANNOT encode the H.264 this codebase hardcodes: {url_line.strip()}"
+    )
+
+
+def test_pin_carries_a_sha256() -> None:
+    """The pin stays fail-closed: a 64-hex digest, never an empty/placeholder pin."""
+    digest_line = next(ln for ln in _read(_SETUP_SCRIPT).splitlines() if "$ExpectedFfmpegSha256" in ln and "=" in ln)
+    assert re.search(r"'[0-9a-f]{64}'", digest_line), f"ffmpeg sha256 pin must be 64 hex chars: {digest_line.strip()}"
+
+
+# --------------------------------------------------------------------------- #
+# layer 2a — the pure parser, replayed against BOTH real dumps
+# --------------------------------------------------------------------------- #
+def test_parse_encoders_reads_the_real_gpl_dump() -> None:
+    """The GPL build advertises the encoder the argv builders hardcode."""
+    encoders = ffmpeg.parse_encoders(_read(_GPL_DUMP))
+    assert ffmpeg.H264_ENCODER in encoders
+    # Sanity that we parsed a whole table, not one lucky line.
+    assert len(encoders) > 200
+    assert "aac" in encoders and "libx265" in encoders
+
+
+def test_parse_encoders_on_the_known_broken_lgpl_dump() -> None:
+    """THE BOTH-STATES CASE: the LGPL build parses fine and simply lacks libx264.
+
+    This is the state that shipped. The parser must NOT report an empty/garbage
+    read here — that would make the detector's silence meaningless. It parses a
+    full, healthy table that genuinely does not contain the encoder we ask for.
+    """
+    encoders = ffmpeg.parse_encoders(_read(_LGPL_DUMP))
+    assert len(encoders) > 200, "the LGPL dump must parse as a healthy table"
+    assert ffmpeg.H264_ENCODER not in encoders
+    # It can still DECODE h264 and encode via OpenH264/hardware — which is exactly
+    # why the failure was invisible until an export was actually attempted.
+    assert "libopenh264" in encoders
+
+
+def test_parse_encoders_ignores_the_legend_header() -> None:
+    """Rows before the ``------`` separator are legend lines, not encoders."""
+    encoders = ffmpeg.parse_encoders(_read(_GPL_DUMP))
+    assert "=" not in encoders
+    assert "Video" not in encoders
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",  # nothing at all
+        "Encoders:\n V..... = Video\n",  # header only, no separator -> no rows
+        " ------\n",  # separator with no rows
+        " ------\nlonelytoken\n",  # a row with too few columns
+        " ------\n VD libx264 short flags\n",  # flag column the wrong width
+    ],
+)
+def test_parse_encoders_fails_closed(text: str) -> None:
+    """Anything unparseable yields an EMPTY set, never a false positive.
+
+    Fail-closed matters: the verdict below treats "encoder absent" as a problem,
+    so a parser that guessed on garbage would invent capability the binary may
+    not have.
+    """
+    assert ffmpeg.parse_encoders(text) == frozenset()
+
+
+# --------------------------------------------------------------------------- #
+# layer 2b — the subprocess seam (injected runner; no real ffmpeg spawned)
+# --------------------------------------------------------------------------- #
+class _FakeCompleted:
+    def __init__(self, returncode: int, stdout: str) -> None:
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_probe_encoders_uses_an_argv_list_and_the_given_binary() -> None:
+    seen: dict[str, object] = {}
+
+    def runner(argv, **kwargs):
+        seen["argv"] = argv
+        seen["kwargs"] = kwargs
+        return _FakeCompleted(0, _read(_GPL_DUMP))
+
+    got = ffmpeg.probe_encoders("/opt/ff/ffmpeg", runner=runner)
+    assert ffmpeg.H264_ENCODER in got
+    assert seen["argv"] == ["/opt/ff/ffmpeg", "-hide_banner", "-encoders"]
+    # bounded, non-shell, captured — same discipline as every other probe here
+    assert seen["kwargs"]["timeout"] == ffmpeg.PROBE_TIMEOUT_SEC
+    assert seen["kwargs"]["check"] is False
+
+
+def test_probe_encoders_fails_closed_on_a_nonzero_exit() -> None:
+    got = ffmpeg.probe_encoders("/opt/ff/ffmpeg", runner=lambda *_a, **_k: _FakeCompleted(1, _read(_GPL_DUMP)))
+    assert got == frozenset()
+
+
+def test_probe_encoders_fails_closed_on_empty_stdout() -> None:
+    got = ffmpeg.probe_encoders("/opt/ff/ffmpeg", runner=lambda *_a, **_k: _FakeCompleted(0, ""))
+    assert got == frozenset()
+
+
+# --------------------------------------------------------------------------- #
+# layer 2c — the self-test verdict the SETUP panel renders
+# --------------------------------------------------------------------------- #
+def test_encoder_check_passes_on_the_gpl_build() -> None:
+    result = self_test.encoder_check(encoders=ffmpeg.parse_encoders(_read(_GPL_DUMP)))
+    assert result.ok is True
+    assert result.required is True
+    assert result.id == "encoder"
+    assert ffmpeg.H264_ENCODER in result.detail
+    assert result.fix_hint == ""
+
+
+def test_encoder_check_FAILS_on_the_lgpl_build_that_shipped() -> None:
+    """The regression assertion: the exact binary that shipped must be rejected."""
+    result = self_test.encoder_check(encoders=ffmpeg.parse_encoders(_read(_LGPL_DUMP)))
+    assert result.ok is False
+    assert result.required is True, "a build that cannot encode H.264 must BLOCK, not warn"
+    assert ffmpeg.H264_ENCODER in result.detail
+    assert result.fix_hint == self_test.ENCODER_FIX
+
+
+def test_encoder_check_reports_a_probe_error() -> None:
+    result = self_test.encoder_check(encoders=frozenset(), error="ffmpeg was not found")
+    assert result.ok is False
+    assert "ffmpeg was not found" in result.detail
+
+
+def test_encoder_check_names_the_h264_alternatives_it_did_find() -> None:
+    """The fix hint is only actionable if it says what the binary CAN do."""
+    result = self_test.encoder_check(encoders=ffmpeg.parse_encoders(_read(_LGPL_DUMP)))
+    assert "libopenh264" in result.detail
+
+
+# --------------------------------------------------------------------------- #
+# layer 2d — the probe seam inside self_test (fail-open, never raises)
+# --------------------------------------------------------------------------- #
+def test_probe_encoder_set_without_an_ffmpeg_path() -> None:
+    encoders, error = self_test.probe_encoder_set(None)
+    assert encoders == frozenset()
+    assert error
+
+
+def test_probe_encoder_set_degrades_when_the_probe_raises() -> None:
+    def boom(_path: str) -> frozenset[str]:
+        raise OSError("binary is not executable")
+
+    encoders, error = self_test.probe_encoder_set("/opt/ff/ffmpeg", probe=boom)
+    assert encoders == frozenset()
+    assert "not executable" in error
+
+
+def test_probe_encoder_set_returns_the_probed_set() -> None:
+    encoders, error = self_test.probe_encoder_set(
+        "/opt/ff/ffmpeg", probe=lambda _p: ffmpeg.parse_encoders(_read(_GPL_DUMP))
+    )
+    assert ffmpeg.H264_ENCODER in encoders
+    assert error == ""
+
+
+# --------------------------------------------------------------------------- #
+# layer 2e — end-to-end through self_test.run(), the RPC the panel calls
+# --------------------------------------------------------------------------- #
+class _Hw:
+    def detect(self):  # noqa: D102 - trivial stub
+        return type("F", (), {"vram_mb": 1, "ram_mb": 2, "cpu_count": 3, "gpu_present": True})()
+
+
+def _run_report(tmp_path: Path, dump: Path):
+    return self_test.run(
+        data_dir=tmp_path,
+        hardware_probe=_Hw(),
+        resolve_tool=lambda name: f"/opt/ff/{name}",
+        find_spec=lambda _m: object(),
+        probe_encoders=lambda _p: ffmpeg.parse_encoders(_read(dump)),
+    )
+
+
+def test_self_test_run_reports_the_encoder_check(tmp_path: Path) -> None:
+    report = _run_report(tmp_path, _GPL_DUMP)
+    encoder = next(c for c in report.checks if c.id == "encoder")
+    assert encoder.ok is True
+    assert report.ok is True
+
+
+def test_self_test_run_BLOCKS_on_the_lgpl_build(tmp_path: Path) -> None:
+    """A binary that cannot encode H.264 must flip the overall verdict to NOT ok.
+
+    Before this fix the same install reported a fully GREEN self-test — ffmpeg
+    resolved, so the panel said "Media tools (FFmpeg): ok" — while every export
+    failed. That green report is the thing being deleted here.
+    """
+    report = _run_report(tmp_path, _LGPL_DUMP)
+    encoder = next(c for c in report.checks if c.id == "encoder")
+    assert encoder.ok is False
+    assert report.ok is False, "the blocking verdict must reflect an unusable encoder"
+    assert any(ffmpeg.H264_ENCODER in p for p in report.problems)
+    # ...and the presence check STILL passes, which is precisely why presence
+    # alone was never sufficient.
+    assert next(c for c in report.checks if c.id == "ffmpeg").ok is True
+
+
+# --------------------------------------------------------------------------- #
+# layer 3 — the REAL staged binary (opt-in; skipped where it is not staged)
+# --------------------------------------------------------------------------- #
+@pytest.mark.e2e
+@pytest.mark.skipif(
+    not _STAGED_FFMPEG.is_file(),
+    reason=f"bundled ffmpeg not staged at {_STAGED_FFMPEG} (run build/python-embed-setup.ps1 -WithFfmpeg)",
+)
+def test_bundled_binary_advertises_the_encoder_we_ask_for() -> None:
+    """The packaging gate: the BUNDLED binary — not PATH's — must have libx264.
+
+    Deliberately does NOT use ``shutil.which``: resolving ffmpeg off PATH is the
+    exact measurement error that let this ship, because the dev/CI PATH ffmpeg is
+    a GPL build while the packaged one was not.
+    """
+    encoders = ffmpeg.probe_encoders(str(_STAGED_FFMPEG))
+    assert ffmpeg.H264_ENCODER in encoders, (
+        f"{_STAGED_FFMPEG} does not advertise {ffmpeg.H264_ENCODER}; "
+        "the ffmpeg pin is probably back on BtbN's LGPL asset"
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.skipif(not _STAGED_FFMPEG.is_file(), reason="bundled ffmpeg not staged")
+def test_bundled_binary_actually_encodes_h264() -> None:
+    """Advertising an encoder is a claim; producing an H.264 file is the receipt."""
+    ffprobe = _STAGED_FFMPEG.with_name("ffprobe.exe")
+    if not ffprobe.is_file():  # pragma: no cover - staged pair is always complete
+        pytest.skip("bundled ffprobe not staged beside ffmpeg")
+    with tempfile.TemporaryDirectory() as td:
+        clip = Path(td) / "probe.mp4"
+        enc = subprocess.run(
+            [
+                str(_STAGED_FFMPEG),
+                "-hide_banner",
+                "-nostdin",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "testsrc=size=320x240:rate=15:duration=1",
+                "-c:v",
+                ffmpeg.H264_ENCODER,
+                "-pix_fmt",
+                "yuv420p",
+                str(clip),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+        assert enc.returncode == 0, f"encode failed: {enc.stderr[-2000:]}"
+        assert clip.is_file() and clip.stat().st_size > 0
+        probed = subprocess.run(
+            [
+                str(ffprobe),
+                "-v",
+                "error",
+                "-select_streams",
+                "v:0",
+                "-show_entries",
+                "stream=codec_name",
+                "-of",
+                "default=nw=1:nk=1",
+                str(clip),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+        assert probed.stdout.strip() == "h264", probed.stdout

--- a/sidecar/tests/test_handlers_self_test.py
+++ b/sidecar/tests/test_handlers_self_test.py
@@ -14,7 +14,8 @@ from pathlib import Path
 from typing import Any
 
 import pytest
-from media_studio import handlers, tools_resolver
+from media_studio import ffmpeg, handlers, tools_resolver
+from media_studio.features import self_test
 from media_studio.handlers import Services
 from media_studio.protocol import RpcContext
 
@@ -46,11 +47,18 @@ def test_register_all_wires_system_self_test(tmp_path: Path) -> None:
 
 def test_self_test_returns_wire_report(tmp_path: Path, ctx: RpcContext, monkeypatch: Any) -> None:
     monkeypatch.setattr(tools_resolver, "resolve_tool", lambda name, _s=None: f"/usr/bin/{name}")
+    # `resolve_tool` above returns a FICTIONAL path, so the real `ffmpeg -encoders`
+    # seam must be stubbed too — otherwise this test's verdict would depend on
+    # whether the host happens to have a working /usr/bin/ffmpeg, which is true on
+    # the Linux CI runner (apt installs one) and false on a Windows dev box. Stub it
+    # to a capable build; the encoder check's own behaviour is proven in
+    # tests/test_ffmpeg_encoders.py against BOTH real builds' captured output.
+    monkeypatch.setattr(self_test, "_default_encoder_probe", lambda _p: {ffmpeg.H264_ENCODER, "aac"})
     out = _services(tmp_path).system_self_test({}, ctx)
 
     assert set(out) == {"ok", "checks", "problems"}
     assert isinstance(out["ok"], bool)
-    assert [c["id"] for c in out["checks"]] == ["data", "device", "cv2", "asr", "ffmpeg"]
+    assert [c["id"] for c in out["checks"]] == ["data", "device", "cv2", "asr", "ffmpeg", "encoder"]
     a_check = out["checks"][0]
     assert set(a_check) == {"id", "label", "ok", "required", "detail", "fixHint"}
     # The tmp data dir is writable and the injected probe + monkeypatched tools pass.
@@ -58,6 +66,32 @@ def test_self_test_returns_wire_report(tmp_path: Path, ctx: RpcContext, monkeypa
     assert by_id["data"]["ok"] is True
     assert by_id["device"]["ok"] is True
     assert by_id["ffmpeg"]["ok"] is True
+    assert by_id["encoder"]["ok"] is True
+
+
+def test_self_test_surfaces_an_ffmpeg_that_cannot_encode_h264(
+    tmp_path: Path, ctx: RpcContext, monkeypatch: Any
+) -> None:
+    """The shipped-defect shape, end to end over the RPC the panel actually calls.
+
+    ffmpeg RESOLVES fine — so the `ffmpeg` row is green, exactly as it was on the
+    broken 1.5 build — but it cannot encode H.264. The report must still block.
+    """
+    monkeypatch.setattr(tools_resolver, "resolve_tool", lambda name, _s=None: f"/usr/bin/{name}")
+    # The real LGPL build's H.264 story: OpenH264 and hardware, no libx264.
+    monkeypatch.setattr(
+        self_test, "_default_encoder_probe", lambda _p: {"libopenh264", "h264_nvenc", "aac"}
+    )
+    out = _services(tmp_path).system_self_test({}, ctx)
+
+    by_id = {c["id"]: c for c in out["checks"]}
+    assert by_id["ffmpeg"]["ok"] is True, "presence still passes — that is the trap"
+    assert by_id["encoder"]["ok"] is False
+    assert by_id["encoder"]["required"] is True
+    assert out["ok"] is False
+    assert any(ffmpeg.H264_ENCODER in p for p in out["problems"]), out["problems"]
+    # The panel must be able to say WHICH encoders the build does have.
+    assert "libopenh264" in by_id["encoder"]["detail"]
 
 
 def test_self_test_cv2_row_is_green_when_opencv_is_importable(

--- a/sidecar/tests/test_handlers_self_test.py
+++ b/sidecar/tests/test_handlers_self_test.py
@@ -79,9 +79,7 @@ def test_self_test_surfaces_an_ffmpeg_that_cannot_encode_h264(
     """
     monkeypatch.setattr(tools_resolver, "resolve_tool", lambda name, _s=None: f"/usr/bin/{name}")
     # The real LGPL build's H.264 story: OpenH264 and hardware, no libx264.
-    monkeypatch.setattr(
-        self_test, "_default_encoder_probe", lambda _p: {"libopenh264", "h264_nvenc", "aac"}
-    )
+    monkeypatch.setattr(self_test, "_default_encoder_probe", lambda _p: {"libopenh264", "h264_nvenc", "aac"})
     out = _services(tmp_path).system_self_test({}, ctx)
 
     by_id = {c["id"]: c for c in out["checks"]}

--- a/sidecar/tests/test_self_test.py
+++ b/sidecar/tests/test_self_test.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from media_studio import ffmpeg as _ff
 from media_studio.features import self_test as st
 from media_studio.features.system_advisor import HardwareInfo
 from runtime_setup.bootstrap import SIDECAR_REQUIREMENTS, load_requirements
@@ -57,6 +58,12 @@ def _run(tmp_path: Path, **over: Any) -> st.SelfTestReport:
         "resolve_tool": lambda name: f"/usr/bin/{name}",
         "find_spec": _find_spec(_all_present()),
         "disk_usage": _disk(50_000),
+        # `resolve_tool` above hands back a FICTIONAL path, so the real
+        # `ffmpeg -encoders` seam would (correctly) fail on it. Stub the encoder
+        # probe to a capable build so these cases keep testing what they are about.
+        # The encoder check's own behaviour is covered in test_ffmpeg_encoders.py,
+        # against the REAL captured output of both the GPL and LGPL builds.
+        "probe_encoders": lambda _p: {_ff.H264_ENCODER, "aac"},
     }
     base.update(over)
     return st.run(**base)
@@ -70,7 +77,10 @@ def test_ok_path_all_green(tmp_path: Path) -> None:
     assert report.ok is True
     assert report.problems == ()
     assert all(c.ok for c in report.checks)
-    assert [c.id for c in report.checks] == ["data", "device", "cv2", "asr", "ffmpeg"]
+    # `encoder` follows `ffmpeg` deliberately: presence first, then CAPABILITY on
+    # that same resolved binary (a resolvable ffmpeg that cannot encode H.264 is
+    # exactly the state that shipped a fully-green panel over a broken product).
+    assert [c.id for c in report.checks] == ["data", "device", "cv2", "asr", "ffmpeg", "encoder"]
 
 
 def test_missing_cv2_is_reported_with_fix_hint(tmp_path: Path) -> None:


### PR DESCRIPTION
## The shipped product could not export a single video

The packaged ffmpeg is BtbN's win64-**LGPL** build, configured `--disable-libx264
--disable-libx265`. Nine sidecar modules — shortmaker, reframe_claudeshorts,
reframe_multispeaker, stabilize, zoom, brandkit, fillers, media_compat,
director_op_engines — plus the renderer's export/convert defaults pass `libx264` as a
**literal argv element**. So every export in the installed build died with
`Unknown encoder 'libx264'` and wrote no output file.

Same argv, same input, same binary, one token changed:

```
-c:v libx264      -> "Unknown encoder 'libx264'", exit 1, no file
-c:v libopenh264  -> output produced
```

And the binary indicts itself: `ffmpeg -version` on the staged exe prints
`--disable-libx264 --disable-libx265` in its own configuration line.

## Why every gate stayed green

CI installs ffmpeg from apt/choco — a GPL build that *has* libx264 — so the gates
measured a different artifact than the one that ships. `packaged.spec.ts` only asserted
the first-run screen renders; it never exported. **A test that resolves ffmpeg off PATH
is worthless for this defect class**, and that is precisely the test we had.

## The fix

`build/python-embed-setup.ps1` repins to the win64-**GPL** asset of the *same* BtbN
release tag and the *same* ffmpeg commit (`autobuild-2026-06-30-13-34`,
`n7.1.5-1-g7d0e842004`) — a deliberate one-dimension change: only `-lgpl-` becomes
`-gpl-`. The sha256 is re-recorded; the superseded LGPL digest is kept in the comment so
a later reader can tell the two assets apart rather than assume the pin merely rotated.

**The 9 hardcoded literals stay on purpose.** A runtime fallback resolver was considered
and rejected: `libopenh264` ignores `-crf` entirely, so an export that "succeeds" by
substitution would silently change every caller's rate-control contract — a quality
regression nobody is told about, which is strictly harder to detect than the crash it
replaces. Which encoder ships is a decision about which *build* ships; it belongs to a
human, not a fallback chain.

What earns its place instead is making the failure **visible before an export is
attempted**:

- `ffmpeg.H264_ENCODER` — one constant the probe and the self-test agree on
- `ffmpeg.parse_encoders()` — pure parser, **fails closed** (garbage yields an empty set,
  never a guessed capability)
- `ffmpeg.probe_encoders(bin)` — takes the binary path *explicitly*, so it probes the
  binary the caller resolved. Probing PATH is the measurement error that hid this.
- `self_test`: a new required `encoder` check. Presence is not capability — the old panel
  reported a green "Media tools (FFmpeg): ok" on an install where every export failed.

## GPL obligation, discharged in three places

Shipping a copyleft binary is new for this repo, so there was nowhere for the source
offer to live. `docs/THIRD-PARTY-LICENSES.md` carries the written offer revision-exact
(tag, asset, sha256, ffmpeg source commit, BtbN build scripts, x264/x265 sources, plus an
offer of physical media at cost). `ThirdPartyNotices.tsx` renders it in the same panel the
model notices use — *an offer the user cannot reach is not an offer*. The
`electron-builder.yml` comment carries the rationale.

The GPL does **not** reach Reframe's own source: the sidecar spawns ffmpeg as a separate
child process over an argv list (`ffmpeg.py` `resolve_binary` + `run`) — no linking, no
shell, no ffmpeg code in our address space. Aggregation, not a derived work.

Verified rather than asserted: the staged dir holds exactly `ffmpeg.exe` / `ffprobe.exe` /
`LICENSE.txt`, and that file opens *"GNU GENERAL PUBLIC LICENSE Version 3"* at 35,147 B
where the old LGPL asset's opened *"GNU LESSER GENERAL PUBLIC LICENSE"* at 7,651 B. That
check also corrected my own first draft, which said GPL-2+; the asset is `--enable-gpl`
**and** `--enable-version3`, so it is GPL-3.0-or-later and the notice now says exactly that.

## The uncomfortable part

`docs/plans/v1.5/techprep-dossier.md` **already said, verbatim**: *"Functional cost of
LGPL: no software libx264/libx265 encoders."* The information was never missing. What was
missing is that nobody traced that cost to the callers, where `libx264` is a hardcoded
literal in nine modules. The licence analysis and the code were each correct in isolation
and were never joined, so the build shipped. The dossier is corrected in place — with that
failure recorded — rather than quietly edited.

## Red proof

Tests written first and shown red: `pytest tests/test_ffmpeg_encoders.py` before
implementing gave **20 failed, 2 passed**. The 2 passes were the pin tests, passing only
because the pin was already fixed — so those were proven red *separately* by checking out
the pre-fix build script, watching `test_pin_names_a_gpl_asset` fail with the lgpl URL in
its message, then restoring. Both states measured, not just the good one.

Fixture-replayed tests run the parser against the **real captured `-encoders` output of
both builds** (13 KB each, same upstream commit). The LGPL fixture is the known-broken
state and the detector must fire on it.

## Residual (stated in the test module too)

The e2e-marked layer only executes where `build/ffmpeg/win` is staged (the Windows
packaging host); Linux CI skips it, **so CI does not prove the bundled binary's real
capability**. Closing that needs a packaged smoke job running the installer's own
`resources/bin/ffmpeg.exe` — which is exactly what `feat/v15-packaged-journey-gate` does.

## Merge order

**This PR must land before `feat/v15-packaged-journey-gate`.** That branch adds an
encoder-capability gate to the e2e Windows leg which fails while the LGPL pin is still in
`build/python-embed-setup.ps1`. Landing the gate first turns Windows e2e red by design.

## Provenance

This lane was produced by a workflow agent that was killed mid-run by a `401 API key is
invalid` (9 of 11 agents died the same way — a credential-refresh race across concurrent
agents, not a code fault). The commits survived in its worktree and were recovered rather
than re-derived. The one uncommitted change — a `ruff format` result the agent applied but
never got to commit — was re-established by running ruff 0.15.17 (the pre-commit pin)
rather than by eye: it reports the committed wrapped form as "would reformat" and the
collapsed form as "already formatted".
