### PR TITLE
feat(installer): give NSIS a real component page and provision it unattended on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ and pick one:
 
 | Asset | What it is |
 |-------|------------|
-| `media-studio-<version>-win-x64.exe` | **NSIS installer** — double-click, choose an install dir, get a Start-menu / desktop shortcut ("Reframe - Media Studio"). Auto-updates in place from here on. |
+| `media-studio-<version>-win-x64.exe` | **NSIS installer** — double-click, choose an install dir, then choose what to set up (see below). Gets a Start-menu / desktop shortcut ("Reframe - Media Studio"). Auto-updates in place from here on. |
 | `media-studio-<version>-win-x64.zip` | **Portable** — unzip anywhere and run `Reframe - Media Studio.exe`. No install, no admin. |
 
 <!-- Deliberately version-agnostic. `electron-builder.yml` derives the artifact name from
@@ -38,9 +38,24 @@ and pick one:
      could not download. Take whatever the Releases page actually offers. -->
 
 
-**First run does the rest automatically.** The download is **slim** (the app + a bundled
-CPython + ffmpeg + the render engine). On first launch the app downloads the heavier pieces
-(ML wheels and the local models you choose) into your user data dir
+**The installer asks once, then first run does the rest automatically.** After the
+directory page the installer shows a **component page**:
+
+| Choice | What gets set up now |
+|--------|----------------------|
+| **Minimum** | The app plus subject tracking, so reframing works right away. |
+| **Default** (recommended) | Adds offline transcription — captions, subtitles and search work out of the box. |
+| **Full** | Everything up front, including the local AI Director model. |
+| **Custom** | Tick the feature packs you want (*Transcription & subtitles*, *AI Director*). |
+
+Whatever you pick is what the app provisions on its first launch — **unattended**, with no
+second prompt. Anything you skip still downloads the first time you use it, and you can
+change the selection later in **Settings**. Upgrading never re-asks and never re-downloads:
+an existing install keeps the profile, models and settings it already has.
+
+The download itself is **slim** (the app + a bundled CPython + ffmpeg + the render engine) —
+**no models are bundled in the installer**. On first launch the app downloads the heavier
+pieces (ML wheels and the local models your choice implies) into your user data dir
 (`%APPDATA%\media-studio`) — resumable and checksummed. Budget a **few GB** of one-time
 download depending on which models you enable. **After that it works fully offline.**
 

--- a/app/main/installerSeed.test.ts
+++ b/app/main/installerSeed.test.ts
@@ -20,6 +20,7 @@ import {
   adoptInstallerProfileSeed,
   installerSeedPath,
   parseInstallerSeed,
+  shouldAwaitProfileChoice,
   type InstallerSeedIo,
 } from './installerSeed';
 import {
@@ -183,6 +184,34 @@ describe('parseInstallerSeed', () => {
     expect(parseInstallerSeed('')).toBeNull();
     expect(parseInstallerSeed('[]')).toBeNull();
     expect(parseInstallerSeed('{"profile":1}')).toBeNull();
+  });
+});
+
+describe('shouldAwaitProfileChoice — when the in-app picker still has to ask', () => {
+  it('skips the picker on the launch that adopted an installer choice (unattended)', () => {
+    expect(shouldAwaitProfileChoice(true, 'first-ever', true)).toBe(false);
+  });
+
+  it('still asks on a first-ever run with no installer choice (the pre-WU-I1 path)', () => {
+    expect(shouldAwaitProfileChoice(true, 'first-ever', false)).toBe(true);
+  });
+
+  it('RE-ASKS after a failed first run, even though a profile is already persisted', () => {
+    // The regression this predicate exists to prevent: keying off "a profile exists at
+    // the data root" would make a first run that died mid-download silently retry the
+    // SAME set on the next launch, with no way back to the chooser to pick a smaller
+    // one. Only an adoption performed on THIS launch suppresses the picker.
+    expect(shouldAwaitProfileChoice(true, 'first-ever', false)).toBe(true);
+  });
+
+  it('never asks on a silent re-bootstrap (it replays the persisted profile)', () => {
+    expect(shouldAwaitProfileChoice(true, 're-bootstrap', false)).toBe(false);
+    expect(shouldAwaitProfileChoice(true, 're-bootstrap', true)).toBe(false);
+  });
+
+  it('never asks when there is no first-run work at all', () => {
+    expect(shouldAwaitProfileChoice(false, 'none', false)).toBe(false);
+    expect(shouldAwaitProfileChoice(false, 'first-ever', false)).toBe(false);
   });
 });
 

--- a/app/main/installerSeed.test.ts
+++ b/app/main/installerSeed.test.ts
@@ -1,0 +1,254 @@
+// installerSeed.test.ts — the NSIS installer -> first-run PROFILE handoff (WU-I1).
+//
+// Two jobs, both mechanical:
+//   (1) the ADOPTION policy (installerSeed.ts) — when a seed the installer wrote is
+//       copied into the resolved data root, and (critically) when it is NOT, because
+//       an EXISTING install must upgrade without re-provisioning or losing its choice;
+//   (2) a cross-file CONFORMANCE gate over build/installer.nsh — the component page's
+//       profile ids, feature-pack ids, labels and the seed filename are pinned against
+//       installProfiles.ts, the single source of truth. Same pattern as
+//       installProfiles.test.ts pinning bootstrap.py. Without this the NSIS page and
+//       the app's profile map are two hand-maintained lists that silently drift, and
+//       a drifted id resolves to `null` at runtime = the picker reappears after an
+//       unattended install (the exact bug this feature exists to remove).
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import {
+  INSTALLER_PROFILE_SEED_FILE,
+  adoptInstallerProfileSeed,
+  installerSeedPath,
+  parseInstallerSeed,
+  type InstallerSeedIo,
+} from './installerSeed';
+import {
+  BUNDLE_IDS,
+  INSTALL_BUNDLES,
+  INSTALL_PROFILES,
+  INSTALL_PROFILE_FILE,
+  INSTALL_PROFILE_IDS,
+  type PersistedInstallProfile,
+} from './installProfiles';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..');
+const INSTALLER_NSH = resolve(REPO_ROOT, 'build', 'installer.nsh');
+
+/** Extract a `!define NAME "value"` from an NSIS source. */
+function nshDefine(src: string, name: string): string {
+  const m = src.match(new RegExp(`^\\s*!define\\s+${name}\\s+"([^"]*)"`, 'm'));
+  if (!m) throw new Error(`!define ${name} not found in installer.nsh`);
+  return m[1];
+}
+
+/** A `!define NAME "a|b|c"` id list, split on `|`. */
+function nshIdList(src: string, name: string): string[] {
+  const raw = nshDefine(src, name);
+  return raw === '' ? [] : raw.split('|');
+}
+
+// ---------------------------------------------------------------------------
+// (1) the adoption policy
+// ---------------------------------------------------------------------------
+
+interface SeedFixture {
+  readonly io: InstallerSeedIo;
+  readonly written: PersistedInstallProfile[];
+}
+
+function fixture(over: Partial<InstallerSeedIo> = {}, writeOk = true): SeedFixture {
+  const written: PersistedInstallProfile[] = [];
+  const io: InstallerSeedIo = {
+    seedPath: 'C:\\Program Files\\Reframe\\.first-run-profile.json',
+    dataRootProfilePath: 'C:\\Users\\u\\AppData\\Roaming\\media-studio\\.first-run-profile.json',
+    readSeed: () => JSON.stringify({ profile: 'full', bundles: [] }),
+    dataRootProfileExists: () => false,
+    writeDataRootProfile: (record) => {
+      written.push(record);
+      return writeOk;
+    },
+    ...over,
+  };
+  return { io, written };
+}
+
+describe('adoptInstallerProfileSeed — the installer choice reaches the data root', () => {
+  it('ADOPTS a valid seed on a fresh install (no profile at the data root yet)', () => {
+    const { io, written } = fixture();
+    expect(adoptInstallerProfileSeed(io)).toEqual({
+      outcome: 'adopted',
+      profile: { profile: 'full', bundles: [] },
+    });
+    expect(written).toEqual([{ profile: 'full', bundles: [] }]);
+  });
+
+  it('adopts a Custom seed with its feature packs', () => {
+    const { io, written } = fixture({
+      readSeed: () => JSON.stringify({ profile: 'custom', bundles: ['ai-director'] }),
+    });
+    expect(adoptInstallerProfileSeed(io).outcome).toBe('adopted');
+    expect(written).toEqual([{ profile: 'custom', bundles: ['ai-director'] }]);
+  });
+
+  it('BACKWARD COMPAT: never overwrites an existing choice (an upgrade keeps its profile)', () => {
+    const { io, written } = fixture({ dataRootProfileExists: () => true });
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'already-chosen', profile: null });
+    expect(written).toEqual([]);
+  });
+
+  it('is a NO-OP when the seed IS the data-root profile (same resolved path)', () => {
+    const same = 'C:\\Users\\u\\AppData\\Roaming\\media-studio\\.first-run-profile.json';
+    const { io, written } = fixture({ seedPath: same, dataRootProfilePath: same });
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'same-path', profile: null });
+    expect(written).toEqual([]);
+  });
+
+  it('treats the same path case-insensitively (Windows paths differ only in case)', () => {
+    const { io, written } = fixture({
+      seedPath: 'C:\\Users\\u\\AppData\\Roaming\\media-studio\\.first-run-profile.json',
+      dataRootProfilePath: 'c:\\users\\u\\appdata\\roaming\\media-studio\\.first-run-profile.json',
+    });
+    expect(adoptInstallerProfileSeed(io).outcome).toBe('same-path');
+    expect(written).toEqual([]);
+  });
+
+  it('reports no-seed when the installer wrote nothing (a portable / zip build)', () => {
+    const { io, written } = fixture({ readSeed: () => undefined });
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'no-seed', profile: null });
+    expect(written).toEqual([]);
+  });
+
+  it('reports invalid-seed on corrupt JSON — the picker still appears, never a wrong set', () => {
+    const { io, written } = fixture({ readSeed: () => '{not json' });
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'invalid-seed', profile: null });
+    expect(written).toEqual([]);
+  });
+
+  it('reports invalid-seed on an unknown profile id (a drifted installer)', () => {
+    const { io } = fixture({ readSeed: () => JSON.stringify({ profile: 'everything' }) });
+    expect(adoptInstallerProfileSeed(io).outcome).toBe('invalid-seed');
+  });
+
+  it('reports write-failed (never throws) when the data root is not writable', () => {
+    const { io } = fixture({}, false);
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'write-failed', profile: null });
+  });
+
+  it('never throws when readSeed itself throws (an unreadable install dir)', () => {
+    const { io } = fixture({
+      readSeed: () => {
+        throw new Error('EACCES');
+      },
+    });
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'no-seed', profile: null });
+  });
+
+  it('never throws when the existence probe throws', () => {
+    const { io } = fixture({
+      dataRootProfileExists: () => {
+        throw new Error('EACCES');
+      },
+    });
+    expect(adoptInstallerProfileSeed(io).outcome).toBe('already-chosen');
+  });
+
+  it('never throws when the write itself throws', () => {
+    const { io } = fixture({
+      writeDataRootProfile: () => {
+        throw new Error('EACCES');
+      },
+    });
+    expect(adoptInstallerProfileSeed(io).outcome).toBe('write-failed');
+  });
+});
+
+describe('parseInstallerSeed', () => {
+  it('parses a valid body into the persisted record', () => {
+    expect(parseInstallerSeed('{"profile":"minimum","bundles":[]}')).toEqual({
+      profile: 'minimum',
+      bundles: [],
+    });
+  });
+
+  it('drops unknown bundles rather than failing the whole seed', () => {
+    expect(parseInstallerSeed('{"profile":"custom","bundles":["transcription","nope"]}')).toEqual({
+      profile: 'custom',
+      bundles: ['transcription'],
+    });
+  });
+
+  it('returns null for undefined / corrupt / legacy bodies', () => {
+    expect(parseInstallerSeed(undefined)).toBeNull();
+    expect(parseInstallerSeed('')).toBeNull();
+    expect(parseInstallerSeed('[]')).toBeNull();
+    expect(parseInstallerSeed('{"profile":1}')).toBeNull();
+  });
+});
+
+describe('installerSeedPath', () => {
+  it('is the seed file inside the install directory', () => {
+    expect(installerSeedPath('C:\\Program Files\\Reframe')).toBe(
+      join('C:\\Program Files\\Reframe', INSTALLER_PROFILE_SEED_FILE),
+    );
+  });
+
+  it('reuses the app profile filename VERBATIM (one schema, one name)', () => {
+    expect(INSTALLER_PROFILE_SEED_FILE).toBe(INSTALL_PROFILE_FILE);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// (2) build/installer.nsh <-> installProfiles.ts conformance
+// ---------------------------------------------------------------------------
+
+describe('build/installer.nsh conforms to installProfiles.ts (no hand-maintained drift)', () => {
+  const nsh = readFileSync(INSTALLER_NSH, 'utf8');
+
+  it('offers exactly the app profile ids, in the same order', () => {
+    expect(nshIdList(nsh, 'REFRAME_PROFILE_IDS')).toEqual([...INSTALL_PROFILE_IDS]);
+  });
+
+  it('offers exactly the app feature-pack ids, in the same order', () => {
+    expect(nshIdList(nsh, 'REFRAME_BUNDLE_IDS')).toEqual([...BUNDLE_IDS]);
+  });
+
+  it('writes the SAME seed filename the app reads', () => {
+    expect(nshDefine(nsh, 'REFRAME_PROFILE_SEED_FILE')).toBe(INSTALLER_PROFILE_SEED_FILE);
+  });
+
+  it('defaults to the profile the app marks recommended', () => {
+    const recommended = INSTALL_PROFILES.find((p) => p.recommended);
+    expect(nshDefine(nsh, 'REFRAME_PROFILE_DEFAULT')).toBe(recommended?.id);
+  });
+
+  it('shows each profile under the app label (same words in the installer and the app)', () => {
+    for (const profile of INSTALL_PROFILES) {
+      expect(nsh).toContain(profile.label);
+    }
+  });
+
+  it('shows each feature pack under the app label', () => {
+    for (const bundle of INSTALL_BUNDLES) {
+      expect(nsh).toContain(bundle.label);
+    }
+  });
+
+  it('emits the persisted schema keys (profile + bundles)', () => {
+    // NSIS spells a literal double quote `$\"`, so the JSON the installer writes is
+    // `"profile"` / `"bundles"` — the exact two keys parsePersistedInstallProfile reads.
+    expect(nsh).toContain('$\\"profile$\\"');
+    expect(nsh).toContain('$\\"bundles$\\"');
+  });
+
+  it('hooks the electron-builder macros it must (page + install-time write)', () => {
+    expect(nsh).toMatch(/^!macro customPageAfterChangeDir$/m);
+    expect(nsh).toMatch(/^!macro customInstall$/m);
+  });
+
+  it('does NOT bundle models into the installer (on-demand only — the NSIS 2 GB ceiling)', () => {
+    // A component page that shipped model bytes would need `File` directives for
+    // them; the packs are asset NAMES routed to bootstrap.py, never payload.
+    expect(nsh).not.toMatch(/^\s*File\s/m);
+  });
+});

--- a/app/main/installerSeed.ts
+++ b/app/main/installerSeed.ts
@@ -35,6 +35,7 @@
 // PURE-BY-SEAM: all filesystem access is injected ({@link InstallerSeedIo}) so the
 // decision is fully testable; main.ts owns the concrete seam.
 import { join } from 'node:path';
+import type { FirstRunKind } from './firstRunGate';
 import {
   INSTALL_PROFILE_FILE,
   parsePersistedInstallProfile,
@@ -107,6 +108,31 @@ export function parseInstallerSeed(raw: string | undefined): PersistedInstallPro
   } catch {
     return null; // corrupt JSON -> fall back to the in-app picker, never a guessed set
   }
+}
+
+/**
+ * WU-I1: whether the in-app ProfilePicker must still ask (main.ts `awaitingProfile`).
+ *
+ * The picker is suppressed for exactly one case: a FIRST-EVER run whose profile was
+ * adopted from the installer ON THIS LAUNCH. That is what makes an install unattended.
+ *
+ * `installerAdoptedThisLaunch` — NOT "a profile exists at the data root" — is the
+ * deliberate condition, and the difference is a real trap. A first run that dies
+ * mid-download leaves its chosen profile persisted but writes no completion marker, so
+ * the NEXT launch is `first-ever` again. Keying off mere existence would silently retry
+ * the SAME set (possibly the one that just filled the disk) with no route back to the
+ * chooser. Keying off this-launch adoption keeps that path exactly as it was before
+ * WU-I1: the picker reappears and the user can pick something smaller.
+ *
+ * Every other case is unchanged: a silent WU-S2 `re-bootstrap` replays the persisted
+ * profile without prompting, and `none` has no first-run work to gate.
+ */
+export function shouldAwaitProfileChoice(
+  firstRun: boolean,
+  firstRunKind: FirstRunKind,
+  installerAdoptedThisLaunch: boolean,
+): boolean {
+  return firstRun && firstRunKind === 'first-ever' && !installerAdoptedThisLaunch;
 }
 
 /** Windows paths are case-insensitive; compare the two profile paths accordingly. */

--- a/app/main/installerSeed.ts
+++ b/app/main/installerSeed.ts
@@ -1,0 +1,167 @@
+// installerSeed.ts — carry the NSIS installer's component choice into first run (WU-I1).
+//
+// THE PROBLEM. The installer now has a real component page (Default / Full / Custom
+// with individually selectable feature packs — build/installer.nsh). The user makes a
+// choice there, and then the app's FIRST-EVER launch used to ask the SAME question
+// again in the in-app ProfilePicker (main.ts `awaitingProfile`). Asking twice is not
+// just noise: the second answer is the one that provisions, so the installer page
+// would be decorative and the install could never be unattended.
+//
+// WHY THE INSTALLER CANNOT JUST WRITE THE DATA ROOT. The persisted profile lives at
+// `<dataRoot>/.first-run-profile.json`, and the data root is RESOLVED AT RUNTIME by
+// dataRootPlan.planDataRoot (env override -> `data-dir.txt` marker -> a legacy
+// `<exeDir>/data` migration -> `%APPDATA%/media-studio`). NSIS cannot evaluate that
+// without re-implementing it, and a second implementation of a path policy is exactly
+// how the two silently drift. So the installer writes a SEED at the one location it
+// knows EXACTLY — `$INSTDIR` — and this module (the single policy owner, in TS) copies
+// it into whatever data root the app actually resolved.
+//
+// WHY `$INSTDIR` AND NOT `<userData>`. `$INSTDIR` is byte-exact on both sides: NSIS
+// has `$INSTDIR`, the app has `dirname(process.execPath)` (dataRootIo.exeDir). The
+// `<userData>` alternative depends on electron-builder's `APP_FILENAME` define
+// matching Electron's `app.getName()`, which is a guess this module refuses to make.
+// `$INSTDIR` is wiped by an in-place NSIS update (app-builder-lib
+// templates/nsis/uninstaller.nsh:187 `RMDir /r $INSTDIR`) — which is CORRECT here: the
+// seed is re-written by every installer run and consumed on the next launch, so it is
+// per-install state, not durable state. Nothing durable is stored there (that is the
+// T13 rule dataRootIo.ts already enforces for `data-dir.txt`).
+//
+// BACKWARD COMPATIBILITY (load-bearing). The seed is adopted ONLY when the resolved
+// data root holds NO profile yet. An existing install therefore keeps the profile it
+// already chose, its models are never re-fetched, and no setting is touched — even
+// though every upgrade re-runs the installer page and re-writes a seed. That guard is
+// the whole backward-compatibility contract and it is unit-tested from both sides.
+//
+// PURE-BY-SEAM: all filesystem access is injected ({@link InstallerSeedIo}) so the
+// decision is fully testable; main.ts owns the concrete seam.
+import { join } from 'node:path';
+import {
+  INSTALL_PROFILE_FILE,
+  parsePersistedInstallProfile,
+  type PersistedInstallProfile,
+} from './installProfiles';
+
+/**
+ * The seed filename the installer writes into `$INSTDIR`. Deliberately the SAME name
+ * (and byte-identical schema) as the app's own persisted profile — one contract, one
+ * parser, no translation layer. installerSeed.test.ts pins the equality.
+ */
+export const INSTALLER_PROFILE_SEED_FILE = INSTALL_PROFILE_FILE;
+
+/** Absolute path of the installer seed for an install directory. */
+export function installerSeedPath(installDir: string): string {
+  return join(installDir, INSTALLER_PROFILE_SEED_FILE);
+}
+
+/**
+ * Why an adoption attempt ended the way it did. Every value is a NORMAL outcome that
+ * must not crash startup — the worst case simply falls back to the in-app picker.
+ *
+ *  - `adopted`        the seed was valid and is now the data root's profile;
+ *  - `already-chosen` the data root already has a profile (an UPGRADE — never clobber);
+ *  - `same-path`      the seed IS the data-root profile (nothing to copy);
+ *  - `no-seed`        no installer seed (a portable/zip build, or an unreadable dir);
+ *  - `invalid-seed`   present but corrupt / from a drifted installer — ignored loudly;
+ *  - `write-failed`   the data root refused the write (read-only / AV lock).
+ */
+export type InstallerSeedOutcome =
+  | 'adopted'
+  | 'already-chosen'
+  | 'same-path'
+  | 'no-seed'
+  | 'invalid-seed'
+  | 'write-failed';
+
+/** The adoption result: the outcome plus the record actually adopted (or `null`). */
+export interface InstallerSeedResult {
+  readonly outcome: InstallerSeedOutcome;
+  readonly profile: PersistedInstallProfile | null;
+}
+
+/** The filesystem seam {@link adoptInstallerProfileSeed} needs (main.ts supplies it). */
+export interface InstallerSeedIo {
+  /** `<installDir>/.first-run-profile.json` — where the installer wrote its choice. */
+  readonly seedPath: string;
+  /** `<dataRoot>/.first-run-profile.json` — where the app reads the choice from. */
+  readonly dataRootProfilePath: string;
+  /** Raw seed body, or `undefined` when absent/unreadable. May throw; treated as absent. */
+  readSeed: () => string | undefined;
+  /** True when the data root already holds a profile. May throw; treated as `true`. */
+  dataRootProfileExists: () => boolean;
+  /** Persist the adopted record at the data root; `false` (or throw) when it failed. */
+  writeDataRootProfile: (record: PersistedInstallProfile) => boolean;
+}
+
+/**
+ * Parse a raw installer-seed body into the validated persisted record, or `null` when
+ * it is absent, empty, not JSON, or not a recognised profile. Reuses
+ * {@link parsePersistedInstallProfile} so the installer seed and the app's own file can
+ * never be validated by two different rules.
+ */
+export function parseInstallerSeed(raw: string | undefined): PersistedInstallProfile | null {
+  if (raw === undefined || raw.trim() === '') {
+    return null;
+  }
+  try {
+    return parsePersistedInstallProfile(JSON.parse(raw));
+  } catch {
+    return null; // corrupt JSON -> fall back to the in-app picker, never a guessed set
+  }
+}
+
+/** Windows paths are case-insensitive; compare the two profile paths accordingly. */
+function samePath(a: string, b: string): boolean {
+  return a.toLowerCase() === b.toLowerCase();
+}
+
+/**
+ * Copy the installer's component choice into the resolved data root, so a first-ever
+ * launch provisions THAT set unattended instead of re-asking.
+ *
+ * NEVER THROWS — every failure mode is a returned {@link InstallerSeedOutcome}, because
+ * a seed problem must degrade to "show the picker", never to a failed startup.
+ *
+ * ORDER MATTERS. `same-path` is checked before the existence probe (when the seed IS
+ * the target, "it already exists" is a tautology, not a user choice), and
+ * `already-chosen` is checked before the seed is even read, so an upgrade does no IO
+ * and cannot be influenced by a corrupt seed.
+ */
+export function adoptInstallerProfileSeed(io: InstallerSeedIo): InstallerSeedResult {
+  if (samePath(io.seedPath, io.dataRootProfilePath)) {
+    return { outcome: 'same-path', profile: null };
+  }
+  // FAIL CLOSED: an unprobeable data root counts as "already chosen". Treating a
+  // transient stat error as "empty" would let a stale seed overwrite a real choice.
+  let exists: boolean;
+  try {
+    exists = io.dataRootProfileExists();
+  } catch {
+    exists = true;
+  }
+  if (exists) {
+    return { outcome: 'already-chosen', profile: null };
+  }
+
+  let raw: string | undefined;
+  try {
+    raw = io.readSeed();
+  } catch {
+    raw = undefined;
+  }
+  if (raw === undefined || raw.trim() === '') {
+    return { outcome: 'no-seed', profile: null };
+  }
+
+  const record = parseInstallerSeed(raw);
+  if (record === null) {
+    return { outcome: 'invalid-seed', profile: null };
+  }
+
+  let ok: boolean;
+  try {
+    ok = io.writeDataRootProfile(record);
+  } catch {
+    ok = false;
+  }
+  return ok ? { outcome: 'adopted', profile: record } : { outcome: 'write-failed', profile: null };
+}

--- a/app/main/installerSeedIo.test.ts
+++ b/app/main/installerSeedIo.test.ts
@@ -1,0 +1,153 @@
+// installerSeedIo.test.ts — the installer-seed seam against a REAL filesystem.
+//
+// The pure policy is covered by installerSeed.test.ts with fakes. This file drives the
+// seam main.ts actually installs, on real temp dirs, because a fake `existsSync` cannot
+// tell you that the write lands at the right path, in the right shape, or that an
+// UPGRADE leaves the previous install untouched. The upgrade case is the load-bearing
+// one: the whole feature re-runs the component page on every install, so the ONLY thing
+// standing between an upgrade and a re-provision is the never-clobber guard proved here.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { adoptInstallerProfileSeed } from './installerSeed';
+import {
+  createInstallerSeedIo,
+  dataRootProfilePath,
+  serializeInstallProfile,
+} from './installerSeedIo';
+import { INSTALL_PROFILE_FILE } from './installProfiles';
+
+let root = '';
+let installDir = '';
+let dataRoot = '';
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'reframe-seed-'));
+  installDir = join(root, 'install');
+  dataRoot = join(root, 'data');
+  mkdirSync(installDir, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Write the seed the NSIS `customInstall` macro produces (CRLF, 2-space, trailing NL). */
+function writeInstallerSeed(profile: string, bundles: readonly string[]): void {
+  const list = bundles.map((b) => `"${b}"`).join(', ');
+  writeFileSync(
+    join(installDir, INSTALL_PROFILE_FILE),
+    `{\r\n  "profile": "${profile}",\r\n  "bundles": [${list}]\r\n}\r\n`,
+    'utf8',
+  );
+}
+
+function adopt(): ReturnType<typeof adoptInstallerProfileSeed> {
+  return adoptInstallerProfileSeed(createInstallerSeedIo(installDir, dataRoot));
+}
+
+describe('fresh install — the component page choice reaches the data root', () => {
+  it('adopts the seed and writes it in the app persistence shape', () => {
+    writeInstallerSeed('custom', ['transcription', 'ai-director']);
+    expect(adopt()).toEqual({
+      outcome: 'adopted',
+      profile: { profile: 'custom', bundles: ['transcription', 'ai-director'] },
+    });
+    const written = readFileSync(dataRootProfilePath(dataRoot), 'utf8');
+    expect(written).toBe(
+      serializeInstallProfile({ profile: 'custom', bundles: ['transcription', 'ai-director'] }),
+    );
+    // Round-trips through the app's own reader: this IS what a first-ever run installs.
+    expect(JSON.parse(written)).toEqual({
+      profile: 'custom',
+      bundles: ['transcription', 'ai-director'],
+    });
+  });
+
+  it('CREATES the data root when it does not exist yet (a first-ever launch)', () => {
+    expect(existsSync(dataRoot)).toBe(false);
+    writeInstallerSeed('full', []);
+    expect(adopt().outcome).toBe('adopted');
+    expect(existsSync(dataRootProfilePath(dataRoot))).toBe(true);
+  });
+
+  it('parses the installer CRLF body byte-for-byte (NSIS writes $\\r$\\n)', () => {
+    writeInstallerSeed('minimum', []);
+    const raw = readFileSync(join(installDir, INSTALL_PROFILE_FILE), 'utf8');
+    expect(raw).toContain('\r\n');
+    expect(adopt().profile).toEqual({ profile: 'minimum', bundles: [] });
+  });
+
+  it('does nothing when there is no installer (a portable / zip extraction)', () => {
+    expect(adopt()).toEqual({ outcome: 'no-seed', profile: null });
+    expect(existsSync(dataRootProfilePath(dataRoot))).toBe(false);
+  });
+
+  it('leaves the data root alone when the seed is corrupt', () => {
+    writeFileSync(join(installDir, INSTALL_PROFILE_FILE), '{ this is not json', 'utf8');
+    expect(adopt().outcome).toBe('invalid-seed');
+    expect(existsSync(dataRootProfilePath(dataRoot))).toBe(false);
+  });
+});
+
+describe('UPGRADE — install old, install new: the existing install survives untouched', () => {
+  it('keeps the old profile, its models and its settings when the new installer differs', () => {
+    // --- the OLD install: a user who chose Full, provisioned, and has state on disk.
+    mkdirSync(join(dataRoot, 'models'), { recursive: true });
+    const oldProfile = serializeInstallProfile({ profile: 'full', bundles: [] });
+    writeFileSync(dataRootProfilePath(dataRoot), oldProfile, 'utf8');
+    writeFileSync(join(dataRoot, '.first-run-complete.json'), '{"ok":true}', 'utf8');
+    writeFileSync(join(dataRoot, 'settings.json'), '{"theme":"dark"}', 'utf8');
+    writeFileSync(join(dataRoot, 'models', 'qwen3-4b.gguf'), 'PRETEND-2.5GB', 'utf8');
+
+    // --- the NEW installer runs and writes its own (different, defaulted) seed.
+    writeInstallerSeed('minimum', []);
+
+    expect(adopt()).toEqual({ outcome: 'already-chosen', profile: null });
+
+    // The profile is byte-identical — no downgrade from Full to Minimum.
+    expect(readFileSync(dataRootProfilePath(dataRoot), 'utf8')).toBe(oldProfile);
+    // Provisioning marker intact -> classifyFirstRun stays 'none' -> no re-download.
+    expect(readFileSync(join(dataRoot, '.first-run-complete.json'), 'utf8')).toBe('{"ok":true}');
+    // Settings intact.
+    expect(readFileSync(join(dataRoot, 'settings.json'), 'utf8')).toBe('{"theme":"dark"}');
+    // Models intact.
+    expect(readFileSync(join(dataRoot, 'models', 'qwen3-4b.gguf'), 'utf8')).toBe('PRETEND-2.5GB');
+  });
+
+  it('is idempotent across repeated installer runs (re-running setup changes nothing)', () => {
+    writeInstallerSeed('default', []);
+    expect(adopt().outcome).toBe('adopted');
+    const afterFirst = readFileSync(dataRootProfilePath(dataRoot), 'utf8');
+
+    writeInstallerSeed('minimum', []);
+    expect(adopt().outcome).toBe('already-chosen');
+    expect(adopt().outcome).toBe('already-chosen');
+    expect(readFileSync(dataRootProfilePath(dataRoot), 'utf8')).toBe(afterFirst);
+  });
+});
+
+describe('createInstallerSeedIo — the paths main.ts wires', () => {
+  it('points at $INSTDIR for the seed and the data root for the profile', () => {
+    const io = createInstallerSeedIo(installDir, dataRoot);
+    expect(io.seedPath).toBe(join(installDir, INSTALL_PROFILE_FILE));
+    expect(io.dataRootProfilePath).toBe(join(dataRoot, INSTALL_PROFILE_FILE));
+  });
+
+  it('short-circuits to same-path when the install dir IS the data root', () => {
+    // A portable layout where both resolve to one folder: adoption is meaningless
+    // and must not rewrite the file it would be reading from.
+    const io = createInstallerSeedIo(installDir, installDir);
+    writeInstallerSeed('full', []);
+    expect(adoptInstallerProfileSeed(io)).toEqual({ outcome: 'same-path', profile: null });
+    expect(readFileSync(join(installDir, INSTALL_PROFILE_FILE), 'utf8')).toContain('\r\n');
+  });
+
+  it('reports write-failed instead of throwing when the data root path is a FILE', () => {
+    // mkdirSync on a path whose parent is a regular file throws ENOTDIR/EEXIST.
+    writeFileSync(dataRoot, 'not a directory', 'utf8');
+    writeInstallerSeed('full', []);
+    expect(adopt()).toEqual({ outcome: 'write-failed', profile: null });
+  });
+});

--- a/app/main/installerSeedIo.ts
+++ b/app/main/installerSeedIo.ts
@@ -1,0 +1,53 @@
+// installerSeedIo.ts — the concrete FILESYSTEM seam for installer-seed adoption.
+//
+// WHY THIS IS ITS OWN MODULE. dataRootIo.ts exists for exactly this reason and says so
+// (dataRootIo.ts:1-12): when the IO half lives as private functions inside main.ts it
+// cannot be imported under vitest (main.ts runs Electron side effects on import), so
+// the seam that actually touches disk ends up with ZERO direct coverage and slips past
+// every gate. The pure decision is installerSeed.ts; this is the half that reads and
+// writes real files, and installerSeedIo.test.ts drives it against real temp dirs —
+// including a simulated old-install -> new-install upgrade.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { INSTALL_PROFILE_FILE, type PersistedInstallProfile } from './installProfiles';
+import { installerSeedPath, type InstallerSeedIo } from './installerSeed';
+
+/** `<dataRoot>/.first-run-profile.json` — the app's persisted install profile. */
+export function dataRootProfilePath(dataRoot: string): string {
+  return join(dataRoot, INSTALL_PROFILE_FILE);
+}
+
+/**
+ * Serialise a profile record exactly as main.ts `persistInstallProfile` does — 2-space
+ * JSON with a trailing newline — so a seed adopted here and a choice made in the in-app
+ * picker produce byte-identical files. One writer shape, no "which one wrote this?".
+ */
+export function serializeInstallProfile(record: PersistedInstallProfile): string {
+  return `${JSON.stringify({ profile: record.profile, bundles: record.bundles }, null, 2)}\n`;
+}
+
+/**
+ * Build the filesystem seam for {@link installerSeed.adoptInstallerProfileSeed}.
+ *
+ * `installDir` is the running executable's directory (`dataRootIo.exeDir()` — the NSIS
+ * `$INSTDIR`), `dataRoot` is the root main.ts resolved this session. Every callback may
+ * throw; the pure policy catches and degrades, so nothing here needs its own try/catch
+ * and no failure mode is silently swallowed twice.
+ */
+export function createInstallerSeedIo(installDir: string, dataRoot: string): InstallerSeedIo {
+  const seedPath = installerSeedPath(installDir);
+  const profilePath = dataRootProfilePath(dataRoot);
+  return {
+    seedPath,
+    dataRootProfilePath: profilePath,
+    readSeed: () => (existsSync(seedPath) ? readFileSync(seedPath, 'utf8') : undefined),
+    dataRootProfileExists: () => existsSync(profilePath),
+    writeDataRootProfile: (record) => {
+      // The data root may not exist yet on a first-ever launch (bootstrap.py creates
+      // it), so create it rather than losing the installer's choice to ENOENT.
+      mkdirSync(dirname(profilePath), { recursive: true });
+      writeFileSync(profilePath, serializeInstallProfile(record), 'utf8');
+      return true;
+    },
+  };
+}

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -1215,6 +1215,13 @@ function bootstrap(): void {
     );
   }
 
+  // WU-I1: pull the NSIS component page's choice into the data root BEFORE the
+  // first-run classification reads it. Packaged-only (dev has no installer) and
+  // lock-holder-only (never write into a tree a live copy owns). The RETURN value —
+  // "an installer choice was adopted on THIS launch" — is what suppresses the picker
+  // below; see shouldAwaitProfileChoice for why mere existence would be wrong.
+  const installerAdopted = app.isPackaged && lock.ok ? adoptInstallerProfile() : false;
+
   // T5: in a packaged build whose runtime env was never built, stage 2 must
   // run BEFORE the sidecar starts (the embeddable python cannot serve
   // `-m media_studio` until bootstrap.py rewrites its ._pth). Dev builds (and
@@ -1226,13 +1233,6 @@ function bootstrap(): void {
   // fingerprint (unreadable resources) or `null` persisted (legacy pre-feature
   // marker) is treated as in-sync — the latter is BACKFILLED below so future bumps
   // are caught without a surprise re-provision now.
-  // WU-I1: pull the NSIS component page's choice into the data root BEFORE the
-  // first-run classification reads it. Packaged-only (dev has no installer) and
-  // lock-holder-only (never write into a tree a live copy owns). The RETURN value —
-  // "an installer choice was adopted on THIS launch" — is what suppresses the picker
-  // below; see shouldAwaitProfileChoice for why mere existence would be wrong.
-  const installerAdopted = app.isPackaged && lock.ok ? adoptInstallerProfile() : false;
-
   const markerExists = existsSync(firstRunCompletePath());
   const shippedFp = shippedRequirementsFingerprint();
   const persistedFp = markerExists ? readPersistedRequirementsFingerprint() : null;

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -25,6 +25,7 @@ import {
 import {
   dataDirMarkerPath,
   exeDataDir,
+  exeDir,
   resolveDataDirMarker,
   stableDataDirMarkerPath,
 } from './dataRootIo';
@@ -53,6 +54,8 @@ import {
   resolveInstallChoice,
   type ResolvedInstallChoice,
 } from './installProfiles';
+import { adoptInstallerProfileSeed } from './installerSeed';
+import { createInstallerSeedIo } from './installerSeedIo';
 import { registerDialogIpc } from './dialogIpc';
 import { resolveScopedMediaPath } from './exportPath';
 import {
@@ -665,6 +668,34 @@ function persistInstallProfile(choice: ResolvedInstallChoice): void {
 }
 
 /**
+ * WU-I1: adopt the install profile the NSIS component page chose.
+ *
+ * The installer writes its answer as a SEED at `$INSTDIR` — the one path NSIS and the
+ * app compute identically (`dirname(process.execPath)`), and the only one NSIS can
+ * name without re-implementing the runtime data-root policy (planDataRoot). This
+ * copies it to `<dataRoot>/.first-run-profile.json` so the first-ever launch
+ * provisions THAT set unattended instead of re-asking in the ProfilePicker.
+ *
+ * The DECISION (including the never-clobber-an-existing-choice guard that keeps an
+ * upgrade from re-provisioning) is the fully-tested pure installerSeed.ts, and the
+ * filesystem half is the equally-tested installerSeedIo.ts seam — both live outside
+ * main.ts precisely so they CAN be tested (the dataRootIo.ts:1-12 rationale).
+ * FAIL-OPEN by construction: every failure mode degrades to "show the picker", never
+ * to a failed startup.
+ */
+function adoptInstallerProfile(): void {
+  const result = adoptInstallerProfileSeed(createInstallerSeedIo(exeDir(), DATA_ROOT));
+  if (result.outcome === 'adopted') {
+    // eslint-disable-next-line no-console
+    console.error(`[bootstrap] adopted the installer's ${result.profile?.profile} profile`);
+  } else if (result.outcome === 'invalid-seed' || result.outcome === 'write-failed') {
+    // Loud, but never fatal — the in-app ProfilePicker still answers the question.
+    // eslint-disable-next-line no-console
+    console.error(`[bootstrap] installer profile seed ignored (${result.outcome})`);
+  }
+}
+
+/**
  * WU-1c: the assets a re-bootstrap / repair should install, resolved from the
  * PERSISTED profile. Returns `null` when no valid profile is persisted (a legacy
  * pre-WU-1c install, a corrupt file, or an unreadable data root) so the caller
@@ -1193,6 +1224,13 @@ function bootstrap(): void {
   // fingerprint (unreadable resources) or `null` persisted (legacy pre-feature
   // marker) is treated as in-sync — the latter is BACKFILLED below so future bumps
   // are caught without a surprise re-provision now.
+  // WU-I1: pull the NSIS component page's choice into the data root BEFORE the
+  // first-run classification reads it. Packaged-only (dev has no installer) and
+  // lock-holder-only (never write into a tree a live copy owns).
+  if (app.isPackaged && lock.ok) {
+    adoptInstallerProfile();
+  }
+
   const markerExists = existsSync(firstRunCompletePath());
   const shippedFp = shippedRequirementsFingerprint();
   const persistedFp = markerExists ? readPersistedRequirementsFingerprint() : null;
@@ -1206,7 +1244,16 @@ function bootstrap(): void {
   // WU-1c: a FIRST-EVER run is INTERACTIVE — the supervisor waits for the user's
   // install-profile choice before spawning bootstrap (awaitingProfile). A silent
   // WU-S2 re-bootstrap reuses the persisted profile and auto-spawns (no picker).
-  const awaitingProfile = firstRun && firstRunKind === 'first-ever';
+  //
+  // WU-I1: …UNLESS the question is already answered. When a profile is persisted at
+  // the data root on a first-ever run it came from the NSIS component page (adopted
+  // just above — the in-app picker cannot have run yet, since it only appears on a
+  // first-ever run and persists on the way to bootstrap). Asking again would make the
+  // installer page decorative and the install non-unattended, so the picker is
+  // skipped and the auto-spawn below feeds bootstrap.py the SAME persisted set the
+  // re-bootstrap path already uses.
+  const awaitingProfile =
+    firstRun && firstRunKind === 'first-ever' && readPersistedInstallAssets() === null;
   // WU-1b: seed the provisioning latch BEFORE the window loads so the renderer's
   // mount-time `provisioning.get` query is correct on the very first frame — a
   // first/re- run withholds the shell (no sidecar to serve its RPCs yet), an
@@ -1448,6 +1495,11 @@ function bootstrap(): void {
   //     ProfilePicker drives it: installProfile.choose -> beginBootstrap above.
   //   * RE-BOOTSTRAP (silent WU-S2 drift) — auto-spawn, REUSING the persisted
   //     profile (argless default when a legacy install has none). Never re-prompts.
+  //   * WU-I1 INSTALLER-SEEDED FIRST-EVER — also auto-spawn: `awaitingProfile` is
+  //     false because the component page already answered, so the SAME
+  //     readPersistedInstallAssets() call installs exactly the chosen packs
+  //     unattended. No new branch is needed; that is the point of reusing the
+  //     `.first-run-profile.json` contract instead of inventing a parallel one.
   if (firstRun && !awaitingProfile) {
     const begin = (): void => kickoffBootstrap(readPersistedInstallAssets());
     // Spawn once the renderer is up so it can observe bootstrap.progress.

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -54,8 +54,8 @@ import {
   resolveInstallChoice,
   type ResolvedInstallChoice,
 } from './installProfiles';
-import { adoptInstallerProfileSeed } from './installerSeed';
-import { createInstallerSeedIo } from './installerSeedIo';
+import { adoptInstallerProfileSeed, shouldAwaitProfileChoice } from './installerSeed';
+import { createInstallerSeedIo, serializeInstallProfile } from './installerSeedIo';
 import { registerDialogIpc } from './dialogIpc';
 import { resolveScopedMediaPath } from './exportPath';
 import {
@@ -656,11 +656,10 @@ function installProfilePath(): string {
  */
 function persistInstallProfile(choice: ResolvedInstallChoice): void {
   try {
-    writeFileSync(
-      installProfilePath(),
-      `${JSON.stringify({ profile: choice.profile, bundles: choice.bundles }, null, 2)}\n`,
-      'utf8',
-    );
+    // WU-I1: serialised by the SAME function the installer-seed adoption uses, so a
+    // profile written by the picker and one adopted from the installer are byte-
+    // identical. Two inlined JSON.stringify calls would be two shapes waiting to drift.
+    writeFileSync(installProfilePath(), serializeInstallProfile(choice), 'utf8');
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(`[bootstrap] could not persist install profile: ${(err as Error).message}`);
@@ -683,16 +682,19 @@ function persistInstallProfile(choice: ResolvedInstallChoice): void {
  * FAIL-OPEN by construction: every failure mode degrades to "show the picker", never
  * to a failed startup.
  */
-function adoptInstallerProfile(): void {
+function adoptInstallerProfile(): boolean {
   const result = adoptInstallerProfileSeed(createInstallerSeedIo(exeDir(), DATA_ROOT));
   if (result.outcome === 'adopted') {
     // eslint-disable-next-line no-console
     console.error(`[bootstrap] adopted the installer's ${result.profile?.profile} profile`);
-  } else if (result.outcome === 'invalid-seed' || result.outcome === 'write-failed') {
+    return true;
+  }
+  if (result.outcome === 'invalid-seed' || result.outcome === 'write-failed') {
     // Loud, but never fatal — the in-app ProfilePicker still answers the question.
     // eslint-disable-next-line no-console
     console.error(`[bootstrap] installer profile seed ignored (${result.outcome})`);
   }
+  return false;
 }
 
 /**
@@ -1226,10 +1228,10 @@ function bootstrap(): void {
   // are caught without a surprise re-provision now.
   // WU-I1: pull the NSIS component page's choice into the data root BEFORE the
   // first-run classification reads it. Packaged-only (dev has no installer) and
-  // lock-holder-only (never write into a tree a live copy owns).
-  if (app.isPackaged && lock.ok) {
-    adoptInstallerProfile();
-  }
+  // lock-holder-only (never write into a tree a live copy owns). The RETURN value —
+  // "an installer choice was adopted on THIS launch" — is what suppresses the picker
+  // below; see shouldAwaitProfileChoice for why mere existence would be wrong.
+  const installerAdopted = app.isPackaged && lock.ok ? adoptInstallerProfile() : false;
 
   const markerExists = existsSync(firstRunCompletePath());
   const shippedFp = shippedRequirementsFingerprint();
@@ -1245,15 +1247,13 @@ function bootstrap(): void {
   // install-profile choice before spawning bootstrap (awaitingProfile). A silent
   // WU-S2 re-bootstrap reuses the persisted profile and auto-spawns (no picker).
   //
-  // WU-I1: …UNLESS the question is already answered. When a profile is persisted at
-  // the data root on a first-ever run it came from the NSIS component page (adopted
-  // just above — the in-app picker cannot have run yet, since it only appears on a
-  // first-ever run and persists on the way to bootstrap). Asking again would make the
-  // installer page decorative and the install non-unattended, so the picker is
-  // skipped and the auto-spawn below feeds bootstrap.py the SAME persisted set the
-  // re-bootstrap path already uses.
-  const awaitingProfile =
-    firstRun && firstRunKind === 'first-ever' && readPersistedInstallAssets() === null;
+  // WU-I1: …UNLESS the NSIS component page already answered on THIS launch, in which
+  // case asking again would make the installer page decorative and the install
+  // non-unattended. The auto-spawn below then feeds bootstrap.py the SAME persisted
+  // set the re-bootstrap path already uses — no new branch. The decision (and why it
+  // keys off this-launch adoption rather than "a profile exists") is the unit-tested
+  // pure shouldAwaitProfileChoice.
+  const awaitingProfile = shouldAwaitProfileChoice(firstRun, firstRunKind, installerAdopted);
   // WU-1b: seed the provisioning latch BEFORE the window loads so the renderer's
   // mount-time `provisioning.get` query is correct on the very first frame — a
   // first/re- run withholds the shell (no sidecar to serve its RPCs yet), an

--- a/build/check-installer-nsh.ps1
+++ b/build/check-installer-nsh.ps1
@@ -1,0 +1,107 @@
+<#
+.SYNOPSIS
+  Compile-check build/installer.nsh (the WU-I1 NSIS component page) with the REAL
+  makensis, without running a full electron-builder packaging pass.
+
+.DESCRIPTION
+  installer.nsh is a text file until makensis parses it. Nothing in the 6-gate quality
+  charter can see inside it: gate:1 skips `build/` (.pre-commit-config.yaml `exclude`),
+  gate:2 is tsc/basedpyright, and the vitest conformance test in
+  app/main/installerSeed.test.ts only pins its IDS AND LABELS against
+  app/main/installProfiles.ts — it cannot tell an unbalanced ${If} from a valid one.
+  So a syntax error here would surface only when a human runs a Windows build.
+
+  This script closes that gap locally. It synthesises the minimum electron-builder
+  context installer.nsh expects (MUI2 + LogicLib + nsDialogs, an install Section, a
+  page slot), inserts BOTH exported macros in the same positions app-builder-lib does
+  (templates/nsis/assistedInstaller.nsh:42 and templates/nsis/installSection.nsh:81),
+  and compiles. It asserts nothing about the produced installer — only that the code
+  we ship is syntactically valid NSIS.
+
+  NOT a CI gate: makensis is a Windows binary that arrives with electron-builder's own
+  download cache, and the `quality` workflow runs on Linux. Adding a gate would also
+  breach QUALITY-CHARTER.md rule 2 (the gate list is closed). Run it by hand after
+  editing installer.nsh, the same way docs_check_mutations.py is run by hand.
+
+.EXAMPLE
+  pwsh -File build/check-installer-nsh.ps1
+#>
+[CmdletBinding()]
+param(
+  # Root of the electron-builder tool cache holding the downloaded NSIS.
+  [string] $NsisCacheRoot = (Join-Path $env:LOCALAPPDATA 'electron-builder\Cache\nsis')
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$nsh = Join-Path $repoRoot 'build\installer.nsh'
+if (-not (Test-Path -LiteralPath $nsh)) {
+  Write-Host "FAILED:installer-nsh missing $nsh"
+  exit 1
+}
+
+$makensis = Get-ChildItem -LiteralPath $NsisCacheRoot -Recurse -Filter 'makensis.exe' -ErrorAction SilentlyContinue |
+  Where-Object { $_.DirectoryName -notmatch '\\Bin$' } |
+  Select-Object -First 1
+if (-not $makensis) {
+  # Absence of the tool is NOT a pass. Say so and exit non-zero so a caller can never
+  # read "no output" as "verified".
+  Write-Host "FAILED:installer-nsh makensis.exe not found under $NsisCacheRoot (run a Windows build once to populate the cache)"
+  exit 1
+}
+
+$work = Join-Path ([System.IO.Path]::GetTempPath()) ("reframe-nsh-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Path $work | Out-Null
+try {
+  # The harness mirrors app-builder-lib's own structure closely enough to expand both
+  # macros in a realistic context, and no further. `Page custom` needs a page slot, so
+  # MUI_PAGE_DIRECTORY stands in for the directory page it is inserted after.
+  $harness = @'
+!include MUI2.nsh
+!include LogicLib.nsh
+!include nsDialogs.nsh
+
+Name "Reframe"
+OutFile "harness.exe"
+InstallDir "$LOCALAPPDATA\Programs\Reframe"
+RequestExecutionLevel user
+
+!include "installer.nsh"
+
+!insertmacro MUI_PAGE_DIRECTORY
+; app-builder-lib inserts this exact macro here (assistedInstaller.nsh:42).
+!ifmacrodef customPageAfterChangeDir
+  !insertmacro customPageAfterChangeDir
+!endif
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_LANGUAGE "English"
+
+Section "install"
+  ; app-builder-lib inserts this exact macro here (installSection.nsh:81).
+  !ifmacrodef customInstall
+    !insertmacro customInstall
+  !endif
+SectionEnd
+'@
+  Set-Content -LiteralPath (Join-Path $work 'harness.nsi') -Value $harness -Encoding UTF8
+  Copy-Item -LiteralPath $nsh -Destination (Join-Path $work 'installer.nsh')
+
+  Push-Location $work
+  try {
+    $out = & $makensis.FullName '/V2' 'harness.nsi' 2>&1
+    $code = $LASTEXITCODE
+  } finally {
+    Pop-Location
+  }
+
+  $out | ForEach-Object { Write-Host $_ }
+  if ($code -ne 0) {
+    Write-Host "FAILED:installer-nsh makensis exit $code"
+    exit $code
+  }
+  Write-Host "SUCCESS:installer-nsh compiled with $($makensis.FullName)"
+  exit 0
+} finally {
+  Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,214 @@
+; installer.nsh — Reframe's NSIS customisation (WU-I1, the v1.5 installer revamp).
+;
+; Wired via electron-builder.yml `nsis.include`. electron-builder emits its defines
+; and `!include`s THIS file BEFORE its own templates/nsis/installer.nsi, so anything
+; here that needs MUI2 / nsDialogs / LogicLib lives INSIDE a macro body (expanded at
+; `!insertmacro` time, i.e. after common.nsh loaded them). Only `Var` declarations and
+; `!define`s sit at file scope. The two standard headers below carry their own include
+; guards, so requesting them early is safe and makes the page functions compilable.
+;
+; WHAT THIS ADDS
+;   1. A real component page after the directory page (`customPageAfterChangeDir`):
+;      Minimum / Default / Full / Custom, with individually selectable feature packs.
+;   2. An install-time write of that choice (`customInstall`) as the SEED the app
+;      adopts on first launch, so the first run provisions unattended instead of
+;      asking the same question again in the in-app ProfilePicker.
+;
+; WHY A nsDialogs PAGE AND NOT `MUI_PAGE_COMPONENTS`. A real MUI components page is
+; driven by NSIS `Section`s, and electron-builder owns the one and only install
+; Section (templates/nsis/installer.nsi:94) plus all of the update / uninstall
+; bookkeeping inside it. Adding Sections would require replacing the whole script
+; (`nsis.script`), forfeiting that machinery — a far larger backward-compatibility
+; risk than this feature is worth. `customPageAfterChangeDir` is the supported hook
+; (templates/nsis/assistedInstaller.nsh:42) and gives the same user-facing page.
+;
+; NO MODEL BYTES SHIP HERE. The packs are asset NAMES routed to bootstrap.py's
+; `--assets`; the weights still download on demand. Bundling them would blow the NSIS
+; ~2 GB format ceiling (see electron-builder.yml's header) and is an owner decision.
+;
+; DRIFT GUARD. Every id, label and filename below is pinned against
+; app/main/installProfiles.ts by app/main/installerSeed.test.ts. Change one side and
+; that test fails — the ids are not a second hand-maintained list.
+
+!include nsDialogs.nsh
+!include LogicLib.nsh
+
+; --- the contract with app/main/installProfiles.ts (pinned by installerSeed.test.ts) ---
+!define REFRAME_PROFILE_IDS "minimum|default|full|custom"
+!define REFRAME_BUNDLE_IDS "transcription|ai-director"
+!define REFRAME_PROFILE_DEFAULT "default"
+!define REFRAME_PROFILE_SEED_FILE ".first-run-profile.json"
+
+; Labels are the app's own words (INSTALL_PROFILES[].label / INSTALL_BUNDLES[].label)
+; so the installer and the first-run UI never describe the same thing differently.
+!define REFRAME_LABEL_MINIMUM "Minimum"
+!define REFRAME_LABEL_DEFAULT "Default"
+!define REFRAME_LABEL_FULL "Full"
+!define REFRAME_LABEL_CUSTOM "Custom"
+!define REFRAME_LABEL_TRANSCRIPTION "Transcription & subtitles"
+!define REFRAME_LABEL_AI_DIRECTOR "AI Director"
+
+; A bare `&` is a keyboard-mnemonic prefix in a Win32 control caption, so the display
+; copy doubles it. Same trick electron-builder uses for the product name
+; (templates/nsis/common.nsh:13) — the canonical label above stays the app's verbatim
+; string for the conformance test, and only the rendered caption is escaped.
+!searchreplace REFRAME_UI_TRANSCRIPTION "${REFRAME_LABEL_TRANSCRIPTION}" "&" "&&"
+
+Var ReframeProfile
+Var ReframeBundles
+Var ReframeDialog
+Var ReframeRadioMinimum
+Var ReframeRadioDefault
+Var ReframeRadioFull
+Var ReframeRadioCustom
+Var ReframeCheckTranscription
+Var ReframeCheckAiDirector
+Var ReframeScratch
+
+; ---------------------------------------------------------------------------
+; The component page
+; ---------------------------------------------------------------------------
+!macro customPageAfterChangeDir
+  Page custom reframeComponentsPageCreate reframeComponentsPageLeave
+
+  ; Grey the feature-pack checkboxes unless Custom is selected — the fixed profiles
+  ; are fully determined by their id (installProfiles.resolveInstallChoice ignores
+  ; bundles for a non-custom profile), so an editable list there would lie.
+  Function reframeSyncBundleEnabled
+    ${NSD_GetState} $ReframeRadioCustom $ReframeScratch
+    ${If} $ReframeScratch == ${BST_CHECKED}
+      EnableWindow $ReframeCheckTranscription 1
+      EnableWindow $ReframeCheckAiDirector 1
+    ${Else}
+      EnableWindow $ReframeCheckTranscription 0
+      EnableWindow $ReframeCheckAiDirector 0
+    ${EndIf}
+  FunctionEnd
+
+  Function reframeOnProfileChanged
+    Pop $ReframeScratch ; the notifying control handle (unused)
+    Call reframeSyncBundleEnabled
+  FunctionEnd
+
+  Function reframeComponentsPageCreate
+    ; A silent / updater-driven run still calls the creator; there is no UI to show,
+    ; so keep the default and move on. The default is safe by construction: the app
+    ; only ADOPTS a seed when the data root has no profile, so an unattended upgrade
+    ; can never downgrade an existing choice (installerSeed.ts).
+    ${If} ${Silent}
+      Abort
+    ${EndIf}
+
+    !insertmacro MUI_HEADER_TEXT "Choose what to set up" \
+      "Everything not installed now downloads the first time you use it."
+
+    nsDialogs::Create 1018
+    Pop $ReframeDialog
+    ${If} $ReframeDialog == error
+      Abort
+    ${EndIf}
+
+    ${NSD_CreateRadioButton} 0 0u 100% 11u "${REFRAME_LABEL_MINIMUM} — app plus subject tracking only"
+    Pop $ReframeRadioMinimum
+    ${NSD_CreateRadioButton} 0 13u 100% 11u "${REFRAME_LABEL_DEFAULT} — also offline transcription (recommended)"
+    Pop $ReframeRadioDefault
+    ${NSD_CreateRadioButton} 0 26u 100% 11u "${REFRAME_LABEL_FULL} — everything up front, including the AI Director model"
+    Pop $ReframeRadioFull
+    ${NSD_CreateRadioButton} 0 39u 100% 11u "${REFRAME_LABEL_CUSTOM} — pick the feature packs below"
+    Pop $ReframeRadioCustom
+
+    ${NSD_CreateLabel} 0 56u 100% 10u "Feature packs (Custom only):"
+    Pop $ReframeScratch
+    ${NSD_CreateCheckbox} 8u 68u 100% 11u "${REFRAME_UI_TRANSCRIPTION}"
+    Pop $ReframeCheckTranscription
+    ${NSD_CreateCheckbox} 8u 81u 100% 11u "${REFRAME_LABEL_AI_DIRECTOR}"
+    Pop $ReframeCheckAiDirector
+
+    ${NSD_CreateLabel} 0 98u 100% 20u \
+      "Models are downloaded on demand, not bundled in this installer. You can add or remove packs later in Settings."
+    Pop $ReframeScratch
+
+    ; Restore the previous answer when the user steps Back, otherwise preselect the
+    ; profile the app itself marks recommended (${REFRAME_PROFILE_DEFAULT}).
+    ${If} $ReframeProfile == "minimum"
+      ${NSD_Check} $ReframeRadioMinimum
+    ${ElseIf} $ReframeProfile == "full"
+      ${NSD_Check} $ReframeRadioFull
+    ${ElseIf} $ReframeProfile == "custom"
+      ${NSD_Check} $ReframeRadioCustom
+    ${Else}
+      ${NSD_Check} $ReframeRadioDefault
+    ${EndIf}
+
+    ${NSD_OnClick} $ReframeRadioMinimum reframeOnProfileChanged
+    ${NSD_OnClick} $ReframeRadioDefault reframeOnProfileChanged
+    ${NSD_OnClick} $ReframeRadioFull reframeOnProfileChanged
+    ${NSD_OnClick} $ReframeRadioCustom reframeOnProfileChanged
+    Call reframeSyncBundleEnabled
+
+    nsDialogs::Show
+  FunctionEnd
+
+  Function reframeComponentsPageLeave
+    StrCpy $ReframeBundles ""
+
+    ${NSD_GetState} $ReframeRadioMinimum $ReframeScratch
+    ${If} $ReframeScratch == ${BST_CHECKED}
+      StrCpy $ReframeProfile "minimum"
+      Return
+    ${EndIf}
+
+    ${NSD_GetState} $ReframeRadioFull $ReframeScratch
+    ${If} $ReframeScratch == ${BST_CHECKED}
+      StrCpy $ReframeProfile "full"
+      Return
+    ${EndIf}
+
+    ${NSD_GetState} $ReframeRadioCustom $ReframeScratch
+    ${If} $ReframeScratch == ${BST_CHECKED}
+      StrCpy $ReframeProfile "custom"
+      ${NSD_GetState} $ReframeCheckTranscription $ReframeScratch
+      ${If} $ReframeScratch == ${BST_CHECKED}
+        StrCpy $ReframeBundles '$\"transcription$\"'
+      ${EndIf}
+      ${NSD_GetState} $ReframeCheckAiDirector $ReframeScratch
+      ${If} $ReframeScratch == ${BST_CHECKED}
+        ${If} $ReframeBundles == ""
+          StrCpy $ReframeBundles '$\"ai-director$\"'
+        ${Else}
+          StrCpy $ReframeBundles '$ReframeBundles, $\"ai-director$\"'
+        ${EndIf}
+      ${EndIf}
+      Return
+    ${EndIf}
+
+    StrCpy $ReframeProfile "${REFRAME_PROFILE_DEFAULT}"
+  FunctionEnd
+!macroend
+
+; ---------------------------------------------------------------------------
+; The seed write
+; ---------------------------------------------------------------------------
+!macro customInstall
+  ; A silent run never showed the page, so nothing set $ReframeProfile.
+  ${If} $ReframeProfile == ""
+    StrCpy $ReframeProfile "${REFRAME_PROFILE_DEFAULT}"
+  ${EndIf}
+
+  ; $INSTDIR is the one path NSIS and the app agree on byte-for-byte (the app reads it
+  ; back as dirname(process.execPath) — dataRootIo.exeDir). The app copies it into
+  ; whatever data root it resolves at runtime, and ONLY when that root has no profile
+  ; yet, so this write can never disturb an existing install (installerSeed.ts).
+  ClearErrors
+  FileOpen $ReframeScratch "$INSTDIR\${REFRAME_PROFILE_SEED_FILE}" w
+  ${IfNot} ${Errors}
+    FileWrite $ReframeScratch '{$\r$\n'
+    FileWrite $ReframeScratch '  $\"profile$\": $\"$ReframeProfile$\",$\r$\n'
+    FileWrite $ReframeScratch '  $\"bundles$\": [$ReframeBundles]$\r$\n'
+    FileWrite $ReframeScratch '}$\r$\n'
+    FileClose $ReframeScratch
+  ${EndIf}
+  ; A failed write is deliberately NOT fatal: the app falls back to its in-app
+  ; profile picker, which is exactly the pre-WU-I1 behaviour.
+  ClearErrors
+!macroend

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -144,8 +144,23 @@ nsis:
   # .ico as win.icon — replaces the default Electron icon everywhere.
   installerIcon: icons/reframe.ico
   uninstallerIcon: icons/reframe.ico
+  # WU-I1: the COMPONENT PAGE. buildResources-relative (../build/installer.nsh).
+  # Adds an nsDialogs page at electron-builder's `customPageAfterChangeDir` hook —
+  # Minimum / Default / Full / Custom with individually selectable feature packs —
+  # and writes the choice as `$INSTDIR/.first-run-profile.json`. The app adopts that
+  # seed into its runtime-resolved data root on first launch (app/main/installerSeed.ts),
+  # so setup provisions the chosen packs UNATTENDED instead of re-asking in the in-app
+  # ProfilePicker. NO model bytes are bundled — the packs are asset names routed to
+  # bootstrap.py `--assets`, and the weights still download on demand (the NSIS ~2 GB
+  # ceiling noted at the top of this file is exactly why).
+  # The ids/labels in that .nsh are pinned against app/main/installProfiles.ts by
+  # app/main/installerSeed.test.ts, so the page and the app cannot drift apart.
+  include: installer.nsh
   # First-run state lives in %APPDATA%/media-studio (envs/models/tools);
-  # uninstall keeps it so a reinstall needs no re-download.
+  # uninstall keeps it so a reinstall needs no re-download. KEEP false: it is also
+  # what makes an upgrade safe — the uninstaller electron-updater runs in-place only
+  # touches %APPDATA%/<app> when this is true (app-builder-lib
+  # templates/nsis/uninstaller.nsh:223-248), and it NEVER touches the data root.
   deleteAppDataOnUninstall: false
   shortcutName: Reframe
 


### PR DESCRIPTION
## An install could never be unattended

The packaged installer had **no component page at all** — `electron-builder.yml nsis:`
carried only oneClick/perMachine/icons. Everything was decided later, in the app: a
first-ever launch raised `awaitingProfile` and the renderer showed the in-app
`ProfilePicker`. Setup finishes, the app opens, and *only then* does it ask the question
the installer should already have answered.

## The obvious fix is the wrong one

Having NSIS write the data root directly would be a mistake: the data root is **resolved at
runtime** by `dataRootPlan.planDataRoot` (env override → `data-dir.txt` marker → legacy
`<exeDir>/data` migration → `%APPDATA%/media-studio`). Re-implementing that policy in NSIS
would create a second copy of a path rule that must never disagree with the first.

Instead, `$INSTDIR` is the **one location both sides compute identically** — NSIS has
`$INSTDIR`, the app has `dirname(process.execPath)`. NSIS writes a *seed* there;
`app/main/installerSeed.ts` is the single policy owner that copies it into whatever data
root the app actually resolved.

It is an **nsDialogs page, not `MUI_PAGE_COMPONENTS`**: a real components page is driven by
NSIS Sections, and electron-builder owns the single install Section together with all the
update/uninstall bookkeeping inside it. Taking that over via `nsis.script` would forfeit
machinery this change has no business touching.

**No model bytes ship.** The packs are asset *names* routed to `bootstrap.py --assets`; the
weights still download on demand.

## Backward compatibility — the load-bearing part

The seed is adopted **only** when the resolved data root holds no profile yet. An existing
install keeps the profile it already chose, re-downloads nothing, and loses no setting —
even though every upgrade re-runs the page and rewrites a seed. The unprobeable-data-root
case **fails closed** to `already-chosen`. Both directions are unit-tested.

The load-bearing test builds an **old install** (profile=full, `.first-run-complete.json`,
settings.json, a stand-in model file), runs a **new** installer seed saying `minimum`, and
asserts all four survive **byte-identical** with outcome `already-chosen`.

## I shipped a real defect in this branch and then fixed it

Commit `155f4dd4` suppressed the picker whenever a profile existed on a first-ever run,
justified with *"on a first-ever run a persisted profile can only have come from the
installer"*. **That premise is false**, and the counter-example is the common failure path:
the picker writes the profile *before* `bootstrap.py` runs, and `bootstrap.py` only writes
`.first-run-complete.json` on full success. So a first run that dies mid-download — no
network, no disk — leaves a persisted profile and **no** marker, and `classifyFirstRun`
correctly returns `first-ever` again next launch.

Under `155f4dd4` that launch would have skipped the picker and silently re-attempted **the
same asset set, with no route back to the chooser**. A user who picked Full and ran out of
disk could not pick Minimum. That is a worse failure than the one this feature set out to
fix, and it was introduced by an overclaim in a comment, not by a hard problem.

`shouldAwaitProfileChoice(firstRun, firstRunKind, installerAdoptedThisLaunch)` now keys the
suppression off an adoption performed on **this launch**, not off mere file existence.
Result: exactly one launch behaves differently from before — the first one after an install,
which is the whole point. Every other path is byte-for-byte the old behaviour, **including
"first run failed, ask again"**.

## Closing a gate blind spot: nothing could read the NSIS

`build/installer.nsh` is executable code no quality gate can see inside — gate 1 skips the
whole `build/` tree (`.pre-commit-config.yaml exclude:` line 18), gate 2 is tsc +
basedpyright, gate 3 is pytest + vitest. The conformance test only parses `!define`s; it
passes happily on a file with an unbalanced `${If}`. **The first signal of a syntax error
would have been a human running a Windows build.**

`build/check-installer-nsh.ps1` compiles it with the *real* makensis from electron-builder's
own download cache, synthesising the minimum context and inserting both exported macros at
the same positions app-builder-lib does.

It is **deliberately not a CI gate**: makensis is a Windows binary and `quality` runs on
Linux, so a gate would be skipped-and-green there — and `QUALITY-CHARTER.md` rule 2 declares
the gate list closed. A missing makensis exits **non-zero** with a `FAILED:` line rather than
passing quietly; absence of the tool is not evidence the script is valid.

**Both states measured:** healthy → `SUCCESS:installer-nsh`, exit 0. Deleting one `${EndIf}`
→ `could not resolve label "_LogicLib_ElseLabel_4"` → `FAILED:installer-nsh`, exit 1.
Reverted, re-ran, green again.

## Verification

`tsc --noEmit` clean · **vitest 212 files / 3783 tests passed** · makensis compile of the
**committed blob bytes** (`git archive HEAD`, 0 CRLF pairs — the LF form CI checks out) →
exit 0 · pre-commit (oxlint, biome, docs-check, gitleaks), charter_check, docs_check all pass.

**TDD, red first** on both feature commits: `Cannot find module ./installerSeed` (26 tests),
then `Cannot find shouldAwaitProfileChoice` (5 failed / 26 passed).

The conformance gate was **mutation-checked in both directions before being trusted**:
dropping `ai-director` from `REFRAME_BUNDLE_IDS` and renaming `REFRAME_PROFILE_SEED_FILE`
each turned it red. Its green is a measurement, not silence.

`electron-builder.yml nsis.include` resolution was confirmed by **reading the installed
app-builder-lib**, not the docs: `NsisTarget.js:600` calls
`packager.getResource(this.options.include, "installer.nsh")`, resolved against
`buildResourcesDir`.

## Conflict surface

Touches `electron-builder.yml`, as does #342 — but in a **disjoint hunk** (`nsis:` block at
L144-166 vs #342's `extraResources` ffmpeg block at L81-116). Verified non-overlapping;
merges cleanly either order. No dependency on #342 or #343.

## Provenance

Produced by a workflow agent killed mid-run by a `401 API key is invalid` (9 of 11 agents
died the same way — a credential-refresh race across concurrent agents, not a code fault).
All five commits were already made; recovered from the worktree rather than re-derived.
