### PR TITLE
feat/v15 speed retime

### DIFF
--- a/app/renderer/src/features/Speed.test.tsx
+++ b/app/renderer/src/features/Speed.test.tsx
@@ -1,0 +1,306 @@
+// Speed.test.tsx — tests for the Speed / slow-motion panel.
+//
+// The panel drives the one RPC this lane added:
+//   speed.retime({videoId, factor}) -> {jobId} -> job.done {path, factor,
+//                                                sourceDurationSec, durationSec}
+// A job, so the terminal payload arrives via the job.done notification; a fake
+// `api` bridge is injected through the `api?` prop, and the click/await idiom is
+// Refine.test.tsx's (await act + a microtask turn, then fire job.done in a
+// second act) — the pattern already proven against this bridge shape.
+//
+// The panel exists because the re-time ENGINE was reachable only through an
+// LLM-planned Director op. These tests pin that a user can now pick a speed and
+// press a button instead.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import Speed, { DEFAULT_SPEED_FACTOR, speedResultPath } from './Speed';
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+import { SPEED_MAX, SPEED_MIN, SPEED_PRESETS } from '../lib/speedPresets';
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+function makeFakeApi(retimeResult: unknown = { jobId: 'job-s' }): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'speed.retime') return retimeResult as T;
+      return {} as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+describe('speedResultPath', () => {
+  it('pulls the output path from a job.done result', () => {
+    expect(speedResultPath({ path: '/x/clip.speed-2p00x.mp4' })).toBe('/x/clip.speed-2p00x.mp4');
+  });
+  it('null when absent or the wrong shape', () => {
+    expect(speedResultPath({})).toBeNull();
+    expect(speedResultPath(null)).toBeNull();
+    expect(speedResultPath({ path: 7 })).toBeNull();
+  });
+});
+
+describe('Speed panel', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+    delete (globalThis as { api?: unknown }).api;
+    vi.restoreAllMocks();
+  });
+
+  async function mount(props: Record<string, unknown>): Promise<void> {
+    await act(async () => {
+      root.render(<Speed videoId="v1" {...props} />);
+    });
+  }
+
+  const q = (sel: string): HTMLElement | null => container.querySelector(sel);
+
+  async function clickAction(action: string): Promise<void> {
+    await act(async () => {
+      (container.querySelector(`button[data-action="${action}"]`) as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+  }
+
+  async function clickPreset(id: string): Promise<void> {
+    await act(async () => {
+      (container.querySelector(`button[data-preset="${id}"]`) as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+  }
+
+  async function setCustom(value: string): Promise<void> {
+    const input = q('[data-tune="factor"]') as HTMLInputElement;
+    await act(async () => {
+      // React tracks the last value on the DOM node, so the NATIVE setter + an
+      // input event is what makes a controlled <input> see a real change in jsdom.
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLInputElement.prototype,
+        'value',
+      )?.set;
+      setter?.call(input, value);
+      input.dispatchEvent(new Event('input', { bubbles: true }));
+      await Promise.resolve();
+    });
+  }
+
+  it('offers one button per preset, including slow motion and 1.5x', async () => {
+    await mount({ api: makeFakeApi().api });
+    const buttons = [...container.querySelectorAll('[data-preset]')];
+    expect(buttons).toHaveLength(SPEED_PRESETS.length);
+    const labels = buttons.map((b) => b.textContent);
+    expect(labels).toContain('0.5x slow motion');
+    expect(labels).toContain('1.5x faster');
+  });
+
+  it('marks the active preset pressed, and moves it on click', async () => {
+    await mount({ api: makeFakeApi().api });
+    expect(q('[data-preset="faster-2"]')?.getAttribute('aria-pressed')).toBe('true');
+    await clickPreset('slowmo-half');
+    expect(q('[data-preset="slowmo-half"]')?.getAttribute('aria-pressed')).toBe('true');
+    expect(q('[data-preset="faster-2"]')?.getAttribute('aria-pressed')).toBe('false');
+  });
+
+  it('predicts the new duration before anything is rendered', async () => {
+    await mount({ api: makeFakeApi().api, sourceDurationSec: 120 });
+    // Default 2x on a 2:00 source -> 1:00.
+    expect(q('[data-field="sourceDuration"]')?.textContent).toBe('2:00');
+    expect(q('[data-field="newDuration"]')?.textContent).toBe('1:00');
+    await clickPreset('slowmo-half');
+    expect(q('[data-field="newDuration"]')?.textContent).toBe('4:00');
+  });
+
+  it('shows a dash for both durations when the source length is unknown', async () => {
+    await mount({ api: makeFakeApi().api });
+    expect(q('[data-field="sourceDuration"]')?.textContent).toBe('—');
+    expect(q('[data-field="newDuration"]')?.textContent).toBe('—');
+  });
+
+  it('sends speed.retime with the chosen factor', async () => {
+    const fake = makeFakeApi();
+    await mount({ api: fake.api, sourceDurationSec: 12 });
+    await clickPreset('slowmo-half');
+    await clickAction('apply');
+    expect(fake.calls.find((c) => c.method === 'speed.retime')?.params).toEqual({
+      videoId: 'v1',
+      factor: 0.5,
+    });
+  });
+
+  it('streams progress for its own job only, then shows the produced file', async () => {
+    const fake = makeFakeApi();
+    await mount({ api: fake.api, sourceDurationSec: 12 });
+    await clickAction('apply');
+    await act(async () => {
+      fake.fireProgress({ jobId: 'someone-else', pct: 99, message: 'not mine' });
+    });
+    expect(q('.progress-pct')?.textContent).toBe('0%');
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-s', pct: 40, message: 'retiming' });
+    });
+    expect(q('.progress-pct')?.textContent).toBe('40%');
+    expect(q('.progress-message')?.textContent).toContain('retiming');
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-s', result: { path: '/out/in.speed-2p00x.mp4' } });
+    });
+    expect(q('[data-section="result"]')?.textContent).toContain('/out/in.speed-2p00x.mp4');
+  });
+
+  it('cancels the running job', async () => {
+    const fake = makeFakeApi();
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    await clickAction('cancel');
+    expect(fake.calls.some((c) => c.method === 'job.cancel')).toBe(true);
+    expect(q('.progress-message')?.textContent).toContain('Cancelling');
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-s', result: { path: '/out/a.mp4' } });
+    });
+  });
+
+  it('a cancel that throws is swallowed (best-effort, no alert)', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockImplementation(
+      async (method: string, params?: Record<string, unknown>) => {
+        fake.calls.push({ method, params });
+        if (method === 'job.cancel') throw new Error('gone');
+        return { jobId: 'job-s' };
+      },
+    );
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    await clickAction('cancel');
+    expect(q('[role="alert"]')).toBeNull();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-s', result: { path: '/out/a.mp4' } });
+    });
+  });
+
+  it('surfaces an rpc rejection as an alert', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('ffmpeg is missing'));
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    expect(q('[role="alert"]')?.textContent).toContain('ffmpeg is missing');
+  });
+
+  it('surfaces a non-Error rejection via String(err)', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce('plain speed error');
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    expect(q('[role="alert"]')?.textContent).toContain('plain speed error');
+  });
+
+  it('surfaces a job.done error payload', async () => {
+    const fake = makeFakeApi();
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-s',
+        result: { error: { message: 're-time failed (ffmpeg exit 3)', type: 'InternalError' } },
+      });
+    });
+    expect(q('[role="alert"]')?.textContent).toContain('re-time failed (ffmpeg exit 3)');
+  });
+
+  it('a response with no jobId settles without a result and without an error', async () => {
+    const fake = makeFakeApi({});
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    expect(q('[data-section="result"]')).toBeNull();
+    expect(q('[role="alert"]')).toBeNull();
+  });
+
+  it('a job.done carrying no path leaves the panel result-free', async () => {
+    const fake = makeFakeApi();
+    await mount({ api: fake.api });
+    await clickAction('apply');
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-s', result: undefined });
+    });
+    expect(q('[data-section="result"]')).toBeNull();
+  });
+
+  it('the custom factor input clamps to the accepted window', async () => {
+    await mount({ api: makeFakeApi().api });
+    await setCustom('999');
+    expect((q('[data-tune="factor"]') as HTMLInputElement).value).toBe(String(SPEED_MAX));
+    await setCustom('0.0001');
+    expect((q('[data-tune="factor"]') as HTMLInputElement).value).toBe(String(SPEED_MIN));
+  });
+
+  it('a blank custom factor falls back to 1x and disables Apply (the no-op guard)', async () => {
+    await mount({ api: makeFakeApi().api });
+    await setCustom('');
+    expect((q('[data-action="apply"]') as HTMLButtonElement).disabled).toBe(true);
+    expect(q('[data-field="noop"]')).not.toBeNull();
+  });
+
+  it('Apply is enabled at a sendable factor', async () => {
+    await mount({ api: makeFakeApi().api });
+    expect((q('[data-action="apply"]') as HTMLButtonElement).disabled).toBe(false);
+    expect(q('[data-field="noop"]')).toBeNull();
+  });
+
+  it('defaults to a real speed-up, not a no-op', () => {
+    expect(DEFAULT_SPEED_FACTOR).not.toBe(1);
+    expect(SPEED_PRESETS.some((p) => p.factor === DEFAULT_SPEED_FACTOR)).toBe(true);
+  });
+
+  it('falls back to the global bridge when no api prop is given', async () => {
+    const fake = makeFakeApi();
+    (globalThis as { api?: unknown }).api = fake.api;
+    await mount({});
+    await clickAction('apply');
+    expect(fake.calls[0]?.method).toBe('speed.retime');
+  });
+
+  it('says plainly that the speed is CONSTANT, so no one reads it as a ramp', async () => {
+    await mount({ api: makeFakeApi().api });
+    expect(container.textContent?.toLowerCase()).toContain('constant');
+  });
+});

--- a/app/renderer/src/features/Speed.test.tsx
+++ b/app/renderer/src/features/Speed.test.tsx
@@ -220,7 +220,9 @@ describe('Speed panel', () => {
 
   it('surfaces an rpc rejection as an alert', async () => {
     const fake = makeFakeApi();
-    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('ffmpeg is missing'));
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new Error('ffmpeg is missing'),
+    );
     await mount({ api: fake.api });
     await clickAction('apply');
     expect(q('[role="alert"]')?.textContent).toContain('ffmpeg is missing');

--- a/app/renderer/src/features/Speed.tsx
+++ b/app/renderer/src/features/Speed.tsx
@@ -1,0 +1,241 @@
+// Speed feature panel — "Change the speed" (slow motion / speed up).
+//
+// WHY THIS EXISTS. The re-time engine has been sound for a long time
+// (`director_op_engines.build_retime_argv`: `setpts=(1/factor)*PTS` plus a legal
+// `atempo` chain so picture and sound stay in sync, with `retime` in
+// WIRED_KINDS) — but nothing could reach it. There was no speed RPC and no speed
+// control in ANY renderer panel, so the only path to a slow-motion clip was to
+// phrase a prompt at the AI Director and hope the planner emitted a `retime` op.
+// This panel plus `speed.retime` is the direct route.
+//
+// Drives ONE RPC over the FROZEN window.api bridge:
+//   speed.retime({videoId, factor}) -> {jobId}
+//     -> job.done {path, factor, sourceDurationSec, durationSec}
+// A long job, so the terminal payload arrives on the `job.done` notification and
+// is read through the shared `waitForJobDone` (same shape as Refine/Diarize).
+//
+// SCOPE, and it is on screen as well as in this comment: the speed is CONSTANT
+// over the whole clip. A keyframed speed RAMP (piecewise `setpts` with
+// segment-wise audio resampling) is a different engine that does not exist in
+// this tree, so the UI must not imply one — `speedPresets.test.ts` asserts no
+// preset advertises a ramp, and the panel copy says "constant" out loud.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import './panels.css';
+import { fmtSeconds, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+import {
+  SPEED_MAX,
+  SPEED_MIN,
+  SPEED_PRESETS,
+  clampFactor,
+  isRetimeFactor,
+  retimedDuration,
+  speedLabel,
+} from '../lib/speedPresets';
+
+/**
+ * The speed the panel opens on. A SPEED-UP, because "this drags, tighten it" is
+ * the common ask, and it must never be 1.0 — that is the one value the sidecar
+ * rejects, so opening on it would present a dead Apply button.
+ */
+export const DEFAULT_SPEED_FACTOR = 2;
+
+/** Shown when there is no duration to show — an unknown length is not "0:00". */
+const NO_DURATION = '—';
+
+/** The output path from a `speed.retime` job.done result (null when missing). */
+export function speedResultPath(result: unknown): string | null {
+  const path = pickField<string>(result, 'path');
+  return typeof path === 'string' ? path : null;
+}
+
+export interface SpeedProps {
+  videoId: string;
+  /**
+   * Source length, used ONLY for the before/after prediction. Optional: when the
+   * caller does not know it the panel shows a dash rather than inventing a
+   * number, and the re-time still works (the sidecar probes for itself).
+   */
+  sourceDurationSec?: number;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+
+export function Speed({ videoId, sourceDurationSec, api }: SpeedProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  const [factor, setFactor] = useState<number>(DEFAULT_SPEED_FACTOR);
+  const [applying, setApplying] = useState<boolean>(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [resultPath, setResultPath] = useState<string>('');
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  const source = sourceDurationSec ?? 0;
+  const predicted = retimedDuration(source, factor);
+  // The sidecar's `resolve_factor` is the authority and REJECTS a bad factor;
+  // gating Apply on the same rule means a doomed request never leaves the UI.
+  const sendable = isRetimeFactor(factor);
+
+  const onCustomFactor = useCallback((raw: string): void => {
+    // A cleared field is not "0.1x" — Number('') is 0, which would clamp to the
+    // floor and silently arm an extreme slow-motion. Blank means "no choice yet",
+    // so it lands on the neutral 1x (which then disables Apply).
+    setFactor(clampFactor(raw === '' ? Number.NaN : Number(raw)));
+  }, []);
+
+  const apply = useCallback(async (): Promise<void> => {
+    // defensive: Apply is disabled while a job runs and at an unsendable factor.
+    /* v8 ignore next */
+    if (applying || !sendable) return;
+    setApplying(true);
+    setError('');
+    setResultPath('');
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      const res = await bridge.rpc<{ jobId: string }>('speed.retime', { videoId, factor });
+      const id = res?.jobId ?? null;
+      setJobId(id);
+      // waitForJobDone REJECTS on an {error} job.done payload, so a failed
+      // re-time surfaces in the catch below instead of looking like a silent no-op.
+      const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
+      const path = speedResultPath(result);
+      if (path) {
+        setResultPath(path);
+        setPct(100);
+        setMessage('Done');
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setApplying(false);
+      setJobId(null);
+    }
+  }, [bridge, videoId, factor, applying, sendable]);
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // defensive: Cancel renders only while `applying && jobId`.
+    /* v8 ignore next */
+    if (!jobId) return;
+    try {
+      await bridge.rpc('job.cancel', { jobId });
+    } catch {
+      // Best-effort: the job may already have finished.
+    }
+    setMessage('Cancelling…');
+  }, [bridge, jobId]);
+
+  return (
+    <section className="feature-panel speed-panel" aria-label="Speed">
+      <h2>Change the Speed</h2>
+      <p className="assets-intro">
+        Re-time the whole clip at one constant speed — picture and sound stay in sync. The original
+        is never touched; the result is written to a new file.
+      </p>
+
+      <div className="field" role="group" aria-label="Speed presets">
+        {SPEED_PRESETS.map((preset) => (
+          <button
+            key={preset.id}
+            type="button"
+            data-preset={preset.id}
+            aria-pressed={factor === preset.factor}
+            onClick={() => setFactor(preset.factor)}
+          >
+            {preset.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="field">
+        <label>
+          Custom speed ({SPEED_MIN}x – {SPEED_MAX}x)
+          <input
+            type="number"
+            step="0.05"
+            min={SPEED_MIN}
+            max={SPEED_MAX}
+            data-tune="factor"
+            value={factor}
+            onChange={(e) => onCustomFactor(e.target.value)}
+          />
+        </label>
+        <span className="speed-readout" data-field="factorLabel">
+          {speedLabel(factor)}
+        </span>
+      </div>
+
+      <dl className="speed-preview" data-section="preview">
+        <div>
+          <dt>Now</dt>
+          <dd data-field="sourceDuration">{source > 0 ? fmtSeconds(source) : NO_DURATION}</dd>
+        </div>
+        <div>
+          <dt>After</dt>
+          <dd data-field="newDuration">{predicted > 0 ? fmtSeconds(predicted) : NO_DURATION}</dd>
+        </div>
+      </dl>
+
+      {!sendable && (
+        <p className="hint" data-field="noop">
+          1x is no change — pick a slower or faster speed to enable Apply.
+        </p>
+      )}
+
+      <div className="actions">
+        <button
+          type="button"
+          data-action="apply"
+          onClick={() => void apply()}
+          disabled={applying || !sendable}
+        >
+          {applying ? 'Re-timing…' : 'Apply speed'}
+        </button>
+        {applying && jobId && (
+          <button
+            type="button"
+            data-action="cancel"
+            className="secondary"
+            onClick={() => void cancel()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {applying && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          {message && <span className="progress-message"> · {message}</span>}
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {resultPath && (
+        <div className="output-done" data-section="result">
+          <span className="output-done-label">Re-timed file</span>
+          <code>{resultPath}</code>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default Speed;

--- a/app/renderer/src/lib/rpc/client.ce.test.ts
+++ b/app/renderer/src/lib/rpc/client.ce.test.ts
@@ -122,3 +122,17 @@ describe('client.reframe.* (V1.1 Lane R per-shot correction)', () => {
     expect(rpc).toHaveBeenCalledWith('reframe.applyOverrides', { plan, overrides });
   });
 });
+
+describe('client.speed.retime (v1.5 — the user-driven door onto the re-time engine)', () => {
+  it('forwards {videoId, factor} for a library video', async () => {
+    const rpc = installApi();
+    await client.speed.retime({ videoId: 'v1' }, 0.5);
+    expect(rpc).toHaveBeenCalledWith('speed.retime', { videoId: 'v1', factor: 0.5 });
+  });
+
+  it('forwards {path, factor} for a direct path', async () => {
+    const rpc = installApi();
+    await client.speed.retime({ path: '/x/clip.mp4' }, 2);
+    expect(rpc).toHaveBeenCalledWith('speed.retime', { path: '/x/clip.mp4', factor: 2 });
+  });
+});

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -239,6 +239,31 @@ export const client = {
     ): Promise<JobHandle & { paths?: string[] }> => rpc('convert.batch', { items }),
   },
 
+  /**
+   * Playback speed. `factor` > 1 speeds up (shorter), < 1 slows down (longer);
+   * the sidecar rejects a non-positive, out-of-window, or exactly-1.0 factor
+   * (`features/speed.py` `resolve_factor`), so validate with `isRetimeFactor`
+   * from `lib/speedPresets` before calling if the value came from a user.
+   *
+   * A job: this resolves with `{jobId}` only, and the terminal
+   * `{path, factor, sourceDurationSec, durationSec}` arrives on `job.done`.
+   *
+   * CONSTANT factor over the whole clip — there is no keyframed ramp engine.
+   */
+  speed: {
+    retime: (
+      target: { videoId?: string; path?: string },
+      factor: number,
+    ): Promise<
+      JobHandle & {
+        path?: string;
+        factor?: number;
+        sourceDurationSec?: number;
+        durationSec?: number;
+      }
+    > => rpc('speed.retime', { ...target, factor }),
+  },
+
   shortmaker: {
     select: (
       videoId: string,

--- a/app/renderer/src/lib/speedPresets.test.ts
+++ b/app/renderer/src/lib/speedPresets.test.ts
@@ -1,0 +1,140 @@
+// speedPresets.test.ts — full-branch coverage of the pure speed/re-time model.
+//
+// The window + the "is this sendable" predicate MIRROR the sidecar's authority
+// (`sidecar/media_studio/features/speed.py` SPEED_MIN / SPEED_MAX /
+// resolve_factor). These tests pin the mirror so the two cannot drift apart
+// unnoticed: a factor this module calls sendable must be one the sidecar accepts.
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  SPEED_MAX,
+  SPEED_MIN,
+  SPEED_PRESETS,
+  clampFactor,
+  isRetimeFactor,
+  retimedDuration,
+  speedLabel,
+} from './speedPresets';
+
+describe('the factor window', () => {
+  it('brackets 1x on both sides (slow motion AND speed-up are reachable)', () => {
+    expect(SPEED_MIN).toBeLessThan(1);
+    expect(SPEED_MAX).toBeGreaterThan(1);
+  });
+
+  it('matches the sidecar authority in speed.py', () => {
+    // If this fails, one side moved and the other did not — fix BOTH.
+    expect(SPEED_MIN).toBe(0.1);
+    expect(SPEED_MAX).toBe(10);
+  });
+});
+
+describe('SPEED_PRESETS', () => {
+  it('offers slow motion AND speed-up, including the 1.5x the brief calls for', () => {
+    const factors = SPEED_PRESETS.map((p) => p.factor);
+    expect(factors.some((f) => f < 1)).toBe(true);
+    expect(factors).toContain(1.5);
+    expect(factors.some((f) => f > 1.5)).toBe(true);
+  });
+
+  it('every preset is a factor the sidecar would accept', () => {
+    for (const preset of SPEED_PRESETS) {
+      expect(isRetimeFactor(preset.factor)).toBe(true);
+    }
+  });
+
+  it('has unique ids and non-empty labels', () => {
+    const ids = SPEED_PRESETS.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const preset of SPEED_PRESETS) expect(preset.label.length).toBeGreaterThan(0);
+  });
+
+  it('offers NO ramp preset — a keyframed ramp is not implemented anywhere', () => {
+    // Guard against a future edit advertising a capability the engine lacks:
+    // build_retime_argv takes ONE scalar factor, so every preset must be constant.
+    for (const preset of SPEED_PRESETS) {
+      expect(Number.isFinite(preset.factor)).toBe(true);
+      expect(preset.label.toLowerCase()).not.toContain('ramp');
+    }
+  });
+});
+
+describe('clampFactor', () => {
+  it('leaves an in-window factor alone', () => {
+    expect(clampFactor(1.5)).toBe(1.5);
+    expect(clampFactor(0.5)).toBe(0.5);
+  });
+
+  it('clamps below the floor and above the ceiling', () => {
+    expect(clampFactor(0.001)).toBe(SPEED_MIN);
+    expect(clampFactor(999)).toBe(SPEED_MAX);
+  });
+
+  it('keeps the exact bounds', () => {
+    expect(clampFactor(SPEED_MIN)).toBe(SPEED_MIN);
+    expect(clampFactor(SPEED_MAX)).toBe(SPEED_MAX);
+  });
+
+  it('falls back to 1x for a non-finite input (a slider can emit NaN)', () => {
+    expect(clampFactor(Number.NaN)).toBe(1);
+    expect(clampFactor(Number.POSITIVE_INFINITY)).toBe(1);
+  });
+});
+
+describe('isRetimeFactor', () => {
+  it('accepts an in-window factor either side of 1x', () => {
+    expect(isRetimeFactor(0.5)).toBe(true);
+    expect(isRetimeFactor(2)).toBe(true);
+  });
+
+  it('rejects exactly 1x — the sidecar refuses it as a no-op', () => {
+    expect(isRetimeFactor(1)).toBe(false);
+  });
+
+  it('rejects out-of-window values', () => {
+    expect(isRetimeFactor(0.05)).toBe(false);
+    expect(isRetimeFactor(11)).toBe(false);
+  });
+
+  it('rejects non-numeric and non-finite input', () => {
+    expect(isRetimeFactor('2')).toBe(false);
+    expect(isRetimeFactor(null)).toBe(false);
+    expect(isRetimeFactor(undefined)).toBe(false);
+    expect(isRetimeFactor(Number.NaN)).toBe(false);
+  });
+});
+
+describe('retimedDuration', () => {
+  it('speeding up shortens, slowing down lengthens', () => {
+    expect(retimedDuration(60, 2)).toBe(30);
+    expect(retimedDuration(60, 0.5)).toBe(120);
+  });
+
+  it('an unknown source duration stays unknown (0)', () => {
+    expect(retimedDuration(0, 2)).toBe(0);
+    expect(retimedDuration(-5, 2)).toBe(0);
+    expect(retimedDuration(Number.NaN, 2)).toBe(0);
+  });
+
+  it('a non-positive factor cannot produce a duration', () => {
+    expect(retimedDuration(60, 0)).toBe(0);
+  });
+});
+
+describe('speedLabel', () => {
+  it('names the direction so the number is never ambiguous', () => {
+    expect(speedLabel(0.5)).toContain('slower');
+    expect(speedLabel(2)).toContain('faster');
+  });
+
+  it('drops a trailing zero so 2x is not "2.00x"', () => {
+    expect(speedLabel(2)).toContain('2x');
+    expect(speedLabel(1.5)).toContain('1.5x');
+    expect(speedLabel(0.25)).toContain('0.25x');
+  });
+
+  it('calls 1x what it is', () => {
+    expect(speedLabel(1)).toBe('1x (no change)');
+  });
+});

--- a/app/renderer/src/lib/speedPresets.ts
+++ b/app/renderer/src/lib/speedPresets.ts
@@ -1,0 +1,96 @@
+// speedPresets.ts — the pure model behind the Speed panel (slow motion / speed-up).
+//
+// The re-time ENGINE has existed for a while (`setpts` + a legal `atempo` chain,
+// `retime` in the Director's WIRED_KINDS) but nothing in the renderer could reach
+// it: no speed RPC, no speed control in any panel. The only path was an
+// LLM-planned Director op, so a user had to phrase a prompt and hope the planner
+// emitted one. This module is the pure half of the control that fixes that —
+// kept render-free so every branch is exhaustively unit tested.
+//
+// SCOPE — the presets are deliberately all CONSTANT factors. A keyframed speed
+// RAMP (piecewise `setpts` with segment-wise audio resampling) is a DIFFERENT
+// engine that does not exist in this tree; `speedPresets.test.ts` asserts no
+// preset advertises one, so the UI can never promise a capability the sidecar
+// cannot deliver.
+//
+// AUTHORITY: `sidecar/media_studio/features/speed.py` is the validator of record
+// (`resolve_factor` REJECTS out-of-window). This module MIRRORS its window so the
+// UI can pre-empt a round trip with a friendly clamp. The renderer cannot read
+// Python, so the two constants are stated twice on purpose and pinned by a test
+// on each side — change one, change both.
+
+/** Slowest playback factor the sidecar accepts (0.1x = ten times longer). */
+export const SPEED_MIN = 0.1;
+/** Fastest playback factor the sidecar accepts (10x = a tenth as long). */
+export const SPEED_MAX = 10;
+
+/** One offered speed. `factor` > 1 speeds up (shorter), < 1 slows down (longer). */
+export interface SpeedPreset {
+  /** Stable id (a radio value / test handle) — never shown to the user. */
+  readonly id: string;
+  /** The button copy. */
+  readonly label: string;
+  /** The playback factor sent as `speed.retime({factor})`. */
+  readonly factor: number;
+}
+
+/**
+ * The offered speeds, slowest first. Two slow-motion steps and three speed-ups,
+ * spanning the range people actually reach for: 0.5x for a highlight beat, 1.5x
+ * for a talking-head that drags, 2x/4x for screen-recording filler.
+ */
+export const SPEED_PRESETS: readonly SpeedPreset[] = [
+  { id: 'slowmo-quarter', label: '0.25x slow motion', factor: 0.25 },
+  { id: 'slowmo-half', label: '0.5x slow motion', factor: 0.5 },
+  { id: 'faster-1p5', label: '1.5x faster', factor: 1.5 },
+  { id: 'faster-2', label: '2x faster', factor: 2 },
+  { id: 'faster-4', label: '4x faster', factor: 4 },
+];
+
+/**
+ * Clamp a factor into [SPEED_MIN, SPEED_MAX] for the slider. A non-finite input
+ * (a slider mid-drag can emit NaN) falls back to 1x — the neutral "no change"
+ * position, never a silent extreme.
+ *
+ * Clamping here is a UI affordance only. The SIDECAR rejects rather than clamps,
+ * deliberately: a user who asks for 100x and is quietly given 10x has been lied
+ * to. The slider simply cannot express 100x in the first place.
+ */
+export function clampFactor(value: number): number {
+  if (!Number.isFinite(value)) return 1;
+  return Math.min(SPEED_MAX, Math.max(SPEED_MIN, value));
+}
+
+/**
+ * True when `value` is a factor `speed.retime` will accept: a finite number,
+ * inside the window, and not exactly 1 (which the sidecar refuses as a no-op).
+ * The Apply control is gated on this, so a rejected request never leaves the UI.
+ */
+export function isRetimeFactor(value: unknown): value is number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return false;
+  if (value === 1) return false;
+  return value >= SPEED_MIN && value <= SPEED_MAX;
+}
+
+/**
+ * The output duration a re-time produces (`source / factor`). Returns 0 for an
+ * unknown source duration or a non-positive factor — "unknown" is not a number
+ * to do arithmetic on, and the panel renders it as a dash rather than "0:00".
+ */
+export function retimedDuration(sourceSec: number, factor: number): number {
+  if (!Number.isFinite(sourceSec) || sourceSec <= 0) return 0;
+  if (!Number.isFinite(factor) || factor <= 0) return 0;
+  return sourceSec / factor;
+}
+
+/**
+ * A factor as human copy — `2x (faster)` / `0.5x (slower)`. The DIRECTION is
+ * spelled out because a bare "0.5x" reads as "half the time" to as many people
+ * as read it "half the speed", and those are opposite edits.
+ */
+export function speedLabel(factor: number): string {
+  // `parseFloat(toFixed(2))` drops trailing zeros: 2.00 -> 2, 1.50 -> 1.5.
+  const n = parseFloat(factor.toFixed(2));
+  if (n === 1) return '1x (no change)';
+  return `${n}x (${n > 1 ? 'faster' : 'slower'})`;
+}

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -166,3 +166,25 @@ describe('Workspace ↔ Subtitles seam', () => {
     expect([...container.querySelectorAll('.cue-text')]).toHaveLength(2);
   });
 });
+
+describe('Workspace ↔ Speed seam', () => {
+  it('mounts the REAL Speed panel on the speed tab, threaded with the video duration', async () => {
+    // The point of this test: before v1.5 the re-time engine had no control in
+    // ANY panel. Asserting the real panel (not the Suspense fallback) is what
+    // proves the door is genuinely reachable from the Workspace.
+    await import('../features/Speed'); // warm the lazy chunk (same idiom as above)
+    rpcMock.mockResolvedValue({ project });
+
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} initialTab="speed" />);
+    });
+    await flush();
+
+    const panel = container.querySelector('.speed-panel');
+    expect(panel).not.toBeNull();
+    // `video.durationSec` is threaded through, so the before/after prediction is
+    // real rather than a dash: 2x on this source halves it.
+    expect(container.querySelector('[data-field="sourceDuration"]')?.textContent).not.toBe('—');
+    expect(container.querySelector('[data-field="newDuration"]')?.textContent).not.toBe('—');
+  });
+});

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -164,6 +164,9 @@ describe('Workspace', () => {
       'Short-maker',
       'Subtitle timeline',
       'Stabilize',
+      // v1.5: the Speed panel joins "Frame & Cut". Before it, the re-time engine
+      // had NO control in any panel — only an LLM-planned Director op reached it.
+      'Speed',
       'Dub',
       'NLE export',
       'Recipes',
@@ -205,6 +208,23 @@ describe('Workspace', () => {
     const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
     expect(frame?.tabIds).toContain('stabilize');
     expect(frame?.advanced).not.toBe(true);
+  });
+
+  it('puts Speed in the Frame & Cut group and selects it from a deep-link', async () => {
+    // The REAL panel mount is asserted in Workspace.seam.test.tsx, which drains
+    // macrotasks — the lazy chunk is a genuine dynamic import and this file's
+    // microtask-only flush() can leave the Suspense fallback up.
+    const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
+    expect(frame?.tabIds).toContain('speed');
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} initialTab="speed" />);
+    });
+    await flush();
+    const speedTab = [...container.querySelectorAll('[role="tab"]')].find(
+      (t) => t.textContent === 'Speed',
+    );
+    expect(speedTab).toBeDefined();
+    expect(speedTab?.getAttribute('aria-selected')).toBe('true');
   });
 
   it('opens the project via project.open and shows the title + tabs', async () => {

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -40,6 +40,8 @@ const Convert = lazy(() => import('../features/Convert'));
 const ShortMaker = lazy(() => import('../features/ShortMaker'));
 const TimelinePanel = lazy(() => import('../features/Timeline'));
 const Dub = lazy(() => import('../features/Dub'));
+// v1.5: constant-factor speed / slow motion over the existing re-time engine.
+const SpeedPanel = lazy(() => import('../features/Speed'));
 const Assets = lazy(() => import('../features/Assets'));
 // captions-export: EDL/CSV NLE timeline export of approved clips.
 const NleExport = lazy(() => import('../features/NleExport'));
@@ -81,6 +83,10 @@ export const WORKSPACE_TABS: TabDef[] = [
   { id: 'shortmaker', label: 'Short-maker' },
   { id: 'timeline', label: 'Subtitle timeline' },
   { id: 'stabilize', label: 'Stabilize' },
+  // v1.5: constant-factor speed / slow motion. The re-time ENGINE was already
+  // wired for the Director, but nothing in the renderer could reach it, so a
+  // user had to prompt the planner and hope. This is the direct control.
+  { id: 'speed', label: 'Speed' },
   { id: 'dub', label: 'Dub' },
   { id: 'nle', label: 'NLE export' },
   { id: 'recipes', label: 'Recipes' },
@@ -100,7 +106,7 @@ export const WORKSPACE_TAB_GROUPS: TabGroup[] = [
     label: 'Speech & Text',
     tabIds: ['transcribe', 'search', 'subtitles', 'diarize', 'refine'],
   },
-  { id: 'frame', label: 'Frame & Cut', tabIds: ['shortmaker', 'timeline', 'stabilize'] },
+  { id: 'frame', label: 'Frame & Cut', tabIds: ['shortmaker', 'timeline', 'stabilize', 'speed'] },
   { id: 'audio', label: 'Audio', tabIds: ['dub'] },
   {
     id: 'deliver',
@@ -306,6 +312,10 @@ export function Workspace({
         );
       case 'stabilize':
         return <Stabilize videoId={video.id} />;
+      case 'speed':
+        // durationSec drives the before/after prediction only; the sidecar
+        // probes the real length itself, so a stale/zero value cannot mis-render.
+        return <SpeedPanel videoId={video.id} sourceDurationSec={video.durationSec} />;
       case 'dub':
         return <Dub videoId={video.id} />;
       case 'nle':

--- a/sidecar/media_studio/features/speed.py
+++ b/sidecar/media_studio/features/speed.py
@@ -1,0 +1,293 @@
+"""Constant-factor speed / slow-motion as a FIRST-CLASS RPC (``speed.retime``).
+
+The re-time ENGINE already existed and is sound: ``director_op_engines``
+``build_retime_argv`` (``setpts=(1/factor)*PTS`` + a legal ``atempo`` chain, so
+picture and sound stay in sync) with ``retime`` in ``WIRED_KINDS``. What did NOT
+exist was any way for a USER to reach it: there was no speed RPC and no speed
+control in any renderer panel, so the only reachable path was an LLM-planned
+Director op — the user had to phrase a prompt and hope the planner emitted a
+``retime``. This module is that missing door, and nothing more.
+
+DELIBERATELY A THIN DOOR. The filtergraph is NOT re-implemented here:
+:func:`build_speed_argv` delegates to the audited Director builder, and
+``tests/test_speed.py::TestArgv::test_delegates_to_the_director_retime_builder``
+asserts byte-equality so the two paths can never drift into two different
+re-timers. The delegation is a LAZY import because
+:mod:`media_studio.features.director_op_engines` pulls the caption/reframe/shorts
+chain, which a lean speed call has no reason to load.
+
+SCOPE — read this before citing the module as "speed ramps are done". This is a
+**CONSTANT** factor over the whole clip. A keyframed speed RAMP (piecewise
+``setpts`` with segment-wise audio resampling) is a DIFFERENT engine and is NOT
+implemented here or anywhere else in the tree; ``docs/plans/v1.5/editing-surface-audit-2026-08.md``
+records it as a later-stage item. A UI that offers "0.5x / 1.5x / 2x" is honest;
+a UI that offers "ramp from 1x to 2x" would not be.
+
+NOT TO BE CONFUSED WITH the two other things in this tree called "retime":
+``features/tts/align.py`` runs its own +/-15% ``atempo`` to fit a dub into its
+source slot, and ``features/caption_polish.py`` "retime" moves CUE timings on the
+subtitle track. Neither changes video playback speed; neither is this.
+
+CONTRACTS.md 4/6/7: argv-list subprocess only (never ``shell=True``); ffmpeg is
+resolved by absolute path through :mod:`media_studio.ffmpeg`; the render goes
+through the shared, drained ``run`` seam. Every heavy dependency is injectable so
+the module unit-tests with no real ffmpeg.
+
+KNOWN LIMIT (inherited, not introduced): ``build_retime_argv`` maps ``[0:a]``
+unconditionally, so a clip with NO audio stream fails the ffmpeg invocation
+rather than re-timing video-only. That is the Director path's existing behaviour
+and is shared, not added, here; fixing it means changing the shared builder for
+both callers, which is outside this module's remit. UNVERIFIED whether any
+library clip is audio-less in practice — the settling experiment is
+``ffprobe -show_streams`` over the library and a ``speed.retime`` call on any hit.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .. import protocol
+from ..jobs import JobContext
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import get_logger
+
+log = get_logger("media_studio.speed")
+
+# Injectable seams (mirror the sibling features):
+#   RunFn   mirrors ffmpeg.run(argv, total_sec, on_progress, should_cancel) -> int
+#   ProbeFn mirrors ffmpeg.ffprobe_duration(path, settings) -> float
+RunFn = Callable[..., int]
+ProbeFn = Callable[..., float]
+# videoId -> absolute media path (or None when unknown).
+Resolver = Callable[[str], str | None]
+
+#: The accepted playback-factor window. Not an ffmpeg limit (``_atempo_chain``
+#: decomposes ANY positive factor into legal [0.5, 2.0] stages) but a SANITY one:
+#: 0.1x turns a 1-minute clip into 10 minutes and 10x makes a 1-hour lecture a
+#: 6-minute blur; beyond that the request is far likelier to be a typo than an
+#: edit. Out-of-window is REJECTED, never silently clamped — a user who asks for
+#: 100x and gets 10x back has been lied to.
+#:
+#: MIRRORED in ``app/renderer/src/lib/speedPresets.ts`` (SPEED_MIN / SPEED_MAX):
+#: the renderer cannot read Python, so the window is stated twice on purpose. The
+#: renderer clamps for a friendly slider; THIS module is the authority and
+#: rejects. If you change one, change both.
+SPEED_MIN = 0.1
+SPEED_MAX = 10.0
+
+
+class SpeedError(RuntimeError):
+    """Raised when the re-time render fails (non-zero ffmpeg exit)."""
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _require_str(params: dict[str, Any], key: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value:
+        raise _invalid(f"{key} (str) is required")
+    return value
+
+
+def resolve_factor(raw: Any) -> float:
+    """Validate a playback ``factor`` at the wire boundary; return it as a float.
+
+    ``factor`` > 1 speeds up (shorter output), < 1 slows down (longer). Rejects,
+    in order: a non-numeric value (``bool`` included — ``isinstance(True, int)``
+    is True in Python, and ``speed.retime(factor=true)`` is a caller bug, not a
+    request for 1x), a non-positive value, exactly 1.0 (a no-op the engine itself
+    refuses), and anything outside [:data:`SPEED_MIN`, :data:`SPEED_MAX`].
+    """
+    if isinstance(raw, bool):
+        raise _invalid("factor must be numeric (got a boolean)")
+    try:
+        factor = float(raw)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        raise _invalid(f"factor must be numeric (got {raw!r})") from None
+    if factor <= 0.0:
+        raise _invalid(f"factor must be greater than 0 (got {factor})")
+    if factor == 1.0:
+        raise _invalid("factor 1.0 is a no-op — pick a slower or faster speed")
+    if not (SPEED_MIN <= factor <= SPEED_MAX):
+        raise _invalid(f"factor must be between {SPEED_MIN} and {SPEED_MAX} (got {factor})")
+    return factor
+
+
+def retimed_duration(source_sec: float, factor: float) -> float:
+    """The output duration a re-time by ``factor`` produces (``source/factor``).
+
+    Returns 0.0 for a non-positive source duration — that is the "probe failed /
+    unknown" signal, and multiplying an unknown by anything is still unknown.
+    """
+    if source_sec <= 0.0:
+        return 0.0
+    return source_sec / factor
+
+
+def speed_output_name(in_path: str, factor: float) -> str:
+    """The output basename for a re-time, e.g. ``lecture.speed-1p50x.mp4``.
+
+    The factor is in the NAME (``.`` -> ``p`` so the stem stays extension-safe) so
+    two speeds of the same source do not overwrite each other in the exports dir.
+    """
+    stem = Path(in_path).stem or "clip"
+    tag = f"{factor:.2f}".replace(".", "p")
+    return f"{stem}.speed-{tag}x.mp4"
+
+
+def build_speed_argv(
+    in_path: str,
+    out_path: str,
+    factor: float,
+    settings: dict[str, Any] | None = None,
+) -> list[str]:
+    """argv that re-times ``in_path`` -> ``out_path`` by ``factor``.
+
+    Delegates to the audited Director builder rather than re-deriving the
+    ``setpts``/``atempo`` graph, so the user-driven RPC and the Director op can
+    never render differently. Lazy import: the Director engine module pulls the
+    caption/reframe/shorts chain, which this call does not need at import time.
+    """
+    from . import director_op_engines as _doe
+
+    return _doe.build_retime_argv(in_path, out_path, factor, settings)
+
+
+class SpeedService:
+    """Owns the ``speed.retime`` RPC over the library/exports seams."""
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver,
+        out_dir: str | os.PathLike,
+        settings_provider: Callable[[], dict[str, Any]] | None = None,
+        run: RunFn | None = None,
+        duration: ProbeFn | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._out_dir = Path(out_dir)
+        self._settings_provider = settings_provider or (lambda: {})
+        self._run = run
+        self._duration = duration
+
+    def _settings(self) -> dict[str, Any]:
+        try:
+            return dict(self._settings_provider() or {})
+        except Exception:  # noqa: BLE001 - settings must never break an op
+            return {}
+
+    def _resolve(self, params: dict[str, Any]) -> str:
+        """Resolve a ``{videoId}`` or ``{path}`` request to a concrete media path."""
+        path = params.get("path")
+        if isinstance(path, str) and path:
+            return path
+        video_id = _require_str(params, "videoId")
+        resolved = self._resolver(video_id)
+        if not resolved:
+            raise _invalid(f"unknown video: {video_id}")
+        return str(resolved)
+
+    def run(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``speed.retime({videoId|path, factor})`` -> ``{jobId}``.
+
+        ``job.done.result`` is ``{path, factor, sourceDurationSec, durationSec}``:
+        the re-timed clip plus the duration arithmetic the UI shows ("6.0s, was
+        12.0s"). Both the factor and the source are validated BEFORE the job is
+        enqueued, so a bad request fails the call rather than a background job the
+        caller then has to poll to discover was never going to work.
+        """
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        in_path = self._resolve(params)
+        factor = resolve_factor(params.get("factor"))
+        settings = self._settings()
+        runner: RunFn = self._run if self._run is not None else _default_run()
+        probe: ProbeFn = self._duration if self._duration is not None else _default_duration()
+        out_dir = self._out_dir
+
+        def job_body(job_ctx: JobContext) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            try:
+                total = float(probe(in_path, settings))
+            except Exception:  # noqa: BLE001 - probe failure only coarsens progress
+                total = 0.0
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = str(out_dir / speed_output_name(in_path, factor))
+            argv = build_speed_argv(in_path, out_path, factor, settings)
+            code = runner(
+                argv,
+                total_sec=retimed_duration(total, factor),
+                on_progress=lambda pct, msg: job_ctx.progress(pct, msg),
+                should_cancel=lambda: job_ctx.cancelled,
+            )
+            if code != 0:
+                raise SpeedError(f"re-time failed (ffmpeg exit {code}) for {in_path}")
+            return {
+                "path": out_path,
+                "factor": factor,
+                "sourceDurationSec": total,
+                "durationSec": retimed_duration(total, factor),
+            }
+
+        job = ctx.jobs.start(job_body)
+        return {"jobId": job.id}
+
+
+def _default_run() -> RunFn:
+    """The real drained ffmpeg runner (lazy so importing this module is cheap)."""
+    from .. import ffmpeg
+
+    return ffmpeg.run
+
+
+def _default_duration() -> ProbeFn:
+    """The real ffprobe duration seam (lazy, same reason as :func:`_default_run`)."""
+    from .. import ffmpeg
+
+    return ffmpeg.ffprobe_duration
+
+
+def register(
+    *,
+    resolver: Resolver,
+    out_dir: str | os.PathLike,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+    run: RunFn | None = None,
+    duration: ProbeFn | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> SpeedService:
+    """Create the service and register ``speed.retime`` (mirrors stabilize.register).
+
+    ``register_fn`` defaults to :func:`protocol.register` (duplicates fail loudly);
+    tests inject a fake registrar. Returns the service for the caller to hold.
+    """
+    service = SpeedService(
+        resolver=resolver,
+        out_dir=out_dir,
+        settings_provider=settings_provider,
+        run=run,
+        duration=duration,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("speed.retime", service.run)
+    log.info("registered speed.retime")
+    return service
+
+
+__all__ = [
+    "SPEED_MAX",
+    "SPEED_MIN",
+    "SpeedError",
+    "SpeedService",
+    "build_speed_argv",
+    "register",
+    "resolve_factor",
+    "retimed_duration",
+    "speed_output_name",
+]

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -406,6 +406,23 @@ def register_all(
         register_fn=reg,
     )
 
+    # speed.retime — the USER-DRIVEN door onto the re-time engine. The engine
+    # (director_op_engines.build_retime_argv, `retime` in WIRED_KINDS) was already
+    # wired, but only an LLM-planned Director op could reach it, so changing
+    # playback speed meant phrasing a prompt and hoping the planner emitted the op.
+    # Same seams as the audio-stabilize group above; the argv is DELEGATED to the
+    # Director builder so the two paths cannot render differently.
+    from ..features import speed as _speed  # local: import-light
+
+    _speed.register(
+        resolver=svc._resolve_video_path,
+        out_dir=svc.exports_dir / "retimed",
+        settings_provider=svc.settings.get,
+        run=svc._ffmpeg_run,
+        duration=svc._ffprobe_duration,
+        register_fn=reg,
+    )
+
     # ---------------------------------------------------------------------- #
     # system-advanced group (this build) — health / recipes / diarize.
     # Each module owns its own register() (mirrors shorts / cues / assets).

--- a/sidecar/media_studio/handlers/library_ops.py
+++ b/sidecar/media_studio/handlers/library_ops.py
@@ -396,8 +396,8 @@ def paths_describe(self: Services, params: dict[str, Any], ctx: RpcContext) -> d
     legacy JSON index the store only reads-then-demotes and never writes.
     ``subDirs`` names the per-feature derivative folders the sidecar writes into —
     ``dubs`` under the data dir; the ffmpeg-derivative folders
-    (``stabilized``/``audiomix``/``trimmed``) under the exports root, matching
-    ``register_all``'s wiring; and ``managed-copies``, the opt-in byte-copy store
+    (``stabilized``/``audiomix``/``trimmed``/``retimed``) under the exports root,
+    matching ``register_all``'s wiring; and ``managed-copies``, the opt-in byte-copy store
     beside the library DB (``keepcopy.STORE_DIRNAME``, rendered by
     ``ManagedStoreMeter`` in the same Settings sub-tab but named nowhere else).
     ``shorts`` is written PER-VIDEO as ``exports/shorts-<videoId>``, so it is
@@ -418,6 +418,7 @@ def paths_describe(self: Services, params: dict[str, Any], ctx: RpcContext) -> d
             "stabilized": str(self.exports_dir / "stabilized"),
             "audiomix": str(self.exports_dir / "audiomix"),
             "trimmed": str(self.exports_dir / "trimmed"),
+            "retimed": str(self.exports_dir / "retimed"),
             "managed-copies": str(Path(self.library.index_path).parent / _keepcopy.STORE_DIRNAME),
         },
     }

--- a/sidecar/tests/test_handlers.py
+++ b/sidecar/tests/test_handlers.py
@@ -217,6 +217,20 @@ def test_register_all_wires_audio_stabilize_group(tmp_path: Path) -> None:
         assert method in registered, f"{method} was not registered"
 
 
+def test_register_all_wires_speed_retime(tmp_path: Path) -> None:
+    """speed.retime is wired, and bound to the SpeedService the module builds.
+
+    The re-time engine was already in WIRED_KINDS but reachable only through an
+    LLM-planned Director op; this asserts the user-driven RPC door is open.
+    """
+    registered: dict[str, Any] = {}
+    handlers.register_all(
+        services=Services(data_dir=tmp_path / "d"),
+        register=lambda name, fn: registered.__setitem__(name, fn),
+    )
+    assert "speed.retime" in registered, "speed.retime was not registered"
+
+
 def test_captions_cues_bound_to_shortmaker_context(services: Services, ctx: RpcContext, video_file: Path) -> None:
     """The registered captions.cues is bound to Services._shortmaker_context, so a
     transcribed video yields WORD-level cues from its persisted transcript (C7)."""

--- a/sidecar/tests/test_handlers_paths.py
+++ b/sidecar/tests/test_handlers_paths.py
@@ -80,12 +80,17 @@ def test_paths_describe_names_the_managed_copy_store(services: Services, ctx: Rp
 def test_paths_describe_subdirs_cover_required_features(services: Services, ctx: RpcContext) -> None:
     result = services.paths_describe({}, ctx)
     sub = result["subDirs"]
-    assert {"shorts", "dubs", "stabilized", "audiomix", "trimmed"} <= set(sub)
+    assert {"shorts", "dubs", "stabilized", "audiomix", "trimmed", "retimed"} <= set(sub)
     # dubs lives under the data dir; the exports-rooted ones under exports.
     assert sub["dubs"] == str(services.data_dir / "dubs")
     assert sub["stabilized"] == str(services.exports_dir / "stabilized")
     assert sub["audiomix"] == str(services.exports_dir / "audiomix")
     assert sub["trimmed"] == str(services.exports_dir / "trimmed")
+    # speed.retime writes here. The docstring on ``paths_describe`` promises this
+    # list MATCHES register_all's wiring, so a new ffmpeg-derivative folder that is
+    # not reported makes that promise false — and PathsPanel iterates subDirs
+    # generically, so the omission would silently hide the folder from the UI.
+    assert sub["retimed"] == str(services.exports_dir / "retimed")
     # Shorts are written PER-VIDEO under exports as ``shorts-<videoId>`` (see
     # register_all's ``out_dir_for=lambda vid: exports_dir / f"shorts-{vid}"``);
     # there is no flat ``exports_dir/shorts`` dir, so report the honest pattern.

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -128,6 +128,9 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         "social.enqueue",
         "social.plan",
         "social.queue",
+        # The user-driven door onto the already-wired `retime` engine: before it
+        # the ONLY way to change playback speed was an LLM-planned Director op.
+        "speed.retime",
         "stabilize.run",
         "subtitles.edit",
         "subtitles.export",

--- a/sidecar/tests/test_speed.py
+++ b/sidecar/tests/test_speed.py
@@ -1,0 +1,251 @@
+"""Tests for features/speed.py — the ``speed.retime`` RPC (constant-factor re-time).
+
+The re-time ENGINE already existed (``director_op_engines.build_retime_argv``:
+``setpts`` + an ``atempo`` chain) but was reachable ONLY as an LLM-planned Director
+op. These tests pin the user-driven RPC that exposes it: parameter validation, the
+argv delegation (anti-drift against the Director builder), the job result shape,
+and registration.
+
+SCOPE (stated so no reader over-reads it): this covers a CONSTANT factor only. A
+keyframed speed RAMP (piecewise ``setpts`` + segment-wise audio resampling) is a
+different engine and is NOT built here — see the module docstring.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import protocol
+from media_studio.features import director_op_engines as _doe
+from media_studio.features import speed as sp
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext, RpcError
+
+
+class RecordingRun:
+    """An ffmpeg ``run`` seam that records argv and reports success."""
+
+    def __init__(self, code: int = 0) -> None:
+        self.calls: list[list[str]] = []
+        self._code = code
+
+    def __call__(self, argv: list[str], **kwargs: Any) -> int:
+        self.calls.append(list(argv))
+        on_progress = kwargs.get("on_progress")
+        if on_progress is not None:
+            on_progress(50.0, "speed")
+        return self._code
+
+
+def _rpc_ctx(registry: JobRegistry) -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=registry)
+
+
+def _svc(tmp_path: Path, **over: Any) -> sp.SpeedService:
+    kwargs: dict[str, Any] = {
+        "resolver": lambda vid: "/lib/in.mp4" if vid == "v1" else None,
+        "out_dir": tmp_path / "speed",
+        "settings_provider": lambda: {"ffmpegPath": "/usr/bin/ffmpeg"},
+        "run": RecordingRun(),
+        "duration": lambda p, s=None: 12.0,
+    }
+    kwargs.update(over)
+    return sp.SpeedService(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# resolve_factor — the boundary validator
+# --------------------------------------------------------------------------- #
+class TestResolveFactor:
+    @pytest.mark.parametrize("raw", [0.5, 1.5, 2, "2.5", 0.1, 10.0])
+    def test_accepts_valid_factors(self, raw: Any) -> None:
+        assert sp.resolve_factor(raw) == float(raw)
+
+    @pytest.mark.parametrize("raw", [None, "fast", {}, [], True])
+    def test_rejects_non_numeric(self, raw: Any) -> None:
+        with pytest.raises(RpcError, match="numeric"):
+            sp.resolve_factor(raw)
+
+    @pytest.mark.parametrize("raw", [0.0, -1.0, -0.5])
+    def test_rejects_non_positive(self, raw: float) -> None:
+        with pytest.raises(RpcError, match="greater than 0"):
+            sp.resolve_factor(raw)
+
+    def test_rejects_exactly_one_as_a_no_op(self) -> None:
+        with pytest.raises(RpcError, match="no-op"):
+            sp.resolve_factor(1.0)
+
+    @pytest.mark.parametrize("raw", [0.09, 10.01, 100.0])
+    def test_rejects_out_of_window(self, raw: float) -> None:
+        with pytest.raises(RpcError, match="between"):
+            sp.resolve_factor(raw)
+
+    def test_window_constants_bracket_one(self) -> None:
+        assert sp.SPEED_MIN < 1.0 < sp.SPEED_MAX
+
+
+# --------------------------------------------------------------------------- #
+# retimed_duration — the pure duration prediction the UI shows
+# --------------------------------------------------------------------------- #
+class TestRetimedDuration:
+    def test_speed_up_shortens(self) -> None:
+        assert sp.retimed_duration(60.0, 2.0) == 30.0
+
+    def test_slow_down_lengthens(self) -> None:
+        assert sp.retimed_duration(60.0, 0.5) == 120.0
+
+    @pytest.mark.parametrize("src", [0.0, -3.0])
+    def test_unknown_source_duration_is_zero(self, src: float) -> None:
+        assert sp.retimed_duration(src, 2.0) == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# argv — delegation to the audited Director builder (anti-drift)
+# --------------------------------------------------------------------------- #
+class TestArgv:
+    def test_delegates_to_the_director_retime_builder(self) -> None:
+        settings = {"ffmpegPath": "/usr/bin/ffmpeg"}
+        mine = sp.build_speed_argv("/in.mp4", "/out.mp4", 2.0, settings)
+        theirs = _doe.build_retime_argv("/in.mp4", "/out.mp4", 2.0, settings)
+        assert mine == theirs
+
+    def test_argv_carries_the_setpts_and_atempo_filtergraph(self) -> None:
+        argv = sp.build_speed_argv("/in.mp4", "/out.mp4", 2.0, {"ffmpegPath": "/usr/bin/ffmpeg"})
+        graph = argv[argv.index("-filter_complex") + 1]
+        assert "setpts=0.500000*PTS" in graph
+        assert "atempo=" in graph
+
+
+# --------------------------------------------------------------------------- #
+# output naming
+# --------------------------------------------------------------------------- #
+class TestOutputName:
+    @pytest.mark.parametrize(
+        ("factor", "expected"),
+        [(0.5, "clip.speed-0p50x.mp4"), (2.0, "clip.speed-2p00x.mp4"), (1.5, "clip.speed-1p50x.mp4")],
+    )
+    def test_name_encodes_the_factor(self, factor: float, expected: str) -> None:
+        assert sp.speed_output_name("/x/clip.mp4", factor) == expected
+
+    def test_pathless_stem_falls_back(self) -> None:
+        assert sp.speed_output_name("", 2.0) == "clip.speed-2p00x.mp4"
+
+
+# --------------------------------------------------------------------------- #
+# the RPC service
+# --------------------------------------------------------------------------- #
+class TestService:
+    def test_run_resolves_videoId_and_returns_the_retimed_clip(self, tmp_path, registry) -> None:
+        run = RecordingRun()
+        svc = _svc(tmp_path, run=run)
+        out = svc.run({"videoId": "v1", "factor": 2.0}, _rpc_ctx(registry))
+        assert "jobId" in out
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["factor"] == 2.0
+        assert job.result["sourceDurationSec"] == 12.0
+        assert job.result["durationSec"] == 6.0
+        assert job.result["path"].endswith("in.speed-2p00x.mp4")
+        assert run.calls, "the ffmpeg seam was never invoked"
+
+    def test_run_accepts_a_direct_path(self, tmp_path, registry) -> None:
+        svc = _svc(tmp_path)
+        out = svc.run({"path": "/x/clip.mp4", "factor": 0.5}, _rpc_ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["durationSec"] == 24.0
+
+    def test_run_rejects_a_bad_factor_before_enqueueing(self, tmp_path, registry) -> None:
+        svc = _svc(tmp_path)
+        with pytest.raises(RpcError, match="no-op"):
+            svc.run({"videoId": "v1", "factor": 1.0}, _rpc_ctx(registry))
+
+    def test_run_unknown_video_raises(self, tmp_path, registry) -> None:
+        svc = _svc(tmp_path, resolver=lambda vid: None)
+        with pytest.raises(RpcError, match="unknown video"):
+            svc.run({"videoId": "ghost", "factor": 2.0}, _rpc_ctx(registry))
+
+    def test_run_missing_video_id_raises(self, tmp_path, registry) -> None:
+        svc = _svc(tmp_path)
+        with pytest.raises(RpcError, match="videoId"):
+            svc.run({"videoId": "", "factor": 2.0}, _rpc_ctx(registry))
+
+    def test_run_without_job_registry_raises(self, tmp_path) -> None:
+        svc = _svc(tmp_path)
+        ctx = RpcContext(emit_notification=lambda obj: None, jobs=None)
+        with pytest.raises(RpcError, match="no job registry"):
+            svc.run({"videoId": "v1", "factor": 2.0}, ctx)
+
+    def test_nonzero_ffmpeg_exit_fails_the_job(self, tmp_path, registry) -> None:
+        svc = _svc(tmp_path, run=RecordingRun(code=3))
+        out = svc.run({"videoId": "v1", "factor": 2.0}, _rpc_ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.error is not None
+        assert "exit 3" in str(job.error)
+
+    def test_settings_provider_raising_yields_empty_settings(self, tmp_path, registry) -> None:
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("settings exploded")
+
+        svc = _svc(tmp_path, settings_provider=boom)
+        out = svc.run({"path": "/x/clip.mp4", "factor": 2.0}, _rpc_ctx(registry))
+        registry.get(out["jobId"]).wait(timeout=5)
+        assert registry.get(out["jobId"]).result["factor"] == 2.0
+
+    def test_probe_failure_only_coarsens_progress(self, tmp_path, registry) -> None:
+        def boom(path: str, settings: Any = None) -> float:
+            raise RuntimeError("ffprobe exploded")
+
+        svc = _svc(tmp_path, duration=boom)
+        out = svc.run({"path": "/x/clip.mp4", "factor": 2.0}, _rpc_ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        # The op still renders; the duration prediction degrades to "unknown" (0.0)
+        # rather than failing the whole re-time.
+        assert job.result["sourceDurationSec"] == 0.0
+        assert job.result["durationSec"] == 0.0
+
+    def test_defaults_construct_without_injected_seams(self, tmp_path) -> None:
+        svc = sp.SpeedService(resolver=lambda vid: None, out_dir=tmp_path)
+        assert svc._settings() == {}
+
+
+# --------------------------------------------------------------------------- #
+# the un-injected default seams — an uncovered default is an unproven default
+# --------------------------------------------------------------------------- #
+class TestDefaultSeams:
+    def test_default_run_is_the_shared_drained_ffmpeg_runner(self) -> None:
+        # The 29-min-freeze lesson: the render MUST go through the shared drained
+        # runner, never a re-implemented drain. Pin the identity.
+        from media_studio import ffmpeg
+
+        assert sp._default_run() is ffmpeg.run
+
+    def test_default_duration_is_the_shared_ffprobe_seam(self) -> None:
+        from media_studio import ffmpeg
+
+        assert sp._default_duration() is ffmpeg.ffprobe_duration
+
+
+# --------------------------------------------------------------------------- #
+# registration
+# --------------------------------------------------------------------------- #
+class TestRegister:
+    def test_register_binds_speed_retime(self, tmp_path) -> None:
+        registered: dict[str, Any] = {}
+        svc = sp.register(
+            resolver=lambda vid: None,
+            out_dir=tmp_path,
+            register_fn=lambda name, fn: registered.__setitem__(name, fn),
+        )
+        assert "speed.retime" in registered
+        assert registered["speed.retime"] == svc.run
+
+    def test_register_default_uses_protocol(self, tmp_path) -> None:
+        # The autouse conftest `_restore_methods` fixture snapshots/restores
+        # protocol.METHODS around each test, so this registration is isolated.
+        sp.register(resolver=lambda vid: None, out_dir=tmp_path)
+        assert "speed.retime" in protocol.METHODS


### PR DESCRIPTION
- **feat(speed): a real speed/re-time RPC engine door (constant factor)**
- **feat(speed): wire speed.retime onto the RPC registry**
- **feat(speed): the pure renderer model for the speed control**
- **feat(speed): the Speed panel — preset speeds, custom factor, live prediction**
- **feat(speed): reach it — Workspace "Speed" tab + a typed client.speed.retime**
- **style(speed): biome format the Speed test (gate:1 would have failed)**
