### PR TITLE
fix(installer): the component page made the installer unbuildable, and its gate could not see it

### DIFF
--- a/build/check-installer-nsh.ps1
+++ b/build/check-installer-nsh.ps1
@@ -51,56 +51,96 @@ if (-not $makensis) {
   exit 1
 }
 
+# TWO PASSES, and /WX. Both additions come from a REAL escape (2026-08-08).
+#
+# v1 of this check modelled only the INSTALLER pass and compiled with /V2 but not /WX. It
+# reported SUCCESS on an installer.nsh that electron-builder could not package at all:
+#
+#     warning 6001: Variable "ReframeProfile" not referenced or never set, wasting memory!
+#     Error: warning treated as error
+#
+# Root cause: electron-builder runs makensis TWICE over the same script -- once for the
+# installer, once for the UNINSTALLER with -DBUILD_UNINSTALLER (app-builder-lib
+# templates/nsis/installer.nsi:90,:95 gate the whole install half on !ifndef BUILD_UNINSTALLER).
+# In that second pass neither custom macro is inserted, so every Var declared at top level and
+# used only inside those macros is declared-and-never-referenced -> 6001 -> /WX -> no installer.
+#
+# v1 was structurally blind to it: it ALWAYS inserted both macros, so it only ever exercised the
+# state that works. That is a probe that is silent in the broken state -- it measured nothing.
+# Both passes now run, and both use /WX exactly as electron-builder does.
+
 $work = Join-Path ([System.IO.Path]::GetTempPath()) ("reframe-nsh-" + [guid]::NewGuid().ToString('N'))
 New-Item -ItemType Directory -Path $work | Out-Null
 try {
-  # The harness mirrors app-builder-lib's own structure closely enough to expand both
-  # macros in a realistic context, and no further. `Page custom` needs a page slot, so
-  # MUI_PAGE_DIRECTORY stands in for the directory page it is inserted after.
-  $harness = @'
-!include MUI2.nsh
-!include LogicLib.nsh
-!include nsDialogs.nsh
-
-Name "Reframe"
-OutFile "harness.exe"
-InstallDir "$LOCALAPPDATA\Programs\Reframe"
-RequestExecutionLevel user
-
-!include "installer.nsh"
-
-!insertmacro MUI_PAGE_DIRECTORY
-; app-builder-lib inserts this exact macro here (assistedInstaller.nsh:42).
-!ifmacrodef customPageAfterChangeDir
-  !insertmacro customPageAfterChangeDir
-!endif
-!insertmacro MUI_PAGE_INSTFILES
-!insertmacro MUI_LANGUAGE "English"
-
-Section "install"
-  ; app-builder-lib inserts this exact macro here (installSection.nsh:81).
-  !ifmacrodef customInstall
-    !insertmacro customInstall
-  !endif
-SectionEnd
-'@
-  Set-Content -LiteralPath (Join-Path $work 'harness.nsi') -Value $harness -Encoding UTF8
   Copy-Item -LiteralPath $nsh -Destination (Join-Path $work 'installer.nsh')
 
-  Push-Location $work
-  try {
-    $out = & $makensis.FullName '/V2' 'harness.nsi' 2>&1
-    $code = $LASTEXITCODE
-  } finally {
-    Pop-Location
+  # $InsertMacros mirrors whether app-builder-lib expands the custom macros in this pass.
+  # `Page custom` needs a page slot, so MUI_PAGE_DIRECTORY stands in for the directory page
+  # customPageAfterChangeDir is inserted after.
+  function Build-Harness([bool]$InsertMacros) {
+    $h = @(
+      '!include MUI2.nsh'
+      '!include LogicLib.nsh'
+      '!include nsDialogs.nsh'
+      ''
+      'Name "Reframe"'
+      'OutFile "harness.exe"'
+      'InstallDir "$LOCALAPPDATA\Programs\Reframe"'
+      'RequestExecutionLevel user'
+      ''
+      '!include "installer.nsh"'
+      ''
+      '!insertmacro MUI_PAGE_DIRECTORY'
+    )
+    if ($InsertMacros) {
+      # app-builder-lib inserts this exact macro here (assistedInstaller.nsh:42).
+      $h += '!ifmacrodef customPageAfterChangeDir'
+      $h += '  !insertmacro customPageAfterChangeDir'
+      $h += '!endif'
+    }
+    $h += '!insertmacro MUI_PAGE_INSTFILES'
+    $h += '!insertmacro MUI_LANGUAGE "English"'
+    $h += ''
+    $h += 'Section "install"'
+    if ($InsertMacros) {
+      # app-builder-lib inserts this exact macro here (installSection.nsh:81).
+      $h += '  !ifmacrodef customInstall'
+      $h += '    !insertmacro customInstall'
+      $h += '  !endif'
+    }
+    $h += 'SectionEnd'
+    return ($h -join "`r`n")
   }
 
-  $out | ForEach-Object { Write-Host $_ }
-  if ($code -ne 0) {
-    Write-Host "FAILED:installer-nsh makensis exit $code"
-    exit $code
+  function Invoke-Pass([string]$Label, [bool]$InsertMacros, [string[]]$ExtraArgs) {
+    Set-Content -LiteralPath (Join-Path $work 'harness.nsi') -Value (Build-Harness $InsertMacros) -Encoding UTF8
+    Push-Location $work
+    try {
+      # /WX is what electron-builder uses. Without it this check cannot see warning 6001.
+      $passOut = & $makensis.FullName '/WX' '/V2' @ExtraArgs 'harness.nsi' 2>&1
+      $passCode = $LASTEXITCODE
+    } finally {
+      Pop-Location
+    }
+    $passOut | ForEach-Object { Write-Host $_ }
+    if ($passCode -ne 0) {
+      Write-Host "FAILED:installer-nsh $Label pass -- makensis exit $passCode"
+      return $passCode
+    }
+    Write-Host "  ok: $Label pass"
+    return 0
   }
-  Write-Host "SUCCESS:installer-nsh compiled with $($makensis.FullName)"
+
+  # Pass 1 -- the installer. Macros inserted, as assistedInstaller.nsh/installSection.nsh do.
+  $rc = Invoke-Pass 'installer' $true @()
+  if ($rc -ne 0) { exit $rc }
+
+  # Pass 2 -- the uninstaller. -DBUILD_UNINSTALLER and NO custom macros, which is what
+  # app-builder-lib actually compiles. This is the pass that caught the 6001 escape.
+  $rc = Invoke-Pass 'uninstaller' $false @('/DBUILD_UNINSTALLER')
+  if ($rc -ne 0) { exit $rc }
+
+  Write-Host "SUCCESS:installer-nsh both passes compiled with $($makensis.FullName)"
   exit 0
 } finally {
   Remove-Item -LiteralPath $work -Recurse -Force -ErrorAction SilentlyContinue

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -54,6 +54,19 @@
 ; string for the conformance test, and only the rendered caption is escaped.
 !searchreplace REFRAME_UI_TRANSCRIPTION "${REFRAME_LABEL_TRANSCRIPTION}" "&" "&&"
 
+; INSTALLER-PASS ONLY. electron-builder runs makensis TWICE over this same script: once for
+; the installer, and once for the uninstaller with -DBUILD_UNINSTALLER (see the build log's
+; `Command line defined: "BUILD_UNINSTALLER"`, and app-builder-lib templates/nsis/installer.nsi
+; :90,:95 which gate the whole install half on `!ifndef BUILD_UNINSTALLER`).
+;
+; Every one of these vars is used ONLY inside customPageAfterChangeDir / customInstall, and
+; app-builder-lib does not insert those macros in the uninstaller pass. Declared unconditionally
+; they were therefore declared-and-never-referenced in that pass, and NSIS emitted
+;   warning 6001: Variable "ReframeProfile" not referenced or never set, wasting memory!
+; which electron-builder compiles with /WX -> "Error: warning treated as error" -> NO INSTALLER
+; IS PRODUCED AT ALL. Measured on this box: the packaging run reached
+; `dist/win-unpacked` and `.nsis.7z` and then died at the uninstaller compile.
+!ifndef BUILD_UNINSTALLER
 Var ReframeProfile
 Var ReframeBundles
 Var ReframeDialog
@@ -64,6 +77,7 @@ Var ReframeRadioCustom
 Var ReframeCheckTranscription
 Var ReframeCheckAiDirector
 Var ReframeScratch
+!endif
 
 ; ---------------------------------------------------------------------------
 ; The component page


### PR DESCRIPTION
fix(installer): the component page made the installer unbuildable, and its gate could not see it

WHAT WAS WRONG
--------------
#344 shipped build/installer.nsh with ten `Var` declarations at top level. Every one of them
is used ONLY inside customPageAfterChangeDir / customInstall.

electron-builder runs makensis TWICE over the same script: once for the installer, and once
for the UNINSTALLER with -DBUILD_UNINSTALLER (app-builder-lib templates/nsis/installer.nsi
:90,:95 gate the whole install half on `!ifndef BUILD_UNINSTALLER`). In that second pass
neither custom macro is inserted, so all ten vars are declared-and-never-referenced:

    warning 6001: Variable "ReframeProfile" not referenced or never set, wasting memory!
    Error: warning treated as error

electron-builder compiles with /WX, so that is fatal. Measured on this box: a full packaging
run from main reached dist/win-unpacked and media-studio-1.4.2-x64.nsis.7z and then DIED at
the uninstaller compile. NO INSTALLER WAS PRODUCED. The .exe sitting in dist/ was ten days
old, from a previous build.

So #344 did not merely add a page -- it made the Windows installer unbuildable. Nothing on
main can currently ship to a user.

WHY EVERY GATE MISSED IT (the more important half)
--------------------------------------------------
gate:1 skips build/ entirely, gate:2 is tsc+basedpyright, gate:3 is pytest+vitest, and
`quality` runs on Linux where makensis does not exist. #344 knew that -- it is exactly why it
added build/check-installer-nsh.ps1, which compiles the .nsh with the REAL makensis.

That check reported SUCCESS on this file. Two reasons, both structural:

  1. It compiled with /V2 but NOT /WX, so warnings could not fail it. electron-builder uses /WX.
  2. It ALWAYS inserted both macros -- i.e. it modelled ONLY the installer pass. The
     uninstaller pass, the one that fails, was never exercised.

A probe that is silent in the broken state measures nothing. #344's commit message claimed the
harness "inserts both exported macros at the same positions app-builder-lib does" -- true for
the installer, and precisely why it was blind: app-builder-lib's other pass inserts NEITHER.
The check was green because it only ever ran the state that works.

THE FIX
-------
build/installer.nsh: wrap the ten Var declarations in `!ifndef BUILD_UNINSTALLER`. Same guard
app-builder-lib uses for its own install half. The macro DEFINITIONS stay unconditional -- a
macro that is defined and never inserted compiles no body, so it costs nothing in that pass.

build/check-installer-nsh.ps1: run BOTH passes, both with /WX.
  pass 1  installer     -- macros inserted, as assistedInstaller.nsh:42 / installSection.nsh:81
  pass 2  uninstaller   -- /DBUILD_UNINSTALLER, NO macros, as app-builder-lib actually compiles

BOTH STATES MEASURED (so the green is a measurement, not silence)
------------------------------------------------------------------
  STATE A, fixed .nsh:
      ok: installer pass
      ok: uninstaller pass
      SUCCESS:installer-nsh both passes compiled          exit 0

  STATE B, .nsh reverted to the shipped #344 form:
      ok: installer pass
      warning 6001: Variable "ReframeProfile" not referenced or never set, wasting memory!
      Error: warning treated as error
      FAILED:installer-nsh uninstaller pass -- makensis exit 1     exit 1

Note the installer pass is GREEN IN BOTH STATES. That is the whole point: the discriminating
signal is the pass v1 never ran.

RESIDUAL, stated inline rather than in a footnote
--------------------------------------------------
* This check is still NOT a CI gate, for the reason #344 gave and QUALITY-CHARTER.md rule 2
  requires (gate list closed; makensis is Windows-only and `quality` is Linux, so a gate there
  would be skipped-and-green). It remains a hand-run local check. UNVERIFIED whether a
  Windows-only CI leg should adopt it; the settling experiment is to add it to the e2e Windows
  job and confirm it fails on STATE B there too.
* I have NOT yet re-run a full electron-builder pass on the fixed file, so "the installer now
  builds end to end" is NOT-CHECKED at this commit. What IS checked is that the exact compile
  which failed now succeeds, both passes, under the same /WX makensis. Confidence that this is
  the whole cause of the packaging failure: almost certain (90-99%) -- the failing message and
  the failing pass are both reproduced and both cleared. Confidence that no OTHER packaging
  problem lies behind it: unknown, because the run never got past this one.
* Only `Var` was guarded. If a future edit adds installer-only !define/Function/Section at top
  level, the same trap applies -- pass 2 is now what catches it.
