### PR TITLE
fix/v15 batch consent rpc

### DIFF
--- a/app/renderer/src/lib/rpc/batchSurface.conformance.test.ts
+++ b/app/renderer/src/lib/rpc/batchSurface.conformance.test.ts
@@ -1,0 +1,65 @@
+// Conformance test for the `batch.*` client/sidecar wire surface.
+//
+// THE CONTRACT: a typed client must never advertise an RPC method the backend
+// cannot serve. `protocol.dispatch` raises METHOD_NOT_FOUND (-32601) for any
+// method absent from the registry (sidecar/media_studio/protocol.py:182-184), so
+// a `client.batch.*` wrapper with no matching `reg("batch.…")` in the sidecar is
+// a latent trap: it type-checks, autocompletes, and fails only at runtime.
+//
+// It reads the REAL source files (not a copy) so adding a client wrapper without
+// registering its handler fails the build. Mirrors the existing cross-boundary
+// precedent in ../captionTemplates.conformance.test.ts. Runs in the default node
+// environment (filesystem access, no jsdom).
+//
+// DIRECTION: the assertion is one-directional (client ⊆ sidecar) BY DESIGN. The
+// sidecar legitimately may register a method the UI has no wrapper for yet; that
+// is unfinished UI, not a lie. Only the reverse — the client promising what the
+// backend cannot serve — is the defect class guarded here.
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// app/renderer/src/lib/rpc -> repo root is five levels up.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..', '..', '..', '..');
+
+const CLIENT_TS = resolve(HERE, 'client.ts');
+const SIDECAR_BATCH_PY = resolve(REPO_ROOT, 'sidecar', 'media_studio', 'features', 'batch.py');
+
+/**
+ * Every `batch.*` method the typed client can put on the wire, parsed from the
+ * `rpc('batch.…')` call literals in client.ts.
+ */
+function clientBatchMethods(): string[] {
+  const src = readFileSync(CLIENT_TS, 'utf8');
+  return [...src.matchAll(/\brpc\(\s*'(batch\.[A-Za-z0-9_]+)'/g)].map((m) => m[1]).sort();
+}
+
+/**
+ * Every `batch.*` method the sidecar actually registers, parsed from the
+ * `reg("batch.…", …)` calls in the batch feature's registration function.
+ */
+function sidecarBatchMethods(): string[] {
+  const src = readFileSync(SIDECAR_BATCH_PY, 'utf8');
+  return [...src.matchAll(/\breg\(\s*"(batch\.[A-Za-z0-9_]+)"/g)].map((m) => m[1]).sort();
+}
+
+describe('batch.* client/sidecar wire-surface conformance', () => {
+  // Detector control (fail-closed): a regex that silently matches nothing would
+  // make the real assertion below vacuously true. These two guards mean a broken
+  // parser fails LOUDLY instead of certifying an empty set as conformant.
+  it('parses a non-empty client surface (guards against a vacuous pass)', () => {
+    expect(clientBatchMethods().length).toBeGreaterThan(0);
+  });
+
+  it('parses a non-empty sidecar surface (guards against a vacuous pass)', () => {
+    expect(sidecarBatchMethods().length).toBeGreaterThan(0);
+  });
+
+  it('advertises no batch.* method the sidecar does not register', () => {
+    const registered = new Set(sidecarBatchMethods());
+    const unserveable = clientBatchMethods().filter((m) => !registered.has(m));
+    expect(unserveable).toEqual([]);
+  });
+});

--- a/app/renderer/src/lib/rpc/client.ce.test.ts
+++ b/app/renderer/src/lib/rpc/client.ce.test.ts
@@ -1,5 +1,5 @@
 // client.ce.test.ts — isolated cross-edit (feature-completion reconcile) coverage
-// for the client.ts wrappers WIRED in this pass: batch.plan / batch.consent, the
+// for the client.ts wrappers WIRED in this pass: batch.plan, the
 // transcribe.start `alignWords` trigger, the director.apply reviewed-op forwarding,
 // and the reframe.* per-shot correction group. Written as a UNIQUELY-named file so
 // it never collides with the shared rpc.test.ts / rpc.property.test.ts; coverage is
@@ -41,14 +41,6 @@ describe('client.batch.plan (§9.1 consent preview)', () => {
     const rpc = installApi();
     await client.batch.plan('b1');
     expect(rpc).toHaveBeenCalledWith('batch.plan', { id: 'b1' });
-  });
-});
-
-describe('client.batch.consent (read-only run/skip preview)', () => {
-  it('forwards {id}', async () => {
-    const rpc = installApi();
-    await client.batch.consent('b1');
-    expect(rpc).toHaveBeenCalledWith('batch.consent', { id: 'b1' });
   });
 });
 

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -724,13 +724,6 @@ export const client = {
       opts?: { confirmCloudBudget?: boolean; acknowledged?: boolean },
     ): Promise<JobHandle> => rpc('batch.start', { id, ...(opts ?? {}) }),
     status: (id: string): Promise<{ batch: BatchState }> => rpc('batch.status', { id }),
-    /**
-     * `batch.consent {id}` -> {consent} — a READ-ONLY run/skip preview computed via
-     * `plan_consent` directly (never short-circuits to None when the budget gate is
-     * off), so BatchConsentCard can always render the split before an `acknowledged`
-     * `start`. Zero provider calls; `confirmCloudBudget` is read from settings.
-     */
-    consent: (id: string): Promise<{ consent: BatchConsent }> => rpc('batch.consent', { id }),
     list: (): Promise<{ batches: BatchSummary[] }> => rpc('batch.list'),
     cancel: (id: string): Promise<{ ok: boolean }> => rpc('batch.cancel', { id }),
     resume: (id: string): Promise<JobHandle & { status?: BatchStatus }> =>


### PR DESCRIPTION
- **docs(v1.5): land the five-lane audit fleet, and let the SSOT gate correct it**
- **test(batch): RED - prove the client advertises an unserveable batch.consent**
- **fix(rpc): delete the dead batch.consent client surface**
