### PR TITLE
feat/v15 social publish

### DIFF
--- a/app/main/keyBridge.ts
+++ b/app/main/keyBridge.ts
@@ -178,6 +178,36 @@ export function planUpsert(
   return { providerId, resolvedKeys, forwardParams };
 }
 
+/**
+ * Carry every NON-provider keystore section onto a freshly-built {@link DecryptedKeys}.
+ *
+ * THE BUG THIS EXISTS TO PREVENT: `saveDecryptedKeys` rebuilds the whole keystore
+ * document from the value it is given, so any section the provider paths forget to
+ * copy forward is ERASED from disk on the next `providers.upsert` / `providers.remove`.
+ * That was previously spelled as an inline `cloudApiKey !== undefined ? … : …`
+ * ternary repeated at three sites — a shape where adding a second section (C14's
+ * `social`) silently destroys it at whichever site was missed. Funnelling all of
+ * them through here makes "a new section must be listed in ONE place" true by
+ * construction.
+ *
+ * `session` wins over `disk` per section, mirroring the provider overlay.
+ */
+function withNonProviderSections(
+  target: DecryptedKeys,
+  disk: DecryptedKeys,
+  session: DecryptedKeys,
+): DecryptedKeys {
+  const out: DecryptedKeys = { providers: target.providers };
+  const cloudApiKey = session.cloudApiKey ?? disk.cloudApiKey;
+  if (cloudApiKey !== undefined) {
+    out.cloudApiKey = cloudApiKey;
+  }
+  if (disk.social !== undefined || session.social !== undefined) {
+    out.social = { ...disk.social, ...session.social };
+  }
+  return out;
+}
+
 /** Constructor deps for {@link KeyBridge} (safeStorage + keystore path are injected). */
 export interface KeyBridgeOptions {
   safeStorage: SafeStorageLike;
@@ -253,8 +283,7 @@ export class KeyBridge {
       if (this.removed.has(id)) continue; // removed this session — never resurrect it
       providers[id] = keys;
     }
-    const cloudApiKey = this.session.cloudApiKey ?? base.cloudApiKey;
-    return cloudApiKey !== undefined ? { providers, cloudApiKey } : { providers };
+    return withNonProviderSections({ providers }, base, this.session);
   }
 
   /** On-disk keystore overlaid with this session's in-memory keys (session wins). */
@@ -311,10 +340,14 @@ export class KeyBridge {
       delete nextProviders[plan.providerId];
       this.removed.add(plan.providerId); // dropping the last key IS a removal
     }
-    const next: DecryptedKeys =
-      current.cloudApiKey !== undefined
-        ? { providers: nextProviders, cloudApiKey: current.cloudApiKey }
-        : { providers: nextProviders };
+    // `current` already merges disk+session, so passing it as BOTH arguments carries
+    // every non-provider section (cloudApiKey, C14 social tokens) forward untouched.
+    // Omitting one here would erase it from disk — see withNonProviderSections.
+    const next: DecryptedKeys = withNonProviderSections(
+      { providers: nextProviders },
+      current,
+      current,
+    );
     // Always keep the session overlay current so injection sees the new keys even
     // when the disk write is refused (session-only) or fails.
     this.session = next;
@@ -353,10 +386,12 @@ export class KeyBridge {
     }
     const nextProviders = { ...current.providers };
     delete nextProviders[providerId];
-    const next: DecryptedKeys =
-      current.cloudApiKey !== undefined
-        ? { providers: nextProviders, cloudApiKey: current.cloudApiKey }
-        : { providers: nextProviders };
+    // Same reasoning as interceptUpsert: every non-provider section rides forward.
+    const next: DecryptedKeys = withNonProviderSections(
+      { providers: nextProviders },
+      current,
+      current,
+    );
     this.session = next;
     this.removed.add(providerId); // holds even if the disk write below is declined
     this.persistKeys(next, read);

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -92,12 +92,42 @@ export interface SecureStatus {
   keystoreUnreadable?: KeystoreUnreadableReason | null;
 }
 
+/**
+ * One connected social platform's OAuth material (C14).
+ *
+ * `accessToken` / `refreshToken` are CREDENTIALS; the remaining fields are display
+ * metadata. The whole record is encrypted as a single blob rather than field-by-
+ * field, so no future field can be added on the non-secret side by mistake.
+ */
+export interface SocialToken {
+  accessToken: string;
+  /** `''` when the platform issued none (some flows return only an access token). */
+  refreshToken: string;
+  /** Epoch seconds; `0` when the platform did not say. */
+  expiresAt: number;
+  /** Display-only account name shown in the UI (e.g. the channel title). */
+  accountLabel: string;
+  /** The scopes actually granted, so the UI can show what was consented to. */
+  scopes: string[];
+}
+
 /** The decrypted key material main injects into the sidecar per-request (never to disk). */
 export interface DecryptedKeys {
   /** providerId -> its raw API keys (rotation pool order preserved). */
   providers: Record<string, string[]>;
   /** The legacy single cloud key, when one was stored. */
   cloudApiKey?: string;
+  /**
+   * C14: platformId -> its OAuth token record, when any platform is connected.
+   *
+   * This section is part of `DecryptedKeys` for a load-bearing reason:
+   * {@link saveDecryptedKeys} REBUILDS the whole keystore document from this value
+   * rather than patching the file, so a section missing from here is a section
+   * ERASED from disk on the next write. Keeping social tokens out of this type
+   * would mean any `providers.upsert` silently destroyed every connected social
+   * account (and vice versa) — see `socialTokens.test.ts`.
+   */
+  social?: Record<string, SocialToken>;
 }
 
 /** Outcome of the one-time legacy-plaintext migration. */
@@ -205,6 +235,13 @@ interface KeystoreFile {
   version: 1;
   providers: Record<string, string[]>;
   cloudApiKey?: string;
+  /**
+   * C14: platformId -> base64 safeStorage ciphertext of the JSON
+   * {@link SocialToken}. ABSENT in every keystore written before C14, which is why
+   * the reader treats a missing `social` key as "no connected accounts" and only an
+   * ill-SHAPED one as corruption.
+   */
+  social?: Record<string, string>;
 }
 
 /**
@@ -334,6 +371,44 @@ function hasPlaintextKeys(keys: DecryptedKeys): boolean {
 /** True for a plain (non-null, non-array) object — the only valid keystore shape. */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * Decode one decrypted {@link SocialToken} blob, or `null` when it is unusable.
+ *
+ * `null` means CORRUPTION, and the caller escalates it to a store-wide
+ * `'shape-invalid'` refusal rather than dropping the entry: a connected account
+ * whose record cannot be read must not be reported as "not connected", because the
+ * next write would then make that loss permanent (the same reasoning as
+ * {@link KeystoreRead}).
+ *
+ * A record with no non-empty `accessToken` is corruption by definition — there is no
+ * credential in it, so it cannot represent a connected account. The remaining fields
+ * are display metadata and are defaulted rather than rejected, so a token written by
+ * an older/newer build that omits one still loads.
+ */
+function parseSocialToken(plaintext: string): SocialToken | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(plaintext);
+  } catch {
+    return null;
+  }
+  if (!isPlainObject(parsed)) {
+    return null;
+  }
+  const accessToken = parsed.accessToken;
+  if (typeof accessToken !== 'string' || accessToken === '') {
+    return null;
+  }
+  const scopes = parsed.scopes;
+  return {
+    accessToken,
+    refreshToken: typeof parsed.refreshToken === 'string' ? parsed.refreshToken : '',
+    expiresAt: typeof parsed.expiresAt === 'number' ? parsed.expiresAt : 0,
+    accountLabel: typeof parsed.accountLabel === 'string' ? parsed.accountLabel : '',
+    scopes: Array.isArray(scopes) ? scopes.filter((s): s is string => typeof s === 'string') : [],
+  };
 }
 
 /**
@@ -702,6 +777,17 @@ function writeKeystore(
   if (keys.cloudApiKey !== undefined) {
     file.cloudApiKey = encryptToBase64(safeStorage, keys.cloudApiKey);
   }
+  if (keys.social !== undefined) {
+    // C14: one ciphertext blob per platform. The WHOLE record is encrypted (not
+    // just the two token fields) so a field added later cannot land on the
+    // plaintext side by omission.
+    const social: Record<string, string> = {};
+    for (const [platform, token] of Object.entries(keys.social)) {
+      if (!isSafeProviderId(platform)) continue; // never persist a proto-polluting id
+      social[platform] = encryptToBase64(safeStorage, JSON.stringify(token));
+    }
+    file.social = social;
+  }
   backupKeystore(keystorePath, new Date());
   writeJsonAtomic(keystorePath, file);
 }
@@ -782,6 +868,36 @@ export function readKeystore(safeStorage: SafeStorageLike, keystorePath: string)
     } catch {
       return unreadable('decrypt-failed');
     }
+  }
+  // C14 social tokens. An ABSENT section is the normal pre-C14 shape and means "no
+  // connected accounts"; a present-but-ill-shaped one is corruption and fails
+  // closed, so a save can never quietly replace real tokens with nothing.
+  if (file.social !== undefined) {
+    if (!isPlainObject(file.social)) {
+      return unreadable('shape-invalid');
+    }
+    const social: Record<string, SocialToken> = {};
+    for (const [platform, blob] of Object.entries(file.social)) {
+      if (typeof blob !== 'string') {
+        return unreadable('shape-invalid');
+      }
+      // As with a provider id, a `__proto__`/`constructor` key cannot have come from
+      // writeKeystore and is not a loadable account, so it is dropped rather than
+      // escalated — dropping it loses no usable credential.
+      if (!isSafeProviderId(platform)) continue;
+      let plaintext: string;
+      try {
+        plaintext = decryptFromBase64(safeStorage, blob);
+      } catch {
+        return unreadable('decrypt-failed');
+      }
+      const token = parseSocialToken(plaintext);
+      if (token === null) {
+        return unreadable('shape-invalid');
+      }
+      social[platform] = token;
+    }
+    out.social = social;
   }
   return { outcome: 'loaded', keys: out, reason: null };
 }

--- a/app/main/keystore.ts
+++ b/app/main/keystore.ts
@@ -998,7 +998,21 @@ export function migrateLegacyPlaintextKeys(
   }
 
   // 1. Re-encrypt every plaintext key into the DPAPI keystore.
-  writeKeystore(safeStorage, keystorePath, keys);
+  //
+  //    CARRY THE EXISTING NON-PROVIDER SECTIONS FORWARD. `keys` came from
+  //    extractPlaintextKeys(settings.json), which by construction only knows about
+  //    PROVIDER material — so writing it verbatim would rebuild the keystore document
+  //    without the C14 `social` section and destroy every connected social account.
+  //    That is reachable whenever plaintext keys REAPPEAR in settings.json after an
+  //    account was connected (a restored settings backup, or a sidecar that
+  //    re-persists a key), which makes it a real wipe path rather than a theoretical
+  //    one. A store we could not READ contributes nothing (fail-closed: never
+  //    fabricate a section from an unreadable blob) — the migration still proceeds,
+  //    because migrating the plaintext keys off disk is the more urgent job.
+  const existing = readKeystore(safeStorage, keystorePath);
+  const carried: DecryptedKeys =
+    existing.keys?.social !== undefined ? { ...keys, social: existing.keys.social } : keys;
+  writeKeystore(safeStorage, keystorePath, carried);
 
   // 2. Strip the raw keys from settings.json (preserving all non-secret settings),
   //    then shred every stale prior copy that could still hold plaintext.

--- a/app/main/socialAuth.test.ts
+++ b/app/main/socialAuth.test.ts
@@ -1,0 +1,310 @@
+// socialAuth.test.ts — C14 desktop OAuth (PKCE + loopback) for social publishing.
+//
+// This is the security-critical half of C14, so the tests are written against the
+// SPEC rather than against the implementation:
+//
+//   * the PKCE challenge is checked with the PUBLISHED RFC 7636 Appendix-B test
+//     vector, so a self-consistent-but-wrong SHA/base64 pairing fails here instead
+//     of failing silently against a real provider;
+//   * the redirect URI guard is checked with real-world hostile shapes (a remote
+//     host, a `127.0.0.1.evil.com` suffix trick, a userinfo `@` trick), because
+//     sending the authorization CODE to a non-loopback host is the one mistake in
+//     this flow that hands an attacker the account;
+//   * the token endpoint is asserted https-only, because the exchange carries the
+//     client secret.
+//
+// No socket is opened anywhere in this file: randomness and hashing are injected.
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+import {
+  OAUTH_ENDPOINTS,
+  PKCE_METHOD,
+  buildAuthorizeUrl,
+  buildTokenExchangeBody,
+  challengeFor,
+  createVerifier,
+  isLoopbackRedirectUri,
+  loopbackRedirectUri,
+  oauthEndpoint,
+  parseCallbackUrl,
+} from './socialAuth';
+
+const sha256 = (input: string): Buffer => createHash('sha256').update(input, 'ascii').digest();
+
+/** Deterministic byte source: 0,1,2,… so a verifier is reproducible in tests. */
+const countingBytes = (n: number): Buffer =>
+  Buffer.from(Array.from({ length: n }, (_, i) => i % 256));
+
+describe('PKCE (RFC 7636)', () => {
+  it('derives the challenge exactly as the RFC 7636 Appendix-B vector does', () => {
+    // The ONLY externally-anchored assertion in the PKCE unit: both values are
+    // published in the RFC, so this fails if the hash, the encoding, or the
+    // padding-strip is wrong — none of which a self-referential test would catch.
+    const verifier = 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk';
+    expect(challengeFor(verifier, sha256)).toBe('E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM');
+  });
+
+  it('uses the S256 method, never plain', () => {
+    // `plain` sends the verifier itself in the authorize URL, defeating PKCE.
+    expect(PKCE_METHOD).toBe('S256');
+  });
+
+  it('creates a verifier inside the RFC length window', () => {
+    const verifier = createVerifier(countingBytes);
+    expect(verifier.length).toBeGreaterThanOrEqual(43);
+    expect(verifier.length).toBeLessThanOrEqual(128);
+  });
+
+  it('creates a verifier from the RFC unreserved character set only', () => {
+    // base64url must be un-padded: `=`, `+` and `/` are not unreserved characters
+    // and would be re-encoded in transit.
+    expect(createVerifier(countingBytes)).toMatch(/^[A-Za-z0-9\-._~]+$/);
+  });
+
+  it('creates a different verifier for different randomness', () => {
+    const a = createVerifier(countingBytes);
+    const b = createVerifier((n) =>
+      Buffer.from(Array.from({ length: n }, (_, i) => (i + 7) % 256)),
+    );
+    expect(a).not.toBe(b);
+  });
+});
+
+describe('loopback redirect URI', () => {
+  it('builds a 127.0.0.1 redirect on the given port', () => {
+    expect(loopbackRedirectUri(51789)).toBe('http://127.0.0.1:51789/oauth/callback');
+  });
+
+  it('accepts its own output', () => {
+    expect(isLoopbackRedirectUri(loopbackRedirectUri(8080))).toBe(true);
+  });
+
+  it('accepts the IPv6 loopback and localhost', () => {
+    expect(isLoopbackRedirectUri('http://[::1]:8080/oauth/callback')).toBe(true);
+    expect(isLoopbackRedirectUri('http://localhost:8080/oauth/callback')).toBe(true);
+  });
+
+  it('REJECTS a remote host', () => {
+    expect(isLoopbackRedirectUri('https://evil.example/oauth/callback')).toBe(false);
+  });
+
+  it('REJECTS a host that merely starts with the loopback literal', () => {
+    // `127.0.0.1.evil.com` resolves off-box; a `startsWith` check would pass it.
+    expect(isLoopbackRedirectUri('http://127.0.0.1.evil.com/oauth/callback')).toBe(false);
+  });
+
+  it('REJECTS a userinfo trick that hides the real host', () => {
+    // The real host here is evil.example — `127.0.0.1` is only the username.
+    expect(isLoopbackRedirectUri('http://127.0.0.1@evil.example/oauth/callback')).toBe(false);
+  });
+
+  it('REJECTS an unparseable URI rather than defaulting to allow', () => {
+    expect(isLoopbackRedirectUri('not a url')).toBe(false);
+  });
+
+  it('REJECTS a non-http scheme on the loopback host', () => {
+    expect(isLoopbackRedirectUri('file://127.0.0.1/oauth/callback')).toBe(false);
+  });
+
+  it('rejects an out-of-range port', () => {
+    expect(() => loopbackRedirectUri(0)).toThrow(/port/i);
+    expect(() => loopbackRedirectUri(70000)).toThrow(/port/i);
+  });
+
+  it('rejects a non-integer port', () => {
+    // A float would stringify into the URI as "8080.5" and never bind.
+    expect(() => loopbackRedirectUri(8080.5)).toThrow(/port/i);
+  });
+});
+
+describe('OAUTH_ENDPOINTS', () => {
+  it('only covers the platforms that support a desktop loopback flow', () => {
+    // instagram_reels and facebook_page are absent DELIBERATELY: Meta's login does
+    // not offer a loopback desktop redirect, and Instagram additionally refuses a
+    // personal account outright. Shipping an endpoint we cannot complete would be
+    // a stub that lies about being wired.
+    expect(Object.keys(OAUTH_ENDPOINTS).sort()).toEqual(['tiktok', 'youtube']);
+  });
+
+  it('uses an https token endpoint everywhere (the exchange carries the secret)', () => {
+    for (const endpoint of Object.values(OAUTH_ENDPOINTS)) {
+      expect(endpoint.tokenUrl.startsWith('https://')).toBe(true);
+      expect(endpoint.authorizeUrl.startsWith('https://')).toBe(true);
+    }
+  });
+
+  it('requests a narrow, purpose-scoped scope set', () => {
+    expect(OAUTH_ENDPOINTS.youtube.scopes).toContain(
+      'https://www.googleapis.com/auth/youtube.upload',
+    );
+  });
+
+  it('resolves a known platform', () => {
+    expect(oauthEndpoint('youtube').platform).toBe('youtube');
+  });
+
+  it('throws for a platform with no desktop flow', () => {
+    expect(() => oauthEndpoint('instagram_reels')).toThrow(/desktop/i);
+  });
+});
+
+describe('buildAuthorizeUrl', () => {
+  const base = {
+    platform: 'youtube',
+    clientId: 'client-123.apps.googleusercontent.com',
+    redirectUri: 'http://127.0.0.1:51789/oauth/callback',
+    state: 'state-abc',
+    codeChallenge: 'E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM',
+  };
+
+  it('carries the PKCE challenge and the S256 method', () => {
+    const url = new URL(buildAuthorizeUrl(base));
+    expect(url.searchParams.get('code_challenge')).toBe(base.codeChallenge);
+    expect(url.searchParams.get('code_challenge_method')).toBe('S256');
+  });
+
+  it('carries the state, redirect and response_type=code', () => {
+    const url = new URL(buildAuthorizeUrl(base));
+    expect(url.searchParams.get('state')).toBe('state-abc');
+    expect(url.searchParams.get('redirect_uri')).toBe(base.redirectUri);
+    expect(url.searchParams.get('response_type')).toBe('code');
+    expect(url.searchParams.get('client_id')).toBe(base.clientId);
+  });
+
+  it('NEVER carries a client secret (the authorize URL opens in a browser)', () => {
+    // The authorize URL is handed to the OS browser and lands in history/logs.
+    expect(buildAuthorizeUrl(base)).not.toMatch(/secret/i);
+  });
+
+  it('refuses a non-loopback redirect', () => {
+    expect(() => buildAuthorizeUrl({ ...base, redirectUri: 'https://evil.example/cb' })).toThrow(
+      /loopback/i,
+    );
+  });
+
+  it('refuses an empty client id rather than building a URL that cannot work', () => {
+    expect(() => buildAuthorizeUrl({ ...base, clientId: '  ' })).toThrow(/clientId/i);
+  });
+
+  it('refuses an empty state (state is the CSRF defence)', () => {
+    expect(() => buildAuthorizeUrl({ ...base, state: '' })).toThrow(/state/i);
+  });
+
+  it('refuses an empty code challenge', () => {
+    expect(() => buildAuthorizeUrl({ ...base, codeChallenge: '' })).toThrow(/challenge/i);
+  });
+});
+
+describe('parseCallbackUrl', () => {
+  const uri = 'http://127.0.0.1:51789/oauth/callback';
+
+  it('returns the code when the state matches', () => {
+    expect(parseCallbackUrl(`${uri}?code=auth-code-1&state=st-1`, 'st-1')).toEqual({
+      code: 'auth-code-1',
+    });
+  });
+
+  it('REJECTS a state mismatch (CSRF / code-injection defence)', () => {
+    expect(() => parseCallbackUrl(`${uri}?code=c&state=WRONG`, 'st-1')).toThrow(/state/i);
+  });
+
+  it('REJECTS a missing state', () => {
+    expect(() => parseCallbackUrl(`${uri}?code=c`, 'st-1')).toThrow(/state/i);
+  });
+
+  it('REJECTS an EQUAL-LENGTH state mismatch', () => {
+    // The comparison is constant-time, which short-circuits on unequal length; a
+    // same-length mismatch is the case that actually exercises the compare itself.
+    expect(() => parseCallbackUrl(`${uri}?code=c&state=st-2`, 'st-1')).toThrow(/state/i);
+  });
+
+  it('surfaces a provider error instead of reporting success', () => {
+    expect(() => parseCallbackUrl(`${uri}?error=access_denied&state=st-1`, 'st-1')).toThrow(
+      /access_denied/,
+    );
+  });
+
+  it('surfaces a provider error even when the state is absent', () => {
+    // A denial can come back without state; reporting "state missing" would hide
+    // the real, user-actionable reason.
+    expect(() => parseCallbackUrl(`${uri}?error=access_denied`, 'st-1')).toThrow(/access_denied/);
+  });
+
+  it('REJECTS a callback with neither code nor error', () => {
+    expect(() => parseCallbackUrl(`${uri}?state=st-1`, 'st-1')).toThrow(/code/i);
+  });
+
+  it('REJECTS an unparseable callback URL', () => {
+    expect(() => parseCallbackUrl('%%%', 'st-1')).toThrow();
+  });
+
+  it('does not leak the expected state into the thrown message', () => {
+    // The message can reach a log; echoing the expected state would let a reader
+    // replay it.
+    let message = '';
+    try {
+      parseCallbackUrl(`${uri}?code=c&state=WRONG`, 'secret-state-value');
+    } catch (err) {
+      message = (err as Error).message;
+    }
+    expect(message).not.toContain('secret-state-value');
+  });
+});
+
+describe('buildTokenExchangeBody', () => {
+  const base = {
+    platform: 'youtube',
+    clientId: 'client-123',
+    clientSecret: 'secret-xyz',
+    code: 'auth-code-1',
+    codeVerifier: 'dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk',
+    redirectUri: 'http://127.0.0.1:51789/oauth/callback',
+  };
+
+  it('sends the verifier so the server can re-derive the challenge', () => {
+    const body = new URLSearchParams(buildTokenExchangeBody(base));
+    expect(body.get('code_verifier')).toBe(base.codeVerifier);
+    expect(body.get('grant_type')).toBe('authorization_code');
+    expect(body.get('code')).toBe('auth-code-1');
+    expect(body.get('redirect_uri')).toBe(base.redirectUri);
+  });
+
+  it('includes the client secret (these platforms require it)', () => {
+    expect(new URLSearchParams(buildTokenExchangeBody(base)).get('client_secret')).toBe(
+      'secret-xyz',
+    );
+  });
+
+  it('omits client_secret entirely when the app has none configured', () => {
+    // An empty string would be sent as `client_secret=`, which some servers treat
+    // as a malformed credential rather than as absent.
+    const body = new URLSearchParams(buildTokenExchangeBody({ ...base, clientSecret: '' }));
+    expect(body.has('client_secret')).toBe(false);
+  });
+
+  it('refuses a non-loopback redirect', () => {
+    expect(() =>
+      buildTokenExchangeBody({ ...base, redirectUri: 'https://evil.example/cb' }),
+    ).toThrow(/loopback/i);
+  });
+
+  it('refuses an empty verifier (that would silently downgrade PKCE)', () => {
+    expect(() => buildTokenExchangeBody({ ...base, codeVerifier: '' })).toThrow(/verifier/i);
+  });
+
+  it('refuses an empty code', () => {
+    expect(() => buildTokenExchangeBody({ ...base, code: '' })).toThrow(/code/i);
+  });
+
+  it('refuses an empty client id', () => {
+    expect(() => buildTokenExchangeBody({ ...base, clientId: '' })).toThrow(/clientId/i);
+  });
+
+  it('NEVER carries the verifier or secret in a loggable joined form', () => {
+    // The body is a URLSearchParams string that a naive error path could log. It
+    // legitimately contains the secret, so callers must treat it as secret — this
+    // test pins that it is a plain body string and NOT wrapped into a URL that
+    // could end up in a browser history or an OS process list.
+    expect(buildTokenExchangeBody(base)).not.toMatch(/^https?:\/\//);
+  });
+});

--- a/app/main/socialAuth.ts
+++ b/app/main/socialAuth.ts
@@ -1,0 +1,298 @@
+// socialAuth.ts — C14 desktop OAuth for social publishing: PKCE, the loopback
+// redirect, and the two pure URL/body builders.
+//
+// WHY A DESKTOP LOOPBACK FLOW AT ALL
+// ----------------------------------
+// Reframe is a local app with no server and no public domain, so it cannot host an
+// https OAuth callback. The only flow available to it is the installed-app pattern:
+// open the provider's consent page in the OS browser, listen on an ephemeral
+// loopback port, and receive the authorization code there. Both platforms wired
+// here document that flow explicitly:
+//
+//   * Google/YouTube — accepts `http://127.0.0.1:<port>` (and `http://[::1]:<port>`)
+//     for a Desktop-app client and supports PKCE S256. The old copy/paste "OOB"
+//     redirect is retired, so loopback is the only remaining option.
+//     https://developers.google.com/identity/protocols/oauth2/native-app
+//   * TikTok — its DESKTOP configuration permits only `localhost` / `127.0.0.1` as
+//     the redirect host and REQUIRES PKCE S256. (It is the *web* configuration that
+//     demands an absolute https URI — reading only that page would wrongly rule
+//     TikTok out for a desktop app.)
+//     https://developers.tiktok.com/doc/login-kit-desktop
+//
+// Instagram and Facebook are DELIBERATELY absent from OAUTH_ENDPOINTS. Meta's login
+// does not offer a loopback desktop redirect, and Instagram's API additionally
+// refuses a personal account outright (see the sidecar capability matrix in
+// `media_studio/features/social_publish.py`). An endpoint entry we cannot actually
+// complete would be a stub that lies about being wired, so there is none.
+//
+// SECRETS
+// -------
+// Nothing here reads, writes, or persists a credential: it is pure string work over
+// values the caller supplies. Two rules are enforced structurally rather than by
+// convention, because each is a single mistake away from account takeover:
+//
+//   1. Every redirect URI that reaches an authorize URL or a token exchange is
+//      re-validated as LOOPBACK (`assertLoopback`). The authorization code is
+//      delivered to that host; pointing it anywhere else hands the code away.
+//      The check parses the URI and compares the resolved HOSTNAME, so a
+//      `127.0.0.1.evil.com` suffix and a `127.0.0.1@evil.example` userinfo trick
+//      both fail — a `startsWith`/`includes` check passes both.
+//   2. The authorize URL never carries the client secret. It is handed to the OS
+//      browser, so it lands in browser history, the OS "recent" lists, and any
+//      shell/process log along the way. Only the token exchange (an https POST
+//      body) may carry it.
+import { timingSafeEqual } from 'node:crypto';
+
+/** The only PKCE method used. `plain` would put the verifier in the browser URL. */
+export const PKCE_METHOD = 'S256';
+
+/** Bytes of entropy behind a verifier: 32 bytes -> 43 base64url chars (the RFC floor). */
+export const VERIFIER_BYTES = 32;
+
+/** The loopback path the callback listener serves. */
+export const CALLBACK_PATH = '/oauth/callback';
+
+/** Hostnames that cannot leave this machine. Compared to the RESOLVED hostname. */
+const LOOPBACK_HOSTS: ReadonlySet<string> = new Set(['127.0.0.1', 'localhost', '[::1]', '::1']);
+
+/** One platform's OAuth endpoints + the scopes Reframe asks for. */
+export interface OauthEndpoint {
+  /** Matches the sidecar capability-matrix id. */
+  platform: string;
+  authorizeUrl: string;
+  tokenUrl: string;
+  /** The narrowest scope set that permits an upload — never a blanket scope. */
+  scopes: readonly string[];
+  /** The doc this entry was read from (2026-08-08). */
+  docUrl: string;
+}
+
+export const OAUTH_ENDPOINTS: Readonly<Record<string, OauthEndpoint>> = {
+  youtube: {
+    platform: 'youtube',
+    authorizeUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    // `youtube.upload` is upload-only: it cannot read or delete the user's
+    // existing videos, which a blanket `youtube` scope would allow.
+    scopes: ['https://www.googleapis.com/auth/youtube.upload'],
+    docUrl: 'https://developers.google.com/identity/protocols/oauth2/native-app',
+  },
+  tiktok: {
+    platform: 'tiktok',
+    authorizeUrl: 'https://www.tiktok.com/v2/auth/authorize/',
+    tokenUrl: 'https://open.tiktokapis.com/v2/oauth/token/',
+    // `video.publish` is direct-post; `user.info.basic` is what identifies the
+    // connected account in the UI. `video.upload` (draft-only) is deliberately not
+    // requested here — a draft the user must finish inside the TikTok app is not
+    // the "direct publish" C14 asks for.
+    scopes: ['user.info.basic', 'video.publish'],
+    docUrl: 'https://developers.tiktok.com/doc/login-kit-desktop',
+  },
+};
+
+/** base64url WITHOUT padding — `=`, `+`, `/` are not RFC 7636 unreserved chars. */
+function base64Url(bytes: Buffer): string {
+  return bytes.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * A fresh PKCE code verifier (RFC 7636 §4.1).
+ *
+ * `randomBytes` is injected so tests are deterministic without stubbing the crypto
+ * module; production passes `node:crypto`'s `randomBytes`.
+ */
+export function createVerifier(randomBytes: (size: number) => Buffer): string {
+  return base64Url(randomBytes(VERIFIER_BYTES));
+}
+
+/**
+ * The S256 code challenge for `verifier` (RFC 7636 §4.2).
+ *
+ * `sha256` is injected for the same reason. Verified against the RFC's published
+ * Appendix-B vector in the unit test, so the hash/encoding pairing is anchored to
+ * the spec rather than to this implementation.
+ */
+export function challengeFor(verifier: string, sha256: (input: string) => Buffer): string {
+  return base64Url(sha256(verifier));
+}
+
+/** The loopback redirect URI the callback listener binds. */
+export function loopbackRedirectUri(port: number): string {
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`socialAuth: port must be an integer in 1-65535, got ${port}`);
+  }
+  return `http://127.0.0.1:${port}${CALLBACK_PATH}`;
+}
+
+/**
+ * Whether `uri` delivers the authorization code to THIS machine.
+ *
+ * Parses the URI and tests the RESOLVED hostname against an exact allowlist, so
+ * neither a suffix (`127.0.0.1.evil.com`) nor a userinfo prefix
+ * (`127.0.0.1@evil.example`) can pass — both defeat a substring check. An
+ * unparseable URI is denied rather than defaulting to allow.
+ */
+export function isLoopbackRedirectUri(uri: string): boolean {
+  let parsed: URL;
+  try {
+    parsed = new URL(uri);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return false;
+  }
+  return LOOPBACK_HOSTS.has(parsed.hostname);
+}
+
+function assertLoopback(redirectUri: string): void {
+  if (!isLoopbackRedirectUri(redirectUri)) {
+    throw new Error(
+      'socialAuth: redirectUri must be a loopback address; refusing to send the auth code off-box',
+    );
+  }
+}
+
+function assertPresent(value: string, field: string): string {
+  const trimmed = value.trim();
+  if (trimmed === '') {
+    throw new Error(`socialAuth: ${field} is required`);
+  }
+  return trimmed;
+}
+
+/** The endpoint set for `platform`, or a throw naming the desktop-flow limitation. */
+export function oauthEndpoint(platform: string): OauthEndpoint {
+  const endpoint = OAUTH_ENDPOINTS[platform];
+  if (endpoint === undefined) {
+    throw new Error(
+      `socialAuth: ${platform} has no desktop loopback OAuth flow, so Reframe cannot connect it from this computer`,
+    );
+  }
+  return endpoint;
+}
+
+export interface AuthorizeUrlOptions {
+  platform: string;
+  clientId: string;
+  redirectUri: string;
+  /** Opaque per-attempt CSRF value; echoed back on the callback. */
+  state: string;
+  codeChallenge: string;
+}
+
+/**
+ * The consent URL to open in the OS browser.
+ *
+ * Carries the PKCE challenge, the state, and the loopback redirect — and, by
+ * construction, NO client secret (see the module note: this URL is logged by the
+ * browser and the OS).
+ */
+export function buildAuthorizeUrl(options: AuthorizeUrlOptions): string {
+  const endpoint = oauthEndpoint(options.platform);
+  assertLoopback(options.redirectUri);
+  const clientId = assertPresent(options.clientId, 'clientId');
+  const state = assertPresent(options.state, 'state');
+  const codeChallenge = assertPresent(options.codeChallenge, 'codeChallenge');
+
+  const url = new URL(endpoint.authorizeUrl);
+  url.searchParams.set('client_id', clientId);
+  url.searchParams.set('redirect_uri', options.redirectUri);
+  url.searchParams.set('response_type', 'code');
+  url.searchParams.set('scope', endpoint.scopes.join(' '));
+  url.searchParams.set('state', state);
+  url.searchParams.set('code_challenge', codeChallenge);
+  url.searchParams.set('code_challenge_method', PKCE_METHOD);
+  return url.toString();
+}
+
+/** Constant-time state comparison (length is the only thing it leaks). */
+function statesMatch(actual: string, expected: string): boolean {
+  const a = Buffer.from(actual, 'utf8');
+  const b = Buffer.from(expected, 'utf8');
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/**
+ * Extract the authorization code from a callback URL, validating `state` first.
+ *
+ * `rawUrl` must be ABSOLUTE. Node's http server hands the handler a path+query, so
+ * the listener is responsible for resolving it against the redirect URI before
+ * calling this (`new URL(req.url, redirectUri).toString()`).
+ *
+ * Order matters: a provider ERROR is surfaced before the state check, because a
+ * user who clicked "deny" gets a callback that may carry no state at all, and
+ * reporting "state missing" there would hide the real, actionable reason.
+ *
+ * The thrown message never echoes the EXPECTED state — that value is a live CSRF
+ * secret for the in-flight attempt and the message can reach a log.
+ */
+export function parseCallbackUrl(rawUrl: string, expectedState: string): { code: string } {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error('socialAuth: the OAuth callback URL could not be parsed');
+  }
+  const params = parsed.searchParams;
+
+  const error = params.get('error');
+  if (error !== null) {
+    // The provider's own machine-readable reason (e.g. `access_denied`), which the
+    // UI shows so the user knows the sign-in was declined rather than broken.
+    throw new Error(`socialAuth: the platform refused the connection (${error})`);
+  }
+
+  const state = params.get('state');
+  if (state === null || !statesMatch(state, expectedState)) {
+    throw new Error(
+      'socialAuth: the OAuth callback state did not match this sign-in attempt; discarding it',
+    );
+  }
+
+  const code = params.get('code');
+  if (code === null || code === '') {
+    throw new Error('socialAuth: the OAuth callback carried no authorization code');
+  }
+  return { code };
+}
+
+export interface TokenExchangeOptions {
+  platform: string;
+  clientId: string;
+  /** `''` when the user's OAuth app has no secret — the field is then OMITTED. */
+  clientSecret: string;
+  code: string;
+  codeVerifier: string;
+  redirectUri: string;
+}
+
+/**
+ * The `application/x-www-form-urlencoded` body for the code->token exchange.
+ *
+ * Returns a BODY string (never a URL): the secret must travel in a POST body over
+ * https, not in a query string that a proxy or an access log would record.
+ *
+ * An empty `clientSecret` omits the field entirely rather than sending
+ * `client_secret=`, which some token endpoints treat as a malformed credential
+ * instead of an absent one.
+ */
+export function buildTokenExchangeBody(options: TokenExchangeOptions): string {
+  oauthEndpoint(options.platform);
+  assertLoopback(options.redirectUri);
+  const clientId = assertPresent(options.clientId, 'clientId');
+  const code = assertPresent(options.code, 'code');
+  const codeVerifier = assertPresent(options.codeVerifier, 'codeVerifier');
+
+  const body = new URLSearchParams({
+    grant_type: 'authorization_code',
+    client_id: clientId,
+    code,
+    code_verifier: codeVerifier,
+    redirect_uri: options.redirectUri,
+  });
+  if (options.clientSecret.trim() !== '') {
+    body.set('client_secret', options.clientSecret.trim());
+  }
+  return body.toString();
+}

--- a/app/main/socialTokens.test.ts
+++ b/app/main/socialTokens.test.ts
@@ -1,0 +1,260 @@
+// socialTokens.test.ts — C14 social OAuth tokens in the EXISTING DPAPI keystore.
+//
+// C14 must not introduce a second secret store: `keystore.ts` already owns every
+// at-rest credential (safeStorage-wrapped, atomic write, pre-overwrite backup,
+// fail-closed on an unreadable blob). Social tokens therefore live in a new `social`
+// section of that same file.
+//
+// THE HAZARD THESE TESTS EXIST FOR
+// --------------------------------
+// `saveDecryptedKeys` does not patch the keystore — it REBUILDS the whole document
+// from the `DecryptedKeys` it is handed. So if the social section were not part of
+// that value, the very next `providers.upsert` (a user typing an API key) would
+// rewrite the file WITHOUT it and silently destroy every connected social account.
+// The reverse holds too: connecting YouTube must not drop the provider keys.
+//
+// Both directions are asserted below, plus backward compatibility (a keystore
+// written before C14 has no `social` key at all and must still load) and the
+// fail-closed rule (a corrupt social section must be reported unreadable rather
+// than reported empty, because "empty" is what makes the next write permanent).
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { KeyBridge } from './keyBridge';
+import {
+  type DecryptedKeys,
+  type SafeStorageLike,
+  type SocialToken,
+  loadDecryptedKeys,
+  readKeystore,
+  saveDecryptedKeys,
+} from './keystore';
+
+/** Reversible fake (the keystore.test.ts idiom): ciphertext = "enc:" + plaintext. */
+function makeSafeStorage(opts: { available?: boolean } = {}): SafeStorageLike {
+  const available = opts.available ?? true;
+  return {
+    isEncryptionAvailable: () => available,
+    encryptString: (plaintext: string) => Buffer.from(`enc:${plaintext}`, 'utf8'),
+    decryptString: (encrypted: Buffer) => encrypted.toString('utf8').replace(/^enc:/, ''),
+  };
+}
+
+const TOKEN: SocialToken = {
+  accessToken: 'ya29.access-SECRET-1111',
+  refreshToken: '1//refresh-SECRET-2222',
+  expiresAt: 1_800_003_600,
+  accountLabel: 'My Channel',
+  scopes: ['https://www.googleapis.com/auth/youtube.upload'],
+};
+
+let dir: string;
+let keystorePath: string;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'reframe-social-'));
+  keystorePath = join(dir, 'secure-keys.json');
+});
+
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('social tokens round-trip through the DPAPI keystore', () => {
+  it('saves and reloads a social token', () => {
+    const safeStorage = makeSafeStorage();
+    saveDecryptedKeys(safeStorage, keystorePath, { providers: {}, social: { youtube: TOKEN } });
+    const loaded = loadDecryptedKeys(safeStorage, keystorePath);
+    expect(loaded.social?.youtube).toEqual(TOKEN);
+  });
+
+  it('never writes a token in plaintext', () => {
+    const safeStorage = makeSafeStorage();
+    saveDecryptedKeys(safeStorage, keystorePath, { providers: {}, social: { youtube: TOKEN } });
+    const raw = readFileSync(keystorePath, 'utf8');
+    // The fake cipher is "enc:"-prefixed, so a plaintext leak is detectable: the
+    // bare secret must not appear, only the enc: form.
+    expect(raw).not.toContain('"ya29.access-SECRET-1111"');
+    expect(raw).not.toContain('"1//refresh-SECRET-2222"');
+    expect(raw).toContain('social');
+  });
+
+  it('refuses to persist when there is no secure backend (no plaintext fallback)', () => {
+    const safeStorage = makeSafeStorage({ available: false });
+    expect(() =>
+      saveDecryptedKeys(safeStorage, keystorePath, { providers: {}, social: { youtube: TOKEN } }),
+    ).toThrow();
+  });
+});
+
+describe('THE NO-WIPE INVARIANT (both directions)', () => {
+  it('a providers.upsert does NOT destroy stored social tokens', () => {
+    const safeStorage = makeSafeStorage();
+    // 1. The user connects YouTube.
+    saveDecryptedKeys(safeStorage, keystorePath, { providers: {}, social: { youtube: TOKEN } });
+    // 2. Later the user pastes a Groq API key. This goes through the SAME keystore
+    //    writer, which rebuilds the whole document.
+    const bridge = new KeyBridge({ safeStorage, keystorePath });
+    bridge.forwardParams('providers.upsert', { id: 'groq', apiKeys: ['gsk-live-KEY1'] });
+    // 3. The social token must still be there.
+    const loaded = loadDecryptedKeys(safeStorage, keystorePath);
+    expect(loaded.social?.youtube).toEqual(TOKEN);
+    expect(loaded.providers.groq).toEqual(['gsk-live-KEY1']);
+  });
+
+  it('a providers.remove does NOT destroy stored social tokens', () => {
+    const safeStorage = makeSafeStorage();
+    saveDecryptedKeys(safeStorage, keystorePath, {
+      providers: { groq: ['gsk-live-KEY1'] },
+      social: { youtube: TOKEN },
+    });
+    const bridge = new KeyBridge({ safeStorage, keystorePath });
+    bridge.forwardParams('providers.remove', { id: 'groq' });
+    const loaded = loadDecryptedKeys(safeStorage, keystorePath);
+    expect(loaded.social?.youtube).toEqual(TOKEN);
+    expect(loaded.providers.groq).toBeUndefined();
+  });
+
+  it('saving a social token does NOT destroy provider keys', () => {
+    const safeStorage = makeSafeStorage();
+    saveDecryptedKeys(safeStorage, keystorePath, { providers: { groq: ['gsk-live-KEY1'] } });
+    const existing = loadDecryptedKeys(safeStorage, keystorePath);
+    saveDecryptedKeys(safeStorage, keystorePath, { ...existing, social: { youtube: TOKEN } });
+    const loaded = loadDecryptedKeys(safeStorage, keystorePath);
+    expect(loaded.providers.groq).toEqual(['gsk-live-KEY1']);
+    expect(loaded.social?.youtube).toEqual(TOKEN);
+  });
+});
+
+describe('backward compatibility + fail-closed reads', () => {
+  it('a pre-C14 keystore with no social section still loads', () => {
+    const safeStorage = makeSafeStorage();
+    // Exactly the shape keystore.ts wrote before this change.
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({
+        version: 1,
+        providers: { groq: [Buffer.from('enc:gsk-old').toString('base64')] },
+      }),
+      'utf8',
+    );
+    const read = readKeystore(safeStorage, keystorePath);
+    expect(read.outcome).toBe('loaded');
+    expect(read.keys?.providers.groq).toEqual(['gsk-old']);
+    expect(read.keys?.social).toBeUndefined();
+  });
+
+  it('a NON-OBJECT social section is unreadable, never silently empty', () => {
+    // Reported "empty" would let the next save overwrite real tokens for good.
+    const safeStorage = makeSafeStorage();
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({ version: 1, providers: {}, social: 'nope' }),
+      'utf8',
+    );
+    const read = readKeystore(safeStorage, keystorePath);
+    expect(read.outcome).toBe('unreadable');
+    expect(read.reason).toBe('shape-invalid');
+    expect(read.keys).toBeNull();
+  });
+
+  it('a non-string social ENTRY is unreadable', () => {
+    const safeStorage = makeSafeStorage();
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({ version: 1, providers: {}, social: { youtube: 7 } }),
+      'utf8',
+    );
+    expect(readKeystore(safeStorage, keystorePath).reason).toBe('shape-invalid');
+  });
+
+  it('a social entry that does not decrypt is unreadable', () => {
+    const safeStorage: SafeStorageLike = {
+      ...makeSafeStorage(),
+      decryptString: () => {
+        throw new Error('DPAPI failed');
+      },
+    };
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({ version: 1, providers: {}, social: { youtube: 'Y2lwaGVy' } }),
+      'utf8',
+    );
+    expect(readKeystore(safeStorage, keystorePath).reason).toBe('decrypt-failed');
+  });
+
+  it('a social entry whose plaintext is not valid JSON is unreadable', () => {
+    const safeStorage = makeSafeStorage();
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({
+        version: 1,
+        providers: {},
+        social: { youtube: Buffer.from('enc:{not json').toString('base64') },
+      }),
+      'utf8',
+    );
+    expect(readKeystore(safeStorage, keystorePath).reason).toBe('shape-invalid');
+  });
+
+  it('a social entry missing its accessToken is unreadable', () => {
+    // A record with no usable credential is corruption, not a connected account.
+    const safeStorage = makeSafeStorage();
+    const blob = Buffer.from(`enc:${JSON.stringify({ accountLabel: 'x' })}`).toString('base64');
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({ version: 1, providers: {}, social: { youtube: blob } }),
+      'utf8',
+    );
+    expect(readKeystore(safeStorage, keystorePath).reason).toBe('shape-invalid');
+  });
+
+  it('fills absent optional fields with safe defaults', () => {
+    const safeStorage = makeSafeStorage();
+    const blob = Buffer.from(`enc:${JSON.stringify({ accessToken: 'at-1' })}`).toString('base64');
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({ version: 1, providers: {}, social: { youtube: blob } }),
+      'utf8',
+    );
+    const read = readKeystore(safeStorage, keystorePath);
+    expect(read.keys?.social?.youtube).toEqual({
+      accessToken: 'at-1',
+      refreshToken: '',
+      expiresAt: 0,
+      accountLabel: '',
+      scopes: [],
+    });
+  });
+
+  it('drops a prototype-polluting platform id rather than writing it', () => {
+    const safeStorage = makeSafeStorage();
+    // Built via JSON.parse, NOT an object literal: `{__proto__: x}` in a literal
+    // sets the PROTOTYPE and creates no own property, so Object.entries would not
+    // see it and this test would pass without the guard ever running.
+    const social = JSON.parse(
+      '{"__proto__": {"accessToken": "bad"}, "youtube": {"accessToken": "ok"}}',
+    );
+    const keys: DecryptedKeys = { providers: {}, social: social as Record<string, SocialToken> };
+    expect(Object.keys(social)).toContain('__proto__'); // detector control
+    saveDecryptedKeys(safeStorage, keystorePath, keys);
+    const raw = readFileSync(keystorePath, 'utf8');
+    expect(raw).not.toContain('__proto__');
+    expect(raw).toContain('youtube');
+  });
+
+  it('drops a prototype-polluting platform id on the READ path too', () => {
+    const safeStorage = makeSafeStorage();
+    const blob = Buffer.from(`enc:${JSON.stringify({ accessToken: 'at-1' })}`).toString('base64');
+    // Written by hand (a hostile/corrupt file), since writeKeystore filters it out.
+    writeFileSync(
+      keystorePath,
+      `{"version":1,"providers":{},"social":{"__proto__":"${blob}","youtube":"${blob}"}}`,
+      'utf8',
+    );
+    const read = readKeystore(safeStorage, keystorePath);
+    expect(read.outcome).toBe('loaded');
+    expect(Object.keys(read.keys?.social ?? {})).toEqual(['youtube']);
+  });
+});

--- a/app/main/socialTokens.test.ts
+++ b/app/main/socialTokens.test.ts
@@ -27,6 +27,7 @@ import {
   type SafeStorageLike,
   type SocialToken,
   loadDecryptedKeys,
+  migrateLegacyPlaintextKeys,
   readKeystore,
   saveDecryptedKeys,
 } from './keystore';
@@ -114,6 +115,56 @@ describe('THE NO-WIPE INVARIANT (both directions)', () => {
     const loaded = loadDecryptedKeys(safeStorage, keystorePath);
     expect(loaded.social?.youtube).toEqual(TOKEN);
     expect(loaded.providers.groq).toBeUndefined();
+  });
+
+  it('the LEGACY-PLAINTEXT MIGRATION does NOT destroy stored social tokens', () => {
+    // The nastiest of the three write paths, and the one an enumeration of
+    // saveDecryptedKeys callers found rather than intuition: the boot-time migration
+    // calls writeKeystore with extractPlaintextKeys(settings), which knows nothing
+    // about the social section. Reachable whenever plaintext keys REAPPEAR in
+    // settings.json after an account was connected (a restored settings backup, a
+    // sidecar that re-persists a key) -- and the cost is every connected account.
+    const safeStorage = makeSafeStorage();
+    saveDecryptedKeys(safeStorage, keystorePath, { providers: {}, social: { youtube: TOKEN } });
+    const settingsPath = join(dir, 'settings.json');
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ providers: [{ id: 'groq', apiKeys: ['gsk-legacy-PLAIN'] }] }),
+      'utf8',
+    );
+
+    const result = migrateLegacyPlaintextKeys(safeStorage, settingsPath, keystorePath);
+    expect(result.status).toBe('migrated');
+
+    const loaded = loadDecryptedKeys(safeStorage, keystorePath);
+    expect(loaded.providers.groq).toEqual(['gsk-legacy-PLAIN']);
+    expect(loaded.social?.youtube).toEqual(TOKEN);
+  });
+
+  it('the migration tolerates an UNREADABLE keystore without inventing a social section', () => {
+    // If the existing keystore cannot be read, the migration must still migrate the
+    // plaintext keys (that is its whole job) rather than abort -- but it must not
+    // fabricate a social section from a store it could not read.
+    const safeStorage: SafeStorageLike = {
+      ...makeSafeStorage(),
+      decryptString: () => {
+        throw new Error('DPAPI failed');
+      },
+    };
+    writeFileSync(
+      keystorePath,
+      JSON.stringify({ version: 1, providers: {}, social: { youtube: 'Y2lwaGVy' } }),
+      'utf8',
+    );
+    const settingsPath = join(dir, 'settings.json');
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ providers: [{ id: 'groq', apiKeys: ['gsk-legacy-PLAIN'] }] }),
+      'utf8',
+    );
+    expect(migrateLegacyPlaintextKeys(safeStorage, settingsPath, keystorePath).status).toBe(
+      'migrated',
+    );
   });
 
   it('saving a social token does NOT destroy provider keys', () => {

--- a/app/renderer/src/features/SocialPublishPanel.test.tsx
+++ b/app/renderer/src/features/SocialPublishPanel.test.tsx
@@ -1,0 +1,458 @@
+// SocialPublishPanel.test.tsx — C14 Publish panel.
+//
+// The assertions that matter here are the honesty ones, because the panel's whole
+// reason to exist is to not promise a publish that cannot happen:
+//
+//   * a BLOCKED platform is un-selectable and shows its own reason verbatim;
+//   * a `local-queue` plan shows the server's warning that Reframe must be running;
+//   * a `platform` plan says the opposite (it posts with the computer off);
+//   * the pre-audit visibility cap is shown BEFORE the first publish.
+
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SocialCapability, SocialQueueEntry, SocialSchedulePlan } from '../lib/rpc';
+
+const capabilitiesMock = vi.fn();
+const planMock = vi.fn();
+const enqueueMock = vi.fn();
+const queueMock = vi.fn();
+const cancelMock = vi.fn();
+
+vi.mock('../lib/rpc', () => ({
+  client: {
+    social: {
+      capabilities: (...a: unknown[]) => capabilitiesMock(...a),
+      plan: (...a: unknown[]) => planMock(...a),
+      enqueue: (...a: unknown[]) => enqueueMock(...a),
+      queue: (...a: unknown[]) => queueMock(...a),
+      cancel: (...a: unknown[]) => cancelMock(...a),
+    },
+  },
+}));
+
+import {
+  SocialPublishPanel,
+  platformLabel,
+  statusLabel,
+  toEpochSeconds,
+} from './SocialPublishPanel';
+
+const YOUTUBE: SocialCapability = {
+  id: 'youtube',
+  label: 'YouTube',
+  publishable: true,
+  personalAccount: true,
+  desktopLoopbackOauth: true,
+  nativeScheduling: true,
+  nativeScheduleMaxSec: null,
+  requiresClientSecret: true,
+  unauditedVisibility: 'Until your project passes the audit, uploads are forced PRIVATE.',
+  docUrl: 'https://developers.google.com/youtube/v3/docs/videos/insert',
+  blockedReason: null,
+};
+
+const INSTAGRAM: SocialCapability = {
+  ...YOUTUBE,
+  id: 'instagram_reels',
+  label: 'Instagram Reels',
+  publishable: false,
+  personalAccount: false,
+  nativeScheduling: false,
+  blockedReason: "Instagram's API only serves a PROFESSIONAL account.",
+};
+
+const IMMEDIATE_PLAN: SocialSchedulePlan = {
+  platform: 'youtube',
+  kind: 'immediate',
+  publishAt: null,
+  requiresAppRunning: false,
+  warning: '',
+  unauditedVisibility: YOUTUBE.unauditedVisibility,
+};
+
+const ENTRY: SocialQueueEntry = {
+  id: 'e1',
+  platform: 'youtube',
+  videoId: 'v1',
+  clipPath: 'clip.mp4',
+  title: 'My clip',
+  description: '',
+  publishAt: null,
+  kind: 'immediate',
+  requiresAppRunning: false,
+  status: 'pending',
+  createdAt: 1_800_000_000,
+  error: '',
+};
+
+let container: HTMLElement | undefined;
+let root: Root | undefined;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capabilitiesMock.mockResolvedValue({ platforms: [YOUTUBE, INSTAGRAM] });
+  planMock.mockResolvedValue({ plan: IMMEDIATE_PLAN });
+  queueMock.mockResolvedValue({ entries: [] });
+  enqueueMock.mockResolvedValue({ entry: ENTRY });
+  cancelMock.mockResolvedValue({ ok: true });
+});
+
+afterEach(() => {
+  // Guarded: the pure-helper tests never mount, so an unconditional unmount here
+  // failed them all with a confusing "cannot read properties of undefined".
+  if (root !== undefined) {
+    const mounted = root;
+    act(() => mounted.unmount());
+  }
+  container?.remove();
+  root = undefined;
+  container = undefined;
+});
+
+function dom(): HTMLElement {
+  if (container === undefined) throw new Error('not rendered');
+  return container;
+}
+
+async function render(props: { clipPath?: string; videoId?: string } = {}): Promise<void> {
+  const host = document.createElement('div');
+  document.body.appendChild(host);
+  container = host;
+  const mounted = createRoot(host);
+  root = mounted;
+  await act(async () => {
+    mounted.render(<SocialPublishPanel clipPath="clip.mp4" videoId="v1" {...props} />);
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+function select(): HTMLSelectElement {
+  return dom().querySelector('select[aria-label="Platform"]') as HTMLSelectElement;
+}
+
+function input(label: string): HTMLInputElement {
+  return dom().querySelector(`input[aria-label="${label}"]`) as HTMLInputElement;
+}
+
+/**
+ * Set a CONTROLLED React field's value the way React notices.
+ *
+ * A plain `el.value = x` + `change` does NOT reach a controlled input: React caches
+ * the node's value via the prototype setter and treats an unchanged cached value as
+ * "no change", so onChange never fires. Going through the prototype descriptor keeps
+ * React's tracker in sync, and inputs need an `input` event (selects use `change`).
+ */
+function setValue(el: HTMLInputElement | HTMLSelectElement, value: string): void {
+  const isSelect = el instanceof HTMLSelectElement;
+  const proto = isSelect ? HTMLSelectElement.prototype : HTMLInputElement.prototype;
+  const setter = Object.getOwnPropertyDescriptor(proto, 'value')?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event(isSelect ? 'change' : 'input', { bubbles: true }));
+}
+
+function buttonByText(text: string): HTMLButtonElement | undefined {
+  return Array.from(dom().querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === text,
+  ) as HTMLButtonElement | undefined;
+}
+
+/** The action/load error slot (distinct from the schedule-preview one). */
+function errorText(): string | undefined {
+  return dom().querySelector('.social-publish__error')?.textContent ?? undefined;
+}
+
+/** The schedule-PREVIEW error slot. */
+function planErrorText(): string | undefined {
+  return dom().querySelector('.social-publish__plan-error')?.textContent ?? undefined;
+}
+
+describe('<SocialPublishPanel /> — pure helpers', () => {
+  it('toEpochSeconds returns null for an empty value', () => {
+    expect(toEpochSeconds('')).toBeNull();
+  });
+
+  it('toEpochSeconds returns null for an unparseable value', () => {
+    expect(toEpochSeconds('not-a-date')).toBeNull();
+  });
+
+  it('toEpochSeconds converts a datetime-local value to whole seconds', () => {
+    expect(toEpochSeconds('2026-08-09T10:30')).toBe(
+      Math.floor(new Date('2026-08-09T10:30').getTime() / 1000),
+    );
+  });
+
+  it('statusLabel distinguishes a platform-held schedule from a Reframe-held one', () => {
+    // "pending" alone would wrongly imply the app must stay open for a
+    // platform-scheduled post.
+    expect(statusLabel({ ...ENTRY, kind: 'platform' })).toBe('scheduled on the platform');
+    expect(statusLabel({ ...ENTRY, kind: 'local-queue', requiresAppRunning: true })).toBe(
+      'queued in Reframe',
+    );
+  });
+
+  it('statusLabel passes a terminal status through', () => {
+    expect(statusLabel({ ...ENTRY, status: 'done' })).toBe('done');
+    expect(statusLabel({ ...ENTRY, status: 'cancelled' })).toBe('cancelled');
+  });
+
+  it('platformLabel resolves a known id to its label', () => {
+    expect(platformLabel([YOUTUBE, INSTAGRAM], 'instagram_reels')).toBe('Instagram Reels');
+  });
+
+  it('platformLabel falls back to the raw id for an unknown platform', () => {
+    // The fallback arm, exercised directly. Inline in the JSX this arm was
+    // unreachable, so the test that claimed to cover it was passing vacuously.
+    expect(platformLabel([YOUTUBE], 'mastodon')).toBe('mastodon');
+  });
+
+  it('platformLabel handles an empty matrix', () => {
+    expect(platformLabel([], 'youtube')).toBe('youtube');
+  });
+});
+
+describe('<SocialPublishPanel /> — blocked platforms', () => {
+  it('lists a blocked platform as disabled and marked unavailable', async () => {
+    await render();
+    const blocked = Array.from(select().options).find((o) => o.value === 'instagram_reels');
+    expect(blocked?.disabled).toBe(true);
+    expect(blocked?.textContent).toContain('unavailable');
+  });
+
+  it('defaults to the first PUBLISHABLE platform, never a blocked one', async () => {
+    capabilitiesMock.mockResolvedValue({ platforms: [INSTAGRAM, YOUTUBE] });
+    await render();
+    expect(select().value).toBe('youtube');
+  });
+
+  it('shows the platform own reason verbatim when a blocked one is selected', async () => {
+    await render();
+    await act(async () => setValue(select(), 'instagram_reels'));
+    expect(dom().textContent).toContain('PROFESSIONAL account');
+  });
+
+  it('does not ask the server for a plan for a blocked platform', async () => {
+    await render();
+    planMock.mockClear();
+    await act(async () => setValue(select(), 'instagram_reels'));
+    expect(planMock).not.toHaveBeenCalled();
+  });
+
+  it('selects nothing when NO platform is publishable', async () => {
+    capabilitiesMock.mockResolvedValue({ platforms: [INSTAGRAM] });
+    await render();
+    expect(select().value).toBe('');
+  });
+});
+
+describe('<SocialPublishPanel /> — the scheduling disclosure', () => {
+  it('shows the server warning verbatim for a local-queue plan', async () => {
+    planMock.mockResolvedValue({
+      plan: {
+        ...IMMEDIATE_PLAN,
+        kind: 'local-queue',
+        requiresAppRunning: true,
+        warning: 'Reframe must be running then.',
+      },
+    });
+    await render();
+    expect(dom().querySelector('.social-publish__warning')?.textContent).toBe(
+      'Reframe must be running then.',
+    );
+  });
+
+  it('says a platform-held schedule survives the computer being off', async () => {
+    planMock.mockResolvedValue({ plan: { ...IMMEDIATE_PLAN, kind: 'platform' } });
+    await render();
+    expect(dom().querySelector('.social-publish__held')?.textContent).toContain('computer is off');
+  });
+
+  it('names the platform the schedule is held on', async () => {
+    planMock.mockResolvedValue({ plan: { ...IMMEDIATE_PLAN, kind: 'platform' } });
+    await render();
+    expect(dom().querySelector('.social-publish__held')?.textContent).toContain('YouTube');
+  });
+
+  it('shows the pre-audit visibility cap before any publish', async () => {
+    await render();
+    expect(dom().querySelector('.social-publish__audit')?.textContent).toContain('PRIVATE');
+  });
+
+  it('omits the audit note when the platform has none', async () => {
+    planMock.mockResolvedValue({ plan: { ...IMMEDIATE_PLAN, unauditedVisibility: '' } });
+    await render();
+    expect(dom().querySelector('.social-publish__audit')).toBeNull();
+  });
+
+  it('re-previews the plan when the time changes', async () => {
+    await render();
+    planMock.mockClear();
+    await act(async () => setValue(input('Publish at'), '2026-08-09T10:30'));
+    expect(planMock).toHaveBeenCalledWith(
+      'youtube',
+      Math.floor(new Date('2026-08-09T10:30').getTime() / 1000),
+    );
+  });
+
+  it('surfaces a plan failure and clears the stale plan', async () => {
+    planMock.mockRejectedValue(new Error('bad time'));
+    await render();
+    expect(planErrorText()).toBe('bad time');
+    expect(dom().querySelector('.social-publish__plan')).toBeNull();
+  });
+
+  it('stringifies a non-Error plan rejection', async () => {
+    planMock.mockRejectedValue('nope');
+    await render();
+    expect(planErrorText()).toBe('Could not check that time');
+  });
+});
+
+describe('<SocialPublishPanel /> — queueing', () => {
+  it('disables the button until a clip and a title are present', async () => {
+    await render({ clipPath: '' });
+    expect(buttonByText('Publish now')?.disabled).toBe(true);
+    expect(dom().textContent).toContain('Export a clip first');
+  });
+
+  it('disables the button when the title is only whitespace', async () => {
+    await render();
+    await act(async () => setValue(input('Post title'), '   '));
+    expect(buttonByText('Publish now')?.disabled).toBe(true);
+  });
+
+  it('sends the job with the clip, title and provenance video id', async () => {
+    await render();
+    await act(async () => setValue(input('Post title'), 'My clip'));
+    await act(async () => buttonByText('Publish now')?.click());
+    expect(enqueueMock).toHaveBeenCalledWith({
+      platform: 'youtube',
+      clipPath: 'clip.mp4',
+      title: 'My clip',
+      description: '',
+      videoId: 'v1',
+      publishAt: null,
+    });
+  });
+
+  it('labels the button Schedule once a time is chosen', async () => {
+    await render();
+    await act(async () => setValue(input('Publish at'), '2026-08-09T10:30'));
+    expect(buttonByText('Schedule')).toBeDefined();
+  });
+
+  it('reloads the queue after a successful enqueue', async () => {
+    await render();
+    await act(async () => setValue(input('Post title'), 'My clip'));
+    queueMock.mockClear();
+    await act(async () => buttonByText('Publish now')?.click());
+    expect(queueMock).toHaveBeenCalled();
+  });
+
+  it('surfaces an enqueue failure', async () => {
+    enqueueMock.mockRejectedValue(new Error('refused'));
+    await render();
+    await act(async () => setValue(input('Post title'), 'My clip'));
+    await act(async () => buttonByText('Publish now')?.click());
+    expect(errorText()).toBe('refused');
+  });
+
+  it('stringifies a non-Error enqueue rejection', async () => {
+    enqueueMock.mockRejectedValue('boom');
+    await render();
+    await act(async () => setValue(input('Post title'), 'My clip'));
+    await act(async () => buttonByText('Publish now')?.click());
+    expect(errorText()).toBe(
+      'Could not queue that publish',
+    );
+  });
+});
+
+describe('<SocialPublishPanel /> — the queue list', () => {
+  it('says so when nothing is queued', async () => {
+    await render();
+    expect(dom().textContent).toContain('Nothing queued yet');
+  });
+
+  it('lists an entry with its human status', async () => {
+    queueMock.mockResolvedValue({ entries: [ENTRY] });
+    await render();
+    expect(dom().querySelector('.social-publish__queue')?.textContent).toContain('My clip');
+  });
+
+  it('cancels a pending entry and reloads', async () => {
+    queueMock.mockResolvedValue({ entries: [ENTRY] });
+    await render();
+    await act(async () => buttonByText('Cancel')?.click());
+    expect(cancelMock).toHaveBeenCalledWith('e1');
+  });
+
+  it('offers no Cancel for a terminal entry', async () => {
+    queueMock.mockResolvedValue({ entries: [{ ...ENTRY, status: 'done' }] });
+    await render();
+    expect(buttonByText('Cancel')).toBeUndefined();
+  });
+
+  it('surfaces a cancel failure', async () => {
+    queueMock.mockResolvedValue({ entries: [ENTRY] });
+    cancelMock.mockRejectedValue(new Error('cancel boom'));
+    await render();
+    await act(async () => buttonByText('Cancel')?.click());
+    expect(errorText()).toBe('cancel boom');
+  });
+
+  it('stringifies a non-Error cancel rejection', async () => {
+    queueMock.mockResolvedValue({ entries: [ENTRY] });
+    cancelMock.mockRejectedValue('x');
+    await render();
+    await act(async () => buttonByText('Cancel')?.click());
+    expect(errorText()).toBe('Cancel failed');
+  });
+});
+
+describe('<SocialPublishPanel /> — load failures', () => {
+  it('surfaces a capabilities failure', async () => {
+    capabilitiesMock.mockRejectedValue(new Error('no platforms'));
+    await render();
+    expect(errorText()).toBe('no platforms');
+  });
+
+  it('stringifies a non-Error capabilities rejection', async () => {
+    capabilitiesMock.mockRejectedValue('nope');
+    await render();
+    expect(errorText()).toBe('Failed to load platforms');
+  });
+
+  it('surfaces a queue-load failure', async () => {
+    queueMock.mockRejectedValue(new Error('queue down'));
+    await render();
+    expect(dom().textContent).toContain('queue down');
+  });
+
+  it('stringifies a non-Error queue rejection', async () => {
+    queueMock.mockRejectedValue('nope');
+    await render();
+    expect(dom().textContent).toContain('Failed to load the publish queue');
+  });
+
+  it('renders with no props at all (defaults)', async () => {
+    // Mounted by hand rather than via render(), which always supplies clipPath —
+    // this exercises the prop DEFAULTS (clipPath='' / videoId='').
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    container = host;
+    const mounted = createRoot(host);
+    root = mounted;
+    await act(async () => {
+      mounted.render(<SocialPublishPanel />);
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(dom().textContent).toContain('Export a clip first');
+  });
+});

--- a/app/renderer/src/features/SocialPublishPanel.test.tsx
+++ b/app/renderer/src/features/SocialPublishPanel.test.tsx
@@ -156,9 +156,9 @@ function setValue(el: HTMLInputElement | HTMLSelectElement, value: string): void
 }
 
 function buttonByText(text: string): HTMLButtonElement | undefined {
-  return Array.from(dom().querySelectorAll('button')).find(
-    (b) => b.textContent?.trim() === text,
-  ) as HTMLButtonElement | undefined;
+  return Array.from(dom().querySelectorAll('button')).find((b) => b.textContent?.trim() === text) as
+    | HTMLButtonElement
+    | undefined;
 }
 
 /** The action/load error slot (distinct from the schedule-preview one). */
@@ -366,9 +366,7 @@ describe('<SocialPublishPanel /> — queueing', () => {
     await render();
     await act(async () => setValue(input('Post title'), 'My clip'));
     await act(async () => buttonByText('Publish now')?.click());
-    expect(errorText()).toBe(
-      'Could not queue that publish',
-    );
+    expect(errorText()).toBe('Could not queue that publish');
   });
 });
 

--- a/app/renderer/src/features/SocialPublishPanel.tsx
+++ b/app/renderer/src/features/SocialPublishPanel.tsx
@@ -1,0 +1,274 @@
+// SocialPublishPanel.tsx — C14 direct publish / scheduling (Deliver → "Publish").
+//
+// THE PANEL'S JOB IS TO NOT LIE. Two of the four platforms C14 named cannot publish
+// to a personal account at all, and a desktop app cannot publish while the machine
+// is off. Both facts are surfaced from the SERVER rather than hardcoded here:
+//
+//   * the platform <select> is built from `social.capabilities()`, and a platform
+//     whose `publishable` is false is rendered as DISABLED with its own
+//     `blockedReason` shown verbatim — so the UI cannot offer a publish the platform
+//     would refuse, and the user learns WHY (e.g. Instagram needs a professional
+//     account, which they change in the Instagram app, not here);
+//   * choosing a time calls `social.plan()` FIRST, purely to preview where that time
+//     would be held. When the plan comes back `local-queue` the panel shows the
+//     server's `warning` text verbatim, because that is the sentence explaining the
+//     post goes out when Reframe next runs rather than at the chosen time.
+//
+// The pre-audit visibility cap (`unauditedVisibility`) is shown before the first
+// publish too — an upload that silently lands as PRIVATE would otherwise look broken.
+//
+// No credential is handled here. OAuth tokens live in the main-process keystore; the
+// renderer never sees one.
+import React, { useCallback, useEffect, useState } from 'react';
+import {
+  client,
+  type SocialCapability,
+  type SocialQueueEntry,
+  type SocialSchedulePlan,
+} from '../lib/rpc';
+import './panels.css';
+
+/** Local-time `datetime-local` value -> epoch seconds, or null when unset/unparseable. */
+export function toEpochSeconds(value: string): number | null {
+  if (value === '') return null;
+  const ms = new Date(value).getTime();
+  return Number.isNaN(ms) ? null : Math.floor(ms / 1000);
+}
+
+/**
+ * The display label for a platform id, falling back to the id itself.
+ *
+ * Extracted as a pure function rather than written inline as
+ * `selected?.label ?? plan.platform`: inline, the fallback arm was UNREACHABLE
+ * (`selected` is non-null wherever a plan exists), so it cost a coverage branch that
+ * no test could honestly reach — and the test that claimed to cover it was passing
+ * vacuously on the non-fallback arm. It is also more correct this way: the label
+ * should track the PLAN's platform, which can momentarily differ from the currently
+ * selected one while a preview is in flight.
+ */
+export function platformLabel(platforms: readonly SocialCapability[], id: string): string {
+  return platforms.find((p) => p.id === id)?.label ?? id;
+}
+
+/** A queue row's status rendered for humans (kept beside the wire values it maps). */
+export function statusLabel(entry: SocialQueueEntry): string {
+  if (entry.status === 'pending' && entry.kind === 'platform') {
+    // A platform-held schedule is NOT waiting on Reframe, so "pending" alone would
+    // wrongly imply the app has to stay open for it.
+    return 'scheduled on the platform';
+  }
+  if (entry.status === 'pending' && entry.requiresAppRunning) {
+    return 'queued in Reframe';
+  }
+  return entry.status;
+}
+
+export interface SocialPublishPanelProps {
+  /** The clip to publish (a rendered export path); empty when nothing is selected. */
+  clipPath?: string;
+  /** Provenance link back to the library item, carried onto the queue entry. */
+  videoId?: string;
+}
+
+/** The Publish panel: pick a platform + time, preview the honest plan, queue it. */
+export function SocialPublishPanel({
+  clipPath = '',
+  videoId = '',
+}: SocialPublishPanelProps): React.ReactElement {
+  const [platforms, setPlatforms] = useState<SocialCapability[]>([]);
+  const [platform, setPlatform] = useState('');
+  const [title, setTitle] = useState('');
+  const [when, setWhen] = useState('');
+  const [plan, setPlan] = useState<SocialSchedulePlan | null>(null);
+  const [entries, setEntries] = useState<SocialQueueEntry[]>([]);
+  const [error, setError] = useState('');
+  /**
+   * The schedule-PREVIEW error, kept apart from {@link error} on purpose.
+   *
+   * The preview effect re-runs on every platform/time keystroke, so if it shared one
+   * slot it would clear whatever the last load or action had reported — a failed
+   * `social.queue()` was measurably erased this way, leaving the panel silent about a
+   * queue it could not read. Each slot is now owned by exactly one code path.
+   */
+  const [planError, setPlanError] = useState('');
+
+  const selected = platforms.find((p) => p.id === platform) ?? null;
+
+  const reloadQueue = useCallback(async () => {
+    try {
+      const { entries: rows } = await client.social.queue();
+      setEntries(rows);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load the publish queue');
+    }
+  }, []);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const { platforms: rows } = await client.social.capabilities();
+        setPlatforms(rows);
+        // Default to the first platform that can ACTUALLY publish, so the panel does
+        // not open pre-set to a blocked one.
+        setPlatform(rows.find((p) => p.publishable)?.id ?? '');
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load platforms');
+      }
+      await reloadQueue();
+    })();
+  }, [reloadQueue]);
+
+  // Preview the plan whenever the platform or the time changes. This is the whole
+  // honesty mechanism: the disclosure appears BEFORE anything is committed.
+  useEffect(() => {
+    if (platform === '' || selected?.publishable !== true) {
+      setPlan(null);
+      return;
+    }
+    void (async () => {
+      try {
+        const { plan: preview } = await client.social.plan(platform, toEpochSeconds(when));
+        setPlan(preview);
+        setPlanError('');
+      } catch (err) {
+        setPlan(null);
+        setPlanError(err instanceof Error ? err.message : 'Could not check that time');
+      }
+    })();
+  }, [platform, when, selected?.publishable]);
+
+  const handleQueue = useCallback(async () => {
+    try {
+      await client.social.enqueue({
+        platform,
+        clipPath,
+        title,
+        description: '',
+        videoId,
+        publishAt: toEpochSeconds(when),
+      });
+      await reloadQueue();
+      setError('');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Could not queue that publish');
+    }
+  }, [platform, clipPath, title, videoId, when, reloadQueue]);
+
+  const handleCancel = useCallback(
+    async (id: string) => {
+      try {
+        await client.social.cancel(id);
+        await reloadQueue();
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Cancel failed');
+      }
+    },
+    [reloadQueue],
+  );
+
+  const canQueue = clipPath !== '' && title.trim() !== '' && selected?.publishable === true;
+
+  return (
+    <section className="social-publish" aria-label="Publish to social platforms">
+      {error !== '' ? (
+        <p role="alert" className="social-publish__error">
+          {error}
+        </p>
+      ) : null}
+      {planError !== '' ? (
+        <p role="alert" className="social-publish__plan-error">
+          {planError}
+        </p>
+      ) : null}
+
+      <label className="social-publish__field">
+        <span>Platform</span>
+        <select
+          aria-label="Platform"
+          value={platform}
+          onChange={(e) => setPlatform(e.target.value)}
+        >
+          {platforms.map((p) => (
+            <option key={p.id} value={p.id} disabled={!p.publishable}>
+              {p.publishable ? p.label : `${p.label} — unavailable`}
+            </option>
+          ))}
+        </select>
+      </label>
+
+      {selected !== null && !selected.publishable ? (
+        <p role="note" className="social-publish__blocked">
+          {selected.blockedReason}
+        </p>
+      ) : null}
+
+      <label className="social-publish__field">
+        <span>Title</span>
+        <input aria-label="Post title" value={title} onChange={(e) => setTitle(e.target.value)} />
+      </label>
+
+      <label className="social-publish__field">
+        <span>Publish at (leave empty to publish now)</span>
+        <input
+          type="datetime-local"
+          aria-label="Publish at"
+          value={when}
+          onChange={(e) => setWhen(e.target.value)}
+        />
+      </label>
+
+      {plan !== null ? (
+        <div className="social-publish__plan">
+          {plan.requiresAppRunning ? (
+            // Verbatim server text — see the module note. This is the sentence that
+            // stops the UI implying a desktop app can post while the machine is off.
+            <p role="alert" className="social-publish__warning">
+              {plan.warning}
+            </p>
+          ) : null}
+          {plan.kind === 'platform' ? (
+            <p className="social-publish__held">
+              Scheduled on {platformLabel(platforms, plan.platform)} itself, so it posts even if
+              this computer is off.
+            </p>
+          ) : null}
+          {plan.unauditedVisibility !== '' ? (
+            <p className="social-publish__audit">{plan.unauditedVisibility}</p>
+          ) : null}
+        </div>
+      ) : null}
+
+      {clipPath === '' ? (
+        <p className="social-publish__empty">
+          Export a clip first — Publish sends a rendered file, not the source video.
+        </p>
+      ) : null}
+
+      <button type="button" disabled={!canQueue} onClick={() => void handleQueue()}>
+        {when === '' ? 'Publish now' : 'Schedule'}
+      </button>
+
+      <h4>Queue</h4>
+      {entries.length === 0 ? (
+        <p className="social-publish__empty">Nothing queued yet.</p>
+      ) : (
+        <ul className="social-publish__queue">
+          {entries.map((entry) => (
+            <li key={entry.id}>
+              <span>
+                {entry.platform} — {entry.title} ({statusLabel(entry)})
+              </span>
+              {entry.status === 'pending' ? (
+                <button type="button" onClick={() => void handleCancel(entry.id)}>
+                  Cancel
+                </button>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default SocialPublishPanel;

--- a/app/renderer/src/features/panels.css
+++ b/app/renderer/src/features/panels.css
@@ -472,3 +472,63 @@
   border-radius: var(--radius-sm);
   background: var(--surface-raised, transparent);
 }
+
+/* ---- C14 social publish / schedule (SocialPublishPanel.tsx) -------------- */
+/* The two disclosure blocks are styled to be NOTICED, not to blend in: a
+   local-queue post genuinely does not go out with the machine off, and the
+   pre-audit visibility cap means an upload can silently land as private. */
+.social-publish {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3, 0.75rem);
+}
+
+.social-publish__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 0.25rem);
+}
+
+.social-publish__error,
+.social-publish__plan-error {
+  color: var(--status-error-text);
+}
+
+.social-publish__plan {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 0.25rem);
+  padding: var(--space-2, 0.5rem);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised, transparent);
+}
+
+.social-publish__warning {
+  font-weight: 600;
+  color: var(--status-warn);
+}
+
+.social-publish__blocked,
+.social-publish__audit {
+  color: var(--text-secondary);
+}
+
+.social-publish__queue {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1, 0.25rem);
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.social-publish__queue li {
+  display: flex;
+  gap: var(--space-2, 0.5rem);
+  align-items: center;
+  justify-content: space-between;
+}
+
+.social-publish__empty {
+  color: var(--text-secondary);
+}

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -861,6 +861,39 @@ describe('WU-0 QoL settings shapes (mirror sidecar DEFAULT_SETTINGS)', () => {
   });
 });
 
+describe('client.social (C14 publish/schedule)', () => {
+  it('social.* forward their params', async () => {
+    const r = installApi();
+    await client.social.capabilities();
+    expect(r).toHaveBeenCalledWith('social.capabilities', undefined);
+    await client.social.plan('tiktok', 1_800_003_600);
+    expect(r).toHaveBeenCalledWith('social.plan', { platform: 'tiktok', publishAt: 1_800_003_600 });
+    await client.social.queue();
+    expect(r).toHaveBeenCalledWith('social.queue', undefined);
+    await client.social.cancel('e1');
+    expect(r).toHaveBeenCalledWith('social.cancel', { id: 'e1' });
+  });
+
+  it('social.plan sends publishAt: null for an immediate preview', async () => {
+    const r = installApi();
+    await client.social.plan('youtube');
+    expect(r).toHaveBeenCalledWith('social.plan', { platform: 'youtube', publishAt: null });
+  });
+
+  it('social.enqueue nests the job under `job`', async () => {
+    const r = installApi();
+    const job = {
+      platform: 'youtube',
+      clipPath: 'a.mp4',
+      title: 'T',
+      description: '',
+      videoId: 'v1',
+    };
+    await client.social.enqueue(job);
+    expect(r).toHaveBeenCalledWith('social.enqueue', { job });
+  });
+});
+
 describe('client.exportPresets / templates / batch (WU11)', () => {
   const PRESET: ExportPreset = {
     id: 'tiktok',

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -79,6 +79,10 @@ import type {
   SetConsentResponse,
   ShortInfo,
   ShortReexportHint,
+  SocialCapability,
+  SocialPublishJob,
+  SocialQueueEntry,
+  SocialSchedulePlan,
   SpendInfo,
   SubtitleFormat,
   SubtitleTrack,
@@ -628,6 +632,29 @@ export const client = {
       rpc('recipes.save', { recipe }),
     delete: (id: string): Promise<{ ok: boolean }> => rpc('recipes.delete', { id }),
     run: (id: string): Promise<JobHandle> => rpc('recipes.run', { id }),
+  },
+
+  /**
+   * `social.*` — C14 direct publish / scheduling.
+   *
+   * Storage + honest decisions only. No token ever crosses this bridge: OAuth
+   * tokens live in the main-process keystore and are injected there, so the
+   * renderer never holds credential material for a platform.
+   */
+  social: {
+    /** The per-platform capability matrix (what each platform actually permits). */
+    capabilities: (): Promise<{ platforms: SocialCapability[] }> => rpc('social.capabilities'),
+    /**
+     * PREVIEW where a publish time would be held, WITHOUT committing anything —
+     * so the "Reframe must be running then" disclosure can be shown while the user
+     * is still choosing a time rather than after they have queued it.
+     */
+    plan: (platform: string, publishAt?: number | null): Promise<{ plan: SocialSchedulePlan }> =>
+      rpc('social.plan', { platform, publishAt: publishAt ?? null }),
+    enqueue: (job: SocialPublishJob): Promise<{ entry: SocialQueueEntry }> =>
+      rpc('social.enqueue', { job }),
+    queue: (): Promise<{ entries: SocialQueueEntry[] }> => rpc('social.queue'),
+    cancel: (id: string): Promise<{ ok: boolean }> => rpc('social.cancel', { id }),
   },
 
   /** `exportPresets.*` — server-persisted platform export presets (WU11). */

--- a/app/renderer/src/lib/rpc/schemas.ts
+++ b/app/renderer/src/lib/rpc/schemas.ts
@@ -1039,6 +1039,80 @@ export interface SavedRecipe {
   steps: RecipeStep[];
 }
 
+// ---- C14 social publish / schedule ----------------------------------------
+//
+// Field names are FROZEN and identical to the Python side
+// (`features/social_publish.py`, `features/social_queue.py`) — the §17 house rule.
+// See `docs/wiring/WIRING-social-publish.md` for the per-platform feasibility and
+// the sources behind each capability flag.
+
+/**
+ * What ONE platform permits a LOCAL desktop app to do. Every flag is a documented
+ * platform rule, not a Reframe policy, so the UI reads this instead of guessing —
+ * two of the four platforms cannot publish to a personal account at all.
+ */
+export interface SocialCapability {
+  id: string;
+  label: string;
+  /** `false` iff `blockedReason` is set — publishing is impossible, not merely unwired. */
+  publishable: boolean;
+  personalAccount: boolean;
+  desktopLoopbackOauth: boolean;
+  /** Whether the PLATFORM can hold a future publish time (survives a powered-off box). */
+  nativeScheduling: boolean;
+  /** How far out the platform accepts a schedule, or `null` when it documents no cap. */
+  nativeScheduleMaxSec: number | null;
+  requiresClientSecret: boolean;
+  /** What an app that has not passed the platform's audit/review is limited to. */
+  unauditedVisibility: string;
+  docUrl: string;
+  blockedReason: string | null;
+}
+
+/** Where a publish time will be held, plus what the user must be told about it. */
+export interface SocialSchedulePlan {
+  platform: string;
+  /** `immediate` | `platform` | `local-queue`. */
+  kind: string;
+  publishAt: number | null;
+  /**
+   * True only for `local-queue`: Reframe itself must be running at `publishAt`,
+   * because the platform has no scheduling API to hand the time to. Always render
+   * `warning` when this is set — a desktop app cannot publish while the machine is
+   * off, and implying otherwise is the lie this flag exists to prevent.
+   */
+  requiresAppRunning: boolean;
+  warning: string;
+  unauditedVisibility: string;
+}
+
+/** A queued publish. Carries NO credential — tokens live only in the main process. */
+export interface SocialQueueEntry {
+  id: string;
+  platform: string;
+  videoId: string;
+  clipPath: string;
+  title: string;
+  description: string;
+  publishAt: number | null;
+  kind: string;
+  requiresAppRunning: boolean;
+  /** `pending` | `publishing` | `done` | `failed` | `cancelled`. */
+  status: string;
+  createdAt: number;
+  error: string;
+}
+
+/** The publish request `social.enqueue` accepts (the server assigns id/status). */
+export interface SocialPublishJob {
+  platform: string;
+  clipPath: string;
+  title: string;
+  description?: string;
+  videoId?: string;
+  publishAt?: number | null;
+}
+
 // ---- Repurpose bundle (WU11) — field names identical to the sidecar -------
 //
 // Wire schemas for the `exportPresets.*` / `templates.*` / `batch.*` groups

--- a/app/renderer/src/views/Deliver.test.tsx
+++ b/app/renderer/src/views/Deliver.test.tsx
@@ -20,6 +20,11 @@ vi.mock('../features/NleExport', () => ({
     <div data-stub="nle-export" data-video={videoId} />
   ),
 }));
+vi.mock('../features/SocialPublishPanel', () => ({
+  SocialPublishPanel: ({ videoId }: { videoId: string }) => (
+    <div data-stub="social-publish" data-video={videoId} />
+  ),
+}));
 
 const VIDEO: Video = {
   id: 'v1',
@@ -79,6 +84,19 @@ describe('Deliver view', () => {
     clickTab('Platform presets');
     expect(q('[data-stub="export-presets"]')).not.toBeNull();
     expect(q('[data-stub="batch-queue"]')).toBeNull();
+  });
+
+  it('switches to the C14 Publish panel and passes the open video for provenance', () => {
+    render(VIDEO);
+    clickTab('Publish');
+    expect(q('[data-stub="social-publish"]')?.getAttribute('data-video')).toBe('v1');
+    expect(q('[data-stub="batch-queue"]')).toBeNull();
+  });
+
+  it('still shows Publish with no video open (a clip can be published standalone)', () => {
+    render(null);
+    clickTab('Publish');
+    expect(q('[data-stub="social-publish"]')?.getAttribute('data-video')).toBe('');
   });
 
   it('hands the open video off to the pro-editor export', () => {

--- a/app/renderer/src/views/Deliver.tsx
+++ b/app/renderer/src/views/Deliver.tsx
@@ -14,12 +14,16 @@ import { TabBar, tabId, tabPanelId, type TabDef } from '../components/TabBar';
 import { BatchQueue } from '../features/BatchQueue';
 import { ExportPresetsPanel } from '../features/ExportPresetsPanel';
 import { NleExport } from '../features/NleExport';
+import { SocialPublishPanel } from '../features/SocialPublishPanel';
 import type { Video } from '../lib/rpc';
 import './deliver.css';
 
 const TABS: TabDef[] = [
   { id: 'batch', label: 'Batch publish' },
   { id: 'presets', label: 'Platform presets' },
+  // C14: direct publish / scheduling. Sits beside "Platform presets" deliberately —
+  // the presets produce the platform-shaped file, this sends it.
+  { id: 'publish', label: 'Publish' },
   { id: 'handoff', label: 'Pro handoff' },
 ];
 
@@ -70,6 +74,7 @@ export function Deliver({ video, onBack }: DeliverProps): React.ReactElement {
       >
         {active === 'batch' ? <BatchQueue /> : null}
         {active === 'presets' ? <ExportPresetsPanel /> : null}
+        {active === 'publish' ? <SocialPublishPanel videoId={video?.id ?? ''} /> : null}
         {active === 'handoff' ? (
           video ? (
             <NleExport videoId={video.id} />

--- a/app/vitest.config.ts
+++ b/app/vitest.config.ts
@@ -41,12 +41,21 @@ export default defineConfig({
       reporter: ['text', 'text-summary'],
       // The renderer is fully gated. WU-U2 also promotes the P0 auto-update
       // AUTHENTICITY verifier + its wiring into the 100% bar: `main/**` otherwise
-      // runs its tests but is NOT threshold-gated, and these two files are
+      // runs its tests but is NOT threshold-gated, and these files are
       // security-critical and fully unit-testable via injected fakes, so they must
       // never silently regress below full branch coverage. The rest of `main/**`
       // (BrowserWindow/IPC bootstrap that needs a real runtime) stays ungated.
+      //
+      // C14 adds `main/socialAuth.ts` on the SAME rationale, and it is the strongest
+      // case yet: it is pure string work over injected randomness/hashing (so it
+      // needs no Electron runtime at all), and every branch in it is a security
+      // decision — the loopback guard that keeps an OAuth authorization code from
+      // being delivered off-box, the constant-time CSRF state compare, and the rule
+      // that the client secret never reaches the browser-bound authorize URL. An
+      // uncovered branch here is an unreviewed way to leak an account.
       include: [
         'renderer/src/**/*.{ts,tsx}',
+        'main/socialAuth.ts',
         'main/updateVerify.ts',
         'main/updater.ts',
       ],

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -135,6 +135,7 @@ so the ids survive the move out of the repo root; this entry is how they stay fi
 | [`wiring/WIRING-T1.md`](wiring/WIRING-T1.md) | timeline subtitle editor |
 | [`wiring/WIRING-T2.md`](wiring/WIRING-T2.md) · [`T3`](wiring/WIRING-T3.md) · [`T4A`](wiring/WIRING-T4A.md) · [`T4B`](wiring/WIRING-T4B.md) · [`T5`](wiring/WIRING-T5.md) | the remaining T-lane unit contracts |
 | [`wiring/WIRING-U1.md`](wiring/WIRING-U1.md) · [`U2`](wiring/WIRING-U2.md) · [`U3`](wiring/WIRING-U3.md) · [`U4`](wiring/WIRING-U4.md) · [`U5`](wiring/WIRING-U5.md) | the U-lane unit contracts |
+| [`wiring/WIRING-social-publish.md`](wiring/WIRING-social-publish.md) | C14 direct publish / scheduling: the per-platform feasibility table with sources (two of four platforms cannot publish to a personal account at all), the no-new-secret-store rule, the residuals, and the owner actions |
 
 ## Evidence and measurement
 

--- a/docs/wiring/WIRING-social-publish.md
+++ b/docs/wiring/WIRING-social-publish.md
@@ -126,6 +126,15 @@ means each user's quota and audit state is their own.
   pure and fully unit-tested — but nothing here opens a socket yet.
 - **The uploaders.** No YouTube resumable upload and no TikTok publish call is
   implemented, so `social.enqueue` records an intent that nothing yet performs.
+- **The token INJECTION path is not wired.** The field name is reserved
+  (`social_queue.INJECTED_TOKENS_FIELD` = `_injectedSocialTokens`) and the sidecar's
+  log redactor already strips it, but `keyBridge.forwardParams` does not yet inject a
+  social token into any method — deliberately, because no sidecar handler performs an
+  upload, and injecting a credential into a method that has no use for it is the
+  opposite of least privilege. The reservation exists so the redactor is ready before
+  the first producer, not to imply a live path.
+- **A local scheduler RUNNER.** `PublishQueueStore.due()` computes which local-queue
+  entries are ready, but no timer calls it yet.
 - **A real OAuth round-trip has NOT been performed** (NOT-CHECKED): it requires a
   registered OAuth app, which is an owner action. Nothing in this feature has been
   proven end-to-end against a live platform, and no claim here should be read as

--- a/docs/wiring/WIRING-social-publish.md
+++ b/docs/wiring/WIRING-social-publish.md
@@ -1,0 +1,153 @@
+# WIRING-social-publish — C14 direct publish / scheduling to social platforms
+
+> **Status:** ACTIVE
+
+C14 was originally declined in [`../plans/v1.5/competitor-research.md`](../plans/v1.5/competitor-research.md)
+(line 23: *"social scheduler/publish (needs cloud/OAuth → at most 'platform-ready export presets')"*),
+and the substitute shipped: `sidecar/media_studio/features/export_presets.py` plus
+`app/renderer/src/features/ExportPresetsPanel.tsx`. The owner overruled that decision, so C14 is
+being built **on top of** the preset catalog rather than around it.
+
+This document is the honest scope record: what each platform actually permits a
+local desktop app to do, what is built, what is not built, and what only the owner
+can do.
+
+---
+
+## 1. Per-platform feasibility (read from the platforms' own docs, 2026-08-08)
+
+Reframe is a **local desktop app with no server and no public domain**. That single
+constraint decides most of the table. Every row below is encoded as data in
+`sidecar/media_studio/features/social_publish.py` (`CAPABILITIES`) with its source
+URL attached, so the UI cannot offer a publish the platform would refuse.
+
+| platform | personal account? | desktop loopback OAuth? | scheduling | verdict |
+|---|---|---|---|---|
+| **YouTube** | yes (personal channel) | yes — `http://127.0.0.1:<port>` + PKCE S256 | **native** (`status.publishAt`) | VIABLE-WITH-OWNER-ACTION |
+| **TikTok** | yes | yes — desktop config allows only `localhost`/`127.0.0.1`, PKCE **required** | **none** — API has no scheduling parameter | VIABLE-WITH-OWNER-ACTION |
+| **Instagram Reels** | **NO** | no | none | **NOT VIABLE** |
+| **Facebook** | **NO** (personal timeline) / yes for a **Page** | no | native for a Page (`scheduled_publish_time`) | Page-only, needs a hosted callback |
+
+Sources (each fetched directly):
+
+- YouTube upload + audit restriction — <https://developers.google.com/youtube/v3/docs/videos/insert>
+  ("All videos uploaded via the `videos.insert` endpoint from unverified API projects
+  created after 28 July 2020 will be restricted to private viewing mode.")
+- Google installed-app OAuth — <https://developers.google.com/identity/protocols/oauth2/native-app>
+  (loopback `http://127.0.0.1:port` / `http://[::1]:port` for desktop; PKCE S256
+  supported; the copy/paste **OOB** redirect "is no longer supported").
+- TikTok Content Posting audit rule — <https://developers.tiktok.com/doc/content-posting-api-get-started>
+  ("All content posted by unaudited clients will be restricted to private viewing mode.")
+- TikTok **desktop** login — <https://developers.tiktok.com/doc/login-kit-desktop>
+  ("Only `localhost` or loopback IP `127.0.0.1` are allowed host names in URI";
+  "TikTok requires the Proof Key for Code Exchange (PKCE) protocol for desktop apps.")
+  **This corrects the obvious assumption**: it is the *web* config
+  (<https://developers.tiktok.com/doc/login-kit-web>) that requires `https`, and
+  reading only that page would wrongly rule TikTok out for a desktop app.
+- Instagram account-type requirement — <https://developers.facebook.com/docs/instagram-platform/overview>
+  ("To use the APIs, your app users must have an **Instagram professional account**.")
+  A personal/consumer account is not served by the API at all, so this is an
+  account setting the user changes in the Instagram app — not something Reframe can
+  engineer around. Content publishing additionally expires an unpublished media
+  container after 24 h and caps publishing at 100 posts / 24 h
+  (<https://developers.facebook.com/docs/instagram-platform/content-publishing>).
+- Facebook personal-timeline publishing — the `publish_actions` permission was
+  **removed on 2018-04-24** and is not granted to new apps, so posting to a user's
+  own profile via the API is no longer possible. Page posts DO support
+  `published=false` + `scheduled_publish_time`, bounded to "between 10 minutes and
+  30 days from the time of the API request"
+  (<https://developers.facebook.com/docs/pages-api/posts>).
+
+### Why Instagram and Facebook get no stub
+
+`instagram_reels` is present in the capability matrix **only** as a blocked row
+carrying its reason, and `facebook_timeline` does not exist at all. Neither has an
+entry in `app/main/socialAuth.ts` `OAUTH_ENDPOINTS`, because Meta's login does not
+offer a loopback desktop redirect. Shipping endpoint constants we cannot complete
+would be a stub that lies about being wired.
+
+---
+
+## 2. Scheduling honesty (the part a desktop app usually gets wrong)
+
+A local app is **off when the machine is off**. `plan_schedule` therefore:
+
+1. prefers handing a future publish time to the **platform** whenever the platform
+   can hold it (YouTube `publishAt`, Facebook Page `scheduled_publish_time`) — that
+   survives a powered-off laptop;
+2. falls back to a **local queue** only when the platform has no scheduling API
+   (TikTok), or when the requested time is beyond the platform's own documented
+   horizon (Facebook's 30 days);
+3. makes the fallback's disclosure structural: a `local-queue` plan always carries
+   `requiresAppRunning: true` plus the verbatim `LOCAL_QUEUE_WARNING`, so a caller
+   cannot render it without also receiving the sentence that says the post goes out
+   when Reframe next runs, not at the chosen time.
+
+`PublishQueueStore.due()` deliberately **excludes** platform-held rows, so a
+natively-scheduled post is never also published by the local runner (a double-post).
+
+---
+
+## 3. Credentials — no new secret store
+
+Social OAuth tokens live in the **existing** keystore, `app/main/keystore.ts`
+(`safeStorage` → DPAPI/Keychain/libsecret), in a new `social` section of
+`secure-keys.json`. No second store was introduced, no token is ever written to
+`settings.json`, a log, a manifest, or the publish queue.
+
+Two structural guarantees, each with a regression test:
+
+- **The queue cannot hold a token.** A queue entry is assembled from the
+  `ENTRY_FIELDS` **allowlist**, so an unrecognised (possibly secret-bearing) field
+  cannot be persisted at all — `social_queue.py`, and the test that scans the
+  persisted bytes in `sidecar/tests/test_social_queue.py`.
+- **A provider write cannot wipe a social token.** `saveDecryptedKeys` REBUILDS the
+  whole keystore document, so any section a caller forgets to copy forward is erased
+  on the next write. `keyBridge.ts` funnels every non-provider section through one
+  `withNonProviderSections` helper, replacing three inline ternaries where adding a
+  second section would have silently destroyed it. Both directions are pinned in
+  `app/main/socialTokens.test.ts`.
+
+### Bring-your-own OAuth app
+
+Every one of these platforms requires a **client secret** at the token exchange, and
+a distributed desktop binary cannot embed a confidential secret (anyone can extract
+it from the download). So Reframe does not ship credentials: the user registers
+their own OAuth app and supplies its client id / secret, which are stored in the
+same keystore. This is the only honest arrangement for a local app, and it also
+means each user's quota and audit state is their own.
+
+---
+
+## 4. What is NOT built (residuals)
+
+- **The loopback HTTP listener and the live token exchange.** `socialAuth.ts` provides
+  the PKCE pair, the authorize URL, the callback parse, and the exchange body — all
+  pure and fully unit-tested — but nothing here opens a socket yet.
+- **The uploaders.** No YouTube resumable upload and no TikTok publish call is
+  implemented, so `social.enqueue` records an intent that nothing yet performs.
+- **A real OAuth round-trip has NOT been performed** (NOT-CHECKED): it requires a
+  registered OAuth app, which is an owner action. Nothing in this feature has been
+  proven end-to-end against a live platform, and no claim here should be read as
+  saying otherwise.
+
+---
+
+## 5. OWNER ACTIONS (only the owner can do these)
+
+1. **YouTube** — create a Google Cloud project, enable the YouTube Data API v3,
+   create an OAuth client of type **Desktop app**, and (to lift the forced-private
+   restriction) submit the project for YouTube's **API audit**. Until the audit
+   passes, every upload is private.
+2. **TikTok** — register a TikTok developer app, add the **Content Posting API** and
+   **Login Kit** products, configure a `http://127.0.0.1:*/oauth/callback` desktop
+   redirect, request the `video.publish` scope, and submit the app for **audit**.
+   Until audited, all posts are `SELF_ONLY`.
+3. **Instagram** (optional, and only if wanted) — convert the Instagram account to a
+   **professional** (Business or Creator) account, then create a Meta app and pass
+   **App Review** for `instagram_content_publish`. Reframe still cannot host the
+   https callback Meta requires, so this needs a hosted redirect the owner runs.
+4. **Facebook Page** (optional) — create a Meta app and pass **App Review** for
+   `pages_manage_posts`; same hosted-callback requirement.
+5. **Decide whether the Meta platforms are worth a hosted callback at all.** If not,
+   YouTube + TikTok are the two Reframe can support purely locally.

--- a/sidecar/media_studio/features/social_publish.py
+++ b/sidecar/media_studio/features/social_publish.py
@@ -48,10 +48,17 @@ fallback carries an explicit ``requires_app_running`` flag plus a warning string
 the UI is expected to show verbatim. The flag is the mechanism: a caller cannot
 render a local-queue plan without also receiving the disclosure.
 
-Pure logic only — no network, no provider imports, no token handling. Tokens for
-these platforms live exclusively in the Electron main process keystore
-(``app/main/keystore.ts``) and are injected per-request; nothing here reads,
-writes, or logs credential material.
+Pure logic only — no network, no provider imports, no token handling. Nothing here
+reads, writes, or logs credential material.
+
+Where tokens live, stated precisely so this comment does not drift into a claim it
+does not support: OAuth tokens are stored in the Electron main-process keystore
+(``app/main/keystore.ts``, ``social`` section). The per-request injection channel
+that provider API keys use is the intended route for handing a token to a future
+uploader, and the field name is reserved
+(``social_queue.INJECTED_TOKENS_FIELD``) and already covered by the log redactor —
+but **no injection path is wired yet, because nothing on this side performs an
+upload**. See ``docs/wiring/WIRING-social-publish.md`` §4 for the full residual list.
 """
 
 from __future__ import annotations

--- a/sidecar/media_studio/features/social_publish.py
+++ b/sidecar/media_studio/features/social_publish.py
@@ -1,0 +1,336 @@
+"""Social publish / schedule (C14) — the per-platform capability matrix.
+
+WHY THIS MODULE IS A MATRIX AND NOT FOUR UPLOADERS
+--------------------------------------------------
+C14 asks for "direct publish / scheduling to social platforms" from Reframe — a
+LOCAL desktop app with no server and no public domain. The four target platforms
+differ sharply in what that actually permits, and **two of the four cannot publish
+to a PERSONAL account at all**. Encoding that as data (rather than discovering it
+at runtime as a 400) is what keeps the UI from offering a publish the platform
+would refuse.
+
+Every row was read off the platform's own current documentation on 2026-08-08; the
+``doc_url`` rides with the row so a future reader can re-check it rather than trust
+this comment. The four findings, each with the fact that decided it:
+
+* **YouTube — PUBLISHABLE, schedules natively.** ``videos.insert`` uploads to a
+  personal channel, Google's installed-app flow accepts a ``http://127.0.0.1:<port>``
+  loopback redirect with PKCE S256 (the copy/paste "OOB" flow is retired), and
+  ``status.publishAt`` lets the PLATFORM hold a future publish. Caveat that ships
+  in the row: uploads from an **unverified** API project created after 2020-07-28
+  are forced to private until the project passes an audit.
+* **TikTok — PUBLISHABLE, cannot schedule.** Contrary to the obvious assumption,
+  TikTok DOES document a desktop flow whose redirect host may only be ``localhost``
+  or ``127.0.0.1`` and for which PKCE S256 is REQUIRED (it is the *web* config that
+  demands an ``https`` URI). But the Content Posting API has no scheduling
+  parameter at all, and an **unaudited** client is restricted to private
+  (``SELF_ONLY``) visibility.
+* **Instagram Reels — NOT PUBLISHABLE from a personal account.** The Instagram
+  Platform API states plainly that an app user must have an Instagram
+  *professional* account (Business or Creator); a personal/consumer account is not
+  served by the API at all. This is a property of the ACCOUNT, not of our app, so
+  no amount of local engineering unblocks it — hence a ``blocked_reason`` rather
+  than a stub uploader.
+* **Facebook — a PAGE only, never a personal timeline.** The ``publish_actions``
+  permission that allowed posting to a user's own profile was removed on
+  2018-04-24 and is not granted to new apps, so there is deliberately NO
+  ``facebook_timeline`` row. Publishing to a Page the user administers IS
+  supported and schedules natively (``published=false`` +
+  ``scheduled_publish_time``), bounded to 30 days out.
+
+HONESTY ABOUT SCHEDULING (the part a desktop app usually lies about)
+--------------------------------------------------------------------
+A local app is OFF when the machine is off, so a purely local scheduler cannot
+honour "post at 09:00 tomorrow" if the laptop is shut. :func:`plan_schedule`
+therefore always prefers handing the future time to the PLATFORM when the platform
+can hold it, and only falls back to a local queue when it cannot — and that
+fallback carries an explicit ``requires_app_running`` flag plus a warning string
+the UI is expected to show verbatim. The flag is the mechanism: a caller cannot
+render a local-queue plan without also receiving the disclosure.
+
+Pure logic only — no network, no provider imports, no token handling. Tokens for
+these platforms live exclusively in the Electron main process keystore
+(``app/main/keystore.ts``) and are injected per-request; nothing here reads,
+writes, or logs credential material.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..protocol import ErrorCode, RpcError
+
+#: Seconds in 30 days — the documented outer bound on a Facebook Page's
+#: ``scheduled_publish_time`` ("between 10 minutes and 30 days from the time of
+#: the API request").
+_FACEBOOK_SCHEDULE_MAX_SEC = 30 * 24 * 60 * 60
+
+#: The plan kinds :func:`plan_schedule` can return.
+KIND_IMMEDIATE = "immediate"
+KIND_PLATFORM = "platform"
+KIND_LOCAL_QUEUE = "local-queue"
+
+#: The verbatim disclosure a local-queue plan carries. A desktop app is not a
+#: server: this text is the whole reason :class:`SchedulePlan` has a warning field.
+LOCAL_QUEUE_WARNING = (
+    "This platform's API cannot hold a scheduled post, so Reframe will publish it "
+    "from this computer at the chosen time. Reframe must be running then — if the "
+    "computer is asleep, shut down, or offline, the post is sent when Reframe next "
+    "runs, not at the time you picked."
+)
+
+
+@dataclass(frozen=True)
+class PlatformCapability:
+    """What ONE platform actually permits a local desktop app to do.
+
+    Every boolean here is a documented platform rule, not a Reframe policy, so a
+    ``False`` cannot be engineered away on our side — it can only change when the
+    platform changes (which is what ``doc_url`` is for).
+    """
+
+    #: Stable wire id (also the settings/queue key).
+    id: str
+    #: Human label for the UI.
+    label: str
+    #: Whether this app can publish here AT ALL. ``False`` iff ``blocked_reason``.
+    publishable: bool
+    #: Whether a PERSONAL (non-professional, non-Page) account can be published to.
+    personal_account: bool
+    #: Whether the platform's OAuth accepts a loopback redirect for a desktop app.
+    desktop_loopback_oauth: bool
+    #: Whether the PLATFORM can hold a future publish time (survives a powered-off
+    #: machine). When ``False`` a future time can only ride the local queue.
+    native_scheduling: bool
+    #: How far out the platform will accept a scheduled time, in seconds; ``None``
+    #: when the platform documents no cap.
+    #:
+    #: UNVERIFIED (youtube): YouTube's ``status.publishAt`` reference states no
+    #: maximum horizon, so this is ``None`` rather than a number invented here. A
+    #: future publishAt further out than YouTube silently tolerates would surface
+    #: as an API error, not as a wrong local decision. SETTLING EXPERIMENT: submit
+    #: a ``publishAt`` several years out against a real audited project and record
+    #: the accepted bound.
+    native_schedule_max_sec: int | None
+    #: Whether the token exchange requires a client secret. ``True`` everywhere
+    #: here, which is precisely why Reframe uses a bring-your-own-OAuth-app model
+    #: (see the module note in ``docs/wiring/WIRING-social-publish.md``): a
+    #: DISTRIBUTED desktop binary cannot embed a confidential client secret.
+    requires_client_secret: bool
+    #: What an app that has NOT passed the platform's review/audit is limited to.
+    #: Surfaced before the first publish so the restriction is never a surprise.
+    unaudited_visibility: str
+    #: The documentation page this row was read from.
+    doc_url: str
+    #: WHY publishing is impossible, or ``None`` when it is possible.
+    blocked_reason: str | None
+
+
+CAPABILITIES: dict[str, PlatformCapability] = {
+    "youtube": PlatformCapability(
+        id="youtube",
+        label="YouTube",
+        publishable=True,
+        personal_account=True,
+        desktop_loopback_oauth=True,
+        native_scheduling=True,
+        native_schedule_max_sec=None,
+        requires_client_secret=True,
+        unaudited_visibility=(
+            "Until your Google Cloud project passes YouTube's API audit, every video "
+            "uploaded through it is forced to PRIVATE. Uploads still succeed; only "
+            "the visibility is capped."
+        ),
+        doc_url="https://developers.google.com/youtube/v3/docs/videos/insert",
+        blocked_reason=None,
+    ),
+    "tiktok": PlatformCapability(
+        id="tiktok",
+        label="TikTok",
+        publishable=True,
+        personal_account=True,
+        desktop_loopback_oauth=True,
+        native_scheduling=False,
+        native_schedule_max_sec=None,
+        requires_client_secret=True,
+        unaudited_visibility=(
+            "Until your TikTok app passes TikTok's audit, all content it posts is "
+            "restricted to private (SELF_ONLY) viewing."
+        ),
+        doc_url="https://developers.tiktok.com/doc/content-posting-api-get-started",
+        blocked_reason=None,
+    ),
+    "instagram_reels": PlatformCapability(
+        id="instagram_reels",
+        label="Instagram Reels",
+        publishable=False,
+        personal_account=False,
+        desktop_loopback_oauth=False,
+        native_scheduling=False,
+        native_schedule_max_sec=None,
+        requires_client_secret=True,
+        unaudited_visibility=(
+            "Publishing needs Advanced Access to instagram_content_publish, which requires Meta App Review."
+        ),
+        doc_url="https://developers.facebook.com/docs/instagram-platform/overview",
+        blocked_reason=(
+            "Instagram's API only serves an Instagram PROFESSIONAL account (Business "
+            "or Creator). A personal Instagram account cannot be published to through "
+            "any API, so Reframe cannot post Reels for you. Converting the account to "
+            "a professional one in the Instagram app is what unblocks this — it is an "
+            "account setting, not something Reframe can work around."
+        ),
+    ),
+    "facebook_page": PlatformCapability(
+        id="facebook_page",
+        label="Facebook Page",
+        publishable=True,
+        # A Page is administered BY a personal account but is not itself one; the
+        # personal TIMELINE has been unpublishable since publish_actions was removed
+        # on 2018-04-24, which is why there is no facebook_timeline row at all.
+        personal_account=False,
+        desktop_loopback_oauth=False,
+        native_scheduling=True,
+        native_schedule_max_sec=_FACEBOOK_SCHEDULE_MAX_SEC,
+        requires_client_secret=True,
+        unaudited_visibility=(
+            "Publishing needs Advanced Access to pages_manage_posts, which requires "
+            "Meta App Review. Before review, only accounts with a role on the app "
+            "(admin / developer / tester) can publish."
+        ),
+        doc_url="https://developers.facebook.com/docs/pages-api/posts",
+        blocked_reason=None,
+    ),
+}
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def capability(platform_id: Any) -> PlatformCapability:
+    """The :class:`PlatformCapability` for ``platform_id``.
+
+    Fails loud on anything unknown rather than defaulting: a typo'd platform must
+    never silently resolve to a row whose rules do not apply to it.
+    """
+    if not isinstance(platform_id, str) or platform_id not in CAPABILITIES:
+        known = ", ".join(sorted(CAPABILITIES))
+        raise _invalid(f"unknown social platform: {platform_id!r} (known: {known})")
+    return CAPABILITIES[platform_id]
+
+
+def _as_row(cap: PlatformCapability) -> dict[str, Any]:
+    """Render one capability as the frozen camelCase wire row."""
+    return {
+        "id": cap.id,
+        "label": cap.label,
+        "publishable": cap.publishable,
+        "personalAccount": cap.personal_account,
+        "desktopLoopbackOauth": cap.desktop_loopback_oauth,
+        "nativeScheduling": cap.native_scheduling,
+        "nativeScheduleMaxSec": cap.native_schedule_max_sec,
+        "requiresClientSecret": cap.requires_client_secret,
+        "unauditedVisibility": cap.unaudited_visibility,
+        "docUrl": cap.doc_url,
+        "blockedReason": cap.blocked_reason,
+    }
+
+
+def describe_capabilities() -> list[dict[str, Any]]:
+    """The whole matrix as id-sorted JSON rows (stable UI order)."""
+    return [_as_row(CAPABILITIES[key]) for key in sorted(CAPABILITIES)]
+
+
+@dataclass(frozen=True)
+class SchedulePlan:
+    """WHERE a publish time will be held, and what the user must be told.
+
+    ``requires_app_running`` exists so the disclosure is structural: a caller
+    cannot obtain a local-queue plan without also receiving the flag and the
+    ``warning`` text that explains a desktop app cannot publish while off.
+    """
+
+    platform: str
+    #: One of :data:`KIND_IMMEDIATE` / :data:`KIND_PLATFORM` / :data:`KIND_LOCAL_QUEUE`.
+    kind: str
+    #: The requested epoch-seconds publish time, or ``None`` for an immediate post.
+    publish_at: float | None
+    #: True only when Reframe itself must be running at ``publish_at``.
+    requires_app_running: bool
+    #: Verbatim user-facing disclosure; ``""`` when there is nothing to disclose.
+    warning: str
+    #: The platform's pre-audit visibility cap, echoed so the UI can show it once.
+    unaudited_visibility: str
+
+
+def _validated_publish_at(publish_at: Any, now: float) -> float:
+    """Coerce + guard a requested publish time into future epoch seconds."""
+    # bool is an int subclass; reject it explicitly so True cannot pose as a time.
+    if isinstance(publish_at, bool) or not isinstance(publish_at, (int, float)):
+        raise _invalid("publishAt must be epoch seconds (a number) or null")
+    moment = float(publish_at)
+    if moment <= now:
+        raise _invalid("publishAt is in the past; pick a future time or publish now")
+    return moment
+
+
+def _holds_natively(cap: PlatformCapability, publish_at: float, now: float) -> bool:
+    """Whether the PLATFORM can hold ``publish_at`` itself.
+
+    False when the platform has no scheduling API at all, and also when the
+    requested time is past the horizon the platform documents — handing an API a
+    time it will reject is worse than queueing locally and saying so.
+    """
+    if not cap.native_scheduling:
+        return False
+    horizon = cap.native_schedule_max_sec
+    return horizon is None or publish_at <= now + horizon
+
+
+def plan_schedule(platform_id: Any, publish_at: Any, *, now: float) -> SchedulePlan:
+    """Decide where a publish time is held, refusing what the platform cannot do.
+
+    ``publish_at`` is epoch seconds, or ``None`` for "publish now". ``now`` is
+    injected (never read from the clock here) so the decision is a pure function
+    and the boundary cases are unit-pinnable.
+
+    Raises :class:`RpcError` (INVALID_PARAMS) for an unknown platform, a platform
+    that cannot be published to at all, or a non-numeric / past time — always
+    BEFORE any queue write, so a refused request leaves no partial state.
+    """
+    cap = capability(platform_id)
+    if not cap.publishable:
+        # blocked_reason is non-None whenever publishable is False (both are set
+        # together per row), so this surfaces the platform's own reason verbatim.
+        raise _invalid(cap.blocked_reason or f"{cap.label} cannot be published to")
+
+    if publish_at is None:
+        return SchedulePlan(
+            platform=cap.id,
+            kind=KIND_IMMEDIATE,
+            publish_at=None,
+            requires_app_running=False,
+            warning="",
+            unaudited_visibility=cap.unaudited_visibility,
+        )
+
+    moment = _validated_publish_at(publish_at, now)
+    if _holds_natively(cap, moment, now):
+        return SchedulePlan(
+            platform=cap.id,
+            kind=KIND_PLATFORM,
+            publish_at=moment,
+            requires_app_running=False,
+            warning="",
+            unaudited_visibility=cap.unaudited_visibility,
+        )
+    return SchedulePlan(
+        platform=cap.id,
+        kind=KIND_LOCAL_QUEUE,
+        publish_at=moment,
+        requires_app_running=True,
+        warning=LOCAL_QUEUE_WARNING,
+        unaudited_visibility=cap.unaudited_visibility,
+    )

--- a/sidecar/media_studio/features/social_queue.py
+++ b/sidecar/media_studio/features/social_queue.py
@@ -1,0 +1,316 @@
+"""Social publish QUEUE + the ``social.*`` RPC group (C14).
+
+The durable record of what Reframe has been asked to publish, stored as one JSON
+document under the data root and written atomically (temp + ``os.replace``), so a
+crash mid-write can never truncate the queue. Storage + pure logic only: no
+network, no provider imports, and — deliberately — no credential handling at all.
+
+THE NO-TOKEN-AT-REST INVARIANT (why the entry shape is an ALLOWLIST)
+-------------------------------------------------------------------
+OAuth tokens for these platforms live ONLY in the Electron main-process keystore
+(``app/main/keystore.ts``, DPAPI/Keychain-wrapped) and are injected per-request
+over the existing stdio JSON-RPC frame, exactly as provider API keys already are.
+This queue file is plain JSON on disk, so a token reaching an entry would be a
+plaintext credential at rest — the precise defect that keystore exists to prevent.
+
+:func:`normalize_job` therefore builds each entry from a fixed field ALLOWLIST
+(:data:`ENTRY_FIELDS`) rather than copying the caller's dict and deleting known
+secret names. A denylist only protects against the secret field names someone
+thought of; an allowlist protects against the one nobody has invented yet, because
+an unrecognised key cannot ride along at all. :func:`is_secret_field` exists for
+the regression that scans the persisted BYTES, so the invariant is asserted
+structurally rather than on one happy path.
+
+REFUSE BEFORE WRITE
+-------------------
+Every guard runs before any filesystem touch, so a rejected enqueue leaves no file
+and no partial row. That matters most for ``instagram_reels``, which
+:mod:`social_publish` marks unpublishable: without the pre-write refusal the queue
+would silently accumulate entries that can never run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .. import protocol
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import get_logger
+from . import social_publish
+
+log = get_logger("media_studio.features.social_queue")
+
+QueueEntry = dict[str, Any]
+
+#: The per-request field name main uses to inject decrypted social tokens
+#: (mirrors ``settings_store.INJECTED_KEYS_FIELD`` for provider keys). Named here
+#: so the strip is enforced at the store boundary as well as at the RPC boundary.
+INJECTED_TOKENS_FIELD = "_injectedSocialTokens"
+
+#: Entry lifecycle. ``publishing`` / ``done`` / ``failed`` are written by the
+#: runner that performs the upload; the store only ever creates ``pending`` and
+#: transitions to ``cancelled``.
+STATUS_PENDING = "pending"
+STATUS_PUBLISHING = "publishing"
+STATUS_DONE = "done"
+STATUS_FAILED = "failed"
+STATUS_CANCELLED = "cancelled"
+
+#: The COMPLETE set of keys a persisted entry may carry. See the module docstring:
+#: this is an allowlist precisely so an unknown (possibly secret-bearing) field
+#: cannot be persisted by accident.
+ENTRY_FIELDS: tuple[str, ...] = (
+    "id",
+    "platform",
+    "videoId",
+    "clipPath",
+    "title",
+    "description",
+    "publishAt",
+    "kind",
+    "requiresAppRunning",
+    "status",
+    "createdAt",
+    "error",
+)
+
+#: Substrings that mark a field name as credential-bearing. Used ONLY by the
+#: structural regression (:func:`is_secret_field`) — the production path relies on
+#: :data:`ENTRY_FIELDS` instead, because a substring denylist is not a security
+#: boundary. Lowercased comparison so ``accessToken`` / ``access_token`` both hit.
+_SECRET_NAME_MARKERS: tuple[str, ...] = ("token", "secret", "password", "credential", "apikey")
+
+
+def is_secret_field(name: str) -> bool:
+    """Whether ``name`` looks credential-bearing (regression helper, not a guard).
+
+    Deliberately generous: it exists so a test can scan the persisted bytes and
+    fail loudly if ANY token-shaped key ever appears, without having to enumerate
+    the field names a future platform might introduce.
+    """
+    lowered = name.replace("_", "").lower()
+    return any(marker in lowered for marker in _SECRET_NAME_MARKERS)
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _require_str(raw: dict[str, Any], key: str) -> str:
+    value = raw.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise _invalid(f"job.{key} (non-empty str) is required")
+    return value.strip()
+
+
+def _optional_str(raw: dict[str, Any], key: str) -> str:
+    """A trimmed optional string; a non-string value is a fail-loud refusal.
+
+    Coercing (``str(value)``) would quietly persist ``"7"`` for a numeric title,
+    so a wrong type is reported instead of normalised away.
+    """
+    value = raw.get(key)
+    if value is None:
+        return ""
+    if not isinstance(value, str):
+        raise _invalid(f"job.{key} must be a str when present")
+    return value.strip()
+
+
+def normalize_job(raw: Any, *, now: float) -> QueueEntry:
+    """Validate a publish request into the frozen :data:`ENTRY_FIELDS` wire shape.
+
+    Runs the platform guard and the schedule plan FIRST, so an unpublishable
+    platform or a past ``publishAt`` raises before the caller ever reaches a write.
+    The resulting entry is assembled key-by-key from the allowlist — the caller's
+    dict is never copied wholesale, so no unexpected (or secret) field survives.
+    """
+    if not isinstance(raw, dict):
+        raise _invalid("job must be an object")
+
+    # capability() + plan_schedule() own the platform/time refusals, including the
+    # blocked-platform reason and the local-vs-platform scheduling decision.
+    plan = social_publish.plan_schedule(raw.get("platform"), raw.get("publishAt"), now=now)
+
+    return {
+        "id": uuid.uuid4().hex[:12],
+        "platform": plan.platform,
+        "videoId": _optional_str(raw, "videoId"),
+        "clipPath": _require_str(raw, "clipPath"),
+        "title": _require_str(raw, "title"),
+        "description": _optional_str(raw, "description"),
+        "publishAt": plan.publish_at,
+        "kind": plan.kind,
+        "requiresAppRunning": plan.requires_app_running,
+        "status": STATUS_PENDING,
+        "createdAt": now,
+        "error": "",
+    }
+
+
+class PublishQueueStore:
+    """A JSON-backed publish queue (atomic temp+rename writes).
+
+    An absent, corrupt, or wrongly-shaped document reads as an EMPTY queue rather
+    than raising: a poisoned file must not brick the Publish panel. Unlike the
+    export-preset catalog there is no reseed — an empty publish queue is a
+    perfectly valid state, so recovering silently loses nothing.
+    """
+
+    def __init__(self, path: str | os.PathLike[str]) -> None:
+        self.path = Path(path)
+
+    def _read(self) -> list[QueueEntry]:
+        if not self.path.exists():
+            return []
+        try:
+            data = json.loads(self.path.read_text(encoding="utf-8"))
+        except (ValueError, OSError) as exc:
+            log.warning("social queue unreadable (%s); treating as empty", exc)
+            return []
+        if not isinstance(data, list):
+            return []
+        return [row for row in data if isinstance(row, dict)]
+
+    def _write(self, entries: list[QueueEntry]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(json.dumps(entries, indent=2, ensure_ascii=False), encoding="utf-8")
+        os.replace(tmp, self.path)
+
+    def list(self) -> list[QueueEntry]:
+        """Every entry, oldest first (insertion order)."""
+        return self._read()
+
+    def enqueue(self, job: Any, *, now: float) -> QueueEntry:
+        """Append a normalized entry and return it.
+
+        Normalization (and every refusal it raises) happens BEFORE the read/write,
+        so a rejected job leaves the queue file exactly as it was — including not
+        creating it at all on a first-ever rejected call.
+        """
+        entry = normalize_job(job, now=now)
+        self._write([*self._read(), entry])
+        return entry
+
+    def cancel(self, entry_id: str) -> bool:
+        """Mark a PENDING entry cancelled. ``False`` when there was nothing to do.
+
+        The row is kept (not deleted) so the panel can still show what was asked
+        for and what became of it. Only ``pending`` is cancellable: an entry the
+        runner already took, finished, failed, or a second cancel of the same row
+        all answer ``False`` rather than rewriting a terminal state.
+        """
+        entries = self._read()
+        changed = False
+        out: list[QueueEntry] = []
+        for entry in entries:
+            if entry.get("id") == entry_id and entry.get("status") == STATUS_PENDING:
+                out.append({**entry, "status": STATUS_CANCELLED})
+                changed = True
+            else:
+                out.append(entry)
+        if changed:
+            self._write(out)
+        return changed
+
+    def due(self, *, now: float) -> list[QueueEntry]:
+        """Pending LOCAL-QUEUE entries whose time has come.
+
+        Deliberately excludes ``kind == "platform"`` rows: those were handed to the
+        platform's own scheduler, so publishing them locally as well would
+        double-post. A row with no ``publishAt`` means "as soon as possible" and is
+        due immediately.
+        """
+        out: list[QueueEntry] = []
+        for entry in self._read():
+            if entry.get("status") != STATUS_PENDING:
+                continue
+            if entry.get("kind") == social_publish.KIND_PLATFORM:
+                continue
+            moment = entry.get("publishAt")
+            if moment is None or float(moment) <= now:
+                out.append(entry)
+        return out
+
+
+def _plan_row(plan: social_publish.SchedulePlan) -> dict[str, Any]:
+    """Render a :class:`~.social_publish.SchedulePlan` as the camelCase wire row."""
+    return {
+        "platform": plan.platform,
+        "kind": plan.kind,
+        "publishAt": plan.publish_at,
+        "requiresAppRunning": plan.requires_app_running,
+        "warning": plan.warning,
+        "unauditedVisibility": plan.unaudited_visibility,
+    }
+
+
+class SocialPublish:
+    """The ``social.*`` handler group — direct-return CRUD over the queue.
+
+    No jobs and no notifications: enqueueing is a storage operation. Performing the
+    upload is a separate concern that needs an injected token, so it deliberately
+    does not live here.
+    """
+
+    def __init__(self, store: PublishQueueStore, clock: Callable[[], float]) -> None:
+        self.store = store
+        self.now = clock
+
+    def capabilities(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``social.capabilities()`` -> ``{platforms:[row]}`` (the honest matrix)."""
+        return {"platforms": social_publish.describe_capabilities()}
+
+    def plan(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``social.plan({platform, publishAt?})`` -> ``{plan}``.
+
+        A PREVIEW seam: the UI calls this while the user is still picking a time so
+        the local-queue disclosure ("Reframe must be running then") can be shown
+        BEFORE anything is committed, not after.
+        """
+        plan = social_publish.plan_schedule(params.get("platform"), params.get("publishAt"), now=self.now())
+        return {"plan": _plan_row(plan)}
+
+    def enqueue(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``social.enqueue({job})`` -> ``{entry}``."""
+        job = params.get("job")
+        if not isinstance(job, dict):
+            raise _invalid("job (object) is required")
+        return {"entry": self.store.enqueue(job, now=self.now())}
+
+    def queue(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``social.queue()`` -> ``{entries:[entry]}``."""
+        return {"entries": self.store.list()}
+
+    def cancel(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``social.cancel({id})`` -> ``{ok}``."""
+        return {"ok": self.store.cancel(_require_str(params, "id"))}
+
+
+def register(
+    *,
+    path: str | os.PathLike[str],
+    clock: Callable[[], float] | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> SocialPublish:
+    """Create a :class:`SocialPublish` over ``path`` and register its five methods.
+
+    ``clock`` and ``register_fn`` default to the wall clock and
+    :func:`protocol.register`; tests inject a frozen clock + a fake registrar so
+    every scheduling boundary is deterministic.
+    """
+    service = SocialPublish(PublishQueueStore(path), clock if clock is not None else time.time)
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("social.capabilities", service.capabilities)
+    reg("social.plan", service.plan)
+    reg("social.enqueue", service.enqueue)
+    reg("social.queue", service.queue)
+    reg("social.cancel", service.cancel)
+    return service

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -442,6 +442,20 @@ def register_all(
         register_fn=reg,
     )
 
+    # social.* (C14): direct publish / scheduling to social platforms. The group is
+    # storage + pure-decision only — the per-platform capability matrix (which of the
+    # four platforms a LOCAL desktop app may publish to at all), the honest
+    # platform-vs-local scheduling decision, and the publish queue at
+    # data_dir/social-queue.json (atomic temp+rename). NO token ever reaches this
+    # side at rest: OAuth tokens live in the main-process keystore and ride the
+    # existing per-request stdio injection, exactly as provider keys do.
+    from ..features import social_queue as _social_queue  # local: import-light
+
+    _social_queue.register(
+        path=svc.data_dir / "social-queue.json",
+        register_fn=reg,
+    )
+
     # templates.* (repurpose WU5): saved multi-source pipelines (a recipe PLUS
     # defaultControls + exportTargets). list/save/delete are direct CRUD; apply
     # runs ONE source through the EXISTING recipe runner after binding steps to

--- a/sidecar/media_studio/models/secrets.py
+++ b/sidecar/media_studio/models/secrets.py
@@ -93,10 +93,27 @@ def scrub_error_body(text: str, keys: Sequence[str]) -> str:
 #: ``apiKey`` (providers.testKey), ``apiKeys`` (providers.upsert pool), and the
 #: legacy single ``cloudApiKey`` are the key-bearing param names in §2;
 #: ``_injectedKeys`` (WU-D2b-2) is the DPAPI-decrypted key bundle main injects on
-#: provider-calling methods — the composition root pops it BEFORE dispatch logs
-#: or records params, and listing it here is the belt-and-suspenders guarantee
-#: that ANY diagnostic that ever sees it strips it wholesale.
-_SECRET_PARAM_FIELDS: tuple[str, ...] = ("apiKey", "apiKeys", "cloudApiKey", "_injectedKeys")
+#: provider-calling methods, and ``_injectedSocialTokens`` (C14) is its exact
+#: analogue for social-platform OAuth tokens — the composition root pops each
+#: BEFORE dispatch logs or records params, and listing them here is the
+#: belt-and-suspenders guarantee that ANY diagnostic that ever sees one strips it
+#: wholesale.
+#:
+#: Both injected names are spelled as LITERALS rather than imported from their
+#: defining modules (``settings_store.INJECTED_KEYS_FIELD`` /
+#: ``features.social_queue.INJECTED_TOKENS_FIELD``): ``settings_store`` imports
+#: :func:`redact` from THIS module, so importing back would be a cycle, and a
+#: ``models`` module must not depend on ``features`` either. The duplication is
+#: therefore structural, not sloppiness — and because a silent drift here would
+#: un-redact a live credential, ``test_secrets.py`` pins both spellings against
+#: their defining constants so a rename cannot land on one side only.
+_SECRET_PARAM_FIELDS: tuple[str, ...] = (
+    "apiKey",
+    "apiKeys",
+    "cloudApiKey",
+    "_injectedKeys",
+    "_injectedSocialTokens",
+)
 
 
 def _redact_secret_fields(entry: dict[str, Any]) -> dict[str, Any]:

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -119,6 +119,14 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         "shorts.reexport",
         "shorts.thumbnail",
         "silence.trim",
+        # C14 social publish/schedule: the capability matrix + the honest
+        # platform-vs-local schedule preview + publish-queue CRUD. Storage and pure
+        # decisions only — no token ever reaches this side at rest.
+        "social.cancel",
+        "social.capabilities",
+        "social.enqueue",
+        "social.plan",
+        "social.queue",
         "stabilize.run",
         "subtitles.edit",
         "subtitles.export",

--- a/sidecar/tests/test_secrets.py
+++ b/sidecar/tests/test_secrets.py
@@ -229,6 +229,39 @@ def test_redact_params_hides_injected_keys_bundle() -> None:
     assert "sk-live-1234" not in repr(out)
 
 
+def test_every_injected_credential_field_name_is_pinned_to_its_definition() -> None:
+    """The redactor's LITERAL field names must match their defining constants.
+
+    ``_SECRET_PARAM_FIELDS`` cannot import either name (``settings_store`` imports
+    from this module, and a ``models`` module must not import ``features``), so the
+    spellings are duplicated by necessity. A rename on one side only would silently
+    stop redacting a LIVE credential — the exact failure the field was added to
+    prevent — so the parity is asserted here instead of trusted.
+    """
+    from media_studio.features.social_queue import INJECTED_TOKENS_FIELD
+    from media_studio.settings_store import INJECTED_KEYS_FIELD
+
+    assert INJECTED_KEYS_FIELD in secrets._SECRET_PARAM_FIELDS
+    assert INJECTED_TOKENS_FIELD in secrets._SECRET_PARAM_FIELDS
+
+
+def test_redact_params_hides_injected_social_tokens_bundle() -> None:
+    # C14: main injects decrypted OAuth tokens for the social platforms under
+    # `_injectedSocialTokens`, the exact same in-memory stdio channel `_injectedKeys`
+    # already uses. It must be stripped by the SAME redactor — a second injected
+    # credential field that the no-log formatter does not know about would reinstate
+    # the leak `_injectedKeys` was added to close.
+    out = secrets.redact_params(
+        {
+            "job": {"platform": "youtube", "title": "clip"},
+            "_injectedSocialTokens": {"youtube": {"accessToken": "ya29.live-SECRET-9999"}},
+        }
+    )
+    assert out["job"] == {"platform": "youtube", "title": "clip"}  # non-secret preserved
+    assert out["_injectedSocialTokens"] == secrets.REDACTION_PLACEHOLDER
+    assert "ya29.live-SECRET-9999" not in repr(out)
+
+
 def test_redact_params_hides_nested_provider_block() -> None:
     # providers.upsert nests the entry under a "provider" key (providers_ops.py).
     out = secrets.redact_params({"provider": {"id": "groq", "provider": "Groq", "apiKeys": ["gsk-nested-KEY7"]}})

--- a/sidecar/tests/test_social_publish.py
+++ b/sidecar/tests/test_social_publish.py
@@ -1,0 +1,187 @@
+"""Social publish/schedule (C14) — the capability matrix + honest schedule planning.
+
+WHY THESE TESTS EXIST
+---------------------
+C14 ("direct publish / scheduling to social platforms") was originally SKIPPED in
+``docs/plans/v1.5/competitor-research.md:23`` in favour of the substitute that
+shipped (platform-ready export presets). The owner overruled that, so the feature
+is being built — but the four target platforms differ SHARPLY in what a LOCAL
+desktop app with no server is actually allowed to do, and two of the four cannot
+publish to a PERSONAL account at all.
+
+The capability matrix under test is where that sourced, per-platform truth lives.
+It is deliberately CODE, not prose: the UI reads it, so the app is structurally
+unable to offer a publish the platform would refuse, and a doc URL rides with
+every row so the claim can be re-checked when a platform changes its rules.
+"""
+
+from __future__ import annotations
+
+import pytest
+from media_studio.features import social_publish
+from media_studio.protocol import ErrorCode, RpcError
+
+# --------------------------------------------------------------------------- #
+# the capability matrix (the encoded feasibility finding)
+# --------------------------------------------------------------------------- #
+
+
+def test_matrix_covers_the_four_researched_platforms() -> None:
+    """The matrix is exactly the four platforms the C14 ask named."""
+    assert set(social_publish.CAPABILITIES) == {
+        "youtube",
+        "tiktok",
+        "instagram_reels",
+        "facebook_page",
+    }
+
+
+def test_every_capability_carries_a_source_url() -> None:
+    """No row may assert a platform rule without the doc it came from."""
+    for cap in social_publish.CAPABILITIES.values():
+        assert cap.doc_url.startswith("https://"), cap.id
+
+
+def test_youtube_is_publishable_with_native_scheduling() -> None:
+    """YouTube: personal channel + desktop loopback/PKCE + ``status.publishAt``."""
+    cap = social_publish.capability("youtube")
+    assert cap.publishable is True
+    assert cap.personal_account is True
+    assert cap.desktop_loopback_oauth is True
+    assert cap.native_scheduling is True
+    assert cap.blocked_reason is None
+
+
+def test_tiktok_is_publishable_but_has_no_native_scheduling() -> None:
+    """TikTok: desktop loopback + PKCE IS supported, but the API cannot schedule."""
+    cap = social_publish.capability("tiktok")
+    assert cap.publishable is True
+    assert cap.desktop_loopback_oauth is True
+    assert cap.native_scheduling is False
+
+
+def test_instagram_reels_is_blocked_for_a_personal_account() -> None:
+    """Instagram REQUIRES a professional account, so a personal one cannot publish."""
+    cap = social_publish.capability("instagram_reels")
+    assert cap.personal_account is False
+    assert cap.publishable is False
+    assert cap.blocked_reason is not None
+    assert "professional" in cap.blocked_reason.lower()
+
+
+def test_facebook_page_is_publishable_and_schedules_natively() -> None:
+    """Facebook: only a PAGE (never a personal timeline), and it schedules natively."""
+    cap = social_publish.capability("facebook_page")
+    assert cap.publishable is True
+    assert cap.native_scheduling is True
+    assert cap.personal_account is False
+
+
+def test_facebook_personal_timeline_is_absent_from_the_matrix() -> None:
+    """``publish_actions`` was removed in 2018, so there is no personal-timeline row."""
+    assert "facebook_timeline" not in social_publish.CAPABILITIES
+    assert "facebook_profile" not in social_publish.CAPABILITIES
+
+
+def test_capability_rejects_an_unknown_platform() -> None:
+    """An unknown id is a fail-loud INVALID_PARAMS, never a silent default."""
+    with pytest.raises(RpcError) as excinfo:
+        social_publish.capability("myspace")
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+
+
+def test_capabilities_wire_payload_is_json_shaped() -> None:
+    """``describe_capabilities`` renders the matrix as plain JSON for the renderer."""
+    rows = social_publish.describe_capabilities()
+    assert isinstance(rows, list)
+    ids = [row["id"] for row in rows]
+    assert ids == sorted(ids), "rows are id-sorted so the UI order is stable"
+    youtube = next(row for row in rows if row["id"] == "youtube")
+    assert youtube["nativeScheduling"] is True
+    assert youtube["publishable"] is True
+    assert youtube["docUrl"].startswith("https://")
+
+
+# --------------------------------------------------------------------------- #
+# honest schedule planning
+# --------------------------------------------------------------------------- #
+NOW = 1_800_000_000.0
+
+
+def test_no_publish_at_plans_an_immediate_publish() -> None:
+    plan = social_publish.plan_schedule("youtube", None, now=NOW)
+    assert plan.kind == "immediate"
+    assert plan.publish_at is None
+    assert plan.requires_app_running is False
+
+
+def test_future_publish_at_on_youtube_is_handed_to_the_platform() -> None:
+    """Native scheduling wins: the PLATFORM holds it, so the machine may be off."""
+    plan = social_publish.plan_schedule("youtube", NOW + 3600, now=NOW)
+    assert plan.kind == "platform"
+    assert plan.publish_at == NOW + 3600
+    assert plan.requires_app_running is False
+
+
+def test_future_publish_at_on_tiktok_falls_back_to_the_local_queue() -> None:
+    """No native scheduling -> a LOCAL queue, and it must say the app must be running."""
+    plan = social_publish.plan_schedule("tiktok", NOW + 3600, now=NOW)
+    assert plan.kind == "local-queue"
+    assert plan.requires_app_running is True
+    assert "running" in plan.warning.lower()
+
+
+def test_a_past_publish_at_is_rejected() -> None:
+    with pytest.raises(RpcError) as excinfo:
+        social_publish.plan_schedule("youtube", NOW - 1, now=NOW)
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+
+
+def test_scheduling_a_blocked_platform_is_rejected() -> None:
+    """A platform that cannot publish at all refuses BEFORE any queue write."""
+    with pytest.raises(RpcError) as excinfo:
+        social_publish.plan_schedule("instagram_reels", None, now=NOW)
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert "professional" in str(excinfo.value).lower()
+
+
+def test_a_non_numeric_publish_at_is_rejected() -> None:
+    with pytest.raises(RpcError):
+        social_publish.plan_schedule("youtube", "tomorrow", now=NOW)  # type: ignore[arg-type]
+
+
+def test_a_boolean_publish_at_is_rejected() -> None:
+    """``bool`` is an ``int`` subclass; True must not pose as an epoch second."""
+    with pytest.raises(RpcError):
+        social_publish.plan_schedule("youtube", True, now=NOW)  # type: ignore[arg-type]
+
+
+def test_platform_plan_beyond_the_native_horizon_falls_back_to_local() -> None:
+    """Past a platform's own scheduling horizon the platform cannot hold it.
+
+    Facebook Pages caps ``scheduled_publish_time`` at 30 days out, so a request
+    further out than that MUST degrade to the local queue (and disclose it)
+    rather than being handed to an API that would reject it.
+    """
+    cap = social_publish.capability("facebook_page")
+    beyond = NOW + cap.native_schedule_max_sec + 1
+    plan = social_publish.plan_schedule("facebook_page", beyond, now=NOW)
+    assert plan.kind == "local-queue"
+    assert plan.requires_app_running is True
+
+
+def test_plan_at_exactly_the_native_horizon_stays_on_the_platform() -> None:
+    """The horizon is inclusive — the boundary belongs to the platform path."""
+    cap = social_publish.capability("facebook_page")
+    edge = NOW + cap.native_schedule_max_sec
+    assert social_publish.plan_schedule("facebook_page", edge, now=NOW).kind == "platform"
+
+
+def test_immediate_plan_has_no_warning() -> None:
+    assert social_publish.plan_schedule("youtube", None, now=NOW).warning == ""
+
+
+def test_platform_plan_discloses_the_unaudited_visibility_limit() -> None:
+    """An unaudited OAuth app has its uploads forced private — say so up front."""
+    plan = social_publish.plan_schedule("youtube", None, now=NOW)
+    assert plan.unaudited_visibility != ""

--- a/sidecar/tests/test_social_queue.py
+++ b/sidecar/tests/test_social_queue.py
@@ -1,0 +1,308 @@
+"""Social publish QUEUE + the ``social.*`` RPC group (C14).
+
+The queue is the durable record of what Reframe has been asked to publish. Two
+properties are load-bearing and each has a test that fails if it regresses:
+
+1. **A queue entry NEVER holds credential material.** OAuth tokens for these
+   platforms live only in the Electron main-process keystore and are injected
+   per-request over the stdio frame. The queue is a JSON file under the data root,
+   so a token landing in an entry would be a plaintext credential at rest — the
+   exact defect ``app/main/keystore.ts`` exists to prevent. ``test_*_no_token_*``
+   asserts the persisted bytes structurally, not by inspecting one happy path.
+2. **A blocked platform is refused BEFORE any write.** ``instagram_reels`` cannot
+   be published to from a personal account at all, so enqueueing it must raise and
+   leave the file untouched rather than accumulating entries that can never run.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from media_studio import protocol
+from media_studio.features import social_publish, social_queue
+from media_studio.protocol import ErrorCode, RpcContext, RpcError
+
+NOW = 1_800_000_000.0
+LATER = NOW + 3600
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda _payload: None, jobs=None)
+
+
+@pytest.fixture()
+def store(tmp_path) -> social_queue.PublishQueueStore:
+    return social_queue.PublishQueueStore(tmp_path / "social-queue.json")
+
+
+def _job(**over) -> dict:
+    base = {
+        "platform": "youtube",
+        "clipPath": "exports/clip-1.mp4",
+        "title": "My clip",
+    }
+    base.update(over)
+    return base
+
+
+# --------------------------------------------------------------------------- #
+# store: absent / corrupt / round-trip
+# --------------------------------------------------------------------------- #
+def test_absent_file_reads_as_an_empty_queue(store) -> None:
+    assert store.list() == []
+
+
+def test_corrupt_file_reads_as_an_empty_queue(store) -> None:
+    """A poisoned file must not crash the panel; it degrades to empty."""
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text("{not json", encoding="utf-8")
+    assert store.list() == []
+
+
+def test_non_list_document_reads_as_an_empty_queue(store) -> None:
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text('{"entries": []}', encoding="utf-8")
+    assert store.list() == []
+
+
+def test_non_dict_rows_are_dropped(store) -> None:
+    store.path.parent.mkdir(parents=True, exist_ok=True)
+    store.path.write_text('["junk", 7]', encoding="utf-8")
+    assert store.list() == []
+
+
+def test_enqueue_round_trips_through_disk(store) -> None:
+    entry = store.enqueue(_job(), now=NOW)
+    assert entry["status"] == social_queue.STATUS_PENDING
+    assert entry["id"]
+    reread = social_queue.PublishQueueStore(store.path).list()
+    assert [e["id"] for e in reread] == [entry["id"]]
+
+
+# --------------------------------------------------------------------------- #
+# the NO-TOKEN-AT-REST invariant
+# --------------------------------------------------------------------------- #
+def test_a_token_field_is_stripped_from_an_enqueued_job(store) -> None:
+    """A caller that passes a token gets it DROPPED, not persisted."""
+    entry = store.enqueue(
+        _job(accessToken="ya29.super-secret", refreshToken="1//refresh", _injectedSocialTokens={"youtube": "t"}),
+        now=NOW,
+    )
+    assert "accessToken" not in entry
+    assert "refreshToken" not in entry
+    assert social_queue.INJECTED_TOKENS_FIELD not in entry
+
+
+def test_no_token_shaped_key_reaches_the_queue_file(store) -> None:
+    """Structural: scan the PERSISTED BYTES, not just the returned entry."""
+    store.enqueue(
+        _job(accessToken="ya29.super-secret", clientSecret="GOCSPX-nope"),
+        now=NOW,
+    )
+    raw = store.path.read_text(encoding="utf-8")
+    assert "ya29.super-secret" not in raw
+    assert "GOCSPX-nope" not in raw
+    for row in json.loads(raw):
+        for key in row:
+            assert not social_queue.is_secret_field(key), key
+
+
+def test_the_entry_wire_shape_is_exactly_the_allowlist(store) -> None:
+    """An entry carries ONLY the documented non-secret fields.
+
+    An allowlist (not a denylist) is what makes the no-token invariant hold for a
+    field nobody has thought of yet: an unknown key cannot ride along at all.
+    """
+    entry = store.enqueue(_job(surpriseField="x"), now=NOW)
+    assert set(entry) == set(social_queue.ENTRY_FIELDS)
+
+
+# --------------------------------------------------------------------------- #
+# normalization + refusals
+# --------------------------------------------------------------------------- #
+def test_a_blocked_platform_is_refused_and_writes_nothing(store) -> None:
+    with pytest.raises(RpcError) as excinfo:
+        store.enqueue(_job(platform="instagram_reels"), now=NOW)
+    assert excinfo.value.code == ErrorCode.INVALID_PARAMS
+    assert not store.path.exists(), "a refused enqueue must leave no file behind"
+
+
+def test_an_unknown_platform_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue(_job(platform="myspace"), now=NOW)
+
+
+def test_a_missing_clip_path_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue({"platform": "youtube", "title": "t"}, now=NOW)
+
+
+def test_a_missing_title_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue({"platform": "youtube", "clipPath": "a.mp4"}, now=NOW)
+
+
+def test_a_non_object_job_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue("nope", now=NOW)
+
+
+def test_optional_fields_default_to_empty(store) -> None:
+    entry = store.enqueue(_job(), now=NOW)
+    assert entry["description"] == ""
+    assert entry["videoId"] == ""
+    assert entry["error"] == ""
+    assert entry["publishAt"] is None
+    assert entry["createdAt"] == NOW
+
+
+def test_optional_fields_are_carried_when_supplied(store) -> None:
+    entry = store.enqueue(_job(description="  hello  ", videoId="vid-7"), now=NOW)
+    assert entry["description"] == "hello"
+    assert entry["videoId"] == "vid-7"
+
+
+def test_a_non_string_description_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue(_job(description=7), now=NOW)
+
+
+def test_a_non_string_video_id_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue(_job(videoId=7), now=NOW)
+
+
+# --------------------------------------------------------------------------- #
+# the schedule plan is recorded ON the entry (honesty travels with the row)
+# --------------------------------------------------------------------------- #
+def test_an_immediate_entry_records_the_immediate_kind(store) -> None:
+    entry = store.enqueue(_job(), now=NOW)
+    assert entry["kind"] == social_publish.KIND_IMMEDIATE
+    assert entry["requiresAppRunning"] is False
+
+
+def test_a_scheduled_youtube_entry_is_held_by_the_platform(store) -> None:
+    entry = store.enqueue(_job(publishAt=LATER), now=NOW)
+    assert entry["kind"] == social_publish.KIND_PLATFORM
+    assert entry["requiresAppRunning"] is False
+    assert entry["publishAt"] == LATER
+
+
+def test_a_scheduled_tiktok_entry_lands_on_the_local_queue(store) -> None:
+    entry = store.enqueue(_job(platform="tiktok", publishAt=LATER), now=NOW)
+    assert entry["kind"] == social_publish.KIND_LOCAL_QUEUE
+    assert entry["requiresAppRunning"] is True
+
+
+def test_a_past_publish_at_is_refused(store) -> None:
+    with pytest.raises(RpcError):
+        store.enqueue(_job(publishAt=NOW - 1), now=NOW)
+
+
+# --------------------------------------------------------------------------- #
+# cancel + due
+# --------------------------------------------------------------------------- #
+def test_cancel_marks_a_pending_entry_cancelled(store) -> None:
+    entry = store.enqueue(_job(), now=NOW)
+    assert store.cancel(entry["id"]) is True
+    assert store.list()[0]["status"] == social_queue.STATUS_CANCELLED
+
+
+def test_cancel_is_false_for_an_unknown_id(store) -> None:
+    assert store.cancel("nope") is False
+
+
+def test_cancel_is_false_for_an_already_cancelled_entry(store) -> None:
+    """Cancel is idempotent-safe: a second call reports "nothing to do"."""
+    entry = store.enqueue(_job(), now=NOW)
+    store.cancel(entry["id"])
+    assert store.cancel(entry["id"]) is False
+
+
+def test_due_returns_only_pending_local_queue_entries_whose_time_has_come(store) -> None:
+    soon = store.enqueue(_job(platform="tiktok", publishAt=NOW + 10), now=NOW)
+    store.enqueue(_job(platform="tiktok", publishAt=NOW + 9999), now=NOW)
+    # A platform-held schedule is the PLATFORM's job, never the local runner's.
+    store.enqueue(_job(platform="youtube", publishAt=NOW + 10), now=NOW)
+    due = store.due(now=NOW + 20)
+    assert [e["id"] for e in due] == [soon["id"]]
+
+
+def test_due_skips_a_cancelled_entry(store) -> None:
+    entry = store.enqueue(_job(platform="tiktok", publishAt=NOW + 10), now=NOW)
+    store.cancel(entry["id"])
+    assert store.due(now=NOW + 20) == []
+
+
+def test_an_immediate_entry_is_due_at_once(store) -> None:
+    """No publishAt means "now", so the runner picks it up on its next sweep."""
+    entry = store.enqueue(_job(platform="tiktok"), now=NOW)
+    assert [e["id"] for e in store.due(now=NOW)] == [entry["id"]]
+
+
+# --------------------------------------------------------------------------- #
+# RPC group
+# --------------------------------------------------------------------------- #
+def test_register_binds_exactly_the_documented_methods(tmp_path) -> None:
+    registered: dict[str, object] = {}
+    social_queue.register(
+        path=tmp_path / "social-queue.json",
+        clock=lambda: NOW,
+        register_fn=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert set(registered) == {
+        "social.capabilities",
+        "social.plan",
+        "social.enqueue",
+        "social.queue",
+        "social.cancel",
+    }
+
+
+def test_register_defaults_to_the_real_registrar_and_clock(tmp_path) -> None:
+    """The production path (no injected registrar/clock) wires the same group."""
+    protocol.clear_methods()
+    svc = social_queue.register(path=tmp_path / "social-queue.json")
+    assert "social.capabilities" in protocol.METHODS
+    # The default clock is the wall clock, so it must produce a real timestamp.
+    assert svc.now() > 0
+
+
+def test_capabilities_rpc_returns_the_matrix(tmp_path) -> None:
+    svc = social_queue.register(path=tmp_path / "q.json", clock=lambda: NOW, register_fn=lambda _n, _f: None)
+    out = svc.capabilities({}, _ctx())
+    assert [row["id"] for row in out["platforms"]] == sorted(social_publish.CAPABILITIES)
+
+
+def test_plan_rpc_previews_the_honest_plan(tmp_path) -> None:
+    svc = social_queue.register(path=tmp_path / "q.json", clock=lambda: NOW, register_fn=lambda _n, _f: None)
+    out = svc.plan({"platform": "tiktok", "publishAt": LATER}, _ctx())
+    assert out["plan"]["kind"] == social_publish.KIND_LOCAL_QUEUE
+    assert out["plan"]["requiresAppRunning"] is True
+    assert "running" in out["plan"]["warning"].lower()
+
+
+def test_plan_rpc_defaults_to_an_immediate_preview(tmp_path) -> None:
+    svc = social_queue.register(path=tmp_path / "q.json", clock=lambda: NOW, register_fn=lambda _n, _f: None)
+    out = svc.plan({"platform": "youtube"}, _ctx())
+    assert out["plan"]["kind"] == social_publish.KIND_IMMEDIATE
+
+
+def test_enqueue_queue_and_cancel_rpcs_round_trip(tmp_path) -> None:
+    svc = social_queue.register(path=tmp_path / "q.json", clock=lambda: NOW, register_fn=lambda _n, _f: None)
+    entry = svc.enqueue({"job": _job()}, _ctx())["entry"]
+    assert [e["id"] for e in svc.queue({}, _ctx())["entries"]] == [entry["id"]]
+    assert svc.cancel({"id": entry["id"]}, _ctx())["ok"] is True
+
+
+def test_enqueue_rpc_requires_a_job_object(tmp_path) -> None:
+    svc = social_queue.register(path=tmp_path / "q.json", clock=lambda: NOW, register_fn=lambda _n, _f: None)
+    with pytest.raises(RpcError):
+        svc.enqueue({}, _ctx())
+
+
+def test_cancel_rpc_requires_an_id(tmp_path) -> None:
+    svc = social_queue.register(path=tmp_path / "q.json", clock=lambda: NOW, register_fn=lambda _n, _f: None)
+    with pytest.raises(RpcError):
+        svc.cancel({}, _ctx())


### PR DESCRIPTION
- **feat(social): encode what each platform actually lets a local app publish**
- **feat(social): a publish queue that structurally cannot hold a token**
- **feat(social): desktop OAuth for publishing, and stop a provider write erasing it**
- **fix(keystore): the legacy-key migration was erasing connected social accounts**
- **feat(social): a Publish panel whose job is to not promise what cannot happen**
