### PR TITLE
feat/v15 aspect matrix

### DIFF
--- a/app/renderer/src/features/export/ExportInspector.test.tsx
+++ b/app/renderer/src/features/export/ExportInspector.test.tsx
@@ -4,8 +4,13 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { EditorProvider } from '../EditorContext';
 import type { EditorSeed } from '../../lib/editorState';
-import { EXPORT_CONFIRM_BLURB, EXPORT_PRIVACY_NOTE, ExportInspector } from './ExportInspector';
-import { exportConvertOptions, presetById } from './exportModel';
+import {
+  EXPORT_CONFIRM_BLURB,
+  EXPORT_FRAMING_NOTE,
+  EXPORT_PRIVACY_NOTE,
+  ExportInspector,
+} from './ExportInspector';
+import { exportConvertOptions, presetsByIds } from './exportModel';
 
 (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -48,28 +53,55 @@ describe('ExportInspector', () => {
     const values = Array.from(container.querySelectorAll('.export-inspector__cell-value')).map(
       (el) => el.textContent,
     );
-    // Honest pre-flight: the second cell states the FRAMING the export actually writes
-    // (the current framing) — never a per-destination aspect the export cannot produce.
-    expect(values).toEqual(['1', 'Original framing', '0:40', '~0:20', '$0.00']);
+    // SCOPE FIX (v1.5 aspect-matrix): the grid gained an ASPECTS cell and "Clips"
+    // became "Files", because a multi-select fan-out writes one file per DISTINCT
+    // aspect. The framing cell (now index 2) still states the framing the export
+    // actually writes — never a per-destination aspect Export cannot produce.
+    expect(values).toEqual(['1', '9:16', 'Original framing', '0:40', '~0:20', '$0.00']);
     expect(q('.export-inspector__privacy')?.textContent).toBe(EXPORT_PRIVACY_NOTE);
     // The primary CTA is present and NOT yet a confirm.
     expect(q('.export-inspector__primary')?.textContent).toBe('Export to TikTok');
     expect(q('.export-inspector__confirm')).toBeNull();
   });
 
-  it('re-summarizes the destination title/CTA but keeps framing destination-independent', () => {
+  it('discloses that the fan-out never re-crops, where the fan-out is chosen', () => {
     render(SEED);
-    const framingCell = (): string | null | undefined =>
-      container.querySelectorAll('.export-inspector__cell-value')[1]?.textContent;
-    expect(framingCell()).toBe('Original framing');
+    // The disclosure the matrix hint used to carry. It has to stay SOMEWHERE
+    // visible: the fan-out writes a file per aspect, but each file keeps the
+    // upstream framing, so a user picking 1:1 must not expect a square re-crop.
+    expect(q('.export-inspector__framing-note')?.textContent).toBe(EXPORT_FRAMING_NOTE);
+    expect(EXPORT_FRAMING_NOTE).toContain('never re-crops');
+  });
+
+  it('ADDS a destination to the fan-out and re-summarizes files + aspects', () => {
+    render(SEED);
+    const cells = (): (string | null)[] =>
+      Array.from(container.querySelectorAll('.export-inspector__cell-value')).map(
+        (el) => el.textContent,
+      );
+    expect(cells()[0]).toBe('1');
     act(() => q<HTMLButtonElement>('[data-preset="square"]')?.click());
+    // Two aspects -> two files, both listed, and the estimate doubles.
+    expect(cells()[0]).toBe('2');
+    expect(cells()[1]).toBe('9:16 · 1:1');
+    expect(cells()[4]).toBe('~0:40');
     expect(q('.export-inspector__preflight-title')?.textContent).toBe(
-      'Ready to export to Square post',
+      'Ready to export to TikTok + 1 more',
     );
-    expect(q('.export-inspector__primary')?.textContent).toBe('Export to Square post');
-    // Honest: switching destination re-summarizes the title + CTA but NEVER the framing —
-    // Export does not re-crop, so the output framing is identical for every destination.
-    expect(framingCell()).toBe('Original framing');
+    expect(q('.export-inspector__primary')?.textContent).toBe('Export to TikTok + 1 more');
+    // Honest: adding a destination NEVER changes the framing — Export does not re-crop.
+    expect(cells()[2]).toBe('Original framing');
+  });
+
+  it('collapses same-aspect destinations to a single file in the pre-flight', () => {
+    render(SEED);
+    act(() => q<HTMLButtonElement>('[data-preset="reels"]')?.click());
+    const cells = Array.from(container.querySelectorAll('.export-inspector__cell-value')).map(
+      (el) => el.textContent,
+    );
+    // TikTok + Reels are two destinations but one 9:16 render.
+    expect(cells[0]).toBe('1');
+    expect(cells[1]).toBe('9:16');
   });
 
   it('states the REFRAMED framing in the pre-flight when the clip carries a crop plan', () => {
@@ -77,7 +109,7 @@ describe('ExportInspector', () => {
       video: { videoId: 'v1', window: { start: 0, end: 40 } },
       cropPlan: { engine: 'verthor' },
     });
-    const framingCell = container.querySelectorAll('.export-inspector__cell-value')[1]?.textContent;
+    const framingCell = container.querySelectorAll('.export-inspector__cell-value')[2]?.textContent;
     expect(framingCell).toBe('Reframed');
   });
 
@@ -109,7 +141,10 @@ describe('ExportInspector', () => {
     // Step 2: "Export now" fires the commit with the chosen preset + render profile.
     act(() => q<HTMLButtonElement>('.export-inspector__confirm-approve')?.click());
     expect(onCommit).toHaveBeenCalledTimes(1);
-    expect(onCommit).toHaveBeenCalledWith(presetById('tiktok'), exportConvertOptions());
+    // SCOPE FIX (v1.5 aspect-matrix): the commit carries the whole ORDERED SET of
+    // destinations, not a single preset — the host de-dupes it into one render
+    // per aspect. Still exactly one commit, still behind the same confirm gate.
+    expect(onCommit).toHaveBeenCalledWith(presetsByIds(['tiktok']), exportConvertOptions());
     // The gate closes after committing.
     expect(q('.export-inspector__confirm')).toBeNull();
   });

--- a/app/renderer/src/features/export/ExportInspector.tsx
+++ b/app/renderer/src/features/export/ExportInspector.tsx
@@ -15,11 +15,12 @@ import type { ConvertOptions } from '../../lib/rpc';
 import { useEditor } from '../EditorContext';
 import {
   type PlatformPreset,
-  buildPreflight,
+  buildFanoutPreflight,
   exportConvertOptions,
+  fanoutDestinationLabel,
   firstAvailablePresetId,
   framingSummary,
-  presetById,
+  presetsByIds,
   windowDurationSec,
 } from './exportModel';
 import { PresetMatrix } from './PresetMatrix';
@@ -33,22 +34,39 @@ export const EXPORT_CONFIRM_BLURB =
   'This is the final render — everything you set is baked into the file. It is written to your ' +
   'machine; nothing is uploaded.';
 
+/**
+ * The framing beat, restated where the fan-out is decided.
+ *
+ * This sentence used to live on the destination matrix ("Aspect is set in Reframe
+ * — Export keeps your current framing"), where it also served as the excuse for a
+ * single-selection radiogroup. The matrix is now a multi-select aspect matrix, so
+ * the sentence moved here — where it is a DISCLOSURE rather than a limitation:
+ * the fan-out writes one file per aspect, but Export does not re-crop, so each
+ * file carries the framing composed upstream in Reframe.
+ */
+export const EXPORT_FRAMING_NOTE =
+  'Every file keeps the framing you composed in Reframe — Export never re-crops.';
+
 export interface ExportInspectorProps {
-  /** Fired only after the explicit confirm — starts the guarded render. */
-  onCommit: (preset: PlatformPreset, options: ConvertOptions) => void;
+  /**
+   * Fired only after the explicit confirm — starts the guarded render for EVERY
+   * chosen destination (the host de-duplicates them into one file per aspect).
+   */
+  onCommit: (presets: PlatformPreset[], options: ConvertOptions) => void;
 }
 
 export function ExportInspector({ onCommit }: ExportInspectorProps): React.ReactElement {
   const { state } = useEditor();
   const durationSec = windowDurationSec(state);
-  const [selected, setSelected] = useState<string>(() => firstAvailablePresetId(durationSec));
+  const [selected, setSelected] = useState<string[]>(() => [firstAvailablePresetId(durationSec)]);
   const [confirming, setConfirming] = useState(false);
   const approveRef = useRef<HTMLButtonElement>(null);
   const confirmTitleId = useId();
   const confirmBlurbId = useId();
 
-  const preset = presetById(selected);
-  const preflight = buildPreflight(state, preset);
+  const presets = presetsByIds(selected);
+  const destination = fanoutDestinationLabel(presets);
+  const preflight = buildFanoutPreflight(state, presets);
   const framing = framingSummary(state);
 
   // WCAG 2.4.3: activating the primary unmounts it and mounts the confirm gate, so
@@ -60,24 +78,28 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
 
   const commit = (): void => {
     setConfirming(false);
-    onCommit(preset, exportConvertOptions());
+    onCommit(presets, exportConvertOptions());
   };
 
   return (
     <aside className="export-inspector" aria-label="Export">
       <PresetMatrix
-        value={selected}
+        values={selected}
         onChange={setSelected}
         durationSec={durationSec}
         disabled={confirming}
       />
 
       <section className="export-inspector__preflight" aria-label="Pre-flight summary">
-        <h3 className="export-inspector__preflight-title">Ready to export to {preset.name}</h3>
+        <h3 className="export-inspector__preflight-title">Ready to export to {destination}</h3>
         <div className="export-inspector__preflight-grid">
           <div className="export-inspector__cell">
-            <span className="export-inspector__cell-label">Clips</span>
+            <span className="export-inspector__cell-label">Files</span>
             <span className="export-inspector__cell-value">{preflight.clipCount}</span>
+          </div>
+          <div className="export-inspector__cell">
+            <span className="export-inspector__cell-label">Aspects</span>
+            <span className="export-inspector__cell-value">{preflight.aspectLabel}</span>
           </div>
           <div className="export-inspector__cell">
             <span className="export-inspector__cell-label">Framing</span>
@@ -96,6 +118,7 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
             <span className="export-inspector__cell-value">{preflight.estSpendLabel}</span>
           </div>
         </div>
+        <p className="export-inspector__framing-note">{EXPORT_FRAMING_NOTE}</p>
       </section>
 
       <p className="export-inspector__privacy">{EXPORT_PRIVACY_NOTE}</p>
@@ -108,7 +131,7 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
           aria-describedby={confirmBlurbId}
         >
           <h3 id={confirmTitleId} className="export-inspector__confirm-title">
-            Export to {preset.name}?
+            Export to {destination}?
           </h3>
           <p id={confirmBlurbId} className="export-inspector__confirm-blurb">
             {EXPORT_CONFIRM_BLURB}
@@ -137,7 +160,7 @@ export function ExportInspector({ onCommit }: ExportInspectorProps): React.React
           className="export-inspector__primary"
           onClick={() => setConfirming(true)}
         >
-          Export to {preset.name}
+          Export to {destination}
         </button>
       )}
     </aside>

--- a/app/renderer/src/features/export/PresetMatrix.test.tsx
+++ b/app/renderer/src/features/export/PresetMatrix.test.tsx
@@ -26,11 +26,11 @@ afterEach(() => {
 const q = <T extends Element>(sel: string): T | null => container.querySelector<T>(sel);
 const all = (sel: string): Element[] => Array.from(container.querySelectorAll(sel));
 
-function render(props: { value?: string; durationSec?: number; disabled?: boolean }): void {
+function render(props: { values?: string[]; durationSec?: number; disabled?: boolean }): void {
   act(() => {
     root.render(
       <PresetMatrix
-        value={props.value ?? 'tiktok'}
+        values={props.values ?? ['tiktok']}
         onChange={onChange}
         durationSec={props.durationSec ?? 30}
         disabled={props.disabled}
@@ -40,7 +40,7 @@ function render(props: { value?: string; durationSec?: number; disabled?: boolea
 }
 
 function keyOnGroup(key: string): void {
-  const group = q<HTMLDivElement>('[role="radiogroup"]');
+  const group = q<HTMLDivElement>('[role="group"]');
   act(() => {
     group?.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
   });
@@ -50,82 +50,111 @@ const optionFor = (id: string): HTMLButtonElement | null =>
   q<HTMLButtonElement>(`[data-preset="${id}"]`);
 
 describe('PresetMatrix', () => {
-  it('renders a real fieldset/radiogroup of destination radios', () => {
-    render({ value: 'tiktok' });
+  it('renders a real fieldset/group of destination CHECKBOXES (multi-select)', () => {
+    render({ values: ['tiktok'] });
     expect(q('fieldset.preset-matrix')).not.toBeNull();
     expect(q('legend')?.textContent).toBe('Deliver to');
-    const radios = all('[role="radio"]');
-    expect(radios.length).toBe(6);
+    // A checkbox group, not a radiogroup: several destinations at once is the
+    // whole point of the aspect matrix.
+    expect(q('[role="radiogroup"]')).toBeNull();
+    const boxes = all('[role="checkbox"]');
+    expect(boxes.length).toBe(6);
     // Named destinations, no codec jargon.
     expect(optionFor('shorts')?.textContent).toContain('YouTube Shorts');
     expect(optionFor('shorts')?.textContent).toContain('9:16');
   });
 
-  it('states that the aspect is set in Reframe so the badges never imply Export output', () => {
-    render({ value: 'tiktok' });
-    // The per-destination aspect is a TARGET set upstream in Reframe — the hint keeps the
-    // badge from implying Export re-crops the frame (Export keeps the current framing).
+  it('offers WIDESCREEN 16:9 as a first-class destination', () => {
+    render({ values: ['tiktok'] });
+    const wide = optionFor('widescreen');
+    expect(wide).not.toBeNull();
+    expect(wide?.textContent).toContain('16:9');
+    expect(wide?.disabled).toBe(false);
+  });
+
+  it('tells the user one file lands per DISTINCT aspect', () => {
+    render({ values: ['tiktok'] });
+    // Replaces the old "aspect is set upstream, Export keeps your framing" hint:
+    // the matrix now drives the aspect, so the hint must state the fan-out rule.
     expect(q('.preset-matrix__hint')?.textContent).toBe(
-      'Aspect is set in Reframe — Export keeps your current framing.',
+      'Pick every destination you need — one file is rendered per distinct aspect.',
     );
   });
 
-  it('reflects the selection through aria-checked + roving tabindex', () => {
-    render({ value: 'reels' });
+  it('reflects EVERY selected destination through aria-checked', () => {
+    render({ values: ['reels', 'square'] });
     expect(optionFor('reels')?.getAttribute('aria-checked')).toBe('true');
-    expect(optionFor('reels')?.tabIndex).toBe(0);
+    expect(optionFor('square')?.getAttribute('aria-checked')).toBe('true');
     expect(optionFor('tiktok')?.getAttribute('aria-checked')).toBe('false');
-    expect(optionFor('tiktok')?.tabIndex).toBe(-1);
   });
 
-  it('selects an available destination on click', () => {
-    render({ value: 'tiktok' });
+  it('ADDS a destination on click instead of replacing the selection', () => {
+    render({ values: ['tiktok'] });
     act(() => optionFor('square')?.click());
-    expect(onChange).toHaveBeenCalledWith('square');
+    expect(onChange).toHaveBeenCalledWith(['tiktok', 'square']);
+  });
+
+  it('removes an already-checked destination on click', () => {
+    render({ values: ['tiktok', 'square'] });
+    act(() => optionFor('tiktok')?.click());
+    expect(onChange).toHaveBeenCalledWith(['square']);
+  });
+
+  it('refuses to uncheck the LAST destination (export needs one)', () => {
+    render({ values: ['tiktok'] });
+    act(() => optionFor('tiktok')?.click());
+    expect(onChange).toHaveBeenCalledWith(['tiktok']);
   });
 
   it('blocks a destination whose cap the clip exceeds (disabled + reason)', () => {
-    render({ value: 'tiktok', durationSec: 120 });
+    render({ values: ['tiktok'], durationSec: 120 });
     const shorts = optionFor('shorts');
     expect(shorts?.disabled).toBe(true);
     expect(shorts?.className).toContain('is-unavailable');
     expect(shorts?.textContent).toContain('trim it first');
-    // A disabled option cannot be chosen.
     act(() => shorts?.click());
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('moves selection to the next SELECTABLE destination on ArrowRight (skipping blocked)', () => {
-    // 120s clip blocks reels (90) + shorts (60); ArrowRight from tiktok lands on feed.
-    render({ value: 'tiktok', durationSec: 120 });
+  it('carries a roving tabindex anchored on the first selected destination', () => {
+    render({ values: ['reels'] });
+    expect(optionFor('reels')?.tabIndex).toBe(0);
+    expect(optionFor('tiktok')?.tabIndex).toBe(-1);
+  });
+
+  it('moves FOCUS (not the selection) to the next selectable destination', () => {
+    // ARIA checkbox-group pattern: arrows navigate, Space/Enter toggles. A 120s
+    // clip blocks reels (90) + shorts (60), so ArrowRight from tiktok lands on feed.
+    render({ values: ['tiktok'], durationSec: 120 });
     keyOnGroup('ArrowRight');
-    expect(onChange).toHaveBeenCalledWith('feed');
-    // Focus follows the roving selection.
     expect(document.activeElement).toBe(optionFor('feed'));
-  });
-
-  it('wraps to the last destination on ArrowLeft', () => {
-    render({ value: 'tiktok', durationSec: 30 });
-    keyOnGroup('ArrowLeft');
-    expect(onChange).toHaveBeenCalledWith('widescreen');
-  });
-
-  it('jumps to the first / last destination on Home / End', () => {
-    render({ value: 'square', durationSec: 30 });
-    keyOnGroup('Home');
-    expect(onChange).toHaveBeenLastCalledWith('tiktok');
-    keyOnGroup('End');
-    expect(onChange).toHaveBeenLastCalledWith('widescreen');
-  });
-
-  it('ignores non-navigation keys', () => {
-    render({ value: 'tiktok' });
-    keyOnGroup('Tab');
+    // Navigating must NOT check anything — that is the radiogroup behaviour we left.
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('wraps focus to the last destination on ArrowLeft', () => {
+    render({ values: ['tiktok'], durationSec: 30 });
+    keyOnGroup('ArrowLeft');
+    expect(document.activeElement).toBe(optionFor('widescreen'));
+  });
+
+  it('jumps focus to the first / last destination on Home / End', () => {
+    render({ values: ['square'], durationSec: 30 });
+    keyOnGroup('Home');
+    expect(document.activeElement).toBe(optionFor('tiktok'));
+    keyOnGroup('End');
+    expect(document.activeElement).toBe(optionFor('widescreen'));
+  });
+
+  it('ignores non-navigation keys', () => {
+    render({ values: ['tiktok'] });
+    keyOnGroup('Tab');
+    expect(onChange).not.toHaveBeenCalled();
+    expect(document.activeElement).toBe(document.body);
+  });
+
   it('locks the whole group (no click, no keyboard) while disabled', () => {
-    render({ value: 'tiktok', disabled: true });
+    render({ values: ['tiktok'], disabled: true });
     expect(optionFor('reels')?.disabled).toBe(true);
     act(() => optionFor('reels')?.click());
     keyOnGroup('ArrowRight');

--- a/app/renderer/src/features/export/PresetMatrix.tsx
+++ b/app/renderer/src/features/export/PresetMatrix.tsx
@@ -1,27 +1,41 @@
 // PresetMatrix.tsx — the per-platform destination matrix (v1.5 §4 Export).
 //
-// A REAL fieldset/radiogroup (role="radiogroup" of role="radio" options with
-// aria-checked + roving tabindex + arrow-key selection), NOT a grid of equal-weight
+// A REAL fieldset/checkbox-group (role="group" of role="checkbox" options with
+// aria-checked + roving tabindex + arrow-key navigation), NOT a grid of equal-weight
 // tiles. Every option is a recognizable DESTINATION (TikTok / Reels / Shorts…)
-// showing its TARGET aspect + length — never codec/bitrate jargon. A hint states
-// that aspect is set upstream in Reframe (Export keeps the current framing), so the
-// per-destination badge never implies Export re-crops the frame. Options carry three
-// states: SELECTED (the amber ring), AVAILABLE (selectable), and UNAVAILABLE (the
-// clip is longer than the platform's cap — blocked with a stated reason). While the
-// export is confirming/running the whole group is disabled so the choice is locked.
+// showing its TARGET aspect + length — never codec/bitrate jargon. Options carry
+// three states: SELECTED (the amber ring), AVAILABLE (selectable), and UNAVAILABLE
+// (the clip is longer than the platform's cap — blocked with a stated reason).
+// While the export is confirming/running the whole group is disabled so the choice
+// is locked.
 //
-// Controlled + presentational: the parent owns `value` and gets `onChange(id)`.
+// MULTI-SELECT (v1.5 aspect-matrix lane). This used to be a single-selection
+// radiogroup whose hint read "aspect is set upstream in Reframe (Export keeps the
+// current framing)" — which made the per-destination aspect badge decorative and
+// made a multi-aspect fan-out impossible anywhere but the batch surface. The group
+// now takes a SET, so one source can target several aspects in one action, and the
+// hint states the real rule: one file per DISTINCT aspect (three vertical
+// destinations are one 9:16 render, not three). The ≥1 invariant lives in the pure
+// `togglePresetId`, so un-checking the last box is a no-op rather than a state the
+// guarded commit would have to defend against.
+//
+// Keyboard follows the WAI-ARIA CHECKBOX-group pattern, which differs from the
+// radiogroup one this replaced: arrows/Home/End move FOCUS only, and Space/Enter
+// toggle (handled natively by the <button>). Selecting on arrow — correct for a
+// radiogroup — would silently check destinations as the user browsed.
+//
+// Controlled + presentational: the parent owns `values` and gets `onChange(ids)`.
 // The keyboard math (skip-unavailable, wrap) is the pure `rovingIndex` helper.
 
-import React, { useRef } from 'react';
-import { PLATFORM_PRESETS, presetAvailability, rovingIndex } from './exportModel';
+import React, { useRef, useState } from 'react';
+import { PLATFORM_PRESETS, presetAvailability, rovingIndex, togglePresetId } from './exportModel';
 import './export.css';
 
 export interface PresetMatrixProps {
-  /** The selected destination id (parent-owned). */
-  value: string;
-  /** Called with the chosen destination id. */
-  onChange: (id: string) => void;
+  /** The selected destination ids (parent-owned; always at least one). */
+  values: readonly string[];
+  /** Called with the NEXT full selection whenever a destination is toggled. */
+  onChange: (ids: string[]) => void;
   /** The clip length (seconds) — drives per-destination availability. */
   durationSec: number;
   /** Locks the whole group while the export is confirming/running. */
@@ -29,23 +43,29 @@ export interface PresetMatrixProps {
 }
 
 export function PresetMatrix({
-  value,
+  values,
   onChange,
   durationSec,
   disabled = false,
 }: PresetMatrixProps): React.ReactElement {
   const buttons = useRef<Array<HTMLButtonElement | null>>([]);
+  // Where the roving tabindex sits. `null` until the user navigates, so the tab
+  // stop starts on the first CHECKED destination (what a returning user expects)
+  // and then follows their arrow keys.
+  const [focusIndex, setFocusIndex] = useState<number | null>(null);
+
   const selectable = PLATFORM_PRESETS.map(
     (preset) => presetAvailability(preset, durationSec).status === 'available',
   );
-  const current = PLATFORM_PRESETS.findIndex((preset) => preset.id === value);
+  const firstChecked = PLATFORM_PRESETS.findIndex((preset) => values.includes(preset.id));
+  const anchor = focusIndex ?? Math.max(0, firstChecked);
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
     if (disabled) return;
-    const next = rovingIndex(event.key, current, selectable);
-    if (next === current) return;
+    const next = rovingIndex(event.key, anchor, selectable);
+    if (next === anchor) return;
     event.preventDefault();
-    onChange(PLATFORM_PRESETS[next].id);
+    setFocusIndex(next);
     buttons.current[next]?.focus();
   };
 
@@ -53,18 +73,18 @@ export function PresetMatrix({
     <fieldset className="preset-matrix">
       <legend className="preset-matrix__legend">Deliver to</legend>
       <p className="preset-matrix__hint">
-        Aspect is set in Reframe — Export keeps your current framing.
+        Pick every destination you need — one file is rendered per distinct aspect.
       </p>
       <div
         className="preset-matrix__grid"
-        role="radiogroup"
-        aria-label="Delivery destination"
+        role="group"
+        aria-label="Delivery destinations"
         onKeyDown={onKeyDown}
       >
         {PLATFORM_PRESETS.map((preset, index) => {
           const availability = presetAvailability(preset, durationSec);
           const unavailable = availability.status === 'unavailable';
-          const selected = preset.id === value;
+          const selected = values.includes(preset.id);
           return (
             <button
               key={preset.id}
@@ -72,13 +92,13 @@ export function PresetMatrix({
                 buttons.current[index] = el;
               }}
               type="button"
-              role="radio"
+              role="checkbox"
               aria-checked={selected}
-              tabIndex={selected ? 0 : -1}
+              tabIndex={index === anchor ? 0 : -1}
               disabled={disabled || unavailable}
               className={`preset-option${selected ? ' is-selected' : ''}${unavailable ? ' is-unavailable' : ''}`}
               data-preset={preset.id}
-              onClick={() => onChange(preset.id)}
+              onClick={() => onChange(togglePresetId(values, preset.id))}
             >
               <span className="preset-option__head">
                 <span className="preset-option__name">{preset.name}</span>

--- a/app/renderer/src/features/export/export.css
+++ b/app/renderer/src/features/export/export.css
@@ -220,6 +220,18 @@
   color: var(--text-primary);
 }
 
+/* The framing disclosure that sits UNDER the file count: the fan-out writes one
+ * file per aspect but never re-crops. Quiet (muted, caption scale) so it reads as
+ * a clarification of the grid above it rather than a competing claim — but it is
+ * body-adjacent, not --text-faint, because a caveat the user cannot read is not a
+ * caveat. */
+.export-inspector__framing-note {
+  margin: var(--space-3) 0 0;
+  font-size: var(--type-caption-size);
+  line-height: var(--type-caption-leading);
+  color: var(--text-muted);
+}
+
 /* The privacy beat — the AA-safe quiet step, never the rejected faint hex. */
 .export-inspector__privacy {
   margin: 0;

--- a/app/renderer/src/features/export/exportModel.test.ts
+++ b/app/renderer/src/features/export/exportModel.test.ts
@@ -3,17 +3,25 @@ import type { EditorState } from '../../lib/editorState';
 import { DEFAULT_CAPTION_DESIGN } from '../../lib/captionDesign';
 import type { Cue } from '../../lib/rpc';
 import {
+  ASPECT_DIMENSIONS,
   PLATFORM_PRESETS,
   type PlatformPreset,
+  aspectFanoutPlan,
+  buildFanoutPreflight,
   buildPreflight,
   captionSummary,
   estimateRenderSec,
   exportConvertOptions,
+  fanoutDestinationLabel,
+  fanoutOutPath,
   firstAvailablePresetId,
   framingSummary,
   presetAvailability,
   presetById,
+  presetsByIds,
   rovingIndex,
+  sanitizeSelection,
+  togglePresetId,
   windowDurationSec,
 } from './exportModel';
 
@@ -222,5 +230,180 @@ describe('rovingIndex', () => {
   });
   it('ignores other keys', () => {
     expect(rovingIndex('Tab', 1, all)).toBe(1);
+  });
+});
+
+// --------------------------------------------------------------------------- //
+// v1.5 aspect-matrix: multi-select + the ONE-source -> N-aspect fan-out plan
+// --------------------------------------------------------------------------- //
+describe('ASPECT_DIMENSIONS (renderer mirror of the sidecar aspect registry)', () => {
+  it('carries every curated aspect INCLUDING the widescreen 16:9', () => {
+    expect(ASPECT_DIMENSIONS).toEqual({
+      '9:16': [1080, 1920],
+      '1:1': [1080, 1080],
+      '4:5': [1080, 1350],
+      '16:9': [1920, 1080],
+    });
+  });
+
+  it('covers every aspect the destination catalog can offer (no unmapped badge)', () => {
+    for (const preset of PLATFORM_PRESETS) {
+      expect(ASPECT_DIMENSIONS[preset.aspect]).toBeDefined();
+    }
+  });
+});
+
+describe('togglePresetId', () => {
+  it('adds an unselected id, preserving order', () => {
+    expect(togglePresetId(['tiktok'], 'square')).toEqual(['tiktok', 'square']);
+  });
+
+  it('removes an already-selected id', () => {
+    expect(togglePresetId(['tiktok', 'square'], 'tiktok')).toEqual(['square']);
+  });
+
+  it('refuses to empty the selection (export always needs a destination)', () => {
+    expect(togglePresetId(['tiktok'], 'tiktok')).toEqual(['tiktok']);
+  });
+});
+
+describe('presetsByIds', () => {
+  it('resolves ids to presets in CATALOG order, not click order', () => {
+    // Clicking widescreen then tiktok must still read top-to-bottom in the UI.
+    expect(presetsByIds(['widescreen', 'tiktok']).map((p) => p.id)).toEqual([
+      'tiktok',
+      'widescreen',
+    ]);
+  });
+
+  it('drops ids that are not in the catalog', () => {
+    expect(presetsByIds(['tiktok', '__nope__']).map((p) => p.id)).toEqual(['tiktok']);
+  });
+});
+
+describe('sanitizeSelection', () => {
+  it('keeps a selection whose destinations all still fit the clip', () => {
+    expect(sanitizeSelection(['tiktok', 'square'], 30)).toEqual(['tiktok', 'square']);
+  });
+
+  it('drops destinations the clip has outgrown', () => {
+    // 120s blocks shorts (60s cap) but not the uncapped square.
+    expect(sanitizeSelection(['shorts', 'square'], 120)).toEqual(['square']);
+  });
+
+  it('falls back to the first AVAILABLE destination when everything is dropped', () => {
+    expect(sanitizeSelection(['shorts'], 120)).toEqual([firstAvailablePresetId(120)]);
+  });
+});
+
+describe('aspectFanoutPlan', () => {
+  it('pairs each distinct aspect with its canonical canvas', () => {
+    expect(aspectFanoutPlan(presetsByIds(['tiktok', 'square', 'widescreen']))).toEqual([
+      { aspect: '9:16', width: 1080, height: 1920 },
+      { aspect: '1:1', width: 1080, height: 1080 },
+      { aspect: '16:9', width: 1920, height: 1080 },
+    ]);
+  });
+
+  it('DEDUPES by aspect — three vertical destinations are ONE render target', () => {
+    // Mirrors the sidecar's aspect.fanout_plan dedupe: TikTok + Reels + Shorts
+    // are three destinations but a single 9:16 file.
+    expect(aspectFanoutPlan(presetsByIds(['tiktok', 'reels', 'shorts']))).toEqual([
+      { aspect: '9:16', width: 1080, height: 1920 },
+    ]);
+  });
+
+  it('is empty for an empty destination list', () => {
+    expect(aspectFanoutPlan([])).toEqual([]);
+  });
+
+  it('skips a destination whose aspect has no canonical canvas', () => {
+    const rogue: PlatformPreset = {
+      id: 'rogue',
+      name: 'Rogue',
+      blurb: '',
+      aspect: '21:9',
+      maxSec: null,
+      lengthHint: '',
+    };
+    expect(aspectFanoutPlan([rogue])).toEqual([]);
+  });
+});
+
+describe('fanoutDestinationLabel', () => {
+  it('names a single destination outright', () => {
+    expect(fanoutDestinationLabel(presetsByIds(['tiktok']))).toBe('TikTok');
+  });
+
+  it('names the first and counts the rest', () => {
+    expect(fanoutDestinationLabel(presetsByIds(['tiktok', 'square']))).toBe('TikTok + 1 more');
+    expect(fanoutDestinationLabel(presetsByIds(['tiktok', 'square', 'widescreen']))).toBe(
+      'TikTok + 2 more',
+    );
+  });
+
+  it('degrades to a neutral word when nothing is selected', () => {
+    expect(fanoutDestinationLabel([])).toBe('your destinations');
+  });
+});
+
+describe('fanoutOutPath', () => {
+  const target = { aspect: '9:16', width: 1080, height: 1920 };
+
+  it('writes NEXT TO the source, tagged with the aspect', () => {
+    expect(fanoutOutPath('/videos/talk.mov', target)).toBe('/videos/talk.9x16.mp4');
+  });
+
+  it('uses an "x" separator so the name is legal on Windows', () => {
+    // ':' is a reserved character in a Windows filename — a raw "9:16" would make
+    // the path unopenable (and would read as an alternate data stream).
+    expect(fanoutOutPath('C:\\clips\\talk.mp4', target)).toBe('C:\\clips\\talk.9x16.mp4');
+    expect(fanoutOutPath('C:\\clips\\talk.mp4', target)).not.toContain(':16');
+  });
+
+  it('keeps a dotted directory out of the stem calculation', () => {
+    expect(fanoutOutPath('/a.b/talk', target)).toBe('/a.b/talk.9x16.mp4');
+  });
+
+  it('honours a non-default container extension', () => {
+    expect(fanoutOutPath('/videos/talk.mov', target, 'mkv')).toBe('/videos/talk.9x16.mkv');
+  });
+});
+
+describe('buildFanoutPreflight', () => {
+  it('reports ONE clip per distinct aspect and lists them', () => {
+    const pre = buildFanoutPreflight(stateWith(), presetsByIds(['tiktok', 'square']));
+    expect(pre.clipCount).toBe(2);
+    expect(pre.aspectLabel).toBe('9:16 · 1:1');
+    expect(pre.targets).toHaveLength(2);
+  });
+
+  it('collapses same-aspect destinations to a single clip', () => {
+    const pre = buildFanoutPreflight(stateWith(), presetsByIds(['tiktok', 'reels']));
+    expect(pre.clipCount).toBe(1);
+    expect(pre.aspectLabel).toBe('9:16');
+  });
+
+  it('scales the render estimate by the number of files', () => {
+    const one = buildFanoutPreflight(stateWith(), presetsByIds(['tiktok']));
+    const two = buildFanoutPreflight(stateWith(), presetsByIds(['tiktok', 'square']));
+    expect(one.estRenderLabel).toBe('~0:15');
+    expect(two.estRenderLabel).toBe('~0:30');
+  });
+
+  it('still costs nothing — the render is LOCAL', () => {
+    expect(buildFanoutPreflight(stateWith(), presetsByIds(['tiktok'])).estSpendLabel).toBe('$0.00');
+  });
+
+  it('carries the clip duration through unchanged', () => {
+    const pre = buildFanoutPreflight(stateWith(), presetsByIds(['tiktok']));
+    expect(pre.durationSec).toBe(30);
+    expect(pre.durationLabel).toBe('0:30');
+  });
+
+  it('reports an empty plan honestly rather than pretending one file', () => {
+    const pre = buildFanoutPreflight(stateWith(), []);
+    expect(pre.clipCount).toBe(0);
+    expect(pre.aspectLabel).toBe('');
   });
 });

--- a/app/renderer/src/features/export/exportModel.ts
+++ b/app/renderer/src/features/export/exportModel.ts
@@ -94,9 +94,51 @@ export const PLATFORM_PRESETS: readonly PlatformPreset[] = [
   },
 ];
 
+/**
+ * Canonical output canvas per curated aspect — the renderer-side MIRROR of the
+ * sidecar registry (`sidecar/media_studio/features/aspect.py::ASPECT_PRESETS`).
+ * 16:9 joined the curated set in the v1.5 aspect-matrix lane; before that the
+ * sidecar's `require_supported_aspect` REJECTED it, so a 16:9 export preset could
+ * not be persisted at all even though this catalog already showed the badge.
+ *
+ * Kept as a literal (not fetched) because it is display + planning data on the
+ * synchronous render path; `ASPECT_DIMENSIONS covers every catalog aspect` in
+ * exportModel.test.ts is the drift guard against the destination list, and
+ * test_aspect.py pins the same four pairs on the sidecar side.
+ */
+export const ASPECT_DIMENSIONS: Readonly<Record<string, readonly [number, number]>> = {
+  '9:16': [1080, 1920],
+  '1:1': [1080, 1080],
+  '4:5': [1080, 1350],
+  '16:9': [1920, 1080],
+};
+
+/** One rendered target of a fan-out: a curated aspect and the canvas it fills. */
+export interface AspectTarget {
+  /** The canonical `"W:H"` aspect id. */
+  aspect: string;
+  /** Output width in pixels. */
+  width: number;
+  /** Output height in pixels. */
+  height: number;
+}
+
 /** Resolve a preset by id, falling back to the first when the id is unknown. */
 export function presetById(id: string): PlatformPreset {
   return PLATFORM_PRESETS.find((preset) => preset.id === id) ?? PLATFORM_PRESETS[0];
+}
+
+/**
+ * Resolve destination ids to presets in CATALOG order (never click order), so a
+ * fan-out plan and every label built from it read top-to-bottom exactly as the
+ * matrix does. Unknown ids are dropped rather than faked into the first preset —
+ * `presetById`'s fallback is right for a single selection, wrong for a set.
+ */
+export function presetsByIds(
+  ids: readonly string[],
+  presets: readonly PlatformPreset[] = PLATFORM_PRESETS,
+): PlatformPreset[] {
+  return presets.filter((preset) => ids.includes(preset.id));
 }
 
 /** A preset is selectable (`available`) or blocked with a stated `reason`. */
@@ -144,6 +186,85 @@ export function firstAvailablePresetId(
 }
 
 /**
+ * Multi-select toggle for the destination matrix. Adds an unselected id at the
+ * END (order-preserving) and removes a selected one — EXCEPT when it is the last
+ * one standing: the guarded commit has no meaning without a destination, so
+ * un-checking the final box is a deliberate no-op rather than a state the
+ * inspector would have to defend against downstream.
+ */
+export function togglePresetId(selected: readonly string[], id: string): string[] {
+  if (!selected.includes(id)) return [...selected, id];
+  if (selected.length === 1) return [...selected];
+  return selected.filter((current) => current !== id);
+}
+
+/**
+ * Re-validate a selection against the current clip length. A destination the clip
+ * has outgrown (the user trimmed longer, or opened a longer video) is dropped so
+ * the commit can never target a blocked platform; if that empties the set we fall
+ * back to the first destination that DOES fit, preserving the ≥1 invariant.
+ */
+export function sanitizeSelection(
+  selected: readonly string[],
+  durationSec: number,
+  presets: readonly PlatformPreset[] = PLATFORM_PRESETS,
+): string[] {
+  const kept = presetsByIds(selected, presets)
+    .filter((preset) => presetAvailability(preset, durationSec).status === 'available')
+    .map((preset) => preset.id);
+  return kept.length > 0 ? kept : [firstAvailablePresetId(durationSec, presets)];
+}
+
+/**
+ * The ONE-source -> N-aspect render matrix: one {@link AspectTarget} per DISTINCT
+ * aspect across the chosen destinations, in catalog order.
+ *
+ * The dedupe is what makes a fan-out honest at the destination level — TikTok,
+ * Reels and Shorts are three destinations but a single 9:16 render, so the plan
+ * holds one entry and the caller writes one file. Mirrors the sidecar's
+ * `aspect.fanout_plan`. A destination whose aspect has no canonical canvas is
+ * skipped rather than guessed at, so an unmapped badge can never invent a canvas.
+ */
+export function aspectFanoutPlan(presets: readonly PlatformPreset[]): AspectTarget[] {
+  const seen = new Set<string>();
+  const plan: AspectTarget[] = [];
+  for (const preset of presets) {
+    const dims = ASPECT_DIMENSIONS[preset.aspect];
+    if (!dims || seen.has(preset.aspect)) continue;
+    seen.add(preset.aspect);
+    plan.push({ aspect: preset.aspect, width: dims[0], height: dims[1] });
+  }
+  return plan;
+}
+
+/** "TikTok" / "TikTok + 2 more" — the destination phrase for buttons + headings. */
+export function fanoutDestinationLabel(presets: readonly PlatformPreset[]): string {
+  if (presets.length === 0) return 'your destinations';
+  if (presets.length === 1) return presets[0].name;
+  return `${presets[0].name} + ${presets.length - 1} more`;
+}
+
+/**
+ * The destination file for ONE fan-out target: `<stem>.<aspect>.<ext>` alongside
+ * the source, which is the location the sidecar's `_confined_output` permits by
+ * default (`sidecar/media_studio/features/convert.py`).
+ *
+ * The aspect is slugged with an "x" (`9x16`), never a colon: ':' is a reserved
+ * character in a Windows filename and `talk.9:16.mp4` would be parsed as an
+ * alternate data stream on `talk.9`, silently producing no visible file. The
+ * stem is split on the LAST separator first so a dotted DIRECTORY (`/a.b/talk`)
+ * cannot be mistaken for an extension.
+ */
+export function fanoutOutPath(sourcePath: string, target: AspectTarget, ext = 'mp4'): string {
+  const cut = Math.max(sourcePath.lastIndexOf('/'), sourcePath.lastIndexOf('\\'));
+  const dir = sourcePath.slice(0, cut + 1);
+  const name = sourcePath.slice(cut + 1);
+  const dot = name.lastIndexOf('.');
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  return `${dir}${stem}.${target.aspect.replace(':', 'x')}.${ext}`;
+}
+
+/**
  * A rough LOCAL render-time estimate (seconds). A local h264 finish runs at a
  * fraction of real time; floored to a few seconds so a tiny clip never estimates
  * "0". Surfaced with a "~" so it always reads as an estimate, never a promise.
@@ -188,6 +309,48 @@ export function buildPreflight(state: EditorState, preset: PlatformPreset): Pref
     durationSec,
     durationLabel: fmtSeconds(durationSec),
     estRenderLabel: `~${fmtSeconds(estimateRenderSec(durationSec))}`,
+    estSpendLabel: formatDollars(0),
+  };
+}
+
+/** The pre-flight summary for a MULTI-aspect fan-out of one source. */
+export interface FanoutPreflight {
+  /** Files this commit produces — one per DISTINCT aspect, not per destination. */
+  clipCount: number;
+  /** The render matrix (aspect + canvas) this commit will execute. */
+  targets: readonly AspectTarget[];
+  /** The aspects as one line ("9:16 · 1:1"); '' when nothing is selected. */
+  aspectLabel: string;
+  /** The clip length in seconds. */
+  durationSec: number;
+  /** The clip length as M:SS. */
+  durationLabel: string;
+  /** The estimated render time for the WHOLE fan-out as ~M:SS. */
+  estRenderLabel: string;
+  /** The estimated spend ($0.00 — a local render never spends). */
+  estSpendLabel: string;
+}
+
+/**
+ * Build the fan-out pre-flight the confirm step restates before the guarded
+ * commit. `clipCount` counts DISTINCT ASPECTS, so picking three vertical
+ * destinations honestly says "1 file" rather than inflating to three, and the
+ * render estimate is the per-file estimate multiplied by that same count. An
+ * empty selection reports 0 — it does not round up to a comforting 1.
+ */
+export function buildFanoutPreflight(
+  state: EditorState,
+  presets: readonly PlatformPreset[],
+): FanoutPreflight {
+  const durationSec = windowDurationSec(state);
+  const targets = aspectFanoutPlan(presets);
+  return {
+    clipCount: targets.length,
+    targets,
+    aspectLabel: targets.map((target) => target.aspect).join(' · '),
+    durationSec,
+    durationLabel: fmtSeconds(durationSec),
+    estRenderLabel: `~${fmtSeconds(estimateRenderSec(durationSec) * targets.length)}`,
     estSpendLabel: formatDollars(0),
   };
 }

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -230,8 +230,19 @@ export const client = {
   },
 
   convert: {
+    /**
+     * `convert.start({videoId|path, options, out?})`.
+     *
+     * `out` names the destination file explicitly. It is NOT new wire surface —
+     * the sidecar has always read it (`convert.start_handler` builds its item
+     * with `"out": params.get("out")`) and CONFINES it to the source's own
+     * directory or the app data root (`convert._confined_output`), because
+     * ffmpeg runs with `-y`. Only the renderer's type was narrower than the
+     * handler. The aspect fan-out needs it: without a per-target name every
+     * target derives the SAME `<stem>.mp4` and the files overwrite each other.
+     */
     start: (
-      target: { videoId?: string; path?: string },
+      target: { videoId?: string; path?: string; out?: string },
       options: ConvertOptions,
     ): Promise<JobHandle & { path?: string }> => rpc('convert.start', { ...target, options }),
     batch: (

--- a/app/renderer/src/views/Export.test.tsx
+++ b/app/renderer/src/views/Export.test.tsx
@@ -170,8 +170,13 @@ describe('Export view', () => {
     render(VIDEO);
     await flush();
     await commit();
+    // SCOPE FIX (v1.5 aspect-matrix): the target now carries an explicit `out`.
+    // Without a per-aspect name every fan-out target derives the same
+    // `<stem>.mp4` and the renders overwrite each other; `out` is long-standing
+    // sidecar surface (convert.start_handler reads params["out"], confined by
+    // convert._confined_output) that the renderer's TYPE simply did not expose.
     expect(convertStartMock).toHaveBeenCalledWith(
-      { videoId: 'v1' },
+      { videoId: 'v1', out: '/clips/x.9x16.mp4' },
       expect.objectContaining({ container: 'mp4', vcodec: 'libx264' }),
     );
     // Determinate progress.
@@ -188,6 +193,78 @@ describe('Export view', () => {
     });
     expect(q('.export-result')?.className).toContain('is-done');
     expect(q('.export-result__path')?.textContent).toBe('/exports/final.mp4');
+  });
+
+  it('fans ONE source out to a file per DISTINCT aspect, each with its own name', async () => {
+    // Check Square (1:1) alongside the default TikTok (9:16) -> two aspects, two
+    // renders, two distinctly-named files from a single guarded commit.
+    convertStartMock
+      .mockResolvedValueOnce({ jobId: 'j1', path: '/clips/x.9x16.mp4' })
+      .mockResolvedValueOnce({ jobId: 'j2', path: '/clips/x.1x1.mp4' });
+    render(VIDEO);
+    await flush();
+    act(() => q<HTMLButtonElement>('[data-preset="square"]')?.click());
+    await commit();
+    expect(convertStartMock).toHaveBeenCalledTimes(2);
+    expect(convertStartMock.mock.calls[0][0]).toEqual({ videoId: 'v1', out: '/clips/x.9x16.mp4' });
+    expect(convertStartMock.mock.calls[1][0]).toEqual({ videoId: 'v1', out: '/clips/x.1x1.mp4' });
+    expect(q('.export-result')?.className).toContain('is-done');
+    const paths = Array.from(container.querySelectorAll('.export-result__path')).map(
+      (el) => el.textContent,
+    );
+    expect(paths).toEqual(['/clips/x.9x16.mp4', '/clips/x.1x1.mp4']);
+  });
+
+  it('collapses same-aspect destinations to ONE render (no duplicate files)', async () => {
+    // TikTok + Reels + Shorts are three destinations but all 9:16 — the fan-out
+    // plan dedupes, so exactly one render runs. This is the assertion that stops
+    // the matrix from shipping three byte-identical copies.
+    convertStartMock.mockResolvedValue({ jobId: 'j1', path: '/clips/x.9x16.mp4' });
+    render(VIDEO);
+    await flush();
+    act(() => q<HTMLButtonElement>('[data-preset="reels"]')?.click());
+    act(() => q<HTMLButtonElement>('[data-preset="shorts"]')?.click());
+    await commit();
+    expect(convertStartMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('spreads fan-out progress across the whole run and counts the files', async () => {
+    convertStartMock.mockResolvedValueOnce({ jobId: 'j1' }).mockResolvedValueOnce({ jobId: 'j2' });
+    render(VIDEO);
+    await flush();
+    act(() => q<HTMLButtonElement>('[data-preset="square"]')?.click());
+    await commit();
+    // File 1 at 60% is 30% of a two-file fan-out, and the message is counted.
+    act(() => progressCb?.({ jobId: 'j1', pct: 60, message: 'Rendering frames…' }));
+    expect(q('.export-progress__pct')?.textContent).toBe('30%');
+    expect(q('.export-progress__message')?.textContent).toBe('[1/2] Rendering frames…');
+    await act(async () => {
+      doneCb?.({ jobId: 'j1', result: { path: '/clips/x.9x16.mp4' } });
+      await flush();
+    });
+    act(() => progressCb?.({ jobId: 'j2', pct: 50, message: 'Rendering frames…' }));
+    expect(q('.export-progress__pct')?.textContent).toBe('75%');
+    expect(q('.export-progress__message')?.textContent).toBe('[2/2] Rendering frames…');
+    await act(async () => {
+      doneCb?.({ jobId: 'j2', result: { path: '/clips/x.1x1.mp4' } });
+      await flush();
+    });
+    expect(q('.export-result')?.className).toContain('is-done');
+  });
+
+  it('stops the fan-out on the first target that produces no file', async () => {
+    // A partial success would hide the missing file behind a green result.
+    convertStartMock.mockResolvedValueOnce({ jobId: 'j1' }).mockResolvedValueOnce({ jobId: 'j2' });
+    render(VIDEO);
+    await flush();
+    act(() => q<HTMLButtonElement>('[data-preset="square"]')?.click());
+    await commit();
+    await act(async () => {
+      doneCb?.({ jobId: 'j1', result: {} });
+      await flush();
+    });
+    expect(convertStartMock).toHaveBeenCalledTimes(1);
+    expect(q('.export-result')?.className).toContain('is-failed');
   });
 
   it('accepts an immediate output path (fast direct-return)', async () => {

--- a/app/renderer/src/views/Export.tsx
+++ b/app/renderer/src/views/Export.tsx
@@ -27,7 +27,12 @@ import { ExportStage } from '../features/export/ExportStage';
 import { ExportInspector } from '../features/export/ExportInspector';
 import { ExportProgress } from '../features/export/ExportProgress';
 import { ExportResult, type ExportOutcome } from '../features/export/ExportResult';
-import type { PlatformPreset } from '../features/export/exportModel';
+import {
+  type PlatformPreset,
+  aspectFanoutPlan,
+  fanoutDestinationLabel,
+  fanoutOutPath,
+} from '../features/export/exportModel';
 import './export.css';
 
 /** idle → running → a terminal outcome (done / failed / cancelled). */
@@ -95,60 +100,83 @@ function ExportWorkspace({
   }, [video.id, dispatch]);
 
   const onCommit = useCallback(
-    async (preset: PlatformPreset, options: ConvertOptions): Promise<void> => {
+    async (presets: PlatformPreset[], options: ConvertOptions): Promise<void> => {
       if (!hasApi()) return;
+      // The FAN-OUT plan, not the destination list: several destinations that
+      // share an aspect (TikTok + Reels + Shorts are all 9:16) collapse to ONE
+      // render, so the user gets one file per distinct aspect and never three
+      // byte-identical copies. Each target gets its own `out` name — without it
+      // every render derives the same `<stem>.mp4` and overwrites the last.
+      const plan = aspectFanoutPlan(presets);
       cancelRequested.current = false;
       setPhase('running');
       setPct(0);
       setMessage('Starting…');
-      setDestination(preset.name);
+      setDestination(fanoutDestinationLabel(presets));
       setPaths([]);
       setError('');
       const controller = new AbortController();
       abort.current = controller;
       let offProgress = (): void => {};
       try {
-        const res = await client.convert.start({ videoId: video.id }, options);
-        const id = res.jobId;
-        jobId.current = id;
-        offProgress = onProgress((event) => {
-          if (event.jobId !== id) return;
-          setPct(event.pct);
-          setMessage(event.message);
-        });
-        // Drain a cancel that landed before this id existed. TERMINAL, not
-        // advisory: the `res.path` fast path below skips `waitForJobDone`, so
-        // without the early return a cancelled job would render a terminal SUCCESS
-        // with a "Show in folder" reveal. Fire-and-forget preserves the
-        // abort-settles-the-UI-first ordering documented in `cancel` below — an
-        // awaited RPC on a queued stdio channel would strand the user on a stale
-        // "Exporting…" panel and invite a duplicate cancel.
-        if (cancelRequested.current) {
-          void client.job.cancel(id).catch(() => {
-            // best-effort: the UI is already settling to 'cancelled'.
-          });
-          setPhase('cancelled');
-          return;
-        }
-        let outPath: string | null = res.path ?? null;
-        if (!outPath) {
-          outPath = await waitForJobDone(
-            { onJobDone },
-            id,
-            (result) => pickField<string>(result, 'path'),
-            DEFAULT_JOB_TIMEOUT_MS,
-            controller.signal,
+        const written: string[] = [];
+        for (let i = 0; i < plan.length; i += 1) {
+          const target = plan[i];
+          const res = await client.convert.start(
+            { videoId: video.id, out: fanoutOutPath(video.path, target) },
+            options,
           );
+          const id = res.jobId;
+          jobId.current = id;
+          // Detach the PREVIOUS target's listener before attaching this one, so a
+          // fan-out cannot leak one subscription per file.
+          offProgress();
+          offProgress = onProgress((event) => {
+            if (event.jobId !== id) return;
+            // Spread each target's 0..100 across its slice of the whole fan-out,
+            // so the bar climbs once end-to-end instead of resetting per file.
+            setPct((i * 100 + event.pct) / plan.length);
+            setMessage(
+              plan.length > 1 ? `[${i + 1}/${plan.length}] ${event.message}` : event.message,
+            );
+          });
+          // Drain a cancel that landed before this id existed. TERMINAL, not
+          // advisory: the `res.path` fast path below skips `waitForJobDone`, so
+          // without the early return a cancelled job would render a terminal SUCCESS
+          // with a "Show in folder" reveal. Fire-and-forget preserves the
+          // abort-settles-the-UI-first ordering documented in `cancel` below — an
+          // awaited RPC on a queued stdio channel would strand the user on a stale
+          // "Exporting…" panel and invite a duplicate cancel.
+          if (cancelRequested.current) {
+            void client.job.cancel(id).catch(() => {
+              // best-effort: the UI is already settling to 'cancelled'.
+            });
+            setPhase('cancelled');
+            return;
+          }
+          let outPath: string | null = res.path ?? null;
+          if (!outPath) {
+            outPath = await waitForJobDone(
+              { onJobDone },
+              id,
+              (result) => pickField<string>(result, 'path'),
+              DEFAULT_JOB_TIMEOUT_MS,
+              controller.signal,
+            );
+          }
+          if (!outPath) {
+            // Stop the whole fan-out on the first target that produced nothing —
+            // reporting a partial success would hide the missing file.
+            setError('The export finished without producing a file.');
+            setPhase('failed');
+            return;
+          }
+          written.push(outPath);
         }
-        if (outPath) {
-          setPaths([outPath]);
-          setPct(100);
-          setMessage('Done');
-          setPhase('done');
-        } else {
-          setError('The export finished without producing a file.');
-          setPhase('failed');
-        }
+        setPaths(written);
+        setPct(100);
+        setMessage('Done');
+        setPhase('done');
       } catch (err) {
         if (err instanceof JobAbortedError) {
           setPhase('cancelled');
@@ -161,7 +189,7 @@ function ExportWorkspace({
         jobId.current = null;
       }
     },
-    [video.id],
+    [video.id, video.path],
   );
 
   const cancel = useCallback(async (): Promise<void> => {
@@ -214,7 +242,7 @@ function ExportWorkspace({
         </div>
         <div className="export-view__panel">
           {phase === 'idle' ? (
-            <ExportInspector onCommit={(preset, options) => void onCommit(preset, options)} />
+            <ExportInspector onCommit={(presets, options) => void onCommit(presets, options)} />
           ) : phase === 'running' ? (
             <ExportProgress
               destination={destination}

--- a/sidecar/media_studio/features/aspect.py
+++ b/sidecar/media_studio/features/aspect.py
@@ -7,38 +7,57 @@ catalog (:mod:`.export_presets`). Before R3 each engine duplicated this aspect
 math "kept in sync with the contract"; this module removes that duplication so
 the engines and the catalog can never drift on what 1:1 / 4:5 / 9:16 mean.
 
-Three curated aspects (the OpusClip / Instagram / TikTok standard, all 1080-wide):
+Four curated aspects (the OpusClip / Instagram / TikTok / YouTube standard):
 
   * **9:16** -> 1080x1920  — vertical (Reels / TikTok / Shorts / Stories),
   * **1:1**  -> 1080x1080  — square (Instagram feed),
-  * **4:5**  -> 1080x1350  — portrait (Instagram / Facebook feed).
+  * **4:5**  -> 1080x1350  — portrait (Instagram / Facebook feed),
+  * **16:9** -> 1920x1080  — widescreen (YouTube / LinkedIn / X, landscape).
 
-:func:`output_dimensions` returns the curated dimensions for those three and a
+:func:`output_dimensions` returns the curated dimensions for those four and a
 generic "fit the long edge to 1920" fallback for any OTHER positive ratio (so a
-programmatic 16:9 / 3:4 target still resolves to even h264 dimensions). This is a
+programmatic 3:4 / 21:9 target still resolves to even h264 dimensions). This is a
 PURE module — no subprocess, no ffmpeg, no native imports — so it stays trivially
 unit-testable and importable by the cycle-sensitive claudeshorts engine.
+
+**Multi-aspect fan-out (v1.5).** :func:`require_supported_aspects` and
+:func:`fanout_plan` are the pure primitives for "one source, N aspects, one
+action": they canonicalize a whole REQUEST, dedupe it so three vertical
+destinations collapse to a single 9:16 render target, and pair each surviving
+aspect with its canonical dimensions. Callers get a plan they can execute; the
+registry stays the only place that knows what an aspect means.
 """
 
 from __future__ import annotations
 
+from collections.abc import Iterable
+from typing import NamedTuple
+
 #: The default export aspect (vertical) — unchanged from V1.
 DEFAULT_ASPECT = "9:16"
 
-#: Curated social export aspects -> canonical (width, height). All 1080-wide,
-#: matching the OpusClip / IG / TikTok delivery sizes. 1:1 and 4:5 are the R3
-#: net-new aspects alongside the original 9:16.
+#: Curated social export aspects -> canonical (width, height), matching the
+#: OpusClip / IG / TikTok / YouTube delivery sizes. 1:1 and 4:5 were the R3
+#: net-new aspects alongside the original 9:16; **16:9 is the v1.5 addition**.
+#:
+#: The three social aspects are 1080-WIDE (portrait/square delivery). 16:9 is
+#: landscape, so its canonical size is 1920x1080 — the standard widescreen
+#: delivery, and byte-identical to what :func:`output_dimensions` already
+#: returned for 16:9 through the generic fallback. Promoting it therefore widens
+#: :data:`SUPPORTED_ASPECTS` (what a caller is ALLOWED to ask for) without moving
+#: a single pixel of existing geometry.
 ASPECT_PRESETS: dict[str, tuple[int, int]] = {
     "9:16": (1080, 1920),
     "1:1": (1080, 1080),
     "4:5": (1080, 1350),
+    "16:9": (1920, 1080),
 }
 
 #: The export-catalog's allowed aspect ids (exactly the curated preset keys).
 SUPPORTED_ASPECTS: frozenset[str] = frozenset(ASPECT_PRESETS)
 
 #: The long edge a NON-preset (generic) ratio is scaled to (h264-even). Matches
-#: the engines' original fallback math so 3:4 / 16:9 dimensions are unchanged.
+#: the engines' original fallback math so 3:4 / 21:9 dimensions are unchanged.
 _FALLBACK_LONG_EDGE = 1920
 
 
@@ -81,9 +100,10 @@ def require_supported_aspect(aspect: str) -> str:
     """Normalize ``aspect`` and assert it is one of the curated :data:`SUPPORTED_ASPECTS`.
 
     Returns the canonical ``"W:H"`` form. Raises ``ValueError`` (fail loud) for a
-    parseable-but-uncurated ratio (e.g. ``16:9``) or for garbage — this is the
+    parseable-but-uncurated ratio (e.g. ``21:9``) or for garbage — this is the
     boundary guard the export catalog uses so it can only ever persist a render
-    target the pipeline actually offers.
+    target the pipeline actually offers. See :func:`require_supported_aspects` for
+    the list form a multi-aspect fan-out crosses.
     """
     norm = normalize_aspect(aspect)
     if norm not in SUPPORTED_ASPECTS:
@@ -94,7 +114,7 @@ def require_supported_aspect(aspect: str) -> str:
 def output_dimensions(aspect: str = DEFAULT_ASPECT) -> tuple[int, int]:
     """Return the ``(width, height)`` the reframe should produce for ``aspect``.
 
-    The three curated social aspects resolve to their fixed 1080-wide dimensions
+    The four curated social aspects resolve to their fixed dimensions
     (:data:`ASPECT_PRESETS`). Any other positive ratio falls back to the engines'
     original generic math: portrait/square fix the HEIGHT to 1920, landscape fix
     the WIDTH to 1920, deriving the other edge from the ratio rounded to even.
@@ -109,13 +129,74 @@ def output_dimensions(aspect: str = DEFAULT_ASPECT) -> tuple[int, int]:
     return _FALLBACK_LONG_EDGE, even(int(round(_FALLBACK_LONG_EDGE * (h / w))))
 
 
+# --------------------------------------------------------------------------- #
+# multi-aspect fan-out (v1.5): ONE source -> N aspect targets, in one action
+# --------------------------------------------------------------------------- #
+class AspectTarget(NamedTuple):
+    """One rendered destination of a fan-out: a curated aspect + its canvas."""
+
+    #: The canonical ``"W:H"`` aspect id (a :data:`SUPPORTED_ASPECTS` member).
+    aspect: str
+    #: Output width in pixels (even, h264-safe).
+    width: int
+    #: Output height in pixels (even, h264-safe).
+    height: int
+
+
+def require_supported_aspects(aspects: Iterable[str]) -> tuple[str, ...]:
+    """Canonicalize + guard a MULTI-aspect request, order-preserving and deduped.
+
+    The list form of :func:`require_supported_aspect`, and the boundary a caller
+    crosses when one action targets several aspects at once. Every member is
+    normalized and must be curated (an uncurated ratio raises, naming that
+    member); duplicates that only differ in spelling — ``"9x16"`` vs ``"9:16"`` —
+    collapse to their FIRST occurrence, so a fan-out can never queue the same
+    render twice. An empty request raises rather than silently rendering nothing.
+
+    A bare ``str`` is rejected explicitly: Python would iterate it CHARACTER by
+    character, so ``"9:16"`` would fan out to ``"9"`` / ``":"`` / ``"1"`` / ``"6"``
+    and fail somewhere downstream with a nonsense message. Fail loud, here.
+    """
+    if isinstance(aspects, str):
+        raise ValueError(f"aspects must be an iterable of aspect strings, got the bare str {aspects!r}")
+    out: list[str] = []
+    seen: set[str] = set()
+    for raw in aspects:
+        norm = require_supported_aspect(raw)
+        if norm not in seen:
+            seen.add(norm)
+            out.append(norm)
+    if not out:
+        raise ValueError("at least one aspect is required")
+    return tuple(out)
+
+
+def fanout_plan(aspects: Iterable[str]) -> tuple[AspectTarget, ...]:
+    """The render matrix for a multi-aspect fan-out of ONE source.
+
+    Returns one :class:`AspectTarget` per DISTINCT requested aspect, in request
+    order, each carrying the canonical canvas from :func:`output_dimensions`. The
+    dedupe is what makes the plan meaningful at the destination level: picking
+    TikTok + Reels + Shorts is three destinations but ONE 9:16 render, so the plan
+    has a single entry and the caller produces a single file.
+
+    Raises ``ValueError`` (via :func:`require_supported_aspects`) for an empty
+    request or any uncurated member — a fan-out plan is only ever built from
+    aspects the pipeline actually offers.
+    """
+    return tuple(AspectTarget(a, *output_dimensions(a)) for a in require_supported_aspects(aspects))
+
+
 __all__ = [
     "ASPECT_PRESETS",
     "DEFAULT_ASPECT",
     "SUPPORTED_ASPECTS",
+    "AspectTarget",
     "even",
+    "fanout_plan",
     "normalize_aspect",
     "output_dimensions",
     "parse_aspect",
     "require_supported_aspect",
+    "require_supported_aspects",
 ]

--- a/sidecar/media_studio/features/export_presets.py
+++ b/sidecar/media_studio/features/export_presets.py
@@ -83,8 +83,9 @@ def _require_supported_aspect(raw_aspect: str) -> str:
     """Canonicalize + guard an aspect against the curated social export set (R3).
 
     Translates the shared registry's ``ValueError`` (garbage OR a parseable-but-
-    uncurated ratio like ``16:9``) into a fail-loud :class:`RpcError`, so a bad
-    save never persists an aspect the engines/UI don't offer.
+    uncurated ratio like ``21:9``) into a fail-loud :class:`RpcError`, so a bad
+    save never persists an aspect the engines/UI don't offer. The curated set is
+    9:16 / 1:1 / 4:5 / 16:9 — 16:9 joined in the v1.5 aspect-matrix lane.
     """
     try:
         return aspect_mod.require_supported_aspect(raw_aspect)
@@ -108,7 +109,7 @@ def normalize_preset(raw: Any) -> ExportPreset:
 
     Clamps the ``minSec``/``maxSec`` window into the hard ``[20, 60]`` range (and
     never lets it invert), floors ``count`` at 1, canonicalizes ``aspect`` and
-    guards it against the curated social set (9:16 / 1:1 / 4:5 — WU R3), and
+    guards it against the curated social set (9:16 / 1:1 / 4:5 / 16:9), and
     rejects an unknown ``captionStyle`` / ``reframeEngine`` with a fail-loud
     ``RpcError`` so a bad save can never persist a half-typed or unrenderable
     record. A missing ``id`` is generated.

--- a/sidecar/tests/test_aspect.py
+++ b/sidecar/tests/test_aspect.py
@@ -2,8 +2,14 @@
 
 The registry is the SINGLE source of truth shared by both reframe engines
 (``reframe`` / ``reframe_claudeshorts``) so the supported social export aspects —
-9:16 (vertical), 1:1 (square), 4:5 (portrait) — and their canonical 1080-wide
-output dimensions can never drift between the two engines or the export catalog.
+9:16 (vertical), 1:1 (square), 4:5 (portrait), 16:9 (widescreen) — and their
+canonical output dimensions can never drift between the two engines or the
+export catalog.
+
+v1.5 aspect-matrix lane: 16:9 is now a FIRST-CLASS curated preset (it used to be
+rejected by :func:`require_supported_aspect`), and the registry grows the pure
+MULTI-aspect primitives (:func:`require_supported_aspects` /
+:func:`fanout_plan`) that let ONE source target N aspects in a single action.
 """
 
 from __future__ import annotations
@@ -59,12 +65,19 @@ def test_normalize_aspect_rejects_garbage():
 # --------------------------------------------------------------------------- #
 # require_supported_aspect
 # --------------------------------------------------------------------------- #
-@pytest.mark.parametrize(("raw", "norm"), [("9x16", "9:16"), ("1:1", "1:1"), ("4:5", "4:5")])
-def test_require_supported_aspect_accepts_the_three(raw, norm):
+@pytest.mark.parametrize(
+    ("raw", "norm"),
+    [("9x16", "9:16"), ("1:1", "1:1"), ("4:5", "4:5"), ("16x9", "16:9")],
+)
+def test_require_supported_aspect_accepts_the_four(raw, norm):
     assert aspect.require_supported_aspect(raw) == norm
 
 
-@pytest.mark.parametrize("unsupported", ["16:9", "3:4", "2:3"])
+# SCOPE FIX (v1.5 aspect-matrix lane): "16:9" used to sit in this rejection list.
+# It is now a FIRST-CLASS curated preset by design, so it moved UP into
+# ``test_require_supported_aspect_accepts_the_four``. No assertion was weakened —
+# the remaining uncurated ratios still fail loud, and the accept-list grew.
+@pytest.mark.parametrize("unsupported", ["3:4", "2:3", "21:9"])
 def test_require_supported_aspect_rejects_unsupported_ratio(unsupported):
     # Parses fine, but is not one of the curated social export aspects -> fail loud.
     with pytest.raises(ValueError, match="unsupported aspect"):
@@ -77,8 +90,88 @@ def test_require_supported_aspect_rejects_garbage():
 
 
 def test_supported_aspects_set_is_the_preset_keys():
-    assert frozenset({"9:16", "1:1", "4:5"}) == aspect.SUPPORTED_ASPECTS
+    assert frozenset({"9:16", "1:1", "4:5", "16:9"}) == aspect.SUPPORTED_ASPECTS
     assert frozenset(aspect.ASPECT_PRESETS) == aspect.SUPPORTED_ASPECTS
+
+
+# --------------------------------------------------------------------------- #
+# require_supported_aspects — the MULTI-aspect (fan-out) request guard
+# --------------------------------------------------------------------------- #
+def test_require_supported_aspects_canonicalizes_and_preserves_order():
+    assert aspect.require_supported_aspects(["16x9", " 4:5 ", "9:16"]) == ("16:9", "4:5", "9:16")
+
+
+def test_require_supported_aspects_dedupes_keeping_first_occurrence():
+    # "9x16" and "9:16" are the SAME target — a fan-out must not render it twice.
+    assert aspect.require_supported_aspects(["9x16", "1:1", "9:16", "1:1"]) == ("9:16", "1:1")
+
+
+def test_require_supported_aspects_rejects_empty():
+    with pytest.raises(ValueError, match="at least one aspect"):
+        aspect.require_supported_aspects([])
+
+
+def test_require_supported_aspects_rejects_a_bare_string():
+    # A bare str is iterable CHAR-BY-CHAR; silently fanning out to "1"/":"/"1"
+    # would be a confusing downstream failure, so reject it at the boundary.
+    with pytest.raises(ValueError, match="iterable of aspect strings"):
+        aspect.require_supported_aspects("9:16")  # type: ignore[arg-type]
+
+
+def test_require_supported_aspects_propagates_the_unsupported_member():
+    with pytest.raises(ValueError, match="unsupported aspect"):
+        aspect.require_supported_aspects(["9:16", "3:4"])
+
+
+# --------------------------------------------------------------------------- #
+# fanout_plan — ONE source -> N aspect targets, in one action
+# --------------------------------------------------------------------------- #
+def test_fanout_plan_pairs_every_aspect_with_its_canonical_dimensions():
+    plan = aspect.fanout_plan(["9:16", "1:1", "4:5", "16:9"])
+    assert plan == (
+        aspect.AspectTarget("9:16", 1080, 1920),
+        aspect.AspectTarget("1:1", 1080, 1080),
+        aspect.AspectTarget("4:5", 1080, 1350),
+        aspect.AspectTarget("16:9", 1920, 1080),
+    )
+
+
+def test_fanout_plan_targets_are_named_tuples():
+    (target,) = aspect.fanout_plan(["16:9"])
+    assert (target.aspect, target.width, target.height) == ("16:9", 1920, 1080)
+
+
+def test_fanout_plan_dedupes_so_one_file_per_distinct_aspect():
+    # Three vertical destinations (TikTok/Reels/Shorts) are ONE render target.
+    assert aspect.fanout_plan(["9:16", "9x16", "9:16"]) == (aspect.AspectTarget("9:16", 1080, 1920),)
+
+
+def test_fanout_plan_rejects_an_uncurated_member():
+    with pytest.raises(ValueError, match="unsupported aspect"):
+        aspect.fanout_plan(["9:16", "2:3"])
+
+
+# --------------------------------------------------------------------------- #
+# consumer proof: the export-preset catalog now ACCEPTS a 16:9 preset
+# --------------------------------------------------------------------------- #
+def test_export_preset_catalog_accepts_a_widescreen_preset():
+    """BOTH-STATES anchor for the widening: this raised ``RpcError`` before 16:9
+    became a curated preset (``export_presets._require_supported_aspect`` →
+    ``aspect.require_supported_aspect``), and must now persist cleanly."""
+    from media_studio.features import export_presets
+
+    saved = export_presets.normalize_preset(
+        {
+            "id": "widescreen",
+            "label": "Widescreen",
+            "aspect": "16x9",
+            "minSec": 20,
+            "maxSec": 60,
+            "count": 1,
+            "captionStyle": "libass",
+        }
+    )
+    assert saved["aspect"] == "16:9"
 
 
 # --------------------------------------------------------------------------- #
@@ -98,6 +191,13 @@ def test_output_dimensions_portrait_4_5_is_1080x1350():
     assert aspect.output_dimensions("4:5") == (1080, 1350)
 
 
+def test_output_dimensions_widescreen_16_9_is_1920x1080():
+    # 16:9 is now a CURATED preset. Its dimensions are byte-identical to what the
+    # generic landscape fallback produced before the widening (1920x1080), so the
+    # promotion changes MEMBERSHIP (require_supported_aspect) — never geometry.
+    assert aspect.output_dimensions("16:9") == (1920, 1080)
+
+
 def test_output_dimensions_accepts_x_form_for_presets():
     assert aspect.output_dimensions("9x16") == (1080, 1920)
 
@@ -110,8 +210,12 @@ def test_output_dimensions_generic_portrait_fixes_height():
 
 
 def test_output_dimensions_generic_landscape_fixes_width_even():
-    w, h = aspect.output_dimensions("16:9")
+    # 21:9 (ultrawide) is NOT curated, so it still exercises the generic LANDSCAPE
+    # branch that 16:9 used to cover before it was promoted to a preset:
+    # round(1920*9/21) = 823 -> even() -> 824.
+    w, h = aspect.output_dimensions("21:9")
     assert w == 1920
+    assert h == 824
     assert h % 2 == 0
 
 

--- a/sidecar/tests/test_export_presets.py
+++ b/sidecar/tests/test_export_presets.py
@@ -116,18 +116,26 @@ class TestNormalizePreset:
                 }
             )
 
-    @pytest.mark.parametrize(("raw", "norm"), [("1:1", "1:1"), ("4:5", "4:5"), ("9x16", "9:16")])
+    @pytest.mark.parametrize(
+        ("raw", "norm"),
+        [("1:1", "1:1"), ("4:5", "4:5"), ("9x16", "9:16"), ("16:9", "16:9"), ("16x9", "16:9")],
+    )
     def test_multi_aspect_accepted_and_canonicalized(self, raw, norm):
-        # WU R3: 1:1 + 4:5 are now valid export aspects alongside 9:16, and an
-        # "WxH" form is canonicalized to "W:H".
+        # WU R3: 1:1 + 4:5 are valid export aspects alongside 9:16, and an "WxH"
+        # form is canonicalized to "W:H". v1.5 aspect-matrix: 16:9 (widescreen)
+        # joined them as a first-class curated preset.
         p = export_presets.normalize_preset(
             {"label": "x", "aspect": raw, "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"}
         )
         assert p["aspect"] == norm
 
-    @pytest.mark.parametrize("bad_aspect", ["16:9", "3:4", "potato", "9", "0:0"])
+    # SCOPE FIX (v1.5 aspect-matrix lane): "16:9" moved OUT of this rejection list
+    # and INTO the accept list above — the catalog now offers it deliberately.
+    # 21:9 replaces it so the uncurated-ratio case still has a landscape member;
+    # no assertion was weakened and the accept-list grew by two cases.
+    @pytest.mark.parametrize("bad_aspect", ["21:9", "3:4", "potato", "9", "0:0"])
     def test_unsupported_or_garbage_aspect_rejected(self, bad_aspect):
-        # A parseable-but-uncurated ratio (16:9) AND outright garbage both fail loud.
+        # A parseable-but-uncurated ratio (21:9) AND outright garbage both fail loud.
         with pytest.raises(RpcError):
             export_presets.normalize_preset(
                 {"label": "x", "aspect": bad_aspect, "minSec": 20, "maxSec": 60, "count": 1, "captionStyle": "libass"}


### PR DESCRIPTION
- **docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it**
- **test(aspect): RED — 16:9 as a first-class preset + the multi-aspect fan-out primitives**
- **feat(aspect): GREEN — 16:9 is a first-class preset, plus the fan-out primitives**
- **test(export): RED — multi-select destinations + the aspect fan-out plan**
- **feat(export): GREEN — the pure multi-select + aspect fan-out model**
- **test(export): RED - the destination matrix as a real MULTI-select group**
- **feat(export): GREEN - the matrix is multi-select and the host really fans out**
- **style(export): quiet caption treatment for the fan-out framing note**
