### PR TITLE
feat/v15 director deferred ops

### DIFF
--- a/sidecar/media_studio/features/director_op_engines.py
+++ b/sidecar/media_studio/features/director_op_engines.py
@@ -92,32 +92,63 @@ WIRED_KINDS: tuple[str, ...] = (
     "export",
 )
 
-#: The op kinds NOT wired to a real engine — each needs a subsystem ffmpeg alone
-#: cannot provide. Logged up front (never silently skipped) so an op of one of
-#: these kinds surfaces as a clear per-op ``failed`` with auto-rollback (the
-#: graceful degradation), never a silent no-op. HONESTLY DEFERRED:
+#: The op kinds NOT wired into :func:`build_engines`. Logged up front (never
+#: silently skipped) so an op of one of these kinds surfaces as a clear per-op
+#: ``failed`` with auto-rollback (the graceful degradation), never a silent no-op.
 #:
-#:   * ``stitchPanorama`` -> the panorama/stitch engine (multi-frame mosaic);
-#:   * ``ocrExtractList``  -> an OCR engine (text recognition, not a render);
-#:   * ``regenScroll``     -> the scroll-regen engine (also needs a panorama).
+#: v1.5 (SCOPE.md O-3) corrects TWO false statements this block used to make.
 #:
-#: v1.5 (SCOPE.md O-3) REMOVED ``reorder`` from this set: it is a segment
-#: permutation the shipped ``fillers.build_segment_cut_argv`` concat already
-#: expresses, so it is now a real wired engine (:func:`make_reorder_engine`) —
-#: it never needed a "multi-clip timeline" subsystem at all.
+#: 1. ``reorder`` is REMOVED from the set. It was deferred as needing "the
+#:    timeline clip-reorder engine (multi-clip permutation)". That premise was
+#:    wrong: it is a permutation of spans within ONE source, which the shipped
+#:    ``fillers.build_segment_cut_argv`` concat already expresses. It is now a
+#:    real wired engine (:func:`make_reorder_engine`) and needed no subsystem.
+#:
+#: 2. The remaining three are NOT missing their engines. ``panorama_stitch.py``,
+#:    ``scroll_regen.py`` and ``ocr_list.py`` each ship a complete, unit-tested
+#:    subsystem with its heavy half behind an injected seam. What is missing is
+#:    only the apply-time ADAPTER, and :data:`DEFERRED_SUBSYSTEMS` now names the
+#:    concrete mechanism each adapter still needs rather than pretending the
+#:    engine itself is absent. The three shared gaps are: span frame-sampling
+#:    (no helper exists anywhere in the tree), a manifest artifact slot plus a
+#:    non-video inverse sentinel (:data:`RESTORE_KEY` restores a video PATH, and
+#:    these ops produce artifacts/text instead), and — for ``regenScroll`` — a
+#:    cross-op handoff, since ``apply_engine.apply_plan`` gives an op no way to
+#:    read a previous op's output. Those are deliberately NOT invented here.
 DEFERRED_KINDS: tuple[str, ...] = (
     "stitchPanorama",
     "regenScroll",
     "ocrExtractList",
 )
 
-#: Each deferred kind -> the subsystem it requires. Surfaced verbatim in the
-#: deferral notice (:func:`log_deferred`) so the unwired set names WHY each is
-#: held back, not just THAT it is.
+#: Each deferred kind -> the work it still needs, naming the SHIPPED module the
+#: adapter would drive. Surfaced verbatim in the deferral notice
+#: (:func:`log_deferred`) so the unwired set says WHY each is held back — and,
+#: since v1.5, says it TRUTHFULLY (the engines exist; the adapters do not).
+#: ``test_deferred_subsystems_name_modules_that_exist`` pins every module named
+#: here to a real importable module, so this text cannot rot into a lie again.
 DEFERRED_SUBSYSTEMS: dict[str, str] = {
-    "stitchPanorama": "the panorama/stitch engine",
-    "regenScroll": "the scroll-regen engine (requires a stitched panorama)",
-    "ocrExtractList": "an OCR engine",
+    "stitchPanorama": (
+        "an apply-time adapter over the shipped panorama/stitch engine "
+        "media_studio.features.panorama_stitch (needs span frame-sampling + a manifest artifact slot)"
+    ),
+    "regenScroll": (
+        "an apply-time adapter over the shipped scroll-regen engine "
+        "media_studio.features.scroll_regen (needs a stitched panorama handed across ops + a span splice)"
+    ),
+    "ocrExtractList": (
+        "an apply-time adapter over the shipped OCR engine "
+        "media_studio.features.ocr_list (needs span frame-sampling + the on-demand rapidocr-onnx asset)"
+    ),
+}
+
+#: Deferred kind -> the SHIPPED engine module its adapter would drive. Kept
+#: beside :data:`DEFERRED_SUBSYSTEMS` so the "engine exists, adapter does not"
+#: claim is machine-checkable rather than prose.
+DEFERRED_ENGINE_MODULES: dict[str, str] = {
+    "stitchPanorama": "media_studio.features.panorama_stitch",
+    "regenScroll": "media_studio.features.scroll_regen",
+    "ocrExtractList": "media_studio.features.ocr_list",
 }
 
 
@@ -1053,6 +1084,7 @@ def log_deferred(log: Any) -> None:
 
 
 __all__ = [
+    "DEFERRED_ENGINE_MODULES",
     "DEFERRED_KINDS",
     "DEFERRED_SUBSYSTEMS",
     "WIRED_KINDS",

--- a/sidecar/media_studio/features/director_op_engines.py
+++ b/sidecar/media_studio/features/director_op_engines.py
@@ -82,6 +82,7 @@ WIRED_KINDS: tuple[str, ...] = (
     "removeSilence",
     "caption",
     "removeFillers",
+    "reorder",
     "reframe",
     "zoomPan",
     "retime",
@@ -100,10 +101,11 @@ WIRED_KINDS: tuple[str, ...] = (
 #:   * ``ocrExtractList``  -> an OCR engine (text recognition, not a render);
 #:   * ``regenScroll``     -> the scroll-regen engine (also needs a panorama).
 #:
-#: ``reorder`` is a multi-clip timeline permutation outside the single-clip
-#: render scope of these adapters and is likewise left deferred.
+#: v1.5 (SCOPE.md O-3) REMOVED ``reorder`` from this set: it is a segment
+#: permutation the shipped ``fillers.build_segment_cut_argv`` concat already
+#: expresses, so it is now a real wired engine (:func:`make_reorder_engine`) —
+#: it never needed a "multi-clip timeline" subsystem at all.
 DEFERRED_KINDS: tuple[str, ...] = (
-    "reorder",
     "stitchPanorama",
     "regenScroll",
     "ocrExtractList",
@@ -113,7 +115,6 @@ DEFERRED_KINDS: tuple[str, ...] = (
 #: deferral notice (:func:`log_deferred`) so the unwired set names WHY each is
 #: held back, not just THAT it is.
 DEFERRED_SUBSYSTEMS: dict[str, str] = {
-    "reorder": "the timeline clip-reorder engine (multi-clip permutation)",
     "stitchPanorama": "the panorama/stitch engine",
     "regenScroll": "the scroll-regen engine (requires a stitched panorama)",
     "ocrExtractList": "an OCR engine",
@@ -301,6 +302,100 @@ def make_cut_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None)
         if restored is not None:
             return restored
         keeps = _keep_for_cut(op)
+        return _render(
+            project_copy,
+            op,
+            lambda i, o: _fillers.build_segment_cut_argv(i, o, keeps, dict(settings or {})),
+            runner=runner,
+            settings=settings,
+        )
+
+    return engine
+
+
+def _is_index(value: Any) -> bool:
+    """True for a real ``int`` (``bool`` is an ``int`` subclass and is NOT one)."""
+    return isinstance(value, int) and not isinstance(value, bool)
+
+
+def _require_segments(op: EditOp) -> list[tuple[float, float]]:
+    """Return the reorder op's ``params['segments']`` as ordered second spans.
+
+    ``segments`` is the ordered list of ``[startMs, endMs]`` source ranges the
+    timeline is built from — for transcript-native editing, one entry per
+    transcript block. Each must be a forward, non-negative pair; anything else
+    is a render error (per-op ``failed`` + rollback), never a silent no-op.
+    """
+    raw = op.params.get("segments")
+    if not isinstance(raw, (list, tuple)) or not raw:
+        raise DirectorEngineError(
+            f"reorder op {op.id!r} requires a non-empty params['segments'] list of [startMs, endMs] pairs"
+        )
+    spans: list[tuple[float, float]] = []
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+            raise DirectorEngineError(
+                f"reorder op {op.id!r} params['segments'][{index}] must be a [startMs, endMs] pair"
+            )
+        start, end = entry
+        if not _is_index(start) or not _is_index(end):
+            raise DirectorEngineError(f"reorder op {op.id!r} params['segments'][{index}] bounds must be integers")
+        if start < 0 or end <= start:
+            raise DirectorEngineError(
+                f"reorder op {op.id!r} params['segments'][{index}] must be a forward, non-negative span"
+            )
+        spans.append((start / 1000.0, end / 1000.0))
+    return spans
+
+
+def _require_order(op: EditOp, count: int) -> list[int]:
+    """Return the reorder op's ``params['order']`` — a PERMUTATION of the indices.
+
+    Omitted ``order`` defaults to the identity, i.e. "keep the segments exactly
+    as listed" (still a real edit: it compacts the gaps BETWEEN segments away).
+    A supplied order must use every segment index exactly once — a subset would
+    silently DELETE a segment and a repeat would duplicate one, so neither is a
+    reorder and both are rejected rather than rendered.
+    """
+    raw = op.params.get("order")
+    if raw is None:
+        return list(range(count))
+    if not isinstance(raw, (list, tuple)):
+        raise DirectorEngineError(f"reorder op {op.id!r} params['order'] must be a list of segment indices")
+    order = [index for index in raw if _is_index(index)]
+    if len(order) != len(raw) or sorted(order) != list(range(count)):
+        raise DirectorEngineError(
+            f"reorder op {op.id!r} params['order'] must be a permutation of the {count} segment indices "
+            "(each index exactly once)"
+        )
+    return order
+
+
+def make_reorder_engine(*, runner: RunFn, settings: Mapping[str, Any] | None = None) -> OpEngine:
+    """Engine for ``reorder``: re-concatenate ``params['segments']`` in a new order.
+
+    The op carries the ordered source ranges (``segments``, ``[startMs, endMs]``
+    pairs — one per transcript block for transcript-native editing) plus the
+    permutation (``order``, defaulting to the identity). The forward render feeds
+    the PERMUTED keep list to ``fillers.build_segment_cut_argv``, whose
+    ``trim``/``atrim`` + ``concat`` graph emits the segments in exactly that
+    order, so the output really is the resequenced clip (the strongest non-no-op
+    proof: keep *i* of the graph is ``segments[order[i]]``).
+
+    This kind was previously DEFERRED as needing "the timeline clip-reorder
+    engine (multi-clip permutation)". That premise was wrong: a permutation of
+    spans within one source is precisely what the shipped segment-cut concat
+    already does, so no new subsystem is required. The inverse restores the
+    pre-reorder reference (undo, no re-render).
+    """
+
+    def engine(op: EditOp, project_copy: ProjectCopy) -> EditOp:
+        restored = _maybe_restore(op, project_copy)
+        if restored is not None:
+            return restored
+        segments = _require_segments(op)
+        order = _require_order(op, len(segments))
+        keeps = [segments[index] for index in order]
         return _render(
             project_copy,
             op,
@@ -934,6 +1029,7 @@ def build_engines(*, runner: RunFn | None = None, settings: Mapping[str, Any] | 
         "removeSilence": make_remove_silence_engine(runner=run, settings=settings),
         "caption": make_caption_engine(runner=run, settings=settings),
         "removeFillers": make_remove_fillers_engine(runner=run, settings=settings),
+        "reorder": make_reorder_engine(runner=run, settings=settings),
         "reframe": make_reframe_engine(runner=run, settings=settings),
         "zoomPan": make_zoom_pan_engine(runner=run, settings=settings),
         "retime": make_retime_engine(runner=run, settings=settings),
@@ -978,6 +1074,7 @@ __all__ = [
     "make_reframe_engine",
     "make_remove_fillers_engine",
     "make_remove_silence_engine",
+    "make_reorder_engine",
     "make_retime_engine",
     "make_translate_caption_engine",
     "make_trim_engine",

--- a/sidecar/media_studio/features/edit_validate.py
+++ b/sidecar/media_studio/features/edit_validate.py
@@ -105,16 +105,61 @@ def _has_clips(params: Mapping[str, Any]) -> bool:
     return any(isinstance(p, str) and p.strip() for p in clips)
 
 
+def _is_panorama_mapping(value: Any) -> bool:
+    """True when ``value`` is the panorama MAPPING the regen engine can consume.
+
+    Mirrors ``scroll_regen._require_panorama`` exactly: a string ``imagePath``,
+    an int (never ``bool``) ``height``, and a list ``frameOffsets``. Keeping the
+    two in step is the whole point — see :func:`_has_panorama`.
+    """
+    if not isinstance(value, Mapping):
+        return False
+    image_path = value.get("imagePath")
+    height = value.get("height")
+    offsets = value.get("frameOffsets")
+    return (
+        isinstance(image_path, str)
+        and bool(image_path.strip())
+        and isinstance(height, int)
+        and not isinstance(height, bool)
+        and isinstance(offsets, list)
+    )
+
+
+def _has_panorama(params: Mapping[str, Any]) -> bool:
+    """True when ``params['panorama']`` is a usable artifact REFERENCE or MAPPING.
+
+    v1.5 (SCOPE.md O-3) fixes a CONFIRMED contradiction. This precondition used
+    to accept ONLY a string (``_params_str`` returns ``""`` for anything else),
+    while ``scroll_regen._require_panorama`` accepts ONLY a mapping. Measured on
+    the pre-fix tree:
+
+        panorama as STRING -> validator "planned"           / engine REJECTED
+        panorama as DICT   -> validator "precondition-unmet" / engine ACCEPTED
+
+    So NO ``regenScroll`` op could be both validator-valid and engine-renderable
+    — a declared-but-impossible op. Both shapes are now accepted: a bare string
+    is an artifact REFERENCE resolved later, and a mapping is the inline
+    artifact the engine consumes directly. A malformed mapping is still dropped,
+    so this TIGHTENS the gate on garbage while unblocking the real shape.
+    """
+    value = params.get("panorama")
+    if isinstance(value, str):
+        return bool(value.strip())
+    return _is_panorama_mapping(value)
+
+
 def _precondition_reason(op: EditOp, understanding: Understanding) -> StatusReason | None:
     """Per-kind precondition checks beyond span/track, or ``None`` if satisfied.
 
     Two preconditions today:
       * ``regenScroll`` must reference a stitched panorama (DESIGN §3 canonical
-        example) via ``params["panorama"]``;
+        example) via ``params["panorama"]`` — either a string artifact reference
+        or the inline mapping the engine consumes (:func:`_has_panorama`);
       * ``join`` must carry a non-empty ``params["clips"]`` list of paths to
         concatenate (V1 IA §h E2 — a join with nothing to join is impossible).
     """
-    if op.kind == "regenScroll" and understanding.require_regen_panorama and not _params_str(op.params, "panorama"):
+    if op.kind == "regenScroll" and understanding.require_regen_panorama and not _has_panorama(op.params):
         return "precondition-unmet"
     if op.kind == "join" and not _has_clips(op.params):
         return "precondition-unmet"

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -79,10 +79,14 @@ def test_build_engines_defaults_runner_to_ffmpeg_run() -> None:
 def test_deferred_kinds_have_no_engine() -> None:
     table = build_engines(runner=FakeRunner())
     assert not (set(DEFERRED_KINDS) & set(table))
-    # The honestly-deferred subsystem ops stay out of the table; reorder too.
-    assert {"stitchPanorama", "regenScroll", "ocrExtractList", "reorder"} <= set(DEFERRED_KINDS)
-    # The ffmpeg-achievable ops moved INTO the wired table.
+    # The honestly-deferred subsystem ops stay out of the table.
+    assert {"stitchPanorama", "regenScroll", "ocrExtractList"} <= set(DEFERRED_KINDS)
+    # The ffmpeg-achievable ops moved INTO the wired table. ``reorder`` joined
+    # them in v1.5 (SCOPE.md O-3): it is a permutation of spans within ONE
+    # source, which the shipped segment-cut concat already expresses, so the
+    # "needs a multi-clip timeline engine" deferral premise was simply wrong.
     assert {
+        "reorder",
         "reframe",
         "zoomPan",
         "retime",
@@ -92,6 +96,7 @@ def test_deferred_kinds_have_no_engine() -> None:
         "translateCaption",
         "export",
     } <= set(WIRED_KINDS)
+    assert "reorder" not in set(DEFERRED_KINDS)
 
 
 def test_deferred_subsystems_cover_every_deferred_kind() -> None:

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -106,6 +106,24 @@ def test_deferred_subsystems_cover_every_deferred_kind() -> None:
     assert "OCR" in engines_mod.DEFERRED_SUBSYSTEMS["ocrExtractList"]
 
 
+def test_deferred_subsystems_name_modules_that_exist() -> None:
+    # v1.5 SCOPE.md O-3 anti-drift. The deferral text used to claim these kinds
+    # were missing "the panorama/stitch engine" / "an OCR engine" — false: each
+    # engine SHIPS and is unit-tested; only the apply-time adapter is missing.
+    # Pin every module the text names to a real importable module so the
+    # corrected wording cannot rot back into that lie (delete panorama_stitch.py
+    # and this test fires).
+    import importlib
+
+    assert set(engines_mod.DEFERRED_ENGINE_MODULES) == set(DEFERRED_KINDS)
+    for kind, module_name in engines_mod.DEFERRED_ENGINE_MODULES.items():
+        assert importlib.import_module(module_name) is not None
+        # the human-readable deferral must cite the same module it claims to need
+        assert module_name in engines_mod.DEFERRED_SUBSYSTEMS[kind]
+        # ...and must say the ADAPTER is what is missing, not the engine
+        assert "adapter" in engines_mod.DEFERRED_SUBSYSTEMS[kind]
+
+
 def test_log_deferred_announces_unwired_kinds_with_subsystems() -> None:
     seen: list[tuple[Any, ...]] = []
 

--- a/sidecar/tests/test_director_op_engines.py
+++ b/sidecar/tests/test_director_op_engines.py
@@ -107,7 +107,7 @@ def test_deferred_subsystems_cover_every_deferred_kind() -> None:
 
 
 def test_deferred_subsystems_name_modules_that_exist() -> None:
-    # v1.5 SCOPE.md O-3 anti-drift. The deferral text used to claim these kinds
+    # v1.5 docs/plans/v1.5/SCOPE.md O-3 anti-drift. The deferral text claimed these kinds were
     # were missing "the panorama/stitch engine" / "an OCR engine" — false: each
     # engine SHIPS and is unit-tested; only the apply-time adapter is missing.
     # Pin every module the text names to a real importable module so the

--- a/sidecar/tests/test_director_render_integration.py
+++ b/sidecar/tests/test_director_render_integration.py
@@ -380,7 +380,7 @@ def test_export_renders_valid_delivery_mp4(sample: Path, tmp_path: Path) -> None
 
 @_SKIP
 def test_reorder_renders_a_real_resequenced_mp4_and_undo_round_trips(sample: Path, tmp_path: Path) -> None:
-    # v1.5 SCOPE.md O-3: ``reorder`` used to hit the "no engine for kind" path.
+    # v1.5 docs/plans/v1.5/SCOPE.md O-3: ``reorder`` used to hit "no engine for kind".
     # It now renders for real. The falsifiable, non-no-op proof available to
     # ffprobe is DURATION: the three kept segments total 1.1 s out of a 1.5 s
     # source, so a no-op copy (1.5 s) is excluded.

--- a/sidecar/tests/test_director_render_integration.py
+++ b/sidecar/tests/test_director_render_integration.py
@@ -379,15 +379,70 @@ def test_export_renders_valid_delivery_mp4(sample: Path, tmp_path: Path) -> None
 
 
 @_SKIP
-@pytest.mark.parametrize("kind", ["stitchPanorama", "regenScroll", "ocrExtractList", "reorder"])
+def test_reorder_renders_a_real_resequenced_mp4_and_undo_round_trips(sample: Path, tmp_path: Path) -> None:
+    # v1.5 SCOPE.md O-3: ``reorder`` used to hit the "no engine for kind" path.
+    # It now renders for real. The falsifiable, non-no-op proof available to
+    # ffprobe is DURATION: the three kept segments total 1.1 s out of a 1.5 s
+    # source, so a no-op copy (1.5 s) is excluded.
+    #
+    # SCOPE (inline, honest): duration proves the segments were re-cut, NOT that
+    # they landed in the permuted ORDER — that is asserted structurally against
+    # the emitted filtergraph in ``test_director_reorder_engine`` (keep *i* is
+    # ``segments[order[i]]``). Settling the order empirically would need a
+    # per-frame pixel/timecode comparison of the testsrc counter, which this
+    # tiny integration clip deliberately does not do.
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    op = EditOp(
+        id="ro1",
+        kind="reorder",
+        span=(0, 1500),
+        params={"segments": [[0, 300], [400, 800], [1100, 1500]], "order": [2, 0, 1]},
+    )
+
+    result, engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "applied"
+    rendered = Path(pc.data["video"]["path"])
+    assert rendered != Path(source_before)
+    duration = _ffprobe_ok(rendered)
+    assert duration == pytest.approx(1.1, abs=0.25)  # 0.3 + 0.4 + 0.4, not the 1.5 s source
+
+    undo = apply_plan(result.inverse_plan, project_copy=pc, engines=engines)
+    assert undo.ops_status[0].status == "applied"
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+def test_reorder_with_a_non_permutation_order_degrades_gracefully(sample: Path, tmp_path: Path) -> None:
+    # A malformed reorder must NOT silently drop a segment: it fails the op and
+    # auto-rolls-back, exactly like the unwired kinds used to (but with a reason
+    # that names the offending param instead of "no engine for kind").
+    pc = _project_copy(tmp_path, sample)
+    source_before = pc.data["video"]["path"]
+    op = EditOp(
+        id="ro2",
+        kind="reorder",
+        span=(0, 1500),
+        params={"segments": [[0, 300], [400, 800]], "order": [1]},  # would DELETE segment 0
+    )
+
+    result, _engines = _apply_one(pc, op)
+
+    assert result.ops_status[0].status == "failed"
+    assert "order" in (result.ops_status[0].status_reason or "")
+    assert Path(pc.data["video"]["path"]) == Path(source_before)
+
+
+@_SKIP
+@pytest.mark.parametrize("kind", ["stitchPanorama", "regenScroll", "ocrExtractList"])
 def test_deferred_kinds_degrade_gracefully(kind: str, sample: Path, tmp_path: Path) -> None:
     # A deferred-kind op has NO engine -> the op is marked failed and the COPY is
     # auto-rolled-back: the source manifest is untouched (graceful degradation,
     # never a crash or a corrupt source).
     pc = _project_copy(tmp_path, sample)
     source_before = pc.data["video"]["path"]
-    span = None if kind == "reorder" else (0, 1500)
-    op = EditOp(id="d1", kind=kind, span=span, params={"panorama": "p"} if kind == "regenScroll" else {})
+    op = EditOp(id="d1", kind=kind, span=(0, 1500), params={"panorama": "p"} if kind == "regenScroll" else {})
 
     result, _engines = _apply_one(pc, op)
 

--- a/sidecar/tests/test_director_reorder_engine.py
+++ b/sidecar/tests/test_director_reorder_engine.py
@@ -1,4 +1,4 @@
-"""Unit tests for the ``reorder`` director op-engine (v1.5 O-3, SCOPE.md).
+"""Unit tests for the ``reorder`` director op-engine (docs/plans/v1.5/SCOPE.md O-3).
 
 ``reorder`` was the ONE op kind in ``models/edit_plan.OpKind`` with no engine
 ANYWHERE in the tree (``stitchPanorama``/``regenScroll``/``ocrExtractList`` each

--- a/sidecar/tests/test_director_reorder_engine.py
+++ b/sidecar/tests/test_director_reorder_engine.py
@@ -1,0 +1,191 @@
+"""Unit tests for the ``reorder`` director op-engine (v1.5 O-3, SCOPE.md).
+
+``reorder`` was the ONE op kind in ``models/edit_plan.OpKind`` with no engine
+ANYWHERE in the tree (``stitchPanorama``/``regenScroll``/``ocrExtractList`` each
+already ship a real subsystem module — ``panorama_stitch.py``, ``scroll_regen.py``,
+``ocr_list.py`` — they were merely unwired). So a prompt asking to reorder clips
+surfaced as a per-op ``failed`` + auto-rollback: the named backend gap blocking
+transcript-native editing.
+
+Same discipline as ``test_director_op_engines``: the ONE impure thing — the
+ffmpeg subprocess — is the injected ``runner``, faked here so the adapter logic
+(param validation, permuted keep list, manifest re-point, recorded inverse,
+dual-mode undo, every error branch) is exercised deterministically with NO real
+ffmpeg.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio.features import director_op_engines as engines_mod
+from media_studio.features.director_op_engines import (
+    DEFERRED_KINDS,
+    WIRED_KINDS,
+    DirectorEngineError,
+    build_engines,
+)
+from media_studio.features.project_copy import ProjectCopy
+from media_studio.models.edit_plan import EditOp
+
+CLIP_SEC = 12.0
+
+#: Three ordered source segments (ms) the reorder permutes.
+SEGMENTS = [[0, 2000], [2000, 5000], [5000, 9000]]
+
+
+def _copy(tmp_path: Path) -> ProjectCopy:
+    """A ProjectCopy whose manifest folder is real (so renders land on disk)."""
+    src = tmp_path / "src.mp4"
+    src.write_bytes(b"\x00source")
+    manifest = tmp_path / ".director-copy" / "project.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    return ProjectCopy(data={"video": {"path": str(src)}}, manifest_path=manifest)
+
+
+class FakeRunner:
+    """A fake ffmpeg runner: stubs the output file (last argv element) + records calls."""
+
+    def __init__(self, *, code: int = 0) -> None:
+        self.code = code
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: Any, total_sec: float = 0.0, **_k: Any) -> int:
+        self.calls.append(list(argv))
+        if self.code == 0:
+            Path(argv[-1]).write_bytes(b"\x00rendered")
+        return self.code
+
+
+@pytest.fixture(autouse=True)
+def _probe(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(engines_mod._ffmpeg, "ffprobe_duration", lambda *_a, **_k: CLIP_SEC)
+
+
+def _op(**params: Any) -> EditOp:
+    return EditOp(id="r1", kind="reorder", span=(0, 9000), params=params)
+
+
+def _filtergraph(runner: FakeRunner) -> str:
+    """The -filter_complex value of the last render (carries the keep order)."""
+    argv = runner.calls[-1]
+    return argv[argv.index("-filter_complex") + 1]
+
+
+# --------------------------------------------------------------------------- #
+# wiring: reorder is a REAL engine now, not a deferred kind
+# --------------------------------------------------------------------------- #
+def test_reorder_is_wired_and_no_longer_deferred() -> None:
+    table = build_engines(runner=FakeRunner())
+    assert "reorder" in table
+    assert "reorder" in WIRED_KINDS
+    assert "reorder" not in DEFERRED_KINDS
+    assert "reorder" not in engines_mod.DEFERRED_SUBSYSTEMS
+
+
+# --------------------------------------------------------------------------- #
+# forward render: the keeps are emitted in the PERMUTED order
+# --------------------------------------------------------------------------- #
+def test_reorder_renders_segments_in_the_permuted_order(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    src_before = pc.data["video"]["path"]
+
+    inverse = build_engines(runner=runner)["reorder"](_op(segments=SEGMENTS, order=[2, 0, 1]), pc)
+
+    graph = _filtergraph(runner)
+    # keep #0 is segment[2] (5.0-9.0s), keep #1 is segment[0], keep #2 is segment[1].
+    assert "trim=start=5.000:end=9.000,setpts=PTS-STARTPTS[v0]" in graph
+    assert "trim=start=0.000:end=2.000,setpts=PTS-STARTPTS[v1]" in graph
+    assert "trim=start=2.000:end=5.000,setpts=PTS-STARTPTS[v2]" in graph
+    assert "concat=n=3:v=1:a=1" in graph
+    # the COPY was RE-POINTED at the render and the inverse restores the old ref.
+    assert pc.data["video"]["path"] != src_before
+    assert inverse.kind == "reorder"
+    assert inverse.params[engines_mod.RESTORE_KEY] == src_before
+
+
+def test_reorder_defaults_order_to_the_segment_sequence(tmp_path: Path) -> None:
+    # ``order`` omitted -> identity: keep the segments as given (compacting gaps).
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+
+    build_engines(runner=runner)["reorder"](_op(segments=[[5000, 9000], [0, 2000]]), pc)
+
+    graph = _filtergraph(runner)
+    assert "trim=start=5.000:end=9.000,setpts=PTS-STARTPTS[v0]" in graph
+    assert "trim=start=0.000:end=2.000,setpts=PTS-STARTPTS[v1]" in graph
+
+
+def test_reorder_persists_the_repointed_manifest(tmp_path: Path) -> None:
+    pc = _copy(tmp_path)
+    build_engines(runner=FakeRunner())["reorder"](_op(segments=SEGMENTS, order=[1, 0, 2]), pc)
+    # the ON-DISK manifest references the render (not just the in-memory dict).
+    assert pc.data["video"]["path"] in pc.manifest_path.read_text(encoding="utf-8")
+
+
+def test_reorder_surfaces_an_ffmpeg_failure(tmp_path: Path) -> None:
+    with pytest.raises(DirectorEngineError, match="ffmpeg exit 1"):
+        build_engines(runner=FakeRunner(code=1))["reorder"](_op(segments=SEGMENTS, order=[1, 0, 2]), _copy(tmp_path))
+
+
+# --------------------------------------------------------------------------- #
+# dual-mode: the recorded inverse RESTORES (never re-renders)
+# --------------------------------------------------------------------------- #
+def test_reorder_inverse_restores_without_re_rendering(tmp_path: Path) -> None:
+    runner = FakeRunner()
+    pc = _copy(tmp_path)
+    original = pc.data["video"]["path"]
+    table = build_engines(runner=runner)
+
+    forward = table["reorder"](_op(segments=SEGMENTS, order=[2, 1, 0]), pc)
+    renders = len(runner.calls)
+    re_inverse = table["reorder"](forward, pc)
+
+    assert pc.data["video"]["path"] == original
+    assert len(runner.calls) == renders  # restore-only: no second render
+    # the re-inverse re-applies the reordered render reference (double-undo).
+    assert re_inverse.params[engines_mod.RESTORE_KEY] != original
+
+
+# --------------------------------------------------------------------------- #
+# validate-and-reject: a malformed reorder is a typed render error, never a
+# silent no-op and never silent content loss
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "params",
+    [
+        {},  # no segments at all (the golden-plan "order only" shape)
+        {"order": [1, 0]},  # order without segments
+        {"segments": []},  # empty list
+        {"segments": "0,2000"},  # not a list
+        {"segments": [[0, 2000], "nope"]},  # entry not a pair
+        {"segments": [[0, 2000], [1000]]},  # entry not a 2-tuple
+        {"segments": [[0, 2000], ["a", "b"]]},  # bounds not integers
+        {"segments": [[0, 2000], [5000, 5000]]},  # empty span (end == start)
+        {"segments": [[0, 2000], [9000, 5000]]},  # inverted span
+        {"segments": [[-1, 2000]]},  # negative start
+    ],
+)
+def test_reorder_rejects_malformed_segments(tmp_path: Path, params: dict[str, Any]) -> None:
+    with pytest.raises(DirectorEngineError, match="segments"):
+        build_engines(runner=FakeRunner())["reorder"](_op(**params), _copy(tmp_path))
+
+
+@pytest.mark.parametrize(
+    "order",
+    [
+        [0, 1],  # too short -> would SILENTLY DROP segment 2
+        [0, 1, 2, 0],  # too long
+        [0, 0, 1],  # duplicate -> repeats a segment
+        [0, 1, 3],  # out of range
+        [0, 1, "2"],  # not an integer
+        [0, 1, True],  # bool is not a valid index
+        "012",  # not a list
+    ],
+)
+def test_reorder_rejects_a_non_permutation_order(tmp_path: Path, order: Any) -> None:
+    with pytest.raises(DirectorEngineError, match="order"):
+        build_engines(runner=FakeRunner())["reorder"](_op(segments=SEGMENTS, order=order), _copy(tmp_path))

--- a/sidecar/tests/test_director_reorder_engine.py
+++ b/sidecar/tests/test_director_reorder_engine.py
@@ -16,6 +16,7 @@ ffmpeg.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any
 
@@ -123,7 +124,11 @@ def test_reorder_persists_the_repointed_manifest(tmp_path: Path) -> None:
     pc = _copy(tmp_path)
     build_engines(runner=FakeRunner())["reorder"](_op(segments=SEGMENTS, order=[1, 0, 2]), pc)
     # the ON-DISK manifest references the render (not just the in-memory dict).
-    assert pc.data["video"]["path"] in pc.manifest_path.read_text(encoding="utf-8")
+    # Parsed, not substring-matched: JSON escapes Windows backslashes, so a raw
+    # `in` over the file text is a false negative on this platform.
+    on_disk = json.loads(pc.manifest_path.read_text(encoding="utf-8"))
+    assert on_disk["video"]["path"] == pc.data["video"]["path"]
+    assert Path(on_disk["video"]["path"]).name == "src.r1.mp4"  # the rendered file, not the source
 
 
 def test_reorder_surfaces_an_ffmpeg_failure(tmp_path: Path) -> None:

--- a/sidecar/tests/test_edit_plan_dsl.py
+++ b/sidecar/tests/test_edit_plan_dsl.py
@@ -291,7 +291,7 @@ def test_regen_precondition_can_be_disabled():
 
 
 # --------------------------------------------------------------------------- #
-# regenScroll panorama shape (v1.5 SCOPE.md O-3 — a CONFIRMED contradiction).
+# regenScroll panorama shape (docs/plans/v1.5/SCOPE.md O-3 — a CONFIRMED contradiction).
 #
 # Measured on the pre-fix tree, two independent probes:
 #   panorama as STRING -> validator 'planned'                / engine REJECTED

--- a/sidecar/tests/test_edit_plan_dsl.py
+++ b/sidecar/tests/test_edit_plan_dsl.py
@@ -290,6 +290,48 @@ def test_regen_precondition_can_be_disabled():
     assert out.ops[0].status == "planned"
 
 
+# --------------------------------------------------------------------------- #
+# regenScroll panorama shape (v1.5 SCOPE.md O-3 — a CONFIRMED contradiction).
+#
+# Measured on the pre-fix tree, two independent probes:
+#   panorama as STRING -> validator 'planned'                / engine REJECTED
+#   panorama as DICT   -> validator 'precondition-unmet'     / engine ACCEPTED
+# i.e. the ONLY shape `scroll_regen._require_panorama` can consume was the one
+# the validator dropped, so NO regenScroll op could be both valid and
+# renderable. The validator must accept the engine's mapping shape — while
+# still rejecting a malformed one (this is a net TIGHTENING for garbage input,
+# not a loosened guard).
+# --------------------------------------------------------------------------- #
+def test_keep_regen_with_a_panorama_mapping_the_engine_can_consume():
+    pano = {"imagePath": "p.png", "height": 900, "frameOffsets": [0, 300]}
+    plan = _plan(ops=(_op("o1", "regenScroll", (0, 1000), panorama=pano),))
+    out = validate_and_reject(plan, understanding=_u())
+    assert out.ops[0].status == "planned"
+
+
+@pytest.mark.parametrize(
+    "pano",
+    [
+        {},  # empty mapping
+        {"imagePath": "p.png"},  # missing height + frameOffsets
+        {"imagePath": "p.png", "height": 900},  # missing frameOffsets
+        {"imagePath": 7, "height": 900, "frameOffsets": []},  # imagePath not a string
+        {"imagePath": "p.png", "height": "900", "frameOffsets": []},  # height not an int
+        {"imagePath": "p.png", "height": True, "frameOffsets": []},  # bool is not a height
+        {"imagePath": "p.png", "height": 900, "frameOffsets": "0,300"},  # offsets not a list
+        {"imagePath": "", "height": 900, "frameOffsets": []},  # blank imagePath
+        "",  # blank artifact reference
+        "   ",  # whitespace-only artifact reference
+        42,  # not a string and not a mapping
+        [],  # not a string and not a mapping
+    ],
+)
+def test_drop_regen_with_a_malformed_panorama(pano):
+    plan = _plan(ops=(_op("o1", "regenScroll", (0, 1000), panorama=pano),))
+    out = validate_and_reject(plan, understanding=_u())
+    assert out.ops[0].status_reason == "precondition-unmet"
+
+
 def test_export_op_exempt_from_span_requirement():
     plan = _plan(ops=(_op("o1", "export", None),))
     out = validate_and_reject(plan, understanding=_u())


### PR DESCRIPTION
- **docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it**
- **test(director): RED — pin the reorder engine contract before it exists**
- **feat(director): GREEN — wire a real `reorder` engine (v1.5 SCOPE.md O-3)**
- **fix(director): unblock regenScroll's impossible panorama, and stop lying about the other deferrals**
- **docs(director): qualify the four bare SCOPE.md citations the docs gate flagged**
