### PR TITLE
fix/v15 timeline naming

### DIFF
--- a/app/e2e/preview.spec.ts
+++ b/app/e2e/preview.spec.ts
@@ -264,14 +264,15 @@ test('Workspace tabs mount, including SemanticSearch', async () => {
   await expect(win.locator('section.semantic-search-panel h2')).toHaveText('Search the transcript');
   await expect(win.locator('input[aria-label="Search the transcript"]')).toBeVisible();
 
-  // "Timeline export" (tab id `nle`) lives in the Deliver cluster, which is
-  // collapsed by default — so REVEAL it first or Playwright's actionability gate
-  // cannot click a `display:none` button. Use `.tabbar__export` (Workspace
-  // handleExport → `setAdvancedOpen(true)`), which is IDEMPOTENT; the
-  // `.tabbar__advanced-toggle` would flip the cluster shut on a second caller.
+  // "NLE export" (tab id `nle`, relabelled from "Timeline export" by the v1.5
+  // timeline-naming lane) lives in the Deliver cluster, which is collapsed by
+  // default — so REVEAL it first or Playwright's actionability gate cannot click
+  // a `display:none` button. Use `.tabbar__export` (Workspace handleExport →
+  // `setAdvancedOpen(true)`), which is IDEMPOTENT; the `.tabbar__advanced-toggle`
+  // would flip the cluster shut on a second caller.
   await win.locator('.tabbar__export').click();
-  // Switch to Timeline export and assert the NleExport panel ITSELF mounted.
-  await win.locator('button', { hasText: 'Timeline export' }).first().click();
+  // Switch to NLE export and assert the NleExport panel ITSELF mounted.
+  await win.locator('button', { hasText: 'NLE export' }).first().click();
   await expect(win.locator('section.nle-panel')).toBeVisible();
   await expect(
     win.locator('section.nle-panel button', { hasText: 'Export timeline' }),
@@ -286,7 +287,7 @@ test('export action yields a real file (NLE timeline export, real button)', asyn
   // Reveal the Deliver cluster first (see the note above): this test must not
   // depend on a sibling test having left it open.
   await win.locator('.tabbar__export').click();
-  await win.locator('button', { hasText: 'Timeline export' }).first().click();
+  await win.locator('button', { hasText: 'NLE export' }).first().click();
   await expect(win.locator('section.nle-panel')).toBeVisible();
   await win.locator('section.nle-panel button', { hasText: 'Export timeline' }).click();
 

--- a/app/renderer/src/components/useJob.test.tsx
+++ b/app/renderer/src/components/useJob.test.tsx
@@ -616,6 +616,13 @@ describe('useJob helpers (pure)', () => {
       label: 'Short-maker',
     });
     expect(featureLabel('tts.dub.start')).toEqual({ feature: 'tts', label: 'Dub' });
+    // v1.5 timeline-naming: FEATURE_LABELS promises parity with the Workspace tab
+    // names, and the `timeline.*` namespace serves the subtitle-CUE editor — so a
+    // toast for it must not say "Timeline" either.
+    expect(featureLabel('timeline.peaks')).toEqual({
+      feature: 'timeline',
+      label: 'Subtitle timeline',
+    });
     expect(featureLabel(null)).toEqual({ feature: 'job', label: 'Job' });
     expect(featureLabel('')).toEqual({ feature: 'job', label: 'Job' });
     // Unknown features fall back to capitalization (forward-compatible).

--- a/app/renderer/src/components/useJob.ts
+++ b/app/renderer/src/components/useJob.ts
@@ -114,7 +114,9 @@ const FEATURE_LABELS: Record<string, string> = {
   convert: 'Convert',
   shortmaker: 'Short-maker',
   media: 'Media',
-  timeline: 'Timeline',
+  // v1.5 timeline-naming: the `timeline.*` namespace (one method, `timeline.peaks`)
+  // serves the subtitle-CUE editor, and this map promises parity with the tab name.
+  timeline: 'Subtitle timeline',
   tts: 'Dub',
   assets: 'Assets',
   project: 'Project',

--- a/app/renderer/src/features/Timeline.test.tsx
+++ b/app/renderer/src/features/Timeline.test.tsx
@@ -213,6 +213,30 @@ describe('<Timeline />', () => {
     });
   }
 
+  // v1.5 timeline-naming: this panel is a subtitle-CUE editor. Its old heading
+  // said "Timeline", which promised a video timeline the app does not have here
+  // (`docs/plans/v1.5/editing-surface-audit-2026-08.md` §0.1). The heading must
+  // name its real subject, and the panel must point at the surfaces where video
+  // trimming ACTUALLY lives today, so the dead end is not silent.
+  it('names its subject and signposts where video trimming really lives', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+
+    expect(container.querySelector('.timeline__title')?.textContent).toBe('Subtitle timeline');
+
+    const note = container.querySelector('.timeline__scope-note');
+    expect(note).not.toBeNull();
+    const text = note?.textContent ?? '';
+    // what it DOES edit
+    expect(text).toContain('subtitle cues');
+    // the disclaimer that removes the lie
+    expect(text).toContain('does not cut the video');
+    // the two routes that DO cut video today: director.apply (prompt-driven) and
+    // Make Shorts' manual interval control (typed timecodes).
+    expect(text).toContain('Director');
+    expect(text).toContain('Manual interval');
+  });
+
   it('loads the track via tracks.list and renders one rect per cue', async () => {
     const fake = makeFakeApi();
     await mount(fake.api);

--- a/app/renderer/src/features/Timeline.tsx
+++ b/app/renderer/src/features/Timeline.tsx
@@ -377,7 +377,25 @@ export function Timeline({
   const playheadLeftPct = duration > 0 ? (playhead / duration) * 100 : 0;
   return (
     <section className="timeline">
-      <h2 className="timeline__title">Timeline</h2>
+      <h2 className="timeline__title">Subtitle timeline</h2>
+
+      {/*
+        v1.5 timeline-naming: this panel used to be called "Timeline", which read
+        as the video timeline of an editor. It is not one — every rect below is a
+        subtitle cue and every toolbar action edits cue text or cue timing. State
+        the scope, then name the two surfaces that DO cut footage today so the
+        user is not left hunting: `director.apply` (trim/cut/join are wired op
+        kinds there) and Make Shorts' Manual interval control (typed timecodes ->
+        shortmaker.export). Static text on purpose — routing out of here would
+        need an onOpen* callback threaded from App.tsx, which is a shared file
+        several v1.5 lanes are already editing.
+      */}
+      <p className="timeline__scope-note">
+        Edits <strong>subtitle cues</strong> — split, merge, retime, and drag caption timings over
+        the waveform. It <strong>does not cut the video</strong>. To trim or cut the footage itself,
+        use <strong>Director</strong> (describe the edit, review the plan before it renders) or{' '}
+        <strong>Make Shorts → Manual interval</strong> (type an exact start and end time).
+      </p>
 
       {error && (
         <p role="alert" className="timeline__error">

--- a/app/renderer/src/features/timeline.css
+++ b/app/renderer/src/features/timeline.css
@@ -147,3 +147,23 @@
 .timeline .timeline__status {
   font-family: var(--font-mono);
 }
+
+/* v1.5 timeline-naming: the scope note sits directly under the heading and says
+   what this lane edits (cues) and where video trimming actually lives. It is
+   standing orientation, not an alert — so it takes the secondary supporting-copy
+   voice at BODY size, not the tracked-caps caption voice (which is the label
+   rung, wrong for a sentence). Quiet enough to ignore once learned, present
+   enough to end the hunt. The <strong> spans carry the load-bearing words and
+   step up to primary text, so the part that must be read clears contrast. */
+.timeline .timeline__scope-note {
+  margin: 0 0 var(--space-4);
+  max-width: 68ch; /* readable measure, not full-panel */
+  color: var(--text-secondary);
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading);
+}
+
+.timeline .timeline__scope-note strong {
+  color: var(--text-primary);
+  font-weight: var(--weight-medium);
+}

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -657,7 +657,7 @@ describe('Workspace tab clusters (WU-3a2)', () => {
 });
 
 // design-review P1: EXPORT is the terminal goal but the "Deliver" cluster
-// (Convert/Timeline export/Recipes/Assets/Tracks) is collapsed behind Advanced.
+// (Convert/NLE export/Recipes/Assets/Tracks) is collapsed behind Advanced.
 // A persistent Export action surfaces it from the default view WITHOUT un-hiding
 // the whole cluster by default — clicking it jumps to the primary export panel
 // (Convert) and reveals the Deliver cluster so its siblings are reachable.

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -133,7 +133,14 @@ async function flush(): Promise<void> {
 }
 
 describe('Workspace', () => {
-  it('exposes the contract tabs in order (P2: +Timeline/Dub/Assets; captions-export: +Timeline export; system-advanced: +Diarize/Recipes)', () => {
+  // SCOPE CHANGE (v1.5 timeline-naming, deliberate): two LABELS moved, ids and
+  // order untouched. 'Timeline' -> 'Subtitle timeline' and 'Timeline export' ->
+  // 'NLE export'. Both old strings promised a video timeline this workspace does
+  // not have: the `timeline` tab mounts features/Timeline.tsx, a subtitle-CUE
+  // editor (`Timeline.tsx:1-8`), and the `nle` tab exports an EDL synthesized
+  // from approved short-maker clips, not a user-authored timeline
+  // (`NleExport.tsx:1-9`). The assertion stays exact and order-sensitive.
+  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes)', () => {
     expect(WORKSPACE_TABS.map((t) => t.label)).toEqual([
       'Transcribe',
       'Search',
@@ -143,12 +150,25 @@ describe('Workspace', () => {
       'Tracks',
       'Convert',
       'Short-maker',
-      'Timeline',
+      'Subtitle timeline',
       'Dub',
-      'Timeline export',
+      'NLE export',
       'Recipes',
       'Assets',
     ]);
+  });
+
+  // The naming invariant, pinned per-id so it survives a tab being inserted or
+  // reordered by another lane. This does NOT forbid a future tab labelled
+  // 'Timeline' — a real video timeline may legitimately claim that name. It
+  // forbids these two SPECIFIC panels from claiming it, because neither is one.
+  it('never lets the subtitle-cue editor or the EDL exporter claim the name "Timeline"', () => {
+    const byId = (id: string): string | undefined => WORKSPACE_TABS.find((t) => t.id === id)?.label;
+    // features/Timeline.tsx = waveform + draggable subtitle CUES.
+    expect(byId('timeline')).toBe('Subtitle timeline');
+    // features/NleExport.tsx = CMX3600 EDL / CSV handoff for Premiere/Resolve.
+    expect(byId('nle')).toBe('NLE export');
+    expect(WORKSPACE_TABS.map((t) => t.label)).not.toContain('Timeline export');
   });
 
   it('opens the project via project.open and shows the title + tabs', async () => {

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -171,6 +171,23 @@ describe('Workspace', () => {
     expect(WORKSPACE_TABS.map((t) => t.label)).not.toContain('Timeline export');
   });
 
+  // A constant saying "Subtitle timeline" is not the same signal as a BUTTON
+  // showing it — the two tests above read WORKSPACE_TABS directly, so a rename
+  // that never reached the rendered strip would still pass them. This one goes
+  // through the real TabBar and reads the DOM, which is the thing a user sees.
+  // Verified as a real detector by mutation: reverting either label in
+  // Workspace.tsx turns this red (see the commit body for the captured output).
+  it('renders the honest labels on the real tab buttons, not just in the array', async () => {
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} />);
+    });
+    await flush();
+    const tabText = (id: string): string | null | undefined =>
+      container.querySelector(`[role="tab"][data-tab-id="${id}"]`)?.textContent;
+    expect(tabText('timeline')).toBe('Subtitle timeline');
+    expect(tabText('nle')).toBe('NLE export');
+  });
+
   it('opens the project via project.open and shows the title + tabs', async () => {
     await act(async () => {
       root.render(<Workspace video={video} onBack={() => {}} />);

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -50,6 +50,23 @@ const Recipes = lazy(() => import('../features/Recipes'));
 // intelligence A: semantic transcript search (seeks the player on a hit).
 const SemanticSearch = lazy(() => import('../features/SemanticSearch'));
 
+/**
+ * v1.5 timeline-naming — two LABELS name their real subject. Ids are untouched
+ * (`timeline` / `nle` are load-bearing for deep-links, taskHub and useJob's
+ * FEATURE_LABELS), and nothing is added, removed or reordered.
+ *
+ * `timeline` mounts features/Timeline.tsx — a waveform strip plus a lane of
+ * draggable subtitle CUES (Timeline.tsx:1-8), whose sidecar registers exactly
+ * one method, `timeline.peaks` (timeline.py:324). No clip lane, no razor. The
+ * bare name "Timeline" promised a video timeline that is not here; a genuine
+ * video-timeline tab is free to claim it later.
+ *
+ * `nle` mounts features/NleExport.tsx — a CMX3600 EDL / CSV handoff whose
+ * events are approved short-maker clips laid back-to-back
+ * (nle_export.py:162,175-177), i.e. a synthesized rough cut, not a timeline the
+ * user authored. Deliver.tsx already calls the same panel "Pro handoff"; this
+ * label was the outlier.
+ */
 export const WORKSPACE_TABS: TabDef[] = [
   { id: 'transcribe', label: 'Transcribe' },
   { id: 'search', label: 'Search' },
@@ -59,20 +76,8 @@ export const WORKSPACE_TABS: TabDef[] = [
   { id: 'tracks', label: 'Tracks' },
   { id: 'convert', label: 'Convert' },
   { id: 'shortmaker', label: 'Short-maker' },
-  // v1.5 timeline-naming: LABEL only — the `timeline` id is load-bearing
-  // (deep-links, taskHub, useJob's FEATURE_LABELS) and does NOT move. This tab
-  // mounts features/Timeline.tsx, a waveform + draggable subtitle-CUE lane
-  // (Timeline.tsx:1-8); the sidecar behind it registers exactly one method,
-  // `timeline.peaks` (timeline.py:324). Calling it "Timeline" promised a video
-  // timeline that does not exist here, so the label names its real subject. A
-  // genuine video-timeline tab is free to claim the bare name later.
   { id: 'timeline', label: 'Subtitle timeline' },
   { id: 'dub', label: 'Dub' },
-  // v1.5 timeline-naming: LABEL only, same reason. This is the CMX3600 EDL /
-  // CSV handoff for Premiere & Resolve (NleExport.tsx:1-9), built by laying
-  // approved short-maker clips back-to-back — it does not export a timeline the
-  // user authored. Deliver.tsx already calls the same panel "Pro handoff"; this
-  // was the outlier. "NLE export" matches the module, the RPC and the CSS class.
   { id: 'nle', label: 'NLE export' },
   { id: 'recipes', label: 'Recipes' },
   { id: 'assets', label: 'Assets' },

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -59,9 +59,21 @@ export const WORKSPACE_TABS: TabDef[] = [
   { id: 'tracks', label: 'Tracks' },
   { id: 'convert', label: 'Convert' },
   { id: 'shortmaker', label: 'Short-maker' },
-  { id: 'timeline', label: 'Timeline' },
+  // v1.5 timeline-naming: LABEL only — the `timeline` id is load-bearing
+  // (deep-links, taskHub, useJob's FEATURE_LABELS) and does NOT move. This tab
+  // mounts features/Timeline.tsx, a waveform + draggable subtitle-CUE lane
+  // (Timeline.tsx:1-8); the sidecar behind it registers exactly one method,
+  // `timeline.peaks` (timeline.py:324). Calling it "Timeline" promised a video
+  // timeline that does not exist here, so the label names its real subject. A
+  // genuine video-timeline tab is free to claim the bare name later.
+  { id: 'timeline', label: 'Subtitle timeline' },
   { id: 'dub', label: 'Dub' },
-  { id: 'nle', label: 'Timeline export' },
+  // v1.5 timeline-naming: LABEL only, same reason. This is the CMX3600 EDL /
+  // CSV handoff for Premiere & Resolve (NleExport.tsx:1-9), built by laying
+  // approved short-maker clips back-to-back — it does not export a timeline the
+  // user authored. Deliver.tsx already calls the same panel "Pro handoff"; this
+  // was the outlier. "NLE export" matches the module, the RPC and the CSS class.
+  { id: 'nle', label: 'NLE export' },
   { id: 'recipes', label: 'Recipes' },
   { id: 'assets', label: 'Assets' },
 ];

--- a/docs/plans/v1.5/editing-surface-audit-2026-08.md
+++ b/docs/plans/v1.5/editing-surface-audit-2026-08.md
@@ -36,6 +36,17 @@ Three measured facts carry that claim:
    `sidecar/media_studio/features/timeline.py:324` registers exactly one method,
    `timeline.peaks`, which returns `{sampleRate, peaks}` — a waveform, nothing more.
 
+   > **NAMING RESOLVED (2026-08, `fix/v15-timeline-naming`) — the finding above stands; only the
+   > LABEL moved.** The tab now reads **"Subtitle timeline"**, the panel heading matches, and the
+   > panel carries a scope note pointing at the two surfaces that actually cut video today
+   > (Director, and Make Shorts → Manual interval). The sibling `"Timeline export"` tab was
+   > relabelled **"NLE export"** in the same pass, because once the first rename landed it became
+   > the only tab still carrying the word and would have caught the same misdirected click; it is
+   > the CMX3600/CSV handoff, whose events are approved short-maker clips laid back-to-back
+   > (row 27). **Nothing in §1's verdicts changes** — no engine, RPC, tab id, order or grouping was
+   > touched, the multi-clip gap is untouched, and the real video-timeline work stays in
+   > `feat/v15-video-timeline`. This is the honesty half of S1.1, not S1.1.
+
 2. **There is no direct-manipulation edit surface at all.** `app/renderer/src/views/Edit.tsx`
    is a 192-line *router*: it renders either `TaskHub` or `Workspace` (`Edit.tsx:153-163`).
    Its own empty state promises *"trim, cut, join, reframe, caption, and more — every edit tool


### PR DESCRIPTION
- **test(timeline): RED — pin the honest names the workspace does not yet use**
- **fix(workspace): stop two tabs promising a video timeline that is not there**
- **refactor(workspace): lift the rename rationale off the tab lines**
- **docs(v1.5): reconcile the editing-surface audit with the label it triggered**
- **test(workspace): assert the labels on the rendered BUTTONS, not just the array**
