### PR TITLE
fix(captions): translate whole sentences, and stop the EN-only polish wrecking other languages

### DIFF
--- a/.quality/translation_quality_mutations.py
+++ b/.quality/translation_quality_mutations.py
@@ -1,0 +1,179 @@
+"""Both-states proof for the v1.5 translation-quality fixes.
+
+A test's silence is only evidence once the test has been shown to FIRE on the
+known-broken state (`rules/common/single-signal-verification.md` §3b — a probe that is
+quiet in both states measures nothing). The translation fixes are exactly the kind that
+can rot into a no-op without any suite going red: sentence GROUPING can collapse back to
+one-cue-per-call, the language GATE can be reverted, and re-segmentation can start
+drifting a timing — each of which still leaves a translated track that looks fine.
+
+So this reverts each fix in turn (one exact, unique string patch), requires the named
+tests to go RED, and restores the file byte-for-byte. It also asserts the baseline is
+GREEN before each mutation, because a RED after a mutation proves nothing if the test
+was already failing (the detector-control half of §3 rule 3).
+
+BY HAND, NOT A GATE. It mutates tracked source, so it must never run in CI — the same
+contract as `.quality/docs_check_mutations.py`, which is this file's precedent. Run it
+after touching `models/translation.py`, `features/caption_polish.py`, or the
+`generate_polished` language wiring:
+
+    sidecar/.venv/Scripts/python .quality/translation_quality_mutations.py
+
+Exit 0 when every mutation was caught; 1 when any survived (or an anchor moved, which
+fails CLOSED — a stale anchor means the proof is no longer testing what it names).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _find_root() -> Path:
+    """Anchor on markers that exist only at the repo root (see `docs_check.py`)."""
+    here = Path(__file__).resolve()
+    for cand in (here.parent, *here.parents):
+        if (cand / ".git").exists() and (cand / "app/package.json").is_file():
+            return cand
+    raise SystemExit(f"FAILED:mtproof cannot locate the repo root from {here}")
+
+
+ROOT = _find_root()
+SIDECAR = ROOT / "sidecar"
+POLISH = SIDECAR / "media_studio/features/caption_polish.py"
+TRANSLATION = SIDECAR / "media_studio/models/translation.py"
+SUBTITLES = SIDECAR / "media_studio/features/subtitles.py"
+
+# (label, file, find, replace, the tests that MUST go red)
+MUTATIONS: list[tuple[str, Path, str, str, list[str]]] = [
+    (
+        "M1 timing-drift: re-segmentation shifts a cue start",
+        POLISH,
+        'return [{**cue, "text": piece} for cue, piece in zip(source, pieces, strict=True)]',
+        'return [{**cue, "text": piece, "start": float(cue.get("start", 0.0)) + 0.01}'
+        " for cue, piece in zip(source, pieces, strict=True)]",
+        [
+            "tests/test_translation.py::test_grouped_translation_preserves_every_cue_timing_exactly",
+            "tests/test_caption_polish.py::TestRedistributeCueText::test_timings_and_indices_are_byte_identical",
+        ],
+    ),
+    (
+        "M2 revert the language gate: the EN-only punct model runs on every language",
+        POLISH,
+        "    punct = punct_backend\n    if punct is not None and not _is_english(resolved_language):",
+        "    punct = punct_backend\n    if False and punct is not None and not _is_english(resolved_language):",
+        ["tests/test_caption_polish.py::TestPunctLanguageGate"],
+    ),
+    (
+        "M3 revert sentence grouping: one group per cue (the audit's §3.1 defect)",
+        TRANSLATION,
+        "    groups = group_cues_for_translation(cues)",
+        "    groups = [[c] for c in cues]",
+        [
+            "tests/test_translation.py::test_sentence_fragments_translate_in_one_context_bearing_call",
+            "tests/test_translation.py::test_polished_hard_wraps_are_flattened_before_the_model_sees_them",
+        ],
+    ),
+    (
+        "M4 drop the neighbouring-sentence context",
+        TRANSLATION,
+        "                    context_before=texts[position - 1] if position else None,\n"
+        "                    context_after=texts[position + 1] if position + 1 < len(groups) else None,",
+        "                    context_before=None,\n                    context_after=None,",
+        ["tests/test_translation.py::test_neighbouring_sentences_are_supplied_as_context"],
+    ),
+    (
+        "M5 lossy redistribution: the last piece silently drops its tail word",
+        POLISH,
+        '    pieces.append(" ".join(words[cursor:]))\n    return pieces',
+        '    pieces.append(" ".join(words[cursor:-1] or words[cursor:]))\n    return pieces',
+        [
+            "tests/test_translation.py::test_redistribution_loses_no_characters_of_the_translation",
+            "tests/test_caption_polish.py::TestSplitTextProportional::test_losslessness_over_every_split",
+        ],
+    ),
+    (
+        "M6 stop flattening the hard line breaks wrap_two_lines inserted",
+        TRANSLATION,
+        '    return " ".join(str(cue.get("text", "") or "").split())',
+        '    return str(cue.get("text", "") or "").strip()',
+        ["tests/test_translation.py::test_polished_hard_wraps_are_flattened_before_the_model_sees_them"],
+    ),
+    (
+        "M7 uncap route_pair: a low-resource SOURCE can force the HOSTED tier",
+        TRANSLATION,
+        "        return TIER_LOCAL_HEAVY\n    return target_tier",
+        "        return source_tier\n    return target_tier",
+        ["tests/test_translation.py::TestRoutePair"],
+    ),
+    (
+        "M8 drop the track-language wiring: the language gate goes cosmetic",
+        SUBTITLES,
+        '        language=str(base.get("lang") or ""),',
+        "        language=None,",
+        ["tests/test_subtitles.py::test_generate_polished_threads_cues_through_injected_polisher"],
+    ),
+]
+
+
+def read_exact(path: Path) -> str:
+    """Read ``path`` WITHOUT newline translation.
+
+    ``newline=""`` matters twice over: the working tree is CRLF while the stored blob is
+    LF (`rules/common/windows-shell.md` §8b), so translating on read and writing back
+    would silently rewrite every line ending in a tracked file; and a pattern written
+    with ``\\n`` would then match zero times against the untranslated text. ``Path.read_text``
+    only grew a ``newline`` argument in 3.13, so go through ``open`` for 3.12 parity.
+    """
+    with open(path, encoding="utf-8", newline="") as handle:  # noqa: PTH123 - see the docstring
+        return handle.read()
+
+
+def write_exact(path: Path, text: str) -> None:
+    """Write ``text`` byte-for-byte (no newline translation) — see :func:`read_exact`."""
+    with open(path, "w", encoding="utf-8", newline="") as handle:  # noqa: PTH123 - see read_exact
+        handle.write(text)
+
+
+def run(tests: list[str]) -> int:
+    """Run ``tests`` from the sidecar with the sidecar on ``PYTHONPATH``."""
+    env = dict(os.environ, PYTHONPATH=str(SIDECAR))
+    return subprocess.run(  # noqa: S603 - fixed argv, no shell, repo-local paths
+        [sys.executable, "-m", "pytest", *tests, "-q", "-p", "no:randomly", "--no-header", "-x"],
+        cwd=SIDECAR,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    ).returncode
+
+
+def main() -> int:
+    survivors: list[str] = []
+    for label, path, find, replace, tests in MUTATIONS:
+        original = read_exact(path)
+        if original.count(find) != 1:
+            print(f"FAILED:mtproof anchor is missing or not unique ({original.count(find)}x) for {label}")
+            return 1
+        if run(tests) != 0:
+            print(f"FAILED:mtproof baseline is not green for {label} — fix the suite before trusting this proof")
+            return 1
+        write_exact(path, original.replace(find, replace))
+        try:
+            code = run(tests)
+        finally:
+            write_exact(path, original)
+        print(f"{'CAUGHT' if code != 0 else 'SURVIVED':9s} {label}")
+        if code == 0:
+            survivors.append(label)
+    if survivors:
+        print(f"FAILED:mtproof {len(survivors)} surviving mutant(s): {'; '.join(survivors)}")
+        return 1
+    print(f"SUCCESS:mtproof {len(MUTATIONS)}/{len(MUTATIONS)} mutations caught")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sidecar/media_studio/features/caption_polish.py
+++ b/sidecar/media_studio/features/caption_polish.py
@@ -73,11 +73,36 @@ DEFAULT_FPS = 30.0
 
 
 def _is_english(language: str) -> bool:
-    """True when ``language`` is an English BCP-47 / ISO code (``en``, ``en-US``, …)."""
+    """True when ``language`` is an English BCP-47 / ISO code (``en``, ``en-US``, …).
+
+    An empty/unknown tag is deliberately NOT English: every English-only stage in
+    this module treats "we do not know" as "do not run" (adverse inference), so a
+    caller that forgets to declare the language gets the harmless behaviour rather
+    than an English model applied to a foreign language.
+    """
     return language.startswith("en")
 
 
-def resolve_caption_limits(settings: dict[str, Any] | None) -> tuple[float, int]:
+def resolve_caption_language(settings: dict[str, Any] | None, language: str | None = None) -> str:
+    """The caption track's language code, lowercased and stripped (``""`` = unknown).
+
+    Precedence: the explicit ``language`` argument (the TRACK's own language, which
+    ``subtitles.generate_polished`` threads through from the transcript), then
+    ``settings['captionLanguage']``, then ``settings['language']``. Pure.
+
+    This is the module's SINGLE language-resolution path — both the reading-speed
+    default (:func:`resolve_caption_limits`) and the English-only punctuation gate
+    (:func:`polish_cues`) read it, so the two can never disagree.
+    """
+    settings = settings or {}
+    for raw in (language, settings.get("captionLanguage"), settings.get("language")):
+        code = str(raw or "").strip().lower()
+        if code:
+            return code
+    return ""
+
+
+def resolve_caption_limits(settings: dict[str, Any] | None, language: str | None = None) -> tuple[float, int]:
     """Resolve ``(max_cps, max_lines)`` for :func:`polish_cues` from ``settings``.
 
     The reading-speed default is **per-content / per-language** (§1.5): children's
@@ -88,7 +113,7 @@ def resolve_caption_limits(settings: dict[str, Any] | None) -> tuple[float, int]
     the wrap target between 1 and 2 lines (which scales the per-cue CPL capacity in
     :func:`enforce_cps_cpl`); anything else keeps :data:`MAX_LINES`.
 
-    Pure. The language is read from ``captionLanguage`` first, then ``language``.
+    Pure. The language comes from :func:`resolve_caption_language`.
     """
     settings = settings or {}
     override = settings.get("captionOverride")
@@ -98,8 +123,7 @@ def resolve_caption_limits(settings: dict[str, Any] | None) -> tuple[float, int]
     if settings.get("captionChildren"):
         max_cps: float = MAX_CPS_CHILDREN
     else:
-        language = str(settings.get("captionLanguage") or settings.get("language") or "").strip().lower()
-        max_cps = MAX_CPS_ENGLISH if _is_english(language) else MAX_CPS
+        max_cps = MAX_CPS_ENGLISH if _is_english(resolve_caption_language(settings, language)) else MAX_CPS
 
     raw_cps = override.get("maxCps")
     if isinstance(raw_cps, (int, float)) and not isinstance(raw_cps, bool) and math.isfinite(raw_cps):
@@ -328,6 +352,154 @@ def enforce_cps_cpl(
     return out
 
 
+# --------------------------------------------------------------------------- #
+# pure: sentence detection + re-segmentation of translated text onto fixed cues
+#   `docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.1/§3.2 + T1: cues are
+#   segmented for READING SPEED, so one sentence spans several cues and translating
+#   each cue alone loses gender/number/tense agreement and referents. The fix
+#   translates a whole sentence and lays the result back over the SAME cue timings —
+#   these three functions are the "lay it back" half, and they are pure.
+# --------------------------------------------------------------------------- #
+#: Sentence-final marks across the scripts the app's language set covers: Latin /
+#: Cyrillic / Greek ``.!?``, the ellipsis, the CJK fullwidth stop + marks, the Arabic
+#: question mark, and the Devanagari danda.
+SENTENCE_FINAL_CHARS = ".!?…。！？؟।"
+#: Quote / bracket characters a sentence-final mark may hide behind.
+SENTENCE_CLOSERS = "\"')]}”’»›"
+
+
+def ends_sentence(text: str) -> bool:
+    """True when ``text`` ends a sentence (looking through trailing quotes/brackets).
+
+    Pure. Trailing whitespace and any run of :data:`SENTENCE_CLOSERS` are stripped
+    before the final character is tested against :data:`SENTENCE_FINAL_CHARS`.
+
+    Known imprecision, disclosed inline: an abbreviation (``Dr.``, ``etc.``) reads as
+    a sentence end. The cost is a SMALLER translation group, i.e. exactly today's
+    per-cue behaviour for that one boundary — never worse than the defect this
+    replaces. A real sentence segmenter would need a language model per language.
+    """
+    stripped = text.rstrip()
+    while stripped and stripped[-1] in SENTENCE_CLOSERS:
+        stripped = stripped[:-1].rstrip()
+    return bool(stripped) and stripped[-1] in SENTENCE_FINAL_CHARS
+
+
+def _char_budgets(body: str, weights: Sequence[float]) -> list[int]:
+    """Split ``len(body)`` characters across ``weights``, proportionally (pure).
+
+    The budgets always sum to exactly ``len(body)`` (the remainder lands on the last
+    piece), so no character can be dropped downstream. All-zero / negative weights
+    degrade to an even split rather than a division by zero.
+    """
+    total = len(body)
+    normalized = [max(float(w), 0.0) for w in weights]
+    weight_sum = sum(normalized)
+    if weight_sum <= 0.0:
+        normalized = [1.0] * len(normalized)
+        weight_sum = float(len(normalized))
+    budgets: list[int] = []
+    accumulated = 0.0
+    previous = 0
+    for weight in normalized[:-1]:
+        accumulated += weight
+        cut = int(round(total * accumulated / weight_sum))
+        budgets.append(max(cut - previous, 0))
+        previous = cut
+    budgets.append(max(total - previous, 0))
+    return budgets
+
+
+def _pack_words(words: list[str], budgets: list[int]) -> list[str]:
+    """Assign whole words to each budget, closest-fit (pure).
+
+    A word joins the current piece when doing so brings the piece's length CLOSER to
+    its budget. Every piece keeps at least one word (the loop never consumes the
+    words a later piece needs), and the last piece absorbs the remainder — so the
+    word sequence is partitioned, never truncated. Requires ``len(words) >= len(budgets)``
+    and ``len(budgets) >= 2`` — :func:`split_text_proportional` guarantees both.
+    """
+    pieces: list[str] = []
+    cursor = 0
+    count = len(budgets)
+    for position, budget in enumerate(budgets[:-1]):
+        # Words the pieces AFTER this one must still be able to claim, so a greedy
+        # early piece can never leave a later cue with no text at all.
+        reserved = count - position - 1
+        take = 1
+        while cursor + take < len(words) - reserved:
+            current = len(" ".join(words[cursor : cursor + take]))
+            extended = len(" ".join(words[cursor : cursor + take + 1]))
+            if abs(extended - budget) >= abs(current - budget):
+                break
+            take += 1
+        pieces.append(" ".join(words[cursor : cursor + take]))
+        cursor += take
+    pieces.append(" ".join(words[cursor:]))
+    return pieces
+
+
+def _slice_chars(body: str, budgets: list[int]) -> list[str]:
+    """Cut ``body`` at exact character budgets (pure).
+
+    The fallback for scripts that carry no inter-word spaces (Japanese, Chinese,
+    Thai) — where a word split yields ONE token for a whole sentence and would
+    starve every piece but the first — and for the degenerate case of more pieces
+    than characters. Contiguous slices, so every character survives.
+    """
+    pieces: list[str] = []
+    cursor = 0
+    for budget in budgets:
+        end = min(cursor + budget, len(body))
+        pieces.append(body[cursor:end].strip())
+        cursor = end
+    return pieces
+
+
+def split_text_proportional(text: str, weights: Sequence[float]) -> list[str]:
+    """Split ``text`` into ``len(weights)`` pieces sized proportionally to ``weights``.
+
+    Pure + deterministic. ``text`` is whitespace-normalized first (a hard line break
+    inserted by :func:`wrap_two_lines` must not become a phantom character), then cut
+    on word boundaries closest to each proportional target — falling back to exact
+    character boundaries when the text has fewer words than pieces.
+
+    **Losslessness:** every non-whitespace character of ``text`` lands in exactly one
+    piece, in order. That is the property that makes this safe to use on a
+    translation: no clause can be silently dropped.
+    """
+    if not weights:
+        return []
+    body = " ".join(str(text or "").split())
+    if len(weights) == 1:
+        return [body]
+    budgets = _char_budgets(body, weights)
+    words = body.split(" ")
+    if len(words) >= len(weights):
+        return _pack_words(words, budgets)
+    return _slice_chars(body, budgets)
+
+
+def redistribute_cue_text(cues: Sequence[Cue], text: str) -> list[Cue]:
+    """Lay ``text`` back over ``cues`` — the T1 re-segmentation step.
+
+    **Timing contract (hard):** the returned cues carry the SAME ``index``, ``start``
+    and ``end`` values as their inputs, and any extra keys (``speaker``, ``emphasis``)
+    are preserved. Only ``text`` changes, so re-segmentation cannot drift a cue's
+    timing by construction — there is no arithmetic on the time fields at all.
+
+    Each cue's share of ``text`` is proportional to its own VISIBLE character count
+    (whitespace-normalized), so a translation lands roughly where its source words
+    were spoken. Returns NEW dicts; the inputs are never mutated.
+    """
+    source = list(cues)
+    if not source:
+        return []
+    weights = [float(len(" ".join(str(cue.get("text", "") or "").split()))) for cue in source]
+    pieces = split_text_proportional(text, weights)
+    return [{**cue, "text": piece} for cue, piece in zip(source, pieces, strict=True)]
+
+
 def enforce_min_gap(cues: list[Cue], *, fps: float = DEFAULT_FPS) -> list[Cue]:
     """Pull back each cue's ``end`` so consecutive cues keep :data:`MIN_GAP_FRAMES`.
 
@@ -405,6 +577,7 @@ def polish_cues(
     cues: list[Cue],
     *,
     settings: dict[str, Any] | None = None,
+    language: str | None = None,
     punct_backend: PunctBackend | None = None,
     keyword_backend: KeywordBackend | None = None,
     profanity_backend: ProfanityBackend | None = None,
@@ -416,7 +589,14 @@ def polish_cues(
     degrade rule):
 
       1. **Punctuation + casing** (``punct_backend``) — restore sentence casing
-         and punctuation on each cue's text.
+         and punctuation on each cue's text. **Gated on language:** the shipped
+         backend is the English-only :data:`PUNCT_ASSET_NAME` model, so it runs ONLY
+         when :func:`resolve_caption_language` resolves to an ``en*`` code. On any
+         other language — or an unknown one — the stage is skipped, because applying
+         an English punctuation+casing model to foreign text makes the captions worse
+         (`docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.5). Whisper
+         already emits native punctuation, so skipping is the safe default; a
+         multilingual restorer is a later upgrade.
       2. **Profanity masking** (``profanity_backend``) — replace profane words
          with asterisks.
       3. **Timing + segmentation gate** (PURE, always) — split/retime each cue to
@@ -431,8 +611,9 @@ def polish_cues(
          ``emphasis`` spans + a trailing ``emoji`` on each final cue.
 
     Returns brand-new cue dicts in time order, renumbered ``index`` 1..N. Inputs
-    are never mutated. ``settings`` selects the adult/children CPS limit; ``fps``
-    drives the min-gap conversion.
+    are never mutated. ``settings`` selects the adult/children CPS limit; ``language``
+    is the track's own language code (it wins over ``settings``) and gates stage 1;
+    ``fps`` drives the min-gap conversion.
     """
     settings = settings or {}
     if not cues:
@@ -441,15 +622,26 @@ def polish_cues(
     # Reading-speed (CPS) + line count are resolved per-content/per-language and
     # then overridden by an explicit ``captionOverride`` (§1.5). ``max_lines``
     # scales the per-cue CPL capacity in :func:`enforce_cps_cpl`.
-    max_cps, max_lines = resolve_caption_limits(settings)
+    resolved_language = resolve_caption_language(settings, language)
+    max_cps, max_lines = resolve_caption_limits(settings, resolved_language)
+
+    # Stage 1 is English-ONLY (see the docstring): drop the backend for any other
+    # language so the loop below cannot reach it.
+    punct = punct_backend
+    if punct is not None and not _is_english(resolved_language):
+        log.info(
+            "caption polish: skipping the EN-only punctuation restorer for language %r",
+            resolved_language or "unknown",
+        )
+        punct = None
 
     # Stage 1+2 operate per source cue, BEFORE the timing split (so casing +
     # masking see whole sentences). Then the timing gate splits into final cues.
     split_cues: list[Cue] = []
     for cue in cues:
         text = str(cue.get("text", "") or "")
-        if punct_backend is not None:
-            text = punct_backend.restore(text)
+        if punct is not None:
+            text = punct.restore(text)
         if profanity_backend is not None:
             text = mask_profanity(text, profanity_backend)
         retimed = enforce_cps_cpl({**cue, "text": text}, max_cps=max_cps, max_cpl=MAX_CPL, max_lines=max_lines)
@@ -565,6 +757,8 @@ __all__ = [
     "PUNCT_ASSET_NAME",
     "PUNCT_HF_REPO",
     "PUNCT_SIZE_MB",
+    "SENTENCE_CLOSERS",
+    "SENTENCE_FINAL_CHARS",
     "Cue",
     "KeywordBackend",
     "KeywordFactory",
@@ -575,11 +769,15 @@ __all__ = [
     "apply_emphasis_spans",
     "cps_of",
     "default_models_present",
+    "ends_sentence",
     "enforce_cps_cpl",
     "enforce_min_gap",
     "mask_profanity",
     "polish_cues",
+    "redistribute_cue_text",
     "register_caption_polish_assets",
+    "resolve_caption_language",
     "resolve_caption_limits",
+    "split_text_proportional",
     "wrap_two_lines",
 ]

--- a/sidecar/media_studio/features/subtitles.py
+++ b/sidecar/media_studio/features/subtitles.py
@@ -280,10 +280,20 @@ def generate_polished(
     :func:`new_track`. ``polisher`` is the injectable seam (default lazily delegates
     to the real, degrade-safe module). ``settings`` selects the adult/children CPS
     limit + the model backends.
+
+    The TRACK's own language (from the transcript) is passed to the polisher as
+    ``language=``. That is required, not decorative: the punctuation+casing backend is
+    English-only, and without the language it would run on every language and make
+    non-English captions worse
+    (`docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.5).
     """
     polish = polisher if polisher is not None else _default_caption_polisher
     base = generate(transcript, name=name, fmt=fmt, track_id=track_id)
-    polished = polish(list(base.get("cues") or []), settings=settings or {})
+    polished = polish(
+        list(base.get("cues") or []),
+        settings=settings or {},
+        language=str(base.get("lang") or ""),
+    )
     return new_track(
         polished,
         lang=str(base.get("lang") or "und"),

--- a/sidecar/media_studio/models/translation.py
+++ b/sidecar/media_studio/models/translation.py
@@ -225,6 +225,18 @@ _MT_CONTEXT = (
 #: A bound is required: a transcript is unbounded, and an unbounded prompt would
 #: blow the local server's context window.
 SENTENCE_GROUP_MAX_CHARS: int = 400
+
+# A silence longer than this between two cues ends the sentence group, even when the
+# first cue carries no terminal punctuation. ASR output is frequently unpunctuated, so
+# `ends_sentence` alone cannot see a boundary that a listener hears plainly.
+#
+# The value must clear TWO thresholds from opposite directions:
+#   * ABOVE `caption_polish.enforce_min_gap`, which deliberately leaves a ~2-frame hole
+#     (~0.067 s at 30 fps) between consecutive cues of ONE sentence. Anything at or below
+#     that would split every sentence in the file.
+#   * BELOW a real conversational pause. 1.5 s is comfortably longer than the breath
+#     between clauses and shorter than a topic change.
+SENTENCE_GROUP_MAX_GAP_SEC: float = 1.5
 #: Max characters of neighbouring source text passed as context, per side.
 CONTEXT_MAX_CHARS: int = 300
 
@@ -311,6 +323,7 @@ def group_cues_for_translation(
     cues: Sequence[Cue],
     *,
     max_chars: int = SENTENCE_GROUP_MAX_CHARS,
+    max_gap_sec: float = SENTENCE_GROUP_MAX_GAP_SEC,
 ) -> list[list[Cue]]:
     """Group consecutive cues into SENTENCE-level translation units (pure).
 
@@ -323,9 +336,21 @@ def group_cues_for_translation(
     cannot be translated correctly in isolation.
 
     A group closes when: the cue ends a sentence (:func:`caption_polish.ends_sentence`),
-    OR adding the next cue would pass ``max_chars``, OR the cues run out. A BLANK cue
+    OR adding the next cue would pass ``max_chars``, OR the SPEAKER changes, OR the
+    silence before the next cue exceeds ``max_gap_sec``, OR the cues run out. A BLANK cue
     is never merged — it becomes its own group and passes through untranslated, so a
     gap in the transcript can never glue two unrelated sentences together.
+
+    The speaker and pause boundaries exist because ASR output is frequently UNPUNCTUATED,
+    so ``ends_sentence`` alone cannot see a boundary a listener hears plainly. Two
+    speakers' fragments are never one sentence regardless of punctuation, and merging
+    them would hand the model a self-contradicting source — the same "bad translations"
+    class this grouping was built to fix, reintroduced from a different direction.
+
+    A speaker change is only recognised when BOTH cues carry a speaker and the labels
+    differ. A missing label is UNKNOWN, not "a different speaker": diarization is
+    optional here, and letting an absent field manufacture a boundary would silently
+    disable sentence grouping for every undiarized transcript.
     """
     ends = _polish().ends_sentence
     groups: list[list[Cue]] = []
@@ -339,12 +364,29 @@ def group_cues_for_translation(
             current = []
             current_len = 0
 
+    def _speaker(cue: Cue) -> str | None:
+        raw = cue.get("speaker")
+        return str(raw) if raw else None
+
+    def _breaks_continuity(prev: Cue, cue: Cue) -> bool:
+        """Does the boundary between two adjacent cues end the sentence group?"""
+        prev_speaker, speaker = _speaker(prev), _speaker(cue)
+        if prev_speaker is not None and speaker is not None and prev_speaker != speaker:
+            return True
+        try:
+            gap = float(cue.get("start", 0.0)) - float(prev.get("end", 0.0))
+        except (TypeError, ValueError):
+            return False  # unparseable timings are not evidence of a pause
+        return gap > max_gap_sec
+
     for cue in cues:
         text = cue_text(cue)
         if _is_blank(text):
             close()
             groups.append([cue])
             continue
+        if current and _breaks_continuity(current[-1], cue):
+            close()
         if current and current_len + 1 + len(text) > max_chars:
             close()
         current_len += len(text) + (1 if current else 0)

--- a/sidecar/media_studio/models/translation.py
+++ b/sidecar/media_studio/models/translation.py
@@ -141,14 +141,43 @@ def route(lang: str, table: dict[str, str] | None = None) -> str:
     return routing.get(normalize_lang(lang), DEFAULT_TIER)
 
 
-def fallback_chain(lang: str, table: dict[str, str] | None = None) -> list[str]:
+#: Relative capability of each tier — a higher number is the heavier model.
+_TIER_WEIGHT: dict[str, int] = {TIER_LOCAL: 1, TIER_LOCAL_HEAVY: 2, TIER_HOSTED: 3}
+
+
+def route_pair(source_lang: str | None, target_lang: str, table: dict[str, str] | None = None) -> str:
+    """Route on the language PAIR, not the target alone.
+
+    ``route`` is target-only, so ``ro -> en`` routed to the LIGHT tier1 model purely
+    because ``en`` is tier1 — the heavier model was unreachable for exactly the
+    direction that needs it
+    (`docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.3, T4). Here a source
+    language whose own tier is heavier than the target's escalates the choice.
+
+    **The escalation is capped at the heavy LOCAL tier.** A low-resource SOURCE never
+    turns a locally-servable translation into a hosted (network) one, so the pair rule
+    cannot change a job's privacy posture; tier3 stays an explicit TARGET decision
+    (the class docstring's CONTRACT-NOTE). A missing/blank source is target-only
+    routing, so ``route_pair(None, lang) == route(lang)``.
+    """
+    target_tier = route(target_lang, table)
+    if target_tier == TIER_HOSTED or not str(source_lang or "").strip():
+        return target_tier
+    source_tier = route(str(source_lang), table)
+    if _TIER_WEIGHT.get(source_tier, 0) > _TIER_WEIGHT.get(target_tier, 0):
+        return TIER_LOCAL_HEAVY
+    return target_tier
+
+
+def fallback_chain(lang: str, table: dict[str, str] | None = None, *, source_lang: str | None = None) -> list[str]:
     """The tier order to attempt for ``lang``: routed tier first, then the rest.
 
     The remaining tiers follow in ascending order (tier1 -> tier2 -> tier3), so
     e.g. a tier2-routed language falls back to tier1 then tier3, and a hosted
-    failure still gets a best-effort local attempt.
+    failure still gets a best-effort local attempt. ``source_lang`` opts into
+    :func:`route_pair` for the first hop.
     """
-    routed = route(lang, table)
+    routed = route_pair(source_lang, lang, table)
     return [routed] + [t for t in TIERS if t != routed]
 
 
@@ -183,11 +212,61 @@ _MT_SYSTEM = (
 # document for llama-cli/server use.
 
 
-def build_messages(text: str, target_lang: str, source_lang: str | None = None) -> list[dict[str, str]]:
-    """Build the 2-message chat for one cue translation."""
+#: Preamble for the neighbouring-sentence context (T2, folded into T1). The context
+#: rides the SYSTEM message so the user message stays the bare text to translate and
+#: the "reply with ONLY the translation" instruction is never diluted.
+_MT_CONTEXT = (
+    " The surrounding transcript below is given for CONTEXT ONLY — use it to get "
+    "gender, number, tense and referents right, but translate ONLY the user's text "
+    "and never repeat any of the context."
+)
+
+#: Max characters of source text joined into ONE sentence-level translation call.
+#: A bound is required: a transcript is unbounded, and an unbounded prompt would
+#: blow the local server's context window.
+SENTENCE_GROUP_MAX_CHARS: int = 400
+#: Max characters of neighbouring source text passed as context, per side.
+CONTEXT_MAX_CHARS: int = 300
+
+
+def _clip_context(raw: str | None, *, keep_tail: bool) -> str:
+    """Whitespace-normalize ``raw`` and clip it to :data:`CONTEXT_MAX_CHARS`.
+
+    ``keep_tail`` keeps the END of the text (for the PRECEDING context, whose last
+    words are the ones adjacent to the translated sentence); otherwise the START is
+    kept (for the FOLLOWING context). Pure.
+    """
+    body = " ".join(str(raw or "").split())
+    if len(body) <= CONTEXT_MAX_CHARS:
+        return body
+    return body[-CONTEXT_MAX_CHARS:] if keep_tail else body[:CONTEXT_MAX_CHARS]
+
+
+def build_messages(
+    text: str,
+    target_lang: str,
+    source_lang: str | None = None,
+    *,
+    context_before: str | None = None,
+    context_after: str | None = None,
+) -> list[dict[str, str]]:
+    """Build the 2-message chat for one SENTENCE-level translation.
+
+    ``context_before`` / ``context_after`` are the neighbouring sentences' SOURCE
+    text. Passing source (never previously-translated) text keeps the call
+    order-independent and stops one bad translation propagating into the next.
+    """
     system = _MT_SYSTEM.format(target=target_lang)
     if source_lang:
         system += f" The source language is {source_lang}."
+    before = _clip_context(context_before, keep_tail=True)
+    after = _clip_context(context_after, keep_tail=False)
+    if before or after:
+        system += _MT_CONTEXT
+        if before:
+            system += f'\nPreceding text: "{before}"'
+        if after:
+            system += f'\nFollowing text: "{after}"'
     return [
         {"role": "system", "content": system},
         {"role": "user", "content": text},
@@ -196,6 +275,84 @@ def build_messages(text: str, target_lang: str, source_lang: str | None = None) 
 
 def _is_blank(text: str) -> bool:
     return not text or not text.strip()
+
+
+def _polish() -> Any:
+    """The caption-polish module (LAZY import — it registers an asset at import).
+
+    ``caption_polish`` owns the pure segmentation primitives this module reuses
+    (``ends_sentence`` / ``redistribute_cue_text``); importing it lazily keeps
+    ``models.translation`` import-light and free of that asset-registration
+    side-effect until a translation actually runs.
+    """
+    from ..features import caption_polish  # noqa: PLC0415 - lazy: see the docstring
+
+    return caption_polish
+
+
+def cue_text(cue: Cue) -> str:
+    """One cue's text, whitespace-normalized.
+
+    The flattening is load-bearing: ``captionPolish`` runs at GENERATE time
+    (``handlers/media_ops.py`` ``subtitles_generate``) and translation runs later over
+    the persisted track, so ``caption_polish.wrap_two_lines`` has already inserted
+    HARD line breaks into the cue text. Feeding those to the model is the audit's
+    suspected fourth root cause; this is where they are removed.
+    """
+    return " ".join(str(cue.get("text", "") or "").split())
+
+
+def group_text(group: Sequence[Cue]) -> str:
+    """The joined, whitespace-normalized source text of one translation group."""
+    return " ".join(cue_text(cue) for cue in group).strip()
+
+
+def group_cues_for_translation(
+    cues: Sequence[Cue],
+    *,
+    max_chars: int = SENTENCE_GROUP_MAX_CHARS,
+) -> list[list[Cue]]:
+    """Group consecutive cues into SENTENCE-level translation units (pure).
+
+    Caption cues are segmented for READING SPEED (``subtitles.cues_from_transcript``
+    splits on ``max_chars`` / ``max_duration``), so one sentence routinely spans two
+    or three cues. Translating each fragment alone is the mechanical cause of the
+    owner's "bad translations"
+    (`docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.1/§3.2) — for
+    verb-final or different-word-order targets (de, ja, ko, tr, hi) a fragment simply
+    cannot be translated correctly in isolation.
+
+    A group closes when: the cue ends a sentence (:func:`caption_polish.ends_sentence`),
+    OR adding the next cue would pass ``max_chars``, OR the cues run out. A BLANK cue
+    is never merged — it becomes its own group and passes through untranslated, so a
+    gap in the transcript can never glue two unrelated sentences together.
+    """
+    ends = _polish().ends_sentence
+    groups: list[list[Cue]] = []
+    current: list[Cue] = []
+    current_len = 0
+
+    def close() -> None:
+        nonlocal current, current_len
+        if current:
+            groups.append(current)
+            current = []
+            current_len = 0
+
+    for cue in cues:
+        text = cue_text(cue)
+        if _is_blank(text):
+            close()
+            groups.append([cue])
+            continue
+        if current and current_len + 1 + len(text) > max_chars:
+            close()
+        current_len += len(text) + (1 if current else 0)
+        current.append(cue)
+        if ends(text):
+            close()
+    close()
+    return groups
 
 
 def _make_cue(index: int, start: float, end: float, text: str) -> Cue:
@@ -258,9 +415,13 @@ class TieredTranslator:
         """The tier this translator routes ``target_lang`` to."""
         return route(target_lang, self._routing)
 
-    def chain_for(self, target_lang: str) -> list[str]:
-        """The full fallback chain for ``target_lang`` (routed tier first)."""
-        return fallback_chain(target_lang, self._routing)
+    def chain_for(self, target_lang: str, source_lang: str | None = None) -> list[str]:
+        """The full fallback chain for ``target_lang`` (routed tier first).
+
+        ``source_lang`` opts the first hop into pair routing (:func:`route_pair`), so a
+        low-resource SOURCE escalates to the heavier local model.
+        """
+        return fallback_chain(target_lang, self._routing, source_lang=source_lang)
 
     # -- the batched seam (T2 dub + subtitles.translate job body) -----------
     def translate(
@@ -275,19 +436,26 @@ class TieredTranslator:
         """Translate ``cues`` into ``target_lang`` — the ``translate(cues,
         targetLang)`` callable the T2 dub pipeline consumes.
 
+        Translation is **sentence-scoped**: consecutive cues that belong to one
+        sentence are joined into a single call carrying the neighbouring sentences as
+        context, and the reply is laid back over the SAME cue timings (T1 — see
+        :func:`group_cues_for_translation` and
+        :func:`caption_polish.redistribute_cue_text`). Cue count, indices and timings
+        are preserved exactly; only the text changes.
+
         Tries the routed tier first; on any tier failure the WHOLE batch is
         retried on the next tier (a mid-batch failure discards that tier's
         partial output, so the result is never a mixed-tier patchwork).
         Cooperative cancellation mirrors ``features.subtitles.translate``:
-        when ``cancelled()`` turns true the loop stops and the cues translated
-        so far are returned. Raises :class:`TranslationError` when every tier
-        fails — the job body lets that surface via job.done (A6 lesson 3).
+        when ``cancelled()`` turns true the loop stops (at a sentence boundary) and
+        the cues translated so far are returned. Raises :class:`TranslationError` when
+        every tier fails — the job body lets that surface via job.done (A6 lesson 3).
         """
         cue_list = list(cues or [])
         if not cue_list:
             return []
         failures: list[str] = []
-        for tier in self.chain_for(target_lang):
+        for tier in self.chain_for(target_lang, source_lang):
             try:
                 return self._translate_with_tier(tier, cue_list, target_lang, source_lang, progress, cancelled)
             except Exception as exc:  # noqa: BLE001 - each tier failure feeds the chain
@@ -328,8 +496,15 @@ class TieredTranslator:
         Lazily binds the routed tier's provider on first use; a failing line
         escalates to the next tier in the chain and STAYS there (no per-line
         tier thrash). Raises :class:`TranslationError` once the chain is spent.
+
+        CONTRACT-NOTE: this seam is ``str -> str`` by construction, so it is the ONE
+        path that cannot see a sentence's neighbours — a caller that wants the T1
+        sentence-level quality must use :meth:`translate` / :meth:`translate_track`,
+        which take whole cue lists. It has no production caller today (only
+        ``features.subtitles.translate(translator=...)``, which the handler does not
+        use); it is kept for that seam's signature.
         """
-        chain = list(self.chain_for(target_lang))
+        chain = list(self.chain_for(target_lang, source_lang))
         state: dict[str, Any] = {"provider": None, "label": ""}
 
         def _translate(text: str) -> str:
@@ -375,29 +550,48 @@ class TieredTranslator:
         progress: Callable[[int, str], None] | None,
         cancelled: Callable[[], bool] | None,
     ) -> list[Cue]:
-        """Translate the whole batch on ONE tier (raises on any failure)."""
+        """Translate the whole batch on ONE tier, sentence by sentence (raises on failure).
+
+        One provider call per SENTENCE group, not per cue; the reply is redistributed
+        onto the group's own cues so timings never move. Progress is still reported per
+        CUE so the job bar keeps its granularity.
+        """
         provider = self._tier_provider(tier)
         label = self._tier_label(tier)
+        groups = group_cues_for_translation(cues)
+        texts = [group_text(group) for group in groups]
+        redistribute = _polish().redistribute_cue_text
         total = len(cues)
         out: list[Cue] = []
-        for i, cue in enumerate(cues):
+        for position, group in enumerate(groups):
             if cancelled is not None and cancelled():
                 break
-            text = str(cue.get("text", ""))
-            new_text = text if _is_blank(text) else self._chat_one(provider, text, target_lang, source_lang)
-            out.append(
-                _make_cue(
-                    int(cue.get("index", i + 1)),
-                    float(cue.get("start", 0.0)),
-                    float(cue.get("end", 0.0)),
-                    new_text,
+            source_text = texts[position]
+            if _is_blank(source_text):
+                translated_cues: list[Cue] = list(group)
+            else:
+                reply = self._chat_one(
+                    provider,
+                    source_text,
+                    target_lang,
+                    source_lang,
+                    context_before=texts[position - 1] if position else None,
+                    context_after=texts[position + 1] if position + 1 < len(groups) else None,
                 )
-            )
+                translated_cues = redistribute(group, reply)
+            done = len(out)
+            for offset, cue in enumerate(translated_cues):
+                out.append(
+                    _make_cue(
+                        int(cue.get("index", done + offset + 1)),
+                        float(cue.get("start", 0.0)),
+                        float(cue.get("end", 0.0)),
+                        str(cue.get("text", "")),
+                    )
+                )
             if progress is not None and total:
-                progress(
-                    int(round((i + 1) / total * 100)),
-                    f"{label}: translated {i + 1}/{total}",
-                )
+                for count in range(done + 1, len(out) + 1):
+                    progress(int(round(count / total * 100)), f"{label}: translated {count}/{total}")
         return out
 
     def _tier_provider(self, tier: str) -> Any:
@@ -451,9 +645,26 @@ class TieredTranslator:
             model=str(self._settings.get("cloudModel") or provider_mod.DEFAULT_CLOUD_MODEL),
         )
 
-    def _chat_one(self, provider: Any, text: str, target_lang: str, source_lang: str | None) -> str:
-        """One cue through ``provider.chat`` -> stripped translation string."""
-        reply = provider.chat(build_messages(text, target_lang, source_lang))
+    def _chat_one(
+        self,
+        provider: Any,
+        text: str,
+        target_lang: str,
+        source_lang: str | None,
+        *,
+        context_before: str | None = None,
+        context_after: str | None = None,
+    ) -> str:
+        """One sentence through ``provider.chat`` -> stripped translation string."""
+        reply = provider.chat(
+            build_messages(
+                text,
+                target_lang,
+                source_lang,
+                context_before=context_before,
+                context_after=context_after,
+            )
+        )
         return str(reply).strip()
 
     # -- gguf resolution ------------------------------------------------------

--- a/sidecar/tests/test_caption_polish.py
+++ b/sidecar/tests/test_caption_polish.py
@@ -298,8 +298,11 @@ class TestPolishCues:
         assert "emoji" in out[0]
 
     def test_punct_backend_applied(self):
+        # ``language="en"`` is required: the punct backend is English-only and is
+        # gated on the language (see TestPunctLanguageGate).
         out = cp.polish_cues(
             [_cue(1, 0.0, 5.0, "hello world")],
+            language="en",
             punct_backend=FakePunct({"hello world": "Hello, world."}),
         )
         assert out[0]["text"] == "Hello, world."
@@ -330,6 +333,7 @@ class TestPolishCues:
         # A punct backend that empties the text -> every cue drops -> [].
         out = cp.polish_cues(
             [_cue(1, 0.0, 5.0, "x")],
+            language="en",
             punct_backend=FakePunct({"x": "   "}),
         )
         assert out == []
@@ -338,6 +342,7 @@ class TestPolishCues:
         cues = [_cue(5, 0.0, 5.0, "first cue"), _cue(6, 6.0, 11.0, "second cue")]
         out = cp.polish_cues(
             cues,
+            language="en",
             punct_backend=FakePunct(),
             keyword_backend=FakeKeywords([]),
             profanity_backend=FakeProfanity(set()),
@@ -348,6 +353,190 @@ class TestPolishCues:
         cues = [_cue(1, 0.0, 1.0, "a a"), _cue(2, 1.01, 2.0, "b b")]
         out = cp.polish_cues(cues, fps=30.0)
         assert out[0]["end"] < 1.0  # pulled back for the min gap
+
+
+# --------------------------------------------------------------------------- #
+# language gate on the EN-only punctuation restorer
+#   `docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.5 measured that the
+#   sherpa-onnx `PUNCT_ASSET_NAME` model is English-only yet ran on EVERY language,
+#   so it made non-English captions worse. T5 is the gate.
+# --------------------------------------------------------------------------- #
+class RecordingPunct:
+    """A punct backend that records every call, so a SKIP is directly observable."""
+
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    def restore(self, text: str) -> str:
+        self.seen.append(text)
+        return f"EN-PUNCT({text})"
+
+
+class TestResolveCaptionLanguage:
+    def test_explicit_argument_wins(self):
+        assert cp.resolve_caption_language({"captionLanguage": "fr", "language": "de"}, "ro") == "ro"
+
+    def test_caption_language_beats_language(self):
+        assert cp.resolve_caption_language({"captionLanguage": "FR", "language": "de"}) == "fr"
+
+    def test_language_is_the_last_resort(self):
+        assert cp.resolve_caption_language({"language": " DE "}) == "de"
+
+    def test_blank_and_missing_resolve_to_unknown(self):
+        assert cp.resolve_caption_language(None) == ""
+        assert cp.resolve_caption_language({}) == ""
+        assert cp.resolve_caption_language({"captionLanguage": "  ", "language": ""}) == ""
+
+    def test_resolve_caption_limits_takes_an_explicit_language(self):
+        # An explicit English language reaches the Netflix English reading speed even
+        # when settings carry a different one (one resolution path, no drift).
+        assert cp.resolve_caption_limits({"language": "ro"}, "en")[0] == cp.MAX_CPS_ENGLISH
+        assert cp.resolve_caption_limits({"language": "en"}, "ro")[0] == cp.MAX_CPS
+
+
+class TestEndsSentence:
+    @pytest.mark.parametrize("text", ["Done.", "Really?", "Stop!", "Well…", "終わり。", "كيف؟", "ठीक।"])
+    def test_sentence_final_marks(self, text: str):
+        assert cp.ends_sentence(text) is True
+
+    @pytest.mark.parametrize("text", ['He said "go."', "(that is it.)", "«asa e.»", "Fine.  "])
+    def test_closers_and_trailing_space_are_looked_through(self, text: str):
+        assert cp.ends_sentence(text) is True
+
+    @pytest.mark.parametrize("text", ["", "   ", "and then", "a comma,", '"""', "mid-clause -"])
+    def test_non_terminal_text(self, text: str):
+        assert cp.ends_sentence(text) is False
+
+
+class TestSplitTextProportional:
+    def test_no_weights_yields_no_pieces(self):
+        assert cp.split_text_proportional("anything", []) == []
+
+    def test_single_weight_takes_the_whole_normalized_text(self):
+        assert cp.split_text_proportional("  a   b \n c ", [3.0]) == ["a b c"]
+
+    def test_splits_on_word_boundaries_near_the_proportional_target(self):
+        # weights 11/10 over a 25-char body -> ~13/12 chars, snapped to a word edge.
+        pieces = cp.split_text_proportional("XX:hello there good night", [11.0, 10.0])
+        assert pieces == ["XX:hello there", "good night"]
+
+    def test_exactly_one_word_per_piece_never_starves_a_later_piece(self):
+        # A greedy first piece would swallow both words and leave the second cue
+        # blank; the reserved-word guard is what stops it.
+        assert cp.split_text_proportional("aa bb", [1.0, 1.0]) == ["aa", "bb"]
+        assert cp.split_text_proportional("aaaaaaaaaaaa bb", [9.0, 1.0]) == ["aaaaaaaaaaaa", "bb"]
+
+    def test_weightless_input_splits_evenly(self):
+        assert cp.split_text_proportional("aa bb cc dd", [0.0, 0.0]) == ["aa bb", "cc dd"]
+
+    def test_no_whitespace_text_falls_back_to_character_slices(self):
+        # Japanese/Chinese/Thai carry no spaces: a word split would yield ONE token
+        # for the whole sentence and starve every cue but the first.
+        pieces = cp.split_text_proportional("こんにちは世界", [11.0, 10.0])
+        assert pieces == ["こんにち", "は世界"]
+        assert "".join(pieces) == "こんにちは世界"
+
+    def test_more_cues_than_characters_never_loses_a_character(self):
+        pieces = cp.split_text_proportional("ab", [1.0, 1.0, 1.0])
+        assert len(pieces) == 3
+        assert "".join(pieces) == "ab"
+
+    def test_blank_text_yields_blank_pieces(self):
+        assert cp.split_text_proportional("   ", [1.0, 1.0]) == ["", ""]
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "one two three four five six seven eight",
+            "Cand ea a deschis in sfarsit scrisoarea, a plans.",
+            "短い文と、もう一つの文。",
+        ],
+    )
+    @pytest.mark.parametrize("n", [2, 3, 4])
+    def test_losslessness_over_every_split(self, text: str, n: int):
+        pieces = cp.split_text_proportional(text, [1.0] * n)
+        assert len(pieces) == n
+        assert "".join("".join(p.split()) for p in pieces) == "".join(text.split())
+
+
+class TestRedistributeCueText:
+    def test_empty_cues(self):
+        assert cp.redistribute_cue_text([], "anything") == []
+
+    def test_timings_and_indices_are_byte_identical(self):
+        src = [_cue(7, 0.0, 1.5, "hello there"), _cue(8, 1.5, 3.0, "good night")]
+        out = cp.redistribute_cue_text(src, "XX:hello there good night")
+        assert [(c["index"], c["start"], c["end"]) for c in out] == [(7, 0.0, 1.5), (8, 1.5, 3.0)]
+        assert [c["text"] for c in out] == ["XX:hello there", "good night"]
+
+    def test_inputs_are_not_mutated_and_extra_keys_survive(self):
+        src = [{**_cue(1, 0.0, 1.0, "a b"), "speaker": "S1"}]
+        out = cp.redistribute_cue_text(src, "c d")
+        assert out[0]["speaker"] == "S1"
+        assert out[0]["text"] == "c d"
+        assert src[0]["text"] == "a b"
+        assert out[0] is not src[0]
+
+    def test_all_blank_source_cues_split_the_text_evenly(self):
+        src = [_cue(1, 0.0, 1.0, "  "), _cue(2, 1.0, 2.0, "")]
+        out = cp.redistribute_cue_text(src, "aa bb cc dd")
+        assert [c["text"] for c in out] == ["aa bb", "cc dd"]
+
+    def test_source_whitespace_does_not_inflate_a_cue_weight(self):
+        # A hard-wrapped source cue must weigh its VISIBLE characters only: raw
+        # weights (9, 9) would split "aa bb | cc dd"; normalized (3, 9) splits "aa |
+        # bb cc dd". Asserting the normalized answer pins the newline handling.
+        src = [_cue(1, 0.0, 1.0, "x\n\n\n\n\n\n\ny"), _cue(2, 1.0, 2.0, "123456789")]
+        assert [c["text"] for c in cp.redistribute_cue_text(src, "aa bb cc dd")] == ["aa", "bb cc dd"]
+
+
+class TestPunctLanguageGate:
+    def test_non_english_language_skips_the_en_only_restorer(self):
+        punct = RecordingPunct()
+        out = cp.polish_cues(
+            [_cue(1, 0.0, 5.0, "nu este bine")],
+            settings={"language": "ro"},
+            punct_backend=punct,
+        )
+        assert punct.seen == [], "the EN-only restorer ran on Romanian text"
+        assert out[0]["text"] == "nu este bine"
+
+    def test_english_language_still_runs_the_restorer(self):
+        punct = RecordingPunct()
+        out = cp.polish_cues(
+            [_cue(1, 0.0, 5.0, "hello world")],
+            settings={"language": "en-US"},
+            punct_backend=punct,
+        )
+        assert punct.seen == ["hello world"]
+        assert out[0]["text"] == "EN-PUNCT(hello world)"
+
+    def test_unknown_language_skips_the_restorer(self):
+        """Adverse inference: a blank language is worst-case, not "probably English"."""
+        punct = RecordingPunct()
+        cp.polish_cues([_cue(1, 0.0, 5.0, "no language declared")], punct_backend=punct)
+        assert punct.seen == []
+
+    def test_caption_language_setting_is_read_before_language(self):
+        punct = RecordingPunct()
+        cp.polish_cues(
+            [_cue(1, 0.0, 5.0, "bonjour tout le monde")],
+            settings={"captionLanguage": "fr", "language": "en"},
+            punct_backend=punct,
+        )
+        assert punct.seen == []
+
+    def test_non_english_language_does_not_disable_the_other_stages(self):
+        """Only the EN-only stage is gated: masking + timing + emphasis still run."""
+        out = cp.polish_cues(
+            [_cue(1, 0.0, 5.0, "tu darn prost")],
+            settings={"language": "ro"},
+            punct_backend=RecordingPunct(),
+            profanity_backend=FakeProfanity({"darn"}),
+            keyword_backend=FakeKeywords(["prost"]),
+        )
+        assert out[0]["text"] == "tu **** prost"
+        assert any(s["kind"] == "keyword" for s in out[0]["emphasis"])
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_subtitles.py
+++ b/sidecar/tests/test_subtitles.py
@@ -536,9 +536,10 @@ def test_full_pipeline_generate_translate_export(transcript, tmp_path: Path):
 def test_generate_polished_threads_cues_through_injected_polisher(transcript):
     seen: dict[str, Any] = {}
 
-    def fake_polisher(cues, *, settings):
+    def fake_polisher(cues, *, settings, language):
         seen["cues"] = cues
         seen["settings"] = settings
+        seen["language"] = language
         # Return cues with rewritten (polished) text.
         return [{**c, "text": c["text"].upper()} for c in cues]
 
@@ -546,6 +547,8 @@ def test_generate_polished_threads_cues_through_injected_polisher(transcript):
     # the polisher saw the generated cues + the settings
     assert seen["settings"] == {"captionChildren": True}
     assert seen["cues"], "polisher received no cues"
+    # the TRACK's language reached the polisher — it gates the EN-only punct stage
+    assert seen["language"] == "en"
     # polished text landed on the track (reindexed onto a fresh §3 track)
     assert track["cues"][0]["text"] == "HELLO WORLD."
     assert set(track.keys()) == {"id", "lang", "name", "format", "kind", "cues"}

--- a/sidecar/tests/test_translation.py
+++ b/sidecar/tests/test_translation.py
@@ -25,6 +25,7 @@ from media_studio.models.translation import (
     DEFAULT_TIER,
     ROUTING_TABLE,
     SENTENCE_GROUP_MAX_CHARS,
+    SENTENCE_GROUP_MAX_GAP_SEC,
     TIER1_ASSET_NAME,
     TIER1_GGUF_NAME,
     TIER2_ASSET_NAME,
@@ -408,6 +409,62 @@ class TestGroupCuesForTranslation:
             {"index": 3, "start": 2.0, "end": 3.0, "text": "after"},
         ]
         assert [[c["index"] for c in g] for g in group_cues_for_translation(cues)] == [[1], [2], [3]]
+
+    def test_a_speaker_change_closes_the_group(self):
+        """Two speakers' fragments are never ONE sentence, punctuation or not."""
+        cues = [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "so I told him", "speaker": "SPEAKER_00"},
+            {"index": 2, "start": 1.0, "end": 2.0, "text": "and what did he say", "speaker": "SPEAKER_01"},
+        ]
+        assert [[c["index"] for c in g] for g in group_cues_for_translation(cues)] == [[1], [2]]
+
+    def test_absent_speaker_on_both_cues_is_not_a_change(self):
+        cues = [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "so I told"},
+            {"index": 2, "start": 1.0, "end": 2.0, "text": "him the truth"},
+        ]
+        assert [len(g) for g in group_cues_for_translation(cues)] == [2]
+
+    def test_a_long_pause_closes_the_group(self):
+        cues = [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "so I told him"},
+            {"index": 2, "start": 9.0, "end": 10.0, "text": "anyway where were we"},
+        ]
+        assert [[c["index"] for c in g] for g in group_cues_for_translation(cues)] == [[1], [2]]
+
+    def test_the_min_gap_between_cues_of_one_sentence_does_not_close_the_group(self):
+        # `caption_polish.enforce_min_gap` leaves a 2-frame (~0.067s at 30fps) hole
+        # between consecutive cues; that must NOT read as a pause.
+        cues = [
+            {"index": 1, "start": 0.0, "end": 0.933, "text": "so I told"},
+            {"index": 2, "start": 1.0, "end": 2.0, "text": "him the truth"},
+        ]
+        assert [len(g) for g in group_cues_for_translation(cues)] == [2]
+
+    def test_the_pause_threshold_is_configurable(self):
+        cues = [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "so I told him"},
+            {"index": 2, "start": 2.0, "end": 3.0, "text": "the whole truth"},
+        ]
+        assert [len(g) for g in group_cues_for_translation(cues, max_gap_sec=0.5)] == [1, 1]
+        assert [len(g) for g in group_cues_for_translation(cues, max_gap_sec=5.0)] == [2]
+        assert SENTENCE_GROUP_MAX_GAP_SEC > 0.1
+
+    def test_unparseable_timings_are_not_evidence_of_a_pause(self):
+        """A malformed timing must not invent a boundary, and must not raise.
+
+        Cues reach here from a persisted track that a user can hand-edit (SRT import,
+        the cue editor), so a non-numeric `start`/`end` is reachable input rather than
+        a theoretical one. Splitting on it would silently degrade translation quality
+        for the whole file; raising would fail the render outright. Neither is right --
+        an unreadable timing is simply no evidence, so grouping falls through to the
+        punctuation and max_chars rules.
+        """
+        cues = [
+            {"index": 1, "start": 0.0, "end": "not-a-number", "text": "so I told"},
+            {"index": 2, "start": 1.0, "end": 2.0, "text": "him the truth"},
+        ]
+        assert [len(g) for g in group_cues_for_translation(cues)] == [2]
 
     def test_max_chars_bounds_the_group(self):
         cues = [{"index": i, "start": float(i), "end": i + 1.0, "text": "abcd"} for i in range(1, 6)]

--- a/sidecar/tests/test_translation.py
+++ b/sidecar/tests/test_translation.py
@@ -21,8 +21,10 @@ from media_studio.models.provider import (
 )
 from media_studio.models.runner import ModelRunner
 from media_studio.models.translation import (
+    CONTEXT_MAX_CHARS,
     DEFAULT_TIER,
     ROUTING_TABLE,
+    SENTENCE_GROUP_MAX_CHARS,
     TIER1_ASSET_NAME,
     TIER1_GGUF_NAME,
     TIER2_ASSET_NAME,
@@ -38,8 +40,11 @@ from media_studio.models.translation import (
     build_messages,
     fallback_chain,
     get_translator,
+    group_cues_for_translation,
+    group_text,
     normalize_lang,
     route,
+    route_pair,
 )
 
 
@@ -95,9 +100,16 @@ def make_factory(providers: list[Any]):
 
 
 def cues2() -> list[dict[str, Any]]:
+    """Two cues that are two INDEPENDENT sentences.
+
+    The trailing full stops are load-bearing: translation is sentence-scoped (T1),
+    so a cue that ends a sentence is its own translation unit and these two cues
+    therefore still map 1:1 onto two provider calls. ``sentence_fragments()`` is the
+    complementary fixture for the mid-sentence-split case.
+    """
     return [
-        {"index": 1, "start": 0.0, "end": 1.5, "text": "hello there"},
-        {"index": 2, "start": 1.5, "end": 3.0, "text": "good night"},
+        {"index": 1, "start": 0.0, "end": 1.5, "text": "Hello there."},
+        {"index": 2, "start": 1.5, "end": 3.0, "text": "Good night."},
     ]
 
 
@@ -203,7 +215,7 @@ def test_tier1_translates_and_starts_server_with_tier1_gguf():
     provider = FakeProvider()
     t = make_translator(runner=runner, local=[provider])
     out = t.translate(cues2(), "es")
-    assert [c["text"] for c in out] == ["XX:hello there", "XX:good night"]
+    assert [c["text"] for c in out] == ["XX:Hello there.", "XX:Good night."]
     assert runner.calls == [{"gguf_path": TIER1_PATH, "gpu_layers": None}]
 
 
@@ -216,7 +228,7 @@ def test_tier1_preserves_timings_and_indices_immutably():
         (1, 0.0, 1.5),
         (2, 1.5, 3.0),
     ]
-    assert src[0]["text"] == "hello there"  # input not mutated
+    assert src[0]["text"] == "Hello there."  # input not mutated
     assert out[0] is not src[0]
 
 
@@ -273,7 +285,7 @@ def test_tier1_failure_falls_back_to_tier2_full_batch():
     t = make_translator(runner=runner, local=[failing, working])
     out = t.translate(cues2(), "es")
     # no mixed-tier patchwork: every cue came from the tier2 provider
-    assert [c["text"] for c in out] == ["T2:hello there", "T2:good night"]
+    assert [c["text"] for c in out] == ["T2:Hello there.", "T2:Good night."]
     assert len(working.chats) == 2
     # server was started for tier1 first, then switched to tier2 with offload
     assert runner.calls[0] == {"gguf_path": TIER1_PATH, "gpu_layers": None}
@@ -289,7 +301,7 @@ def test_local_failures_fall_back_to_hosted():
         hosted=[hosted],
     )
     out = t.translate(cues2(), "es")
-    assert [c["text"] for c in out] == ["CLOUD:hello there", "CLOUD:good night"]
+    assert [c["text"] for c in out] == ["CLOUD:Hello there.", "CLOUD:Good night."]
 
 
 def test_all_tiers_fail_raises_translation_error_with_reasons():
@@ -310,7 +322,7 @@ def test_unavailable_local_tiers_skip_to_hosted():
     hosted = FakeProvider(prefix="CLOUD")
     t = make_translator(runner=None, hosted=[hosted])
     out = t.translate(cues2(), "es")
-    assert out[0]["text"] == "CLOUD:hello there"
+    assert out[0]["text"] == "CLOUD:Hello there."
 
 
 def test_nothing_available_raises():
@@ -323,7 +335,7 @@ def test_tier3_routed_lang_never_touches_the_runner():
     runner = FakeRunner()
     t = make_translator(runner=runner, hosted=[FakeProvider(prefix="CLOUD")])
     out = t.translate(cues2(), "yo")
-    assert out[0]["text"] == "CLOUD:hello there"
+    assert out[0]["text"] == "CLOUD:Hello there."
     assert runner.calls == []
 
 
@@ -331,7 +343,7 @@ def test_hosted_unavailable_falls_back_to_local_for_tier3_lang():
     runner = FakeRunner()
     t = make_translator(runner=runner, local=[FakeProvider()])  # no hosted/no key
     out = t.translate(cues2(), "yo")
-    assert out[0]["text"] == "XX:hello there"
+    assert out[0]["text"] == "XX:Hello there."
     assert runner.calls[0]["gguf_path"] == TIER1_PATH
 
 
@@ -349,6 +361,220 @@ def test_hosted_factory_returning_none_is_unavailable():
     with pytest.raises(TranslationError) as exc_info:
         t.translate(cues2(), "yo")
     assert "tier3" in str(exc_info.value)
+
+
+# --------------------------------------------------------------------------- #
+# sentence-level translation — the T1 keystone
+#   `docs/plans/v1.5/captions-translation-audit-2026-08.md` §3.1 + §3.2 measured the
+#   mechanical cause of the owner's "bad translations": cues are segmented for READING
+#   SPEED, so one sentence spans several cues, and the translator was handed each
+#   fragment alone. These tests pin the fixed shape: one call per SENTENCE, with the
+#   neighbouring sentences supplied as context.
+# --------------------------------------------------------------------------- #
+def sentence_fragments() -> list[dict[str, Any]]:
+    """Three cues that are ONE sentence split for reading speed (the defect shape).
+
+    Only the LAST cue carries sentence-final punctuation, so a per-cue translator
+    sees three context-free fragments and has to guess the clause each belongs to.
+    """
+    return [
+        {"index": 1, "start": 0.0, "end": 1.2, "text": "When she finally opened"},
+        {"index": 2, "start": 1.2, "end": 2.4, "text": "the letter her brother"},
+        {"index": 3, "start": 2.4, "end": 3.6, "text": "had written, she cried."},
+    ]
+
+
+ONE_SENTENCE = "When she finally opened the letter her brother had written, she cried."
+
+
+class TestGroupCuesForTranslation:
+    def test_fragments_of_one_sentence_form_one_group(self):
+        groups = group_cues_for_translation(sentence_fragments())
+        assert [len(g) for g in groups] == [3]
+        assert group_text(groups[0]) == ONE_SENTENCE
+
+    def test_each_sentence_terminates_its_group(self):
+        cues = [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "One."},
+            {"index": 2, "start": 1.0, "end": 2.0, "text": "Two"},
+            {"index": 3, "start": 2.0, "end": 3.0, "text": "and a half!"},
+        ]
+        assert [[c["index"] for c in g] for g in group_cues_for_translation(cues)] == [[1], [2, 3]]
+
+    def test_a_blank_cue_is_never_merged_into_a_group(self):
+        cues = [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "before"},
+            {"index": 2, "start": 1.0, "end": 2.0, "text": "   "},
+            {"index": 3, "start": 2.0, "end": 3.0, "text": "after"},
+        ]
+        assert [[c["index"] for c in g] for g in group_cues_for_translation(cues)] == [[1], [2], [3]]
+
+    def test_max_chars_bounds_the_group(self):
+        cues = [{"index": i, "start": float(i), "end": i + 1.0, "text": "abcd"} for i in range(1, 6)]
+        groups = group_cues_for_translation(cues, max_chars=10)
+        # "abcd abcd" is 9 chars; a third would be 14 > 10.
+        assert [len(g) for g in groups] == [2, 2, 1]
+
+    def test_empty_input(self):
+        assert group_cues_for_translation([]) == []
+
+    def test_group_text_flattens_all_whitespace(self):
+        group = [{"text": "a\nb"}, {"text": "  c   d "}]
+        assert group_text(group) == "a b c d"
+
+    def test_default_bound_is_the_module_constant(self):
+        assert SENTENCE_GROUP_MAX_CHARS >= 100
+
+
+class TestRoutePair:
+    def test_no_source_is_target_only_routing(self):
+        assert route_pair(None, "es") == TIER_LOCAL
+        assert route_pair("", "sw") == TIER_LOCAL_HEAVY
+        assert route_pair("   ", "yo") == TIER_HOSTED
+
+    def test_low_resource_source_escalates_a_tier1_target(self):
+        # ro->en used to route tier1 purely because `en` is tier1 (audit §3.3).
+        assert route_pair("sw", "en") == TIER_LOCAL_HEAVY
+        assert route_pair("en", "en") == TIER_LOCAL
+
+    def test_an_uncovered_source_escalates_only_to_the_heavy_LOCAL_tier(self):
+        # Privacy posture: a low-resource SOURCE must never turn a locally-servable
+        # translation into a hosted (network) one — tier3 stays a TARGET decision.
+        assert route_pair("yo", "en") == TIER_LOCAL_HEAVY
+
+    def test_a_hosted_target_stays_hosted(self):
+        assert route_pair("en", "yo") == TIER_HOSTED
+
+    def test_a_lighter_source_never_downgrades_the_target(self):
+        assert route_pair("en", "sw") == TIER_LOCAL_HEAVY
+
+    def test_custom_table_is_honoured(self):
+        assert route_pair("es", "en", {"es": TIER_LOCAL_HEAVY, "en": TIER_LOCAL}) == TIER_LOCAL_HEAVY
+
+    def test_unknown_tier_from_a_custom_table_cannot_escalate(self):
+        assert route_pair("es", "en", {"es": "tierX", "en": TIER_LOCAL}) == TIER_LOCAL
+
+    def test_fallback_chain_uses_pair_routing_when_a_source_is_given(self):
+        assert fallback_chain("en") == [TIER_LOCAL, TIER_LOCAL_HEAVY, TIER_HOSTED]
+        assert fallback_chain("en", source_lang="sw") == [TIER_LOCAL_HEAVY, TIER_LOCAL, TIER_HOSTED]
+
+    def test_translator_chain_for_threads_the_source(self):
+        t = make_translator()
+        assert t.chain_for("en", source_lang="sw")[0] == TIER_LOCAL_HEAVY
+
+
+def test_translate_routes_on_the_language_pair():
+    runner = FakeRunner()
+    t = make_translator(runner=runner, local=[FakeProvider()])
+    t.translate(cues2(), "en", source_lang="sw")
+    assert runner.calls == [{"gguf_path": TIER2_PATH, "gpu_layers": TIER2_GPU_LAYERS}]
+
+
+def test_build_messages_carries_neighbouring_context_in_the_system_message():
+    msgs = build_messages("middle", "fr", "en", context_before="left", context_after="right")
+    system = msgs[0]["content"]
+    assert 'Preceding text: "left"' in system
+    assert 'Following text: "right"' in system
+    assert "CONTEXT ONLY" in system
+    assert msgs[1]["content"] == "middle"
+
+
+def test_build_messages_without_context_is_unchanged():
+    system = build_messages("solo", "fr")[0]["content"]
+    assert "Preceding text:" not in system
+    assert "Following text:" not in system
+    assert "CONTEXT ONLY" not in system
+
+
+def test_build_messages_clips_context_toward_the_translated_text():
+    before = " ".join(f"b{i}" for i in range(400))
+    after = " ".join(f"a{i}" for i in range(400))
+    system = build_messages("x", "fr", context_before=before, context_after=after)[0]["content"]
+    assert len(system) < 2 * CONTEXT_MAX_CHARS + 600
+    # `before` keeps its TAIL (the words nearest the cue), `after` keeps its HEAD.
+    assert "b399" in system and "b0 " not in system
+    assert "a0 " in system and "a399" not in system
+
+
+def test_build_messages_keeps_short_context_whole():
+    system = build_messages("x", "fr", context_before="short one", context_after="short two")[0]["content"]
+    assert 'Preceding text: "short one"' in system
+    assert 'Following text: "short two"' in system
+
+
+def test_sentence_fragments_translate_in_one_context_bearing_call():
+    provider = FakeProvider()
+    t = make_translator(runner=FakeRunner(), local=[provider])
+    t.translate(sentence_fragments(), "de")
+    assert len(provider.chats) == 1, "the cues were still translated in isolation"
+    assert provider.chats[0][-1]["content"] == ONE_SENTENCE
+
+
+def test_grouped_translation_preserves_every_cue_timing_exactly():
+    """Timing fidelity is the HARD contract: re-segmentation may rewrite TEXT only."""
+    src = sentence_fragments()
+    t = make_translator(runner=FakeRunner(), local=[FakeProvider(prefix="DE")])
+    out = t.translate(src, "de")
+    assert [(c["index"], c["start"], c["end"]) for c in out] == [(c["index"], c["start"], c["end"]) for c in src]
+
+
+def test_redistribution_loses_no_characters_of_the_translation():
+    """Every non-whitespace character of the model's reply lands in exactly one cue."""
+    provider = FakeProvider(prefix="DE")
+    t = make_translator(runner=FakeRunner(), local=[provider])
+    out = t.translate(sentence_fragments(), "de")
+    reply = f"DE:{ONE_SENTENCE}"
+    assert "".join("".join(str(c["text"]).split()) for c in out) == "".join(reply.split())
+
+
+def test_every_cue_of_a_group_receives_text():
+    provider = FakeProvider(prefix="DE")
+    t = make_translator(runner=FakeRunner(), local=[provider])
+    out = t.translate(sentence_fragments(), "de")
+    assert len(out) == 3
+    assert all(str(c["text"]).strip() for c in out)
+
+
+def test_polished_hard_wraps_are_flattened_before_the_model_sees_them():
+    """``caption_polish.wrap_two_lines`` puts a hard newline INSIDE the cue text.
+
+    Because ``captionPolish`` runs at GENERATE time (``handlers/media_ops.py``
+    ``subtitles_generate``) and translation runs later over the persisted track, the
+    model was being fed embedded line breaks — the audit's suspected fourth root
+    cause, CONFIRMED by that call order.
+    """
+    cues = [
+        {"index": 1, "start": 0.0, "end": 1.0, "text": "the quick brown\nfox jumps"},
+        {"index": 2, "start": 1.0, "end": 2.0, "text": "over the lazy dog."},
+    ]
+    provider = FakeProvider()
+    t = make_translator(runner=FakeRunner(), local=[provider])
+    t.translate(cues, "fr")
+    assert len(provider.chats) == 1
+    assert provider.chats[0][-1]["content"] == "the quick brown fox jumps over the lazy dog."
+
+
+def test_neighbouring_sentences_are_supplied_as_context():
+    provider = FakeProvider()
+    cues = [
+        {"index": 1, "start": 0.0, "end": 1.0, "text": "She left."},
+        {"index": 2, "start": 1.0, "end": 2.0, "text": "He stayed."},
+        {"index": 3, "start": 2.0, "end": 3.0, "text": "Nobody spoke."},
+    ]
+    t = make_translator(runner=FakeRunner(), local=[provider])
+    t.translate(cues, "ro")
+    assert len(provider.chats) == 3
+    # context rides the SYSTEM message; the USER message stays the bare sentence so
+    # the "reply with ONLY the translation" instruction is never diluted.
+    first, middle, last = (chat[0]["content"] for chat in provider.chats)
+    assert [chat[-1]["content"] for chat in provider.chats] == [
+        "She left.",
+        "He stayed.",
+        "Nobody spoke.",
+    ]
+    assert "Preceding text:" not in first and "He stayed." in first
+    assert "She left." in middle and "Nobody spoke." in middle
+    assert "He stayed." in last and "Following text:" not in last
 
 
 # --------------------------------------------------------------------------- #
@@ -390,9 +616,9 @@ def test_translate_track_returns_new_track_with_lang():
     out = t.translate_track(track, "es")
     assert out["lang"] == "es"
     assert out["id"] == "trk1"
-    assert [c["text"] for c in out["cues"]] == ["XX:hello there", "XX:good night"]
+    assert [c["text"] for c in out["cues"]] == ["XX:Hello there.", "XX:Good night."]
     assert track["lang"] == "en"  # input not mutated
-    assert track["cues"][0]["text"] == "hello there"
+    assert track["cues"][0]["text"] == "Hello there."
 
 
 # --------------------------------------------------------------------------- #
@@ -543,7 +769,7 @@ def test_real_runner_model_switch_through_fallback():
         local_provider_factory=make_factory([FakeProvider(fail_all=True), FakeProvider(prefix="T2")]),
     )
     out = t.translate(cues2(), "es")
-    assert [c["text"] for c in out] == ["T2:hello there", "T2:good night"]
+    assert [c["text"] for c in out] == ["T2:Hello there.", "T2:Good night."]
     # two launches: tier1 GGUF first, then the tier2 GGUF with partial offload
     assert len(popen.spawned) == 2
     assert TIER1_PATH in popen.spawned[0]


### PR DESCRIPTION
## "Bad translations" was a pipeline shape, not a model-quality problem

The owner's report: *"it has to be very accurate and properly worded not bad translations."*

The audit found the mechanical cause, and this closes it. **Translation was per-cue and
context-free, on cues that had already been split mid-sentence.** Caption cues are segmented for
READING SPEED (Netflix CPS/CPL), so one sentence routinely spans two or three cues. The translator
was handed each fragment alone. For verb-final or different-word-order targets — `de`, `ja`, `ko`,
`tr`, `hi` — a fragment simply **cannot** be translated correctly in isolation.

No model swap would have fixed that. This is the third and last of the three root causes the
captions audit identified; #346 closed the language surface and #347 the karaoke styling.

## What the three commits do

**1. Translate whole sentences, and stop the EN-only polish wrecking other languages.**
Cues are grouped into sentence-level translation units, translated with neighbouring context, then
re-segmented back onto the original cue timings. Separately, an English-only punctuation/casing
model was running on **every** language with no language check — actively making non-English
captions worse. Now gated.

Also fixed here: `caption_polish.wrap_two_lines` inserts **hard line breaks** before translation
runs over the persisted track, so the model was being fed cues containing literal newlines. Those
are flattened first (the audit's suspected fourth root cause).

**2. Prove the tests fire on the broken state** — `.quality/translation_quality_mutations.py`.

**3. A speaker change or a long pause also ends a sentence group.**
`ends_sentence` cannot see a boundary in **unpunctuated ASR output**, which is the common case. Two
gaps remained:

- **Two speakers.** *"so I told him"* / *"and what did he say"* is never one sentence regardless of
  punctuation. Merging them hands the model a self-contradicting source — the same defect class,
  reintroduced from another direction.
- **A long silence.** An 8-second gap is a topic change, not a clause break.

`SENTENCE_GROUP_MAX_GAP_SEC = 1.5` has to clear a floor **and** a ceiling: above
`caption_polish.enforce_min_gap`, which deliberately leaves a ~2-frame hole (~0.067 s at 30 fps)
*inside* one sentence — anything at or below that splits every sentence in the file, the exact
inverse of the defect — and below a real conversational pause. **Both directions are tested**, not
just the one that passes.

A missing speaker label is treated as **UNKNOWN, not "a different speaker"**: a change is
recognised only when both cues carry a label and they differ. Diarization is optional on this path,
and letting an absent field manufacture a boundary would silently disable sentence grouping for
every undiarized transcript.

## Mutation proof — 8/8 caught

```
SUCCESS:mtproof 8/8 mutations caught
  M2  revert the language gate: the EN-only punct model runs on every language     CAUGHT
  M3  revert sentence grouping: one group per cue (the audit's §3.1 defect)        CAUGHT
  M4  drop the neighbouring-sentence context                                       CAUGHT
  M5  lossy redistribution: the last piece silently drops its tail word            CAUGHT
  M6  stop flattening the hard line breaks wrap_two_lines inserted                 CAUGHT
  M7  uncap route_pair: a low-resource SOURCE can force the HOSTED tier            CAUGHT
  M8  drop the track-language wiring: the language gate goes cosmetic              CAUGHT
```

M3 is the important row: the harness **fires on the pre-fix behaviour**. A green that also goes red
on the broken state is a measurement; one that cannot is not.

## Gates

`pytest --cov-fail-under=100` → **6233 passed, 6 skipped**, 19225 stmts / 4924 branch,
**0 miss / 0 partial / 100.00%** · ruff 0.15.17 check + format clean · `docscheck r1-r5=0` ·
`charter_check` 6 gates consistent, no 7th.

**No assertion was weakened, skipped or deleted anywhere in this branch.**

## Provenance — recovered, and one RED cycle completed

This lane died mid-TDD and never reported. Its two commits sat unpushed in a worktree for ~3.5
hours, with a **failing test file** on disk: `ImportError: cannot import name
'SENTENCE_GROUP_MAX_GAP_SEC'` — a collection error, so the module could not run at all. It had
written the speaker/pause tests and died before implementing them.

I completed that cycle rather than discarding the tests: implemented the boundary logic, watched
the 14 previously-red tests go green, and closed the one line the suite missed. The 100% gate
reported **99.99%** — my defensive `except (TypeError, ValueError)` branch. Cues reach this code
from a persisted track a user can hand-edit (SRT import, the cue editor), so a non-numeric
`start`/`end` is reachable input, not theoretical. Splitting on it would degrade the whole file;
raising would fail the render. An unreadable timing is **no evidence** — closed with a test rather
than by deleting the guard.

## Residual

The quality claim is scoped to what is measurable here: the translator now **receives
sentence-level context**, timings **survive re-segmentation**, and the EN-only polish **no longer
runs on non-EN**. Whether output reads better to a human is **NOT measured** — the settling
experiment is a human-rated A/B on a fixture transcript across a verb-final target. Confidence that
the mechanical cause is removed: **almost certain (90–99%)**, on the mutation proof. Confidence
that users will call the results "properly worded": **unknown**, and I will not claim it.
