### PR TITLE
feat/v15 asr vocabulary

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -81,7 +81,7 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 - `shortmaker.select({videoId, prompt, controls})` -> `{jobId}` -> `{candidates}` ; controls = `{count,minSec,maxSec,aspect,language,captionStyle}`
 - `shortmaker.export({videoId, candidateIds})` -> `{jobId}` -> `{clips:[{path}]}`
 - `job.cancel({jobId})` -> `{ok}` ; `job.status({jobId})` -> `{status,pct}`
-- `settings.get()` / `settings.set({...})` -> includes `{useCloud:bool, cloudApiKey?, modelsDir, ffmpegPath}` (editing-refinement adds the `captionSpeakerLabels` setting key; the refine tunables are per-call RPC params, not settings — see §A5)
+- `settings.get()` / `settings.set({...})` -> includes `{useCloud:bool, cloudApiKey?, modelsDir, ffmpegPath}` (editing-refinement adds the `captionSpeakerLabels` setting key; the refine tunables are per-call RPC params, not settings — see §A5. The v1.5 custom ASR dictionary adds `asrVocabulary` — see §A9)
 
 ## 3. Data schemas (Python TypedDict / TS interface — keep field names identical both sides)
 - **Word** `{text:str, start:float, end:float}` ; **Segment** `{start:float, end:float, text:str, words:[Word]}`
@@ -256,3 +256,51 @@ system-advanced group **directly after `diarize`** —
 - T5: electron-builder.yml · build/* · sidecar runtime_setup/* + media_studio/tools_resolver.py(+tests)
 - WIRING (last, serialized): handlers.py · __main__.py · Workspace.tsx · App.tsx · preload.ts · main.ts ·
   lib/rpc.ts · app/package.json · CONTRACTS conformance.
+
+## A9. Custom ASR dictionary — the `asrVocabulary` settings key (v1.5, additive)
+
+ONE new persisted settings key. No new RPC method, no change to any frozen wire shape:
+it rides the existing `settings.get()` / `settings.set({...})` (base §2), exactly like the
+sibling `asrEngine` / `transcribeDevice` knobs.
+
+| Key | Type | Default | Meaning |
+|---|---|---|---|
+| `asrVocabulary` | `Array<string \| {term, soundsLike?[]}>` | `[]` | proper nouns / brand names / jargon the ASR must get right. A bare string is shorthand for `{term}`; `soundsLike` lists the mis-transcriptions to rewrite onto `term` (e.g. `"re frame"` -> `"Reframe"`). |
+
+TS shape: `AsrVocabularyTerm` / `AsrVocabularySetting` in `app/renderer/src/lib/rpc/schemas.ts`.
+Reader: `sidecar/media_studio/features/asr_vocabulary.py`. Empty (the default) is
+byte-identical to pre-v1.5: no biasing string is built and the transcript object is
+returned unchanged.
+
+**The two engines are treated DIFFERENTLY, because their backends differ:**
+
+- **whisper** — real decode-time biasing. faster-whisper (pinned `1.2.1`) accepts both
+  `initial_prompt` and `hotwords` on `WhisperModel.transcribe`; `features/transcribe.py`
+  now sends both, and forwards each ONLY when non-empty so the zero-vocabulary call is
+  unchanged. `hotwords` is the load-bearing one — upstream re-applies it on EVERY decode
+  window, while `initial_prompt` seeds only the first — and this wrapper never passes
+  `prefix`, so upstream's "hotwords has no effect if prefix is not None" cannot bite.
+- **parakeet** — post-correction ONLY. The NeMo adapter
+  (`features/parakeet_asr_backend.py` `_RealParakeetModel.transcribe`) calls
+  `model.transcribe([audio], timestamps=True)` and forwards no prompt/hotword argument,
+  so there is nothing to bias with on that path.
+
+The rule-based post-correction (`asr_vocabulary.apply_corrections`) therefore runs for
+BOTH engines — including the whisper fallback after a Parakeet degrade. It rewrites the
+segment text and the word list with the SAME compiled rules, whole-word and longest-match
+first, merging a multi-word alias into one word that keeps the first word's `start` and
+the last word's `end`. That keeps §3 `Segment.text` and `Segment.words` consistent, which
+is what karaoke/CTC consumers depend on. No timing is invented.
+
+SECURITY: the value crosses the untrusted renderer RPC boundary, so every pattern is
+`re.escape`-d (no user string is ever compiled as regex syntax) and term count, term
+length, alias count, alias word-span and biasing-string length are all capped. Every
+malformed shape degrades to "no vocabulary" — a typo'd setting can never fail a job. The
+key is pure DATA and must never join `EXECUTABLE_SETTING_KEYS` (asserted by a test).
+
+SCOPE NOTE (deliberate, disclosed): the captions/translation audit proposed a single
+unified `translationGlossary` shared by ASR **and** the MT prompt. Only the ASR half is
+built here — the translation flow was owned by a concurrent lane, and coupling the two
+keys across lanes would have created a cross-lane dependency. If the unified glossary is
+wanted later, the translation side can read this same key (or merge a second one); no
+migration is needed because `asrVocabulary` is additive and defaults to empty.

--- a/app/renderer/src/lib/rpc/schemas.ts
+++ b/app/renderer/src/lib/rpc/schemas.ts
@@ -1023,6 +1023,31 @@ export interface SavePresetsBlock {
 }
 
 /**
+ * One custom-dictionary entry (v1.5 asr-vocabulary). `term` is the canonical
+ * spelling that must end up in the transcript; `soundsLike` lists the
+ * mis-transcriptions to rewrite onto it (e.g. `"re frame"` -> `"Reframe"`).
+ *
+ * Field names are FROZEN, identical to the sidecar
+ * `features/asr_vocabulary.parse_terms` reader.
+ */
+export interface AsrVocabularyTerm {
+  term: string;
+  soundsLike?: string[];
+}
+
+/**
+ * The `asrVocabulary` settings value (sidecar `DEFAULT_SETTINGS`, default `[]`).
+ * A bare string is shorthand for `{ term }` with no aliases, so the UI may write
+ * either form. Written through the ordinary `settings.set` — there is no
+ * dedicated RPC, exactly like the sibling `asrEngine` / `transcribeDevice` knobs.
+ *
+ * The sidecar is TOLERANT of every malformed shape (a non-array, a junk entry, an
+ * over-long term) — it degrades to "no vocabulary" rather than failing the job —
+ * so the UI never has to guarantee validity to keep transcription working.
+ */
+export type AsrVocabularySetting = Array<string | AsrVocabularyTerm>;
+
+/**
  * system-advanced saved pipeline recipe — field names FROZEN, identical to the
  * sidecar `recipes.normalize_recipe` shape. A `Step` names an existing RPC
  * method + its params; param values may use the `"$N.key"` prior-step reference

--- a/sidecar/media_studio/features/asr_vocabulary.py
+++ b/sidecar/media_studio/features/asr_vocabulary.py
@@ -1,0 +1,407 @@
+"""Custom ASR dictionary — proper-noun / jargon biasing + rule post-correction.
+
+Proper nouns, brand names and jargon ("Reframe", "ctranslate2", "C++") are the
+words an ASR model has the least evidence for, and until now this sidecar had
+**no** way to tell either engine about them: a repo-wide search for
+``initial_prompt|hotwords|custom_dict|glossary|word_list|customVocab`` over
+``sidecar/media_studio`` returned zero hits, and neither
+:func:`media_studio.features.transcribe.transcribe_file` nor
+:func:`media_studio.features.parakeet_asr.transcribe_file` exposed a
+vocabulary parameter.
+
+**What each backend actually supports** — this drove the design, and the two
+halves are deliberately different:
+
+* **faster-whisper (pinned 1.2.1, `sidecar/requirements.lock.txt`).**
+  ``WhisperModel.transcribe`` accepts ``initial_prompt: str | Iterable[int] |
+  None`` ("text … to provide as a prompt for the first window") **and**
+  ``hotwords: str | None`` ("Hotwords/hint phrases to provide the model with.
+  Has no effect if prefix is not None"). Both are verified against the upstream
+  ``v1.2.1`` tag, not from memory. So whisper gets REAL decode-time biasing —
+  :func:`build_initial_prompt` and :func:`build_hotwords`. This wrapper never
+  passes ``prefix``, so the ``hotwords`` caveat cannot bite.
+* **Parakeet (NeMo).** This repo's adapter — ``parakeet_asr_backend.
+  _RealParakeetModel.transcribe`` — calls ``self._model.transcribe([audio],
+  timestamps=True)`` and forwards **nothing else**; there is no prompt/hotword
+  argument on that path at all. So for Parakeet the only available lever is the
+  post-hoc rule pass.
+
+:func:`apply_corrections` is therefore the ENGINE-AGNOSTIC half: a deterministic,
+whole-word, longest-match-first rewrite over a §3 ``Transcript`` that fixes both
+the segment text **and** the word list (timings preserved, multi-word aliases
+merged into one word) so karaoke/CTC consumers never see a segment and its words
+disagree.
+
+Pure stdlib; no heavy-ML import, no I/O. The settings value is UNTRUSTED (it
+crosses the renderer RPC boundary), so every pattern is :func:`re.escape`-d — no
+user string is ever compiled as regex syntax — and term/alias counts and lengths
+are capped.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..util import get_logger
+
+log = get_logger("media_studio.features.asr_vocabulary")
+
+#: the settings key holding the user's term list (see ``settings_store``).
+VOCAB_SETTINGS_KEY = "asrVocabulary"
+
+#: at most this many distinct terms are honoured (the tail is dropped).
+MAX_TERMS = 256
+#: a term / alias longer than this is not a term — it is skipped.
+MAX_TERM_CHARS = 80
+#: at most this many ``soundsLike`` aliases per term.
+MAX_ALIASES_PER_TERM = 16
+#: an alias may span at most this many whitespace-separated words; this is what
+#: bounds the word-merge scan window in :func:`apply_corrections`.
+MAX_ALIAS_WORDS = 8
+#: hard character budget for either biasing string. Whisper's prompt window is
+#: ~224 tokens; this keeps the string well inside it and bounds the settings
+#: value's influence on the decode.
+MAX_PROMPT_CHARS = 700
+#: the sentence frame the glossary terms are listed in for ``initial_prompt``.
+PROMPT_PREFIX = "Glossary: "
+PROMPT_SUFFIX = "."
+
+# Type aliases matching CONTRACTS.md §3 (plain JSON-able dicts both sides).
+Word = dict[str, Any]
+Segment = dict[str, Any]
+Transcript = dict[str, Any]
+
+#: a run of characters that are NOT word characters (punctuation/space).
+_NON_WORD = r"\W*"
+
+
+@dataclass(frozen=True)
+class VocabTerm:
+    """One canonical term plus the mis-transcriptions that should map onto it.
+
+    ``term`` is the spelling that ends up in the transcript; ``sounds_like`` are
+    additional (already normalized, casefold-deduped) phrases that the ASR is
+    known to emit instead. The canonical term is ALWAYS matched too — that is
+    what fixes a mere casing miss (``reframe`` -> ``Reframe``).
+    """
+
+    term: str
+    sounds_like: tuple[str, ...] = field(default=())
+
+
+@dataclass(frozen=True)
+class _CompiledRules:
+    """The compiled form of a term list (built once per correction pass)."""
+
+    #: alternation used for the per-word / per-segment substitution.
+    word_re: re.Pattern[str]
+    #: ``\\W* (alternation) \\W*`` used to test "this whole span IS the phrase".
+    span_re: re.Pattern[str]
+    #: casefolded token tuple -> canonical replacement.
+    by_key: dict[tuple[str, ...], str]
+    #: the longest alias, in words — the word-merge scan window.
+    max_span: int
+
+
+# --------------------------------------------------------------------------- #
+# parsing the untrusted settings value
+# --------------------------------------------------------------------------- #
+def _has_word_char(value: str) -> bool:
+    """True when ``value`` contains at least one word character.
+
+    A phrase made only of punctuation can never satisfy the ``(?<!\\w)`` /
+    ``(?!\\w)`` boundaries a rule is built with, so it would compile into a rule
+    that can never fire — it is dropped at parse time instead.
+    """
+    return re.search(r"\w", value) is not None
+
+
+def _clean_phrase(value: Any) -> str:
+    """Normalize one term/alias: trim, collapse inner whitespace, validate.
+
+    Returns ``""`` for anything that is not a usable phrase — a non-string, an
+    empty/whitespace-only value, a value longer than :data:`MAX_TERM_CHARS`, or
+    one with no word character at all.
+    """
+    if not isinstance(value, str):
+        return ""
+    trimmed = " ".join(value.split())
+    if not trimmed or len(trimmed) > MAX_TERM_CHARS or not _has_word_char(trimmed):
+        return ""
+    return trimmed
+
+
+def _parse_aliases(value: Any, term: str) -> tuple[str, ...]:
+    """Normalize a ``soundsLike`` list into deduped, capped alias phrases.
+
+    An alias equal (casefold) to the term is dropped — the canonical term is
+    already a pattern, so it would be a duplicate rule. An alias spanning more
+    than :data:`MAX_ALIAS_WORDS` words is dropped so the word-merge scan window
+    stays bounded.
+    """
+    if not isinstance(value, list | tuple):
+        return ()
+    out: list[str] = []
+    seen: set[str] = {term.casefold()}
+    for raw in value:
+        alias = _clean_phrase(raw)
+        key = alias.casefold()
+        if not alias or key in seen or len(alias.split()) > MAX_ALIAS_WORDS:
+            continue
+        seen.add(key)
+        out.append(alias)
+        if len(out) >= MAX_ALIASES_PER_TERM:
+            break
+    return tuple(out)
+
+
+def _parse_entry(entry: Any) -> VocabTerm | None:
+    """Parse ONE settings entry — a bare string OR ``{term, soundsLike}``."""
+    if isinstance(entry, str):
+        term = _clean_phrase(entry)
+        return VocabTerm(term) if term else None
+    if not isinstance(entry, dict):
+        return None
+    term = _clean_phrase(entry.get("term"))
+    if not term:
+        return None
+    return VocabTerm(term, _parse_aliases(entry.get("soundsLike"), term))
+
+
+def parse_terms(settings: dict[str, Any] | None) -> tuple[VocabTerm, ...]:
+    """Read ``settings[VOCAB_SETTINGS_KEY]`` into normalized :class:`VocabTerm`s.
+
+    TOLERANT by design (mirrors ``transcribe.selected_asr_engine``): a missing
+    key, a non-list value, and every unusable entry inside the list degrade to
+    "no vocabulary" rather than raising — a typo'd setting must never break
+    transcription. Terms are deduped case-insensitively (first wins) and capped
+    at :data:`MAX_TERMS`.
+    """
+    if not isinstance(settings, dict):
+        return ()
+    raw = settings.get(VOCAB_SETTINGS_KEY)
+    if not isinstance(raw, list | tuple):
+        return ()
+    out: list[VocabTerm] = []
+    seen: set[str] = set()
+    for entry in raw:
+        parsed = _parse_entry(entry)
+        if parsed is None or parsed.term.casefold() in seen:
+            continue
+        seen.add(parsed.term.casefold())
+        out.append(parsed)
+        if len(out) >= MAX_TERMS:
+            break
+    return tuple(out)
+
+
+# --------------------------------------------------------------------------- #
+# the faster-whisper biasing strings
+# --------------------------------------------------------------------------- #
+def _fit(parts: Sequence[str], separator: str, prefix: str, suffix: str) -> str | None:
+    """Join as many leading ``parts`` as fit :data:`MAX_PROMPT_CHARS`, else None.
+
+    Truncation drops the TAIL — a term is either fully present or absent, never
+    cut mid-word (a half word would bias the decode toward a non-word). When not
+    even the first part fits, there is no honest string to send: ``None``.
+    """
+    chosen: list[str] = []
+    for part in parts:
+        candidate = prefix + separator.join([*chosen, part]) + suffix
+        if len(candidate) > MAX_PROMPT_CHARS:
+            break
+        chosen.append(part)
+    if not chosen:
+        return None
+    return prefix + separator.join(chosen) + suffix
+
+
+def build_initial_prompt(terms: Sequence[VocabTerm]) -> str | None:
+    """The faster-whisper ``initial_prompt`` for ``terms`` (None when empty).
+
+    ``initial_prompt`` is prepended as *previous context* for the first window,
+    so it must read like natural text — a bare comma list biases the decoder
+    toward emitting a list. ``"Glossary: A, B."`` keeps it a sentence.
+    """
+    return _fit([t.term for t in terms], ", ", PROMPT_PREFIX, PROMPT_SUFFIX)
+
+
+def build_hotwords(terms: Sequence[VocabTerm]) -> str | None:
+    """The faster-whisper ``hotwords`` string for ``terms`` (None when empty).
+
+    Unlike ``initial_prompt`` this is a bare space-separated hint phrase list —
+    that is the shape faster-whisper documents for the parameter.
+    """
+    return _fit([t.term for t in terms], " ", "", "")
+
+
+# --------------------------------------------------------------------------- #
+# the engine-agnostic rule pass
+# --------------------------------------------------------------------------- #
+def _phrase_pattern(tokens: Sequence[str]) -> str:
+    """A whole-word regex for ``tokens`` — every token is :func:`re.escape`-d.
+
+    ``(?<!\\w) … (?!\\w)`` (not ``\\b``) so a term ending in punctuation such as
+    ``C++`` still anchors correctly, and inner whitespace is ``\\s+`` so the
+    phrase matches across any run of spaces/newlines.
+    """
+    return r"(?<!\w)" + r"\s+".join(re.escape(t) for t in tokens) + r"(?!\w)"
+
+
+def _compile_rules(terms: Sequence[VocabTerm]) -> _CompiledRules | None:
+    """Compile ``terms`` into the two regexes + the key->replacement table.
+
+    Every phrase (each term plus each of its aliases) becomes one alternative,
+    ordered LONGEST FIRST so Python's leftmost-first alternation yields
+    longest-match semantics (``open ai codex`` wins over ``open ai``). Duplicate
+    phrases across terms are dropped, first term wins. ``None`` when no phrase
+    survives — the caller then leaves the transcript untouched.
+    """
+    ordered: list[tuple[str, ...]] = []
+    by_key: dict[tuple[str, ...], str] = {}
+    for term in terms:
+        for phrase in (term.term, *term.sounds_like):
+            tokens = tuple(phrase.split())
+            key = tuple(t.casefold() for t in tokens)
+            if not tokens or key in by_key:
+                continue
+            by_key[key] = term.term
+            ordered.append(tokens)
+    if not ordered:
+        return None
+    ordered.sort(key=lambda toks: (len(toks), sum(len(t) for t in toks)), reverse=True)
+    alternation = "|".join(f"(?:{_phrase_pattern(toks)})" for toks in ordered)
+    return _CompiledRules(
+        word_re=re.compile(alternation, re.IGNORECASE),
+        span_re=re.compile(f"{_NON_WORD}(?P<phrase>{alternation}){_NON_WORD}", re.IGNORECASE),
+        by_key=by_key,
+        max_span=max(len(toks) for toks in ordered),
+    )
+
+
+def _replacement_for(rules: _CompiledRules, matched: str) -> str:
+    """Canonical spelling for a matched phrase (identity if somehow unknown).
+
+    The match came from an alternation of the SAME escaped tokens the table is
+    keyed on, so the casefolded token tuple is guaranteed to be present; the
+    ``get`` default exists so an exotic Unicode case-fold asymmetry degrades to
+    "leave the text alone" instead of raising mid-transcription.
+    """
+    return rules.by_key.get(tuple(t.casefold() for t in matched.split()), matched)
+
+
+def _rewrite_text(rules: _CompiledRules, text: str) -> str:
+    """Apply every rule to ``text`` in ONE pass (no cascade re-matching)."""
+    return rules.word_re.sub(lambda m: _replacement_for(rules, m.group(0)), text)
+
+
+def _num(value: Any) -> float:
+    """Coerce a JSON time value to float; anything non-numeric becomes 0.0."""
+    return float(value) if isinstance(value, int | float) else 0.0
+
+
+def _field(item: Any, key: str) -> Any:
+    """``item[key]`` when ``item`` is a dict, else ``None`` (untrusted input)."""
+    return item.get(key) if isinstance(item, dict) else None
+
+
+def _leading_ws(text: str) -> str:
+    """The leading whitespace of ``text`` (faster-whisper words carry one)."""
+    return text[: len(text) - len(text.lstrip())]
+
+
+def _merge_span(rules: _CompiledRules, words: Sequence[Any], index: int) -> tuple[int, Word] | None:
+    """Try to collapse ``words[index:index+n]`` (n>=2) into one corrected word.
+
+    Longest span first. The WHOLE span must be the phrase (modulo surrounding
+    punctuation) — ``span_re`` is a ``fullmatch``, so ``re frame-shift`` is left
+    alone rather than half-rewritten. On success the merged word keeps the first
+    word's start and the last word's end, so no timing is invented or lost.
+    """
+    limit = min(rules.max_span, len(words) - index)
+    for span in range(limit, 1, -1):
+        bodies = [str(_field(words[k], "text") or "").strip() for k in range(index, index + span)]
+        if not all(bodies):
+            continue
+        joined = " ".join(bodies)
+        matched = rules.span_re.fullmatch(joined)
+        if matched is None:
+            continue
+        head, tail = joined[: matched.start("phrase")], joined[matched.end("phrase") :]
+        first = words[index]
+        text = _leading_ws(str(_field(first, "text") or "")) + head
+        return span, {
+            "text": text + _replacement_for(rules, matched.group("phrase")) + tail,
+            "start": _num(_field(first, "start")),
+            "end": _num(_field(words[index + span - 1], "end")),
+        }
+    return None
+
+
+def _correct_words(rules: _CompiledRules, words: Sequence[Any]) -> list[Word]:
+    """Rewrite a word list: merge multi-word aliases, then fix single words."""
+    out: list[Word] = []
+    index = 0
+    while index < len(words):
+        merged = _merge_span(rules, words, index)
+        if merged is not None:
+            span, word = merged
+            out.append(word)
+            index += span
+            continue
+        raw = words[index]
+        out.append(
+            {
+                "text": _rewrite_text(rules, str(_field(raw, "text") or "")),
+                "start": _num(_field(raw, "start")),
+                "end": _num(_field(raw, "end")),
+            }
+        )
+        index += 1
+    return out
+
+
+def _correct_segment(rules: _CompiledRules, seg: Any) -> Segment:
+    """Rewrite one §3 ``Segment``; start/end pass through untouched."""
+    raw_words = _field(seg, "words")
+    words = raw_words if isinstance(raw_words, list) else []
+    return {
+        "start": _num(_field(seg, "start")),
+        "end": _num(_field(seg, "end")),
+        "text": _rewrite_text(rules, str(_field(seg, "text") or "")),
+        "words": _correct_words(rules, words),
+    }
+
+
+def apply_corrections(transcript: Transcript, terms: Sequence[VocabTerm]) -> Transcript:
+    """Return ``transcript`` with every vocabulary rule applied (PURE).
+
+    The input is never mutated; with no usable terms the SAME object is returned
+    so the zero-vocabulary path costs nothing. Both the segment text and the word
+    list are rewritten by the same compiled rules, so a karaoke/CTC consumer can
+    never see a segment whose text and words disagree.
+    """
+    rules = _compile_rules(terms)
+    if rules is None:
+        return transcript
+    raw_segments = transcript.get("segments")
+    segments = raw_segments if isinstance(raw_segments, list) else []
+    return {**transcript, "segments": [_correct_segment(rules, seg) for seg in segments]}
+
+
+__all__ = [
+    "MAX_ALIASES_PER_TERM",
+    "MAX_ALIAS_WORDS",
+    "MAX_PROMPT_CHARS",
+    "MAX_TERMS",
+    "MAX_TERM_CHARS",
+    "VOCAB_SETTINGS_KEY",
+    "VocabTerm",
+    "apply_corrections",
+    "build_hotwords",
+    "build_initial_prompt",
+    "parse_terms",
+]

--- a/sidecar/media_studio/features/transcribe.py
+++ b/sidecar/media_studio/features/transcribe.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import Any, Protocol
 
 from ..util import clamp, get_logger
+from . import asr_vocabulary as _vocabulary
 
 log = get_logger("media_studio.features.transcribe")
 
@@ -321,6 +322,8 @@ def transcribe_file(
     model: str = DEFAULT_MODEL,
     device: str = DEFAULT_DEVICE,
     compute_type: str = DEFAULT_GPU_COMPUTE,
+    initial_prompt: str | None = None,
+    hotwords: str | None = None,
     on_progress: ProgressCb | None = None,
     should_cancel: CancelProbe | None = None,
 ) -> Transcript:
@@ -329,6 +332,16 @@ def transcribe_file(
     ``loader`` is the (injected/mocked) model loader seam — never imported here.
     When ``language`` is ``None`` the model auto-detects it; the detected code is
     returned in ``Transcript.language``.
+
+    ``initial_prompt`` / ``hotwords`` are faster-whisper's two vocabulary-biasing
+    knobs (verified present on ``WhisperModel.transcribe`` at the pinned 1.2.1 —
+    ``sidecar/requirements.lock.txt``). Each is forwarded ONLY when not ``None``,
+    so a caller with no custom dictionary produces the exact same call as before
+    this parameter existed. This wrapper never passes ``prefix``, so the upstream
+    "``hotwords`` has no effect if ``prefix`` is not None" caveat cannot apply.
+    Build them with :mod:`media_studio.features.asr_vocabulary`; the rule-based
+    post-correction is deliberately NOT applied here (this stays a pure ASR
+    seam) — :func:`transcribe_with_engine` owns it.
 
     Progress is reported against the media duration that faster-whisper exposes
     on its ``info`` object: as each segment's ``end`` advances we map it to a
@@ -345,10 +358,21 @@ def transcribe_file(
     )
     log.info("transcribing %s on %s (lang=%s)", audio_path, device_used, language or "auto")
 
+    # Only pass a biasing knob that was actually asked for: an explicit
+    # ``initial_prompt=None`` is a valid faster-whisper call, but omitting the
+    # kwarg keeps the zero-vocabulary call shape identical to the pre-vocabulary
+    # one (which is what the injected fakes and the E2E tiny model assert on).
+    biasing: dict[str, Any] = {}
+    if initial_prompt is not None:
+        biasing["initial_prompt"] = initial_prompt
+    if hotwords is not None:
+        biasing["hotwords"] = hotwords
+
     segments_iter, info = whisper_model.transcribe(
         audio_path,
         language=language,
         word_timestamps=True,
+        **biasing,
     )
 
     duration = float(_attr(info, "duration") or 0.0)
@@ -457,8 +481,25 @@ def transcribe_with_engine(
     non-GPU machine runs cpu/int8 with a CPU-appropriate model directly — instead
     of attempting cuda and relying on the exception fallback. ``detect_probe`` is
     the injectable CUDA-availability seam.
+
+    **Custom vocabulary** (``settings['asrVocabulary']``) is applied here, and the
+    two engines get DIFFERENT treatment because their backends differ:
+
+      * whisper -> real decode-time biasing via ``initial_prompt`` + ``hotwords``
+        **and** the post-correction pass;
+      * parakeet -> post-correction ONLY. This repo's NeMo adapter
+        (``parakeet_asr_backend._RealParakeetModel.transcribe``) calls
+        ``model.transcribe([audio], timestamps=True)`` and forwards no prompt or
+        hotword argument, so there is nothing to bias with on that path.
+
+    The correction runs on whichever transcript is returned — including the
+    whisper fallback after a Parakeet degrade — so the user's term list is
+    honoured regardless of which engine actually produced the words. The
+    cancelled-empty result is the one exception: correcting an empty transcript
+    is a no-op, so it is returned untouched (and identity-preserving).
     """
     model, device, compute_type = resolve_transcribe_target(settings, probe=detect_probe)
+    terms = _vocabulary.parse_terms(settings)
     engine = selected_asr_engine(settings)
     if engine == PARAKEET_ENGINE:
         runner = parakeet_runner if parakeet_runner is not None else _default_parakeet_runner
@@ -472,7 +513,7 @@ def transcribe_with_engine(
             should_cancel=should_cancel,
         )
         if result.get("segments"):
-            return result
+            return _vocabulary.apply_corrections(result, terms)
         if should_cancel is not None and should_cancel():
             # Cancelled before the first chunk completed -> the empty transcript
             # is the EXPECTED cancel result, NOT a weights-missing degrade. Do
@@ -481,15 +522,20 @@ def transcribe_with_engine(
             return result
         # Parakeet degraded (offline + weights missing) -> whisper fallback.
         log.info("parakeet produced no segments; falling back to whisper")
-    return transcribe_file(
-        audio_path,
-        loader=loader,
-        language=language,
-        model=model,
-        device=device,
-        compute_type=compute_type,
-        on_progress=on_progress,
-        should_cancel=should_cancel,
+    return _vocabulary.apply_corrections(
+        transcribe_file(
+            audio_path,
+            loader=loader,
+            language=language,
+            model=model,
+            device=device,
+            compute_type=compute_type,
+            initial_prompt=_vocabulary.build_initial_prompt(terms),
+            hotwords=_vocabulary.build_hotwords(terms),
+            on_progress=on_progress,
+            should_cancel=should_cancel,
+        ),
+        terms,
     )
 
 

--- a/sidecar/media_studio/settings_store.py
+++ b/sidecar/media_studio/settings_store.py
@@ -152,6 +152,18 @@ DEFAULT_SETTINGS: dict[str, Any] = {
     # export UI offers first. ``subtitleFormat`` in {srt,vtt,...}; ``nleFormat`` in
     # {edl,fcpxml,...}; ``nleFps`` the timeline frame rate. Pure data.
     "exportDefaults": {"subtitleFormat": "srt", "nleFormat": "edl", "nleFps": 30},
+    # Custom ASR dictionary (v1.5 asr-vocabulary): the user's proper-noun /
+    # brand-name / jargon term list, consumed by
+    # ``features/asr_vocabulary.parse_terms`` and applied by
+    # ``features/transcribe.transcribe_with_engine``. Each entry is either a bare
+    # string ("Reframe") or {term, soundsLike[]} where ``soundsLike`` lists the
+    # mis-transcriptions to rewrite onto ``term`` (e.g. "re frame" -> "Reframe").
+    # Pure DATA — it is only ever compiled into re.escape-d literal patterns, so
+    # it must NEVER join EXECUTABLE_SETTING_KEYS. Listed here so it is
+    # discoverable in ``settings.get`` on first launch (same treatment as the
+    # ``asrEngine`` / ``transcribeDevice`` knobs, which are likewise free-form).
+    # Empty = no biasing and no post-correction: byte-identical to pre-v1.5.
+    "asrVocabulary": [],
     # Saved export/pipeline presets (WU-10/WU-11): ``presets`` is a name->preset
     # map; ``active`` is the last-applied preset name. NOTE: ``settings.set`` is a
     # SHALLOW top-level merge — writing ``savePresets`` REPLACES the whole block,

--- a/sidecar/tests/test_asr_vocabulary.py
+++ b/sidecar/tests/test_asr_vocabulary.py
@@ -35,9 +35,7 @@ def test_parse_terms_accepts_plain_strings():
 
 
 def test_parse_terms_accepts_dicts_with_sounds_like():
-    terms = V.parse_terms(
-        {V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame", " reframed ", ""]}]}
-    )
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame", " reframed ", ""]}]})
     assert len(terms) == 1
     assert terms[0].term == "Reframe"
     assert terms[0].sounds_like == ("re frame", "reframed")
@@ -61,7 +59,9 @@ def test_parse_terms_skips_junk_entries(junk: Any):
 
 
 def test_parse_terms_ignores_non_string_and_non_list_sounds_like():
-    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "A", "soundsLike": "nope"}, {"term": "B", "soundsLike": [1]}]})
+    terms = V.parse_terms(
+        {V.VOCAB_SETTINGS_KEY: [{"term": "A", "soundsLike": "nope"}, {"term": "B", "soundsLike": [1]}]}
+    )
     assert terms == (V.VocabTerm("A", ()), V.VocabTerm("B", ()))
 
 
@@ -175,20 +175,26 @@ def _seg(text: str, words: list[tuple[str, float, float]]) -> dict[str, Any]:
 
 
 def test_apply_corrections_without_terms_is_identity():
-    t = _transcript(_seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)]))
+    t = _transcript(
+        _seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)])
+    )
     assert V.apply_corrections(t, ()) is t
 
 
 def test_apply_corrections_fixes_a_multi_word_alias_in_segment_text():
     terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
-    t = _transcript(_seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)]))
+    t = _transcript(
+        _seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)])
+    )
     out = V.apply_corrections(t, terms)
     assert out["segments"][0]["text"] == " Reframe is good"
 
 
 def test_apply_corrections_merges_the_word_span_and_keeps_the_outer_timings():
     terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
-    t = _transcript(_seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)]))
+    t = _transcript(
+        _seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)])
+    )
     words = V.apply_corrections(t, terms)["segments"][0]["words"]
     assert [w["text"] for w in words] == [" Reframe", " is", " good"]
     assert words[0]["start"] == pytest.approx(0.0)
@@ -228,7 +234,12 @@ def test_apply_corrections_does_not_match_inside_a_longer_word():
 
 def test_apply_corrections_prefers_the_longest_alias():
     terms = V.parse_terms(
-        {V.VOCAB_SETTINGS_KEY: [{"term": "OpenAI Codex", "soundsLike": ["open ai codex"]}, {"term": "OpenAI", "soundsLike": ["open ai"]}]}
+        {
+            V.VOCAB_SETTINGS_KEY: [
+                {"term": "OpenAI Codex", "soundsLike": ["open ai codex"]},
+                {"term": "OpenAI", "soundsLike": ["open ai"]},
+            ]
+        }
     )
     t = _transcript(
         _seg(
@@ -243,7 +254,9 @@ def test_apply_corrections_prefers_the_longest_alias():
 
 def test_apply_corrections_handles_a_term_with_non_word_characters():
     terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "C++", "soundsLike": ["see plus plus"]}]})
-    t = _transcript(_seg(" see plus plus code", [(" see", 0.0, 0.4), (" plus", 0.4, 0.8), (" plus", 0.8, 1.2), (" code", 1.2, 2.0)]))
+    t = _transcript(
+        _seg(" see plus plus code", [(" see", 0.0, 0.4), (" plus", 0.4, 0.8), (" plus", 0.8, 1.2), (" code", 1.2, 2.0)])
+    )
     out = V.apply_corrections(t, terms)
     assert out["segments"][0]["text"] == " C++ code"
     assert [w["text"] for w in out["segments"][0]["words"]] == [" C++", " code"]

--- a/sidecar/tests/test_asr_vocabulary.py
+++ b/sidecar/tests/test_asr_vocabulary.py
@@ -353,6 +353,40 @@ def test_apply_corrections_skips_a_span_whose_words_are_blank():
     assert [w["text"] for w in out["segments"][0]["words"]] == [" re", "   ", " frame"]
 
 
+# --------------------------------------------------------------------------- #
+# the settings surface — the key is discoverable and round-trips through the store
+# --------------------------------------------------------------------------- #
+def test_default_settings_declares_the_vocabulary_key_as_an_empty_list():
+    from media_studio.settings_store import DEFAULT_SETTINGS
+
+    assert DEFAULT_SETTINGS[V.VOCAB_SETTINGS_KEY] == []
+
+
+def test_the_term_list_round_trips_through_the_settings_store(tmp_path: Any):
+    from media_studio.settings_store import SettingsStore
+
+    path = tmp_path / "settings.json"
+    store = SettingsStore(config_path=path)
+    # A fresh install is backfilled with the empty list -> no vocabulary.
+    assert V.parse_terms(store.get()) == ()
+
+    merged = store.set({V.VOCAB_SETTINGS_KEY: ["Reframe", {"term": "C++", "soundsLike": ["see plus plus"]}]})
+    assert V.parse_terms(merged) == (V.VocabTerm("Reframe", ()), V.VocabTerm("C++", ("see plus plus",)))
+
+    # ...and survives a reload from disk (a NEW store over the same file).
+    reloaded = V.parse_terms(SettingsStore(config_path=path).get())
+    assert [t.term for t in reloaded] == ["Reframe", "C++"]
+
+
+def test_the_settings_surface_never_writes_an_executable_path():
+    # Guard against the vocabulary key drifting into the refused set: it is pure
+    # data, so settings.set must accept it (EXECUTABLE_SETTING_KEYS is the list
+    # of keys that reach a subprocess argv, and this must never join it).
+    from media_studio.settings_store import EXECUTABLE_SETTING_KEYS
+
+    assert V.VOCAB_SETTINGS_KEY not in EXECUTABLE_SETTING_KEYS
+
+
 def test_apply_corrections_does_not_merge_a_span_that_runs_into_a_longer_word():
     # "re frame-shift" is NOT the phrase "re frame": the span match is a
     # fullmatch, so a half-rewrite ("Reframe-shift" losing "-shift") is refused.

--- a/sidecar/tests/test_asr_vocabulary.py
+++ b/sidecar/tests/test_asr_vocabulary.py
@@ -101,6 +101,13 @@ def test_parse_terms_accepts_a_tuple_value():
     assert V.parse_terms({V.VOCAB_SETTINGS_KEY: ("Reframe",)}) == (V.VocabTerm("Reframe", ()),)
 
 
+def test_parse_terms_skips_a_term_with_no_word_characters():
+    # A punctuation-only phrase can never satisfy the (?<!\w)/(?!\w) boundaries
+    # a rule is built with, so it is refused rather than compiled into a rule
+    # that can never fire.
+    assert V.parse_terms({V.VOCAB_SETTINGS_KEY: ["...", "Reframe"]}) == (V.VocabTerm("Reframe", ()),)
+
+
 # --------------------------------------------------------------------------- #
 # build_initial_prompt / build_hotwords — the faster-whisper biasing strings
 # --------------------------------------------------------------------------- #
@@ -327,3 +334,29 @@ def test_apply_corrections_matches_across_a_word_carrying_inner_punctuation():
     t = _transcript(_seg(' "re frame."', [(' "re', 0.0, 0.5), (' frame."', 0.5, 1.0)]))
     out = V.apply_corrections(t, terms)
     assert out["segments"][0]["words"][0]["text"] == ' "Reframe."'
+
+
+def test_apply_corrections_with_only_blank_hand_built_terms_is_identity():
+    # apply_corrections is public: a caller can hand it a VocabTerm that never
+    # went through parse_terms. No compilable phrase => the transcript is
+    # returned untouched (an empty alternation would match everywhere).
+    t = _transcript(_seg(" reframe", [(" reframe", 0.0, 1.0)]))
+    assert V.apply_corrections(t, (V.VocabTerm("   ", ()),)) is t
+
+
+def test_apply_corrections_skips_a_span_whose_words_are_blank():
+    # A blank word inside a candidate span makes the joined phrase ambiguous, so
+    # the merge is refused and the single-word pass runs instead.
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
+    t = _transcript(_seg(" re  frame", [(" re", 0.0, 0.5), ("   ", 0.5, 0.6), (" frame", 0.6, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" re", "   ", " frame"]
+
+
+def test_apply_corrections_does_not_merge_a_span_that_runs_into_a_longer_word():
+    # "re frame-shift" is NOT the phrase "re frame": the span match is a
+    # fullmatch, so a half-rewrite ("Reframe-shift" losing "-shift") is refused.
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
+    t = _transcript(_seg(" re frame-shift", [(" re", 0.0, 0.5), (" frame-shift", 0.5, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" re", " frame-shift"]

--- a/sidecar/tests/test_asr_vocabulary.py
+++ b/sidecar/tests/test_asr_vocabulary.py
@@ -1,0 +1,329 @@
+"""Unit tests for media_studio.features.asr_vocabulary (custom ASR dictionary).
+
+Pure stdlib: no ASR backend, no model, no network. The module under test turns a
+user-supplied term list (``settings['asrVocabulary']``) into (a) the two
+faster-whisper biasing strings and (b) a deterministic rule-based post-correction
+over a §3 ``Transcript`` — the half that works for EVERY engine, including the
+NeMo Parakeet adapter which exposes no biasing parameter at all.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.features import asr_vocabulary as V
+
+
+# --------------------------------------------------------------------------- #
+# parse_terms — tolerant normalization of an untrusted settings value
+# --------------------------------------------------------------------------- #
+def test_parse_terms_absent_settings_yields_no_terms():
+    assert V.parse_terms(None) == ()
+    assert V.parse_terms({}) == ()
+
+
+@pytest.mark.parametrize("bad", ["Reframe", 7, {"term": "Reframe"}, None])
+def test_parse_terms_non_list_value_yields_no_terms(bad: Any):
+    assert V.parse_terms({V.VOCAB_SETTINGS_KEY: bad}) == ()
+
+
+def test_parse_terms_accepts_plain_strings():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe", "  ctranslate2  "]})
+    assert [t.term for t in terms] == ["Reframe", "ctranslate2"]
+    assert all(t.sounds_like == () for t in terms)
+
+
+def test_parse_terms_accepts_dicts_with_sounds_like():
+    terms = V.parse_terms(
+        {V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame", " reframed ", ""]}]}
+    )
+    assert len(terms) == 1
+    assert terms[0].term == "Reframe"
+    assert terms[0].sounds_like == ("re frame", "reframed")
+
+
+def test_parse_terms_drops_alias_equal_to_the_term_case_insensitively():
+    # The canonical term is ALWAYS a pattern, so an alias that only differs in
+    # case would be a duplicate rule — dropped at parse time.
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["REFRAME", "re frame"]}]})
+    assert terms[0].sounds_like == ("re frame",)
+
+
+def test_parse_terms_dedupes_aliases_case_insensitively():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame", "Re Frame"]}]})
+    assert terms[0].sounds_like == ("re frame",)
+
+
+@pytest.mark.parametrize("junk", [None, 7, [], {}, {"term": ""}, {"term": "   "}, {"term": 5}, ""])
+def test_parse_terms_skips_junk_entries(junk: Any):
+    assert V.parse_terms({V.VOCAB_SETTINGS_KEY: [junk, "Reframe"]}) == (V.VocabTerm("Reframe", ()),)
+
+
+def test_parse_terms_ignores_non_string_and_non_list_sounds_like():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "A", "soundsLike": "nope"}, {"term": "B", "soundsLike": [1]}]})
+    assert terms == (V.VocabTerm("A", ()), V.VocabTerm("B", ()))
+
+
+def test_parse_terms_skips_over_long_terms_and_aliases():
+    long_term = "x" * (V.MAX_TERM_CHARS + 1)
+    terms = V.parse_terms(
+        {V.VOCAB_SETTINGS_KEY: [long_term, {"term": "Reframe", "soundsLike": [long_term, "re frame"]}]}
+    )
+    assert [t.term for t in terms] == ["Reframe"]
+    assert terms[0].sounds_like == ("re frame",)
+
+
+def test_parse_terms_caps_alias_count_per_term():
+    aliases = [f"alias{i}" for i in range(V.MAX_ALIASES_PER_TERM + 5)]
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": aliases}]})
+    assert len(terms[0].sounds_like) == V.MAX_ALIASES_PER_TERM
+
+
+def test_parse_terms_caps_total_term_count():
+    many = [f"term{i}" for i in range(V.MAX_TERMS + 10)]
+    assert len(V.parse_terms({V.VOCAB_SETTINGS_KEY: many})) == V.MAX_TERMS
+
+
+def test_parse_terms_dedupes_terms_case_insensitively_first_wins():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe", {"term": "reframe", "soundsLike": ["re frame"]}]})
+    assert terms == (V.VocabTerm("Reframe", ()),)
+
+
+def test_parse_terms_skips_alias_that_is_only_punctuation():
+    # An alias with no word characters can never match a word boundary; it is
+    # dropped rather than compiled into a rule that can never fire.
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["...", "re frame"]}]})
+    assert terms[0].sounds_like == ("re frame",)
+
+
+def test_parse_terms_accepts_a_tuple_value():
+    assert V.parse_terms({V.VOCAB_SETTINGS_KEY: ("Reframe",)}) == (V.VocabTerm("Reframe", ()),)
+
+
+# --------------------------------------------------------------------------- #
+# build_initial_prompt / build_hotwords — the faster-whisper biasing strings
+# --------------------------------------------------------------------------- #
+def test_build_initial_prompt_none_without_terms():
+    assert V.build_initial_prompt(()) is None
+
+
+def test_build_initial_prompt_lists_the_terms():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe", "ctranslate2"]})
+    assert V.build_initial_prompt(terms) == "Glossary: Reframe, ctranslate2."
+
+
+def test_build_initial_prompt_truncates_to_the_char_budget():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [f"term{i:04d}" for i in range(V.MAX_TERMS)]})
+    prompt = V.build_initial_prompt(terms)
+    assert prompt is not None
+    assert len(prompt) <= V.MAX_PROMPT_CHARS
+    # Truncation drops the TAIL, never mangles a term.
+    assert prompt.startswith("Glossary: term0000, term0001")
+    assert prompt.endswith(".")
+
+
+def test_build_initial_prompt_returns_none_when_even_one_term_overflows():
+    # A single term longer than the whole budget cannot be represented; the
+    # biasing string is omitted rather than emitted truncated mid-word.
+    term = V.VocabTerm("y" * (V.MAX_PROMPT_CHARS + 10), ())
+    assert V.build_initial_prompt((term,)) is None
+
+
+def test_build_hotwords_none_without_terms():
+    assert V.build_hotwords(()) is None
+
+
+def test_build_hotwords_space_joins_the_terms():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe", "ctranslate2"]})
+    assert V.build_hotwords(terms) == "Reframe ctranslate2"
+
+
+def test_build_hotwords_truncates_to_the_char_budget():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [f"term{i:04d}" for i in range(V.MAX_TERMS)]})
+    hot = V.build_hotwords(terms)
+    assert hot is not None
+    assert len(hot) <= V.MAX_PROMPT_CHARS
+
+
+def test_build_hotwords_returns_none_when_the_single_term_overflows():
+    term = V.VocabTerm("y" * (V.MAX_PROMPT_CHARS + 10), ())
+    assert V.build_hotwords((term,)) is None
+
+
+# --------------------------------------------------------------------------- #
+# apply_corrections — the engine-agnostic rule pass
+# --------------------------------------------------------------------------- #
+def _transcript(*segments: dict[str, Any]) -> dict[str, Any]:
+    return {"language": "en", "segments": list(segments), "durationSec": 9.0}
+
+
+def _seg(text: str, words: list[tuple[str, float, float]]) -> dict[str, Any]:
+    return {
+        "start": words[0][1] if words else 0.0,
+        "end": words[-1][2] if words else 0.0,
+        "text": text,
+        "words": [{"text": t, "start": s, "end": e} for t, s, e in words],
+    }
+
+
+def test_apply_corrections_without_terms_is_identity():
+    t = _transcript(_seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)]))
+    assert V.apply_corrections(t, ()) is t
+
+
+def test_apply_corrections_fixes_a_multi_word_alias_in_segment_text():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
+    t = _transcript(_seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " Reframe is good"
+
+
+def test_apply_corrections_merges_the_word_span_and_keeps_the_outer_timings():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
+    t = _transcript(_seg(" re frame is good", [(" re", 0.0, 0.5), (" frame", 0.5, 1.0), (" is", 1.0, 1.2), (" good", 1.2, 2.0)]))
+    words = V.apply_corrections(t, terms)["segments"][0]["words"]
+    assert [w["text"] for w in words] == [" Reframe", " is", " good"]
+    assert words[0]["start"] == pytest.approx(0.0)
+    assert words[0]["end"] == pytest.approx(1.0)
+
+
+def test_apply_corrections_fixes_the_canonical_terms_own_casing():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(" reframe rocks", [(" reframe", 0.0, 1.0), (" rocks", 1.0, 2.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " Reframe rocks"
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" Reframe", " rocks"]
+
+
+def test_apply_corrections_preserves_trailing_punctuation_on_a_word():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(" reframe.", [(" reframe.", 0.0, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " Reframe."
+    assert out["segments"][0]["words"][0]["text"] == " Reframe."
+
+
+def test_apply_corrections_preserves_leading_punctuation_on_a_word():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(' "reframe"', [(' "reframe"', 0.0, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["words"][0]["text"] == ' "Reframe"'
+
+
+def test_apply_corrections_does_not_match_inside_a_longer_word():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(" reframes reframed", [(" reframes", 0.0, 1.0), (" reframed", 1.0, 2.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " reframes reframed"
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" reframes", " reframed"]
+
+
+def test_apply_corrections_prefers_the_longest_alias():
+    terms = V.parse_terms(
+        {V.VOCAB_SETTINGS_KEY: [{"term": "OpenAI Codex", "soundsLike": ["open ai codex"]}, {"term": "OpenAI", "soundsLike": ["open ai"]}]}
+    )
+    t = _transcript(
+        _seg(
+            " open ai codex ships",
+            [(" open", 0.0, 0.4), (" ai", 0.4, 0.8), (" codex", 0.8, 1.2), (" ships", 1.2, 2.0)],
+        )
+    )
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " OpenAI Codex ships"
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" OpenAI Codex", " ships"]
+
+
+def test_apply_corrections_handles_a_term_with_non_word_characters():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "C++", "soundsLike": ["see plus plus"]}]})
+    t = _transcript(_seg(" see plus plus code", [(" see", 0.0, 0.4), (" plus", 0.4, 0.8), (" plus", 0.8, 1.2), (" code", 1.2, 2.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " C++ code"
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" C++", " code"]
+
+
+def test_apply_corrections_leaves_unrelated_text_untouched():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(" nothing to see", [(" nothing", 0.0, 1.0), (" to", 1.0, 1.5), (" see", 1.5, 2.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " nothing to see"
+
+
+def test_apply_corrections_preserves_the_transcript_envelope():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(" reframe", [(" reframe", 0.0, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert set(out.keys()) == {"language", "segments", "durationSec"}
+    assert out["language"] == "en"
+    assert out["durationSec"] == pytest.approx(9.0)
+    assert set(out["segments"][0].keys()) == {"start", "end", "text", "words"}
+
+
+def test_apply_corrections_does_not_mutate_the_input():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg(" reframe", [(" reframe", 0.0, 1.0)]))
+    V.apply_corrections(t, terms)
+    assert t["segments"][0]["text"] == " reframe"
+    assert t["segments"][0]["words"][0]["text"] == " reframe"
+
+
+def test_apply_corrections_tolerates_a_segment_without_words():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = {"language": "en", "segments": [{"start": 0.0, "end": 1.0, "text": " reframe"}], "durationSec": 1.0}
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["text"] == " Reframe"
+    assert out["segments"][0]["words"] == []
+
+
+def test_apply_corrections_tolerates_a_transcript_without_segments():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    assert V.apply_corrections({"language": "en", "durationSec": 0.0}, terms)["segments"] == []
+
+
+def test_apply_corrections_tolerates_non_list_segments():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    assert V.apply_corrections({"segments": "nope"}, terms)["segments"] == []
+
+
+def test_apply_corrections_tolerates_a_non_dict_segment():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    out = V.apply_corrections({"segments": ["nope"]}, terms)
+    assert out["segments"] == [{"start": 0.0, "end": 0.0, "text": "", "words": []}]
+
+
+def test_apply_corrections_tolerates_a_non_dict_word():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = {"segments": [{"start": 0.0, "end": 1.0, "text": " reframe", "words": ["nope"]}]}
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["words"] == [{"text": "", "start": 0.0, "end": 0.0}]
+
+
+def test_apply_corrections_tolerates_a_span_running_past_the_last_word():
+    # "re" is the last word: the two-word alias cannot fit, so the single-word
+    # scan must still run instead of indexing out of range.
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
+    t = _transcript(_seg(" hello re", [(" hello", 0.0, 1.0), (" re", 1.0, 2.0)]))
+    out = V.apply_corrections(t, terms)
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" hello", " re"]
+
+
+def test_apply_corrections_skips_a_word_whose_body_is_empty():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: ["Reframe"]})
+    t = _transcript(_seg("  reframe", [("   ", 0.0, 0.1), (" reframe", 0.1, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert [w["text"] for w in out["segments"][0]["words"]] == ["   ", " Reframe"]
+
+
+def test_apply_corrections_caps_the_alias_word_span():
+    # An alias longer than MAX_ALIAS_WORDS tokens is refused at parse time so the
+    # word scan window stays bounded.
+    alias = " ".join(f"w{i}" for i in range(V.MAX_ALIAS_WORDS + 1))
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": [alias, "re frame"]}]})
+    assert terms[0].sounds_like == ("re frame",)
+
+
+def test_apply_corrections_matches_across_a_word_carrying_inner_punctuation():
+    terms = V.parse_terms({V.VOCAB_SETTINGS_KEY: [{"term": "Reframe", "soundsLike": ["re frame"]}]})
+    t = _transcript(_seg(' "re frame."', [(' "re', 0.0, 0.5), (' frame."', 0.5, 1.0)]))
+    out = V.apply_corrections(t, terms)
+    assert out["segments"][0]["words"][0]["text"] == ' "Reframe."'

--- a/sidecar/tests/test_transcribe_vocabulary.py
+++ b/sidecar/tests/test_transcribe_vocabulary.py
@@ -111,9 +111,7 @@ def test_transcribe_file_does_not_post_correct_on_its_own():
 # --------------------------------------------------------------------------- #
 def test_with_engine_sends_both_biasing_strings_from_settings():
     model = FakeModel()
-    transcribe.transcribe_with_engine(
-        "/v.mp4", loader=FakeLoader(model), settings=_cpu_settings(asrVocabulary=VOCAB)
-    )
+    transcribe.transcribe_with_engine("/v.mp4", loader=FakeLoader(model), settings=_cpu_settings(asrVocabulary=VOCAB))
     assert model.calls[0]["initial_prompt"] == "Glossary: Reframe."
     assert model.calls[0]["hotwords"] == "Reframe"
 

--- a/sidecar/tests/test_transcribe_vocabulary.py
+++ b/sidecar/tests/test_transcribe_vocabulary.py
@@ -1,0 +1,258 @@
+"""Vocabulary plumbing through media_studio.features.transcribe.
+
+Covers the wiring the asr-vocabulary lane adds on top of the pure
+``asr_vocabulary`` module (tested separately in ``test_asr_vocabulary.py``):
+
+  * ``transcribe_file`` forwards ``initial_prompt`` / ``hotwords`` to the
+    faster-whisper model ONLY when they are given, so the zero-vocabulary call
+    shape is byte-identical to before this lane.
+  * ``transcribe_with_engine`` derives both biasing strings from
+    ``settings['asrVocabulary']`` for the whisper path, passes NOTHING extra to
+    Parakeet (its adapter has no biasing hook), and post-corrects the transcript
+    of EITHER engine — including the whisper fallback after a Parakeet degrade.
+
+No model is ever loaded: the loader/runner seams are faked.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.features import transcribe
+
+VOCAB = [{"term": "Reframe", "soundsLike": ["re frame"]}]
+
+
+class _Word:
+    def __init__(self, word: str, start: float, end: float):
+        self.word = word
+        self.start = start
+        self.end = end
+
+
+class _Segment:
+    def __init__(self, start: float, end: float, text: str, words: list[_Word]):
+        self.start = start
+        self.end = end
+        self.text = text
+        self.words = words
+
+
+class _Info:
+    def __init__(self, language: str = "en", duration: float = 4.0):
+        self.language = language
+        self.duration = duration
+
+
+class FakeModel:
+    """A stand-in WhisperModel recording every transcribe kwarg it receives."""
+
+    def __init__(self, text: str = " re frame is good"):
+        pieces = text.split()
+        self.calls: list[dict[str, Any]] = []
+        words = [_Word(f" {p}", float(i), float(i + 1)) for i, p in enumerate(pieces)]
+        self._segments = [_Segment(0.0, float(len(pieces)), text, words)]
+
+    def transcribe(self, audio: str, **kwargs: Any):
+        self.calls.append({"audio": audio, **kwargs})
+        return (s for s in self._segments), _Info()
+
+
+class FakeLoader:
+    def __init__(self, model: FakeModel):
+        self._model = model
+        self.loads: list[tuple[str, str, str]] = []
+
+    def load(self, model: str, device: str, compute_type: str):
+        self.loads.append((model, device, compute_type))
+        return self._model
+
+
+def _cpu_settings(**extra: Any) -> dict[str, Any]:
+    """Force the CPU target so no CUDA probe runs during the test."""
+    return {transcribe.TRANSCRIBE_DEVICE_KEY: "cpu", **extra}
+
+
+# --------------------------------------------------------------------------- #
+# transcribe_file — the forwarding seam
+# --------------------------------------------------------------------------- #
+def test_transcribe_file_omits_biasing_kwargs_by_default():
+    model = FakeModel()
+    transcribe.transcribe_file("/v.mp4", loader=FakeLoader(model))
+    assert "initial_prompt" not in model.calls[0]
+    assert "hotwords" not in model.calls[0]
+
+
+def test_transcribe_file_forwards_initial_prompt_when_given():
+    model = FakeModel()
+    transcribe.transcribe_file("/v.mp4", loader=FakeLoader(model), initial_prompt="Glossary: Reframe.")
+    assert model.calls[0]["initial_prompt"] == "Glossary: Reframe."
+    assert "hotwords" not in model.calls[0]
+
+
+def test_transcribe_file_forwards_hotwords_when_given():
+    model = FakeModel()
+    transcribe.transcribe_file("/v.mp4", loader=FakeLoader(model), hotwords="Reframe")
+    assert model.calls[0]["hotwords"] == "Reframe"
+    assert "initial_prompt" not in model.calls[0]
+
+
+def test_transcribe_file_does_not_post_correct_on_its_own():
+    # transcribe_file stays a PURE ASR seam: biasing in, raw transcript out.
+    # The rule pass belongs to the settings-aware transcribe_with_engine.
+    model = FakeModel()
+    out = transcribe.transcribe_file("/v.mp4", loader=FakeLoader(model), hotwords="Reframe")
+    assert out["segments"][0]["text"] == " re frame is good"
+
+
+# --------------------------------------------------------------------------- #
+# transcribe_with_engine — whisper path
+# --------------------------------------------------------------------------- #
+def test_with_engine_sends_both_biasing_strings_from_settings():
+    model = FakeModel()
+    transcribe.transcribe_with_engine(
+        "/v.mp4", loader=FakeLoader(model), settings=_cpu_settings(asrVocabulary=VOCAB)
+    )
+    assert model.calls[0]["initial_prompt"] == "Glossary: Reframe."
+    assert model.calls[0]["hotwords"] == "Reframe"
+
+
+def test_with_engine_sends_no_biasing_when_no_vocabulary_is_configured():
+    model = FakeModel()
+    transcribe.transcribe_with_engine("/v.mp4", loader=FakeLoader(model), settings=_cpu_settings())
+    assert "initial_prompt" not in model.calls[0]
+    assert "hotwords" not in model.calls[0]
+
+
+def test_with_engine_post_corrects_the_whisper_transcript():
+    model = FakeModel()
+    out = transcribe.transcribe_with_engine(
+        "/v.mp4", loader=FakeLoader(model), settings=_cpu_settings(asrVocabulary=VOCAB)
+    )
+    assert out["segments"][0]["text"] == " Reframe is good"
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" Reframe", " is", " good"]
+
+
+def test_with_engine_leaves_the_transcript_alone_without_a_vocabulary():
+    model = FakeModel()
+    out = transcribe.transcribe_with_engine("/v.mp4", loader=FakeLoader(model), settings=_cpu_settings())
+    assert out["segments"][0]["text"] == " re frame is good"
+
+
+# --------------------------------------------------------------------------- #
+# transcribe_with_engine — parakeet path
+# --------------------------------------------------------------------------- #
+def _parakeet_transcript() -> dict[str, Any]:
+    return {
+        "language": "en",
+        "segments": [
+            {
+                "start": 0.0,
+                "end": 3.0,
+                "text": " re frame is good",
+                "words": [
+                    {"text": " re", "start": 0.0, "end": 0.5},
+                    {"text": " frame", "start": 0.5, "end": 1.0},
+                    {"text": " is", "start": 1.0, "end": 2.0},
+                    {"text": " good", "start": 2.0, "end": 3.0},
+                ],
+            }
+        ],
+        "durationSec": 3.0,
+    }
+
+
+def test_with_engine_post_corrects_the_parakeet_transcript():
+    calls: list[dict[str, Any]] = []
+
+    def runner(audio_path: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return _parakeet_transcript()
+
+    out = transcribe.transcribe_with_engine(
+        "/v.mp4",
+        loader=FakeLoader(FakeModel()),
+        settings=_cpu_settings(asrEngine="parakeet", asrVocabulary=VOCAB),
+        parakeet_runner=runner,
+    )
+    assert out["segments"][0]["text"] == " Reframe is good"
+    assert [w["text"] for w in out["segments"][0]["words"]] == [" Reframe", " is", " good"]
+
+
+def test_with_engine_sends_no_biasing_kwargs_to_parakeet():
+    # Its adapter (parakeet_asr_backend._RealParakeetModel.transcribe) forwards
+    # only the audio path + timestamps, so there is nothing to bias with.
+    calls: list[dict[str, Any]] = []
+
+    def runner(audio_path: str, **kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return _parakeet_transcript()
+
+    transcribe.transcribe_with_engine(
+        "/v.mp4",
+        loader=FakeLoader(FakeModel()),
+        settings=_cpu_settings(asrEngine="parakeet", asrVocabulary=VOCAB),
+        parakeet_runner=runner,
+    )
+    assert "initial_prompt" not in calls[0]
+    assert "hotwords" not in calls[0]
+
+
+def test_with_engine_corrects_the_whisper_fallback_after_a_parakeet_degrade():
+    model = FakeModel()
+
+    def degraded(audio_path: str, **kwargs: Any) -> dict[str, Any]:
+        return {"language": "", "segments": [], "durationSec": 0.0}
+
+    out = transcribe.transcribe_with_engine(
+        "/v.mp4",
+        loader=FakeLoader(model),
+        settings=_cpu_settings(asrEngine="parakeet", asrVocabulary=VOCAB),
+        parakeet_runner=degraded,
+    )
+    assert out["segments"][0]["text"] == " Reframe is good"
+    assert model.calls[0]["hotwords"] == "Reframe"
+
+
+def test_with_engine_returns_a_cancelled_parakeet_result_untouched():
+    empty = {"language": "en", "segments": [], "durationSec": 0.0}
+
+    def cancelled(audio_path: str, **kwargs: Any) -> dict[str, Any]:
+        return empty
+
+    out = transcribe.transcribe_with_engine(
+        "/v.mp4",
+        loader=FakeLoader(FakeModel()),
+        settings=_cpu_settings(asrEngine="parakeet", asrVocabulary=VOCAB),
+        parakeet_runner=cancelled,
+        should_cancel=lambda: True,
+    )
+    # No whisper model is loaded for an already-cancelled job (the multi-GB
+    # fallback must not fire), and the empty result is returned as-is.
+    assert out is empty
+
+
+def test_with_engine_tolerates_a_malformed_vocabulary_setting():
+    model = FakeModel()
+    out = transcribe.transcribe_with_engine(
+        "/v.mp4", loader=FakeLoader(model), settings=_cpu_settings(asrVocabulary="not-a-list")
+    )
+    assert out["segments"][0]["text"] == " re frame is good"
+    assert "hotwords" not in model.calls[0]
+
+
+def test_with_engine_biasing_survives_a_none_settings_object():
+    model = FakeModel()
+    out = transcribe.transcribe_with_engine("/v.mp4", loader=FakeLoader(model), settings=None)
+    assert out["segments"][0]["text"] == " re frame is good"
+    assert model.calls[0]["language"] is None
+
+
+@pytest.mark.parametrize("engine", ["whisper", "parakeet"])
+def test_vocabulary_key_is_the_documented_settings_key(engine: str):
+    # One spelling, shared by both engines and by the settings surface.
+    from media_studio.features import asr_vocabulary
+
+    assert asr_vocabulary.VOCAB_SETTINGS_KEY == "asrVocabulary"
+    assert engine in transcribe.ASR_ENGINES


### PR DESCRIPTION
- **docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it**
- **test(asr): RED — custom ASR vocabulary/glossary suite before any implementation**
- **feat(asr): GREEN — asr_vocabulary, the custom-dictionary core**
- **feat(asr): plumb the custom vocabulary through transcribe.py**
- **feat(settings): declare asrVocabulary so the term list is discoverable**
- **docs(asr): CONTRACTS §A9 + the TS wire type for asrVocabulary**
- **style(asr): ruff-format the two new test files at the pinned 0.15.17**
