### PR TITLE
fix(caption): let a gallery style reach the karaoke burn

### DIFF
--- a/app/renderer/src/components/CaptionDesigner.test.tsx
+++ b/app/renderer/src/components/CaptionDesigner.test.tsx
@@ -91,6 +91,27 @@ describe('<CaptionDesigner />', () => {
     expect(active?.style.color.replace(/\s/g, '')).toContain('255,255,0');
   });
 
+  it('lets an explicit activeColor override the karaoke alternation (burn parity)', () => {
+    // The sidecar's resolve_karaoke_style COLLAPSES the yellow/green alternation to
+    // an explicit override.activeColor, so the preview must do the same or it shows
+    // a colour the burn will not produce. Before this fix the karaoke branch passed
+    // karaokeActiveColor(w.index) UNCONDITIONALLY into wordColor's
+    // `activeColorOverride ?? visual.activeColor`, and since karaokeActiveColor never
+    // returns undefined the folded override.activeColor was unreachable.
+    render({
+      design: {
+        style: 'opusclip-karaoke',
+        box: DEFAULT_CAPTION_DESIGN.box,
+        override: { activeColor: '#FF00FF' },
+      },
+    });
+    tick(container, 11.5); // cue index 0 — would be yellow without the override
+    const line = container.querySelector('.caption-designer__line') as HTMLElement;
+    const active = [...line.querySelectorAll('span')].find((s) => s.textContent === 'Hello');
+    expect(active?.style.color.replace(/\s/g, '')).toContain('255,0,255');
+    expect(active?.style.color.replace(/\s/g, '')).not.toContain('255,255,0');
+  });
+
   it('alternates the karaoke accent by the ABSOLUTE cue index, not the line-local position', () => {
     // A >LINE_GAP_SEC gap isolates cue index 1 onto its own line, so its line-local
     // slice position is 0 (even) while its ABSOLUTE cue index is 1 (odd). The correct

--- a/app/renderer/src/components/CaptionDesigner.tsx
+++ b/app/renderer/src/components/CaptionDesigner.tsx
@@ -19,7 +19,7 @@ import { CaptionStylePicker } from './CaptionStylePicker';
 import { CaptionCustomizer } from './CaptionCustomizer';
 import { activeLine, wordColor } from './CaptionOverlay';
 import { isNoCaption } from '../lib/captionTemplates';
-import { isKaraokeStyle, karaokeActiveColor } from '../lib/captionKaraokePreset';
+import { isKaraokeStyle, karaokeActiveColorFor } from '../lib/captionKaraokePreset';
 import { captionSampleStyle, previewSizeScale, previewVisual } from '../lib/captionOverridePreview';
 import { type CaptionBand, bandBox, boxBand } from '../lib/captionPosition';
 import type { CaptionContentContext } from '../lib/captionDefaults';
@@ -107,7 +107,9 @@ export function CaptionDesigner({
                       color: wordColor(
                         w,
                         visual,
-                        karaoke ? karaokeActiveColor(w.index) : undefined,
+                        karaoke
+                          ? karaokeActiveColorFor(w.index, design.override?.activeColor)
+                          : undefined,
                       ),
                       backgroundColor: w.active ? visual.activeBackground : 'transparent',
                     }}

--- a/app/renderer/src/features/caption/CaptionStage.test.tsx
+++ b/app/renderer/src/features/caption/CaptionStage.test.tsx
@@ -120,6 +120,27 @@ describe('CaptionStage', () => {
     expect(q('.caption-stage__sample')?.getAttribute('data-karaoke-pop')).toBe('true');
   });
 
+  it('paints the karaoke active word with an explicit activeColor override (burn parity)', () => {
+    // The sidecar's resolve_karaoke_style collapses the yellow/green alternation to
+    // an explicit override.activeColor, so the Stage — which claims in its own header
+    // to render "exactly as it will export" — must too. Without the override the
+    // word at absolute cue index 1 would be GREEN (#00FF00).
+    setReducedMotion(false);
+    render({
+      video: { videoId: 'v1', window: { start: 0, end: 10 } },
+      cues: PHRASE,
+      design: {
+        ...DEFAULT_CAPTION_DESIGN,
+        style: 'opusclip-karaoke',
+        override: { activeColor: '#FF00FF' },
+      },
+    });
+    seekTo(3.5); // cue index 1 "there" is active
+    const active = q<HTMLElement>('.caption-stage__word.is-active');
+    expect(active?.style.color.replace(/\s/g, '')).toContain('255,0,255');
+    expect(active?.style.color.replace(/\s/g, '')).not.toContain('0,255,0');
+  });
+
   it('leaves the karaoke pop OFF under prefers-reduced-motion', () => {
     setReducedMotion(true);
     render({

--- a/app/renderer/src/features/caption/CaptionStage.tsx
+++ b/app/renderer/src/features/caption/CaptionStage.tsx
@@ -20,7 +20,7 @@ import { CaptionBox } from '../../components/CaptionBox';
 import { activeLine, wordColor } from '../../components/CaptionOverlay';
 import { prefersReducedMotion } from '../../components/UsageBar';
 import { isNoCaption } from '../../lib/captionTemplates';
-import { isKaraokeStyle, karaokeActiveColor } from '../../lib/captionKaraokePreset';
+import { isKaraokeStyle, karaokeActiveColorFor } from '../../lib/captionKaraokePreset';
 import {
   captionSampleStyle,
   previewSizeScale,
@@ -73,7 +73,9 @@ export function CaptionStage(): React.ReactElement {
                       color: wordColor(
                         w,
                         visual,
-                        karaoke ? karaokeActiveColor(w.index) : undefined,
+                        karaoke
+                          ? karaokeActiveColorFor(w.index, design.override?.activeColor)
+                          : undefined,
                       ),
                       backgroundColor: w.active ? visual.activeBackground : 'transparent',
                     }}

--- a/app/renderer/src/lib/captionKaraokePreset.test.ts
+++ b/app/renderer/src/lib/captionKaraokePreset.test.ts
@@ -23,6 +23,7 @@ import {
   SAFE_AREA_BOTTOM_FRACTION,
   isKaraokeStyle,
   karaokeActiveColor,
+  karaokeActiveColorFor,
   safeAreaMarginV,
 } from './captionKaraokePreset';
 
@@ -76,6 +77,23 @@ describe('karaokeActiveColor', () => {
     expect(karaokeActiveColor(Number.NaN)).toBe('#FFFF00');
     expect(karaokeActiveColor(-1)).toBe('#00FF00');
     expect(karaokeActiveColor(2.9)).toBe('#FFFF00');
+  });
+});
+
+describe('karaokeActiveColorFor (mirrors sidecar resolve_karaoke_style)', () => {
+  it('alternates when no activeColor override is set', () => {
+    expect(karaokeActiveColorFor(0)).toBe('#FFFF00');
+    expect(karaokeActiveColorFor(1)).toBe('#00FF00');
+    expect(karaokeActiveColorFor(0, undefined)).toBe('#FFFF00');
+  });
+
+  it('collapses the alternation to an explicit activeColor', () => {
+    // Mirrors resolve_karaoke_style: `(active, active) if active else ALTERNATION`.
+    // Both parities must return the override, or the preview would still alternate
+    // for half the words while the burn used one colour throughout.
+    expect(karaokeActiveColorFor(0, '#FF00FF')).toBe('#FF00FF');
+    expect(karaokeActiveColorFor(1, '#FF00FF')).toBe('#FF00FF');
+    expect(karaokeActiveColorFor(7, '#FF00FF')).toBe('#FF00FF');
   });
 });
 

--- a/app/renderer/src/lib/captionKaraokePreset.ts
+++ b/app/renderer/src/lib/captionKaraokePreset.ts
@@ -68,6 +68,22 @@ export function karaokeActiveColor(index: number): string {
 }
 
 /**
+ * The active-word accent for `index`, honouring an explicit `CaptionOverride
+ * .activeColor` — the renderer mirror of the sidecar's `resolve_karaoke_style`,
+ * where a named active colour COLLAPSES the yellow/green alternation to that one
+ * colour (a user who names the lit-word colour asked for exactly that colour).
+ *
+ * This exists because `wordColor(word, visual, activeColorOverride)` resolves
+ * `activeColorOverride ?? visual.activeColor`, and `karaokeActiveColor` NEVER
+ * returns undefined — so passing it unconditionally made the override that
+ * `previewVisual` folds into `visual.activeColor` unreachable for karaoke, and the
+ * preview painted an alternating accent the burn would not produce.
+ */
+export function karaokeActiveColorFor(index: number, activeColorOverride?: string): string {
+  return activeColorOverride ?? karaokeActiveColor(index);
+}
+
+/**
  * Vertical margin (px) that keeps the line inside the 9:16 safe area — the
  * renderer mirror of sidecar `safe_area_margin_v`. `top` clears the top ~10%;
  * `center` is centred (0); anything else (`bottom`, the default) clears the

--- a/sidecar/media_studio/features/caption.py
+++ b/sidecar/media_studio/features/caption.py
@@ -301,6 +301,77 @@ def _default_style_line(
     )
 
 
+def hook_overlay_parts(
+    hook_title: str | None,
+    cues: Sequence[CueLike],
+    play_x: int,
+    play_y: int,
+    source_start: float = 0.0,
+    total_sec: float = 0.0,
+    hook_card: bool = False,
+    hook_card_sec: float = 0.0,
+) -> tuple[list[str], list[str]]:
+    """``(style lines, event lines)`` for the P3-A hook headline / WU-SP2 card.
+
+    Shared by :func:`build_ass` and
+    :func:`media_studio.features.caption_karaoke.build_karaoke_ass` so the hook
+    overlay is byte-identical whichever libass body style is selected (the
+    headline is an independent Style + event drawn ABOVE the captions, so it is
+    orthogonal to the body caption's look).
+
+    A blank / absent ``hook_title`` yields ``([], [])``. Otherwise:
+
+    - ``hook_card`` renders the OpusClip CARD (white opaque box, bold black,
+      upper third) time-boxed to the first ``hook_card_sec`` seconds, capped to
+      ``total_sec`` when known — it REPLACES the plain headline, never both.
+    - the plain headline is a bold top-anchored line spanning ``total_sec`` if
+      known, else the last cue's clip-local end or a 60 s floor (the §5 hard max
+      clip length) so it persists across the whole clip.
+
+    Pure. The hook text is user-ish data and is escaped + soft-wrapped by
+    :func:`wrap_hook_title` before it reaches any ASS field.
+    """
+    title_text = wrap_hook_title(hook_title or "")
+    if not title_text:
+        return [], []
+
+    if hook_card:
+        card_end = _hook_card.hook_card_end_sec(hook_card_sec, total_sec)
+        return (
+            [_hook_card.hook_card_style_line(play_x, play_y)],
+            [
+                f"Dialogue: 0,{format_ass_timestamp(0.0)},{format_ass_timestamp(card_end)},"
+                f"{_hook_card.HOOK_CARD_STYLE_NAME},,0,0,0,,{title_text}"
+            ],
+        )
+
+    # P3-A: a bold, larger, TOP-anchored headline style (Alignment 8 = top-
+    # centre). Slightly larger than the body caption with a thicker outline so
+    # it reads as a headline; safe top margin keeps it off the very edge.
+    title_size = max(14, int(round(play_y * 0.055)))
+    title_margin_v = max(12, int(round(play_y * 0.07)))
+    style = (
+        f"Style: {_HOOK_TITLE_STYLE},Arial,"
+        f"{title_size},"
+        "&H00FFFFFF,&H000000FF,&H00000000,&H96000000,"
+        "-1,0,0,0,"
+        "100,100,0,0,1,4,2,"
+        f"8,60,60,{title_margin_v},1"
+    )
+
+    title_end = float(total_sec)
+    if title_end <= 0.0:
+        # No probed duration: span to the last cue (clip-local) or a 60s floor
+        # (the §5 hard max clip length) so the headline persists.
+        cue_ends = [rebase_cue_time(c.get("end", 0.0), source_start) for c in cues]
+        title_end = max([*cue_ends, _HOOK_TITLE_FALLBACK_SEC], default=_HOOK_TITLE_FALLBACK_SEC)
+    event = (
+        f"Dialogue: 0,{format_ass_timestamp(0.0)},{format_ass_timestamp(title_end)},"
+        f"{_HOOK_TITLE_STYLE},,0,0,0,,{title_text}"
+    )
+    return [style], [event]
+
+
 def build_ass(
     cues: Sequence[CueLike],
     width: int = 1080,
@@ -360,31 +431,24 @@ def build_ass(
     if resolved.position_band is not None:
         alignment, margin_v = _band_position(resolved.position_band, default_margin_v)
 
-    styles = [
-        _default_style_line(resolved, font_size, alignment, margin_l, margin_r, margin_v),
-    ]
-
-    # P3-A: a bold, larger, TOP-anchored headline style (Alignment 8 = top-
-    # centre). Slightly larger than the body caption with a thicker outline so
-    # it reads as a headline; safe top margin keeps it off the very edge.
     # V1.1 WU SP2: a carded clip (top-N by virality) swaps the plain headline for
     # the OpusClip HOOK CARD style — a white opaque box with bold black text in
-    # the upper third, time-boxed to the first ~5 s (the event below).
-    title_text = wrap_hook_title(hook_title or "")
-    if title_text:
-        if hook_card:
-            styles.append(_hook_card.hook_card_style_line(play_x, play_y))
-        else:
-            title_size = max(14, int(round(play_y * 0.055)))
-            title_margin_v = max(12, int(round(play_y * 0.07)))
-            styles.append(
-                "Style: HookTitle,Arial,"
-                f"{title_size},"
-                "&H00FFFFFF,&H000000FF,&H00000000,&H96000000,"
-                "-1,0,0,0,"
-                "100,100,0,0,1,4,2,"
-                f"8,60,60,{title_margin_v},1"
-            )
+    # the upper third, time-boxed to the first ~5 s.
+    hook_styles, hook_events = hook_overlay_parts(
+        hook_title,
+        cues,
+        play_x,
+        play_y,
+        source_start=source_start,
+        total_sec=total_sec,
+        hook_card=hook_card,
+        hook_card_sec=hook_card_sec,
+    )
+
+    styles = [
+        _default_style_line(resolved, font_size, alignment, margin_l, margin_r, margin_v),
+        *hook_styles,
+    ]
 
     header = [
         "[Script Info]",
@@ -408,31 +472,8 @@ def build_ass(
         "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
     ]
 
-    events: list[str] = []
-
-    # P3-A: emit the hook-title event FIRST so it draws above the body captions.
-    # WU SP2: a carded clip emits a HookCard event time-boxed to the first ~5 s
-    # (NOT the whole clip), capped to the clip length when known.
-    if title_text:
-        if hook_card:
-            card_end = _hook_card.hook_card_end_sec(hook_card_sec, total_sec)
-            events.append(
-                f"Dialogue: 0,{format_ass_timestamp(0.0)},{format_ass_timestamp(card_end)},"
-                f"{_hook_card.HOOK_CARD_STYLE_NAME},,0,0,0,,{title_text}"
-            )
-        else:
-            title_end = float(total_sec)
-            if title_end <= 0.0:
-                # No probed duration: span to the last cue (clip-local) or a 60s
-                # floor (the §5 hard max clip length) so the headline persists.
-                cue_ends = [rebase_cue_time(c.get("end", 0.0), source_start) for c in cues]
-                title_end = max(
-                    [*cue_ends, _HOOK_TITLE_FALLBACK_SEC],
-                    default=_HOOK_TITLE_FALLBACK_SEC,
-                )
-            events.append(
-                f"Dialogue: 0,{format_ass_timestamp(0.0)},{format_ass_timestamp(title_end)},HookTitle,,0,0,0,,{title_text}"
-            )
+    # P3-A: the hook-title event is emitted FIRST so it draws above the body captions.
+    events: list[str] = [*hook_events]
 
     for cue in cues:
         raw_start = cue.get("start", 0.0)
@@ -634,8 +675,19 @@ class CaptionEngine:
 
         When ``karaoke`` is set (the V1.1 WU SP1 ``opusclip-karaoke`` preset), the
         OpusClip word-by-word karaoke ASS is built instead of the standard
-        document — same temp-file burn/soft-mux path. ``hook_title``/``override``
-        do not apply to the karaoke preset (its look is fixed by the teardown).
+        document — same temp-file burn/soft-mux path.
+
+        v1.5 lane-karaoke: the karaoke branch receives the SAME styling arguments as
+        the standard document. It used to take only cues + canvas + ``source_start``
+        on the premise that "its look is fixed by the teardown", which silently
+        discarded ``override``, ``position``, ``hook_title``, ``total_sec``,
+        ``hook_card`` and ``hook_card_sec`` — so a style tuned in the gallery had no
+        effect on a karaoke burn even though the renderer's live preview painted it.
+        The teardown flourishes that are genuinely karaoke-only (the alternating
+        per-word accent and the ``\\t \\fscx`` scale-pop) survive any override; the
+        one control that cannot apply, per-word ``emphasis`` bolding, is declined
+        explicitly with its reason in
+        :mod:`media_studio.features.caption_karaoke`.
         """
         if karaoke:
             from . import caption_karaoke as _karaoke  # lazy: avoid an import cycle
@@ -645,6 +697,12 @@ class CaptionEngine:
                 width=width,
                 height=height,
                 source_start=source_start,
+                override=override,
+                position=position,
+                hook_title=hook_title,
+                total_sec=total_sec,
+                hook_card=hook_card,
+                hook_card_sec=hook_card_sec,
             )
         else:
             ass_doc = build_ass(

--- a/sidecar/media_studio/features/caption_karaoke.py
+++ b/sidecar/media_studio/features/caption_karaoke.py
@@ -32,14 +32,59 @@ Load-bearing colour detail (the silent-wrong-colour trap, mirrored from
 alpha). The palette below is declared as ``#RRGGBB`` and the resolved ``&H`` forms
 are pinned as constants whose drift from :func:`caption_override.hex_to_ass_color`
 is asserted by the unit tests.
+
+STYLING CONTRACT (v1.5 lane-karaoke). The preset used to be style-LOCKED: its
+``build_karaoke_ass`` took only cues + canvas + ``source_start``, so a
+:class:`caption_override.CaptionOverride` tuned in the gallery was silently
+discarded while the renderer's live preview
+(``captionOverridePreview.previewVisual`` folded onto
+``captionTemplates.KARAOKE_PRESET_VISUAL``) painted the tuned look — the preview
+and the burn disagreed. Every user-settable control now reaches the burn:
+
+===================== =========================================================
+control               how the karaoke preset honours it
+===================== =========================================================
+``fontFamily``        Style ``Fontname`` (curated allowlist; else ``Anton``)
+``sizeScale``         multiplies the canvas-derived base size (>= 12 floor)
+``textColor``         Style ``PrimaryColour`` (the white fill words reset to)
+``spokenColor``       fill FALLBACK when ``textColor`` is absent
+``activeColor``       the inline ``\1c`` accent — COLLAPSES the alternation
+``box`` / ``outline`` Style ``BorderStyle`` / ``Outline`` width
+``uppercase``         per-word casing (tri-state; preset default all-caps)
+``positionBand``      safe-area band -> ``Alignment`` + ``MarginV``
+``captionPosition``   the normalised ``{x,y,w,h}`` box (shared helpers)
+``hook_title``        the P3-A headline / WU-SP2 card overlay (shared emitter)
+===================== =========================================================
+
+EXPLICITLY DECLINED, with the mechanical reason (NOT a silent drop):
+
+* **``emphasis`` spans -> bold.** The karaoke Style sets ``Bold=-1``
+  (:data:`KARAOKE_BOLD`) — the whole line is already bold — so the ``{\b1}``
+  wrap :func:`caption.render_cue_text` uses cannot render any contrast here. It
+  would emit tags with zero visual effect. Not applied; see
+  :func:`build_line_text`.
+* **``maxLines`` / ``maxCps``.** Consumed at cue GENERATION by
+  :func:`caption_polish.resolve_caption_limits`, i.e. UPSTREAM of all three
+  engines, so they are not karaoke drops. This preset then re-groups the words it
+  is given into its own 1-4-words-per-line look (the teardown model).
 """
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from typing import Any
 
-from .caption import CueLike, escape_ass_text, format_ass_timestamp, rebase_cue_time
+from . import caption_override as _override
+from .caption import (
+    CueLike,
+    caption_position_fields,
+    escape_ass_text,
+    format_ass_timestamp,
+    hook_overlay_parts,
+    normalize_caption_box,
+    rebase_cue_time,
+)
 
 # --------------------------------------------------------------------------- #
 # preset identity
@@ -100,9 +145,112 @@ def is_karaoke_style(style: Any) -> bool:
     return isinstance(style, str) and style.strip().lower() == OPUSCLIP_KARAOKE_STYLE
 
 
-def active_color_for_index(index: int) -> str:
-    """Inline ``\\1c`` colour for the word at absolute ``index`` (yellow/green alt)."""
-    return KARAOKE_ACTIVE_INLINE[index % 2]
+def active_color_for_index(index: int, palette: tuple[str, str] = KARAOKE_ACTIVE_INLINE) -> str:
+    """Inline ``\\1c`` colour for the word at absolute ``index`` (yellow/green alt).
+
+    ``palette`` defaults to the teardown-verified yellow/green pair; a resolved
+    :class:`ResolvedKaraokeStyle` passes its own (see
+    :func:`resolve_karaoke_style`, where an explicit ``activeColor`` collapses both
+    slots to one colour).
+    """
+    return palette[index % 2]
+
+
+# --------------------------------------------------------------------------- #
+# override resolution — the CaptionOverride merged onto the KARAOKE base
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class ResolvedKaraokeStyle:
+    """The karaoke visual after merging a validated ``CaptionOverride`` patch.
+
+    Deliberately NOT :class:`caption_override.ResolvedCaptionStyle`: that dataclass
+    resolves against the libass-NORMAL base (Arial, outline width 3), so reusing it
+    would silently thin the preset's signature thick outline (4 -> 3) on any render
+    that merely *has* an override. These defaults are the karaoke preset's own, so
+    an absent/empty override reproduces the teardown look byte-for-byte.
+
+    ``uppercase`` / ``position_band`` are TRI-STATE (``None`` = the field was absent
+    or malformed, so :func:`build_karaoke_ass` keeps its own argument's value).
+    """
+
+    font_name: str = KARAOKE_FONT
+    size_scale: float = 1.0
+    primary_color: str = KARAOKE_FILL
+    secondary_color: str = KARAOKE_FILL
+    outline_color: str = KARAOKE_OUTLINE
+    back_color: str = KARAOKE_BACK
+    border_style: int = KARAOKE_BORDER_STYLE
+    outline_width: int = KARAOKE_OUTLINE_WIDTH
+    shadow: int = KARAOKE_SHADOW
+    active_colors: tuple[str, str] = KARAOKE_ACTIVE_INLINE
+    uppercase: bool | None = None
+    position_band: str | None = None
+
+
+def _style_colour(inline: str | None) -> str | None:
+    """A ``&HAABBGGRR&`` inline colour as the Style-line form (no trailing ``&``).
+
+    :func:`caption_override.hex_to_ass_color` emits the inline form; Style lines in
+    this module are written without the trailing ``&`` (matching
+    :data:`KARAOKE_FILL`). ``None`` in -> ``None`` out, so the caller keeps the
+    preset colour.
+    """
+    return inline.rstrip("&") if inline else None
+
+
+def _resolve_karaoke_border(box: bool | None, outline: bool | None) -> tuple[int, int]:
+    """``(BorderStyle, Outline width)`` from the ``box`` / ``outline`` toggles.
+
+    Same precedence as :func:`caption_override._resolve_border` (a solid card and a
+    pure outline are mutually exclusive — the card wins) but resolved against the
+    KARAOKE defaults, so an untouched pair keeps the preset's THICK outline
+    (:data:`KARAOKE_OUTLINE_WIDTH`) instead of the normal path's thinner one.
+    """
+    if box is True:
+        return 3, KARAOKE_OUTLINE_WIDTH  # opaque box card
+    if outline is False:
+        return KARAOKE_BORDER_STYLE, 0  # stroke explicitly off
+    return KARAOKE_BORDER_STYLE, KARAOKE_OUTLINE_WIDTH
+
+
+def resolve_karaoke_style(override: Mapping[str, Any] | None) -> ResolvedKaraokeStyle:
+    """Merge a ``CaptionOverride`` patch onto the OpusClip karaoke base visual.
+
+    Validation is DELEGATED to :func:`caption_override.apply_override` (curated
+    font allowlist, strict ``#RRGGBB`` hex, clamped ``sizeScale``, known position
+    band) so the two libass paths can never drift on what counts as a valid patch;
+    only the DEFAULTS a dropped field falls back to are karaoke's own. A malformed
+    field degrades to the preset value field-by-field and never raises.
+
+    Two karaoke-specific semantics:
+
+    * ``fontFamily`` falls back to :data:`KARAOKE_FONT`. An absent/off-allowlist
+      font resolves to :data:`caption_override.BASE_FONT` (``Arial``), which is NOT
+      a member of ``CURATED_CAPTION_FONTS`` — so that sentinel unambiguously means
+      "untouched" and can never be a real user pick.
+    * an explicit ``activeColor`` COLLAPSES the yellow/green alternation to that one
+      colour. The alternation is the preset's default flourish; a user who names an
+      active colour asked for the lit word to be that colour, and alternating it
+      against a leftover green would defeat the setting.
+    """
+    o = override or {}
+    base = _override.apply_override(o)
+    fill = _style_colour(base.text_color or base.spoken_color) or KARAOKE_FILL
+    active = base.active_color
+    border_style, outline_width = _resolve_karaoke_border(
+        _override.as_bool(o.get("box")), _override.as_bool(o.get("outline"))
+    )
+    return ResolvedKaraokeStyle(
+        font_name=KARAOKE_FONT if base.font_name == _override.BASE_FONT else base.font_name,
+        size_scale=base.size_scale,
+        primary_color=fill,
+        secondary_color=fill,
+        border_style=border_style,
+        outline_width=outline_width,
+        active_colors=(active, active) if active else KARAOKE_ACTIVE_INLINE,
+        uppercase=_override.as_bool(o.get("uppercase")),
+        position_band=base.position_band,
+    )
 
 
 def safe_area_margin_v(height: int, band: str) -> int:
@@ -197,6 +345,12 @@ def build_line_text(
     upper-cased when requested, the OpusClip all-caps look) BEFORE assembly so the
     inserted override tags can never be corrupted and caption text can never inject
     ASS.
+
+    A cue's ``emphasis`` spans are deliberately NOT bolded here (unlike
+    :func:`caption.render_cue_text`): the karaoke Style is ``Bold=-1``
+    (:data:`KARAOKE_BOLD`), so the whole line already renders bold and a ``{\\b1}``
+    wrap could not produce any visible contrast. This is an explicit decline with a
+    mechanical reason, not a dropped feature — see the module docstring.
     """
     parts: list[str] = []
     for index, word in enumerate(line_words):
@@ -212,18 +366,26 @@ def build_karaoke_style_line(
     margin_l: int,
     margin_r: int,
     margin_v: int,
+    resolved: ResolvedKaraokeStyle | None = None,
 ) -> str:
     """The OpusClip karaoke ``Style: Default`` line (all-caps condensed base look).
 
     White fill, a thick dark outline + shadow (``BorderStyle=1``), bold condensed
     font. The active-word colour + scale-pop are applied inline per word; this
     Style is the white-fill/outline base every word resets (``\\r``) back to.
+
+    ``resolved`` supplies the font / colours / border after a ``CaptionOverride``
+    merge; ``None`` means the un-tuned preset, so the emitted line is
+    byte-identical to the pre-override V1.1 output. ``Bold`` is deliberately NOT
+    overridable — the karaoke look is always bold (which is also why per-word
+    ``emphasis`` bolding is declined; see the module docstring).
     """
+    style = resolved or resolve_karaoke_style(None)
     return (
-        f"Style: Default,{KARAOKE_FONT},{font_size},"
-        f"{KARAOKE_FILL},{KARAOKE_FILL},{KARAOKE_OUTLINE},{KARAOKE_BACK},"
+        f"Style: Default,{style.font_name},{font_size},"
+        f"{style.primary_color},{style.secondary_color},{style.outline_color},{style.back_color},"
         f"{KARAOKE_BOLD},0,0,0,"
-        f"100,100,0,0,{KARAOKE_BORDER_STYLE},{KARAOKE_OUTLINE_WIDTH},{KARAOKE_SHADOW},"
+        f"100,100,0,0,{style.border_style},{style.outline_width},{style.shadow},"
         f"{alignment},{margin_l},{margin_r},{margin_v},1"
     )
 
@@ -235,6 +397,12 @@ def build_karaoke_ass(
     source_start: float = 0.0,
     position_band: str = "bottom",
     uppercase: bool = True,
+    override: Mapping[str, Any] | None = None,
+    position: Any = None,
+    hook_title: str | None = None,
+    total_sec: float = 0.0,
+    hook_card: bool = False,
+    hook_card_sec: float = 0.0,
 ) -> str:
     r"""Build a complete OpusClip-style karaoke ASS document for ``cues``.
 
@@ -248,14 +416,60 @@ def build_karaoke_ass(
       word highlighted (alternating yellow/green + scale-pop). Words whose window
       lies entirely before the clip (end <= start after re-base) are skipped, but
       still advance the alternation so the accent order is stable.
+
+    Styling (v1.5 lane-karaoke — see the module docstring for the full table):
+
+    - ``override`` is a validated ``CaptionOverride`` merged onto the preset by
+      :func:`resolve_karaoke_style`; ``None``/``{}`` reproduces the teardown look
+      byte-for-byte. Its ``positionBand`` / ``uppercase`` fields, when present, WIN
+      over the ``position_band`` / ``uppercase`` arguments (which stay the defaults
+      for direct callers).
+    - ``position`` is the renderer's normalised ``{x,y,w,h}`` caption box, resolved
+      with the SAME :func:`caption.normalize_caption_box` /
+      :func:`caption.caption_position_fields` helpers the normal path uses. A
+      present ``positionBand`` then re-anchors ``Alignment``/``MarginV`` while the
+      box keeps the fine L/R offset — the ordering
+      :func:`caption.build_ass` uses.
+    - ``hook_title`` / ``total_sec`` / ``hook_card`` / ``hook_card_sec`` emit the
+      headline-or-card overlay via the shared :func:`caption.hook_overlay_parts`,
+      so the overlay is byte-identical across both libass paths.
     """
     play_x = int(width)
     play_y = int(height)
-    band = _resolve_band(position_band)
-    alignment = KARAOKE_BAND_ALIGNMENT[band]
-    margin_v = safe_area_margin_v(play_y, band)
+    resolved = resolve_karaoke_style(override)
+
+    # The override's coarse band wins over the caller's argument when present.
+    band = _resolve_band(position_band if resolved.position_band is None else resolved.position_band)
+    band_alignment = KARAOKE_BAND_ALIGNMENT[band]
+    band_margin_v = safe_area_margin_v(play_y, band)
     margin_h = max(0, int(round(play_x * SIDE_MARGIN_FRACTION)))
+
+    # P4 §4: honour the renderer's normalised caption POSITION box when present;
+    # otherwise keep the safe-area band placement. Malformed boxes fall back to the
+    # band (no silent crash).
+    box = normalize_caption_box(position)
+    if box is None:
+        alignment, margin_l, margin_r, margin_v = band_alignment, margin_h, margin_h, band_margin_v
+    else:
+        alignment, margin_l, margin_r, margin_v = caption_position_fields(box, play_x, play_y)
+    if resolved.position_band is not None:
+        # An explicit band re-anchors; the box still supplies the fine L/R offset.
+        alignment, margin_v = band_alignment, band_margin_v
+
+    upper = uppercase if resolved.uppercase is None else resolved.uppercase
+    hook_styles, hook_events = hook_overlay_parts(
+        hook_title,
+        cues,
+        play_x,
+        play_y,
+        source_start=source_start,
+        total_sec=total_sec,
+        hook_card=hook_card,
+        hook_card_sec=hook_card_sec,
+    )
+
     font_size = max(12, int(round(play_y * 0.05)))
+    font_size = max(12, int(round(font_size * resolved.size_scale)))
 
     header = [
         "[Script Info]",
@@ -273,13 +487,15 @@ def build_karaoke_ass(
             "ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, "
             "Alignment, MarginL, MarginR, MarginV, Encoding"
         ),
-        build_karaoke_style_line(font_size, alignment, margin_h, margin_h, margin_v),
+        build_karaoke_style_line(font_size, alignment, margin_l, margin_r, margin_v, resolved),
+        *hook_styles,
         "",
         "[Events]",
         "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
     ]
 
-    events: list[str] = []
+    # The hook overlay is emitted FIRST so it draws above the karaoke line.
+    events: list[str] = [*hook_events]
     global_index = 0
     # Bug-sweep: the shortmaker pipeline feeds ONE-WORD cues (features._cues_for_clip
     # emits a cue per transcript word), so grouping per-cue collapsed every karaoke
@@ -289,13 +505,13 @@ def build_karaoke_ass(
     all_words = [word for cue in cues for word in words_from_cue(cue)]
     for line in group_into_lines(all_words):
         for active_index, word in enumerate(line):
-            color = active_color_for_index(global_index)
+            color = active_color_for_index(global_index, resolved.active_colors)
             global_index += 1
             start = rebase_cue_time(word.get("start", 0.0), source_start)
             end = rebase_cue_time(word.get("end", 0.0), source_start)
             if end <= start:
                 continue  # entirely before the clip (or zero-length after re-base)
-            text = build_line_text(line, active_index, color, uppercase=uppercase)
+            text = build_line_text(line, active_index, color, uppercase=upper)
             events.append(
                 f"Dialogue: 0,{format_ass_timestamp(start)},{format_ass_timestamp(end)},Default,,0,0,0,,{text}"
             )
@@ -325,12 +541,14 @@ __all__ = [
     "SAFE_AREA_BOTTOM_FRACTION",
     "SAFE_AREA_TOP_FRACTION",
     "SIDE_MARGIN_FRACTION",
+    "ResolvedKaraokeStyle",
     "active_color_for_index",
     "build_karaoke_ass",
     "build_karaoke_style_line",
     "build_line_text",
     "group_into_lines",
     "is_karaoke_style",
+    "resolve_karaoke_style",
     "safe_area_margin_v",
     "words_from_cue",
 ]

--- a/sidecar/media_studio/features/caption_karaoke.py
+++ b/sidecar/media_studio/features/caption_karaoke.py
@@ -233,7 +233,7 @@ def resolve_karaoke_style(override: Mapping[str, Any] | None) -> ResolvedKaraoke
       active colour asked for the lit word to be that colour, and alternating it
       against a leftover green would defeat the setting.
     """
-    o = override or {}
+    o = _override.as_mapping(override)
     base = _override.apply_override(o)
     fill = _style_colour(base.text_color or base.spoken_color) or KARAOKE_FILL
     active = base.active_color

--- a/sidecar/media_studio/features/caption_karaoke.py
+++ b/sidecar/media_studio/features/caption_karaoke.py
@@ -47,7 +47,7 @@ control               how the karaoke preset honours it
 ``fontFamily``        Style ``Fontname`` (curated allowlist; else ``Anton``)
 ``sizeScale``         multiplies the canvas-derived base size (>= 12 floor)
 ``textColor``         Style ``PrimaryColour`` (the white fill words reset to)
-``spokenColor``       fill FALLBACK when ``textColor`` is absent
+``spokenColor``       inline ``\1c`` on ALREADY-SPOKEN words (its own third state)
 ``activeColor``       the inline ``\1c`` accent — COLLAPSES the alternation
 ``box`` / ``outline`` Style ``BorderStyle`` / ``Outline`` width
 ``uppercase``         per-word casing (tri-state; preset default all-caps)
@@ -63,10 +63,20 @@ EXPLICITLY DECLINED, with the mechanical reason (NOT a silent drop):
   wrap :func:`caption.render_cue_text` uses cannot render any contrast here. It
   would emit tags with zero visual effect. Not applied; see
   :func:`build_line_text`.
-* **``maxLines`` / ``maxCps``.** Consumed at cue GENERATION by
-  :func:`caption_polish.resolve_caption_limits`, i.e. UPSTREAM of all three
-  engines, so they are not karaoke drops. This preset then re-groups the words it
-  is given into its own 1-4-words-per-line look (the teardown model).
+* **``maxLines`` / ``maxCps``.** NEITHER libass burn path consumes them:
+  :func:`caption_polish.polish_cues` (which calls
+  :func:`caption_polish.resolve_caption_limits`) has exactly one production
+  caller, :func:`subtitles.generate_polished` via ``handlers/media_ops.py:53`` —
+  the SOFT-SUBTITLE route. The burn's cue list comes from
+  ``shortmaker._cues_for_clip``, which never calls it. So they shape the sidecar
+  subtitle file, not a burn, and :func:`caption.build_ass` ignores them
+  identically — pre-existing and engine-SYMMETRIC, not a karaoke drop. This
+  preset re-groups the words it is given into its own 1-4-words-per-line look
+  (the teardown model) regardless.
+
+  *(Earlier wording here claimed they were "consumed at cue generation upstream of
+  all three engines". That was REFUTED: `polish_cues` appears nowhere in
+  `shortmaker.py`. The code was and is correct; only the sentence was wrong.)*
 """
 
 from __future__ import annotations
@@ -183,6 +193,9 @@ class ResolvedKaraokeStyle:
     outline_width: int = KARAOKE_OUTLINE_WIDTH
     shadow: int = KARAOKE_SHADOW
     active_colors: tuple[str, str] = KARAOKE_ACTIVE_INLINE
+    #: inline ``\1c`` colour for ALREADY-SPOKEN words, or ``None`` for the preset's
+    #: behaviour (no persistent spoken state — they reset to the white Style fill).
+    spoken_color: str | None = None
     uppercase: bool | None = None
     position_band: str | None = None
 
@@ -222,7 +235,7 @@ def resolve_karaoke_style(override: Mapping[str, Any] | None) -> ResolvedKaraoke
     only the DEFAULTS a dropped field falls back to are karaoke's own. A malformed
     field degrades to the preset value field-by-field and never raises.
 
-    Two karaoke-specific semantics:
+    Three karaoke-specific semantics:
 
     * ``fontFamily`` falls back to :data:`KARAOKE_FONT`. An absent/off-allowlist
       font resolves to :data:`caption_override.BASE_FONT` (``Arial``), which is NOT
@@ -232,10 +245,18 @@ def resolve_karaoke_style(override: Mapping[str, Any] | None) -> ResolvedKaraoke
       colour. The alternation is the preset's default flourish; a user who names an
       active colour asked for the lit word to be that colour, and alternating it
       against a leftover green would defeat the setting.
+    * ``spokenColor`` is its OWN role, never folded into the fill. This preset emits
+      one event per word, so within an event the words before the active one are
+      already spoken and can carry their own inline accent — the same three-state
+      paint the renderer preview implements at ``CaptionOverlay.wordColor:161-163``
+      (active -> activeColor, spoken -> spokenColor, else textColor). An earlier
+      version resolved ``text_color or spoken_color`` into ``PrimaryColour``, which
+      both discarded ``spokenColor`` whenever ``textColor`` was set AND wrongly
+      painted NOT-yet-spoken words with it — a preview/burn divergence.
     """
     o = _override.as_mapping(override)
     base = _override.apply_override(o)
-    fill = _style_colour(base.text_color or base.spoken_color) or KARAOKE_FILL
+    fill = _style_colour(base.text_color) or KARAOKE_FILL
     active = base.active_color
     border_style, outline_width = _resolve_karaoke_border(
         _override.as_bool(o.get("box")), _override.as_bool(o.get("outline"))
@@ -248,6 +269,7 @@ def resolve_karaoke_style(override: Mapping[str, Any] | None) -> ResolvedKaraoke
         border_style=border_style,
         outline_width=outline_width,
         active_colors=(active, active) if active else KARAOKE_ACTIVE_INLINE,
+        spoken_color=base.spoken_color,
         uppercase=_override.as_bool(o.get("uppercase")),
         position_band=base.position_band,
     )
@@ -332,19 +354,35 @@ def _active_word_block(word_text: str, color: str) -> str:
     )
 
 
+def _spoken_word_block(word_text: str, color: str) -> str:
+    r"""Inline ASS for an ALREADY-SPOKEN word: a flat ``\1c`` recolour, then ``\r``.
+
+    No ``\t`` animation — the scale-pop belongs to the word being spoken NOW. Emits
+    ``{\1c<color>}WORD{\r}`` so the rest of the line keeps the Style default.
+    """
+    return f"{{\\1c{color}}}{word_text}{{\\r}}"
+
+
 def build_line_text(
     line_words: Sequence[dict[str, Any]],
     active_index: int,
     active_color: str,
     uppercase: bool = True,
+    spoken_color: str | None = None,
 ) -> str:
     """ASS ``Dialogue`` text for a line with word ``active_index`` highlighted.
 
-    The active word gets :func:`_active_word_block` (alternating colour + pop); the
-    others render as the plain white Style default. Every word is escaped (and
-    upper-cased when requested, the OpusClip all-caps look) BEFORE assembly so the
-    inserted override tags can never be corrupted and caption text can never inject
-    ASS.
+    Three states, mirroring the renderer preview's ``CaptionOverlay.wordColor``:
+    the word at ``active_index`` gets :func:`_active_word_block` (accent + pop);
+    words BEFORE it are already spoken and get :func:`_spoken_word_block` when
+    ``spoken_color`` is set; everything else renders as the plain Style default.
+    With ``spoken_color=None`` (the un-tuned preset) spoken words reset to the white
+    fill, which is the teardown look and what ``KARAOKE_PRESET_VISUAL.spokenColor``
+    mirrors on the renderer side.
+
+    Every word is escaped (and upper-cased when requested, the OpusClip all-caps
+    look) BEFORE assembly so the inserted override tags can never be corrupted and
+    caption text can never inject ASS.
 
     A cue's ``emphasis`` spans are deliberately NOT bolded here (unlike
     :func:`caption.render_cue_text`): the karaoke Style is ``Bold=-1``
@@ -356,7 +394,12 @@ def build_line_text(
     for index, word in enumerate(line_words):
         raw = str(word.get("text") or "")
         text = escape_ass_text(raw.upper() if uppercase else raw)
-        parts.append(_active_word_block(text, active_color) if index == active_index else text)
+        if index == active_index:
+            parts.append(_active_word_block(text, active_color))
+        elif index < active_index and spoken_color:
+            parts.append(_spoken_word_block(text, spoken_color))
+        else:
+            parts.append(text)
     return " ".join(parts)
 
 
@@ -511,7 +554,7 @@ def build_karaoke_ass(
             end = rebase_cue_time(word.get("end", 0.0), source_start)
             if end <= start:
                 continue  # entirely before the clip (or zero-length after re-base)
-            text = build_line_text(line, active_index, color, uppercase=upper)
+            text = build_line_text(line, active_index, color, uppercase=upper, spoken_color=resolved.spoken_color)
             events.append(
                 f"Dialogue: 0,{format_ass_timestamp(start)},{format_ass_timestamp(end)},Default,,0,0,0,,{text}"
             )

--- a/sidecar/media_studio/features/caption_override.py
+++ b/sidecar/media_studio/features/caption_override.py
@@ -108,6 +108,20 @@ def hex_to_ass_color(value: Any, alpha: str = "00") -> str | None:
     return f"&H{alpha}{bb}{gg}{rr}&".upper()
 
 
+def as_mapping(value: Any) -> Mapping[str, Any]:
+    """``value`` when it is a ``Mapping``, else an EMPTY mapping.
+
+    ``captionOverride`` is an untrusted wire value handed straight through by
+    ``shortmaker._lazy_caption``, so a list / string / number arriving in that slot
+    must degrade to "no override" exactly like any other malformed field — this
+    module promises it "never raises", and without this guard a non-Mapping reached
+    ``.get`` and killed the render with ``AttributeError``. ``bool`` is a Mapping-less
+    ``int`` and is rejected by the same check. Mirrors the ``isinstance`` guard
+    :func:`caption_polish.resolve_caption_limits` already applies to the same field.
+    """
+    return value if isinstance(value, Mapping) else {}
+
+
 def as_bool(value: Any) -> bool | None:
     """Return ``value`` when it is a genuine ``bool``, else ``None`` (absent).
 
@@ -194,7 +208,7 @@ def apply_override(override: Mapping[str, Any] | None) -> ResolvedCaptionStyle:
     (or, failing that, the karaoke ``spokenColor``) -> ``PrimaryColour``;
     ``activeColor`` -> ``SecondaryColour``.
     """
-    o = override or {}
+    o = as_mapping(override)
 
     raw_font = o.get("fontFamily")
     font_name = raw_font.strip() if isinstance(raw_font, str) else ""
@@ -255,6 +269,7 @@ __all__ = [
     "ResolvedCaptionStyle",
     "apply_override",
     "as_bool",
+    "as_mapping",
     "hex_to_ass_color",
     "resolve_caption_style",
 ]

--- a/sidecar/media_studio/features/caption_override.py
+++ b/sidecar/media_studio/features/caption_override.py
@@ -108,8 +108,14 @@ def hex_to_ass_color(value: Any, alpha: str = "00") -> str | None:
     return f"&H{alpha}{bb}{gg}{rr}&".upper()
 
 
-def _as_bool(value: Any) -> bool | None:
-    """Return ``value`` when it is a genuine ``bool``, else ``None`` (absent)."""
+def as_bool(value: Any) -> bool | None:
+    """Return ``value`` when it is a genuine ``bool``, else ``None`` (absent).
+
+    The tri-state matters: a deliberate ``False`` (e.g. ``outline: false``) must be
+    distinguishable from an ABSENT field, which keeps the template's value. Shared
+    with :mod:`.caption_karaoke`, whose preset base differs from this module's, so
+    it resolves the same toggles against its own defaults.
+    """
     return value if isinstance(value, bool) else None
 
 
@@ -200,7 +206,7 @@ def apply_override(override: Mapping[str, Any] | None) -> ResolvedCaptionStyle:
     primary = text_color or spoken_color or BASE_PRIMARY
     secondary = active_color or BASE_SECONDARY
 
-    border_style, outline_width = _resolve_border(_as_bool(o.get("box")), _as_bool(o.get("outline")))
+    border_style, outline_width = _resolve_border(as_bool(o.get("box")), as_bool(o.get("outline")))
 
     band = o.get("positionBand")
     position_band = band if band in POSITION_BAND_ALIGNMENT else None
@@ -215,7 +221,7 @@ def apply_override(override: Mapping[str, Any] | None) -> ResolvedCaptionStyle:
         border_style=border_style,
         outline_width=outline_width,
         shadow=BASE_SHADOW,
-        uppercase=_as_bool(o.get("uppercase")) or False,
+        uppercase=as_bool(o.get("uppercase")) or False,
         position_band=position_band,
         text_color=text_color,
         active_color=active_color,
@@ -248,6 +254,7 @@ __all__ = [
     "SIZE_SCALE_MIN",
     "ResolvedCaptionStyle",
     "apply_override",
+    "as_bool",
     "hex_to_ass_color",
     "resolve_caption_style",
 ]

--- a/sidecar/tests/e2e/test_karaoke_burn.py
+++ b/sidecar/tests/e2e/test_karaoke_burn.py
@@ -168,3 +168,57 @@ def test_build_karaoke_ass_burns_through_real_libass_to_nonzero_frames(tmp_path:
 
     frames = _frame_count(out)
     assert frames > 0, f"karaoke burn produced no decodable frames ({frames})"
+
+
+def test_tuned_karaoke_ass_also_burns_through_real_libass(tmp_path: Path) -> None:
+    r"""A STYLED karaoke document must rasterise too (v1.5 lane-karaoke).
+
+    The unit suite proves a ``CaptionOverride`` now changes the emitted karaoke ASS,
+    and the test above proves the UN-tuned document is valid libass. Neither proves
+    the TUNED document is: an override rewrites ``Fontname``, the ``&H`` colour
+    slots, ``BorderStyle``/``Outline``, ``Alignment``/``MarginV``, and adds a
+    ``HookTitle`` style + event. This burns that document through real
+    ffmpeg/libass so the styling path cannot ship a document libass rejects.
+    """
+    override = {
+        "fontFamily": "Bebas Neue",  # a curated face (in the burn fontconfig set)
+        "sizeScale": 1.4,
+        "textColor": "#101010",
+        "activeColor": "#FF00FF",
+        "box": True,  # BorderStyle=3, the opaque-card branch
+        "uppercase": False,
+        "positionBand": "top",
+    }
+    ass = build_karaoke_ass(
+        _CUES,
+        width=_W,
+        height=_H,
+        override=override,
+        position={"x": 0.1, "y": 0.05, "w": 0.8, "h": 0.2},
+        hook_title="Tuned karaoke hook",
+    )
+    # The tuned document really is tuned (else this test would prove nothing).
+    assert "Bebas Neue" in ass and ",100,100,0,0,3," in ass and "Style: HookTitle," in ass
+    assert ass != build_karaoke_ass(_CUES, width=_W, height=_H)
+
+    clip = tmp_path / "src.mp4"
+    out = tmp_path / "karaoke_tuned.mp4"
+    _make_clip(clip)
+
+    returned = CaptionEngine().render(
+        str(clip),
+        _CUES,
+        str(out),
+        burn=True,
+        width=_W,
+        height=_H,
+        karaoke=True,
+        override=override,
+        position={"x": 0.1, "y": 0.05, "w": 0.8, "h": 0.2},
+        hook_title="Tuned karaoke hook",
+    )
+    assert returned == str(out)
+    assert out.exists() and out.stat().st_size > 0
+
+    frames = _frame_count(out)
+    assert frames > 0, f"tuned karaoke burn produced no decodable frames ({frames})"

--- a/sidecar/tests/test_caption_karaoke_styling.py
+++ b/sidecar/tests/test_caption_karaoke_styling.py
@@ -408,6 +408,17 @@ class TestEverySettableFieldReachesTheBurn:
         default_cps, default_lines = cp.resolve_caption_limits({})
         assert (max_cps, max_lines) != (default_cps, default_lines)
 
+    @pytest.mark.parametrize("malformed", [[1, 2], "an-override", 7, 0.5, True])
+    def test_a_non_mapping_override_degrades_instead_of_raising(self, malformed: Any) -> None:
+        # `captionOverride` is an UNTRUSTED wire value: shortmaker passes
+        # `settings.get("captionOverride")` straight through (shortmaker.py:441).
+        # apply_override's docstring promises a malformed override "degrades
+        # field-by-field ... never raises", so a non-Mapping must behave like an
+        # absent one on BOTH libass paths, not crash the render with AttributeError.
+        assert ck.build_karaoke_ass([KARAOKE_CUE], override=malformed) == ck.build_karaoke_ass([KARAOKE_CUE])
+        assert caption.build_ass([KARAOKE_CUE], override=malformed) == caption.build_ass([KARAOKE_CUE])
+        assert co.apply_override(malformed) == co.apply_override(None)
+
     @pytest.mark.parametrize(
         "override",
         [

--- a/sidecar/tests/test_caption_karaoke_styling.py
+++ b/sidecar/tests/test_caption_karaoke_styling.py
@@ -1,0 +1,364 @@
+r"""Karaoke caption STYLING parity (v1.5 lane-karaoke).
+
+``CaptionEngine.render(karaoke=True)`` used to call ``build_karaoke_ass`` with only
+``cues``/``width``/``height``/``source_start``, silently dropping SIX styling
+parameters that were in scope at the call site — ``override``, ``position``,
+``hook_title``, ``total_sec``, ``hook_card`` and ``hook_card_sec``. Net effect: a
+user picked a style + tuned it in the gallery and the karaoke renderer ignored
+every setting, while the renderer's LIVE PREVIEW (``captionOverridePreview
+.previewVisual`` folded onto ``KARAOKE_PRESET_VISUAL``) showed the tuned look. The
+preview and the burn disagreed.
+
+These tests are OUTPUT-level on purpose: each one proves the emitted ASS DIFFERS
+between two settings (or matches an exact expected token), never merely that a
+value reached a function. The no-override case is pinned byte-for-byte so the
+teardown-verified OpusClip preset can never silently drift.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import ffmpeg
+from media_studio.features import caption
+from media_studio.features import caption_karaoke as ck
+from media_studio.features import hook_card as hc
+from media_studio.features.caption import CaptionEngine
+
+# --------------------------------------------------------------------------- #
+# fixtures / helpers
+# --------------------------------------------------------------------------- #
+#: two aligned words so the karaoke builder emits two per-word Dialogue events.
+KARAOKE_CUE: dict[str, Any] = {
+    "index": 1,
+    "start": 0.0,
+    "end": 1.0,
+    "text": "go now",
+    "words": [
+        {"text": "go", "start": 0.0, "end": 0.5},
+        {"text": "now", "start": 0.5, "end": 1.0},
+    ],
+}
+
+
+@pytest.fixture()
+def fake_ffmpeg(monkeypatch, tmp_path: Path):
+    """Make ffmpeg.ffmpeg_path resolve to a fake binary (no real ffmpeg)."""
+    fake = tmp_path / "ffmpeg"
+    fake.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(ffmpeg, "ffmpeg_path", lambda settings=None: str(fake))
+    return str(fake)
+
+
+def render_karaoke_ass(monkeypatch, **render_kw: Any) -> str:
+    """The ASS document ``render(karaoke=True, **render_kw)`` hands to ffmpeg.
+
+    Spies on the temp-file seam so the assertion is on the bytes libass would
+    actually consume — the only place a dropped parameter is observable.
+    """
+    written: dict[str, str] = {}
+    real_mkstemp = caption.tempfile.mkstemp
+
+    def spy_mkstemp(*a: Any, **k: Any):
+        fd, path = real_mkstemp(*a, **k)
+        written["path"] = path
+        return fd, path
+
+    monkeypatch.setattr(caption.tempfile, "mkstemp", spy_mkstemp)
+
+    captured: dict[str, str] = {}
+
+    def runner(argv, total_sec=0.0, on_progress=None, should_cancel=None):
+        captured["ass"] = Path(written["path"]).read_text(encoding="utf-8")
+        return 0
+
+    engine = CaptionEngine(runner=runner)
+    engine.render("/in.mp4", [KARAOKE_CUE], "/out.mp4", karaoke=True, **render_kw)
+    return captured["ass"]
+
+
+def style_line(doc: str, name: str = "Default") -> str:
+    """The single ``Style: <name>,...`` line in ``doc`` (fails loudly if absent)."""
+    matches = [ln for ln in doc.splitlines() if ln.startswith(f"Style: {name},")]
+    assert len(matches) == 1, f"expected exactly one Style: {name} line, got {matches}"
+    return matches[0]
+
+
+def event_lines(doc: str, name: str) -> list[str]:
+    """Every ``Dialogue:`` line in ``doc`` that uses the ``name`` style."""
+    return [ln for ln in doc.splitlines() if ln.startswith("Dialogue: ") and f",{name},," in ln]
+
+
+# --------------------------------------------------------------------------- #
+# THE REGRESSION: render(karaoke=True) must thread the styling parameters
+# --------------------------------------------------------------------------- #
+class TestRenderThreadsStyling:
+    """Each case changes ONE render() styling argument and requires the ASS to move."""
+
+    def test_two_different_overrides_produce_different_ass(self, fake_ffmpeg, monkeypatch):
+        # The headline both-states proof: if the override is dropped, these are
+        # byte-identical and the styling is unreachable from the gallery.
+        red = render_karaoke_ass(monkeypatch, override={"textColor": "#FF0000"})
+        blue = render_karaoke_ass(monkeypatch, override={"textColor": "#0000FF"})
+        assert red != blue
+
+    def test_override_font_reaches_the_style_line(self, fake_ffmpeg, monkeypatch):
+        doc = render_karaoke_ass(monkeypatch, override={"fontFamily": "Bebas Neue"})
+        assert style_line(doc).startswith("Style: Default,Bebas Neue,")
+
+    def test_position_box_reaches_the_style_line(self, fake_ffmpeg, monkeypatch):
+        boxed = render_karaoke_ass(monkeypatch, position={"x": 0.1, "y": 0.05, "w": 0.8, "h": 0.1})
+        plain = render_karaoke_ass(monkeypatch)
+        assert style_line(boxed) != style_line(plain)
+        # top-anchored box: Alignment 8, MarginL/R 108, MarginV 96.
+        assert style_line(boxed).endswith(",8,108,108,96,1")
+
+    def test_hook_title_reaches_the_document(self, fake_ffmpeg, monkeypatch):
+        doc = render_karaoke_ass(monkeypatch, hook_title="Watch this")
+        assert style_line(doc, "HookTitle").startswith("Style: HookTitle,Arial,")
+        assert event_lines(doc, "HookTitle") == [
+            "Dialogue: 0,0:00:00.00,0:01:00.00,HookTitle,,0,0,0,,Watch this"
+        ]
+
+    def test_total_sec_bounds_the_hook_title_span(self, fake_ffmpeg, monkeypatch):
+        doc = render_karaoke_ass(monkeypatch, hook_title="Watch this", total_sec=12.0)
+        assert event_lines(doc, "HookTitle") == [
+            "Dialogue: 0,0:00:00.00,0:00:12.00,HookTitle,,0,0,0,,Watch this"
+        ]
+
+    def test_hook_card_reaches_the_document(self, fake_ffmpeg, monkeypatch):
+        doc = render_karaoke_ass(
+            monkeypatch, hook_title="Watch this", hook_card=True, hook_card_sec=5.0
+        )
+        assert style_line(doc, hc.HOOK_CARD_STYLE_NAME) == hc.hook_card_style_line(1080, 1920)
+        assert event_lines(doc, hc.HOOK_CARD_STYLE_NAME) == [
+            "Dialogue: 0,0:00:00.00,0:00:05.00,HookCard,,0,0,0,,Watch this"
+        ]
+        # the card REPLACES the plain headline style (never both).
+        assert "Style: HookTitle," not in doc
+
+    def test_hook_card_sec_bounds_the_card(self, fake_ffmpeg, monkeypatch):
+        doc = render_karaoke_ass(
+            monkeypatch, hook_title="Watch this", hook_card=True, hook_card_sec=2.0
+        )
+        assert event_lines(doc, hc.HOOK_CARD_STYLE_NAME) == [
+            "Dialogue: 0,0:00:00.00,0:00:02.00,HookCard,,0,0,0,,Watch this"
+        ]
+
+    def test_no_styling_args_keeps_the_preset_look(self, fake_ffmpeg, monkeypatch):
+        # Back-compat keystone: an un-tuned karaoke render is byte-identical to the
+        # teardown-verified preset the pure builder emits.
+        doc = render_karaoke_ass(monkeypatch)
+        assert doc == ck.build_karaoke_ass([KARAOKE_CUE])
+
+
+# --------------------------------------------------------------------------- #
+# resolve_karaoke_style — the override merged onto the KARAOKE base
+# --------------------------------------------------------------------------- #
+class TestResolveKaraokeStyle:
+    def test_empty_override_is_the_preset(self):
+        for empty in (None, {}):
+            resolved = ck.resolve_karaoke_style(empty)
+            assert resolved.font_name == ck.KARAOKE_FONT
+            assert resolved.size_scale == 1.0
+            assert resolved.primary_color == ck.KARAOKE_FILL
+            assert resolved.secondary_color == ck.KARAOKE_FILL
+            assert resolved.outline_color == ck.KARAOKE_OUTLINE
+            assert resolved.back_color == ck.KARAOKE_BACK
+            assert resolved.border_style == ck.KARAOKE_BORDER_STYLE
+            assert resolved.outline_width == ck.KARAOKE_OUTLINE_WIDTH
+            assert resolved.shadow == ck.KARAOKE_SHADOW
+            assert resolved.active_colors == ck.KARAOKE_ACTIVE_INLINE
+            # tri-state: absent, so the caller's own default wins.
+            assert resolved.uppercase is None
+            assert resolved.position_band is None
+
+    def test_font_must_be_in_the_curated_allowlist(self):
+        assert ck.resolve_karaoke_style({"fontFamily": "Oswald"}).font_name == "Oswald"
+        # an off-allowlist face would not exist in the burn fontconfig set -> preset.
+        assert ck.resolve_karaoke_style({"fontFamily": "Comic Sans MS"}).font_name == ck.KARAOKE_FONT
+
+    def test_size_scale_is_clamped(self):
+        assert ck.resolve_karaoke_style({"sizeScale": 1.5}).size_scale == 1.5
+        assert ck.resolve_karaoke_style({"sizeScale": 99.0}).size_scale == 1.8
+        assert ck.resolve_karaoke_style({"sizeScale": 0.01}).size_scale == 0.6
+        assert ck.resolve_karaoke_style({"sizeScale": "big"}).size_scale == 1.0
+
+    def test_text_color_becomes_the_fill(self):
+        resolved = ck.resolve_karaoke_style({"textColor": "#FF0000"})
+        assert resolved.primary_color == "&H000000FF"
+        assert resolved.secondary_color == "&H000000FF"
+
+    def test_spoken_color_is_the_fill_fallback(self):
+        # Mirrors caption_override.apply_override: textColor wins, else spokenColor.
+        assert ck.resolve_karaoke_style({"spokenColor": "#00FF00"}).primary_color == "&H0000FF00"
+        both = ck.resolve_karaoke_style({"textColor": "#FF0000", "spokenColor": "#00FF00"})
+        assert both.primary_color == "&H000000FF"
+
+    def test_bad_hex_keeps_the_preset_fill(self):
+        assert ck.resolve_karaoke_style({"textColor": "red"}).primary_color == ck.KARAOKE_FILL
+
+    def test_active_color_collapses_the_alternation(self):
+        # An explicit active colour is a deliberate single accent; alternating it
+        # against the preset green would defeat the setting.
+        resolved = ck.resolve_karaoke_style({"activeColor": "#FF00FF"})
+        assert resolved.active_colors == ("&H00FF00FF&", "&H00FF00FF&")
+
+    def test_bad_active_hex_keeps_the_alternation(self):
+        assert ck.resolve_karaoke_style({"activeColor": "nope"}).active_colors == ck.KARAOKE_ACTIVE_INLINE
+
+    @pytest.mark.parametrize(
+        ("override", "expected"),
+        [
+            ({}, (ck.KARAOKE_BORDER_STYLE, ck.KARAOKE_OUTLINE_WIDTH)),
+            ({"box": True}, (3, ck.KARAOKE_OUTLINE_WIDTH)),
+            ({"outline": True}, (1, ck.KARAOKE_OUTLINE_WIDTH)),
+            ({"outline": False}, (1, 0)),
+            # a solid card and a pure outline are exclusive — the card wins.
+            ({"box": True, "outline": False}, (3, ck.KARAOKE_OUTLINE_WIDTH)),
+            ({"box": False}, (ck.KARAOKE_BORDER_STYLE, ck.KARAOKE_OUTLINE_WIDTH)),
+        ],
+    )
+    def test_border_resolution_keeps_the_thick_karaoke_outline(self, override, expected):
+        resolved = ck.resolve_karaoke_style(override)
+        assert (resolved.border_style, resolved.outline_width) == expected
+
+    def test_uppercase_is_tri_state(self):
+        assert ck.resolve_karaoke_style({"uppercase": True}).uppercase is True
+        assert ck.resolve_karaoke_style({"uppercase": False}).uppercase is False
+        assert ck.resolve_karaoke_style({"uppercase": "yes"}).uppercase is None
+
+    def test_position_band_must_be_known(self):
+        assert ck.resolve_karaoke_style({"positionBand": "top"}).position_band == "top"
+        assert ck.resolve_karaoke_style({"positionBand": "sideways"}).position_band is None
+
+
+# --------------------------------------------------------------------------- #
+# build_karaoke_ass — every threaded parameter must MOVE the output
+# --------------------------------------------------------------------------- #
+class TestBuildKaraokeAssStyling:
+    def test_preset_style_line_is_pinned(self):
+        # The drift guard for the whole feature: 1920*0.05 = 96 px, 1080*0.06 = 65
+        # px side margins, 1920*0.18 = 346 px up from the bottom, Alignment 2.
+        assert style_line(ck.build_karaoke_ass([KARAOKE_CUE])) == (
+            "Style: Default,Anton,96,&H00FFFFFF,&H00FFFFFF,&H00000000,&H64000000,"
+            "-1,0,0,0,100,100,0,0,1,4,2,2,65,65,346,1"
+        )
+
+    def test_size_scale_scales_the_font(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"sizeScale": 1.5})
+        assert style_line(doc).startswith("Style: Default,Anton,144,")
+
+    def test_size_scale_never_goes_below_the_floor(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], height=100, override={"sizeScale": 0.6})
+        # 100*0.05 = 5 -> floored to 12, then 12*0.6 = 7.2 -> floored to 12 again.
+        assert style_line(doc).startswith("Style: Default,Anton,12,")
+
+    def test_text_color_changes_the_primary_colour(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"textColor": "#FF0000"})
+        assert ",&H000000FF,&H000000FF," in style_line(doc)
+
+    def test_active_color_changes_the_inline_accent(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"activeColor": "#FF00FF"})
+        assert r"{\1c&H00FF00FF&\t(0,120,\fscx115\fscy115)}GO{\r}" in doc
+        # both words now use the SAME accent (the alternation is collapsed).
+        assert ck.KARAOKE_ACTIVE_INLINE[1] not in doc
+
+    def test_box_switches_to_an_opaque_card(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"box": True})
+        assert ",100,100,0,0,3,4,2," in style_line(doc)
+
+    def test_outline_off_drops_the_stroke_width(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"outline": False})
+        assert ",100,100,0,0,1,0,2," in style_line(doc)
+
+    def test_uppercase_off_keeps_the_transcript_casing(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"uppercase": False})
+        assert "go" in doc
+        assert "GO" not in doc
+
+    def test_override_position_band_beats_the_explicit_default(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"positionBand": "top"})
+        # top band: Alignment 8, MarginV 1920*0.10 = 192.
+        assert style_line(doc).endswith(",8,65,65,192,1")
+
+    def test_explicit_position_band_still_works(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], position_band="center")
+        assert style_line(doc).endswith(",5,65,65,0,1")
+
+    def test_position_box_sets_alignment_and_margins(self):
+        doc = ck.build_karaoke_ass(
+            [KARAOKE_CUE], position={"x": 0.1, "y": 0.05, "w": 0.8, "h": 0.1}
+        )
+        assert style_line(doc).endswith(",8,108,108,96,1")
+
+    def test_malformed_position_box_falls_back_to_the_band(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], position={"x": "nope"})
+        assert style_line(doc).endswith(",2,65,65,346,1")
+
+    def test_override_band_re_anchors_but_keeps_the_box_side_margins(self):
+        doc = ck.build_karaoke_ass(
+            [KARAOKE_CUE],
+            position={"x": 0.2, "y": 0.7, "w": 0.6, "h": 0.2},
+            override={"positionBand": "top"},
+        )
+        # band wins on Alignment + MarginV; the box keeps the fine L/R offset.
+        assert style_line(doc).endswith(",8,216,216,192,1")
+
+    def test_hook_title_adds_a_headline_style_and_event(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], hook_title="Watch this")
+        assert style_line(doc, "HookTitle") == (
+            "Style: HookTitle,Arial,106,&H00FFFFFF,&H000000FF,&H00000000,&H96000000,"
+            "-1,0,0,0,100,100,0,0,1,4,2,8,60,60,134,1"
+        )
+        assert event_lines(doc, "HookTitle") == [
+            "Dialogue: 0,0:00:00.00,0:01:00.00,HookTitle,,0,0,0,,Watch this"
+        ]
+
+    def test_blank_hook_title_adds_nothing(self):
+        assert ck.build_karaoke_ass([KARAOKE_CUE], hook_title="   ") == ck.build_karaoke_ass(
+            [KARAOKE_CUE]
+        )
+
+    def test_hook_title_is_escaped(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], hook_title=r"{\fake}pwn")
+        assert r"{\fake}" not in doc
+
+    def test_hook_card_replaces_the_headline(self):
+        doc = ck.build_karaoke_ass(
+            [KARAOKE_CUE], hook_title="Watch this", hook_card=True, hook_card_sec=5.0
+        )
+        assert style_line(doc, hc.HOOK_CARD_STYLE_NAME) == hc.hook_card_style_line(1080, 1920)
+        assert "Style: HookTitle," not in doc
+
+    def test_hook_card_is_capped_to_the_clip(self):
+        doc = ck.build_karaoke_ass(
+            [KARAOKE_CUE],
+            hook_title="Watch this",
+            hook_card=True,
+            hook_card_sec=5.0,
+            total_sec=3.0,
+        )
+        assert event_lines(doc, hc.HOOK_CARD_STYLE_NAME) == [
+            "Dialogue: 0,0:00:00.00,0:00:03.00,HookCard,,0,0,0,,Watch this"
+        ]
+
+    def test_the_karaoke_effects_survive_a_full_override(self):
+        # A tuned karaoke render keeps its word-by-word reveal + scale-pop; only
+        # the flat visual fields move.
+        doc = ck.build_karaoke_ass(
+            [KARAOKE_CUE],
+            override={
+                "fontFamily": "Oswald",
+                "sizeScale": 1.2,
+                "textColor": "#101010",
+                "activeColor": "#FF00FF",
+                "box": True,
+                "uppercase": False,
+                "positionBand": "center",
+            },
+        )
+        assert r"\t(0,120,\fscx115\fscy115)" in doc
+        assert len(event_lines(doc, "Default")) == 2

--- a/sidecar/tests/test_caption_karaoke_styling.py
+++ b/sidecar/tests/test_caption_karaoke_styling.py
@@ -24,6 +24,7 @@ import pytest
 from media_studio import ffmpeg
 from media_studio.features import caption
 from media_studio.features import caption_karaoke as ck
+from media_studio.features import caption_polish as cp
 from media_studio.features import hook_card as hc
 from media_studio.features.caption import CaptionEngine
 
@@ -346,3 +347,70 @@ class TestBuildKaraokeAssStyling:
         )
         assert r"\t(0,120,\fscx115\fscy115)" in doc
         assert len(event_lines(doc, "Default")) == 2
+
+
+# --------------------------------------------------------------------------- #
+# DoD guard: EVERY settable CaptionOverride field, enumerated
+# --------------------------------------------------------------------------- #
+#: Every field of the renderer's ``CaptionOverride`` interface
+#: (``app/renderer/src/lib/captionOverride.ts:27-50``), with two distinguishable
+#: values. Adding a field there without wiring it here makes this go RED — which is
+#: the point: a silent drop is exactly the defect this module exists to prevent.
+OVERRIDE_FIELD_CASES: list[tuple[str, Any, Any]] = [
+    ("fontFamily", "Anton", "Bebas Neue"),
+    ("sizeScale", 0.8, 1.6),
+    ("textColor", "#FF0000", "#0000FF"),
+    ("activeColor", "#FF00FF", "#00FFFF"),
+    ("spokenColor", "#123456", "#654321"),
+    ("outline", True, False),
+    ("box", True, False),
+    ("uppercase", True, False),
+    ("positionBand", "top", "bottom"),
+    ("maxLines", 1, 2),
+    ("maxCps", 10, 30),
+]
+
+#: The only fields that legitimately do NOT change the karaoke ASS: they are
+#: consumed at cue GENERATION (upstream of all three caption engines), so they were
+#: never karaoke drops. Proven executable by
+#: :meth:`TestEverySettableFieldReachesTheBurn.test_upstream_fields_are_really_consumed_upstream`.
+UPSTREAM_ONLY_FIELDS = frozenset({"maxLines", "maxCps"})
+
+
+class TestEverySettableFieldReachesTheBurn:
+    """The Definition of Done, enumerated field by field."""
+
+    @pytest.mark.parametrize(("field", "value_a", "value_b"), OVERRIDE_FIELD_CASES)
+    def test_field_moves_the_ass_unless_it_is_an_upstream_field(self, field: str, value_a: Any, value_b: Any) -> None:
+        doc_a = ck.build_karaoke_ass([KARAOKE_CUE], override={field: value_a})
+        doc_b = ck.build_karaoke_ass([KARAOKE_CUE], override={field: value_b})
+        if field in UPSTREAM_ONLY_FIELDS:
+            assert doc_a == doc_b, f"{field} unexpectedly reached the karaoke ASS"
+        else:
+            assert doc_a != doc_b, f"{field} is SILENTLY DROPPED by the karaoke renderer"
+
+    def test_upstream_fields_are_really_consumed_upstream(self) -> None:
+        # Makes the UPSTREAM_ONLY_FIELDS exemption evidence rather than an assertion:
+        # caption_polish reads both off captionOverride at cue generation
+        # (caption_polish.py:104-109), i.e. before any engine sees a cue.
+        max_cps, max_lines = cp.resolve_caption_limits({"captionOverride": {"maxCps": 11, "maxLines": 1}})
+        assert (max_cps, max_lines) == (11.0, 1)
+        default_cps, default_lines = cp.resolve_caption_limits({})
+        assert (max_cps, max_lines) != (default_cps, default_lines)
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            None,
+            {},
+            # a present override whose OTHER fields are absent must not disturb the
+            # preset — the trap `ResolvedCaptionStyle` would have sprung by resolving
+            # the outline against the libass-normal base and thinning it 4 -> 3.
+            {"uppercase": True},
+            {"maxCps": 17},
+            {"fontFamily": "not-a-curated-font"},
+            {"textColor": "not-a-hex"},
+        ],
+    )
+    def test_untouched_fields_keep_the_preset_byte_for_byte(self, override: Any) -> None:
+        assert ck.build_karaoke_ass([KARAOKE_CUE], override=override) == ck.build_karaoke_ass([KARAOKE_CUE])

--- a/sidecar/tests/test_caption_karaoke_styling.py
+++ b/sidecar/tests/test_caption_karaoke_styling.py
@@ -24,6 +24,7 @@ import pytest
 from media_studio import ffmpeg
 from media_studio.features import caption
 from media_studio.features import caption_karaoke as ck
+from media_studio.features import caption_override as co
 from media_studio.features import caption_polish as cp
 from media_studio.features import hook_card as hc
 from media_studio.features.caption import CaptionEngine
@@ -172,6 +173,15 @@ class TestResolveKaraokeStyle:
         assert ck.resolve_karaoke_style({"fontFamily": "Oswald"}).font_name == "Oswald"
         # an off-allowlist face would not exist in the burn fontconfig set -> preset.
         assert ck.resolve_karaoke_style({"fontFamily": "Comic Sans MS"}).font_name == ck.KARAOKE_FONT
+
+    def test_base_font_stays_off_the_allowlist(self):
+        # LOAD-BEARING for resolve_karaoke_style: it detects "fontFamily untouched"
+        # by comparing apply_override's result to caption_override.BASE_FONT. That
+        # sentinel is only unambiguous while BASE_FONT is NOT a font a user can pick.
+        # Adding "Arial" to CURATED_CAPTION_FONTS would make an explicit Arial pick
+        # silently render as Anton — so this fails the day that happens, pointing here.
+        assert co.BASE_FONT not in co.CURATED_CAPTION_FONTS
+        assert ck.KARAOKE_FONT in co.CURATED_CAPTION_FONTS
 
     def test_size_scale_is_clamped(self):
         assert ck.resolve_karaoke_style({"sizeScale": 1.5}).size_scale == 1.5

--- a/sidecar/tests/test_caption_karaoke_styling.py
+++ b/sidecar/tests/test_caption_karaoke_styling.py
@@ -118,20 +118,14 @@ class TestRenderThreadsStyling:
     def test_hook_title_reaches_the_document(self, fake_ffmpeg, monkeypatch):
         doc = render_karaoke_ass(monkeypatch, hook_title="Watch this")
         assert style_line(doc, "HookTitle").startswith("Style: HookTitle,Arial,")
-        assert event_lines(doc, "HookTitle") == [
-            "Dialogue: 0,0:00:00.00,0:01:00.00,HookTitle,,0,0,0,,Watch this"
-        ]
+        assert event_lines(doc, "HookTitle") == ["Dialogue: 0,0:00:00.00,0:01:00.00,HookTitle,,0,0,0,,Watch this"]
 
     def test_total_sec_bounds_the_hook_title_span(self, fake_ffmpeg, monkeypatch):
         doc = render_karaoke_ass(monkeypatch, hook_title="Watch this", total_sec=12.0)
-        assert event_lines(doc, "HookTitle") == [
-            "Dialogue: 0,0:00:00.00,0:00:12.00,HookTitle,,0,0,0,,Watch this"
-        ]
+        assert event_lines(doc, "HookTitle") == ["Dialogue: 0,0:00:00.00,0:00:12.00,HookTitle,,0,0,0,,Watch this"]
 
     def test_hook_card_reaches_the_document(self, fake_ffmpeg, monkeypatch):
-        doc = render_karaoke_ass(
-            monkeypatch, hook_title="Watch this", hook_card=True, hook_card_sec=5.0
-        )
+        doc = render_karaoke_ass(monkeypatch, hook_title="Watch this", hook_card=True, hook_card_sec=5.0)
         assert style_line(doc, hc.HOOK_CARD_STYLE_NAME) == hc.hook_card_style_line(1080, 1920)
         assert event_lines(doc, hc.HOOK_CARD_STYLE_NAME) == [
             "Dialogue: 0,0:00:00.00,0:00:05.00,HookCard,,0,0,0,,Watch this"
@@ -140,9 +134,7 @@ class TestRenderThreadsStyling:
         assert "Style: HookTitle," not in doc
 
     def test_hook_card_sec_bounds_the_card(self, fake_ffmpeg, monkeypatch):
-        doc = render_karaoke_ass(
-            monkeypatch, hook_title="Watch this", hook_card=True, hook_card_sec=2.0
-        )
+        doc = render_karaoke_ass(monkeypatch, hook_title="Watch this", hook_card=True, hook_card_sec=2.0)
         assert event_lines(doc, hc.HOOK_CARD_STYLE_NAME) == [
             "Dialogue: 0,0:00:00.00,0:00:02.00,HookCard,,0,0,0,,Watch this"
         ]
@@ -289,9 +281,7 @@ class TestBuildKaraokeAssStyling:
         assert style_line(doc).endswith(",5,65,65,0,1")
 
     def test_position_box_sets_alignment_and_margins(self):
-        doc = ck.build_karaoke_ass(
-            [KARAOKE_CUE], position={"x": 0.1, "y": 0.05, "w": 0.8, "h": 0.1}
-        )
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], position={"x": 0.1, "y": 0.05, "w": 0.8, "h": 0.1})
         assert style_line(doc).endswith(",8,108,108,96,1")
 
     def test_malformed_position_box_falls_back_to_the_band(self):
@@ -313,23 +303,17 @@ class TestBuildKaraokeAssStyling:
             "Style: HookTitle,Arial,106,&H00FFFFFF,&H000000FF,&H00000000,&H96000000,"
             "-1,0,0,0,100,100,0,0,1,4,2,8,60,60,134,1"
         )
-        assert event_lines(doc, "HookTitle") == [
-            "Dialogue: 0,0:00:00.00,0:01:00.00,HookTitle,,0,0,0,,Watch this"
-        ]
+        assert event_lines(doc, "HookTitle") == ["Dialogue: 0,0:00:00.00,0:01:00.00,HookTitle,,0,0,0,,Watch this"]
 
     def test_blank_hook_title_adds_nothing(self):
-        assert ck.build_karaoke_ass([KARAOKE_CUE], hook_title="   ") == ck.build_karaoke_ass(
-            [KARAOKE_CUE]
-        )
+        assert ck.build_karaoke_ass([KARAOKE_CUE], hook_title="   ") == ck.build_karaoke_ass([KARAOKE_CUE])
 
     def test_hook_title_is_escaped(self):
         doc = ck.build_karaoke_ass([KARAOKE_CUE], hook_title=r"{\fake}pwn")
         assert r"{\fake}" not in doc
 
     def test_hook_card_replaces_the_headline(self):
-        doc = ck.build_karaoke_ass(
-            [KARAOKE_CUE], hook_title="Watch this", hook_card=True, hook_card_sec=5.0
-        )
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], hook_title="Watch this", hook_card=True, hook_card_sec=5.0)
         assert style_line(doc, hc.HOOK_CARD_STYLE_NAME) == hc.hook_card_style_line(1080, 1920)
         assert "Style: HookTitle," not in doc
 

--- a/sidecar/tests/test_caption_karaoke_styling.py
+++ b/sidecar/tests/test_caption_karaoke_styling.py
@@ -194,11 +194,42 @@ class TestResolveKaraokeStyle:
         assert resolved.primary_color == "&H000000FF"
         assert resolved.secondary_color == "&H000000FF"
 
-    def test_spoken_color_is_the_fill_fallback(self):
-        # Mirrors caption_override.apply_override: textColor wins, else spokenColor.
-        assert ck.resolve_karaoke_style({"spokenColor": "#00FF00"}).primary_color == "&H0000FF00"
+    def test_spoken_color_is_a_separate_role_not_the_fill(self):
+        # spokenColor paints ALREADY-SPOKEN words only — the third state the preview
+        # implements at CaptionOverlay.wordColor:162
+        # (`if (word.spoken) return visual.spokenColor || visual.textColor`).
+        # It must NOT be folded into the whole-line fill: with textColor also set the
+        # burn would discard it, and with only spokenColor set every not-yet-spoken
+        # word would wrongly take it too.
+        spoken_only = ck.resolve_karaoke_style({"spokenColor": "#00FF00"})
+        assert spoken_only.primary_color == ck.KARAOKE_FILL  # fill untouched
+        assert spoken_only.spoken_color == "&H0000FF00&"  # inline form, own role
+
         both = ck.resolve_karaoke_style({"textColor": "#FF0000", "spokenColor": "#00FF00"})
         assert both.primary_color == "&H000000FF"
+        assert both.spoken_color == "&H0000FF00&"  # NOT discarded
+
+        assert ck.resolve_karaoke_style({}).spoken_color is None  # no persistent state
+        assert ck.resolve_karaoke_style({"spokenColor": "bad"}).spoken_color is None
+
+    def test_spoken_words_get_the_spoken_colour_in_the_events(self):
+        # Within one per-word event the words BEFORE the active one are already
+        # spoken; they must carry the spoken accent, and the ones after must not.
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], override={"spokenColor": "#00FF00"})
+        events = event_lines(doc, "Default")
+        # event 0: "GO" active, "NOW" not yet spoken -> no spoken accent anywhere.
+        assert r"{\1c&H0000FF00&}" not in events[0]
+        # event 1: "NOW" active, "GO" already spoken -> GO carries the spoken accent.
+        assert r"{\1c&H0000FF00&}GO{\r}" in events[1]
+
+    def test_spoken_colour_is_absent_without_the_override(self):
+        doc = ck.build_karaoke_ass([KARAOKE_CUE])
+        # Un-tuned: already-spoken words reset to the white Style fill, matching
+        # KARAOKE_PRESET_VISUAL.spokenColor === textColor in the renderer mirror.
+        assert event_lines(doc, "Default")[1] == (
+            "Dialogue: 0,0:00:00.50,0:00:01.00,Default,,0,0,0,,"
+            r"GO {\1c&H0000FF00&\t(0,120,\fscx115\fscy115)}NOW{\r}"
+        )
 
     def test_bad_hex_keeps_the_preset_fill(self):
         assert ck.resolve_karaoke_style({"textColor": "red"}).primary_color == ck.KARAOKE_FILL
@@ -300,12 +331,16 @@ class TestBuildKaraokeAssStyling:
         assert style_line(doc).endswith(",2,65,65,346,1")
 
     def test_override_band_re_anchors_but_keeps_the_box_side_margins(self):
-        doc = ck.build_karaoke_ass(
-            [KARAOKE_CUE],
-            position={"x": 0.2, "y": 0.7, "w": 0.6, "h": 0.2},
-            override={"positionBand": "top"},
-        )
-        # band wins on Alignment + MarginV; the box keeps the fine L/R offset.
+        # The box is chosen so its OWN MarginV differs from the band's: bottom edge
+        # at y+h = 0.8 -> (1 - 0.8) * 1920 = 384, whereas band "top" -> 0.10 * 1920
+        # = 192. With y = 0.7 both come to 192 and the assertion below would pass
+        # even if MarginV had come from the box — proving only the Alignment flip.
+        box = {"x": 0.2, "y": 0.6, "w": 0.6, "h": 0.2}
+        without_band = ck.build_karaoke_ass([KARAOKE_CUE], position=box)
+        assert style_line(without_band).endswith(",2,216,216,384,1")
+
+        doc = ck.build_karaoke_ass([KARAOKE_CUE], position=box, override={"positionBand": "top"})
+        # band wins on Alignment + MarginV (8 / 192); the box keeps the L/R offset.
         assert style_line(doc).endswith(",8,216,216,192,1")
 
     def test_hook_title_adds_a_headline_style_and_event(self):
@@ -380,10 +415,12 @@ OVERRIDE_FIELD_CASES: list[tuple[str, Any, Any]] = [
     ("maxCps", 10, 30),
 ]
 
-#: The only fields that legitimately do NOT change the karaoke ASS: they are
-#: consumed at cue GENERATION (upstream of all three caption engines), so they were
-#: never karaoke drops. Proven executable by
-#: :meth:`TestEverySettableFieldReachesTheBurn.test_upstream_fields_are_really_consumed_upstream`.
+#: The only fields that legitimately do NOT change the karaoke ASS. They shape the
+#: SOFT-SUBTITLE route only (`caption_polish.polish_cues` -> its single production
+#: caller `subtitles.generate_polished`); the burn's cue list comes from
+#: `shortmaker._cues_for_clip`, which never calls it. `caption.build_ass` ignores
+#: them identically, so this is engine-SYMMETRIC and pre-existing, not a karaoke
+#: drop. Guarded by :meth:`…test_upstream_fields_are_not_on_either_burn_path`.
 UPSTREAM_ONLY_FIELDS = frozenset({"maxLines", "maxCps"})
 
 
@@ -399,14 +436,23 @@ class TestEverySettableFieldReachesTheBurn:
         else:
             assert doc_a != doc_b, f"{field} is SILENTLY DROPPED by the karaoke renderer"
 
-    def test_upstream_fields_are_really_consumed_upstream(self) -> None:
-        # Makes the UPSTREAM_ONLY_FIELDS exemption evidence rather than an assertion:
-        # caption_polish reads both off captionOverride at cue generation
-        # (caption_polish.py:104-109), i.e. before any engine sees a cue.
-        max_cps, max_lines = cp.resolve_caption_limits({"captionOverride": {"maxCps": 11, "maxLines": 1}})
-        assert (max_cps, max_lines) == (11.0, 1)
-        default_cps, default_lines = cp.resolve_caption_limits({})
-        assert (max_cps, max_lines) != (default_cps, default_lines)
+    def test_upstream_fields_are_not_on_either_burn_path(self) -> None:
+        # The exemption's REAL justification is SYMMETRY: neither libass burn path
+        # consumes these, so karaoke is not dropping anything the normal path keeps.
+        #
+        # (An earlier version asserted `resolve_caption_limits` reads them and called
+        # that proof they were "consumed upstream of all three engines". REFUTED:
+        # `polish_cues` appears nowhere in shortmaker.py — its only production caller
+        # is `subtitles.generate_polished` via handlers/media_ops.py:53, the
+        # soft-subtitle route. Reading that function proved nothing about the burn.)
+        for field, value in (("maxCps", 11), ("maxLines", 1)):
+            assert caption.build_ass([KARAOKE_CUE], override={field: value}) == caption.build_ass([KARAOKE_CUE]), (
+                f"build_ass now honours {field}, so karaoke dropping it IS an asymmetry"
+            )
+
+        # They are live on the soft-subtitle route that does own them.
+        assert cp.resolve_caption_limits({"captionOverride": {"maxCps": 11, "maxLines": 1}}) == (11.0, 1)
+        assert cp.resolve_caption_limits({}) != (11.0, 1)
 
     @pytest.mark.parametrize("malformed", [[1, 2], "an-override", 7, 0.5, True])
     def test_a_non_mapping_override_degrades_instead_of_raising(self, malformed: Any) -> None:


### PR DESCRIPTION
## Karaoke captions could not be styled at all

`caption.py:640-648` called `build_karaoke_ass(cues, width, height, source_start)` and **dropped six
parameters**: `override`, `position`, `hook_title`, `total_sec`, `hook_card`, `hook_card_sec`.

The audit finding is **CONFIRMED**, and confirmed by a *second, independent* signal rather than by
re-reading the audit: the renderer already promised the opposite. `captionOverridePreview.previewVisual`
folds the override onto `captionTemplates.KARAOKE_PRESET_VISUAL`, so **the live preview painted the
tuned look while the burn discarded it.** A user picked a style, saw it, and got something else.

## RED proof (commit `927e982d`, 40 failed / 3 passed)

```
def test_two_different_overrides_produce_different_ass(...):
    red  = render_karaoke_ass(monkeypatch, override={"textColor": "#FF0000"})
    blue = render_karaoke_ass(monkeypatch, override={"textColor": "#0000FF"})
>   assert red != blue
E   AssertionError: assert '[Script Info]...' != '[Script Info]...'   # byte-identical
```

## The fix

`resolve_karaoke_style` merges a `CaptionOverride` onto the **karaoke** base. It delegates
*validation* to `apply_override` so the two paths cannot drift, but keeps karaoke's own *defaults* —
reusing `ResolvedCaptionStyle` would have thinned the signature outline 4→3 on any render that
merely *had* an override. `position` uses the same `normalize_caption_box` /
`caption_position_fields` helpers with the same box-then-band ordering. The hook overlay becomes one
shared `caption.hook_overlay_parts`; **182 exact-content tests stayed green across that extraction**,
which is the equivalence proof.

**Declined with a mechanical reason, not silently:** `emphasis`→bold. The karaoke Style sets
`Bold=-1`, so `{\b1}` cannot render contrast. `maxLines`/`maxCps` shape only the soft-subtitle route.

**DoD measured exhaustively:** all 11 `CaptionOverride` fields, two values each — **9 WIRED** (output
demonstrably moves), 2 expected-inert. Back-compat byte-identical for `None`, `{}`, and the trap case
`{"uppercase": True}`.

## The adversarial review refuted its own completeness claim — 4 findings, all confirmed, all fixed

1. **`activeColor` — the lane created a NEW divergence.** `wordColor` resolves
   `activeColorOverride ?? visual.activeColor`, and `karaokeActiveColor` never returns undefined, so
   the folded override was **unreachable**. Preview painted `rgb(255,255,0)`, burn produced magenta.
   Fixed both sides via `karaokeActiveColorFor`.
2. **`spokenColor` was folded into the whole-line fill** — discarded when `textColor` was set, and
   wrongly painting not-yet-spoken words. Now its own third state, matching the preview.
3. The band test was **degenerate** (192 == 192 either way). De-degenerated.
4. The `maxLines`/`maxCps` justification was **false** — `polish_cues` appears nowhere in
   `shortmaker.py`. Re-grounded on engine symmetry.

Also fixed a **pre-existing crash**: a non-Mapping `captionOverride` raised `AttributeError` on
*both* libass paths, contradicting `apply_override`'s "never raises" docstring.

## Gates

`sidecar 6220 passed`, 100% line+branch, `--cov-fail-under=100` reached · `renderer 3746 passed`,
100% on all four metrics · **e2e real libass: 2 passed, including a TUNED ASS burned through real
ffmpeg** · ruff 0.15.17 `All checks passed` / `401 files already formatted` · basedpyright 1.39.8
**0 errors** · pre-commit all 6 hooks Passed · `docscheck r1-r5=0` · charter 6 gates, no 7th ·
semgrep **0 findings** over 604 files.

Detectors validated **both-states** throughout — the drift-guard replica, the injection probe and
the new sentinel guard each fire on a deliberately broken input.

## Residuals

- **UNVERIFIED-flake:** `test_handlers_director.py::...renders_real_media_end_to_end` failed once in
  5 full runs (`join(timeout=5)` on a real ffmpeg render; 20/20 in isolation; never touches
  captions). The lane withdrew its "fastest run" argument as support — it points the other way.
- `shortmaker` passes no `total_sec` to **either** libass path, so the hook-title span always falls
  back to `max(cue_ends, 60s)`. Pre-existing and symmetric.
- `caption_override` (BorderStyle=3 + `BackColour`) and `hook_card` (BorderStyle=3 + white
  `OutlineColour`) disagree on which slot paints a box. Pre-existing; karaoke follows
  `caption_override` for parity with the normal path.
- **`captions-translation-audit-2026-08.md` §4.2 is now stale** ("karaoke is style-locked", 5 `NO`
  cells). Deliberately not edited — three lanes were audited into that one file. Reconciled separately.
- No CHANGELOG entry: newest section is `[1.4.2]`; opening a v1.5 section is a governance call.

## Conflict surface

**0 shared files** with `fix/v15-caption-languages`, and a mechanical
`git merge --no-commit --no-ff` between them yields **0 conflicts**. Merges in either order.
