### PR TITLE
feat(e2e): gate the SHIPPED ffmpeg against the encoders we hardcode

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -230,6 +230,31 @@ jobs:
         # release workflow's job, not this gate's.
         run: npx electron-builder --config ../electron-builder.yml --win --publish never
 
+      # --- ANTI-RECURRENCE: does the ffmpeg we just PACKAGED actually work? ---
+      # v1.4 shipped a bundled ffmpeg (BtbN win64-LGPL, --disable-libx264
+      # --disable-libx265) that cannot encode H.264, while the sidecar hardcodes
+      # the literal token "libx264" at 13 sites across 9 modules. Every export on
+      # the shipped product died with "Unknown encoder 'libx264'", and CI stayed
+      # green the whole time because every ffmpeg-consuming step above installs
+      # ffmpeg from apt/choco — a GPL build that HAS libx264. The gates measured a
+      # binary the user never runs.
+      #
+      # This step probes the binary electron-builder just staged into the package
+      # (resources/bin — the exact path the packaged main wires MEDIA_STUDIO_FFMPEG
+      # to) and fails the leg if it cannot encode what the code demands. It runs
+      # BEFORE the Playwright specs because it is seconds-fast and its failure
+      # explains every downstream export failure at once.
+      #
+      # Not a 7th quality gate: e2e.yml is the dispatch/nightly workflow, so the
+      # closed 6-gate charter (QUALITY-CHARTER.md rule 2) is untouched.
+      - name: Verify the PACKAGED ffmpeg can encode what the pipeline hardcodes
+        if: runner.os == 'Windows'
+        working-directory: sidecar
+        shell: pwsh
+        # Single line on purpose: a PowerShell backtick continuation breaks on any
+        # trailing whitespace, and a CI step is a bad place to discover that.
+        run: python -m media_studio.encoders --ffmpeg "$env:GITHUB_WORKSPACE/dist/win-unpacked/resources/bin/ffmpeg.exe"
+
       - name: E2E GUI — vitest DOM caption + nasty-caption proofs
         working-directory: app
         run: npm run test:e2e:dom

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -341,6 +341,22 @@ export function probePlayable(
 }
 
 /**
+ * The `resources/bin/ffmpeg` that a PACKAGED artifact actually ships and runs.
+ *
+ * electron-builder maps `build/ffmpeg/win -> resources/bin` (electron-builder.yml
+ * extraResources), and the packaged main process points the sidecar at exactly
+ * this path via MEDIA_STUDIO_FFMPEG (`buildSidecarEnv`; see app/main/
+ * sidecar.env.test.ts §A3 — `<resourcesPath>/bin/ffmpeg.exe`). So this is THE
+ * binary a shipped export runs through, and the only one whose capabilities a
+ * packaged smoke may trust. Verified against a real install: an executable at
+ * `D:/Program Files/Reframe/Reframe.exe` yields
+ * `D:/Program Files/Reframe/resources/bin/ffmpeg.exe`.
+ */
+export function bundledFfmpegPath(executablePath: string): string {
+  return join(dirname(executablePath), 'resources', 'bin', `ffmpeg${process.platform === 'win32' ? '.exe' : ''}`);
+}
+
+/**
  * Resolve `ffprobe` for the spec's OWN independent probe of a produced clip.
  * Mirrors generateSample's ffmpeg resolution so the golden journey carries no new
  * precondition beyond the ffmpeg/ffprobe toolchain it already needs: RF_FFPROBE

--- a/app/e2e/packaged.spec.ts
+++ b/app/e2e/packaged.spec.ts
@@ -18,7 +18,16 @@
 // build.
 
 import { test, expect, _electron as electron, type ElectronApplication } from '@playwright/test';
-import { findBuiltApp, seedEnvironment, type SeededEnv } from './fixtures';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import {
+  SIDECAR_DIR,
+  bundledFfmpegPath,
+  findBuiltApp,
+  seedEnvironment,
+  type BuiltApp,
+  type SeededEnv,
+} from './fixtures';
 
 // The packaged artifact is ONLY produced on the Windows leg (electron-builder.yml
 // has a win: target; the embeddable CPython + ffmpeg staging is Windows-only —
@@ -30,6 +39,9 @@ test.describe('packaged (shipped binary) E2E', () => {
 
   let seeded: SeededEnv;
   let app: ElectronApplication;
+  // Kept at suite scope so the artifact-level checks below can reach the
+  // packaged tree (its resources/bin) without re-resolving it.
+  let built: BuiltApp;
   const consoleErrors: string[] = [];
   // Capture the packaged MAIN process stdout/stderr — that is where the spawned
   // sidecar's startup errors (Python ENOENT, import traceback, first-run
@@ -44,7 +56,6 @@ test.describe('packaged (shipped binary) E2E', () => {
     // require a package — preview.spec must stay free to use RF_E2E_DEV.
     const prev = process.env.RF_E2E_REQUIRE_PACKAGED;
     process.env.RF_E2E_REQUIRE_PACKAGED = '1';
-    let built: ReturnType<typeof findBuiltApp>;
     try {
       built = findBuiltApp();
     } finally {
@@ -67,6 +78,50 @@ test.describe('packaged (shipped binary) E2E', () => {
 
   test.afterAll(async () => {
     await app?.close();
+  });
+
+  // ── THE ANTI-RECURRENCE CHECK ────────────────────────────────────────────
+  // v1.4 shipped a bundled ffmpeg (BtbN win64-LGPL, --disable-libx264
+  // --disable-libx265) that cannot encode H.264, while the sidecar passes the
+  // literal token "libx264" to -c:v from 13 sites across 9 modules. Every
+  // export on the shipped product died with "Unknown encoder 'libx264'".
+  //
+  // WHY NOTHING CAUGHT IT — and why this check belongs HERE specifically:
+  // golden-journey.spec.ts DOES independently ffprobe the produced clip for
+  // h264/1080x1920, but it never requires the packaged artifact, so on the
+  // Windows leg (e2e.yml sets RF_E2E_DEV=1) findBuiltApp returns the DEV build.
+  // A dev build leaves MEDIA_STUDIO_FFMPEG unset (sidecar.env.test.ts §A3), so
+  // the sidecar falls through to the choco ffmpeg on PATH — a GPL build that
+  // HAS libx264. The journey's codec assertion was therefore measuring a binary
+  // the user never runs. packaged.spec is the ONLY spec that hard-requires the
+  // real artifact, so it is the only place this can be checked honestly.
+  //
+  // Delegating to `python -m media_studio.encoders` keeps ONE source of truth
+  // for the required-encoder list (media_studio/encoders.py REQUIRED_ENCODERS,
+  // itself kept in sync with the tree by an AST scan) instead of a second,
+  // drift-prone copy in TypeScript.
+  test('the packaged bundled ffmpeg provides every encoder the pipeline hardcodes', () => {
+    const bundled = bundledFfmpegPath(built.executablePath!);
+    expect(
+      existsSync(bundled),
+      `the packaged artifact must ship resources/bin/ffmpeg — missing at ${bundled}`,
+    ).toBe(true);
+
+    const probe = spawnSync(
+      seeded.python,
+      ['-m', 'media_studio.encoders', '--ffmpeg', bundled],
+      { cwd: SIDECAR_DIR, encoding: 'utf8' },
+    );
+    const report = `${probe.stdout ?? ''}${probe.stderr ?? ''}`.trim();
+    // Surface the verdict on green runs too, so the smoke self-documents WHICH
+    // binary it measured — a capability claim that does not name the binary it
+    // probed is unfalsifiable.
+    console.log(`[packaged] encoder-capability report:\n${report}`);
+    expect(
+      probe.status,
+      'the SHIPPED ffmpeg cannot encode what the pipeline hardcodes — every affected ' +
+        `export will fail with "Unknown encoder" on the user's machine.\n${report}`,
+    ).toBe(0);
   });
 
   test('the shipped package reports app.isPackaged === true', async () => {

--- a/sidecar/media_studio/encoders.py
+++ b/sidecar/media_studio/encoders.py
@@ -1,0 +1,275 @@
+"""Encoder-capability gate: can the RESOLVED ffmpeg encode what we hardcode?
+
+THE DEFECT THIS EXISTS TO PREVENT
+---------------------------------
+Reframe v1.4 shipped with a bundled ffmpeg (BtbN win64-**LGPL**, configured
+``--disable-libx264 --disable-libx265``) that cannot encode H.264 -- while nine
+sidecar modules pass the literal string ``libx264`` to ``-c:v``. On the shipped
+product every export died with ``Unknown encoder 'libx264'`` and produced no
+file. Measured on the installed build (same argv, same input, same binary, only
+the encoder token changed): ``-c:v libx264`` -> ``Unknown encoder``;
+``-c:v libopenh264`` -> output produced.
+
+Every gate was green throughout, because CI installs ffmpeg from apt/choco --
+a GPL build that HAS libx264. **The gates measured a binary the user never
+runs.** Unit tests, 100% coverage, and a launching app cannot see this class of
+defect: it lives in the gap between the toolchain CI installs and the toolchain
+that ships.
+
+WHAT THIS MODULE ADDS
+---------------------
+The cheap, deterministic half of the anti-recurrence net: ask the ffmpeg that
+will ACTUALLY be invoked (:func:`media_studio.ffmpeg.resolve_binary` -- the same
+resolution order the pipeline uses) which encoders it lists, and compare that
+against every encoder the source tree hardcodes.
+
+It follows the shape already proven by
+:func:`media_studio.features.stabilize.vidstab_available`, which probes the same
+binary for a missing *filter*. libx264 was the same class of gap with no probe.
+
+Two independent halves, so neither can drift silently:
+
+* :func:`available_encoders` -- what the binary CAN do (runtime probe).
+* :func:`scan_source_encoders` -- what the code DEMANDS (static AST scan).
+
+:data:`REQUIRED_ENCODERS` is the declared contract between them;
+``tests/test_encoders.py`` fails if the tree hardcodes an encoder the contract
+does not list, so a future ``-c:v libsvtav1`` cannot re-open the blind spot.
+
+Runnable three ways, all identical in behaviour:
+
+* ``python -m media_studio.encoders``                       (default resolution)
+* ``python -m media_studio.encoders --ffmpeg <path>``       (a specific binary)
+* imported, via :func:`missing_encoders`                    (in-process)
+
+Exits non-zero with a ``FAILED:encoder-capability`` marker naming the missing
+encoders, or zero with ``SUCCESS:encoder-capability`` (``ci-hygiene.md`` 1:
+terminal marker, fail closed).
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import subprocess
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from . import ffmpeg
+from .util import get_logger
+
+log = get_logger("media_studio.encoders")
+
+#: Root of the shipped Python package -- what :func:`scan_source_encoders` walks.
+PACKAGE_ROOT = Path(__file__).resolve().parent
+
+#: Bound the capability probe. ``ffmpeg -encoders`` is a pure metadata dump
+#: (no input file is opened), so this is generous.
+PROBE_TIMEOUT_SEC = 20.0
+
+#: Every encoder the shipped pipeline passes to ffmpeg as a LITERAL argv token.
+#: Kept in sync with the tree by ``test_required_encoders_covers_every_encoder_
+#: hardcoded_in_the_tree``. Adding an encoder to the code without adding it here
+#: fails that test; adding it here without the bundled ffmpeg supporting it fails
+#: this gate against the package. Both directions are closed.
+#:
+#: Derived from :func:`scan_source_encoders` over the real tree, NOT from memory:
+#:   aac       14 sites (shortmaker, reframe_*, audiomix, fillers, dub, ...)
+#:   libx264   13 sites across 9 modules -- the encoder the LGPL build lacks
+#:   pcm_s16le  2 sites (features/tts/align.py, features/tts/edgetts.py)
+#: ``pcm_s16le`` is a NATIVE ffmpeg encoder (present even in the LGPL build --
+#: verified against the shipped binary), so it is listed for completeness, not
+#: because it is currently at risk.
+REQUIRED_ENCODERS: tuple[str, ...] = ("aac", "libx264", "pcm_s16le")
+
+#: ffmpeg flags whose NEXT argv element names an encoder.
+_STREAM_CODEC_FLAGS = frozenset({"-c:v", "-c:a", "-vcodec", "-acodec"})
+
+#: Option-dict keys whose value names an encoder (``build_convert_argv`` opts).
+_CODEC_KEYS = frozenset({"vcodec", "acodec"})
+
+#: Values that are directives, not encoders -- ``copy`` is a stream copy and
+#: needs no encoder at all.
+_NOT_AN_ENCODER = frozenset({"copy"})
+
+#: Vendored third-party trees. Excluded for the same reason ruff excludes them
+#: (pyproject ``extend-exclude``): they are kept byte-faithful to upstream and
+#: are not part of THIS project's ffmpeg contract.
+_VENDORED = ("_lightasd", "_vinet_s", "_transnetv2")
+
+#: One row of ``ffmpeg -encoders``: six flag characters (``V....D``), the
+#: encoder name, then a description. Anchored on the flag block so the legend
+#: header (`` V..... = Video``) cannot be misread as an encoder named ``=``.
+_ENCODER_ROW = re.compile(r"^\s*[VAS][.A-Z0-9]{5}\s+(?P<name>\S+)\s")
+
+#: A subprocess-runner seam (``subprocess.run``-shaped), injected in tests.
+ProbeRunner = Callable[..., Any]
+
+
+def parse_encoders(text: str) -> frozenset[str]:
+    """Encoder names listed in ``ffmpeg -encoders`` output.
+
+    Rows are only read AFTER the ``------`` separator, so the flag legend above
+    it can never be parsed as an encoder. Unrecognised output yields an empty
+    set -- the gate then reports everything missing rather than waving it
+    through (fail closed).
+    """
+    names: set[str] = set()
+    past_separator = False
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not past_separator:
+            past_separator = bool(stripped) and set(stripped) == {"-"}
+            continue
+        match = _ENCODER_ROW.match(line)
+        if match:
+            names.add(match.group("name"))
+    return frozenset(names)
+
+
+def build_encoders_probe_argv(settings: Mapping[str, Any] | None = None) -> list[str]:
+    """argv for the capability probe against the RESOLVED ffmpeg binary."""
+    return [ffmpeg.ffmpeg_path(settings), "-hide_banner", "-encoders"]
+
+
+def available_encoders(
+    settings: Mapping[str, Any] | None = None,
+    probe_runner: ProbeRunner | None = None,
+) -> frozenset[str]:
+    """Encoders the resolved ffmpeg actually advertises.
+
+    Any failure (no ffmpeg resolvable, spawn error, timeout) yields an EMPTY set
+    so the caller reports the requirement as missing. A probe that cannot run is
+    never evidence that the capability is present. ``probe_runner`` is injected
+    in tests so no real ffmpeg is spawned.
+    """
+    runner = probe_runner if probe_runner is not None else subprocess.run
+    try:
+        argv = build_encoders_probe_argv(settings)
+    except Exception:  # noqa: BLE001 - no ffmpeg resolvable -> nothing available
+        log.warning("ffmpeg not found for the encoder-capability probe")
+        return frozenset()
+    try:
+        completed = runner(argv, capture_output=True, text=True, check=False, timeout=PROBE_TIMEOUT_SEC)
+    except Exception:  # noqa: BLE001 - any spawn failure -> nothing available
+        log.warning("encoder-capability probe failed to spawn ffmpeg")
+        return frozenset()
+    out = (getattr(completed, "stdout", "") or "") + (getattr(completed, "stderr", "") or "")
+    return parse_encoders(out)
+
+
+def missing_encoders(
+    required: Sequence[str] | None = None,
+    settings: Mapping[str, Any] | None = None,
+    probe_runner: ProbeRunner | None = None,
+) -> tuple[str, ...]:
+    """Required encoders the resolved ffmpeg does NOT provide (sorted).
+
+    Empty tuple == the binary can encode everything the pipeline asks of it.
+    """
+    wanted = REQUIRED_ENCODERS if required is None else tuple(required)
+    have = available_encoders(settings, probe_runner=probe_runner)
+    return tuple(sorted(set(wanted) - have))
+
+
+def _literal(node: ast.AST | None) -> str | None:
+    """The value of a string-literal AST node, else ``None`` (dynamic value)."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+def _encoders_in(node: ast.AST) -> list[str]:
+    """Encoder names hardcoded in one AST node.
+
+    Two shapes are recognised, matching how the tree actually spells them:
+    an argv sequence (``[..., "-c:v", "libx264", ...]``) and an options dict
+    (``{"vcodec": "libx264", "acodec": "aac"}``).
+    """
+    found: list[str] = []
+    if isinstance(node, (ast.List, ast.Tuple)):
+        for index, element in enumerate(node.elts[:-1]):
+            flag = _literal(element)
+            if flag in _STREAM_CODEC_FLAGS:
+                value = _literal(node.elts[index + 1])
+                if value:
+                    found.append(value)
+    elif isinstance(node, ast.Dict):
+        for key, value_node in zip(node.keys, node.values, strict=True):
+            if _literal(key) in _CODEC_KEYS:
+                value = _literal(value_node)
+                if value:
+                    found.append(value)
+    return [name for name in found if name not in _NOT_AN_ENCODER]
+
+
+def scan_source_encoders(root: Path | str) -> dict[str, tuple[str, ...]]:
+    """Map every hardcoded encoder name under ``root`` to the sites that use it.
+
+    A STATIC scan (no import, no execution) so it is safe to run over the whole
+    package. Only literal values are reported -- a dynamically-chosen encoder is
+    invisible here by construction, which is a limitation worth stating rather
+    than papering over: this catches the hardcoded case that actually shipped.
+    """
+    base = Path(root)
+    found: dict[str, set[str]] = {}
+    for path in sorted(base.rglob("*.py")):
+        if any(part in _VENDORED for part in path.parts):
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        except (SyntaxError, ValueError, UnicodeDecodeError, OSError):
+            # A malformed or unreadable file must not take the scan down; it
+            # simply contributes nothing.
+            log.warning("encoder scan skipped unparseable file: %s", path.name)
+            continue
+        for node in ast.walk(tree):
+            for name in _encoders_in(node):
+                site = f"{path.relative_to(base).as_posix()}:{getattr(node, 'lineno', 0)}"
+                found.setdefault(name, set()).add(site)
+    return {name: tuple(sorted(sites)) for name, sites in sorted(found.items())}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI gate. 0 == the resolved ffmpeg can encode everything we hardcode.
+
+    Prints the binary it probed: a capability verdict that does not name the
+    binary it measured is unfalsifiable -- and measuring the wrong binary is
+    precisely how the libx264 defect reached users.
+    """
+    parser = argparse.ArgumentParser(
+        prog="media_studio.encoders",
+        description="Verify the resolved ffmpeg provides every encoder the pipeline hardcodes.",
+    )
+    parser.add_argument(
+        "--ffmpeg",
+        default=None,
+        help="ffmpeg binary (or its directory) to probe; default: the app's own resolution order.",
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+
+    settings: dict[str, Any] = {"ffmpegPath": args.ffmpeg} if args.ffmpeg else {}
+    try:
+        resolved = ffmpeg.resolve_binary("ffmpeg", settings)
+    except Exception as exc:  # noqa: BLE001 - unresolvable ffmpeg is a FAILED gate
+        print(f"FAILED:encoder-capability could not resolve ffmpeg ({exc})")
+        return 1
+
+    print(f"encoder-capability: probed {resolved}")
+    missing = missing_encoders(settings=settings)
+    if missing:
+        print(
+            f"FAILED:encoder-capability missing={','.join(missing)} in {resolved} — "
+            "the pipeline passes these as literal -c:v/-c:a tokens, so every affected "
+            "export will die with \"Unknown encoder\". Bundle an ffmpeg built with them."
+        )
+        return 1
+    print(f"SUCCESS:encoder-capability {resolved} provides all of: {', '.join(REQUIRED_ENCODERS)}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — module CLI entry point
+    raise SystemExit(main())

--- a/sidecar/media_studio/encoders.py
+++ b/sidecar/media_studio/encoders.py
@@ -264,7 +264,7 @@ def main(argv: list[str] | None = None) -> int:
         print(
             f"FAILED:encoder-capability missing={','.join(missing)} in {resolved} — "
             "the pipeline passes these as literal -c:v/-c:a tokens, so every affected "
-            "export will die with \"Unknown encoder\". Bundle an ffmpeg built with them."
+            'export will die with "Unknown encoder". Bundle an ffmpeg built with them.'
         )
         return 1
     print(f"SUCCESS:encoder-capability {resolved} provides all of: {', '.join(REQUIRED_ENCODERS)}")

--- a/sidecar/tests/test_encoders.py
+++ b/sidecar/tests/test_encoders.py
@@ -1,0 +1,397 @@
+"""Tests for the encoder-capability gate (``media_studio.encoders``).
+
+WHY THIS SUITE EXISTS
+---------------------
+Reframe shipped a build whose bundled ffmpeg (BtbN win64-**LGPL**, configured
+``--disable-libx264 --disable-libx265``) CANNOT encode H.264, while nine sidecar
+modules pass the literal string ``libx264`` to ``-c:v``. Every export therefore
+died with ``Unknown encoder 'libx264'`` on the shipped product -- and every gate
+was green, because CI installs ffmpeg from apt/choco (a GPL build that HAS
+libx264). The gate measured a binary the user never runs.
+
+The tests below pin the missing check: given the ffmpeg that will actually be
+invoked, does it list every encoder the pipeline hardcodes? The two fixture
+blobs are REAL ``ffmpeg -encoders`` output captured from two real binaries on
+the authoring machine (see the constants), so the parser is exercised against
+the exact bytes it must handle, not an idealised mock.
+
+Fully hermetic: every probe runs through an injected ``probe_runner`` (or a
+monkeypatched ``subprocess.run``), so this suite never spawns ffmpeg and never
+touches the network -- it stays green on a machine with no ffmpeg at all.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import encoders
+
+# --------------------------------------------------------------------------- #
+# REAL captured `ffmpeg -encoders` output (trimmed to the load-bearing lines).
+# --------------------------------------------------------------------------- #
+# Captured from the SHIPPED binary: D:/Program Files/Reframe/resources/bin/ffmpeg.exe
+# ffmpeg n7.1.5-1-g7d0e842004-20260703, configured --disable-libx264 --disable-libx265
+# --enable-libopenh264. This is the state that shipped broken.
+LGPL_ENCODERS = """Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ .F.... = Frame-level multithreading
+ ..S... = Slice-level multithreading
+ ...X.. = Codec is experimental
+ ....B. = Supports draw_horiz_band
+ .....D = Supports direct rendering method 1
+ ------
+ V....D a64multi             Multicolor charset for Commodore 64 (codec a64_multi)
+ V....D libopenh264          OpenH264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D libsvtav1            SVT-AV1(Scalable Video Technology for AV1) encoder
+ A....D aac                  AAC (Advanced Audio Coding)
+ A....D aac_mf               AAC via MediaFoundation (codec aac)
+ A....D pcm_s16le            PCM signed 16-bit little-endian
+ S....D srt                  SubRip subtitle
+"""
+
+# Captured from a GPL build on PATH (WinGet ffmpeg) -- the state CI measures.
+GPL_ENCODERS = """Encoders:
+ V..... = Video
+ A..... = Audio
+ S..... = Subtitle
+ ------
+ V....D libx264              libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 (codec h264)
+ V....D libx264rgb           libx264 H.264 / AVC / MPEG-4 AVC / MPEG-4 part 10 RGB (codec h264)
+ V....D libx265              libx265 H.265 / HEVC (codec hevc)
+ A....D aac                  AAC (Advanced Audio Coding)
+ A....D pcm_s16le            PCM signed 16-bit little-endian
+"""
+
+
+class _ProbeResult:
+    """Minimal ``subprocess.CompletedProcess`` stand-in for the probe seam.
+
+    Deliberately NOT ``test_boundary._FakeCompleted``: that one is a stderr-only
+    stand-in (``__init__(self, stderr)``) for the silencedetect parser, and has
+    no ``stdout``. The encoder listing arrives on stdout on most builds and on
+    stderr on some, so this stub carries both plus a return code.
+    """
+
+    def __init__(self, stdout: str = "", stderr: str = "", returncode: int = 0) -> None:
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def _runner(stdout: str = "", stderr: str = "", returncode: int = 0) -> Any:
+    """A ``probe_runner`` that returns fixed output and records the argv it saw."""
+
+    calls: list[list[str]] = []
+
+    def run(argv: list[str], **_kwargs: Any) -> _ProbeResult:
+        calls.append(list(argv))
+        return _ProbeResult(stdout, stderr, returncode)
+
+    run.calls = calls  # type: ignore[attr-defined]
+    return run
+
+
+# --------------------------------------------------------------------------- #
+# parse_encoders -- the pure parser
+# --------------------------------------------------------------------------- #
+def test_parse_encoders_reads_names_from_the_real_lgpl_listing():
+    got = encoders.parse_encoders(LGPL_ENCODERS)
+    assert "libopenh264" in got
+    assert "aac" in got
+    assert "libsvtav1" in got
+    assert "srt" in got
+
+
+def test_parse_encoders_does_not_invent_libx264_on_the_lgpl_build():
+    """THE REGRESSION: the shipped binary must NOT report libx264."""
+    assert "libx264" not in encoders.parse_encoders(LGPL_ENCODERS)
+
+
+def test_parse_encoders_finds_libx264_on_a_gpl_build():
+    got = encoders.parse_encoders(GPL_ENCODERS)
+    assert "libx264" in got
+    assert "libx265" in got
+
+
+def test_parse_encoders_ignores_the_flag_legend_header():
+    """` V..... = Video` must not be parsed as an encoder named `=`."""
+    got = encoders.parse_encoders(LGPL_ENCODERS)
+    assert "=" not in got
+    assert "Video" not in got
+    assert "Encoders:" not in got
+
+
+def test_parse_encoders_on_empty_text_is_empty():
+    assert encoders.parse_encoders("") == frozenset()
+
+
+def test_parse_encoders_without_a_separator_yields_nothing():
+    """Fail CLOSED: unrecognised output must not be read as `everything is fine`."""
+    assert encoders.parse_encoders("total garbage\nno separator here\n") == frozenset()
+
+
+def test_parse_encoders_skips_non_row_lines_after_the_separator():
+    """A blank line or a wrapped description after `------` is not an encoder."""
+    text = " ------\n\n   continued description text\n V....D real  Real encoder\n"
+    assert encoders.parse_encoders(text) == frozenset({"real"})
+
+
+# --------------------------------------------------------------------------- #
+# build_encoders_probe_argv
+# --------------------------------------------------------------------------- #
+def test_build_probe_argv_targets_the_resolved_binary(tmp_path: Path):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    argv = encoders.build_encoders_probe_argv({"ffmpegPath": str(exe)})
+    assert argv[0] == str(exe)
+    assert "-encoders" in argv
+
+
+def encoders_exe_suffix() -> str:
+    """`.exe` on Windows, empty elsewhere (mirrors ffmpeg._EXE)."""
+    return ".exe" if sys.platform.startswith("win") else ""
+
+
+# --------------------------------------------------------------------------- #
+# available_encoders -- the injected probe
+# --------------------------------------------------------------------------- #
+def test_available_encoders_parses_the_probe_stdout(tmp_path: Path):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    run = _runner(stdout=GPL_ENCODERS)
+    got = encoders.available_encoders({"ffmpegPath": str(exe)}, probe_runner=run)
+    assert "libx264" in got
+
+
+def test_available_encoders_also_reads_stderr(tmp_path: Path):
+    """Some builds print the listing on stderr; both streams are folded."""
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    run = _runner(stdout="", stderr=GPL_ENCODERS)
+    assert "libx264" in encoders.available_encoders({"ffmpegPath": str(exe)}, probe_runner=run)
+
+
+def test_available_encoders_is_empty_when_ffmpeg_cannot_be_resolved(monkeypatch: pytest.MonkeyPatch):
+    """Fail CLOSED: no ffmpeg => no encoders => the gate reports missing."""
+    monkeypatch.setattr(
+        encoders,
+        "build_encoders_probe_argv",
+        lambda *_a, **_k: (_ for _ in ()).throw(RuntimeError("no ffmpeg")),
+    )
+    assert encoders.available_encoders({}, probe_runner=_runner()) == frozenset()
+
+
+def test_available_encoders_is_empty_when_the_probe_raises(tmp_path: Path):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+
+    def boom(_argv: list[str], **_kwargs: Any) -> _ProbeResult:
+        raise OSError("spawn failed")
+
+    assert encoders.available_encoders({"ffmpegPath": str(exe)}, probe_runner=boom) == frozenset()
+
+
+def test_available_encoders_defaults_to_subprocess_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The default runner is subprocess.run (exercises the `is None` arm)."""
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _ProbeResult(stdout=GPL_ENCODERS))
+    assert "libx264" in encoders.available_encoders({"ffmpegPath": str(exe)})
+
+
+# --------------------------------------------------------------------------- #
+# missing_encoders -- the verdict
+# --------------------------------------------------------------------------- #
+def test_missing_encoders_names_libx264_on_the_shipped_lgpl_build(tmp_path: Path):
+    """THE SHIPPED DEFECT, reproduced as a unit assertion."""
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    missing = encoders.missing_encoders(
+        settings={"ffmpegPath": str(exe)}, probe_runner=_runner(stdout=LGPL_ENCODERS)
+    )
+    # EXACTLY libx264: the shipped LGPL build really does provide aac and
+    # pcm_s16le, so a broader "missing" set would mean the parser is wrong
+    # rather than the binary being incapable.
+    assert missing == ("libx264",)
+
+
+def test_missing_encoders_is_empty_on_a_gpl_build(tmp_path: Path):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    missing = encoders.missing_encoders(
+        settings={"ffmpegPath": str(exe)}, probe_runner=_runner(stdout=GPL_ENCODERS)
+    )
+    assert missing == ()
+
+
+def test_missing_encoders_honours_an_explicit_required_set(tmp_path: Path):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    missing = encoders.missing_encoders(
+        required=("libx264", "libvvenc"),
+        settings={"ffmpegPath": str(exe)},
+        probe_runner=_runner(stdout=GPL_ENCODERS),
+    )
+    assert missing == ("libvvenc",)
+
+
+def test_missing_encoders_returns_sorted_output(tmp_path: Path):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    missing = encoders.missing_encoders(
+        required=("zzz", "aaa"),
+        settings={"ffmpegPath": str(exe)},
+        probe_runner=_runner(stdout=GPL_ENCODERS),
+    )
+    assert missing == ("aaa", "zzz")
+
+
+# --------------------------------------------------------------------------- #
+# REQUIRED_ENCODERS <-> the real source tree (anti-drift)
+# --------------------------------------------------------------------------- #
+def test_required_encoders_declares_libx264_and_aac():
+    assert "libx264" in encoders.REQUIRED_ENCODERS
+    assert "aac" in encoders.REQUIRED_ENCODERS
+
+
+def test_scan_source_encoders_finds_the_hardcoded_libx264_in_the_real_tree():
+    """The scanner must SEE the nine modules that hardcode libx264."""
+    found = encoders.scan_source_encoders(encoders.PACKAGE_ROOT)
+    assert "libx264" in found
+    # features/shortmaker.py is one of the known sites (the export stage).
+    assert any("shortmaker" in site for site in found["libx264"])
+
+
+def test_required_encoders_covers_every_encoder_hardcoded_in_the_tree():
+    """ANTI-DRIFT: add a new `-c:v <enc>` anywhere and this fails until declared.
+
+    Without this, a future module could hardcode an encoder the bundled ffmpeg
+    lacks and the capability gate would never look for it -- the exact blind spot
+    that let libx264 ship.
+    """
+    found = set(encoders.scan_source_encoders(encoders.PACKAGE_ROOT))
+    undeclared = sorted(found - set(encoders.REQUIRED_ENCODERS))
+    assert undeclared == [], f"hardcoded but not declared in REQUIRED_ENCODERS: {undeclared}"
+
+
+def test_scan_source_encoders_reads_c_v_argv_literals(tmp_path: Path):
+    (tmp_path / "m.py").write_text('argv = ["ffmpeg", "-c:v", "libtest", "out.mp4"]\n')
+    found = encoders.scan_source_encoders(tmp_path)
+    assert "libtest" in found
+
+
+def test_scan_source_encoders_reads_c_a_argv_literals(tmp_path: Path):
+    (tmp_path / "m.py").write_text('argv = ["ffmpeg", "-c:a", "atest", "out.mp4"]\n')
+    assert "atest" in encoders.scan_source_encoders(tmp_path)
+
+
+def test_scan_source_encoders_reads_vcodec_and_acodec_dict_values(tmp_path: Path):
+    (tmp_path / "m.py").write_text('opts = {"vcodec": "vdict", "acodec": "adict"}\n')
+    found = encoders.scan_source_encoders(tmp_path)
+    assert "vdict" in found
+    assert "adict" in found
+
+
+def test_scan_source_encoders_ignores_copy_and_dynamic_values(tmp_path: Path):
+    """`copy` is a stream-copy directive, not an encoder; non-literals are skipped."""
+    (tmp_path / "m.py").write_text(
+        'a = ["-c:v", "copy"]\nb = ["-c:a", chosen]\nc = {"vcodec": other}\n'
+    )
+    assert encoders.scan_source_encoders(tmp_path) == {}
+
+
+def test_scan_source_encoders_skips_unparseable_files(tmp_path: Path):
+    """A syntactically broken file must not crash the scan."""
+    (tmp_path / "bad.py").write_text("def (((\n")
+    (tmp_path / "ok.py").write_text('a = ["-c:v", "libok"]\n')
+    assert "libok" in encoders.scan_source_encoders(tmp_path)
+
+
+def test_scan_source_encoders_ignores_a_trailing_flag(tmp_path: Path):
+    """`-c:v` as the LAST element has no value to read."""
+    (tmp_path / "m.py").write_text('a = ["ffmpeg", "-c:v"]\n')
+    assert encoders.scan_source_encoders(tmp_path) == {}
+
+
+def test_scan_source_encoders_records_the_site(tmp_path: Path):
+    (tmp_path / "m.py").write_text('a = ["-c:v", "libsite"]\n')
+    sites = encoders.scan_source_encoders(tmp_path)["libsite"]
+    assert any("m.py" in s for s in sites)
+
+
+# --------------------------------------------------------------------------- #
+# main() -- the CLI gate (ci-hygiene.md 1: terminal marker, fail-closed)
+# --------------------------------------------------------------------------- #
+def test_main_fails_and_names_the_missing_encoder_on_the_lgpl_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _ProbeResult(stdout=LGPL_ENCODERS))
+    rc = encoders.main(["--ffmpeg", str(exe)])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAILED:encoder-capability" in out
+    assert "libx264" in out
+
+
+def test_main_succeeds_on_a_gpl_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _ProbeResult(stdout=GPL_ENCODERS))
+    rc = encoders.main(["--ffmpeg", str(exe)])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "SUCCESS:encoder-capability" in out
+
+
+def test_main_reports_the_binary_it_probed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """A gate that does not name the binary it measured is unfalsifiable."""
+    exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
+    exe.write_text("stub")
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _ProbeResult(stdout=GPL_ENCODERS))
+    encoders.main(["--ffmpeg", str(exe)])
+    assert str(exe) in capsys.readouterr().out
+
+
+def test_main_with_no_args_probes_the_default_resolution(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _ProbeResult(stdout=GPL_ENCODERS))
+    monkeypatch.setattr(encoders.ffmpeg, "resolve_binary", lambda *_a, **_k: "ffmpeg")
+    assert encoders.main([]) == 0
+    assert "SUCCESS:encoder-capability" in capsys.readouterr().out
+
+
+def test_main_fails_closed_when_ffmpeg_is_unresolvable(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+):
+    """No ffmpeg at all is a FAILED gate, never a silent pass."""
+
+    def unresolvable(*_a: Any, **_k: Any) -> str:
+        raise encoders.ffmpeg.FfmpegNotFound("nope")
+
+    monkeypatch.setattr(encoders.ffmpeg, "resolve_binary", unresolvable)
+    rc = encoders.main([])
+    out = capsys.readouterr().out
+    assert rc == 1
+    assert "FAILED:encoder-capability" in out
+
+
+def test_main_defaults_argv_to_sys_argv(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]):
+    """`argv=None` reads sys.argv[1:] (the `python -m` entry point)."""
+    monkeypatch.setattr(sys, "argv", ["media_studio.encoders"])
+    monkeypatch.setattr(subprocess, "run", lambda *_a, **_k: _ProbeResult(stdout=GPL_ENCODERS))
+    monkeypatch.setattr(encoders.ffmpeg, "resolve_binary", lambda *_a, **_k: "ffmpeg")
+    assert encoders.main() == 0
+    assert "SUCCESS:encoder-capability" in capsys.readouterr().out

--- a/sidecar/tests/test_encoders.py
+++ b/sidecar/tests/test_encoders.py
@@ -212,9 +212,7 @@ def test_missing_encoders_names_libx264_on_the_shipped_lgpl_build(tmp_path: Path
     """THE SHIPPED DEFECT, reproduced as a unit assertion."""
     exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
     exe.write_text("stub")
-    missing = encoders.missing_encoders(
-        settings={"ffmpegPath": str(exe)}, probe_runner=_runner(stdout=LGPL_ENCODERS)
-    )
+    missing = encoders.missing_encoders(settings={"ffmpegPath": str(exe)}, probe_runner=_runner(stdout=LGPL_ENCODERS))
     # EXACTLY libx264: the shipped LGPL build really does provide aac and
     # pcm_s16le, so a broader "missing" set would mean the parser is wrong
     # rather than the binary being incapable.
@@ -224,9 +222,7 @@ def test_missing_encoders_names_libx264_on_the_shipped_lgpl_build(tmp_path: Path
 def test_missing_encoders_is_empty_on_a_gpl_build(tmp_path: Path):
     exe = tmp_path / f"ffmpeg{encoders_exe_suffix()}"
     exe.write_text("stub")
-    missing = encoders.missing_encoders(
-        settings={"ffmpegPath": str(exe)}, probe_runner=_runner(stdout=GPL_ENCODERS)
-    )
+    missing = encoders.missing_encoders(settings={"ffmpegPath": str(exe)}, probe_runner=_runner(stdout=GPL_ENCODERS))
     assert missing == ()
 
 
@@ -300,9 +296,7 @@ def test_scan_source_encoders_reads_vcodec_and_acodec_dict_values(tmp_path: Path
 
 def test_scan_source_encoders_ignores_copy_and_dynamic_values(tmp_path: Path):
     """`copy` is a stream-copy directive, not an encoder; non-literals are skipped."""
-    (tmp_path / "m.py").write_text(
-        'a = ["-c:v", "copy"]\nb = ["-c:a", chosen]\nc = {"vcodec": other}\n'
-    )
+    (tmp_path / "m.py").write_text('a = ["-c:v", "copy"]\nb = ["-c:a", chosen]\nc = {"vcodec": other}\n')
     assert encoders.scan_source_encoders(tmp_path) == {}
 
 


### PR DESCRIPTION
## The oracle already existed. It was aimed at the wrong binary.

This lane was scoped as "build a packaged golden-journey smoke". It turned out
`app/e2e/golden-journey.spec.ts` already exists (329 lines) and already ends in a
deterministic independent `ffprobe` postcondition — exact 1080x1920, h264, yuv420p,
container duration ±0.6s, >10 KB, aac. So the real question was never *"build it"*. It was
**"why did it not catch the codec defect"**.

### Root cause (measured, not inferred)

`golden-journey` calls `findBuiltApp()`, which returns the **dev** build whenever
`RF_E2E_DEV=1` and the caller has not set `RF_E2E_REQUIRE_PACKAGED` (`fixtures.ts:55-60`).
Only `packaged.spec.ts` sets that flag. `e2e.yml:269` sets `RF_E2E_DEV=1` on the Windows
leg. A dev build leaves `MEDIA_STUDIO_FFMPEG` unset, so the sidecar falls through to PATH —
the choco GPL ffmpeg installed at `e2e.yml:167`, which *has* libx264.

**The oracle was real, and it was pointed at a binary the user never runs.**

### What this adds

`sidecar/media_studio/encoders.py` — an encoder-capability gate with **two independent
halves so neither can drift**:

- `available_encoders()` probes `ffmpeg -encoders` on the binary resolved by the app's *own*
  order (not PATH)
- `scan_source_encoders()` is an AST scan of the tree for encoders hardcoded as `-c:v`/`-c:a`
  argv literals or `vcodec`/`acodec` dict values
- `REQUIRED_ENCODERS` is the declared contract, and a test fails if the tree hardcodes an
  encoder it does not list

It follows the shape already proven by `features/stabilize.vidstab_available` — same class
of gap, for a filter.

**The AST scan earned itself on first run.** It found a *third* hardcoded encoder absent
from both the briefing and my initial declaration: `pcm_s16le` at `features/tts/align.py:173`
and `features/tts/edgetts.py:75`. It is native to ffmpeg and present in the shipped build, so
not a second defect — but it was invisible, and now it is covered.

### Both-states proof (the detector fires on the broken state)

Two real binaries on this box:

```
A) python -m media_studio.encoders --ffmpeg "D:\Program Files\Reframe\resources\bin\ffmpeg.exe"
   FAILED:encoder-capability missing=libx264 ... EXITCODE=1
B) python -m media_studio.encoders --ffmpeg "<winget>/ffmpeg.exe"
   SUCCESS:encoder-capability ... aac, libx264, pcm_s16le ... EXITCODE=0
```

And again through the exact derivation `packaged.spec.ts` composes
(`dirname(exe)+resources/bin`): same derivation, same gate, **opposite verdicts**. Proven to
fire on the broken state, not merely to be silent on a fixed one.

### Gates run

`ruff 0.15.17 check + format` (re-verified against the **LF blob** via `git cat-file`, not
just the CRLF worktree) · `basedpyright 1.39.8` 0/0 on `encoders.py` · full sidecar
`pytest --cov-fail-under=100` → **6170 passed, 100.00%** (baseline 6137 + 33 new) ·
`tsc -p app/tsconfig.e2e.json` 0 errors with `--listFiles` proving it loads both edited
files · `docs_check` r1–r5 = 0 · `charter_check` "6 gates consistent" (no 7th gate added) ·
`yaml.safe_load(e2e.yml)` parses, step present and Windows-gated.

**Fail-first:** `pytest tests/test_encoders.py` before implementing →
`ImportError: cannot import name 'encoders'`.

### Detector checks run on itself

- A background pytest launched with an invalid `| Tail -n 40` pipe reported **exit 0 with an
  empty output file**. Discarded and re-run rather than banked as green.
- The first YAML probe filtered on `"ncoder"` and returned `[]` for a step that *is* present
  ("...can encode..."). Broken detector, not a missing step — re-probed and confirmed.
- Removed a node_modules junction with `Directory.Delete(path, false)`, **not**
  `Remove-Item -Recurse` (which can follow a junction and delete the shared checkout's
  node_modules); verified the shared `typescript/bin/tsc` present before and after.

### Residual — stated, not papered over

**This is NOT "a video went into the packaged .exe and a video came out".** The full
import → reframe 9:16 → export journey still runs against the dev build on the Windows leg.
I deliberately did not flip it: `packaged.spec.ts:106-115` documents that a cold packaged
first-run pip-installs the heavy sidecar runtime (multi-minute, network-bound) and cannot
answer RPCs inside a CI window. Making the real journey packaged needs a pre-warmed sidecar
env — larger than this lane.

- Confidence the **codec class specifically** cannot silently re-ship: **almost certain
  (90–99%)** — both-states on two real binaries plus the AST anti-drift test.
- Confidence this closes **all** packaged-runtime gaps: **unlikely (20–45%)**. It does not.

**UNVERIFIED (inline):** the new `packaged.spec.ts` test has not been *executed* — this
worktree has no `dist/`. What is verified: it type-checks (with `--listFiles` proving
inclusion), and the exact command it composes was run both-states above. Settling
experiment: stage the runtime, `npx electron-builder --win`, then
`npx playwright test e2e/packaged.spec.ts` — expect RED with LGPL staged, GREEN once the GPL
pin lands.

**NOT-CHECKED:** opengrep, gitleaks, osv-scanner, vitest, app main tsc were not run locally.
No renderer/main source and no dependencies were touched, so I expect them unaffected — but I
did not measure them and will not claim they pass.

**Scope note:** `scan_source_encoders` only sees *literal* encoder tokens. A dynamically
chosen encoder is invisible to it by construction. That is in the module docstring rather
than papered over; it catches the hardcoded case that actually shipped.

## Merge order

**Depends on #342.** `build/python-embed-setup.ps1` pins the LGPL asset until that lands, and
this gate will correctly fail the e2e Windows leg until it does — the gate working as
designed, not a defect in it. Merge #342 first.

## Provenance

Produced by a workflow agent that returned `PARTIAL` with the residuals above; 9 of its 11
sibling agents were killed by a `401 API key is invalid` (a credential-refresh race across
concurrent agents, not a code fault). The cross-lane dependency on #342 stated here was
*not* handed to me by the workflow — its cross-lane agent was one of the nine that died. It
was re-derived from the two surviving artifacts.
