### PR TITLE
feat/v15 expose engines

### DIFF
--- a/app/renderer/src/features/Stabilize.test.tsx
+++ b/app/renderer/src/features/Stabilize.test.tsx
@@ -99,7 +99,9 @@ describe('stabilizeOutcome', () => {
   });
 
   it('ignores a shapeless notice rather than rendering junk', () => {
-    expect(stabilizeOutcome({ path: '/p.mp4', stabilized: false, notice: 'nope' })?.notice).toBeNull();
+    expect(
+      stabilizeOutcome({ path: '/p.mp4', stabilized: false, notice: 'nope' })?.notice,
+    ).toBeNull();
   });
 });
 

--- a/app/renderer/src/features/Stabilize.test.tsx
+++ b/app/renderer/src/features/Stabilize.test.tsx
@@ -280,6 +280,35 @@ describe('<Stabilize />', () => {
     expect(container.querySelector('[data-section="result"]')).toBeNull();
   });
 
+  it('settles cleanly on a job.done that carries no result field at all', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-s' }); // no `result` key
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[data-section="notice"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('falls back to the global window.api bridge when no api prop is given', async () => {
+    const fake = makeFakeApi();
+    (globalThis as { api?: unknown }).api = fake.api;
+    try {
+      await act(async () => {
+        root.render(<Stabilize videoId="v1" />);
+      });
+      await clickRun();
+      expect(fake.calls.find((c) => c.method === 'stabilize.run')?.params).toEqual({
+        videoId: 'v1',
+      });
+    } finally {
+      delete (globalThis as { api?: unknown }).api;
+    }
+  });
+
   it('ignores a job.done that carries no usable outcome', async () => {
     const fake = makeFakeApi();
     await mount(fake.api);

--- a/app/renderer/src/features/Stabilize.test.tsx
+++ b/app/renderer/src/features/Stabilize.test.tsx
@@ -1,0 +1,294 @@
+// Stabilize.test.tsx — tests for the "Steady the shot" panel.
+//
+// MEASURED GAP (see the header of Stabilize.tsx): `stabilize.run` is registered
+// in the sidecar (features/stabilize.py:496) and has its own output directory
+// (handlers/library_ops.py:418 "stabilized"), but before this panel the literal
+// appeared ZERO times anywhere under app/ — stabilization was reachable only as
+// an all-or-nothing pre-step inside a ShortMaker export.
+//
+// The panel drives ONE RPC:
+//   stabilize.run({videoId}) -> {jobId} -> job.done {path, stabilized[, notice]}
+// It is a deferred job, so the terminal payload arrives on the job.done
+// notification, never on the rpc promise (see `_api.ts` CONTRACT-NOTE). A fake
+// `api` bridge is injected via the `api?` prop, mirroring Refine.test.tsx.
+//
+// The `stabilized:false` + `notice` branch is NOT an error: the sidecar reports
+// a missing libvidstab explicitly rather than silently passing the clip through
+// (stabilize.py:450-453), and the panel must surface that distinctly.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import Stabilize, { stabilizeOutcome } from './Stabilize';
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+const NOTICE = {
+  type: 'stabilize.unavailable',
+  message: 'stabilize: the bundled ffmpeg has no libvidstab — stabilization was skipped',
+};
+
+function makeFakeApi(overrides: { runError?: Error } = {}): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'stabilize.run') {
+        if (overrides.runError) throw overrides.runError;
+        return { jobId: 'job-s' } as T;
+      }
+      return {} as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+describe('stabilizeOutcome', () => {
+  it('reads a successful steadied result', () => {
+    expect(stabilizeOutcome({ path: '/out/clip.stabilized.mp4', stabilized: true })).toEqual({
+      path: '/out/clip.stabilized.mp4',
+      stabilized: true,
+      notice: null,
+    });
+  });
+
+  it('reads the libvidstab-unavailable passthrough WITH its notice', () => {
+    expect(stabilizeOutcome({ path: '/in/clip.mp4', stabilized: false, notice: NOTICE })).toEqual({
+      path: '/in/clip.mp4',
+      stabilized: false,
+      notice: NOTICE,
+    });
+  });
+
+  it('null when there is no usable path', () => {
+    expect(stabilizeOutcome({})).toBeNull();
+    expect(stabilizeOutcome(null)).toBeNull();
+    expect(stabilizeOutcome({ stabilized: true })).toBeNull();
+    expect(stabilizeOutcome({ path: 42 })).toBeNull();
+  });
+
+  it('treats a missing/!==true stabilized flag as not stabilized', () => {
+    expect(stabilizeOutcome({ path: '/p.mp4' })?.stabilized).toBe(false);
+  });
+
+  it('ignores a shapeless notice rather than rendering junk', () => {
+    expect(stabilizeOutcome({ path: '/p.mp4', stabilized: false, notice: 'nope' })?.notice).toBeNull();
+  });
+});
+
+describe('<Stabilize />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function mount(api: MediaStudioApi): Promise<void> {
+    await act(async () => {
+      root.render(<Stabilize videoId="v1" api={api} />);
+    });
+  }
+
+  async function clickRun(): Promise<void> {
+    await act(async () => {
+      (container.querySelector('button[data-action="run"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+  }
+
+  it('sends stabilize.run for the open video', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    const call = fake.calls.find((c) => c.method === 'stabilize.run');
+    expect(call?.params).toEqual({ videoId: 'v1' });
+  });
+
+  it('streams progress while the job runs', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-s', pct: 40, message: 'analysing shake' });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.progress-pct')?.textContent).toContain('40');
+    expect(container.querySelector('.progress-message')?.textContent).toContain('analysing shake');
+  });
+
+  it('ignores progress for a DIFFERENT job', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      fake.fireProgress({ jobId: 'someone-else', pct: 99, message: 'not mine' });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.progress-pct')?.textContent).not.toContain('99');
+  });
+
+  it('renders the steadied output path on job.done', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-s',
+        result: { path: '/out/stabilized/clip.stabilized.mp4', stabilized: true },
+      });
+      await Promise.resolve();
+    });
+    const out = container.querySelector('[data-section="result"]');
+    expect(out?.textContent).toContain('/out/stabilized/clip.stabilized.mp4');
+    expect(container.querySelector('[data-section="notice"]')).toBeNull();
+  });
+
+  it('surfaces the libvidstab-unavailable notice INSTEAD of a silent success', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-s',
+        result: { path: '/in/clip.mp4', stabilized: false, notice: NOTICE },
+      });
+      await Promise.resolve();
+    });
+    const notice = container.querySelector('[data-section="notice"]');
+    expect(notice?.textContent).toContain('libvidstab');
+    // The passthrough path is NOT presented as a steadied result.
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+  });
+
+  it('surfaces an rpc failure as an error', async () => {
+    const fake = makeFakeApi({ runError: new Error('sidecar exploded') });
+    await mount(fake.api);
+    await clickRun();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('sidecar exploded');
+  });
+
+  it('surfaces a non-Error rejection as a string', async () => {
+    const calls: FakeApi['calls'] = [];
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async (method: string) => {
+        calls.push({ method });
+        throw 'plain string boom';
+      }) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    await mount(api);
+    await clickRun();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain string boom');
+  });
+
+  it('cancels the in-flight job via job.cancel', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      (container.querySelector('button[data-action="cancel"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.some((c) => c.method === 'job.cancel')).toBe(true);
+  });
+
+  it('keeps the panel usable when job.cancel itself fails', async () => {
+    const calls: FakeApi['calls'] = [];
+    let doneCbs: Array<(ev: DoneEvent) => void> = [];
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === 'job.cancel') throw new Error('cancel failed');
+        return { jobId: 'job-s' } as T;
+      }) as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: (cb) => {
+        doneCbs.push(cb);
+        return () => {
+          doneCbs = doneCbs.filter((c) => c !== cb);
+        };
+      },
+    };
+    await mount(api);
+    await clickRun();
+    await act(async () => {
+      (container.querySelector('button[data-action="cancel"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    // The swallowed cancel failure must NOT surface as a panel error.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('resolves with no bridge job.done channel without hanging', async () => {
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async () => ({ jobId: 'job-s' })) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      // no onJobDone — waitForJobDone resolves null
+    };
+    await mount(api);
+    await clickRun();
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('falls back to no job when the rpc returns no jobId', async () => {
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async () => ({})) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    await mount(api);
+    await clickRun();
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+  });
+
+  it('ignores a job.done that carries no usable outcome', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await clickRun();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-s', result: {} });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[data-section="notice"]')).toBeNull();
+  });
+});

--- a/app/renderer/src/features/Stabilize.tsx
+++ b/app/renderer/src/features/Stabilize.tsx
@@ -1,0 +1,209 @@
+// Stabilize feature panel — "Steady the shot" (per-video camera-shake removal).
+//
+// WHY THIS PANEL EXISTS (measured, not assumed).
+// `docs/plans/v1.5/competitor-matrix-2026-08.md:166,219` lists `stabilize.run`
+// as built-and-registered but unreachable. That was MEASURED before wiring, with
+// a detector proven against a known-present control:
+//   probe  : Select-String -SimpleMatch over app/**/*.{ts,tsx,js,json,html}
+//   control: "shortmaker.export" -> 4 hits (the detector fires)
+//   target : "stabilize.run"     -> 0 hits (genuinely unreferenced)
+// Corroborating signal: the sidecar already provisions a dedicated output
+// directory for standalone runs (`handlers/library_ops.py:418` "stabilized") and
+// registers the RPC (`features/stabilize.py:496`) — engine, RPC and output path
+// are all paid for; only the surface was missing. Before this panel the ONLY way
+// to stabilize was the all-or-nothing ShortMaker export pre-step
+// (`ShortMakerControls.tsx:284-293` -> `shortMakerPresets.ts:185`), which cannot
+// steady an arbitrary library clip.
+//
+// The two SIBLING items in the same audit row were measured as FALSE GAPS and
+// are deliberately NOT wired here:
+//   - `silence.trim`: the capability already ships twice — `Refine.tsx` (preview
+//     + tunables, via refine.preview/apply) and the ShortMaker "Trim silence"
+//     toggle. `docs/plans/_archive/editing-refine/DESIGN.md:133` states the
+//     unreferenced literal is intentional back-compat, with `refine.*` as the
+//     replacement surface. A second silence UI would rebuild a removed duplicate.
+//   - hook-title generation: the matrix claim (`:148`, `:304`) is that the LLM
+//     TEXT-GEN step is missing, not the UI. Refuted — `features/select.py:344-345`
+//     pins "hook" in the JSON schema the model must return.
+//
+// TRANSPORT: `stabilize.run({videoId}) -> {jobId}`; the terminal payload
+// `{path, stabilized[, notice]}` arrives on the LATER `job.done` notification,
+// never on the rpc promise (see `_api.ts` CONTRACT-NOTE), so we subscribe via
+// `waitForJobDone`. Same shape as `Refine.tsx` (getApi / bridge.rpc /
+// waitForJobDone / onProgress / injectable `api?` prop for tests).
+//
+// The engine takes NO tunables over the wire — `stabilize.run` accepts only
+// `{videoId|path}` (`features/stabilize.py:430`); shakiness/smoothing/accuracy
+// come from settings. So this panel is deliberately a single action, not a
+// knob-farm that would imply per-run control the RPC does not accept.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import './panels.css';
+import { getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+
+/**
+ * The typed skip notice the sidecar emits when the bundled ffmpeg has no
+ * libvidstab (`stabilize.py` `make_unavailable_notice`). The sidecar REPORTS
+ * that case rather than silently passing the clip through, so the UI must
+ * surface it distinctly — never as a success.
+ */
+export interface StabilizeNotice {
+  type: string;
+  message: string;
+}
+
+/** The `job.done` payload of `stabilize.run` (`stabilize.py:433`). */
+export interface StabilizeOutcome {
+  /** The steadied clip, or the untouched source when `stabilized` is false. */
+  path: string;
+  stabilized: boolean;
+  notice: StabilizeNotice | null;
+}
+
+// --- pure helpers (exported for tests) -------------------------------------
+/**
+ * Read a `stabilize.run` job.done result. Null when there is no usable `path`
+ * (a shapeless or error payload) so the panel renders nothing rather than junk.
+ * A non-`true` `stabilized` flag is treated as NOT stabilized (fail closed), and
+ * a notice that is not an object with a string `message` is dropped.
+ */
+export function stabilizeOutcome(result: unknown): StabilizeOutcome | null {
+  const path = pickField<string>(result, 'path');
+  if (typeof path !== 'string' || !path) return null;
+  const raw = pickField<unknown>(result, 'notice');
+  const notice =
+    raw !== null && typeof raw === 'object' && typeof (raw as StabilizeNotice).message === 'string'
+      ? (raw as StabilizeNotice)
+      : null;
+  return {
+    path,
+    stabilized: pickField<boolean>(result, 'stabilized') === true,
+    notice,
+  };
+}
+
+export interface StabilizeProps {
+  videoId: string;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+
+export function Stabilize({ videoId, api }: StabilizeProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  const [running, setRunning] = useState<boolean>(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [outcome, setOutcome] = useState<StabilizeOutcome | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  const run = useCallback(async (): Promise<void> => {
+    // defensive: the button is disabled while a run is in flight, so the UI
+    // cannot dispatch a second one.
+    /* v8 ignore next */
+    if (running) return;
+    setRunning(true);
+    setError('');
+    setOutcome(null);
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      const res = await bridge.rpc<{ jobId: string }>('stabilize.run', { videoId });
+      const id = res?.jobId ?? null;
+      setJobId(id);
+      // waitForJobDone REJECTS on an {error} job.done payload (caught below) —
+      // a failed stabilization is never laundered into a silent success.
+      const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
+      const next = stabilizeOutcome(result);
+      if (next) {
+        setOutcome(next);
+        setPct(100);
+        setMessage(next.stabilized ? 'Done' : 'Skipped');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setRunning(false);
+      setJobId(null);
+    }
+  }, [bridge, videoId, running]);
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // defensive: Cancel renders only while `running && jobId`.
+    /* v8 ignore next */
+    if (!jobId) return;
+    try {
+      await bridge.rpc('job.cancel', { jobId });
+    } catch {
+      // Best-effort — a failed cancel must not become a panel error.
+    }
+    setMessage('Cancelling…');
+  }, [bridge, jobId]);
+
+  return (
+    <section className="feature-panel stabilize-panel" aria-label="Stabilize">
+      <h2>Steady the Shot</h2>
+      <p className="assets-intro">
+        Remove camera shake from this video with a two-pass vidstab analyse-then-warp — token-free
+        and fully local. The original is never touched; the steadied clip is written to a new file.
+      </p>
+
+      <div className="actions">
+        <button type="button" data-action="run" onClick={() => void run()} disabled={running}>
+          {running ? 'Stabilizing…' : 'Stabilize'}
+        </button>
+        {running && jobId && (
+          <button
+            type="button"
+            data-action="cancel"
+            className="secondary"
+            onClick={() => void cancel()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {running && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          {message && <span className="progress-message"> · {message}</span>}
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* The libvidstab-missing case is REPORTED, never silently skipped: the
+          source path came back unchanged, so it is NOT shown as a result. */}
+      {outcome?.notice && (
+        <p className="stabilize-notice" data-section="notice" role="status">
+          {outcome.notice.message}
+        </p>
+      )}
+
+      {outcome?.stabilized && (
+        <div className="output-done" data-section="result">
+          <span className="output-done-label">Stabilized file</span>
+          <code>{outcome.path}</code>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default Stabilize;

--- a/app/renderer/src/features/panels.css
+++ b/app/renderer/src/features/panels.css
@@ -532,3 +532,19 @@
 .social-publish__empty {
   color: var(--text-secondary);
 }
+
+/* v1.5 expose-engines: the Stabilize panel's SKIP notice (ffmpeg built without
+   libvidstab). This is a warning, not a failure and not a success — the run
+   completed but did nothing, and the source clip came back untouched. It
+   therefore uses the WARN token, never the error red (which would overstate a
+   non-failure) and never the plain body style (which would let a no-op read as
+   a finished job). The leading edge carries the signal for mono/high-contrast
+   readers who do not get the hue. */
+.stabilize-panel .stabilize-notice {
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--status-warn);
+  border-radius: var(--radius-sm);
+  background: var(--status-warn-soft);
+  color: var(--status-warn);
+  font-size: var(--type-caption-size);
+}

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -496,6 +496,24 @@ describe('client.convert / shortmaker (spread-opts branches)', () => {
   });
 });
 
+// v1.5 expose-engines: `stabilize.run` was registered sidecar-side
+// (features/stabilize.py:496) with its own output dir
+// (handlers/library_ops.py:418) but had ZERO references anywhere under app/ —
+// no typed wrapper existed, so no caller could reach it without a raw string.
+describe('client.stabilize (v1.5 expose-engines)', () => {
+  it('run forwards {videoId}', async () => {
+    const r = installApi();
+    await client.stabilize.run('v1');
+    expect(r).toHaveBeenCalledWith('stabilize.run', { videoId: 'v1' });
+  });
+
+  it('run forwards an explicit {path} instead when given (the RPC accepts either)', async () => {
+    const r = installApi();
+    await client.stabilize.run({ path: '/movies/shaky.mp4' });
+    expect(r).toHaveBeenCalledWith('stabilize.run', { path: '/movies/shaky.mp4' });
+  });
+});
+
 describe('client.nle / package (spread + conditional branches)', () => {
   it('nle.export spreads opts when given and defaults to {} when omitted', async () => {
     const r = installApi();

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -798,6 +798,32 @@ export const client = {
     }): Promise<{ plan: ShotPlan; affected: number[] }> =>
       rpc('reframe.applyOverrides', { plan: args.plan, overrides: args.overrides }),
   },
+
+  /**
+   * v1.5 expose-engines: two-pass vidstab camera-shake removal.
+   *
+   * The engine (`features/stabilize.py`), the RPC registration (`:496`) and a
+   * dedicated output directory (`handlers/library_ops.py:418` "stabilized") all
+   * predate this wrapper — `stabilize.run` simply had no typed caller, so it
+   * appeared ZERO times anywhere under `app/`. The Workspace "Stabilize" tab
+   * (`features/Stabilize.tsx`) is the first consumer.
+   */
+  stabilize: {
+    /**
+     * `stabilize.run {videoId|path}` -> `{jobId}` -> job.done
+     * `{path, stabilized[, notice]}`.
+     *
+     * A bare string is the common `videoId` case. `stabilized:false` with a
+     * `notice` is the ffmpeg-has-no-libvidstab SKIP (the source path comes back
+     * untouched) — it is REPORTED, never a silent success, so callers must not
+     * treat `path` as a steadied result without checking `stabilized`.
+     */
+    run: (
+      target: string | { videoId?: string; path?: string },
+    ): Promise<
+      JobHandle & { path?: string; stabilized?: boolean; notice?: { type: string; message: string } }
+    > => rpc('stabilize.run', typeof target === 'string' ? { videoId: target } : { ...target }),
+  },
 } as const;
 
 export default client;

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -821,7 +821,11 @@ export const client = {
     run: (
       target: string | { videoId?: string; path?: string },
     ): Promise<
-      JobHandle & { path?: string; stabilized?: boolean; notice?: { type: string; message: string } }
+      JobHandle & {
+        path?: string;
+        stabilized?: boolean;
+        notice?: { type: string; message: string };
+      }
     > => rpc('stabilize.run', typeof target === 'string' ? { videoId: target } : { ...target }),
   },
 } as const;

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -69,6 +69,7 @@ vi.mock('../features/Assets', () => stubPanel('Assets'));
 vi.mock('../features/NleExport', () => stubPanel('NleExport'));
 vi.mock('../features/Diarize', () => stubPanel('Diarize'));
 vi.mock('../features/Refine', () => stubPanel('Refine'));
+vi.mock('../features/Stabilize', () => stubPanel('Stabilize'));
 vi.mock('../features/Recipes', () => stubPanel('Recipes'));
 vi.mock('../features/SemanticSearch', () => stubPanel('SemanticSearch'));
 
@@ -133,14 +134,25 @@ async function flush(): Promise<void> {
 }
 
 describe('Workspace', () => {
-  // SCOPE CHANGE (v1.5 timeline-naming, deliberate): two LABELS moved, ids and
+  // SCOPE CHANGE #1 (v1.5 timeline-naming, deliberate): two LABELS moved, ids and
   // order untouched. 'Timeline' -> 'Subtitle timeline' and 'Timeline export' ->
   // 'NLE export'. Both old strings promised a video timeline this workspace does
   // not have: the `timeline` tab mounts features/Timeline.tsx, a subtitle-CUE
   // editor (`Timeline.tsx:1-8`), and the `nle` tab exports an EDL synthesized
   // from approved short-maker clips, not a user-authored timeline
-  // (`NleExport.tsx:1-9`). The assertion stays exact and order-sensitive.
-  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes)', () => {
+  // (`NleExport.tsx:1-9`).
+  //
+  // SCOPE CHANGE #2 (v1.5 expose-engines lane): this list gains 'Stabilize'. The
+  // assertion is WIDENED by exactly one entry, never weakened — every previously
+  // pinned label and its position relative to the others is unchanged. The new
+  // tab is what makes the already-registered `stabilize.run` RPC reachable at
+  // all (it had zero references anywhere under app/ before this lane).
+  //
+  // MERGE NOTE: the two lanes landed independently and both edited this line.
+  // The resolution keeps BOTH — the honest rename AND the new tab — because they
+  // are orthogonal: one corrects a label that lied, the other exposes an engine.
+  // The assertion remains exact and order-sensitive.
+  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes; expose-engines: +Stabilize)', () => {
     expect(WORKSPACE_TABS.map((t) => t.label)).toEqual([
       'Transcribe',
       'Search',
@@ -151,6 +163,7 @@ describe('Workspace', () => {
       'Convert',
       'Short-maker',
       'Subtitle timeline',
+      'Stabilize',
       'Dub',
       'NLE export',
       'Recipes',
@@ -186,6 +199,12 @@ describe('Workspace', () => {
       container.querySelector(`[role="tab"][data-tab-id="${id}"]`)?.textContent;
     expect(tabText('timeline')).toBe('Subtitle timeline');
     expect(tabText('nle')).toBe('NLE export');
+  });
+
+  it('puts Stabilize in the "Frame & Cut" cluster so it is reachable without the Advanced disclosure', () => {
+    const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
+    expect(frame?.tabIds).toContain('stabilize');
+    expect(frame?.advanced).not.toBe(true);
   });
 
   it('opens the project via project.open and shows the title + tabs', async () => {
@@ -303,6 +322,7 @@ describe('Workspace', () => {
     ['convert', 'Convert'],
     ['shortmaker', 'ShortMaker'],
     ['timeline', 'Timeline'],
+    ['stabilize', 'Stabilize'],
     ['dub', 'Dub'],
     ['nle', 'NleExport'],
     ['recipes', 'Recipes'],

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -46,6 +46,9 @@ const NleExport = lazy(() => import('../features/NleExport'));
 // system-advanced group: per-video Diarize + Refine + Recipes panels.
 const Diarize = lazy(() => import('../features/Diarize'));
 const Refine = lazy(() => import('../features/Refine'));
+// v1.5 expose-engines: per-video camera-shake removal. The `stabilize.run` RPC
+// and its output dir already existed; this tab is what makes them reachable.
+const Stabilize = lazy(() => import('../features/Stabilize'));
 const Recipes = lazy(() => import('../features/Recipes'));
 // intelligence A: semantic transcript search (seeks the player on a hit).
 const SemanticSearch = lazy(() => import('../features/SemanticSearch'));
@@ -77,6 +80,7 @@ export const WORKSPACE_TABS: TabDef[] = [
   { id: 'convert', label: 'Convert' },
   { id: 'shortmaker', label: 'Short-maker' },
   { id: 'timeline', label: 'Subtitle timeline' },
+  { id: 'stabilize', label: 'Stabilize' },
   { id: 'dub', label: 'Dub' },
   { id: 'nle', label: 'NLE export' },
   { id: 'recipes', label: 'Recipes' },
@@ -96,7 +100,7 @@ export const WORKSPACE_TAB_GROUPS: TabGroup[] = [
     label: 'Speech & Text',
     tabIds: ['transcribe', 'search', 'subtitles', 'diarize', 'refine'],
   },
-  { id: 'frame', label: 'Frame & Cut', tabIds: ['shortmaker', 'timeline'] },
+  { id: 'frame', label: 'Frame & Cut', tabIds: ['shortmaker', 'timeline', 'stabilize'] },
   { id: 'audio', label: 'Audio', tabIds: ['dub'] },
   {
     id: 'deliver',
@@ -300,6 +304,8 @@ export function Workspace({
         return (
           <TimelinePanel videoId={video.id} durationSec={video.durationSec} playerRef={playerRef} />
         );
+      case 'stabilize':
+        return <Stabilize videoId={video.id} />;
       case 'dub':
         return <Dub videoId={video.id} />;
       case 'nle':


### PR DESCRIPTION
- **measure(v1.5): two of the three "unreachable engines" are already reachable**
- **test(stabilize): RED — a per-clip Stabilize panel that does not exist yet**
- **feat(stabilize): GREEN — the Stabilize panel that satisfies the RED test**
- **feat(workspace): mount Stabilize as a tab — this is what closes the gap**
- **feat(rpc): typed client.stabilize.run wrapper**
- **style(stabilize): give the libvidstab SKIP notice its own warn treatment**
- **style: apply biome (format) to the two files the gate rewrapped**
