### PR TITLE
feat/v15 subtitle import

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -74,6 +74,7 @@ response resolves when done — long jobs return `{"jobId"}` immediately and str
 - `transcribe.start({videoId, language?})` -> `{jobId}` ; streams progress ; `job.done.result` = `{transcript}`
 - `subtitles.generate({videoId})` -> `{track}` ; `subtitles.edit({trackId, cues})` -> `{track}`
 - `subtitles.translate({trackId, targetLang})` -> `{jobId}` -> `{track}` ; `subtitles.export({trackId, format})` -> `{path}` (format: srt|ass|vtt)
+- `subtitles.import({videoId, text, format, name?, lang?})` -> `{track}` (v1.5 AMENDMENT — an ADDITION, not a rename; format: srt|ass|vtt, `.SRT`/`ssa` folded). Direct-return. `text` is the subtitle file's CONTENT, not a path: the renderer reads the picked file with the File API, so the sidecar never opens a renderer-supplied filesystem path. Refuses a zero-cue parse rather than adding an empty track
 - `tracks.list({videoId})` -> `{tracks}` ; `tracks.rename({trackId,name})` ; `tracks.relabel({trackId,lang})`
 - `tracks.add({videoId, trackId})` ; `tracks.remove({videoId, trackId})` ; `tracks.burn({videoId, trackId})` -> `{jobId}` -> `{path}` ; `tracks.strip({videoId, trackId})` -> `{path}`
 - `convert.start({videoId|path, options})` -> `{jobId}` -> `{path}` ; options = `{container,vcodec,acodec,scale,fps,crf,audioOnly,audioFormat}`

--- a/app/renderer/src/features/Subtitles.test.tsx
+++ b/app/renderer/src/features/Subtitles.test.tsx
@@ -10,7 +10,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-import Subtitles from './Subtitles';
+import Subtitles, { formatFromFilename } from './Subtitles';
 import type { DoneEvent, MediaStudioApi, ProgressEvent, SubtitleTrack } from './_api';
 
 interface FakeApi {
@@ -36,7 +36,13 @@ function track(over: Partial<SubtitleTrack> = {}): SubtitleTrack {
 }
 
 function makeFakeApi(
-  opts: { generated?: SubtitleTrack; translateInline?: SubtitleTrack; exportPath?: string } = {},
+  opts: {
+    generated?: SubtitleTrack;
+    translateInline?: SubtitleTrack;
+    exportPath?: string;
+    imported?: SubtitleTrack;
+    importError?: string;
+  } = {},
 ): FakeApi {
   const calls: FakeApi['calls'] = [];
   let progressCbs: Array<(ev: ProgressEvent) => void> = [];
@@ -50,6 +56,10 @@ function makeFakeApi(
         return { jobId: 'job-tr', track: opts.translateInline } as T;
       }
       if (method === 'subtitles.export') return { path: opts.exportPath ?? '/out/sub.srt' } as T;
+      if (method === 'subtitles.import') {
+        if (opts.importError) throw new Error(opts.importError);
+        return { track: opts.imported ?? track({ id: 'tr-imported', name: 'fixes.srt' }) } as T;
+      }
       return {} as T;
     }) as MediaStudioApi['rpc'],
     onProgress: (cb) => {
@@ -359,6 +369,116 @@ describe('<Subtitles />', () => {
       await Promise.resolve();
     });
     expect(container.querySelector('[role="alert"]')?.textContent).toContain('export boom');
+  });
+
+  // --- import: bring a hand-corrected SRT/VTT/ASS back IN (v1.5 audit 5.1) ----
+  //
+  // The control reads the picked file's TEXT with the standard File API and sends
+  // the text, so no Electron dialog/preload channel is involved and the sidecar
+  // never opens a renderer-supplied path.
+
+  function importInput(): HTMLInputElement {
+    return container.querySelector('.import-row input[type="file"]') as HTMLInputElement;
+  }
+
+  // FileReader settles on a macrotask, so a bare `await Promise.resolve()` is not
+  // enough to see the resulting render — drain the timer queue too.
+  async function pick(file: File): Promise<void> {
+    const input = importInput();
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+    });
+  }
+
+  it('offers the import control even with NO track (that is the whole point)', async () => {
+    // The user has no generated track yet and wants to load their own file, so
+    // the control must live OUTSIDE the `track && (...)` block.
+    const fake = makeFakeApi();
+    await mount(fake);
+    expect(container.querySelector('.track-meta')).toBeNull();
+    expect(importInput()).not.toBeNull();
+  });
+
+  it('sends the file text and the extension-derived format, then adopts the track', async () => {
+    const fake = makeFakeApi();
+    const onTrackChange = vi.fn();
+    await mount(fake, { onTrackChange });
+    const srt = '1\n00:00:00,000 --> 00:00:02,000\nHand corrected\n';
+    await pick(new File([srt], 'my fixes.SRT', { type: 'text/plain' }));
+    expect(fake.calls.find((c) => c.method === 'subtitles.import')?.params).toEqual({
+      videoId: 'v1',
+      text: srt,
+      format: 'SRT',
+      name: 'my fixes.SRT',
+    });
+    // Adopted into the panel AND pushed to the parent.
+    expect(container.querySelector('.track-meta')?.textContent).toContain('fixes.srt');
+    expect(onTrackChange).toHaveBeenCalledTimes(1);
+  });
+
+  it('derives the format from the last dot (a dotted stem must not fool it)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake);
+    await pick(new File(['WEBVTT\n\n'], 'ep.01.final.vtt', { type: 'text/plain' }));
+    expect(fake.calls.find((c) => c.method === 'subtitles.import')?.params?.format).toBe('vtt');
+  });
+
+  it('surfaces the sidecar rejection for an unsupported file', async () => {
+    const fake = makeFakeApi({ importError: "unsupported subtitle format: 'docx'" });
+    await mount(fake);
+    await pick(new File(['nope'], 'notes.docx', { type: 'text/plain' }));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('docx');
+  });
+
+  it('does nothing when the picker is dismissed with no file', async () => {
+    const fake = makeFakeApi();
+    await mount(fake);
+    const input = importInput();
+    Object.defineProperty(input, 'files', { value: [], configurable: true });
+    await act(async () => {
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'subtitles.import')).toBeUndefined();
+  });
+
+  it('uses String(err) when the import rejects with a non-Error value', async () => {
+    const fake = makeFakeApi();
+    (fake.api.rpc as ReturnType<typeof vi.fn>).mockRejectedValueOnce('plain import error');
+    await mount(fake);
+    await pick(new File(['x'], 'a.srt', { type: 'text/plain' }));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain import error');
+  });
+
+  it('surfaces a FileReader failure and never calls the rpc with empty text', async () => {
+    // Real path: the file is deleted or its permissions change between the pick
+    // and the read. Resolving empty text instead would reach the sidecar as a
+    // bogus "no cues found" and blame the user's file for a local read error.
+    const fake = makeFakeApi();
+    await mount(fake);
+    class FailingReader {
+      onload: (() => void) | null = null;
+      onerror: (() => void) | null = null;
+      result: string | null = null;
+      readAsText(): void {
+        setTimeout(() => this.onerror?.(), 0);
+      }
+    }
+    vi.stubGlobal('FileReader', FailingReader);
+    await pick(new File(['x'], 'gone.srt', { type: 'text/plain' }));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('Could not read');
+    expect(fake.calls.find((c) => c.method === 'subtitles.import')).toBeUndefined();
+    vi.unstubAllGlobals();
+  });
+
+  it('exports formatFromFilename as a pure extension reader', () => {
+    expect(formatFromFilename('a.srt')).toBe('srt');
+    expect(formatFromFilename('ep.01.final.VTT')).toBe('VTT');
+    // No dot: forwarded whole so the SIDECAR names the bad format, not this panel.
+    expect(formatFromFilename('subtitles')).toBe('subtitles');
   });
 
   // --- both arms of each `instanceof Error ? message : String(err)` ternary ---

--- a/app/renderer/src/features/Subtitles.tsx
+++ b/app/renderer/src/features/Subtitles.tsx
@@ -42,7 +42,44 @@ const TARGET_LANGS: Array<{ code: string; label: string }> = [
   { code: 'zh', label: 'Chinese' },
 ];
 
-type Busy = 'none' | 'generating' | 'translating' | 'exporting' | 'saving';
+type Busy = 'none' | 'generating' | 'translating' | 'exporting' | 'saving' | 'importing';
+
+/** File-picker filter for the import control (`ssa` is an alias of `ass`). */
+const IMPORT_ACCEPT = '.srt,.vtt,.ass,.ssa';
+
+/**
+ * The format token to send for a picked file: everything after the LAST dot, so a
+ * dotted stem (`ep.01.final.vtt`) still resolves to `vtt`. A name with no dot is
+ * forwarded unchanged and the sidecar rejects it with a named, typed error rather
+ * than this panel inventing its own format vocabulary.
+ */
+export function formatFromFilename(name: string): string {
+  const dot = name.lastIndexOf('.');
+  return dot === -1 ? name : name.slice(dot + 1);
+}
+
+/**
+ * Read a picked file as UTF-8 text.
+ *
+ * Deliberately `FileReader` and not `Blob.text()`: `Blob.prototype.text` is
+ * MISSING in jsdom 24.1.3 (measured — `typeof Blob.prototype.text === 'undefined'`)
+ * while `FileReader` is implemented, and Chromium (the real Electron renderer) has
+ * both. One code path that works in production AND under test beats a `.text()`
+ * call that needs a polyfill shim in the suite — a shim would mean the test
+ * exercises the polyfill rather than the code that ships.
+ *
+ * A read failure (file deleted or permissions revoked between pick and read) is a
+ * real, reachable path, so it rejects rather than resolving empty text — an empty
+ * string would reach the sidecar as a bogus "no cues found".
+ */
+export function readFileText(file: File): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
+    reader.readAsText(file);
+  });
+}
 
 export function Subtitles({
   videoId,
@@ -162,6 +199,41 @@ export function Subtitles({
     [track],
   );
 
+  // Import a hand-corrected subtitle file (v1.5 captions audit §5.1). Reads the
+  // picked file's TEXT with the standard File API and sends the text, so no
+  // Electron dialog/preload channel is needed and the sidecar never opens a
+  // renderer-supplied path. Deliberately available with NO track present — a user
+  // who already has their own SRT should not have to generate one first.
+  const importFile = useCallback(
+    async (ev: React.ChangeEvent<HTMLInputElement>) => {
+      const input = ev.target;
+      const file = input.files?.[0];
+      if (!file) return; // picker dismissed
+      setBusy('importing');
+      setError('');
+      setStatus(`Importing ${file.name}…`);
+      try {
+        const text = await readFileText(file);
+        const res = await getApi().rpc<{ track: SubtitleTrack }>('subtitles.import', {
+          videoId,
+          text,
+          format: formatFromFilename(file.name),
+          name: file.name,
+        });
+        applyTrack(res.track);
+        setStatus(`Imported ${res.track.cues.length} cues from ${file.name}`);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+        setStatus('');
+      } finally {
+        setBusy('none');
+        // Clear the input so re-picking the SAME file fires `change` again.
+        input.value = '';
+      }
+    },
+    [videoId, applyTrack],
+  );
+
   const translate = useCallback(async () => {
     // defensive null-narrowing: the Translate button renders only inside
     // `track && (...)`, so track is non-null here.
@@ -254,6 +326,21 @@ export function Subtitles({
         <button type="button" onClick={generate} disabled={anyBusy || !videoId}>
           {busy === 'generating' ? 'Generating…' : 'Generate subtitles'}
         </button>
+      </div>
+
+      {/* Import sits OUTSIDE the `track && (...)` block on purpose: a user who
+          already hand-corrected an SRT must not have to generate one first. */}
+      <div className="field import-row">
+        <label htmlFor="subtitles-import-file">
+          {busy === 'importing' ? 'Importing…' : 'Import subtitle file'}
+        </label>
+        <input
+          id="subtitles-import-file"
+          type="file"
+          accept={IMPORT_ACCEPT}
+          disabled={anyBusy || !videoId}
+          onChange={importFile}
+        />
       </div>
 
       {track && (

--- a/app/renderer/src/features/Subtitles.tsx
+++ b/app/renderer/src/features/Subtitles.tsx
@@ -71,11 +71,20 @@ export function formatFromFilename(name: string): string {
  * A read failure (file deleted or permissions revoked between pick and read) is a
  * real, reachable path, so it rejects rather than resolving empty text — an empty
  * string would reach the sidecar as a bogus "no cues found".
+ *
+ * The `load` handler casts instead of guarding: `readAsText` always leaves a
+ * string in `result`, because the `ArrayBuffer` and `null` arms of the union
+ * belong to `readAsArrayBuffer` and to the pre-read state respectively. A
+ * `?? ''` fallback here was measured as the ONE uncovered branch in the whole
+ * renderer suite (6606/6607) — it is unreachable, so the only way to keep it
+ * would be a coverage-ignore comment papering over a branch no test can enter.
+ * Deleting the dead arm is the honest fix; the reachable failure mode is
+ * `onerror`, and that one IS tested.
  */
 export function readFileText(file: File): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
-    reader.onload = () => resolve(String(reader.result ?? ''));
+    reader.onload = () => resolve(reader.result as string);
     reader.onerror = () => reject(new Error(`Could not read ${file.name}`));
     reader.readAsText(file);
   });

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -400,6 +400,26 @@ describe('client.subtitles (spread-opts branches)', () => {
     expect(r).toHaveBeenCalledWith('subtitles.export', { trackId: 't1', format: 'srt' });
   });
 
+  // v1.5 captions audit section 5.1: the tolerant SRT/VTT/ASS readers had no
+  // production caller. This is the client half of the wire that gives them one.
+  it('import forwards videoId/text/format and spreads optional name+lang', async () => {
+    const r = installApi();
+    await client.subtitles.import('v1', '1\n00:00:00,000 --> 00:00:01,000\nhi\n', 'srt');
+    expect(r).toHaveBeenCalledWith('subtitles.import', {
+      videoId: 'v1',
+      text: '1\n00:00:00,000 --> 00:00:01,000\nhi\n',
+      format: 'srt',
+    });
+    await client.subtitles.import('v1', 'WEBVTT\n\n', 'vtt', { name: 'fixed.vtt', lang: 'ro' });
+    expect(r).toHaveBeenCalledWith('subtitles.import', {
+      videoId: 'v1',
+      text: 'WEBVTT\n\n',
+      format: 'vtt',
+      name: 'fixed.vtt',
+      lang: 'ro',
+    });
+  });
+
   it('translate spreads opts when given and defaults to {} when omitted', async () => {
     const r = installApi();
     await client.subtitles.translate('t1', 'es');

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -210,6 +210,17 @@ export const client = {
       rpc('subtitles.translate', { trackId, targetLang, ...(opts ?? {}) }),
     export: (trackId: string, format: SubtitleFormat): Promise<{ path: string }> =>
       rpc('subtitles.export', { trackId, format }),
+    // v1.5 escape hatch: bring a hand-corrected SRT/VTT/ASS back IN. `text` is the
+    // file's CONTENT, not a path — the caller reads it with the standard File API,
+    // so the sidecar never opens a renderer-supplied filesystem path. `format` is
+    // passed raw (the sidecar folds '.SRT'/'ssa' and rejects anything else).
+    import: (
+      videoId: string,
+      text: string,
+      format: string,
+      opts?: { name?: string; lang?: string },
+    ): Promise<{ track: SubtitleTrack }> =>
+      rpc('subtitles.import', { videoId, text, format, ...(opts ?? {}) }),
   },
 
   tracks: {

--- a/sidecar/media_studio/features/subtitles.py
+++ b/sidecar/media_studio/features/subtitles.py
@@ -760,13 +760,28 @@ _PARSERS: dict[str, Callable[[str], list[Cue]]] = {
 }
 
 
-def _normalize_format(fmt: str) -> str:
+def normalize_format(fmt: str) -> str:
+    """Canonicalize a user-supplied format string to one of :data:`FORMATS`.
+
+    Tolerates the shapes a file picker actually produces — surrounding space, a
+    leading dot, upper case — and folds the ``ssa`` alias onto ``ass``. Raises
+    :class:`ValueError` for anything else, which the handler layer maps to a
+    typed ``INVALID_PARAMS``.
+
+    Public because ``subtitles.import`` must stamp the NORMALIZED format onto the
+    track it builds (``new_track`` stores ``fmt`` verbatim); re-deriving it in the
+    handler would be a second, drifting copy of this rule.
+    """
     f = str(fmt).strip().lower().lstrip(".")
     if f == "ssa":
         f = "ass"
     if f not in FORMATS:
         raise ValueError(f"unsupported subtitle format: {fmt!r} (want one of {FORMATS})")
     return f
+
+
+#: Back-compat private alias — this module's own callers were written against it.
+_normalize_format = normalize_format
 
 
 def serialize(track: SubtitleTrack, fmt: str) -> str:

--- a/sidecar/media_studio/handlers/_services.py
+++ b/sidecar/media_studio/handlers/_services.py
@@ -248,6 +248,7 @@ class Services:
     subtitles_generate = media_ops.subtitles_generate
     subtitles_edit = media_ops.subtitles_edit
     subtitles_export = media_ops.subtitles_export
+    subtitles_import = media_ops.subtitles_import
     subtitles_translate = media_ops.subtitles_translate
     tracks_list = media_ops.tracks_list
     tracks_rename = media_ops.tracks_rename

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -129,6 +129,11 @@ def register_all(
     reg("subtitles.edit", svc.subtitles_edit)
     reg("subtitles.translate", svc.subtitles_translate)
     reg("subtitles.export", svc.subtitles_export)
+    # v1.5 escape hatch: bring a hand-corrected SRT/VTT/ASS back IN. The tolerant
+    # parsers existed since v1 with no production caller; this is that caller.
+    # Direct-return, and the wire carries the subtitle TEXT (not a path), so the
+    # sidecar never opens a renderer-supplied filesystem path.
+    reg("subtitles.import", svc.subtitles_import)
 
     reg("tracks.list", svc.tracks_list)
     reg("tracks.rename", svc.tracks_rename)

--- a/sidecar/media_studio/handlers/media_ops.py
+++ b/sidecar/media_studio/handlers/media_ops.py
@@ -96,6 +96,51 @@ def subtitles_export(self: Services, params: dict[str, Any], ctx: RpcContext) ->
     return {"path": path}
 
 
+def subtitles_import(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+    """``subtitles.import({videoId, text, format, name?, lang?})`` -> ``{track}``. Direct-return.
+
+    The hand-corrected-subtitle escape hatch. ``features/subtitles.py`` has had
+    tolerant ``read_srt`` / ``read_vtt`` / ``read_ass`` parsers since v1, but until
+    now NO production caller — the registered surface was generate/edit/translate/
+    export only, so a user who fixed proper nouns in an external editor had no way
+    back in (competitor-research.md:22, the #1 caption complaint).
+
+    CONTRACT-NOTE: the wire carries the subtitle TEXT, not a path. The renderer
+    reads the picked file with the standard File API, so this handler never opens
+    a renderer-supplied filesystem path — there is no traversal surface to guard
+    and no new Electron dialog/preload channel to maintain. (``track_from_file``
+    stays the on-disk seam for internal/test callers.)
+    """
+    video_id = _require_str(params, "videoId")
+    text = params.get("text")
+    if not isinstance(text, str) or not text.strip():
+        raise _invalid("text (str) is required")
+    fmt_raw = _require_str(params, "format")
+    try:
+        fmt = _subtitles.normalize_format(fmt_raw)
+        cues = _subtitles.parse(text, fmt)
+    except ValueError as exc:
+        raise _invalid(str(exc)) from exc
+    if not cues:
+        # Adding an empty track would LOOK like success while silently losing the
+        # user's file. Refuse loudly instead, and leave the project untouched.
+        raise _invalid(f"no {fmt} cues found in the imported subtitle text")
+    lang = params.get("lang")
+    name = params.get("name")
+    track = _subtitles.new_track(
+        cues,
+        lang=lang if isinstance(lang, str) and lang else "und",
+        name=name if isinstance(name, str) and name else "Imported subtitles",
+        fmt=fmt,
+        kind="soft",
+    )
+    project = self._load_or_create_project(video_id)
+    _tracks.add_track(project.data, track)
+    project.save()
+    log.info("subtitles.import video=%s fmt=%s cues=%d", video_id, fmt, len(cues))
+    return {"track": track}
+
+
 def subtitles_translate(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
     """``subtitles.translate({trackId, targetLang, bilingual?, order?})`` -> ``{jobId}`` (§2).
 

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -135,6 +135,10 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         "subtitles.edit",
         "subtitles.export",
         "subtitles.generate",
+        # v1.5 DELIBERATE addition (captions audit section 5.1): the hand-corrected
+        # SRT/VTT/ASS import. Verified this gate is not vacuous — registering the
+        # method with the set unchanged failed test_rpc_surface_is_byte_identical.
+        "subtitles.import",
         "subtitles.translate",
         "system.advisor",
         "system.health",

--- a/sidecar/tests/test_handlers_subtitles_import.py
+++ b/sidecar/tests/test_handlers_subtitles_import.py
@@ -60,9 +60,7 @@ def _add_video(services: Services, video_file: Path) -> str:
 # --------------------------------------------------------------------------- #
 # happy path — the parser finally has a production caller
 # --------------------------------------------------------------------------- #
-def test_import_srt_returns_a_track_with_the_parsed_cues(
-    services: Services, ctx: RpcContext, video_file: Path
-) -> None:
+def test_import_srt_returns_a_track_with_the_parsed_cues(services: Services, ctx: RpcContext, video_file: Path) -> None:
     vid = _add_video(services, video_file)
     res = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": "srt"}, ctx)
     track = res["track"]
@@ -74,9 +72,7 @@ def test_import_srt_returns_a_track_with_the_parsed_cues(
     assert track["kind"] == "soft"
 
 
-def test_import_persists_the_track_onto_the_project(
-    services: Services, ctx: RpcContext, video_file: Path
-) -> None:
+def test_import_persists_the_track_onto_the_project(services: Services, ctx: RpcContext, video_file: Path) -> None:
     vid = _add_video(services, video_file)
     imported = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": "srt"}, ctx)["track"]
     # Re-open from disk: the import must SURVIVE, or "bring my SRT back in" is a lie.
@@ -85,9 +81,7 @@ def test_import_persists_the_track_onto_the_project(
     assert imported["id"] in ids
 
 
-def test_import_honours_name_and_lang_and_defaults_them(
-    services: Services, ctx: RpcContext, video_file: Path
-) -> None:
+def test_import_honours_name_and_lang_and_defaults_them(services: Services, ctx: RpcContext, video_file: Path) -> None:
     vid = _add_video(services, video_file)
     named = services.subtitles_import(
         {"videoId": vid, "text": SRT_TEXT, "format": "srt", "name": "my-fixes.srt", "lang": "ro"}, ctx
@@ -112,9 +106,9 @@ def test_import_vtt_and_ass_round_trip_through_the_same_handler(
     assert services.subtitles_import({"videoId": vid, "text": vtt, "format": "vtt"}, ctx)["track"]["cues"][0][
         "text"
     ] == ("From VTT")
-    assert services.subtitles_import({"videoId": vid, "text": ass_text, "format": "ass"}, ctx)["track"]["cues"][
-        0
-    ]["text"] == ("From ASS")
+    assert services.subtitles_import({"videoId": vid, "text": ass_text, "format": "ass"}, ctx)["track"]["cues"][0][
+        "text"
+    ] == ("From ASS")
 
 
 def test_import_normalizes_the_format_string(services: Services, ctx: RpcContext, video_file: Path) -> None:
@@ -123,9 +117,7 @@ def test_import_normalizes_the_format_string(services: Services, ctx: RpcContext
     track = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": ".SRT"}, ctx)["track"]
     assert track["format"] == "srt"
     ssa = "[Events]\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hi\n"
-    assert services.subtitles_import({"videoId": vid, "text": ssa, "format": "ssa"}, ctx)["track"]["format"] == (
-        "ass"
-    )
+    assert services.subtitles_import({"videoId": vid, "text": ssa, "format": "ssa"}, ctx)["track"]["format"] == ("ass")
 
 
 def test_import_tolerates_crlf_and_bom_and_missing_indices(
@@ -148,9 +140,7 @@ def test_import_requires_video_id(services: Services, ctx: RpcContext) -> None:
 
 
 @pytest.mark.parametrize("bad", [None, "", "   \n  ", 123, ["nope"]])
-def test_import_rejects_missing_or_blank_text(
-    services: Services, ctx: RpcContext, video_file: Path, bad: Any
-) -> None:
+def test_import_rejects_missing_or_blank_text(services: Services, ctx: RpcContext, video_file: Path, bad: Any) -> None:
     vid = _add_video(services, video_file)
     with pytest.raises(RpcError) as exc:
         services.subtitles_import({"videoId": vid, "text": bad, "format": "srt"}, ctx)
@@ -165,9 +155,7 @@ def test_import_rejects_an_unsupported_format(services: Services, ctx: RpcContex
     assert "docx" in str(exc.value)
 
 
-def test_import_rejects_text_that_parses_to_zero_cues(
-    services: Services, ctx: RpcContext, video_file: Path
-) -> None:
+def test_import_rejects_text_that_parses_to_zero_cues(services: Services, ctx: RpcContext, video_file: Path) -> None:
     """Silently adding an EMPTY track would look like success and lose the user's file."""
     vid = _add_video(services, video_file)
     with pytest.raises(RpcError) as exc:

--- a/sidecar/tests/test_handlers_subtitles_import.py
+++ b/sidecar/tests/test_handlers_subtitles_import.py
@@ -1,0 +1,177 @@
+"""Handler tests for ``subtitles.import`` — the v1.5 hand-corrected-SRT escape hatch.
+
+Closes the gap measured in ``docs/plans/v1.5/captions-translation-audit-2026-08.md``
+§5.1: the PARSERS (``read_srt`` / ``read_vtt`` / ``read_ass``) were complete and
+tested, but had **no production caller** — every hit outside ``subtitles.py`` was a
+test, so a user with a hand-corrected ``.srt`` could not bring it back in.
+
+Wire shape: ``subtitles.import({videoId, text, format, name?, lang?}) -> {track}``.
+The renderer reads the picked file's TEXT with the standard File API and sends the
+text — NOT a path. That keeps the sidecar off the renderer-supplied filesystem
+entirely (no traversal surface) and needs no new Electron dialog/preload channel.
+
+Seam style mirrors ``test_handlers_captions_export.py``: a tmp-dir ``Services``
+with stub ffmpeg/whisper seams, so no subprocess / heavy dep is touched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import library as _library
+from media_studio.handlers import Services
+from media_studio.protocol import ErrorCode, RpcContext, RpcError
+
+SRT_TEXT = "1\n00:00:00,000 --> 00:00:02,000\nHand corrected\n\n2\n00:00:02,000 --> 00:00:04,000\nSecond line\n"
+
+
+def fake_run(*_a: Any, **_k: Any) -> int:
+    return 0
+
+
+def fake_probe(*_a: Any, **_k: Any) -> float:
+    return 12.0
+
+
+@pytest.fixture
+def video_file(tmp_path: Path) -> Path:
+    p = tmp_path / "talk.mp4"
+    p.write_bytes(b"\x00fake")
+    return p
+
+
+@pytest.fixture
+def services(tmp_path: Path) -> Services:
+    return Services(data_dir=tmp_path / "data", ffmpeg_run=fake_run, ffprobe_duration=fake_probe)
+
+
+@pytest.fixture
+def ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=None)
+
+
+def _add_video(services: Services, video_file: Path) -> str:
+    services.library = _library.Library(services.data_dir / "library.json", probe_duration=lambda _p: 12.0)
+    return services.library.add(str(video_file))["id"]
+
+
+# --------------------------------------------------------------------------- #
+# happy path — the parser finally has a production caller
+# --------------------------------------------------------------------------- #
+def test_import_srt_returns_a_track_with_the_parsed_cues(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    vid = _add_video(services, video_file)
+    res = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": "srt"}, ctx)
+    track = res["track"]
+    assert [c["text"] for c in track["cues"]] == ["Hand corrected", "Second line"]
+    assert [c["index"] for c in track["cues"]] == [1, 2]
+    assert track["cues"][0]["start"] == 0.0
+    assert track["cues"][1]["end"] == 4.0
+    assert track["format"] == "srt"
+    assert track["kind"] == "soft"
+
+
+def test_import_persists_the_track_onto_the_project(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    vid = _add_video(services, video_file)
+    imported = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": "srt"}, ctx)["track"]
+    # Re-open from disk: the import must SURVIVE, or "bring my SRT back in" is a lie.
+    reopened = services._load_or_create_project(vid)
+    ids = [t["id"] for t in reopened.data["tracks"]]
+    assert imported["id"] in ids
+
+
+def test_import_honours_name_and_lang_and_defaults_them(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    vid = _add_video(services, video_file)
+    named = services.subtitles_import(
+        {"videoId": vid, "text": SRT_TEXT, "format": "srt", "name": "my-fixes.srt", "lang": "ro"}, ctx
+    )["track"]
+    assert named["name"] == "my-fixes.srt"
+    assert named["lang"] == "ro"
+    defaulted = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": "srt"}, ctx)["track"]
+    assert defaulted["name"] == "Imported subtitles"
+    assert defaulted["lang"] == "und"
+
+
+def test_import_vtt_and_ass_round_trip_through_the_same_handler(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    vid = _add_video(services, video_file)
+    vtt = "WEBVTT\n\n00:00:00.000 --> 00:00:01.500\nFrom VTT\n"
+    ass_text = (
+        "[Events]\n"
+        "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n"
+        "Dialogue: 0,0:00:00.00,0:00:01.50,Default,,0,0,0,,From ASS\n"
+    )
+    assert services.subtitles_import({"videoId": vid, "text": vtt, "format": "vtt"}, ctx)["track"]["cues"][0][
+        "text"
+    ] == ("From VTT")
+    assert services.subtitles_import({"videoId": vid, "text": ass_text, "format": "ass"}, ctx)["track"]["cues"][
+        0
+    ]["text"] == ("From ASS")
+
+
+def test_import_normalizes_the_format_string(services: Services, ctx: RpcContext, video_file: Path) -> None:
+    """A picker hands us the raw extension: '.SRT'. 'ssa' is an alias of 'ass'."""
+    vid = _add_video(services, video_file)
+    track = services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": ".SRT"}, ctx)["track"]
+    assert track["format"] == "srt"
+    ssa = "[Events]\nDialogue: 0,0:00:00.00,0:00:01.00,Default,,0,0,0,,Hi\n"
+    assert services.subtitles_import({"videoId": vid, "text": ssa, "format": "ssa"}, ctx)["track"]["format"] == (
+        "ass"
+    )
+
+
+def test_import_tolerates_crlf_and_bom_and_missing_indices(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    """The engine's tolerance must reach the wire — a Windows-authored SRT is the norm."""
+    vid = _add_video(services, video_file)
+    raw = "﻿00:00:00,000 --> 00:00:01,000\r\nNo index, CRLF, BOM\r\n"
+    track = services.subtitles_import({"videoId": vid, "text": raw, "format": "srt"}, ctx)["track"]
+    assert [c["text"] for c in track["cues"]] == ["No index, CRLF, BOM"]
+
+
+# --------------------------------------------------------------------------- #
+# rejection paths — typed INVALID_PARAMS, never a deep crash
+# --------------------------------------------------------------------------- #
+def test_import_requires_video_id(services: Services, ctx: RpcContext) -> None:
+    with pytest.raises(RpcError) as exc:
+        services.subtitles_import({"text": SRT_TEXT, "format": "srt"}, ctx)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+
+
+@pytest.mark.parametrize("bad", [None, "", "   \n  ", 123, ["nope"]])
+def test_import_rejects_missing_or_blank_text(
+    services: Services, ctx: RpcContext, video_file: Path, bad: Any
+) -> None:
+    vid = _add_video(services, video_file)
+    with pytest.raises(RpcError) as exc:
+        services.subtitles_import({"videoId": vid, "text": bad, "format": "srt"}, ctx)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+
+
+def test_import_rejects_an_unsupported_format(services: Services, ctx: RpcContext, video_file: Path) -> None:
+    vid = _add_video(services, video_file)
+    with pytest.raises(RpcError) as exc:
+        services.subtitles_import({"videoId": vid, "text": SRT_TEXT, "format": "docx"}, ctx)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+    assert "docx" in str(exc.value)
+
+
+def test_import_rejects_text_that_parses_to_zero_cues(
+    services: Services, ctx: RpcContext, video_file: Path
+) -> None:
+    """Silently adding an EMPTY track would look like success and lose the user's file."""
+    vid = _add_video(services, video_file)
+    with pytest.raises(RpcError) as exc:
+        services.subtitles_import({"videoId": vid, "text": "this is not a subtitle file", "format": "srt"}, ctx)
+    assert exc.value.code == ErrorCode.INVALID_PARAMS
+    # The project must be left untouched — no half-imported empty track.
+    assert services._load_or_create_project(vid).data.get("tracks") in ([], None)


### PR DESCRIPTION
- **docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it**
- **test(subtitles): red tests for the missing subtitles.import wire**
- **feat(subtitles): register subtitles.import so the SRT parsers get a caller**
- **feat(subtitles): add the Subtitles.tsx import control + client.subtitles.import**
- **docs(contracts): amend section 2 with subtitles.import (explicit, not silent)**
- **style(subtitles): ruff-format the import test to the pinned 0.15.17 shape**
- **fix(subtitles): delete the unreachable ?? fallback in readFileText**
