### PR TITLE
fix/v15 ux criticals

### DIFF
--- a/app/main/appMenu.test.ts
+++ b/app/main/appMenu.test.ts
@@ -1,0 +1,148 @@
+// appMenu.test.ts — the application menu template (appMenu.ts).
+//
+// C2 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5): the app shipped Electron's
+// STOCK menu, so `Edit ▸ Undo (Ctrl+Z)` advertised an undo the app does not have.
+// Three independent signals that no app-wide undo exists:
+//   1. `main.ts` imported no `Menu` and called no `setApplicationMenu` (§4.1),
+//   2. docs/plans/v1.5/editing-surface-audit-2026-08.md row 25 — "PARTIAL, two
+//      disjoint mechanisms, no app-wide stack": `director.undo`
+//      (sidecar handlers/composition.py) inverts DIRECTOR ops only, and
+//      `timelineOps.ts` keeps a 100-entry history for SUBTITLE CUES only,
+//   3. neither is reachable from a global accelerator.
+//
+// So the stock item lied twice: the menu was named "Edit", which in this app's IA
+// is a RAIL DESTINATION (views/Edit.tsx) meaning "edit this video", and the item
+// was named a bare "Undo" with no scope. The roles themselves are honest — they
+// really do undo TYPING in a focused field — so the fix scopes the labels rather
+// than deleting working behaviour: a "Text" menu with "Undo typing"/"Redo typing".
+//
+// These tests hold that contract, and hold the dev-only View items off a packaged
+// build (H1 — DevTools and Force Reload were shipped to end users).
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { MenuItemConstructorOptions } from 'electron';
+import { buildAppMenuTemplate } from './appMenu';
+
+/** Every item in the template tree, depth-first (top-level entries included). */
+function flatten(items: readonly MenuItemConstructorOptions[]): MenuItemConstructorOptions[] {
+  const out: MenuItemConstructorOptions[] = [];
+  for (const item of items) {
+    out.push(item);
+    if (Array.isArray(item.submenu)) {
+      out.push(...flatten(item.submenu as MenuItemConstructorOptions[]));
+    }
+  }
+  return out;
+}
+
+function roles(items: readonly MenuItemConstructorOptions[]): string[] {
+  return flatten(items)
+    .map((item) => item.role)
+    .filter((role): role is NonNullable<MenuItemConstructorOptions['role']> => role != null);
+}
+
+function labels(items: readonly MenuItemConstructorOptions[]): string[] {
+  return flatten(items)
+    .map((item) => item.label)
+    .filter((label): label is string => typeof label === 'string');
+}
+
+function submenuOf(
+  items: readonly MenuItemConstructorOptions[],
+  label: string,
+): MenuItemConstructorOptions[] {
+  const found = items.find((item) => item.label === label);
+  if (!found || !Array.isArray(found.submenu)) {
+    throw new Error(`no top-level menu labelled "${label}"`);
+  }
+  return found.submenu as MenuItemConstructorOptions[];
+}
+
+describe('buildAppMenuTemplate', () => {
+  it('never offers a bare "Undo"/"Redo" — the app has no app-wide undo stack', () => {
+    for (const isDev of [true, false]) {
+      const all = labels(buildAppMenuTemplate({ isDev }));
+      expect(all).not.toContain('Undo');
+      expect(all).not.toContain('Redo');
+    }
+  });
+
+  it('never names a top-level menu "Edit" — that label is a rail destination here', () => {
+    for (const isDev of [true, false]) {
+      expect(buildAppMenuTemplate({ isDev }).map((item) => item.label)).not.toContain('Edit');
+    }
+  });
+
+  it('keeps native text-field undo/redo, scoped honestly to typing', () => {
+    const text = submenuOf(buildAppMenuTemplate({ isDev: false }), 'Text');
+    expect(text).toContainEqual(expect.objectContaining({ role: 'undo', label: 'Undo typing' }));
+    expect(text).toContainEqual(expect.objectContaining({ role: 'redo', label: 'Redo typing' }));
+  });
+
+  // SCOPE NOTE — an earlier draft of the test above also pinned
+  // `accelerator: 'CmdOrCtrl+Shift+Z'` on redo. That is WRONG on this app's primary
+  // platform: Windows' native redo is Ctrl+Y, and an explicit `accelerator`
+  // OVERRIDES the role's per-platform default, so pinning it would have traded one
+  // defect for a keyboard regression. The requirement is the inverse — leave the
+  // accelerator unset so Electron supplies the platform-correct binding. Only the
+  // LABEL is ours to change; the binding is the platform's.
+  it('leaves the role accelerators to the platform (Windows redo is Ctrl+Y)', () => {
+    const text = submenuOf(buildAppMenuTemplate({ isDev: false }), 'Text');
+    for (const item of text) {
+      expect(item.accelerator).toBeUndefined();
+    }
+  });
+
+  it('keeps the clipboard + select-all roles working', () => {
+    const text = roles(submenuOf(buildAppMenuTemplate({ isDev: false }), 'Text'));
+    expect(text).toEqual(expect.arrayContaining(['cut', 'copy', 'paste', 'delete', 'selectAll']));
+  });
+
+  it('withholds DevTools, Reload and Force Reload from a packaged build', () => {
+    const shipped = roles(buildAppMenuTemplate({ isDev: false }));
+    expect(shipped).not.toContain('toggleDevTools');
+    expect(shipped).not.toContain('reload');
+    expect(shipped).not.toContain('forceReload');
+  });
+
+  it('offers DevTools, Reload and Force Reload in development', () => {
+    const dev = roles(buildAppMenuTemplate({ isDev: true }));
+    expect(dev).toEqual(expect.arrayContaining(['toggleDevTools', 'reload', 'forceReload']));
+  });
+
+  it('keeps zoom and full-screen in BOTH builds (they are not dev tools)', () => {
+    for (const isDev of [true, false]) {
+      expect(roles(buildAppMenuTemplate({ isDev }))).toEqual(
+        expect.arrayContaining(['resetZoom', 'zoomIn', 'zoomOut', 'togglefullscreen']),
+      );
+    }
+  });
+
+  it('gives Help ▸ About a real home (main.ts already configures the panel)', () => {
+    expect(roles(submenuOf(buildAppMenuTemplate({ isDev: false }), 'Help'))).toContain('about');
+  });
+
+  it('has a labelled, non-empty submenu under every top-level entry', () => {
+    for (const isDev of [true, false]) {
+      const top = buildAppMenuTemplate({ isDev });
+      expect(top.length).toBeGreaterThan(0);
+      for (const item of top) {
+        expect(typeof item.label).toBe('string');
+        expect(Array.isArray(item.submenu)).toBe(true);
+        expect((item.submenu as MenuItemConstructorOptions[]).length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  // This repo has shipped ORPHANED modules before (SavePresetsControls and
+  // PathsPanel both existed, tested, and unreachable). A menu template nothing
+  // installs would leave the stock lying menu in place and the tests above would
+  // still pass, so assert the wiring exists.
+  it('is actually installed by main.ts (not an orphaned module)', () => {
+    const src = readFileSync(join(__dirname, 'main.ts'), 'utf8');
+    expect(src).toMatch(/buildAppMenuTemplate/);
+    expect(src).toMatch(/Menu\.setApplicationMenu\(/);
+    expect(src).toMatch(/Menu\.buildFromTemplate\(/);
+  });
+});

--- a/app/main/appMenu.ts
+++ b/app/main/appMenu.ts
@@ -23,8 +23,15 @@
 // preset names) instead of deleting a working feature to silence a wording bug.
 //
 // Accelerators are deliberately NOT set on role items: an explicit `accelerator`
-// overrides the role's per-platform default, and Windows' native redo is Ctrl+Y,
-// not Ctrl+Shift+Z. Only the labels are ours; the bindings stay the platform's.
+// OVERRIDES the role's per-platform default. Only the labels are ours; the
+// bindings stay the platform's. MEASURED, not assumed — Electron 43.3.0 on
+// win32, reading `Menu.getApplicationMenu()` back after installing this exact
+// template:
+//     role=undo      -> CommandOrControl+Z
+//     role=redo      -> Control+Y        <-- NOT Ctrl+Shift+Z
+//     role=cut/copy/paste/selectAll -> CommandOrControl+X/C/V/A
+// So pinning `CmdOrCtrl+Shift+Z` on redo (an early draft did) would have traded
+// the C2 wording defect for a broken Windows redo binding.
 //
 // This is a PURE template builder — it touches no Electron runtime object — so it
 // is unit-testable without a live app (appMenu.test.ts). `main.ts` feeds it

--- a/app/main/appMenu.ts
+++ b/app/main/appMenu.ts
@@ -8,8 +8,9 @@
 //        the FRAMING lied twice. "Edit" is a rail destination in this app's IA
 //        (views/Edit.tsx = "edit this video"), so an `Edit` menu reads as
 //        video-edit undo; and a bare "Undo" claims an app-wide stack that does
-//        not exist. editing-surface-audit-2026-08.md row 25 measures the real
-//        state: "PARTIAL — two disjoint mechanisms, no app-wide stack" —
+//        not exist. docs/plans/v1.5/editing-surface-audit-2026-08.md row 25
+//        measures the real state: "PARTIAL — two disjoint mechanisms, no
+//        app-wide stack" —
 //        `director.undo` inverts DIRECTOR ops only, and `timelineOps.ts` keeps a
 //        100-entry history for SUBTITLE CUES only. Neither can back a global
 //        Ctrl+Z, and this module does not pretend otherwise.

--- a/app/main/appMenu.ts
+++ b/app/main/appMenu.ts
@@ -1,0 +1,105 @@
+// appMenu.ts — the application menu template (CONTRACTS.md §1: main process).
+//
+// Reframe previously installed NO menu, so Electron's stock one shipped verbatim.
+// Two defects came with it (docs/plans/v1.5/uiux-qol-audit-2026-08.md §4.1, §5):
+//
+//   C2 — `Edit ▸ Undo (Ctrl+Z)` advertised an undo the app does not have. The
+//        role itself is honest (it really does undo TYPING in a focused field);
+//        the FRAMING lied twice. "Edit" is a rail destination in this app's IA
+//        (views/Edit.tsx = "edit this video"), so an `Edit` menu reads as
+//        video-edit undo; and a bare "Undo" claims an app-wide stack that does
+//        not exist. editing-surface-audit-2026-08.md row 25 measures the real
+//        state: "PARTIAL — two disjoint mechanisms, no app-wide stack" —
+//        `director.undo` inverts DIRECTOR ops only, and `timelineOps.ts` keeps a
+//        100-entry history for SUBTITLE CUES only. Neither can back a global
+//        Ctrl+Z, and this module does not pretend otherwise.
+//
+//   H1 — DevTools and Force Reload were reachable in a packaged consumer build.
+//
+// The fix keeps every role that genuinely works and tells the truth about scope:
+// the menu is named "Text" and its items are "Undo typing" / "Redo typing". That
+// preserves text-field undo everywhere (the Director goal box, caption editors,
+// preset names) instead of deleting a working feature to silence a wording bug.
+//
+// Accelerators are deliberately NOT set on role items: an explicit `accelerator`
+// overrides the role's per-platform default, and Windows' native redo is Ctrl+Y,
+// not Ctrl+Shift+Z. Only the labels are ours; the bindings stay the platform's.
+//
+// This is a PURE template builder — it touches no Electron runtime object — so it
+// is unit-testable without a live app (appMenu.test.ts). `main.ts` feeds it
+// `!app.isPackaged` and installs the result.
+import type { MenuItemConstructorOptions } from 'electron';
+
+export interface AppMenuOptions {
+  /** `!app.isPackaged`. Gates the developer-only View items (H1). */
+  isDev: boolean;
+}
+
+/** The View items that must never reach a packaged consumer build (H1). */
+function devViewItems(): MenuItemConstructorOptions[] {
+  return [
+    { role: 'reload' },
+    { role: 'forceReload' },
+    { role: 'toggleDevTools' },
+    { type: 'separator' },
+  ];
+}
+
+/**
+ * Build the application menu template.
+ *
+ * Top-level: File · Text · View · Window · Help. There is deliberately no "Edit"
+ * menu — see the C2 note above.
+ */
+export function buildAppMenuTemplate({ isDev }: AppMenuOptions): MenuItemConstructorOptions[] {
+  return [
+    {
+      label: 'File',
+      submenu: [{ role: 'quit', label: 'Quit Reframe' }],
+    },
+    {
+      // NOT "Edit": that word names a rail destination in this app (views/Edit.tsx).
+      // These items act on the FOCUSED TEXT FIELD and say so.
+      label: 'Text',
+      submenu: [
+        { role: 'undo', label: 'Undo typing' },
+        { role: 'redo', label: 'Redo typing' },
+        { type: 'separator' },
+        { role: 'cut' },
+        { role: 'copy' },
+        { role: 'paste' },
+        { role: 'delete' },
+        { type: 'separator' },
+        { role: 'selectAll' },
+      ],
+    },
+    {
+      label: 'View',
+      submenu: [
+        // Reload / Force Reload / DevTools are development affordances: in a
+        // packaged build Force Reload silently discards renderer state mid-job
+        // and DevTools is a support-call generator. Zoom and full screen are
+        // ordinary user controls and stay in both builds.
+        ...(isDev ? devViewItems() : []),
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+      ],
+    },
+    {
+      label: 'Window',
+      submenu: [{ role: 'minimize' }, { role: 'close' }],
+    },
+    {
+      // main.ts already calls `app.setAboutPanelOptions(...)` and its comment
+      // claims a "Help ▸ About" home for it — which did not exist while no menu
+      // was installed. This gives that panel the surface it was configured for.
+      label: 'Help',
+      submenu: [{ role: 'about', label: 'About Reframe' }],
+    },
+  ];
+}
+
+export default buildAppMenuTemplate;

--- a/app/main/main.ts
+++ b/app/main/main.ts
@@ -10,7 +10,8 @@
 // server in development (ELECTRON_RENDERER_URL) and from the built bundle
 // (out/renderer/index.html) in production. Security baseline: contextIsolation
 // ON, nodeIntegration OFF, sandbox ON — the renderer only sees `window.api`.
-import { app, BrowserWindow, ipcMain, net, safeStorage, session, shell } from 'electron';
+import { app, BrowserWindow, ipcMain, Menu, net, safeStorage, session, shell } from 'electron';
+import { buildAppMenuTemplate } from './appMenu';
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync, readdirSync, readFileSync, writeFileSync, promises as fsp } from 'node:fs';
 import { extname, join, resolve as resolvePath, sep } from 'node:path';
@@ -1551,6 +1552,14 @@ if (!app.requestSingleInstanceLock()) {
     // user-facing About surface. applicationName is the display brand "Reframe";
     // applicationVersion reads package.json.version (1.4.0) via Electron.
     app.setAboutPanelOptions({ applicationName: 'Reframe', applicationVersion: app.getVersion() });
+    // C2 + H1 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §4.1, §5): install a real
+    // menu. Until now Electron's STOCK menu shipped verbatim, which advertised
+    // `Edit ▸ Undo (Ctrl+Z)` — an app-wide undo this app does not have — and left
+    // DevTools + Force Reload reachable in a packaged consumer build. The template
+    // is pure and unit-tested in appMenu.test.ts; `isDev` gates the dev-only View
+    // items. This is also what finally gives `setAboutPanelOptions` above the
+    // "Help ▸ About" home its comment already claimed.
+    Menu.setApplicationMenu(Menu.buildFromTemplate(buildAppMenuTemplate({ isDev })));
     bootstrap();
 
     app.on('activate', () => {

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -861,6 +861,34 @@ button {
   color: var(--text-muted);
 }
 
+/* M2: the way forward out of the empty Edit section. Deliberately the SAME
+   ghost/raised voice as .caption-view__back (caption.css:17) and
+   .export-view__back (export.css:17) rather than a fourth CTA treatment — M3
+   flags four different CTA styles for this one "you need media" state. No accent
+   fill: an empty landing is not an active state (see .edit--empty above). */
+.edit__empty-back {
+  margin-top: var(--space-3);
+  padding: var(--control-pad-btn);
+  font-size: var(--type-control-size);
+  font-weight: var(--weight-medium);
+  color: var(--text-secondary);
+  background: var(--surface-raised);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background var(--dur-fast) var(--ease-out);
+}
+
+.edit__empty-back:hover {
+  background: var(--surface-hover);
+  color: var(--text-primary);
+}
+
+.edit__empty-back:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
 .library__list {
   list-style: none;
   margin: 0;

--- a/app/renderer/src/views/Edit.test.tsx
+++ b/app/renderer/src/views/Edit.test.tsx
@@ -120,6 +120,39 @@ describe('<Edit />', () => {
     expect(workspace()).toBeNull();
   });
 
+  // C3 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5) — the empty state PROMISED
+  // "trim, cut, join, reframe, caption, and more — every edit tool lives here".
+  // The merged editing-surface audit measures the opposite for the first three:
+  // docs/plans/v1.5/editing-surface-audit-2026-08.md:44 — "no trim, no cut, no
+  // join tab"; :45-48 — those engines are reachable "only through" the AI
+  // Director, and "a user cannot drag a cut"; rows 1-3 (:82-84) mark trim, cut
+  // and split "engine BUILT ... UI MISSING". Nothing named in this copy may be a
+  // verb the user cannot reach from here.
+  it('does not promise editing verbs the app cannot deliver', () => {
+    act(() => root.render(<Edit video={null} onBack={() => undefined} />));
+    const hint = container.querySelector('.edit__empty-hint')!.textContent!;
+    // Guard the guard: the copy must actually be present, or the absence checks
+    // below would pass over an empty string.
+    expect(hint.length).toBeGreaterThan(20);
+    for (const unreachable of ['trim', 'cut', 'join']) {
+      expect(hint.toLowerCase()).not.toContain(unreachable);
+    }
+    // ...and it must still say something true about what IS reachable.
+    expect(hint.toLowerCase()).toContain('subtitle');
+  });
+
+  // M2 — Edit was the only one of eight empty states with no way forward. The
+  // sibling views already ship this affordance (views/Caption.tsx:102-104,
+  // views/Export.tsx:251-253); Edit did not.
+  it('offers a way forward to the Library', () => {
+    const onBack = vi.fn();
+    act(() => root.render(<Edit video={null} onBack={onBack} />));
+    const back = container.querySelector<HTMLButtonElement>('.edit__empty-back');
+    expect(back).not.toBeNull();
+    act(() => back!.click());
+    expect(onBack).toHaveBeenCalledTimes(1);
+  });
+
   it('lands on the Task Hub (not the Workspace) when a video is opened', async () => {
     act(() => root.render(<Edit video={makeVideo()} onBack={() => undefined} />));
     await flush();

--- a/app/renderer/src/views/Edit.tsx
+++ b/app/renderer/src/views/Edit.tsx
@@ -179,10 +179,30 @@ export function Edit({
           <span className="edit__empty-timecode">--:--</span>
         </div>
         <p className="edit__empty-title">No video open</p>
+        {/* C3 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5) — this used to read
+            "trim, cut, join, reframe, caption, and more — every edit tool lives
+            here". Three of those verbs are not reachable from this section, and
+            the "every tool lives here" clause was the widest part of the claim:
+            Make Shorts and the Director are top-level rail destinations, and
+            WU-3a4 deliberately moved ShortMaker OUT of the Workspace.
+            docs/plans/v1.5/editing-surface-audit-2026-08.md:44 measures the tab
+            list as "no trim, no cut, no join tab"; :45-48 finds those engines
+            reachable "only through" the AI Director and concludes "a user cannot
+            drag a cut"; rows 1-3 (:82-84) mark trim/cut/split "engine BUILT ...
+            UI MISSING". So the copy now names only verbs this section actually
+            reaches, and says where the missing one lives instead of implying it
+            is here. Pinned by Edit.test.tsx. If a manual cut surface lands
+            later, widen this sentence in the SAME commit that ships it. */}
         <p className="edit__empty-hint">
-          Open a video from the Library to trim, cut, join, reframe, caption, and more — every edit
-          tool lives here.
+          Open a video from the Library to transcribe it, add subtitles, reframe it to vertical, dub
+          it, or hand it to the AI Director. Shortening a clip goes through the Director for now.
         </p>
+        {/* M2 — Edit was the only one of eight empty states with no way forward.
+            Same affordance and voice as the sibling views (Caption.tsx:102-104,
+            Export.tsx:251-253), which already shipped it. */}
+        <button type="button" className="edit__empty-back" onClick={onBack}>
+          ← Library
+        </button>
       </div>
     );
   }

--- a/app/renderer/src/views/Settings.test.tsx
+++ b/app/renderer/src/views/Settings.test.tsx
@@ -213,6 +213,41 @@ describe('Settings sub-nav', () => {
     expect(container.querySelector('[data-testid="providers"]')).toBeNull();
   });
 
+  // C1 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5): Settings LANDS SCROLLED, so
+  // the section's own title and its primary CTA start above the fold — measured on
+  // the installed app at ~503 px for MODELS & SYSTEM, which is the DEFAULT tab.
+  //
+  // `.settings__panel` (views/settings.css:12, `overflow: auto`) is the ONE scroll
+  // container, and React reuses that DOM node across sections (it carries no `key`
+  // and the switch only swaps its children) — so the previous section's offset
+  // survives the switch. These assert the OFFSET on the container itself, never a
+  // prop: the panel must read `scrollTop === 0` after any section change.
+  it('returns the panel to the top when the section changes', async () => {
+    await mount('health');
+    const panel = container.querySelector<HTMLElement>('.settings__panel')!;
+    panel.scrollTop = 503;
+    // Detector control: if this read is not 503, jsdom is not retaining the offset
+    // and the assertion below would be vacuous. Fail loud instead.
+    expect(panel.scrollTop).toBe(503);
+    await act(async () => {
+      subtab('Models & System').click();
+    });
+    await flush();
+    expect(panel.scrollTop).toBe(0);
+  });
+
+  it('returns the panel to the top when a section routes programmatically', async () => {
+    await mount('providers');
+    const panel = container.querySelector<HTMLElement>('.settings__panel')!;
+    panel.scrollTop = 412;
+    expect(panel.scrollTop).toBe(412);
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="open-models"]')!.click();
+    });
+    await flush();
+    expect(panel.scrollTop).toBe(0);
+  });
+
   it('routes a Models readiness key/consent action to the Providers section', async () => {
     await mount('models');
     expect(container.querySelector('[data-testid="models"]')).not.toBeNull();

--- a/app/renderer/src/views/Settings.tsx
+++ b/app/renderer/src/views/Settings.tsx
@@ -14,7 +14,15 @@
 //   * providers — NEW "Providers & Keys" placeholder (real empty-state; later
 //                 WUs wire components/ProviderKeyRow + AddKeyRow here),
 //   * health    — the existing app-global System Health diagnostic screen.
-import React, { Suspense, lazy, useCallback, useEffect, useState } from 'react';
+import React, {
+  Suspense,
+  lazy,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { TabBar, tabId, tabPanelId, type TabDef } from '../components/TabBar';
 import { SystemHealth } from '../features/SystemHealth';
 import { ProvidersKeys } from '../features/ProvidersKeys';
@@ -227,11 +235,46 @@ export function Settings({ initialSection }: SettingsProps): React.ReactElement 
   /* v8 ignore next -- find always resolves for a known active id. */
   const current = SETTINGS_SECTIONS.find((s) => s.id === active) ?? SETTINGS_SECTIONS[0];
 
+  // C1 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5) — Settings LANDED SCROLLED,
+  // so a section's own title and its primary CTA started above the fold. Measured
+  // on the installed app at ~503 px for MODELS & SYSTEM — the DEFAULT tab, hence
+  // the first screen a new user sees, with the ONLY "Download the Multimodal
+  // model" button off-screen.
+  //
+  // `.settings__panel` (settings.css:12, `overflow: auto`) is this view's ONE
+  // scroll container, and React reuses that DOM node across sections — it carries
+  // no `key`, and a section change only swaps its children — so the offset the
+  // user left on the PREVIOUS section survives into the next one. Measured in
+  // Settings.test.tsx by reading the container's own `scrollTop`.
+  //
+  // A layout effect (not `useEffect`) so the reset lands in the same frame as the
+  // swap and the user never sees the mid-panel paint. `panelRef` is always
+  // attached by the time an effect runs, so assert non-null rather than adding an
+  // unreachable branch (the `btnRefs.current[nextId]!` / `goalRef.current!`
+  // convention already used in TabBar.tsx:201 and DirectorPanel.tsx:473).
+  //
+  // SCOPE — this fixes the offset CARRIED ACROSS a section change, which is the
+  // audit's HEALTH→MODELS entry. UNVERIFIED: whether the audit's other entry
+  // (Library→Settings, a fresh mount, which starts at 0 and is reset again here)
+  // shares this cause; no renderer code scrolls this container (`scrollIntoView`,
+  // `scrollTo` and `window.scroll` have zero hits under renderer/src), so any
+  // residual offset there would have to come from the browser (focus restoration
+  // or scroll anchoring) AFTER this effect, which a mount-time reset would not
+  // catch. Settling experiment: open the packaged app with `Ctrl+Shift+I`, enter
+  // Settings from the Library, and log `.settings__panel.scrollTop` on an
+  // interval across the first second — a value that starts 0 and grows names an
+  // asynchronous scroller this reset cannot see.
+  const panelRef = useRef<HTMLDivElement>(null);
+  useLayoutEffect(() => {
+    panelRef.current!.scrollTop = 0;
+  }, [active]);
+
   return (
     <div className="settings" aria-label="Settings">
       <TabBar tabs={SUB_TABS} active={active} onSelect={setActive} />
       <div
         className="settings__panel"
+        ref={panelRef}
         role="tabpanel"
         id={tabPanelId(active)}
         aria-labelledby={tabId(active)}


### PR DESCRIPTION
- **fix(settings): stop Settings landing scrolled past its own title and CTA**
- **fix(main): the menu no longer promises an undo the app does not have**
- **fix(edit): the empty state stops promising tools the app does not have**
- **docs(main): record the MEASURED menu accelerators, not the assumed ones**
