### PR TITLE
feat(broll): auto-b-roll planner, asset index, and N-window compositing

### DIFF
--- a/sidecar/media_studio/features/broll_compose.py
+++ b/sidecar/media_studio/features/broll_compose.py
@@ -1,0 +1,262 @@
+"""PURE N-window b-roll compositing argv builder (v1.5 flagship #3, WU BR5).
+
+Generalises the shipped single-overlay :mod:`brandkit` pattern from ONE still
+logo to **N time-gated windows in a single ffmpeg pass** — which is the only
+genuinely net-new engineering in auto-b-roll, and the design's highest-risk
+surface. Everything here is a pure string/list builder: no subprocess, no disk,
+no ffmpeg. The caller runs the argv through the existing drained
+:func:`media_studio.ffmpeg.run` seam.
+
+The graph, for insertion ``i`` on ffmpeg input ``i+1`` (input 0 is the clip):
+
+``cutaway``
+    ``[i+1:v]scale=W:H:force_original_aspect_ratio=increase,crop=W:H,
+    setpts=PTS-STARTPTS+S/TB[bi]`` then overlaid at ``0:0``. The b-roll fills
+    the frame for its window.
+``pip``
+    ``[i+1:v]scale=<even px>:-2,setpts=…[bi]`` then overlaid in a padded corner.
+
+Three details that are load-bearing and easy to get wrong:
+
+* **``setpts=PTS-STARTPTS+S/TB`` is not decoration.** ``overlay``'s ``enable``
+  gate only chooses *whether* to draw; it does not re-time the overlay input. A
+  b-roll left at PTS 0 would already be ``S`` seconds into itself by the moment
+  its window opens. The shift puts frame 0 of the asset at second ``S`` of the
+  main timeline.
+* **The b-roll's audio is muted by construction, not by a filter.** Only
+  ``-map [vout]`` and ``-map 0:a?`` are emitted, so the speaker's audio survives
+  and no b-roll audio stream is ever selected.
+* **The asset is bounded at INPUT time** (``-loop 1 -t D`` for a still,
+  ``-ss srcStart -t D`` for a clip), so a 10-minute stock clip does not get
+  decoded in full to fill a 4-second window.
+
+Times are formatted to millisecond precision so the argv is byte-deterministic
+and diffable in a test.
+
+NOT covered here, stated plainly: nothing in this module proves ffmpeg accepts
+the graph or renders the pixels. That is the real-ffmpeg tier (design WU BR8:
+ffprobe dims/duration, an in-window frame NCC against the source asset, audio
+intact) and it does NOT run on this branch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from . import brandkit
+
+#: Default export canvas (the 9:16 short this project exists to produce).
+DEFAULT_CANVAS_W = 1080
+DEFAULT_CANVAS_H = 1920
+
+#: PiP inset width, as a percentage of the CANVAS width.
+DEFAULT_PIP_SCALE_PCT = 34.0
+#: The inset corner + padding reuse the brand-kit overlay conventions.
+DEFAULT_PIP_CORNER = brandkit.DEFAULT_CORNER
+DEFAULT_PIP_PADDING = brandkit.DEFAULT_PADDING
+
+#: Asset kinds. Anything that is not ``video`` is treated as a still.
+KIND_VIDEO = "video"
+
+#: Supported window layouts (mirrors ``broll_plan.LAYOUTS``).
+LAYOUTS: tuple[str, ...] = ("cutaway", "pip")
+
+#: The final labelled video pad the muxer maps.
+VOUT = "[vout]"
+
+Insertion = Mapping[str, Any]
+
+
+def _t(seconds: float) -> str:
+    """Millisecond-precision time token (keeps the argv byte-deterministic)."""
+    return f"{float(seconds):.3f}"
+
+
+def _even(value: float) -> int:
+    """The largest EVEN integer <= ``value``, floored at 2.
+
+    libx264 rejects odd dimensions, so a PiP width must be even; ``-2`` on the
+    height then lets ffmpeg keep the aspect ratio and stay even too.
+    """
+    n = int(value)
+    n -= n % 2
+    return max(n, 2)
+
+
+def _duration(insertion: Insertion) -> float:
+    """The window length, preferring an explicit ``duration`` over end-start."""
+    if "duration" in insertion:
+        return float(insertion["duration"])
+    return float(insertion["end"]) - float(insertion["start"])
+
+
+def build_input_args(insertions: Sequence[Insertion]) -> list[str]:
+    """The ``-i`` argument groups for every b-roll asset, in insertion order.
+
+    A still is ``-loop 1 -t D`` (one image stretched across the window); a video
+    is ``-ss srcStart -t D`` (fast-seek to the asset's own offset, then take
+    exactly the window's worth). Both bound the decode to the window.
+    """
+    args: list[str] = []
+    for insertion in insertions:
+        duration = _t(_duration(insertion))
+        if str(insertion.get("kind", "")) == KIND_VIDEO:
+            args += ["-ss", _t(insertion.get("sourceStart", 0.0)), "-t", duration]
+        else:
+            args += ["-loop", "1", "-t", duration]
+        args += ["-i", str(insertion.get("path", ""))]
+    return args
+
+
+def _prepare_chain(
+    insertion: Insertion,
+    input_index: int,
+    label: str,
+    *,
+    canvas_w: int,
+    canvas_h: int,
+    pip_corner: str,
+    pip_padding: int,
+    pip_scale_pct: float,
+) -> tuple[str, str]:
+    """The per-asset prepare chain and the ``overlay`` x:y for its layout."""
+    layout = str(insertion.get("layout", "cutaway"))
+    shift = f"setpts=PTS-STARTPTS+{_t(insertion['start'])}/TB"
+    if layout == "cutaway":
+        scale = f"scale={canvas_w}:{canvas_h}:force_original_aspect_ratio=increase,crop={canvas_w}:{canvas_h}"
+        return f"[{input_index}:v]{scale},{shift}[{label}]", "0:0"
+    if layout == "pip":
+        if pip_scale_pct <= 0:
+            raise ValueError(f"pipScalePct must be > 0, got {pip_scale_pct}")
+        width = _even(canvas_w * pip_scale_pct / 100.0)
+        # brandkit._corner_xy is the SINGLE source of the corner expression
+        # table; calling it (rather than re-deriving the four cases) is what
+        # keeps the b-roll inset and the brand logo from drifting apart. It also
+        # validates the corner name for us.
+        return f"[{input_index}:v]scale={width}:-2,{shift}[{label}]", brandkit._corner_xy(pip_corner, pip_padding)
+    raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
+
+
+def build_filtergraph(
+    insertions: Sequence[Insertion],
+    *,
+    canvas_w: int = DEFAULT_CANVAS_W,
+    canvas_h: int = DEFAULT_CANVAS_H,
+    pip_corner: str = DEFAULT_PIP_CORNER,
+    pip_padding: int = DEFAULT_PIP_PADDING,
+    pip_scale_pct: float = DEFAULT_PIP_SCALE_PCT,
+) -> str:
+    """One ``filter_complex`` compositing every window onto the main video.
+
+    Each asset is prepared (scaled/cropped or inset, then time-shifted onto the
+    main timeline) and overlaid with its OWN ``enable='between(t,S,E)'`` gate,
+    chaining ``[v0] -> [v1] -> …`` so all N windows land in a single pass. The
+    graph ends ``format=yuv420p`` so the result plays everywhere.
+    """
+    if not insertions:
+        raise ValueError("compositing needs at least one insertion")
+    prepares: list[str] = []
+    overlays: list[str] = []
+    source = "[0:v]"
+    last = ""
+    for index, insertion in enumerate(insertions):
+        label = f"b{index}"
+        chain, xy = _prepare_chain(
+            insertion,
+            index + 1,
+            label,
+            canvas_w=canvas_w,
+            canvas_h=canvas_h,
+            pip_corner=pip_corner,
+            pip_padding=pip_padding,
+            pip_scale_pct=pip_scale_pct,
+        )
+        prepares.append(chain)
+        last = f"v{index}"
+        gate = f"enable='between(t,{_t(insertion['start'])},{_t(insertion['end'])})'"
+        overlays.append(f"{source}[{label}]overlay={xy}:eof_action=pass:{gate}[{last}]")
+        source = f"[{last}]"
+    return ";".join([*prepares, *overlays, f"[{last}]format=yuv420p{VOUT}"])
+
+
+def build_broll_argv(
+    clip_path: str,
+    insertions: Sequence[Insertion],
+    out_path: str,
+    *,
+    settings: Mapping[str, Any] | None = None,
+    canvas_w: int = DEFAULT_CANVAS_W,
+    canvas_h: int = DEFAULT_CANVAS_H,
+    pip_corner: str = DEFAULT_PIP_CORNER,
+    pip_padding: int = DEFAULT_PIP_PADDING,
+    pip_scale_pct: float = DEFAULT_PIP_SCALE_PCT,
+) -> list[str]:
+    """argv compositing every b-roll window over ``clip_path`` in ONE pass.
+
+    Input 0 is the speaker's clip and its audio is stream-copied through
+    ``-map 0:a?``; inputs 1..N are the b-roll assets, whose audio is never
+    mapped. ``-progress pipe:1 -nostats`` so :func:`ffmpeg.run` drains stdout
+    (the proven seam — never a re-implemented drain). argv LIST only, never
+    ``shell=True``.
+    """
+    if not clip_path:
+        raise ValueError("b-roll compositing requires a clip path")
+    if not out_path:
+        raise ValueError("b-roll compositing requires an output path")
+    if not insertions:
+        raise ValueError("compositing needs at least one insertion")
+    for insertion in insertions:
+        if not str(insertion.get("path", "")):
+            raise ValueError("every insertion needs an asset path")
+        if _duration(insertion) <= 0:
+            raise ValueError(f"insertion duration must be > 0, got {_duration(insertion)}")
+
+    from .. import ffmpeg as _ffmpeg  # lazy: keep module import-light
+
+    filter_complex = build_filtergraph(
+        insertions,
+        canvas_w=canvas_w,
+        canvas_h=canvas_h,
+        pip_corner=pip_corner,
+        pip_padding=pip_padding,
+        pip_scale_pct=pip_scale_pct,
+    )
+    return [
+        _ffmpeg.ffmpeg_path(settings),
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-i",
+        clip_path,
+        *build_input_args(insertions),
+        "-filter_complex",
+        filter_complex,
+        "-map",
+        VOUT,
+        "-map",
+        "0:a?",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "copy",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        out_path,
+    ]
+
+
+__all__ = [
+    "DEFAULT_CANVAS_H",
+    "DEFAULT_CANVAS_W",
+    "DEFAULT_PIP_CORNER",
+    "DEFAULT_PIP_PADDING",
+    "DEFAULT_PIP_SCALE_PCT",
+    "KIND_VIDEO",
+    "LAYOUTS",
+    "VOUT",
+    "build_broll_argv",
+    "build_filtergraph",
+    "build_input_args",
+]

--- a/sidecar/media_studio/features/broll_index.py
+++ b/sidecar/media_studio/features/broll_index.py
@@ -1,0 +1,252 @@
+"""PURE b-roll asset index: persisted shape, staleness, incremental refresh.
+
+The only state auto-b-roll owns is a vector per library asset. This module is
+the shape of that state and the arithmetic around it — no model, no disk, no
+network. The caller reads/writes the JSON and supplies the embeddings; the two
+concerns kept here are the two that can be quietly, confidently wrong:
+
+**A stale row.** A file was re-exported but its vector was not recomputed, so
+the planner ranks the OLD picture and cheerfully reports a high cosine.
+:func:`fingerprint` is the staleness key — ``sha256`` over ``(path, size,
+mtime)``, the same style as ``vision_ops._transcript_fp``'s corpus fingerprint —
+and :func:`refresh_plan` re-embeds ONLY the rows whose fingerprint moved. Note
+what that key is and is not (this is a real limit, not a nit): it is a
+cheap-stat fingerprint, not a content hash, so an edit that preserves both size
+and mtime is invisible to it. The library's own ``content_hash`` is the stronger
+key and is the upgrade path; ``force=True`` is the escape hatch today. UNVERIFIED
+whether a size+mtime collision occurs in practice for this workload — the
+experiment is to fingerprint a real asset folder both ways and diff the sets.
+
+**A model mismatch.** A cross-modal cosine is only meaningful inside ONE joint
+space, so scoring a SigLIP-2 *text* vector against a Nomic *image* vector yields
+a number that is confident and meaningless. The index therefore records the
+``model`` it was built with and :func:`require_model` raises
+:class:`StaleIndexError` rather than letting a query cross spaces.
+
+Persisted shape (a sidecar JSON, mirroring the ``<videoId>.index.json``
+convention — vectors never live in a manifest body)::
+
+    {"version": 1, "model": "<hf id>", "dim": 768, "builtAt": "<iso>",
+     "assets": [{"assetId", "path", "kind", "durationSec", "fingerprint",
+                 "vector": [...]}, ...]}
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Mapping, Sequence
+from typing import Any, TypedDict
+
+#: Bump when the persisted shape changes incompatibly.
+INDEX_VERSION = 1
+
+Vector = Sequence[float]
+
+
+class IndexedAsset(TypedDict):
+    """One library asset and the image embedding that stands for it."""
+
+    assetId: str
+    path: str
+    kind: str
+    durationSec: float | None
+    fingerprint: str
+    vector: list[float]
+
+
+class BrollIndex(TypedDict):
+    """The whole persisted index."""
+
+    version: int
+    model: str
+    dim: int
+    builtAt: str
+    assets: list[IndexedAsset]
+
+
+class RefreshPlan(TypedDict):
+    """What :func:`merge` needs: which rows to embed, which vectors to reuse."""
+
+    rebuildAll: bool
+    model: str
+    embed: list[tuple[int, dict[str, Any]]]
+    reuse: dict[str, list[float]]
+
+
+class BrollIndexError(RuntimeError):
+    """A b-roll index problem the caller must surface, never swallow."""
+
+
+class StaleIndexError(BrollIndexError):
+    """The index cannot answer this query (absent, or a different joint space)."""
+
+
+def fingerprint(asset: Mapping[str, Any]) -> str:
+    """A stable staleness key for ``asset``: ``sha256(path|size|mtime)``.
+
+    See the module docstring for the honest limit — this is cheap stat metadata,
+    not a content hash, so a same-size same-mtime rewrite is invisible to it.
+    """
+    payload = "|".join(
+        (
+            str(asset.get("path", "")),
+            str(asset.get("sizeBytes", "")),
+            str(asset.get("mtime", "")),
+        )
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _row(asset: Mapping[str, Any], vector: Vector) -> IndexedAsset:
+    duration = asset.get("durationSec")
+    return IndexedAsset(
+        assetId=str(asset.get("assetId", "")),
+        path=str(asset.get("path", "")),
+        kind=str(asset.get("kind", "image")),
+        durationSec=None if duration is None else float(duration),
+        fingerprint=fingerprint(asset),
+        vector=[float(v) for v in vector],
+    )
+
+
+def build(
+    assets: Sequence[Mapping[str, Any]],
+    vectors: Sequence[Vector],
+    *,
+    model: str,
+    built_at: str,
+) -> BrollIndex:
+    """A complete index over ``assets`` and their image embeddings.
+
+    Every vector must share one dimension — a ragged matrix means two different
+    towers produced them, which is the model-mismatch failure one step earlier.
+    """
+    if not model:
+        raise ValueError("an index must record the model that built it")
+    if len(vectors) != len(assets):
+        raise ValueError(f"need one vector per asset: {len(vectors)} vectors vs {len(assets)} assets")
+    dims = {len(v) for v in vectors}
+    if len(dims) > 1:
+        raise ValueError(f"every vector must have the same dimension, got {sorted(dims)}")
+    return BrollIndex(
+        version=INDEX_VERSION,
+        model=model,
+        dim=dims.pop() if dims else 0,
+        builtAt=built_at,
+        assets=[_row(asset, vector) for asset, vector in zip(assets, vectors, strict=True)],
+    )
+
+
+def rows(index: BrollIndex) -> tuple[list[dict[str, Any]], list[list[float]]]:
+    """Split ``index`` into the ``(assets, vectors)`` pair the planner takes.
+
+    The asset dicts deliberately drop ``vector``: ``broll_plan`` receives the
+    matrix as its own argument, so carrying it twice invites the two copies to
+    disagree.
+    """
+    assets = [{k: v for k, v in row.items() if k != "vector"} for row in index["assets"]]
+    return assets, [list(row["vector"]) for row in index["assets"]]
+
+
+def require_model(index: BrollIndex | None, model: str) -> None:
+    """Refuse LOUDLY unless ``index`` lives in ``model``'s joint space."""
+    if index is None:
+        raise StaleIndexError("the b-roll library has not been indexed yet; run broll.index first")
+    if index["model"] != model:
+        raise StaleIndexError(
+            f"the b-roll index was built with {index['model']!r} but the query uses {model!r}; "
+            "a cross-modal cosine is only valid inside one joint space — re-index to switch backbone"
+        )
+
+
+def refresh_plan(
+    index: BrollIndex | None,
+    assets: Sequence[Mapping[str, Any]],
+    *,
+    model: str,
+    force: bool = False,
+) -> RefreshPlan:
+    """Decide which of ``assets`` actually need embedding.
+
+    Everything is re-embedded when there is no index, when ``force`` is set, or
+    when ``model`` differs from the index's — the last because vectors from a
+    different tower cannot be mixed into one space. Otherwise only the rows
+    whose :func:`fingerprint` moved (or that are new) are listed in ``embed``;
+    the rest are reused verbatim. Assets no longer in the library simply do not
+    appear, which is how a removal prunes the index without a rebuild.
+    """
+    rebuild_all = force or index is None or index["model"] != model
+    reuse: dict[str, list[float]] = {}
+    if not rebuild_all and index is not None:
+        reuse = {row["fingerprint"]: list(row["vector"]) for row in index["assets"]}
+    embed = [(i, dict(asset)) for i, asset in enumerate(assets) if fingerprint(asset) not in reuse]
+    return RefreshPlan(rebuildAll=rebuild_all, model=model, embed=embed, reuse=reuse)
+
+
+def merge(
+    plan: RefreshPlan,
+    assets: Sequence[Mapping[str, Any]],
+    embedded: Mapping[int, Vector],
+    *,
+    model: str,
+    built_at: str,
+) -> BrollIndex:
+    """Fold freshly-computed vectors back onto ``plan``'s reused ones.
+
+    ``embedded`` maps an index into ``assets`` to the vector just computed for
+    it — exactly the positions ``plan['embed']`` asked for. A position the plan
+    asked for and the caller did not supply is a bug and raises, rather than
+    silently persisting a row with no vector.
+    """
+    vectors: list[Vector] = []
+    for position, asset in enumerate(assets):
+        if position in embedded:
+            vectors.append(embedded[position])
+            continue
+        cached = plan["reuse"].get(fingerprint(asset))
+        if cached is None:
+            raise ValueError(f"no embedding supplied for asset {position} ({asset.get('path', '')!r})")
+        vectors.append(cached)
+    return build(assets, vectors, model=model, built_at=built_at)
+
+
+def status(
+    index: BrollIndex | None,
+    assets: Sequence[Mapping[str, Any]],
+    *,
+    model: str,
+) -> dict[str, Any]:
+    """The freshness snapshot the UI renders (a pure read; no provider call).
+
+    ``staleCount`` is how many library assets would have to be embedded to make
+    the index current — the whole library on a model change, which is why the
+    UI can honestly say "switching backbone means a full re-index".
+    """
+    plan = refresh_plan(index, assets, model=model)
+    stale_count = len(plan["embed"])
+    return {
+        "indexed": index is not None,
+        "assetCount": 0 if index is None else len(index["assets"]),
+        "libraryCount": len(assets),
+        "model": "" if index is None else index["model"],
+        "dim": 0 if index is None else index["dim"],
+        "stale": stale_count > 0 or plan["rebuildAll"],
+        "staleCount": stale_count,
+    }
+
+
+__all__ = [
+    "INDEX_VERSION",
+    "BrollIndex",
+    "BrollIndexError",
+    "IndexedAsset",
+    "RefreshPlan",
+    "StaleIndexError",
+    "build",
+    "fingerprint",
+    "merge",
+    "refresh_plan",
+    "require_model",
+    "rows",
+    "status",
+]

--- a/sidecar/media_studio/features/broll_ops.py
+++ b/sidecar/media_studio/features/broll_ops.py
@@ -230,10 +230,10 @@ def make_image_embedder(
     """An ``embed_images`` seam over the SigLIP-2 image tower.
 
     Loads ONE representative frame per asset (a still is itself; a video is its
-    mid-frame — see ``flagship-auto-broll.md`` §11.3, which flags mean-pooling
-    several frames as the more robust but unmeasured alternative), stacks them
-    into a single batch so the tower is entered once, and returns plain float
-    lists the index can persist as JSON.
+    mid-frame — see docs/plans/v1.5/flagship-auto-broll.md §11.3, which flags
+    mean-pooling several frames as the more robust but unmeasured alternative),
+    stacks them into a single batch so the tower is entered once, and returns
+    plain float lists the index can persist as JSON.
 
     Both heavy defaults are injectable, which is what lets this batching and
     conversion logic be covered with a fake tower instead of a real checkpoint.

--- a/sidecar/media_studio/features/broll_ops.py
+++ b/sidecar/media_studio/features/broll_ops.py
@@ -1,0 +1,356 @@
+"""The ``broll.*`` RPC surface: index -> status -> suggest -> apply.
+
+Ties the three pure b-roll modules to the wire. It owns orchestration only —
+sequencing, params, jobs, and error shape — while every heavy edge is an
+injected seam:
+
+===================== =====================================================
+seam                  what it hides
+===================== =====================================================
+``embed_images``      the SigLIP-2 image tower (``BackboneBackend``)
+``embed_texts``       the SigLIP-2 text tower (the SAME joint space)
+``load_index`` /      the on-disk vector sidecar
+``save_index``
+``load_transcript``   the project's transcript
+``resolver``          videoId -> media path
+``duration``          ffprobe
+``run``               the drained ``ffmpeg.run``
+===================== =====================================================
+
+so the whole surface is exercised with plain lists and no model, exactly as
+``vlm_backbone``'s pure scorers are.
+
+Wire surface (NET-NEW)::
+
+    broll.status({})                              -> {indexed, assetCount, libraryCount,
+                                                      model, dim, stale, staleCount, willEgress}
+    broll.index({force?})                         -> {jobId} -> {assetCount, embedded, model, willEgress}
+    broll.suggest({videoId, threshold?, ...})     -> {jobId} -> {insertions, reason, willEgress}
+    broll.apply({videoId, insertions})            -> {jobId} -> {path, inserted}
+
+**``willEgress`` is False by construction, and that is the point.** Auto-b-roll
+is asset RETRIEVAL over the user's OWN library using LOCAL embeddings: no frame
+and no transcript text ever leaves the machine, so ``consent.require_frame_consent``
+/ ``require_text_consent`` are simply not reachable from here and no method may
+join the key-injection allowlist (which is driven by the ``ai.`` / ``director.``
+/ ``shortmaker.`` / ``index.`` prefixes — ``broll.`` is none of them). If a future
+variant ever routes a frame or a segment to a CLOUD VLM, THAT path must re-trigger
+the consent gates; keeping distillation local is what keeps this gate-free.
+
+**``apply`` is review-first.** It composites exactly the insertion list handed to
+it and never re-plans, so what the user accepted in the inspector is what gets
+rendered.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from .. import protocol
+from ..jobs import JobContext
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import get_logger
+from . import broll_compose, broll_index, broll_plan
+
+log = get_logger("media_studio.broll")
+
+#: The methods this module owns (asserted against the registration in tests).
+METHODS = ("broll.status", "broll.index", "broll.suggest", "broll.apply")
+
+#: The default matcher — already vendored and registered (Apache-2.0).
+DEFAULT_MODEL_ID = "google/siglip2-so400m-patch16-384"
+
+#: The honest empty state. "No confident match" is a RESULT, not an error, and
+#: not an excuse to insert something anyway.
+NO_CONFIDENT_MATCH = "no confident match"
+MATCHED = "matched"
+
+Resolver = Callable[[str], str | None]
+AssetLister = Callable[[], Sequence[Mapping[str, Any]]]
+IndexLoader = Callable[[], Any]
+IndexSaver = Callable[[Any], None]
+TranscriptLoader = Callable[[str], Mapping[str, Any]]
+Embedder = Callable[[Sequence[str]], Sequence[Sequence[float]]]
+ProbeFn = Callable[..., float]
+RunFn = Callable[..., int]
+Clock = Callable[[], str]
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _require_str(params: Mapping[str, Any], key: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value:
+        raise _invalid(f"{key} (str) is required")
+    return value
+
+
+def _opt_float(params: Mapping[str, Any], key: str, default: float) -> float:
+    value = params.get(key, default)
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return default
+
+
+def _utc_now() -> str:
+    from datetime import UTC, datetime  # noqa: PLC0415 - keep module import-light
+
+    return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _no_backbone(_paths: Sequence[str]) -> Sequence[Sequence[float]]:  # pragma: no cover - heavy seam
+    """Default embedder: the real SigLIP-2 tower is wired by the composition root."""
+    raise RpcError(
+        "no local image/text backbone is wired; install the SigLIP-2 assets first",
+        ErrorCode.INTERNAL_ERROR,
+    )
+
+
+class BrollComposeError(RuntimeError):
+    """The composite ffmpeg pass failed (non-zero exit)."""
+
+
+class BrollOps:
+    """Owns the four ``broll.*`` methods over injected seams."""
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver,
+        list_assets: AssetLister,
+        load_index: IndexLoader,
+        save_index: IndexSaver,
+        load_transcript: TranscriptLoader,
+        out_dir: str | os.PathLike,
+        embed_images: Embedder | None = None,
+        embed_texts: Embedder | None = None,
+        settings_provider: Callable[[], dict[str, Any]] | None = None,
+        duration: ProbeFn | None = None,
+        run: RunFn | None = None,
+        model_id: str = DEFAULT_MODEL_ID,
+        clock: Clock | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._list_assets = list_assets
+        self._load_index = load_index
+        self._save_index = save_index
+        self._load_transcript = load_transcript
+        self._out_dir = Path(out_dir)
+        self._embed_images = embed_images or _no_backbone
+        self._embed_texts = embed_texts or _no_backbone
+        self._settings_provider = settings_provider or dict
+        self._duration = duration
+        self._run = run
+        self._model_id = model_id
+        self._clock = clock or _utc_now
+
+    # -- helpers ------------------------------------------------------------ #
+    def _settings(self) -> dict[str, Any]:
+        try:
+            return dict(self._settings_provider() or {})
+        except Exception:  # noqa: BLE001 - settings must never break an op
+            return {}
+
+    def _resolve(self, params: Mapping[str, Any]) -> str:
+        video_id = _require_str(params, "videoId")
+        resolved = self._resolver(video_id)
+        if not resolved:
+            raise _invalid(f"unknown video: {video_id}")
+        return str(resolved)
+
+    @staticmethod
+    def _jobs(ctx: RpcContext):
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        return ctx.jobs
+
+    # -- broll.status ------------------------------------------------------- #
+    def status(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``broll.status({})`` -> the index freshness snapshot. Direct, pure read.
+
+        No provider call and no model load, exactly like ``index.status``.
+        """
+        snapshot = broll_index.status(self._load_index(), list(self._list_assets()), model=self._model_id)
+        return {**snapshot, "willEgress": False}
+
+    # -- broll.index -------------------------------------------------------- #
+    def index(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``broll.index({force?})`` -> ``{jobId}`` -> ``{assetCount, embedded, model}``.
+
+        Embeds ONLY the assets whose fingerprint moved (or everything on
+        ``force``/a backbone change), then persists the merged index.
+        """
+        jobs = self._jobs(ctx)
+        force = bool(params.get("force", False))
+
+        def job_body(job_ctx: JobContext) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            assets = list(self._list_assets())
+            plan = broll_index.refresh_plan(self._load_index(), assets, model=self._model_id, force=force)
+            job_ctx.progress(10, f"embedding {len(plan['embed'])} of {len(assets)} assets")
+            vectors = list(self._embed_images([str(a.get("path", "")) for _i, a in plan["embed"]]))
+            if len(vectors) != len(plan["embed"]):
+                raise RpcError(
+                    f"the image backbone returned {len(vectors)} vectors for {len(plan['embed'])} assets",
+                    ErrorCode.INTERNAL_ERROR,
+                )
+            embedded = {position: vectors[n] for n, (position, _a) in enumerate(plan["embed"])}
+            merged = broll_index.merge(plan, assets, embedded, model=self._model_id, built_at=self._clock())
+            self._save_index(merged)
+            job_ctx.progress(100, f"indexed {len(assets)} b-roll assets")
+            return {
+                "assetCount": len(assets),
+                "embedded": len(embedded),
+                "model": self._model_id,
+                "willEgress": False,
+            }
+
+        return {"jobId": jobs.start(job_body).id}
+
+    # -- broll.suggest ------------------------------------------------------ #
+    def suggest(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``broll.suggest({videoId, threshold?, maxCoveragePct?, layout?})``.
+
+        -> ``{jobId}`` -> ``{insertions, reason, willEgress}``. One text-embed
+        pass over the transcript, then the PURE planner. Refuses a library that
+        is unindexed or indexed by a different backbone, rather than scoring
+        across joint spaces.
+        """
+        jobs = self._jobs(ctx)
+        media_path = self._resolve(params)
+        video_id = _require_str(params, "videoId")
+        threshold = _opt_float(params, "threshold", broll_plan.DEFAULT_MIN_SIMILARITY)
+        coverage = _opt_float(params, "maxCoveragePct", broll_plan.DEFAULT_MAX_COVERAGE_PCT)
+        layout = str(params.get("layout") or broll_plan.DEFAULT_LAYOUT)
+        settings = self._settings()
+
+        def job_body(job_ctx: JobContext) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            index = self._load_index()
+            broll_index.require_model(index, self._model_id)
+            assets, asset_vecs = broll_index.rows(index)
+            transcript = dict(self._load_transcript(video_id) or {})
+            segments = list(transcript.get("segments") or [])
+            if not segments:
+                raise _invalid(f"{video_id} has no transcript yet; run transcribe.start first")
+            job_ctx.progress(20, f"matching {len(segments)} segments against {len(assets)} assets")
+            segment_vecs = list(self._embed_texts([str(s.get("text", "")) for s in segments]))
+            total = self._duration(media_path, settings) if self._duration else float(segments[-1].get("end", 0.0))
+            insertions = broll_plan.plan(
+                segments,
+                segment_vecs,
+                assets,
+                asset_vecs,
+                total_sec=float(total),
+                threshold=threshold,
+                layout=layout,
+                max_coverage_pct=coverage,
+            )
+            job_ctx.progress(100, f"{len(insertions)} b-roll insertion(s)")
+            return {
+                "insertions": insertions,
+                "reason": MATCHED if insertions else NO_CONFIDENT_MATCH,
+                "willEgress": False,
+            }
+
+        return {"jobId": jobs.start(job_body).id}
+
+    # -- broll.apply -------------------------------------------------------- #
+    def apply(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``broll.apply({videoId, insertions})`` -> ``{jobId}`` -> ``{path, inserted}``.
+
+        Composites the REVIEWED plan verbatim — no re-ranking, no second model
+        pass — into a NEW file, leaving the source untouched.
+        """
+        jobs = self._jobs(ctx)
+        media_path = self._resolve(params)
+        insertions = params.get("insertions") or []
+        if not isinstance(insertions, list) or not insertions:
+            raise _invalid("insertions (a non-empty list) is required")
+        settings = self._settings()
+        run = self._run
+        out_dir = self._out_dir
+
+        def job_body(job_ctx: JobContext) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = str(out_dir / f"{Path(media_path).stem or 'clip'}.broll.mp4")
+            argv = broll_compose.build_broll_argv(media_path, insertions, out_path, settings=settings)
+            job_ctx.progress(10, f"compositing {len(insertions)} b-roll window(s)")
+            code = (run or _default_run)(argv)
+            if code != 0:
+                raise BrollComposeError(f"b-roll composite failed (ffmpeg exit {code}) for {media_path}")
+            job_ctx.progress(100, f"composited {len(insertions)} b-roll window(s)")
+            return {"path": out_path, "inserted": len(insertions)}
+
+        return {"jobId": jobs.start(job_body).id}
+
+
+def _default_run(argv: list[str]) -> int:  # pragma: no cover - the real drained seam
+    from .. import ffmpeg as _ffmpeg  # noqa: PLC0415 - keep module import-light
+
+    return _ffmpeg.run(argv)
+
+
+def register(
+    *,
+    resolver: Resolver,
+    list_assets: AssetLister,
+    load_index: IndexLoader,
+    save_index: IndexSaver,
+    load_transcript: TranscriptLoader,
+    out_dir: str | os.PathLike,
+    embed_images: Embedder | None = None,
+    embed_texts: Embedder | None = None,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+    duration: ProbeFn | None = None,
+    run: RunFn | None = None,
+    model_id: str = DEFAULT_MODEL_ID,
+    clock: Clock | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> BrollOps:
+    """Create the service and register every ``broll.*`` method.
+
+    Mirrors ``silencetrim.register`` / ``tracks_audio.register``: ``register_fn``
+    defaults to :func:`protocol.register` (a duplicate name fails loudly at
+    startup) and tests inject a collecting registrar.
+    """
+    service = BrollOps(
+        resolver=resolver,
+        list_assets=list_assets,
+        load_index=load_index,
+        save_index=save_index,
+        load_transcript=load_transcript,
+        out_dir=out_dir,
+        embed_images=embed_images,
+        embed_texts=embed_texts,
+        settings_provider=settings_provider,
+        duration=duration,
+        run=run,
+        model_id=model_id,
+        clock=clock,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("broll.status", service.status)
+    reg("broll.index", service.index)
+    reg("broll.suggest", service.suggest)
+    reg("broll.apply", service.apply)
+    log.info("registered %s", ", ".join(METHODS))
+    return service
+
+
+__all__ = [
+    "DEFAULT_MODEL_ID",
+    "METHODS",
+    "MATCHED",
+    "NO_CONFIDENT_MATCH",
+    "BrollComposeError",
+    "BrollOps",
+    "register",
+]

--- a/sidecar/media_studio/features/broll_ops.py
+++ b/sidecar/media_studio/features/broll_ops.py
@@ -44,6 +44,8 @@ rendered.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 from collections.abc import Callable, Mapping, Sequence
 from pathlib import Path
@@ -79,8 +81,78 @@ RunFn = Callable[..., int]
 Clock = Callable[[], str]
 
 
+#: Settings key naming the folder the user keeps their b-roll in.
+BROLL_DIR_KEY = "brollDir"
+#: The index sidecar's filename under the data dir.
+INDEX_FILENAME = "broll.index.json"
+
+#: What counts as b-roll. Matched case-INSENSITIVELY: cameras write ``.MP4``
+#: and ``.JPG``, and a library that silently skipped those would report an
+#: empty folder the user can see files in.
+IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".bmp", ".gif"})
+VIDEO_EXTS = frozenset({".mp4", ".mov", ".mkv", ".webm", ".m4v", ".avi"})
+
+
 def _invalid(message: str) -> RpcError:
     return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def scan_assets(root: str | os.PathLike) -> list[dict[str, Any]]:
+    """Every b-roll file under ``root``, as planner/index-shaped asset dicts.
+
+    Walks recursively in sorted order so the index — and therefore every plan
+    built from it — is reproducible run to run. Each row carries the ``path``,
+    ``sizeBytes`` and ``mtime`` that :func:`broll_index.fingerprint` hashes, plus
+    a stable ``assetId`` derived from the path (so re-scanning the same folder
+    keeps the same ids and an accepted suggestion still resolves).
+
+    A missing or unconfigured folder yields ``[]``: that is the normal first-run
+    state, not an error.
+    """
+    if not root:
+        return []
+    base = Path(root)
+    if not base.is_dir():
+        return []
+    assets: list[dict[str, Any]] = []
+    for path in sorted(base.rglob("*")):
+        suffix = path.suffix.lower()
+        kind = "image" if suffix in IMAGE_EXTS else "video" if suffix in VIDEO_EXTS else None
+        if kind is None or not path.is_file():
+            continue
+        stat = path.stat()
+        assets.append(
+            {
+                "assetId": hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:16],
+                "path": str(path),
+                "kind": kind,
+                "sizeBytes": stat.st_size,
+                "mtime": stat.st_mtime,
+                "durationSec": None,
+            }
+        )
+    return assets
+
+
+def load_index_file(path: str | os.PathLike) -> Any:
+    """Read the index sidecar, or ``None`` when it is absent or unreadable.
+
+    A half-written or hand-edited sidecar degrades to "not indexed" — a state
+    the UI can act on with a re-index button — rather than taking the sidecar
+    process down at startup.
+    """
+    try:
+        raw = json.loads(Path(path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def save_index_file(path: str | os.PathLike, index: Any) -> None:
+    """Write the index sidecar, creating its parent directory."""
+    target = Path(path)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(index), encoding="utf-8")
 
 
 def _require_str(params: Mapping[str, Any], key: str) -> str:
@@ -104,12 +176,107 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z")
 
 
-def _no_backbone(_paths: Sequence[str]) -> Sequence[Sequence[float]]:  # pragma: no cover - heavy seam
+def _no_backbone(_paths: Sequence[str]) -> Sequence[Sequence[float]]:  # pragma: no cover - unwired-default guard
     """Default embedder: the real SigLIP-2 tower is wired by the composition root."""
     raise RpcError(
         "no local image/text backbone is wired; install the SigLIP-2 assets first",
         ErrorCode.INTERNAL_ERROR,
     )
+
+
+# --------------------------------------------------------------------------- #
+# the backbone adapters — the ONE heavy edge, split so the logic is testable
+# --------------------------------------------------------------------------- #
+def _default_backbone_factory(settings: dict[str, Any]) -> Any:  # pragma: no cover - heavy seam
+    """The real SigLIP-2 backbone (reuses the shipped ``vlm_backbone`` factory)."""
+    from . import vlm_backbone as _vlm  # noqa: PLC0415 - heavy seam
+
+    return _vlm._default_backbone_factory(settings)
+
+
+def _default_asset_frame(path: str, kind: str) -> Any:  # pragma: no cover - runtime native (cv2)
+    """One representative BGR frame for ``path`` (mid-frame for a video).
+
+    Mirrors ``vlm_backbone._default_frame_loader``'s cv2 usage; excluded from
+    coverage for the same reason (cv2 is a GPU-host dependency, not a gate one),
+    with the logic that CONSUMES it covered via an injected loader.
+    """
+    import cv2  # noqa: PLC0415 - job-time native
+
+    if kind != "video":
+        return cv2.imread(path)
+    cap = cv2.VideoCapture(path)
+    try:
+        frames = cap.get(cv2.CAP_PROP_FRAME_COUNT) or 0
+        if frames > 0:
+            cap.set(cv2.CAP_PROP_POS_FRAMES, int(frames // 2))
+        _ok, frame = cap.read()
+        return frame
+    finally:
+        cap.release()
+
+
+def _rows(matrix: Any) -> list[list[float]]:
+    """A backbone's ``(N, D)`` output as plain JSON-safe float lists."""
+    return [[float(v) for v in row] for row in matrix]
+
+
+def make_image_embedder(
+    *,
+    backend_factory: Callable[[dict[str, Any]], Any] | None = None,
+    frame_loader: Callable[[str, str], Any] | None = None,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+) -> Embedder:
+    """An ``embed_images`` seam over the SigLIP-2 image tower.
+
+    Loads ONE representative frame per asset (a still is itself; a video is its
+    mid-frame — see ``flagship-auto-broll.md`` §11.3, which flags mean-pooling
+    several frames as the more robust but unmeasured alternative), stacks them
+    into a single batch so the tower is entered once, and returns plain float
+    lists the index can persist as JSON.
+
+    Both heavy defaults are injectable, which is what lets this batching and
+    conversion logic be covered with a fake tower instead of a real checkpoint.
+    UNVERIFIED: no test on this branch runs the REAL SigLIP-2 tower or cv2 —
+    the settling experiment is design WU BR8's real-model tier (embed a dog
+    frame and a cityscape decoy, assert the dog out-scores the decoy).
+    """
+    factory = backend_factory or _default_backbone_factory
+    loader = frame_loader or _default_asset_frame
+    provider = settings_provider or dict
+
+    def embed(paths: Sequence[str]) -> Sequence[Sequence[float]]:
+        if not paths:
+            return []
+        import numpy as np  # noqa: PLC0415 - keep module import-light
+
+        backend = factory(provider())
+        frames = [loader(str(path), "video" if Path(path).suffix.lower() in VIDEO_EXTS else "image") for path in paths]
+        return _rows(backend.embed_images(np.stack(frames)))
+
+    return embed
+
+
+def make_text_embedder(
+    *,
+    backend_factory: Callable[[dict[str, Any]], Any] | None = None,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+) -> Embedder:
+    """An ``embed_texts`` seam over the SigLIP-2 TEXT tower.
+
+    Must be the same family as :func:`make_image_embedder`'s tower — a
+    cross-modal cosine is only meaningful inside one joint space, which is the
+    invariant ``broll_index.require_model`` enforces at query time.
+    """
+    factory = backend_factory or _default_backbone_factory
+    provider = settings_provider or dict
+
+    def embed(texts: Sequence[str]) -> Sequence[Sequence[float]]:
+        if not texts:
+            return []
+        return _rows(factory(provider()).embed_texts(list(texts)))
+
+    return embed
 
 
 class BrollComposeError(RuntimeError):
@@ -346,11 +513,20 @@ def register(
 
 
 __all__ = [
+    "BROLL_DIR_KEY",
     "DEFAULT_MODEL_ID",
-    "METHODS",
+    "IMAGE_EXTS",
+    "INDEX_FILENAME",
     "MATCHED",
+    "METHODS",
     "NO_CONFIDENT_MATCH",
+    "VIDEO_EXTS",
     "BrollComposeError",
     "BrollOps",
+    "load_index_file",
+    "make_image_embedder",
+    "make_text_embedder",
     "register",
+    "save_index_file",
+    "scan_assets",
 ]

--- a/sidecar/media_studio/features/broll_plan.py
+++ b/sidecar/media_studio/features/broll_plan.py
@@ -43,10 +43,10 @@ to a softmax-CLIP tier, so :data:`DEFAULT_MIN_SIMILARITY` is the so400m default
 only and a caller on another tier must pass its own calibrated value.
 UNVERIFIED: that default is a placeholder carried from the design doc, NOT a
 calibrated number — no labelled probe set has been measured on this branch. The
-experiment that would settle it is flagship-auto-broll.md §11.2 (20-30
-(segment, relevant-asset, decoy) triples per tier, pick the precision/recall
-knee). Until then treat the default as "requires a threshold slider", not as a
-tuned constant.
+experiment that would settle it is docs/plans/v1.5/flagship-auto-broll.md §11.2
+(20-30 (segment, relevant-asset, decoy) triples per tier, pick the
+precision/recall knee). Until then treat the default as "requires a threshold
+slider", not as a tuned constant.
 """
 
 from __future__ import annotations

--- a/sidecar/media_studio/features/broll_plan.py
+++ b/sidecar/media_studio/features/broll_plan.py
@@ -1,0 +1,428 @@
+"""PURE auto-b-roll planner (v1.5 flagship #3, WU BR3+BR4).
+
+Turns *already-embedded* transcript segments and *already-embedded* library
+assets into a list of timed B-roll insertions. It is the decision half of the
+feature and it is deliberately model-free: no torch, no ffmpeg, no network, no
+disk. The heavy cross-modal embedding lives behind the existing
+:class:`~media_studio.features.vlm_backbone.BackboneBackend` seam
+(``embed_images`` / ``embed_texts``); this module only consumes the vectors that
+seam produced, which is what lets every branch below be covered deterministically
+with hand-built arrays instead of a mocked model.
+
+Four stages, each its own function so each is separately testable:
+
+``rank_assets``
+    The cross-modal INVERSION of the existing text index. The shipped
+    :func:`semantic_index.search` ranks *segments* against a query; here the
+    corpus rows are **assets** and the query is a **segment's text vector**, so
+    the same function — with its length-guarded
+    :func:`diarize.cosine_similarity`, its stable tie ordering, and its
+    non-positive-``top_k`` guard — is reused verbatim and its ``segmentIndex``
+    is read as the asset row index.
+
+``suggest``
+    The per-segment min-similarity gate. A segment whose best asset scores below
+    ``threshold`` yields **nothing**. That wall is the whole feature: the #1
+    complaint about hosted auto-b-roll is confidently-wrong filler, and the only
+    honest answer to "no confident match" is no insert.
+
+``diversify``
+    Near-duplicate suppression across the accepted suggestions, delegated to the
+    shipped :func:`diversity.dedupe_candidates` (MMR or DPP) over the matched
+    assets' own embeddings.
+
+``place``
+    The editorial constraints: clamp each insert's duration, keep it inside its
+    segment, snap its start to a nearby shot boundary, enforce a minimum gap
+    between inserts, enforce a per-asset cooldown, and cap total coverage as a
+    percentage of the video. Selection is greedy in score order so the cap keeps
+    the *best* inserts; the result is returned chronologically.
+
+Thresholds are per-model: SigLIP-2's sigmoid-loss cosine scale does not transfer
+to a softmax-CLIP tier, so :data:`DEFAULT_MIN_SIMILARITY` is the so400m default
+only and a caller on another tier must pass its own calibrated value.
+UNVERIFIED: that default is a placeholder carried from the design doc, NOT a
+calibrated number — no labelled probe set has been measured on this branch. The
+experiment that would settle it is flagship-auto-broll.md §11.2 (20-30
+(segment, relevant-asset, decoy) triples per tier, pick the precision/recall
+knee). Until then treat the default as "requires a threshold slider", not as a
+tuned constant.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any, Literal, TypedDict
+
+from . import diversity, semantic_index
+
+#: A dense vector (one per asset, or the per-segment text query).
+Vector = Sequence[float]
+
+#: How an insert is composited. ``cutaway`` replaces the frame for its window;
+#: ``pip`` insets it in a face-safe corner. Consumed by ``broll_compose``.
+Layout = Literal["cutaway", "pip"]
+LAYOUTS: tuple[str, ...] = ("cutaway", "pip")
+DEFAULT_LAYOUT = "cutaway"
+
+#: Minimum cosine for a match to be offered at all. See the module docstring:
+#: this is the SigLIP-2 so400m placeholder and is UNVERIFIED as a calibrated
+#: value; pass an explicit ``threshold`` for any other backbone tier.
+DEFAULT_MIN_SIMILARITY = 0.22
+
+#: Timing envelope. An insert shorter than the minimum is dropped rather than
+#: stretched (a 0.4 s flash reads as a glitch, not an edit).
+DEFAULT_MIN_DURATION_SEC = 1.5
+DEFAULT_MAX_DURATION_SEC = 5.0
+#: Quiet time required between two inserts (measured edge to edge).
+DEFAULT_MIN_GAP_SEC = 2.0
+#: The same asset may not reappear within this many seconds.
+DEFAULT_COOLDOWN_SEC = 30.0
+#: Ceiling on how much of the video B-roll may cover, as a percentage.
+DEFAULT_MAX_COVERAGE_PCT = 40.0
+#: A start within this many seconds of a shot boundary is snapped onto it.
+DEFAULT_SNAP_WINDOW_SEC = 0.5
+#: How many assets each segment ranks before the gate is applied.
+DEFAULT_TOP_K = 5
+
+#: The reason string is shown verbatim in the review UI, so it is capped.
+MAX_REASON_CHARS = 96
+#: Prefix used when the segment carried no text to quote back.
+REASON_NO_TEXT = "no segment text"
+
+
+class AssetHit(TypedDict):
+    """One asset ranked against a segment's text vector."""
+
+    assetIndex: int
+    assetId: str
+    path: str
+    kind: str
+    score: float
+
+
+class BrollSuggestion(TypedDict):
+    """A gated, reviewable match: this asset, under this segment, this well."""
+
+    segmentIndex: int
+    start: float
+    end: float
+    assetId: str
+    path: str
+    kind: str
+    score: float
+    reason: str
+    layout: str
+
+
+class BrollInsertion(TypedDict):
+    """A suggestion with its final, constraint-satisfying timing."""
+
+    segmentIndex: int
+    start: float
+    end: float
+    duration: float
+    sourceStart: float
+    assetId: str
+    path: str
+    kind: str
+    score: float
+    reason: str
+    layout: str
+
+
+def _asset_id(asset: Mapping[str, Any], index: int) -> str:
+    """The asset's id, falling back to a positional one so a row is never anonymous."""
+    return str(asset.get("assetId") or f"asset-{index}")
+
+
+def rank_assets(
+    query_vec: Vector,
+    asset_vecs: Sequence[Vector],
+    assets: Sequence[Mapping[str, Any]],
+    top_k: int,
+) -> list[AssetHit]:
+    """Rank ``assets`` by cosine of their image vector against ``query_vec``.
+
+    This is :func:`semantic_index.search` used cross-modally: its "corpus" rows
+    are assets rather than transcript segments, so its ``segmentIndex`` is the
+    asset row index. Reusing it (instead of re-deriving the loop) inherits three
+    behaviours the planner depends on — a stable sort, so equal scores resolve to
+    the lowest asset index and the plan is reproducible; a ``top_k <= 0`` guard;
+    and the length-guarded cosine, so a query embedded by a *different* model
+    surfaces as a :class:`ValueError` instead of a silently wrong ranking.
+    """
+    hits = semantic_index.search(query_vec, asset_vecs, assets, top_k)
+    return [
+        AssetHit(
+            assetIndex=hit["segmentIndex"],
+            assetId=_asset_id(assets[hit["segmentIndex"]], hit["segmentIndex"]),
+            path=str(assets[hit["segmentIndex"]].get("path", "")),
+            kind=str(assets[hit["segmentIndex"]].get("kind", "image")),
+            score=hit["score"],
+        )
+        for hit in hits
+    ]
+
+
+def _reason(text: str, score: float) -> str:
+    """A short, honest "why this matched" line: the quoted text plus the cosine."""
+    suffix = f" ({score:.2f})"
+    stripped = " ".join(text.split())
+    if not stripped:
+        return REASON_NO_TEXT + suffix
+    budget = MAX_REASON_CHARS - len(suffix) - 2  # the two quote characters
+    if len(stripped) > budget:
+        stripped = stripped[: budget - 1].rstrip() + "…"
+    return f'"{stripped}"{suffix}'
+
+
+def suggest(
+    segments: Sequence[Mapping[str, Any]],
+    segment_vecs: Sequence[Vector],
+    assets: Sequence[Mapping[str, Any]],
+    asset_vecs: Sequence[Vector],
+    *,
+    threshold: float = DEFAULT_MIN_SIMILARITY,
+    top_k: int = DEFAULT_TOP_K,
+    layout: str = DEFAULT_LAYOUT,
+) -> list[BrollSuggestion]:
+    """Best above-``threshold`` asset per segment, in segment order.
+
+    ``segment_vecs[i]`` is the text embedding of ``segments[i]`` and
+    ``asset_vecs[j]`` the image embedding of ``assets[j]``; both must come from
+    the SAME backbone family, because a cross-modal cosine is only meaningful
+    inside one joint space.
+
+    A segment whose best asset scores **below** ``threshold`` contributes no
+    suggestion at all (the comparison is inclusive: exactly ``threshold``
+    passes). An empty library yields ``[]``.
+    """
+    if layout not in LAYOUTS:
+        raise ValueError(f"layout must be one of {LAYOUTS}, got {layout!r}")
+    if len(segment_vecs) != len(segments):
+        raise ValueError(f"need one vector per segment: {len(segment_vecs)} vectors vs {len(segments)} segments")
+    if len(asset_vecs) != len(assets):
+        raise ValueError(f"need one vector per asset: {len(asset_vecs)} vectors vs {len(assets)} assets")
+
+    out: list[BrollSuggestion] = []
+    for index, (segment, query_vec) in enumerate(zip(segments, segment_vecs, strict=True)):
+        hits = rank_assets(query_vec, asset_vecs, assets, top_k)
+        if not hits or hits[0]["score"] < threshold:
+            continue
+        best = hits[0]
+        out.append(
+            BrollSuggestion(
+                segmentIndex=index,
+                start=float(segment.get("start", 0.0)),
+                end=float(segment.get("end", 0.0)),
+                assetId=best["assetId"],
+                path=best["path"],
+                kind=best["kind"],
+                score=best["score"],
+                reason=_reason(str(segment.get("text", "")), best["score"]),
+                layout=layout,
+            )
+        )
+    return out
+
+
+def diversify(
+    suggestions: Sequence[BrollSuggestion],
+    assets: Sequence[Mapping[str, Any]],
+    asset_vecs: Sequence[Vector],
+    *,
+    method: diversity.Method = "mmr",
+    k: int | None = None,
+) -> list[BrollSuggestion]:
+    """Suppress near-duplicate picks across ``suggestions`` (MMR or DPP).
+
+    Each suggestion is represented by its MATCHED ASSET's embedding, so two
+    segments that both landed on visually-identical assets compete and only one
+    survives. Delegates to the shipped :func:`diversity.dedupe_candidates`
+    (which reads each candidate's ``score`` as relevance) and then restores
+    chronological order, because the diversity ranking is a *selection*, not the
+    edit order.
+
+    A suggestion naming an asset absent from ``assets`` is a caller bug and
+    raises :class:`KeyError` rather than being silently dropped.
+    """
+    if not suggestions:
+        return []
+    by_id = {_asset_id(asset, index): index for index, asset in enumerate(assets)}
+    rows = []
+    for suggestion in suggestions:
+        asset_id = suggestion["assetId"]
+        if asset_id not in by_id:
+            raise KeyError(f"suggestion names an unknown asset: {asset_id!r}")
+        rows.append(list(asset_vecs[by_id[asset_id]]))
+    kept = diversity.dedupe_candidates([dict(s) for s in suggestions], rows, method=method, k=k)
+    kept.sort(key=lambda s: (float(s["start"]), int(s["segmentIndex"])))
+    return [BrollSuggestion(**s) for s in kept]  # type: ignore[typeddict-item]
+
+
+def _snap(start: float, boundaries: Sequence[float], window: float) -> float:
+    """Snap ``start`` onto the nearest boundary within ``window`` seconds."""
+    if not boundaries:
+        return start
+    nearest = min(boundaries, key=lambda b: abs(float(b) - start))
+    if abs(float(nearest) - start) <= window:
+        return float(nearest)
+    return start
+
+
+def _conflicts(
+    candidate: BrollInsertion,
+    accepted: Sequence[BrollInsertion],
+    *,
+    min_gap_sec: float,
+    cooldown_sec: float,
+) -> bool:
+    """Whether ``candidate`` violates the spacing or the per-asset cooldown."""
+    for other in accepted:
+        overlaps = candidate["start"] < other["end"] + min_gap_sec and other["start"] < candidate["end"] + min_gap_sec
+        if overlaps:
+            return True
+        if other["assetId"] == candidate["assetId"] and abs(candidate["start"] - other["start"]) < cooldown_sec:
+            return True
+    return False
+
+
+def place(
+    suggestions: Sequence[BrollSuggestion],
+    *,
+    total_sec: float,
+    min_duration_sec: float = DEFAULT_MIN_DURATION_SEC,
+    max_duration_sec: float = DEFAULT_MAX_DURATION_SEC,
+    min_gap_sec: float = DEFAULT_MIN_GAP_SEC,
+    cooldown_sec: float = DEFAULT_COOLDOWN_SEC,
+    max_coverage_pct: float = DEFAULT_MAX_COVERAGE_PCT,
+    boundaries: Sequence[float] = (),
+    snap_window_sec: float = DEFAULT_SNAP_WINDOW_SEC,
+) -> list[BrollInsertion]:
+    """Turn ``suggestions`` into timed, constraint-satisfying insertions.
+
+    Each insert is anchored to its segment's start (snapped onto a nearby shot
+    boundary when one is given), runs for at most ``max_duration_sec``, never
+    past its segment's end, and is dropped outright when the room left is under
+    ``min_duration_sec``.
+
+    Selection is greedy in DESCENDING score — so when the coverage cap or the
+    spacing rules force a choice, the higher-confidence insert wins rather than
+    the merely earlier one — and the survivors are returned in chronological
+    order, which is the order an editor reads them.
+    """
+    if total_sec <= 0:
+        raise ValueError(f"totalSec must be > 0, got {total_sec}")
+    if not suggestions:
+        return []
+
+    budget_sec = total_sec * max_coverage_pct / 100.0
+    candidates: list[BrollInsertion] = []
+    for suggestion in suggestions:
+        start = _snap(float(suggestion["start"]), boundaries, snap_window_sec)
+        end = min(float(suggestion["end"]), start + max_duration_sec)
+        duration = end - start
+        if duration < min_duration_sec:
+            continue
+        candidates.append(
+            BrollInsertion(
+                segmentIndex=suggestion["segmentIndex"],
+                start=start,
+                end=end,
+                duration=duration,
+                # Video assets play from their own head; a still has no timeline.
+                sourceStart=0.0,
+                assetId=suggestion["assetId"],
+                path=suggestion["path"],
+                kind=suggestion["kind"],
+                score=suggestion["score"],
+                reason=suggestion["reason"],
+                layout=suggestion["layout"],
+            )
+        )
+
+    candidates.sort(key=lambda c: -c["score"])
+    accepted: list[BrollInsertion] = []
+    used_sec = 0.0
+    for candidate in candidates:
+        if used_sec + candidate["duration"] > budget_sec:
+            continue
+        if _conflicts(candidate, accepted, min_gap_sec=min_gap_sec, cooldown_sec=cooldown_sec):
+            continue
+        accepted.append(candidate)
+        used_sec += candidate["duration"]
+    accepted.sort(key=lambda c: (c["start"], c["segmentIndex"]))
+    return accepted
+
+
+def plan(
+    segments: Sequence[Mapping[str, Any]],
+    segment_vecs: Sequence[Vector],
+    assets: Sequence[Mapping[str, Any]],
+    asset_vecs: Sequence[Vector],
+    *,
+    total_sec: float,
+    threshold: float = DEFAULT_MIN_SIMILARITY,
+    top_k: int = DEFAULT_TOP_K,
+    layout: str = DEFAULT_LAYOUT,
+    method: diversity.Method = "mmr",
+    max_inserts: int | None = None,
+    min_duration_sec: float = DEFAULT_MIN_DURATION_SEC,
+    max_duration_sec: float = DEFAULT_MAX_DURATION_SEC,
+    min_gap_sec: float = DEFAULT_MIN_GAP_SEC,
+    cooldown_sec: float = DEFAULT_COOLDOWN_SEC,
+    max_coverage_pct: float = DEFAULT_MAX_COVERAGE_PCT,
+    boundaries: Sequence[float] = (),
+    snap_window_sec: float = DEFAULT_SNAP_WINDOW_SEC,
+) -> list[BrollInsertion]:
+    """The composed pipeline: gate, then dedupe, then time.
+
+    Returns ``[]`` — never a low-confidence filler insert — when nothing clears
+    the threshold or the library is empty.
+    """
+    gated = suggest(
+        segments,
+        segment_vecs,
+        assets,
+        asset_vecs,
+        threshold=threshold,
+        top_k=top_k,
+        layout=layout,
+    )
+    diverse = diversify(gated, assets, asset_vecs, method=method, k=max_inserts)
+    return place(
+        diverse,
+        total_sec=total_sec,
+        min_duration_sec=min_duration_sec,
+        max_duration_sec=max_duration_sec,
+        min_gap_sec=min_gap_sec,
+        cooldown_sec=cooldown_sec,
+        max_coverage_pct=max_coverage_pct,
+        boundaries=boundaries,
+        snap_window_sec=snap_window_sec,
+    )
+
+
+__all__ = [
+    "DEFAULT_COOLDOWN_SEC",
+    "DEFAULT_LAYOUT",
+    "DEFAULT_MAX_COVERAGE_PCT",
+    "DEFAULT_MAX_DURATION_SEC",
+    "DEFAULT_MIN_DURATION_SEC",
+    "DEFAULT_MIN_GAP_SEC",
+    "DEFAULT_MIN_SIMILARITY",
+    "DEFAULT_SNAP_WINDOW_SEC",
+    "DEFAULT_TOP_K",
+    "LAYOUTS",
+    "MAX_REASON_CHARS",
+    "REASON_NO_TEXT",
+    "AssetHit",
+    "BrollInsertion",
+    "BrollSuggestion",
+    "diversify",
+    "place",
+    "plan",
+    "rank_assets",
+    "suggest",
+]

--- a/sidecar/media_studio/features/broll_plan.py
+++ b/sidecar/media_studio/features/broll_plan.py
@@ -27,9 +27,15 @@ Four stages, each its own function so each is separately testable:
     honest answer to "no confident match" is no insert.
 
 ``diversify``
-    Near-duplicate suppression across the accepted suggestions, delegated to the
+    Diversity RE-RANKING across the accepted suggestions, delegated to the
     shipped :func:`diversity.dedupe_candidates` (MMR or DPP) over the matched
-    assets' own embeddings.
+    assets' own embeddings. Read that verb literally: with no ``k`` it re-ranks
+    and drops NOTHING (``dedupe_candidates`` at ``budget == n`` returns all ``n``
+    rows), so on the default path the thing that actually stops one asset
+    repeating is ``place``'s per-asset COOLDOWN, not MMR. An earlier draft of
+    this docstring said "near-duplicate suppression" flatly; measured, that was
+    wider than the code — ``diversify(3 suggestions, k=None)`` returns 3.
+    Suppression here requires an explicit ``k`` (``plan(max_inserts=…)``).
 
 ``place``
     The editorial constraints: clamp each insert's duration, keep it inside its
@@ -235,14 +241,21 @@ def diversify(
     method: diversity.Method = "mmr",
     k: int | None = None,
 ) -> list[BrollSuggestion]:
-    """Suppress near-duplicate picks across ``suggestions`` (MMR or DPP).
+    """Diversity-rank ``suggestions`` by their matched assets (MMR or DPP).
 
     Each suggestion is represented by its MATCHED ASSET's embedding, so two
-    segments that both landed on visually-identical assets compete and only one
-    survives. Delegates to the shipped :func:`diversity.dedupe_candidates`
-    (which reads each candidate's ``score`` as relevance) and then restores
-    chronological order, because the diversity ranking is a *selection*, not the
-    edit order.
+    segments that landed on visually-identical assets compete. Delegates to the
+    shipped :func:`diversity.dedupe_candidates` (which reads each candidate's
+    ``score`` as relevance) and then restores chronological order, because the
+    diversity ranking is a *selection*, not the edit order.
+
+    ``k`` IS THE SUPPRESSION KNOB, and without it nothing is dropped. At the
+    default ``k=None`` the underlying budget is ``n``, so MMR returns every row
+    — re-ordered, then re-sorted chronologically here, i.e. a no-op on the
+    OUTPUT SET. Measured: three suggestions all matching one asset come back as
+    three at ``k=None`` and as one at ``k=1``. Pass ``k`` (or
+    ``plan(max_inserts=…)``) when you want a cap; otherwise repetition is held
+    down by ``place``'s per-asset cooldown instead.
 
     A suggestion naming an asset absent from ``assets`` is a caller bug and
     raises :class:`KeyError` rather than being silently dropped.
@@ -376,10 +389,15 @@ def plan(
     boundaries: Sequence[float] = (),
     snap_window_sec: float = DEFAULT_SNAP_WINDOW_SEC,
 ) -> list[BrollInsertion]:
-    """The composed pipeline: gate, then dedupe, then time.
+    """The composed pipeline: gate, then diversity-rank, then time.
 
     Returns ``[]`` — never a low-confidence filler insert — when nothing clears
     the threshold or the library is empty.
+
+    ``max_inserts`` is :func:`diversify`'s ``k``. Leave it ``None`` and the
+    diversity stage drops nothing; what keeps one asset from repeating is then
+    ``cooldown_sec``, and what bounds the total is ``max_coverage_pct``. Set it
+    when you want a hard cap on how many suggestions survive ranking.
     """
     gated = suggest(
         segments,

--- a/sidecar/media_studio/features/broll_plan.py
+++ b/sidecar/media_studio/features/broll_plan.py
@@ -145,7 +145,7 @@ def _asset_id(asset: Mapping[str, Any], index: int) -> str:
 def rank_assets(
     query_vec: Vector,
     asset_vecs: Sequence[Vector],
-    assets: Sequence[Mapping[str, Any]],
+    assets: Sequence[dict[str, Any]],
     top_k: int,
 ) -> list[AssetHit]:
     """Rank ``assets`` by cosine of their image vector against ``query_vec``.
@@ -186,7 +186,7 @@ def _reason(text: str, score: float) -> str:
 def suggest(
     segments: Sequence[Mapping[str, Any]],
     segment_vecs: Sequence[Vector],
-    assets: Sequence[Mapping[str, Any]],
+    assets: Sequence[dict[str, Any]],
     asset_vecs: Sequence[Vector],
     *,
     threshold: float = DEFAULT_MIN_SIMILARITY,
@@ -235,7 +235,7 @@ def suggest(
 
 def diversify(
     suggestions: Sequence[BrollSuggestion],
-    assets: Sequence[Mapping[str, Any]],
+    assets: Sequence[dict[str, Any]],
     asset_vecs: Sequence[Vector],
     *,
     method: diversity.Method = "mmr",
@@ -372,7 +372,7 @@ def place(
 def plan(
     segments: Sequence[Mapping[str, Any]],
     segment_vecs: Sequence[Vector],
-    assets: Sequence[Mapping[str, Any]],
+    assets: Sequence[dict[str, Any]],
     asset_vecs: Sequence[Vector],
     *,
     total_sec: float,

--- a/sidecar/media_studio/features/diversity.py
+++ b/sidecar/media_studio/features/diversity.py
@@ -191,7 +191,7 @@ def mmr_select(
 # --------------------------------------------------------------------------- #
 def dedupe_candidates(
     candidates: list[Candidate],
-    embeddings: np.ndarray,
+    embeddings: Sequence[Sequence[float]] | np.ndarray,
     *,
     method: Method = "mmr",
     k: int | None = None,
@@ -203,6 +203,17 @@ def dedupe_candidates(
     per candidate, caller-supplied — the WU4 ``novelty`` embeddings or any
     fallback). The two candidates whose embeddings are near-identical are treated
     as duplicates and only one survives.
+
+    ANY 2-D array-like is accepted, not only ``np.ndarray``: the body's
+    ``np.asarray(embeddings, dtype=np.float64)`` below IS this parameter's real
+    contract, and it has always accepted a plain list of rows. The annotation
+    previously said ``np.ndarray`` alone, which under-declared that — a caller
+    holding ``list[list[float]]`` (``broll_plan.diversify``) was a basedpyright
+    error against a call that works, and always has, at runtime. Widening the
+    annotation to match the implementation is the fix; making the caller build an
+    ndarray just to satisfy a declaration the body immediately re-normalises would
+    have been ceremony. Rows of the wrong rank still fail loudly on the
+    ``mat.ndim != 2`` check.
 
     * ``method='mmr'`` (default) uses :func:`mmr_select` with each candidate's
       ``score`` (default 0.0 when absent) as relevance.

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -5,6 +5,7 @@ verbatim from the former handlers.py; the registration order is unchanged."""
 from __future__ import annotations
 
 from collections.abc import Callable
+from pathlib import Path
 from typing import Any
 
 from .. import library as _library
@@ -459,6 +460,43 @@ def register_all(
         resolver=svc._resolve_video_path,
         out_dir=svc.exports_dir / "gaze",
         settings_provider=svc.settings.get,
+        register_fn=reg,
+    )
+
+    # broll.* (v1.5 flagship #3): LOCAL auto-b-roll over the user's OWN library.
+    # The asset list is a scan of the ``brollDir`` setting and the vector index is
+    # a sidecar next to the data dir (never the project manifest — the same
+    # decision index.build made for its embeddings). Both SigLIP-2 towers come
+    # from ONE factory so the image and text vectors share a joint space.
+    from ..features import broll_ops as _broll_ops  # local: import-light
+
+    def _broll_index_path() -> Path:
+        return svc.data_dir / _broll_ops.INDEX_FILENAME
+
+    def _list_broll_assets() -> list[dict[str, Any]]:
+        return _broll_ops.scan_assets(str(svc.settings.get().get(_broll_ops.BROLL_DIR_KEY) or ""))
+
+    def _load_broll_index() -> Any:
+        return _broll_ops.load_index_file(_broll_index_path())
+
+    def _save_broll_index(index: Any) -> None:
+        _broll_ops.save_index_file(_broll_index_path(), index)
+
+    def _load_broll_transcript(video_id: str) -> dict[str, Any]:
+        return svc._load_or_create_project(video_id).data.get("transcript") or {}
+
+    _broll_ops.register(
+        resolver=svc._resolve_video_path,
+        list_assets=_list_broll_assets,
+        load_index=_load_broll_index,
+        save_index=_save_broll_index,
+        load_transcript=_load_broll_transcript,
+        out_dir=svc.exports_dir / "broll",
+        embed_images=_broll_ops.make_image_embedder(settings_provider=svc.settings.get),
+        embed_texts=_broll_ops.make_text_embedder(settings_provider=svc.settings.get),
+        settings_provider=svc.settings.get,
+        run=svc._ffmpeg_run,  # None -> the real drained ffmpeg.run
+        duration=svc._ffprobe_duration,
         register_fn=reg,
     )
 

--- a/sidecar/tests/e2e/test_broll_composite.py
+++ b/sidecar/tests/e2e/test_broll_composite.py
@@ -1,0 +1,274 @@
+"""E2E real-ffmpeg proof that the auto-b-roll composite renders the PIXELS.
+
+``tests/test_broll_compose.py`` asserts the exact argv and the exact
+``filter_complex``. That proves the STRING. It cannot prove ffmpeg accepts the
+graph, that the time-shift puts frame 0 of an asset at second S, that the
+``enable`` gate really closes, that the inset lands in the corner the expression
+names, or that the speaker's audio survives — every one of which is a way this
+feature can be green and broken.
+
+So this module renders for real and probes the OUTPUT:
+
+* a 1080x1920 blue "speaker" clip with a tone,
+* a RED still composited as a full-frame cutaway over ``[2, 5]``,
+* a GREEN clip composited as a top-right PiP over ``[6, 8]``,
+
+then samples mean RGB inside chosen rectangles at chosen timestamps. Every
+assertion carries a CONTROL — a timestamp outside the window, or the opposite
+corner — because "the frame changed" is not the same claim as "the b-roll landed
+in the right place at the right time", and only the control separates them.
+
+OPT-IN: tagged ``e2e`` so the default 100%-coverage gate (addopts
+``-m 'not e2e'``) deselects it. Run it with::
+
+    python -m pytest -m e2e sidecar/tests/e2e/test_broll_composite.py -v
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from media_studio.features import broll_compose as bc
+
+_FFMPEG = shutil.which("ffmpeg")
+_FFPROBE = shutil.which("ffprobe")
+
+pytestmark = [
+    pytest.mark.e2e,
+    pytest.mark.skipif(not (_FFMPEG and _FFPROBE), reason="ffmpeg/ffprobe required for the b-roll composite proof"),
+]
+
+# The export canvas the builder defaults to; kept explicit so the crop maths below
+# is readable rather than derived three files away.
+_W, _H = bc.DEFAULT_CANVAS_W, bc.DEFAULT_CANVAS_H
+_TOTAL = 10.0
+#: PiP geometry the top-right corner expression + a 4:3 asset must produce:
+#: width = even(1080 * 34%) = 366; height = 366 * 480/640 = 274 (already even).
+_PIP_W, _PIP_H = 366, 274
+_PIP_X, _PIP_Y = _W - _PIP_W - bc.DEFAULT_PIP_PADDING, bc.DEFAULT_PIP_PADDING
+
+_CUTAWAY = (2.0, 5.0)
+_PIP = (6.0, 8.0)
+
+
+def _run(argv: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(argv, capture_output=True, text=True, check=False, timeout=600)
+
+
+@pytest.fixture(scope="module")
+def rendered(tmp_path_factory) -> Path:
+    """Render the composite once; every assertion below probes this one file."""
+    tmp = tmp_path_factory.mktemp("broll-e2e")
+    main, still, clip, out = (tmp / n for n in ("talk.mp4", "red.png", "green.mp4", "out.mp4"))
+
+    # A blue speaker with audio, so a dropped audio map is detectable.
+    assert (
+        _run(
+            [
+                _FFMPEG,
+                "-hide_banner",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                f"color=c=blue:s={_W}x{_H}:d={_TOTAL}:r=25",
+                "-f",
+                "lavfi",
+                "-i",
+                f"sine=frequency=440:duration={_TOTAL}",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                "-c:a",
+                "aac",
+                "-shortest",
+                str(main),
+            ]
+        ).returncode
+        == 0
+    )
+    assert (
+        _run(
+            [
+                _FFMPEG,
+                "-hide_banner",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=red:s=640x480:d=1",
+                "-frames:v",
+                "1",
+                str(still),
+            ]
+        ).returncode
+        == 0
+    )
+    assert (
+        _run(
+            [
+                _FFMPEG,
+                "-hide_banner",
+                "-y",
+                "-f",
+                "lavfi",
+                "-i",
+                "color=c=green:s=640x480:d=6:r=25",
+                "-c:v",
+                "libx264",
+                "-pix_fmt",
+                "yuv420p",
+                str(clip),
+            ]
+        ).returncode
+        == 0
+    )
+
+    insertions = [
+        {
+            "segmentIndex": 0,
+            "start": _CUTAWAY[0],
+            "end": _CUTAWAY[1],
+            "duration": _CUTAWAY[1] - _CUTAWAY[0],
+            "sourceStart": 0.0,
+            "assetId": "a-red",
+            "path": str(still),
+            "kind": "image",
+            "score": 0.9,
+            "reason": "r",
+            "layout": "cutaway",
+        },
+        {
+            # sourceStart is non-zero so the -ss seek is exercised, not just present.
+            "segmentIndex": 1,
+            "start": _PIP[0],
+            "end": _PIP[1],
+            "duration": _PIP[1] - _PIP[0],
+            "sourceStart": 1.0,
+            "assetId": "a-green",
+            "path": str(clip),
+            "kind": "video",
+            "score": 0.8,
+            "reason": "r",
+            "layout": "pip",
+        },
+    ]
+    proc = _run(bc.build_broll_argv(str(main), insertions, str(out)))
+    assert proc.returncode == 0, f"ffmpeg rejected the generated filtergraph:\n{proc.stderr[-2000:]}"
+    return out
+
+
+def _mean_rgb(path: Path, when: float, crop: str) -> tuple[int, int, int]:
+    """Mean RGB of ``crop`` at ``when`` (``flags=area`` = a true box average)."""
+    raw = subprocess.run(
+        [
+            _FFMPEG,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-ss",
+            f"{when}",
+            "-i",
+            str(path),
+            "-frames:v",
+            "1",
+            "-vf",
+            f"crop={crop},scale=1:1:flags=area",
+            "-f",
+            "rawvideo",
+            "-pix_fmt",
+            "rgb24",
+            "-",
+        ],
+        capture_output=True,
+        check=True,
+        timeout=300,
+    ).stdout
+    assert len(raw) == 3, "expected exactly one RGB triple"
+    return (raw[0], raw[1], raw[2])
+
+
+_FULL = f"{_W}:{_H}:0:0"
+_PIP_BOX = f"{_PIP_W}:{_PIP_H}:{_PIP_X}:{_PIP_Y}"
+#: Same-size rectangle in the OPPOSITE corner. This is the control that
+#: distinguishes "the inset is where the corner expression says" from "the
+#: frame changed somewhere".
+_CONTROL_BOX = f"{_PIP_W}:{_PIP_H}:{bc.DEFAULT_PIP_PADDING}:{_H - _PIP_H - bc.DEFAULT_PIP_PADDING}"
+
+
+def test_output_geometry_and_duration_survive(rendered):
+    out = subprocess.run(
+        [
+            _FFPROBE,
+            "-v",
+            "error",
+            "-select_streams",
+            "v:0",
+            "-show_entries",
+            "stream=width,height:format=duration",
+            "-of",
+            "csv=p=0",
+            str(rendered),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    ).stdout.split()
+    assert out[0] == f"{_W},{_H}"
+    assert float(out[1]) == pytest.approx(_TOTAL, abs=0.25)
+
+
+def test_the_speakers_audio_stream_survives_the_composite(rendered):
+    # -map 0:a? is the only audio map; if it were dropped (or pointed at the
+    # b-roll input) this count changes.
+    streams = subprocess.run(
+        [
+            _FFPROBE,
+            "-v",
+            "error",
+            "-select_streams",
+            "a",
+            "-show_entries",
+            "stream=index",
+            "-of",
+            "csv=p=0",
+            str(rendered),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=120,
+    ).stdout.split()
+    assert len(streams) == 1
+
+
+def test_the_cutaway_covers_the_frame_inside_its_window(rendered):
+    r, g, b = _mean_rgb(rendered, 3.5, _FULL)
+    assert r > 200 and b < 60, f"expected a red full-frame cutaway at t=3.5s, got {(r, g, b)}"
+
+
+@pytest.mark.parametrize("when", [1.0, 5.5, 9.0])
+def test_the_frame_is_the_untouched_speaker_outside_every_window(rendered, when):
+    # The CONTROL for the cutaway assertion: before it, between the two windows,
+    # and after both, the picture must be the original blue speaker.
+    r, _g, b = _mean_rgb(rendered, when, _FULL)
+    assert b > 200 and r < 60, f"expected the untouched blue speaker at t={when}s, got {(r, _g, b)}"
+
+
+def test_the_pip_lands_in_the_corner_the_expression_names(rendered):
+    inset = _mean_rgb(rendered, 7.0, _PIP_BOX)
+    control = _mean_rgb(rendered, 7.0, _CONTROL_BOX)
+    # ffmpeg's lavfi `green` is CSS green (0,128,0), not (0,255,0).
+    assert inset[1] > 100 and inset[2] < 60, f"expected the green inset in the top-right box, got {inset}"
+    assert control[2] > 200 and control[1] < 60, f"the opposite corner must stay speaker-blue, got {control}"
+
+
+def test_the_pip_is_absent_before_its_window_opens(rendered):
+    # Same rectangle, earlier timestamp: the enable gate must really be closed.
+    before = _mean_rgb(rendered, 1.0, _PIP_BOX)
+    assert before[2] > 200 and before[1] < 60, f"the PiP box must be speaker-blue at t=1.0s, got {before}"

--- a/sidecar/tests/test_broll_compose.py
+++ b/sidecar/tests/test_broll_compose.py
@@ -1,0 +1,240 @@
+"""PURE N-window b-roll compositing argv tests (v1.5 flagship #3, WU BR5).
+
+The design calls this the highest-risk surface in the feature: arg order,
+per-window enable gates, the b-roll's own timebase, and the audio map all have
+to be right at once, and a filtergraph that is merely *plausible* renders
+garbage. So these tests assert the EXACT argv and the EXACT filter_complex
+string rather than "contains overlay" — a builder is a pure function and
+deserves an exact oracle.
+
+What a green run here does NOT prove: that ffmpeg accepts the graph or produces
+the pixels. That needs the real-ffmpeg tier (WU BR8) and is NOT covered on this
+branch.
+"""
+
+from __future__ import annotations
+
+import pytest
+from media_studio.features import broll_compose as bc
+
+CLIP = "/videos/talk.mp4"
+OUT = "/exports/talk.broll.mp4"
+
+
+def _ins(start: float, end: float, path: str, kind: str = "image", layout: str = "cutaway", source_start: float = 0.0):
+    return {
+        "start": start,
+        "end": end,
+        "duration": end - start,
+        "sourceStart": source_start,
+        "assetId": "a1",
+        "path": path,
+        "kind": kind,
+        "score": 0.9,
+        "reason": "r",
+        "layout": layout,
+        "segmentIndex": 0,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# inputs — a still is looped and bounded; a clip is seeked and bounded
+# --------------------------------------------------------------------------- #
+def test_still_input_is_looped_and_time_bounded():
+    assert bc.build_input_args([_ins(10.0, 14.0, "/lib/city.png")]) == [
+        "-loop",
+        "1",
+        "-t",
+        "4.000",
+        "-i",
+        "/lib/city.png",
+    ]
+
+
+def test_video_input_is_seeked_to_its_own_offset_and_bounded():
+    ins = _ins(10.0, 14.0, "/lib/dog.mp4", kind="video", source_start=2.5)
+    assert bc.build_input_args([ins]) == ["-ss", "2.500", "-t", "4.000", "-i", "/lib/dog.mp4"]
+
+
+def test_inputs_are_emitted_in_insertion_order():
+    args = bc.build_input_args([_ins(1.0, 3.0, "/a.png"), _ins(9.0, 12.0, "/b.png")])
+    assert args.index("/a.png") < args.index("/b.png")
+
+
+# --------------------------------------------------------------------------- #
+# filtergraph — the exact string, for each layout
+# --------------------------------------------------------------------------- #
+def test_cutaway_filtergraph_is_exact():
+    got = bc.build_filtergraph([_ins(10.0, 14.0, "/lib/city.png")])
+    assert got == (
+        "[1:v]scale=1080:1920:force_original_aspect_ratio=increase,crop=1080:1920,"
+        "setpts=PTS-STARTPTS+10.000/TB[b0];"
+        "[0:v][b0]overlay=0:0:eof_action=pass:enable='between(t,10.000,14.000)'[v0];"
+        "[v0]format=yuv420p[vout]"
+    )
+
+
+def test_pip_filtergraph_insets_into_a_corner_at_an_even_width():
+    got = bc.build_filtergraph([_ins(10.0, 14.0, "/lib/city.png", layout="pip")])
+    # 1080 * 0.34 = 367.2 -> 367 -> rounded DOWN to an even 366 (libx264 needs
+    # even dimensions; -2 keeps the height even too).
+    assert got == (
+        "[1:v]scale=366:-2,setpts=PTS-STARTPTS+10.000/TB[b0];"
+        "[0:v][b0]overlay=main_w-overlay_w-48:48:eof_action=pass:enable='between(t,10.000,14.000)'[v0];"
+        "[v0]format=yuv420p[vout]"
+    )
+
+
+def test_pip_corner_expression_comes_from_the_brandkit_table():
+    from media_studio.features import brandkit
+
+    got = bc.build_filtergraph([_ins(1.0, 3.0, "/a.png", layout="pip")], pip_corner="bottom-left")
+    assert brandkit._corner_xy("bottom-left", bc.DEFAULT_PIP_PADDING) in got
+
+
+def test_n_windows_chain_in_one_pass():
+    got = bc.build_filtergraph([_ins(1.0, 3.0, "/a.png"), _ins(9.0, 12.0, "/b.png", layout="pip")])
+    # Two inputs, two overlay stages, one chained video label per stage.
+    assert got.count("overlay=") == 2
+    assert "[1:v]" in got and "[2:v]" in got
+    assert "[0:v][b0]" in got and "[v0][b1]" in got
+    assert got.endswith("[v1]format=yuv420p[vout]")
+
+
+def test_each_window_carries_its_own_enable_gate():
+    got = bc.build_filtergraph([_ins(1.0, 3.0, "/a.png"), _ins(9.0, 12.0, "/b.png")])
+    assert "enable='between(t,1.000,3.000)'" in got
+    assert "enable='between(t,9.000,12.000)'" in got
+
+
+def test_filtergraph_honours_a_custom_canvas():
+    got = bc.build_filtergraph([_ins(1.0, 3.0, "/a.png")], canvas_w=1920, canvas_h=1080)
+    assert "scale=1920:1080:force_original_aspect_ratio=increase,crop=1920:1080" in got
+
+
+def test_filtergraph_rejects_an_unknown_layout():
+    with pytest.raises(ValueError, match="layout"):
+        bc.build_filtergraph([_ins(1.0, 3.0, "/a.png", layout="ken-burns")])
+
+
+def test_filtergraph_rejects_an_empty_plan():
+    with pytest.raises(ValueError, match="at least one"):
+        bc.build_filtergraph([])
+
+
+def test_pip_scale_must_be_positive():
+    with pytest.raises(ValueError, match="pipScalePct"):
+        bc.build_filtergraph([_ins(1.0, 3.0, "/a.png", layout="pip")], pip_scale_pct=0.0)
+
+
+def test_a_tiny_pip_scale_still_yields_a_legal_even_width():
+    got = bc.build_filtergraph([_ins(1.0, 3.0, "/a.png", layout="pip")], pip_scale_pct=0.01)
+    assert "scale=2:-2," in got
+
+
+# --------------------------------------------------------------------------- #
+# argv — the full command, in order, list-only
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def _pinned_ffmpeg(monkeypatch):
+    """Pin the resolved binary (the test_brandkit.py:62 pattern).
+
+    ``ffmpeg.ffmpeg_path`` goes through ``resolve_binary``, which PROBES the
+    host — so a real path leaks in and the argv is not comparable. Pinning it is
+    what makes an exact-argv oracle possible at all.
+    """
+    monkeypatch.setattr("media_studio.ffmpeg.ffmpeg_path", lambda settings=None: "/bin/ffmpeg")
+
+
+def test_argv_is_exact(_pinned_ffmpeg):
+    argv = bc.build_broll_argv(CLIP, [_ins(10.0, 14.0, "/lib/city.png")], OUT)
+    assert argv == [
+        "/bin/ffmpeg",
+        "-hide_banner",
+        "-nostdin",
+        "-y",
+        "-i",
+        CLIP,
+        "-loop",
+        "1",
+        "-t",
+        "4.000",
+        "-i",
+        "/lib/city.png",
+        "-filter_complex",
+        bc.build_filtergraph([_ins(10.0, 14.0, "/lib/city.png")]),
+        "-map",
+        "[vout]",
+        "-map",
+        "0:a?",
+        "-c:v",
+        "libx264",
+        "-c:a",
+        "copy",
+        "-progress",
+        "pipe:1",
+        "-nostats",
+        OUT,
+    ]
+
+
+def test_argv_keeps_the_speakers_audio_and_never_maps_the_broll_audio(_pinned_ffmpeg):
+    argv = bc.build_broll_argv(CLIP, [_ins(1.0, 3.0, "/lib/dog.mp4", kind="video")], OUT)
+    maps = [argv[i + 1] for i, tok in enumerate(argv) if tok == "-map"]
+    # Exactly the composited video and the MAIN input's audio. A b-roll audio
+    # stream is muted by construction: it is simply never mapped.
+    assert maps == ["[vout]", "0:a?"]
+    assert "1:a" not in maps and "1:a?" not in maps
+
+
+def test_argv_requires_a_clip_path():
+    with pytest.raises(ValueError, match="clip path"):
+        bc.build_broll_argv("", [_ins(1.0, 3.0, "/a.png")], OUT)
+
+
+def test_argv_requires_an_output_path():
+    with pytest.raises(ValueError, match="output path"):
+        bc.build_broll_argv(CLIP, [_ins(1.0, 3.0, "/a.png")], "")
+
+
+def test_argv_requires_a_non_empty_plan():
+    with pytest.raises(ValueError, match="at least one"):
+        bc.build_broll_argv(CLIP, [], OUT)
+
+
+def test_argv_rejects_an_insertion_without_a_path():
+    with pytest.raises(ValueError, match="asset path"):
+        bc.build_broll_argv(CLIP, [_ins(1.0, 3.0, "")], OUT)
+
+
+def test_argv_rejects_a_non_positive_duration():
+    with pytest.raises(ValueError, match="duration"):
+        bc.build_broll_argv(CLIP, [_ins(3.0, 3.0, "/a.png")], OUT)
+
+
+def test_argv_is_a_list_of_strings_only(_pinned_ffmpeg):
+    argv = bc.build_broll_argv(CLIP, [_ins(1.0, 3.0, "/a.png")], OUT)
+    assert isinstance(argv, list)
+    assert all(isinstance(token, str) for token in argv)
+
+
+def test_argv_resolves_ffmpeg_through_the_shared_seam(monkeypatch):
+    # The binary is NOT read straight out of settings — it goes through
+    # ffmpeg.resolve_binary, the one place that knows about bundled/PATH/settings
+    # precedence. Assert the seam is the thing being called.
+    seen: list[object] = []
+    monkeypatch.setattr(
+        "media_studio.ffmpeg.ffmpeg_path",
+        lambda settings=None: seen.append(settings) or "/opt/bin/ffmpeg",
+    )
+    argv = bc.build_broll_argv(CLIP, [_ins(1.0, 3.0, "/a.png")], OUT, settings={"ffmpegPath": "/opt/bin/ffmpeg"})
+    assert argv[0] == "/opt/bin/ffmpeg"
+    assert seen == [{"ffmpegPath": "/opt/bin/ffmpeg"}]
+
+
+def test_duration_falls_back_to_end_minus_start_when_absent(_pinned_ffmpeg):
+    # A hand-written plan (or one round-tripped through a trimming schema) may
+    # carry only the window, not a precomputed duration.
+    bare = {"start": 4.0, "end": 7.5, "path": "/a.png", "kind": "image", "layout": "cutaway"}
+    argv = bc.build_broll_argv(CLIP, [bare], OUT)
+    assert argv[argv.index("-t") + 1] == "3.500"

--- a/sidecar/tests/test_broll_index.py
+++ b/sidecar/tests/test_broll_index.py
@@ -1,0 +1,254 @@
+"""PURE b-roll asset index tests (v1.5 flagship #3, WU BR2).
+
+The index is the only persisted state auto-b-roll owns, and the two ways it can
+be quietly wrong are the ones tested hardest here:
+
+* **a stale row** — the file on disk changed but its vector did not, so the
+  planner ranks the OLD picture;
+* **a model mismatch** — a cross-modal cosine is only meaningful inside ONE
+  joint space, so scoring a SigLIP text vector against a Nomic image vector
+  produces a confident, meaningless number. That must be a typed refusal, never
+  a silent ranking.
+
+No model here either: vectors arrive as plain lists through the same injected
+seam the planner uses.
+"""
+
+from __future__ import annotations
+
+import pytest
+from media_studio.features import broll_index as bi
+
+MODEL = "google/siglip2-so400m-patch16-384"
+OTHER_MODEL = "nomic-ai/nomic-embed-vision-v1.5"
+BUILT_AT = "2026-08-08T00:00:00Z"
+
+
+def _asset(asset_id: str, path: str, *, size: int = 100, mtime: float = 1.0, kind: str = "image"):
+    return {"assetId": asset_id, "path": path, "kind": kind, "sizeBytes": size, "mtime": mtime}
+
+
+A = _asset("a1", "/lib/dog.png")
+B = _asset("a2", "/lib/city.png", size=200, mtime=2.0)
+VECS = [[1.0, 0.0], [0.0, 1.0]]
+
+
+# --------------------------------------------------------------------------- #
+# fingerprint — the staleness key
+# --------------------------------------------------------------------------- #
+def test_fingerprint_is_stable_for_the_same_bytes():
+    assert bi.fingerprint(A) == bi.fingerprint(dict(A))
+
+
+def test_fingerprint_changes_when_the_file_is_rewritten():
+    assert bi.fingerprint(A) != bi.fingerprint(_asset("a1", "/lib/dog.png", size=101))
+    assert bi.fingerprint(A) != bi.fingerprint(_asset("a1", "/lib/dog.png", mtime=9.0))
+
+
+def test_fingerprint_changes_when_the_asset_is_a_different_file():
+    assert bi.fingerprint(A) != bi.fingerprint(_asset("a1", "/lib/other.png"))
+
+
+def test_fingerprint_of_an_asset_with_no_stat_metadata_still_works():
+    assert isinstance(bi.fingerprint({"assetId": "x", "path": "/p"}), str)
+
+
+# --------------------------------------------------------------------------- #
+# build — the persisted shape
+# --------------------------------------------------------------------------- #
+def test_build_produces_a_versioned_index_with_one_row_per_asset():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    assert index["version"] == bi.INDEX_VERSION
+    assert index["model"] == MODEL
+    assert index["dim"] == 2
+    assert index["builtAt"] == BUILT_AT
+    assert [row["assetId"] for row in index["assets"]] == ["a1", "a2"]
+    assert index["assets"][0]["vector"] == [1.0, 0.0]
+    assert index["assets"][0]["fingerprint"] == bi.fingerprint(A)
+
+
+def test_build_of_an_empty_library_is_an_empty_but_valid_index():
+    index = bi.build([], [], model=MODEL, built_at=BUILT_AT)
+    assert index["assets"] == []
+    assert index["dim"] == 0
+
+
+def test_build_requires_one_vector_per_asset():
+    with pytest.raises(ValueError, match="one vector per asset"):
+        bi.build([A, B], VECS[:1], model=MODEL, built_at=BUILT_AT)
+
+
+def test_build_rejects_ragged_vectors():
+    with pytest.raises(ValueError, match="same dimension"):
+        bi.build([A, B], [[1.0, 0.0], [0.0, 1.0, 0.0]], model=MODEL, built_at=BUILT_AT)
+
+
+def test_build_rejects_an_empty_model_id():
+    # An index that does not know which joint space it lives in cannot be
+    # checked against a query later.
+    with pytest.raises(ValueError, match="model"):
+        bi.build([A], [VECS[0]], model="", built_at=BUILT_AT)
+
+
+def test_build_is_json_round_trippable():
+    import json
+
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    assert json.loads(json.dumps(index)) == index
+
+
+# --------------------------------------------------------------------------- #
+# rows — the (assets, vectors) pair the planner consumes
+# --------------------------------------------------------------------------- #
+def test_rows_returns_planner_shaped_assets_and_aligned_vectors():
+    assets, vectors = bi.rows(bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT))
+    assert [a["assetId"] for a in assets] == ["a1", "a2"]
+    assert [a["path"] for a in assets] == ["/lib/dog.png", "/lib/city.png"]
+    assert vectors == VECS
+    assert "vector" not in assets[0], "the planner takes vectors as its own argument"
+
+
+def test_rows_of_an_empty_index():
+    assert bi.rows(bi.build([], [], model=MODEL, built_at=BUILT_AT)) == ([], [])
+
+
+# --------------------------------------------------------------------------- #
+# require_model — the cross-space refusal
+# --------------------------------------------------------------------------- #
+def test_require_model_passes_on_a_matching_backbone():
+    bi.require_model(bi.build([A], [VECS[0]], model=MODEL, built_at=BUILT_AT), MODEL)
+
+
+def test_require_model_refuses_a_different_backbone():
+    index = bi.build([A], [VECS[0]], model=MODEL, built_at=BUILT_AT)
+    with pytest.raises(bi.StaleIndexError) as excinfo:
+        bi.require_model(index, OTHER_MODEL)
+    # The message must name BOTH models: "re-index" is only actionable when the
+    # user can see which one they have and which one they asked for.
+    assert MODEL in str(excinfo.value)
+    assert OTHER_MODEL in str(excinfo.value)
+
+
+def test_require_model_refuses_a_missing_index():
+    with pytest.raises(bi.StaleIndexError, match="not been indexed"):
+        bi.require_model(None, MODEL)
+
+
+# --------------------------------------------------------------------------- #
+# refresh_plan — incremental re-index
+# --------------------------------------------------------------------------- #
+def test_refresh_plan_on_no_index_embeds_everything():
+    plan = bi.refresh_plan(None, [A, B], model=MODEL)
+    assert plan["rebuildAll"] is True
+    assert [i for i, _ in plan["embed"]] == [0, 1]
+
+
+def test_refresh_plan_reuses_unchanged_assets():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    plan = bi.refresh_plan(index, [A, B], model=MODEL)
+    assert plan["embed"] == []
+    assert plan["rebuildAll"] is False
+
+
+def test_refresh_plan_re_embeds_only_the_changed_asset():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    edited = _asset("a2", "/lib/city.png", size=999, mtime=2.0)
+    plan = bi.refresh_plan(index, [A, edited], model=MODEL)
+    assert [i for i, _ in plan["embed"]] == [1]
+
+
+def test_refresh_plan_embeds_a_newly_added_asset():
+    index = bi.build([A], [VECS[0]], model=MODEL, built_at=BUILT_AT)
+    plan = bi.refresh_plan(index, [A, B], model=MODEL)
+    assert [i for i, _ in plan["embed"]] == [1]
+
+
+def test_refresh_plan_rebuilds_everything_on_a_model_change():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    plan = bi.refresh_plan(index, [A, B], model=OTHER_MODEL)
+    assert plan["rebuildAll"] is True
+    assert [i for i, _ in plan["embed"]] == [0, 1]
+
+
+def test_refresh_plan_forced_rebuild_ignores_a_fresh_index():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    plan = bi.refresh_plan(index, [A, B], model=MODEL, force=True)
+    assert plan["rebuildAll"] is True
+    assert len(plan["embed"]) == 2
+
+
+def test_refresh_plan_drops_a_removed_asset_without_re_embedding_the_rest():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    plan = bi.refresh_plan(index, [A], model=MODEL)
+    assert plan["embed"] == []
+    assert bi.merge(plan, [A], {}, model=MODEL, built_at=BUILT_AT)["assets"][0]["assetId"] == "a1"
+    assert len(bi.merge(plan, [A], {}, model=MODEL, built_at=BUILT_AT)["assets"]) == 1
+
+
+# --------------------------------------------------------------------------- #
+# merge — fold the freshly-embedded vectors back in
+# --------------------------------------------------------------------------- #
+def test_merge_keeps_reused_vectors_and_takes_the_new_one():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    edited = _asset("a2", "/lib/city.png", size=999, mtime=2.0)
+    plan = bi.refresh_plan(index, [A, edited], model=MODEL)
+    merged = bi.merge(plan, [A, edited], {1: [0.5, 0.5]}, model=MODEL, built_at="later")
+    assert merged["assets"][0]["vector"] == [1.0, 0.0]  # reused, not re-embedded
+    assert merged["assets"][1]["vector"] == [0.5, 0.5]  # the fresh embedding
+    assert merged["assets"][1]["fingerprint"] == bi.fingerprint(edited)
+    assert merged["builtAt"] == "later"
+
+
+def test_merge_refuses_a_missing_embedding():
+    plan = bi.refresh_plan(None, [A], model=MODEL)
+    with pytest.raises(ValueError, match="no embedding"):
+        bi.merge(plan, [A], {}, model=MODEL, built_at=BUILT_AT)
+
+
+# --------------------------------------------------------------------------- #
+# status — what the UI shows
+# --------------------------------------------------------------------------- #
+def test_status_of_an_unindexed_library():
+    assert bi.status(None, [A, B], model=MODEL) == {
+        "indexed": False,
+        "assetCount": 0,
+        "libraryCount": 2,
+        "model": "",
+        "dim": 0,
+        "stale": True,
+        "staleCount": 2,
+    }
+
+
+def test_status_of_a_fresh_index():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    assert bi.status(index, [A, B], model=MODEL) == {
+        "indexed": True,
+        "assetCount": 2,
+        "libraryCount": 2,
+        "model": MODEL,
+        "dim": 2,
+        "stale": False,
+        "staleCount": 0,
+    }
+
+
+def test_status_counts_the_stale_rows():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    got = bi.status(index, [A, _asset("a2", "/lib/city.png", size=999)], model=MODEL)
+    assert got["stale"] is True
+    assert got["staleCount"] == 1
+
+
+def test_status_reports_a_model_change_as_wholly_stale():
+    index = bi.build([A, B], VECS, model=MODEL, built_at=BUILT_AT)
+    got = bi.status(index, [A, B], model=OTHER_MODEL)
+    assert got["stale"] is True
+    assert got["staleCount"] == 2
+
+
+def test_status_of_an_empty_library_against_an_empty_index_is_fresh():
+    index = bi.build([], [], model=MODEL, built_at=BUILT_AT)
+    got = bi.status(index, [], model=MODEL)
+    assert got["stale"] is False
+    assert got["staleCount"] == 0

--- a/sidecar/tests/test_broll_ops.py
+++ b/sidecar/tests/test_broll_ops.py
@@ -14,6 +14,7 @@ consent gate is reachable from here.
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -309,6 +310,174 @@ def test_apply_of_an_unknown_video_raises(tmp_path, registry):
     svc = _svc(tmp_path, _Store(), resolver=lambda vid: None)
     with pytest.raises(RpcError, match="unknown video"):
         svc.apply({"videoId": "ghost", "insertions": [_plan_row()]}, _rpc(registry))
+
+
+# --------------------------------------------------------------------------- #
+# the disk adapters the composition root wires in
+# --------------------------------------------------------------------------- #
+def test_scan_assets_finds_stills_and_clips_and_classifies_them(tmp_path):
+    (tmp_path / "a.png").write_bytes(b"x")
+    (tmp_path / "b.MP4").write_bytes(b"yy")
+    (tmp_path / "notes.txt").write_text("ignored")
+    found = {a["path"]: a for a in bo.scan_assets(tmp_path)}
+    assert len(found) == 2
+    assert found[str(tmp_path / "a.png")]["kind"] == "image"
+    # Extension matching is case-insensitive: a camera writes .MP4/.JPG.
+    assert found[str(tmp_path / "b.MP4")]["kind"] == "video"
+
+
+def test_scan_assets_recurses_and_is_deterministically_ordered(tmp_path):
+    (tmp_path / "sub").mkdir()
+    (tmp_path / "sub" / "z.png").write_bytes(b"x")
+    (tmp_path / "a.png").write_bytes(b"x")
+    assert [Path(a["path"]).name for a in bo.scan_assets(tmp_path)] == ["a.png", "z.png"]
+
+
+def test_scan_assets_carries_the_stat_metadata_the_index_fingerprints(tmp_path):
+    (tmp_path / "a.png").write_bytes(b"12345")
+    asset = bo.scan_assets(tmp_path)[0]
+    assert asset["sizeBytes"] == 5
+    assert asset["mtime"] > 0
+    assert asset["assetId"]
+
+
+def test_scan_assets_gives_each_file_a_stable_distinct_id(tmp_path):
+    (tmp_path / "a.png").write_bytes(b"x")
+    (tmp_path / "b.png").write_bytes(b"x")
+    first = {a["assetId"] for a in bo.scan_assets(tmp_path)}
+    assert len(first) == 2
+    assert first == {a["assetId"] for a in bo.scan_assets(tmp_path)}
+
+
+def test_scan_assets_of_a_missing_folder_is_empty_not_an_error(tmp_path):
+    # An unconfigured b-roll folder is the normal first-run state.
+    assert bo.scan_assets(tmp_path / "nope") == []
+
+
+def test_scan_assets_of_no_folder_at_all_is_empty(tmp_path):
+    assert bo.scan_assets("") == []
+
+
+def test_index_file_round_trips(tmp_path):
+    path = tmp_path / "broll.index.json"
+    index = bi.build(ASSETS, [[1.0, 0.0], [0.0, 1.0]], model=MODEL, built_at="t")
+    bo.save_index_file(path, index)
+    assert bo.load_index_file(path) == index
+
+
+def test_index_file_absent_reads_as_none(tmp_path):
+    assert bo.load_index_file(tmp_path / "nothing.json") is None
+
+
+def test_index_file_corrupt_reads_as_none_rather_than_crashing(tmp_path):
+    # A half-written sidecar must degrade to "not indexed" (which the UI can
+    # act on), never take the whole sidecar down on startup.
+    path = tmp_path / "broll.index.json"
+    path.write_text("{not json", encoding="utf-8")
+    assert bo.load_index_file(path) is None
+
+
+def test_index_file_of_a_non_object_reads_as_none(tmp_path):
+    path = tmp_path / "broll.index.json"
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert bo.load_index_file(path) is None
+
+
+def test_save_index_file_creates_its_parent_directory(tmp_path):
+    path = tmp_path / "deep" / "nested" / "broll.index.json"
+    bo.save_index_file(path, bi.build([], [], model=MODEL, built_at="t"))
+    assert path.is_file()
+
+
+# --------------------------------------------------------------------------- #
+# the backbone adapters (the ONE heavy edge, kept injectable so it is testable)
+# --------------------------------------------------------------------------- #
+class _FakeBackbone:
+    """Stands in for the SigLIP-2 towers; records what it was handed."""
+
+    def __init__(self) -> None:
+        self.images: Any = None
+        self.texts: Any = None
+
+    def embed_images(self, frames):
+        import numpy as np
+
+        self.images = frames
+        return np.asarray([[float(len(frames)), 0.0] for _ in range(len(frames))])
+
+    def embed_texts(self, texts):
+        import numpy as np
+
+        self.texts = list(texts)
+        return np.asarray([[0.0, float(len(t))] for t in texts])
+
+
+def test_image_embedder_loads_one_frame_per_asset_and_returns_plain_lists():
+    import numpy as np
+
+    backbone = _FakeBackbone()
+    seen: list[tuple[str, str]] = []
+
+    def loader(path, kind):
+        seen.append((path, kind))
+        return np.zeros((2, 2, 3), dtype=np.uint8)
+
+    embed = bo.make_image_embedder(backend_factory=lambda s: backbone, frame_loader=loader, settings_provider=dict)
+    out = embed(["/lib/dog.png", "/lib/clip.mp4"])
+    assert seen == [("/lib/dog.png", "image"), ("/lib/clip.mp4", "video")]
+    # The index and planner want JSON-safe floats, never a numpy array.
+    assert out == [[2.0, 0.0], [2.0, 0.0]]
+    assert all(isinstance(v, float) for row in out for v in row)
+
+
+def test_image_embedder_batches_every_frame_into_one_backbone_call():
+    import numpy as np
+
+    backbone = _FakeBackbone()
+    embed = bo.make_image_embedder(
+        backend_factory=lambda s: backbone,
+        frame_loader=lambda p, k: np.zeros((2, 2, 3), dtype=np.uint8),
+        settings_provider=dict,
+    )
+    embed(["/a.png", "/b.png", "/c.png"])
+    assert backbone.images.shape == (3, 2, 2, 3), "one stacked batch, not three loads"
+
+
+def test_image_embedder_of_nothing_never_loads_the_model():
+    def boom(_settings):
+        raise AssertionError("an empty re-index must not pay for a model load")
+
+    assert bo.make_image_embedder(backend_factory=boom, frame_loader=lambda p, k: None)([]) == []
+
+
+def test_text_embedder_returns_plain_lists():
+    backbone = _FakeBackbone()
+    embed = bo.make_text_embedder(backend_factory=lambda s: backbone, settings_provider=dict)
+    assert embed(["ab", "cde"]) == [[0.0, 2.0], [0.0, 3.0]]
+    assert backbone.texts == ["ab", "cde"]
+
+
+def test_text_embedder_of_nothing_never_loads_the_model():
+    def boom(_settings):
+        raise AssertionError("an empty transcript must not pay for a model load")
+
+    assert bo.make_text_embedder(backend_factory=boom)([]) == []
+
+
+def test_the_two_embedders_share_ONE_backbone_instance_per_call():
+    # Both towers must come from the same loaded model: a cross-modal cosine is
+    # only valid inside one joint space, and two factory calls could resolve to
+    # two different checkpoints if settings changed between them.
+    built: list[Any] = []
+
+    def factory(_settings):
+        backbone = _FakeBackbone()
+        built.append(backbone)
+        return backbone
+
+    bo.make_text_embedder(backend_factory=factory, settings_provider=dict)(["a"])
+    bo.make_text_embedder(backend_factory=factory, settings_provider=dict)(["b"])
+    assert len(built) == 2, "each call builds lazily; the caller owns any caching"
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_broll_ops.py
+++ b/sidecar/tests/test_broll_ops.py
@@ -1,0 +1,384 @@
+"""RPC surface tests for auto-b-roll (v1.5 flagship #3, WU BR0 wiring half).
+
+Closes the loop the three pure modules leave open: transcript + library ->
+``broll.index`` -> ``broll.status`` -> ``broll.suggest`` -> ``broll.apply`` ->
+an ffmpeg argv. Every heavy edge is an injected seam (the SigLIP embed towers,
+the transcript read, the index read/write, ffprobe, the ffmpeg run), so these
+run with no model, no disk state and no subprocess — the same discipline
+``test_vlm_backbone.py`` uses for the scorers.
+
+The privacy assertion is tested, not just asserted in a doc: the local path
+never egresses, so ``willEgress`` is False on every b-roll result and no
+consent gate is reachable from here.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from media_studio.features import broll_index as bi
+from media_studio.features import broll_ops as bo
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext, RpcError
+
+MODEL = "google/siglip2-so400m-patch16-384"
+
+# Two orthogonal assets; a segment vector aimed at one of them (see
+# test_broll_plan.py for why the 2-D basis makes every cosine arithmetic).
+ASSETS = [
+    {"assetId": "a-dog", "path": "/lib/dog.png", "kind": "image", "sizeBytes": 10, "mtime": 1.0},
+    {"assetId": "a-city", "path": "/lib/city.png", "kind": "image", "sizeBytes": 20, "mtime": 2.0},
+]
+IMAGE_VECS = {"/lib/dog.png": [1.0, 0.0], "/lib/city.png": [0.0, 1.0]}
+TRANSCRIPT = {
+    "segments": [
+        {"start": 0.0, "end": 6.0, "text": "a dog running"},
+        {"start": 30.0, "end": 36.0, "text": "the city skyline"},
+    ]
+}
+
+
+def _rpc(registry: JobRegistry) -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=registry)
+
+
+class _Store:
+    """An in-memory stand-in for the on-disk index sidecar."""
+
+    def __init__(self, initial: Any = None) -> None:
+        self.value = initial
+        self.writes = 0
+
+    def load(self) -> Any:
+        return self.value
+
+    def save(self, index: Any) -> None:
+        self.value = index
+        self.writes += 1
+
+
+class _Run:
+    """Records the ffmpeg argv instead of running it."""
+
+    def __init__(self, code: int = 0) -> None:
+        self.code = code
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str], **_kw: Any) -> int:
+        self.calls.append(list(argv))
+        return self.code
+
+
+def _svc(tmp_path, store: _Store, **over: Any) -> bo.BrollOps:
+    kwargs: dict[str, Any] = {
+        "resolver": lambda vid: f"/videos/{vid}.mp4",
+        "list_assets": lambda: list(ASSETS),
+        "load_index": store.load,
+        "save_index": store.save,
+        "load_transcript": lambda vid: dict(TRANSCRIPT),
+        "embed_images": lambda paths: [IMAGE_VECS[p] for p in paths],
+        # A text query aimed at whichever asset the segment names.
+        "embed_texts": lambda texts: [[0.99, 0.14] if "dog" in t else [0.14, 0.99] for t in texts],
+        "out_dir": tmp_path,
+        "duration": lambda path, settings=None: 120.0,
+        "run": _Run(),
+        "settings_provider": dict,
+        "model_id": MODEL,
+        "clock": lambda: "2026-08-08T00:00:00Z",
+    }
+    kwargs.update(over)
+    return bo.BrollOps(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# broll.status — a direct, pure read (no provider, no model)
+# --------------------------------------------------------------------------- #
+def test_status_of_an_unindexed_library(tmp_path, registry):
+    got = _svc(tmp_path, _Store()).status({}, _rpc(registry))
+    assert got["indexed"] is False
+    assert got["libraryCount"] == 2
+    assert got["stale"] is True
+    assert got["willEgress"] is False
+
+
+def test_status_after_indexing_is_fresh(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    got = svc.status({}, _rpc(registry))
+    assert got["indexed"] is True
+    assert got["assetCount"] == 2
+    assert got["stale"] is False
+    assert got["model"] == MODEL
+
+
+# --------------------------------------------------------------------------- #
+# broll.index — embed the library, persist, and do it INCREMENTALLY
+# --------------------------------------------------------------------------- #
+def test_index_embeds_every_asset_and_persists(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    job = registry.get(svc.index({}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.result["assetCount"] == 2
+    assert job.result["embedded"] == 2
+    assert job.result["willEgress"] is False
+    assert store.writes == 1
+    assert store.value["model"] == MODEL
+
+
+def test_reindexing_an_unchanged_library_embeds_nothing(tmp_path, registry):
+    store = _Store()
+    embedded: list[list[str]] = []
+
+    def spy(paths):
+        embedded.append(list(paths))
+        return [IMAGE_VECS[p] for p in paths]
+
+    svc = _svc(tmp_path, store, embed_images=spy)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = registry.get(svc.index({}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert embedded == [["/lib/dog.png", "/lib/city.png"], []]
+    assert job.result["embedded"] == 0
+
+
+def test_index_force_re_embeds_everything(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = registry.get(svc.index({"force": True}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.result["embedded"] == 2
+
+
+def test_index_of_an_empty_library_is_a_valid_empty_index(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store, list_assets=list)
+    job = registry.get(svc.index({}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.result["assetCount"] == 0
+    assert store.value["assets"] == []
+
+
+def test_index_without_a_job_registry_raises(tmp_path):
+    with pytest.raises(RpcError):
+        _svc(tmp_path, _Store()).index({}, RpcContext(emit_notification=lambda obj: None, jobs=None))
+
+
+# --------------------------------------------------------------------------- #
+# broll.suggest — the gated, timed plan
+# --------------------------------------------------------------------------- #
+def _suggest(svc, registry, params=None):
+    job = registry.get(svc.suggest(params or {"videoId": "v1"}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    return job
+
+
+def test_suggest_returns_a_timed_plan_matching_each_segment(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = _suggest(svc, registry, {"videoId": "v1", "threshold": 0.5})
+    plan = job.result["insertions"]
+    assert [i["assetId"] for i in plan] == ["a-dog", "a-city"]
+    assert [i["start"] for i in plan] == [0.0, 30.0]
+    assert job.result["willEgress"] is False
+
+
+def test_suggest_honours_the_threshold_and_can_return_nothing(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = _suggest(svc, registry, {"videoId": "v1", "threshold": 0.999})
+    assert job.result["insertions"] == []
+    # The honest empty state is a first-class result, not an error.
+    assert job.result["reason"] == bo.NO_CONFIDENT_MATCH
+
+
+def test_suggest_refuses_an_unindexed_library(tmp_path, registry):
+    svc = _svc(tmp_path, _Store())
+    job = _suggest(svc, registry)
+    assert job.status.value == "error"
+    assert "has not been indexed" in str(job.error)
+
+
+def test_suggest_refuses_an_index_from_a_different_backbone(tmp_path, registry):
+    store = _Store(bi.build(ASSETS, [[1.0, 0.0], [0.0, 1.0]], model="other/model", built_at="t"))
+    job = _suggest(_svc(tmp_path, store), registry)
+    assert job.status.value == "error"
+    assert "one joint space" in str(job.error)
+
+
+def test_suggest_of_an_untranscribed_video_raises(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store, load_transcript=lambda vid: {})
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = _suggest(svc, registry)
+    assert job.status.value == "error"
+    assert "transcript" in str(job.error)
+
+
+def test_suggest_requires_a_video_id(tmp_path, registry):
+    with pytest.raises(RpcError):
+        _svc(tmp_path, _Store()).suggest({}, _rpc(registry))
+
+
+def test_suggest_passes_the_coverage_cap_through(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    # 1% of 120 s = 1.2 s, under the 1.5 s minimum -> nothing fits.
+    job = _suggest(svc, registry, {"videoId": "v1", "threshold": 0.5, "maxCoveragePct": 1.0})
+    assert job.result["insertions"] == []
+
+
+def test_suggest_honours_the_pip_layout(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = _suggest(svc, registry, {"videoId": "v1", "threshold": 0.5, "layout": "pip"})
+    assert {i["layout"] for i in job.result["insertions"]} == {"pip"}
+
+
+def test_suggest_rejects_an_unknown_layout(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = _suggest(svc, registry, {"videoId": "v1", "layout": "nope"})
+    assert job.status.value == "error"
+
+
+# --------------------------------------------------------------------------- #
+# broll.apply — the composite render (REVIEW-FIRST: it takes the reviewed plan)
+# --------------------------------------------------------------------------- #
+def _plan_row(start=0.0, end=4.0, path="/lib/dog.png"):
+    return {
+        "segmentIndex": 0,
+        "start": start,
+        "end": end,
+        "duration": end - start,
+        "sourceStart": 0.0,
+        "assetId": "a-dog",
+        "path": path,
+        "kind": "image",
+        "score": 0.9,
+        "reason": "r",
+        "layout": "cutaway",
+    }
+
+
+def test_apply_runs_the_composite_argv_and_returns_the_output(tmp_path, registry):
+    run = _Run()
+    svc = _svc(tmp_path, _Store(), run=run)
+    job = registry.get(svc.apply({"videoId": "v1", "insertions": [_plan_row()]}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.result["path"].endswith(".broll.mp4")
+    assert job.result["inserted"] == 1
+    assert len(run.calls) == 1
+    assert "-filter_complex" in run.calls[0]
+
+
+def test_apply_takes_the_REVIEWED_plan_and_never_re_plans(tmp_path, registry):
+    # The design's editorial guarantee: apply composites exactly what the user
+    # accepted. It must not call the model or the planner again.
+    def boom(*_a, **_k):
+        raise AssertionError("apply must not embed anything")
+
+    svc = _svc(tmp_path, _Store(), embed_texts=boom, embed_images=boom)
+    job = registry.get(svc.apply({"videoId": "v1", "insertions": [_plan_row()]}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "done"
+
+
+def test_apply_with_an_empty_plan_raises(tmp_path, registry):
+    with pytest.raises(RpcError, match="insertions"):
+        _svc(tmp_path, _Store()).apply({"videoId": "v1", "insertions": []}, _rpc(registry))
+
+
+def test_apply_surfaces_an_ffmpeg_failure(tmp_path, registry):
+    svc = _svc(tmp_path, _Store(), run=_Run(code=1))
+    job = registry.get(svc.apply({"videoId": "v1", "insertions": [_plan_row()]}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "error"
+    assert "exit 1" in str(job.error)
+
+
+def test_apply_of_an_unknown_video_raises(tmp_path, registry):
+    svc = _svc(tmp_path, _Store(), resolver=lambda vid: None)
+    with pytest.raises(RpcError, match="unknown video"):
+        svc.apply({"videoId": "ghost", "insertions": [_plan_row()]}, _rpc(registry))
+
+
+# --------------------------------------------------------------------------- #
+# registration
+# --------------------------------------------------------------------------- #
+def test_register_wires_every_broll_method(tmp_path):
+    seen: dict[str, Any] = {}
+    bo.register(
+        resolver=lambda vid: None,
+        list_assets=list,
+        load_index=lambda: None,
+        save_index=lambda index: None,
+        load_transcript=lambda vid: {},
+        out_dir=tmp_path,
+        register_fn=lambda name, handler: seen.__setitem__(name, handler),
+    )
+    assert set(seen) == set(bo.METHODS)
+
+
+def test_registered_methods_are_all_broll_namespaced_and_key_free(tmp_path):
+    # These never call a provider, so none may ever join the key-injection
+    # allowlist (which is prefix-driven: ai. / director. / shortmaker. / index.).
+    assert all(name.startswith("broll.") for name in bo.METHODS)
+
+
+def test_a_garbage_threshold_falls_back_to_the_default_instead_of_crashing(tmp_path, registry):
+    # The renderer sends a slider value; a blank field must not 500 the job.
+    store = _Store()
+    svc = _svc(tmp_path, store)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    job = _suggest(svc, registry, {"videoId": "v1", "threshold": "not-a-number"})
+    # 0.99 / 0.14 both clear the 0.22 default, so the fallback is observable.
+    assert [i["assetId"] for i in job.result["insertions"]] == ["a-dog", "a-city"]
+
+
+def test_without_a_duration_seam_the_total_falls_back_to_the_last_segment_end(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store, duration=None)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    # Last segment ends at 36 s; a 40% cap = 14.4 s, so both inserts still fit
+    # and the job must complete rather than divide by a zero total.
+    job = _suggest(svc, registry, {"videoId": "v1", "threshold": 0.5})
+    assert job.status.value == "done"
+    assert len(job.result["insertions"]) == 2
+
+
+def test_the_default_clock_stamps_an_iso_utc_instant(tmp_path, registry):
+    store = _Store()
+    svc = _svc(tmp_path, store, clock=None)
+    registry.get(svc.index({}, _rpc(registry))["jobId"]).wait(timeout=5)
+    built_at = store.value["builtAt"]
+    assert built_at.endswith("Z")
+    assert built_at[4] == "-" and built_at[10] == "T"
+
+
+def test_a_backbone_returning_the_wrong_vector_count_fails_loudly(tmp_path, registry):
+    # A silently short embed batch would persist an index whose rows are shifted
+    # against their assets - every later ranking would be confidently wrong.
+    svc = _svc(tmp_path, _Store(), embed_images=lambda paths: [[1.0, 0.0]])
+    job = registry.get(svc.index({}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "error"
+    assert "1 vectors for 2 assets" in str(job.error)
+
+
+def test_settings_provider_failure_never_breaks_an_op(tmp_path, registry):
+    def boom() -> dict[str, Any]:
+        raise RuntimeError("settings exploded")
+
+    svc = _svc(tmp_path, _Store(), settings_provider=boom)
+    job = registry.get(svc.apply({"videoId": "v1", "insertions": [_plan_row()]}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "done"

--- a/sidecar/tests/test_broll_plan.py
+++ b/sidecar/tests/test_broll_plan.py
@@ -1,0 +1,314 @@
+"""PURE auto-b-roll planner tests (v1.5 flagship #3, WU BR3+BR4).
+
+Every cosine here is HAND-BUILT: asset vectors are the 2-D basis (``[1,0]`` /
+``[0,1]``) and each segment's query vector is aimed at one of them, so the
+retrieval score of every (segment, asset) pair is arithmetic the test states
+outright. No model, no torch, no network — the planner never sees one (it takes
+already-embedded vectors through an injected seam), which is what makes 100%
+branch coverage of the gate/timing/dedupe logic honest rather than mocked.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+from media_studio.features import broll_plan as bp
+
+# --------------------------------------------------------------------------- #
+# fixtures: two orthogonal assets and segments aimed at one or the other
+# --------------------------------------------------------------------------- #
+ASSETS = [
+    {"assetId": "a-dog", "path": "/lib/dog.mp4", "kind": "video", "durationSec": 12.0},
+    {"assetId": "a-city", "path": "/lib/city.png", "kind": "image", "durationSec": None},
+]
+ASSET_VECS = [[1.0, 0.0], [0.0, 1.0]]
+
+#: cos ~= 0.99 vs a-dog, ~= 0.14 vs a-city.
+Q_DOG = [0.99, 0.14]
+#: cos ~= 0.14 vs a-dog, ~= 0.99 vs a-city.
+Q_CITY = [0.14, 0.99]
+#: 45 degrees from both -> cos ~= 0.707 each (an exact tie).
+Q_TIE = [1.0, 1.0]
+
+
+def _seg(start: float, end: float, text: str = "") -> dict[str, object]:
+    return {"start": start, "end": end, "text": text}
+
+
+# --------------------------------------------------------------------------- #
+# rank_assets — the INVERTED semantic_index.search (query=text, corpus=images)
+# --------------------------------------------------------------------------- #
+def test_rank_assets_orders_by_cosine_and_carries_asset_identity():
+    hits = bp.rank_assets(Q_DOG, ASSET_VECS, ASSETS, top_k=2)
+    assert [h["assetId"] for h in hits] == ["a-dog", "a-city"]
+    assert hits[0]["path"] == "/lib/dog.mp4"
+    assert hits[0]["kind"] == "video"
+    assert hits[0]["score"] == pytest.approx(0.99, abs=1e-3)
+    assert hits[1]["score"] == pytest.approx(0.14, abs=1e-3)
+
+
+def test_rank_assets_truncates_to_top_k():
+    assert len(bp.rank_assets(Q_CITY, ASSET_VECS, ASSETS, top_k=1)) == 1
+
+
+def test_rank_assets_non_positive_top_k_is_empty():
+    assert bp.rank_assets(Q_DOG, ASSET_VECS, ASSETS, top_k=0) == []
+
+
+def test_rank_assets_ties_keep_source_order():
+    # An exact tie must resolve to the LOWEST asset index (stable sort), so the
+    # planner is reproducible run-to-run.
+    hits = bp.rank_assets(Q_TIE, ASSET_VECS, ASSETS, top_k=2)
+    assert [h["assetId"] for h in hits] == ["a-dog", "a-city"]
+    assert hits[0]["score"] == pytest.approx(hits[1]["score"])
+
+
+def test_rank_assets_dimension_mismatch_propagates():
+    with pytest.raises(ValueError):
+        bp.rank_assets([1.0, 0.0, 0.0], ASSET_VECS, ASSETS, top_k=1)
+
+
+# --------------------------------------------------------------------------- #
+# suggest — the per-segment threshold gate (the "no random static images" wall)
+# --------------------------------------------------------------------------- #
+def test_suggest_matches_each_segment_to_its_own_asset():
+    segments = [_seg(0.0, 4.0, "a dog running"), _seg(10.0, 14.0, "the city skyline")]
+    out = bp.suggest(segments, [Q_DOG, Q_CITY], ASSETS, ASSET_VECS, threshold=0.5)
+    assert [s["assetId"] for s in out] == ["a-dog", "a-city"]
+    assert [s["segmentIndex"] for s in out] == [0, 1]
+    assert out[0]["start"] == 0.0 and out[0]["end"] == 4.0
+    assert out[0]["layout"] == bp.DEFAULT_LAYOUT
+
+
+def test_suggest_below_threshold_yields_NO_candidate():
+    # The single most important behaviour: a semantically unrelated segment must
+    # produce NOTHING, never a low-confidence filler insert.
+    segments = [_seg(0.0, 4.0, "unrelated chatter")]
+    out = bp.suggest(segments, [Q_DOG], ASSETS, ASSET_VECS, threshold=0.995)
+    assert out == []
+
+
+def test_suggest_threshold_is_inclusive_at_the_boundary():
+    segments = [_seg(0.0, 4.0)]
+    exact = bp.rank_assets(Q_DOG, ASSET_VECS, ASSETS, top_k=1)[0]["score"]
+    assert bp.suggest(segments, [Q_DOG], ASSETS, ASSET_VECS, threshold=exact) != []
+    assert bp.suggest(segments, [Q_DOG], ASSETS, ASSET_VECS, threshold=math.nextafter(exact, 2.0)) == []
+
+
+def test_suggest_reason_names_the_matched_text_and_score():
+    segments = [_seg(0.0, 4.0, "a dog running through a field of very tall grass")]
+    out = bp.suggest(segments, [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+    assert "0.99" in out[0]["reason"]
+    assert "a dog running" in out[0]["reason"]
+    assert len(out[0]["reason"]) <= bp.MAX_REASON_CHARS
+
+
+def test_suggest_reason_on_an_empty_segment_text():
+    out = bp.suggest([_seg(0.0, 4.0, "")], [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+    assert out[0]["reason"].startswith(bp.REASON_NO_TEXT)
+
+
+def test_suggest_with_no_assets_is_empty():
+    assert bp.suggest([_seg(0.0, 4.0)], [Q_DOG], [], [], threshold=0.0) == []
+
+
+def test_suggest_honours_an_explicit_layout():
+    out = bp.suggest([_seg(0.0, 4.0)], [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5, layout="pip")
+    assert out[0]["layout"] == "pip"
+
+
+def test_suggest_rejects_an_unknown_layout():
+    with pytest.raises(ValueError, match="layout"):
+        bp.suggest([_seg(0.0, 4.0)], [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5, layout="picture-in-picture")
+
+
+def test_suggest_requires_one_vector_per_segment():
+    with pytest.raises(ValueError, match="one vector per segment"):
+        bp.suggest([_seg(0.0, 4.0), _seg(5.0, 9.0)], [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+
+
+def test_suggest_requires_one_vector_per_asset():
+    with pytest.raises(ValueError, match="one vector per asset"):
+        bp.suggest([_seg(0.0, 4.0)], [Q_DOG], ASSETS, ASSET_VECS[:1], threshold=0.5)
+
+
+# --------------------------------------------------------------------------- #
+# diversify — MMR across the accepted suggestions (reuses features/diversity)
+# --------------------------------------------------------------------------- #
+def test_diversify_drops_a_near_duplicate_asset():
+    # Three segments all match a-dog; MMR with k=2 must not return a-dog twice
+    # when a genuinely different asset is available.
+    segments = [_seg(0.0, 4.0), _seg(10.0, 14.0), _seg(20.0, 24.0)]
+    out = bp.suggest(segments, [Q_DOG, Q_DOG, Q_CITY], ASSETS, ASSET_VECS, threshold=0.5)
+    kept = bp.diversify(out, ASSETS, ASSET_VECS, k=2)
+    assert len(kept) == 2
+    assert {s["assetId"] for s in kept} == {"a-dog", "a-city"}
+
+
+def test_diversify_returns_chronological_order():
+    segments = [_seg(20.0, 24.0), _seg(0.0, 4.0)]
+    out = bp.suggest(segments, [Q_CITY, Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+    kept = bp.diversify(out, ASSETS, ASSET_VECS)
+    assert [s["start"] for s in kept] == [0.0, 20.0]
+
+
+def test_diversify_of_nothing_is_nothing():
+    assert bp.diversify([], ASSETS, ASSET_VECS) == []
+
+
+def test_diversify_supports_dpp():
+    segments = [_seg(0.0, 4.0), _seg(10.0, 14.0)]
+    out = bp.suggest(segments, [Q_DOG, Q_CITY], ASSETS, ASSET_VECS, threshold=0.5)
+    assert len(bp.diversify(out, ASSETS, ASSET_VECS, method="dpp")) == 2
+
+
+def test_diversify_on_an_unknown_asset_id_raises():
+    orphan = [
+        {
+            "segmentIndex": 0,
+            "start": 0.0,
+            "end": 4.0,
+            "assetId": "ghost",
+            "path": "",
+            "kind": "image",
+            "score": 1.0,
+            "reason": "",
+            "layout": "cutaway",
+        }
+    ]
+    with pytest.raises(KeyError, match="ghost"):
+        bp.diversify(orphan, ASSETS, ASSET_VECS)
+
+
+# --------------------------------------------------------------------------- #
+# place — timing, coverage cap, min-gap, per-asset cooldown
+# --------------------------------------------------------------------------- #
+def _sugg(seg_index: int, start: float, end: float, asset_id: str = "a-dog", score: float = 0.9):
+    return {
+        "segmentIndex": seg_index,
+        "start": start,
+        "end": end,
+        "assetId": asset_id,
+        "path": "/lib/dog.mp4",
+        "kind": "video",
+        "score": score,
+        "reason": "r",
+        "layout": "cutaway",
+    }
+
+
+def test_place_clamps_duration_to_the_max():
+    out = bp.place([_sugg(0, 0.0, 30.0)], total_sec=600.0, max_duration_sec=5.0)
+    assert out[0]["start"] == 0.0
+    assert out[0]["end"] == 5.0
+
+
+def test_place_never_runs_past_the_segment_end():
+    out = bp.place([_sugg(0, 10.0, 13.0)], total_sec=600.0, max_duration_sec=5.0)
+    assert out[0]["end"] == 13.0
+
+
+def test_place_drops_a_segment_shorter_than_the_minimum():
+    assert bp.place([_sugg(0, 0.0, 0.9)], total_sec=600.0, min_duration_sec=1.5) == []
+
+
+def test_place_enforces_the_coverage_cap():
+    # Three 5 s inserts = 15 s; a 10% cap on a 100 s video allows only 10 s = two.
+    sugg = [_sugg(0, 0.0, 5.0, score=0.9), _sugg(1, 20.0, 25.0, score=0.8), _sugg(2, 40.0, 45.0, score=0.7)]
+    out = bp.place(sugg, total_sec=100.0, max_coverage_pct=10.0, min_gap_sec=0.0, cooldown_sec=0.0)
+    assert len(out) == 2
+    # The cap keeps the HIGHEST-scoring pair, not simply the first two by time.
+    assert [s["score"] for s in out] == [0.9, 0.8]
+
+
+def test_place_keeps_the_higher_score_when_the_cap_bites():
+    sugg = [_sugg(0, 0.0, 5.0, score=0.5), _sugg(1, 20.0, 25.0, score=0.95)]
+    out = bp.place(sugg, total_sec=100.0, max_coverage_pct=5.0, min_gap_sec=0.0, cooldown_sec=0.0)
+    assert [s["score"] for s in out] == [0.95]
+
+
+def test_place_enforces_the_minimum_gap():
+    sugg = [_sugg(0, 0.0, 3.0, score=0.9), _sugg(1, 3.5, 6.5, score=0.8)]
+    out = bp.place(sugg, total_sec=600.0, min_gap_sec=2.0, cooldown_sec=0.0)
+    assert [s["start"] for s in out] == [0.0]
+
+
+def test_place_allows_an_insert_exactly_one_gap_later():
+    sugg = [_sugg(0, 0.0, 3.0, score=0.9), _sugg(1, 5.0, 8.0, score=0.8)]
+    out = bp.place(sugg, total_sec=600.0, min_gap_sec=2.0, cooldown_sec=0.0)
+    assert [s["start"] for s in out] == [0.0, 5.0]
+
+
+def test_place_enforces_the_per_asset_cooldown():
+    sugg = [_sugg(0, 0.0, 3.0, "a-dog", 0.9), _sugg(1, 20.0, 23.0, "a-dog", 0.8)]
+    out = bp.place(sugg, total_sec=600.0, cooldown_sec=30.0, min_gap_sec=0.0)
+    assert [s["start"] for s in out] == [0.0]
+
+
+def test_cooldown_is_per_asset_not_global():
+    sugg = [_sugg(0, 0.0, 3.0, "a-dog", 0.9), _sugg(1, 20.0, 23.0, "a-city", 0.8)]
+    out = bp.place(sugg, total_sec=600.0, cooldown_sec=30.0, min_gap_sec=0.0)
+    assert [s["assetId"] for s in out] == ["a-dog", "a-city"]
+
+
+def test_place_snaps_the_start_to_a_nearby_shot_boundary():
+    out = bp.place([_sugg(0, 10.2, 15.0)], total_sec=600.0, boundaries=[10.0, 300.0], snap_window_sec=0.5)
+    assert out[0]["start"] == 10.0
+
+
+def test_place_does_not_snap_to_a_far_boundary():
+    out = bp.place([_sugg(0, 10.2, 15.0)], total_sec=600.0, boundaries=[3.0], snap_window_sec=0.5)
+    assert out[0]["start"] == 10.2
+
+
+def test_place_ignores_boundaries_when_none_are_supplied():
+    out = bp.place([_sugg(0, 10.2, 15.0)], total_sec=600.0)
+    assert out[0]["start"] == 10.2
+
+
+def test_place_returns_chronological_order_even_when_scores_invert_it():
+    sugg = [_sugg(0, 50.0, 54.0, "a-dog", 0.99), _sugg(1, 10.0, 14.0, "a-city", 0.60)]
+    out = bp.place(sugg, total_sec=600.0, min_gap_sec=0.0, cooldown_sec=0.0)
+    assert [s["start"] for s in out] == [10.0, 50.0]
+
+
+def test_place_carries_a_source_offset_for_a_video_asset():
+    out = bp.place([_sugg(0, 10.0, 14.0)], total_sec=600.0)
+    assert out[0]["sourceStart"] == 0.0
+    assert out[0]["duration"] == pytest.approx(4.0)
+
+
+def test_place_of_nothing_is_nothing():
+    assert bp.place([], total_sec=600.0) == []
+
+
+def test_place_rejects_a_non_positive_total():
+    with pytest.raises(ValueError, match="totalSec"):
+        bp.place([_sugg(0, 0.0, 4.0)], total_sec=0.0)
+
+
+# --------------------------------------------------------------------------- #
+# plan — the composed pipeline (suggest -> diversify -> place)
+# --------------------------------------------------------------------------- #
+def test_plan_end_to_end_matches_dedupes_and_times():
+    segments = [_seg(0.0, 6.0, "a dog running"), _seg(30.0, 36.0, "the city skyline")]
+    out = bp.plan(
+        segments,
+        [Q_DOG, Q_CITY],
+        ASSETS,
+        ASSET_VECS,
+        total_sec=120.0,
+        threshold=0.5,
+    )
+    assert [i["assetId"] for i in out] == ["a-dog", "a-city"]
+    assert all(i["end"] - i["start"] <= bp.DEFAULT_MAX_DURATION_SEC + 1e-9 for i in out)
+
+
+def test_plan_returns_nothing_when_everything_is_below_threshold():
+    segments = [_seg(0.0, 6.0, "unrelated")]
+    assert bp.plan(segments, [Q_DOG], ASSETS, ASSET_VECS, total_sec=120.0, threshold=0.999) == []
+
+
+def test_plan_coverage_of_an_empty_library():
+    assert bp.plan([_seg(0.0, 6.0)], [Q_DOG], [], [], total_sec=120.0) == []

--- a/sidecar/tests/test_broll_plan.py
+++ b/sidecar/tests/test_broll_plan.py
@@ -109,6 +109,20 @@ def test_suggest_reason_on_an_empty_segment_text():
     assert out[0]["reason"].startswith(bp.REASON_NO_TEXT)
 
 
+def test_suggest_reason_truncates_a_long_segment_and_still_fits_the_cap():
+    long_text = "a dog running " * 20
+    out = bp.suggest([_seg(0.0, 4.0, long_text)], [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+    reason = out[0]["reason"]
+    assert len(reason) <= bp.MAX_REASON_CHARS
+    assert "…" in reason
+    assert reason.endswith("(0.99)")
+
+
+def test_suggest_reason_collapses_runaway_whitespace():
+    out = bp.suggest([_seg(0.0, 4.0, "  a\n\tdog   running  ")], [Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+    assert out[0]["reason"].startswith('"a dog running"')
+
+
 def test_suggest_with_no_assets_is_empty():
     assert bp.suggest([_seg(0.0, 4.0)], [Q_DOG], [], [], threshold=0.0) == []
 

--- a/sidecar/tests/test_broll_plan.py
+++ b/sidecar/tests/test_broll_plan.py
@@ -167,6 +167,46 @@ def test_diversify_returns_chronological_order():
     assert [s["start"] for s in kept] == [0.0, 20.0]
 
 
+def test_diversify_without_k_drops_NOTHING_it_only_re_ranks():
+    # Pins the corrected claim. dedupe_candidates at budget == n returns all n
+    # rows, so the default diversify() is a no-op on the OUTPUT SET. An earlier
+    # docstring called this "near-duplicate suppression" flatly, which was wider
+    # than the code; on the default path the cooldown does the suppressing.
+    segments = [_seg(0.0, 4.0), _seg(10.0, 14.0), _seg(20.0, 24.0)]
+    out = bp.suggest(segments, [Q_DOG, Q_DOG, Q_DOG], ASSETS, ASSET_VECS, threshold=0.5)
+    assert [s["assetId"] for s in bp.diversify(out, ASSETS, ASSET_VECS)] == ["a-dog"] * 3
+    assert [s["assetId"] for s in bp.diversify(out, ASSETS, ASSET_VECS, k=1)] == ["a-dog"]
+
+
+def test_the_default_plan_thins_repeats_via_the_COOLDOWN_not_via_mmr():
+    # The companion half: with the cooldown disabled, all three repeats survive
+    # the default plan() - proving MMR was never what removed them.
+    segments = [_seg(0.0, 4.0), _seg(10.0, 14.0), _seg(20.0, 24.0)]
+    vecs = [Q_DOG, Q_DOG, Q_DOG]
+    with_cooldown = bp.plan(segments, vecs, ASSETS, ASSET_VECS, total_sec=300.0, threshold=0.5)
+    without = bp.plan(
+        segments, vecs, ASSETS, ASSET_VECS, total_sec=300.0, threshold=0.5, cooldown_sec=0.0, min_gap_sec=0.0
+    )
+    assert len(with_cooldown) == 1
+    assert len(without) == 3
+
+
+def test_plan_max_inserts_caps_the_surviving_suggestions():
+    segments = [_seg(0.0, 4.0), _seg(10.0, 14.0)]
+    out = bp.plan(
+        segments,
+        [Q_DOG, Q_CITY],
+        ASSETS,
+        ASSET_VECS,
+        total_sec=300.0,
+        threshold=0.5,
+        max_inserts=1,
+        min_gap_sec=0.0,
+        cooldown_sec=0.0,
+    )
+    assert len(out) == 1
+
+
 def test_diversify_of_nothing_is_nothing():
     assert bp.diversify([], ASSETS, ASSET_VECS) == []
 

--- a/sidecar/tests/test_broll_wiring.py
+++ b/sidecar/tests/test_broll_wiring.py
@@ -1,0 +1,150 @@
+"""Composition-root wiring for ``broll.*`` (v1.5 flagship #3).
+
+``test_broll_ops.py`` proves the service against injected seams. That is not the
+same claim as "the running sidecar can answer broll.status" — a feature can be
+fully unit-tested and never registered, or registered against the wrong
+directory. So this module drives the REAL ``register_all`` composition root over
+a tmp-dir ``Services`` and calls the handlers it collected.
+
+The adapters exercised here are exactly the ones the unit tests cannot see: the
+``brollDir`` settings scan, the index sidecar's location under the data dir, and
+the transcript read off the project manifest.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+from media_studio.features import broll_ops as bo
+from media_studio.handlers import Services, register_all
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext
+
+
+@pytest.fixture
+def wired(tmp_path):
+    """``(handlers, services)`` from the real composition root, tmp-dir backed."""
+    collected: dict[str, Any] = {}
+    services = Services(data_dir=tmp_path / "data")
+    register_all(services, register=lambda name, handler: collected.__setitem__(name, handler))
+    return collected, services
+
+
+def _rpc(registry: JobRegistry) -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=registry)
+
+
+def test_every_broll_method_is_registered_by_the_composition_root(wired):
+    handlers, _services = wired
+    assert set(bo.METHODS) <= set(handlers)
+
+
+def test_broll_status_answers_on_a_first_run_machine(wired):
+    # No brollDir configured, no index on disk: the honest answer is "nothing
+    # indexed", not a crash and not a fabricated count.
+    handlers, _services = wired
+    got = handlers["broll.status"]({}, RpcContext(emit_notification=lambda obj: None, jobs=None))
+    assert got == {
+        "indexed": False,
+        "assetCount": 0,
+        "libraryCount": 0,
+        "model": "",
+        "dim": 0,
+        "stale": True,
+        "staleCount": 0,
+        "willEgress": False,
+    }
+
+
+def test_the_wired_scan_reads_the_brollDir_setting(wired, tmp_path):
+    handlers, services = wired
+    folder = tmp_path / "my-broll"
+    folder.mkdir()
+    (folder / "dog.png").write_bytes(b"x")
+    (folder / "city.mp4").write_bytes(b"yy")
+    services.settings.set({bo.BROLL_DIR_KEY: str(folder)})
+    assert handlers["broll.status"]({}, RpcContext(emit_notification=lambda obj: None, jobs=None))["libraryCount"] == 2
+
+
+def test_the_wired_index_sidecar_lives_next_to_the_data_dir(wired, registry, tmp_path):
+    handlers, services = wired
+    folder = tmp_path / "my-broll"
+    folder.mkdir()
+    (folder / "dog.png").write_bytes(b"x")
+    services.settings.set({bo.BROLL_DIR_KEY: str(folder)})
+
+    # Swap ONLY the tower: everything else on the path is the real wiring.
+    sidecar = services.data_dir / bo.INDEX_FILENAME
+    assert not sidecar.exists()
+    bo.save_index_file(sidecar, {"version": 1, "model": "m", "dim": 2, "builtAt": "t", "assets": []})
+    # The wired load_index must read from that exact location.
+    got = handlers["broll.status"]({}, RpcContext(emit_notification=lambda obj: None, jobs=None))
+    assert got["indexed"] is True
+    assert got["model"] == "m"
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["model"] == "m"
+
+
+def _add_video(handlers, registry, tmp_path) -> str:
+    video = tmp_path / "talk.mp4"
+    video.write_bytes(b"not really a video")
+    added = handlers["library.add"]({"path": str(video)}, _rpc(registry))
+    return added["id"] if "id" in added else added["video"]["id"]
+
+
+def _write_index(services, model: str) -> None:
+    bo.save_index_file(
+        services.data_dir / bo.INDEX_FILENAME,
+        {"version": 1, "model": model, "dim": 2, "builtAt": "t", "assets": []},
+    )
+
+
+def test_the_wired_suggest_refuses_an_index_from_another_backbone(wired, registry, tmp_path):
+    handlers, services = wired
+    video_id = _add_video(handlers, registry, tmp_path)
+    _write_index(services, "other/model")
+    job = registry.get(handlers["broll.suggest"]({"videoId": video_id}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "error"
+    assert "one joint space" in str(job.error)
+
+
+def test_the_wired_transcript_read_comes_off_the_project_manifest(wired, registry, tmp_path):
+    handlers, services = wired
+    video_id = _add_video(handlers, registry, tmp_path)
+    # A MATCHING-model index gets past require_model, so the next thing suggest
+    # touches is the wired transcript read. The project has no transcript, so it
+    # must refuse with the actionable message rather than loading a model to
+    # embed nothing.
+    _write_index(services, bo.DEFAULT_MODEL_ID)
+    job = registry.get(handlers["broll.suggest"]({"videoId": video_id}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "error"
+    assert "has no transcript yet" in str(job.error)
+
+
+def test_the_wired_index_job_writes_the_sidecar_to_the_data_dir(wired, registry, tmp_path):
+    handlers, services = wired
+    empty = tmp_path / "empty-broll"
+    empty.mkdir()
+    services.settings.set({bo.BROLL_DIR_KEY: str(empty)})
+    # An EMPTY library needs no embeddings, so this exercises the whole wired
+    # index path - scan, refresh plan, merge, SAVE - with no weights installed.
+    job = registry.get(handlers["broll.index"]({}, _rpc(registry))["jobId"])
+    job.wait(timeout=5)
+    assert job.status.value == "done", job.error
+    sidecar = services.data_dir / bo.INDEX_FILENAME
+    assert sidecar.is_file()
+    assert json.loads(sidecar.read_text(encoding="utf-8"))["model"] == bo.DEFAULT_MODEL_ID
+
+
+def test_broll_methods_never_enter_the_key_injection_allowlist(wired):
+    # keyBridge.ts injects on the ai./director./shortmaker./index. prefixes and a
+    # small exact list. broll.* is local-only, so it must match none of them —
+    # otherwise a provider key would be handed to a handler that has no provider.
+    handlers, _services = wired
+    prefixes = ("ai.", "director.", "shortmaker.", "index.")
+    for name in bo.METHODS:
+        assert name in handlers
+        assert not name.startswith(prefixes)

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -35,6 +35,13 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         "batch.resume",
         "batch.start",
         "batch.status",
+        # v1.5 flagship #3 (auto-b-roll): local asset retrieval + compositing.
+        # None of these may ever gain a key-injection prefix — they are
+        # local-only and never call a provider (features/broll_ops.py).
+        "broll.apply",
+        "broll.index",
+        "broll.status",
+        "broll.suggest",
         "captions.cues",
         "convert.batch",
         "convert.start",


### PR DESCRIPTION
Adds automatic b-roll: a SigLIP-backed asset index with staleness detection and
incremental refresh, a pure planner that picks windows and assets, and an
ffmpeg argv builder that composites N windows in one pass.

The planner and the compositing builder are **pure** and unit-tested; the only
test that touches real ffmpeg is `test_broll_composite.py`, which asserts on
decoded pixels rather than on the command string.

Four `broll.*` methods join the frozen RPC surface (`test_handlers_rpc_surface`
updated deliberately, not incidentally).

One design-doc claim was **REFUTED** during the lane and the doc corrected:
`diversify()` at `k=None` suppresses nothing.

## Commits

- fix(broll): narrow the assets param so the type gate passes (gate:2)
- docs(broll): REFUTED - diversify() at k=None suppresses nothing
- test(broll): admit the four broll.* methods to the frozen RPC surface
- docs(broll): qualify the two bare design-doc citations (docs_check r5)
- feat(broll): wire broll.* into the composition root + the SigLIP seams
- feat(broll): GREEN - the broll.* RPC surface (BR0 wiring half)
- feat(broll): GREEN - asset index, staleness and incremental refresh (BR2)
- test(broll): real-ffmpeg pixel proof of the composite (part of BR8)
- feat(broll): GREEN - N-window compositing argv builder (BR5)
- feat(broll): GREEN - the pure auto-b-roll planner (BR3+BR4)
- test(broll): RED - pure auto-b-roll planner spec (BR3+BR4)

