### PR TITLE
feat(transcript-edit): delete-a-word transcript editing with preview and undo

### DIFF
--- a/app/renderer/src/App.director-state.test.tsx
+++ b/app/renderer/src/App.director-state.test.tsx
@@ -142,6 +142,17 @@ vi.mock('./components/JobQueue', () => ({
   JOBQUEUE_PANEL_ID: 'jobqueue-panel',
 }));
 vi.mock('./components/SidecarBanner', () => ({ SidecarBanner: () => <div /> }));
+// Same doctrine as the sibling views above, applied to a Workspace feature panel
+// this suite never exercises. `open-video` routes through the real Edit ->
+// Workspace, whose panel module graph is resolved during the test; adding the
+// v1.5 Transcript-edit panel pushed the FIRST case past the 5s default timeout
+// (measured: 3/3 fail at the default, 3/3 pass at --testTimeout=30000, so it is a
+// transform-cost cliff, not a behaviour break). Stubbing the panel keeps this
+// suite measuring Director state instead of module-graph cost. UNVERIFIED whether
+// CI's Linux runner would have crossed the same cliff — settled by reverting this
+// mock and reading the gate-tests-coverage vitest step; the stub is correct either
+// way because the panel is irrelevant here.
+vi.mock('./features/TranscriptEditor', () => ({ default: () => <div /> }));
 
 import { App } from './App';
 

--- a/app/renderer/src/features/TranscriptEditor.test.tsx
+++ b/app/renderer/src/features/TranscriptEditor.test.tsx
@@ -1,0 +1,417 @@
+// TranscriptEditor.test.tsx — the transcript-native editing pane (v1.5 flagship #2).
+//
+// Drives the four sidecar RPCs behind a fake `api` bridge (mirroring
+// Refine.test.tsx):
+//   transcript.get({videoId})                 -> {transcript}            (DIRECT)
+//   transcript.previewEdit({videoId, edits})  -> {plan}                  (DIRECT)
+//   transcript.applyEdit({videoId, edits})    -> {jobId} -> job.done {path, editId}
+//   transcript.undoEdit({videoId})            -> {editId, path}          (DIRECT)
+
+// @vitest-environment jsdom
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+import TranscriptEditor, {
+  errMessage,
+  extractApply,
+  extractPlan,
+  extractTranscript,
+  undoPath,
+} from './TranscriptEditor';
+
+(globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+
+const TRANSCRIPT = {
+  language: 'en',
+  durationSec: 10,
+  segments: [
+    {
+      start: 0,
+      end: 3.5,
+      text: 'we um should ship',
+      words: [
+        { wordId: 'w0-0', segmentIndex: 0, wordIndex: 0, text: 'we', start: 0, end: 0.5 },
+        { wordId: 'w0-1', segmentIndex: 0, wordIndex: 1, text: 'um', start: 1, end: 1.4 },
+        { wordId: 'w0-2', segmentIndex: 0, wordIndex: 2, text: 'should', start: 2, end: 2.5 },
+        { wordId: 'w0-3', segmentIndex: 0, wordIndex: 3, text: 'ship', start: 3, end: 3.5 },
+      ],
+    },
+  ],
+};
+
+const PLAN = {
+  keeps: [
+    [0, 3],
+    [3.5, 10],
+  ],
+  stats: {
+    wordsDeleted: 1,
+    deletedSec: 0.5,
+    fillersRemoved: 0,
+    fillerSeconds: 0,
+    silenceRemovedSec: 0,
+    keptSec: 9.5,
+    removedSec: 0.5,
+  },
+  cues: [],
+  rejected: [],
+};
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+function makeFakeApi(overrides: Record<string, unknown> = {}): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const table: Record<string, unknown> = {
+    'transcript.get': { transcript: TRANSCRIPT },
+    'transcript.previewEdit': { plan: PLAN },
+    'transcript.applyEdit': { jobId: 'job-t' },
+    'transcript.undoEdit': { editId: 'tedit-1', path: '/lib/in.mp4' },
+    ...overrides,
+  };
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      const value = table[method];
+      if (value instanceof Error) throw value;
+      return (value ?? {}) as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+describe('extractTranscript', () => {
+  it('pulls a transcript with segments', () => {
+    expect(extractTranscript({ transcript: TRANSCRIPT })).toEqual(TRANSCRIPT);
+  });
+  it('is null when absent, null, or shapeless', () => {
+    expect(extractTranscript({})).toBeNull();
+    expect(extractTranscript(null)).toBeNull();
+    expect(extractTranscript({ transcript: { segments: 'nope' } })).toBeNull();
+  });
+});
+
+describe('extractPlan', () => {
+  it('pulls the plan from a previewEdit result', () => {
+    expect(extractPlan({ plan: PLAN })).toEqual(PLAN);
+  });
+  it('is null when absent or shapeless', () => {
+    expect(extractPlan({})).toBeNull();
+    expect(extractPlan({ plan: { keeps: [], stats: null } })).toBeNull();
+  });
+});
+
+describe('extractApply', () => {
+  it('reads the output path and edit id', () => {
+    expect(extractApply({ path: '/out/in.edited.mp4', editId: 'tedit-1' })).toEqual({
+      path: '/out/in.edited.mp4',
+      editId: 'tedit-1',
+    });
+  });
+  it('tolerates a null editId (a pass-through apply)', () => {
+    expect(extractApply({ path: '/lib/in.mp4', editId: null })).toEqual({
+      path: '/lib/in.mp4',
+      editId: null,
+    });
+  });
+  it('is null without a path', () => {
+    expect(extractApply({})).toBeNull();
+    expect(extractApply(null)).toBeNull();
+  });
+});
+
+describe('errMessage', () => {
+  it('uses an Error message verbatim', () => {
+    expect(errMessage(new Error('ffmpeg exit 1'))).toBe('ffmpeg exit 1');
+  });
+  it('stringifies a non-Error throw', () => {
+    expect(errMessage('bridge went away')).toBe('bridge went away');
+  });
+});
+
+describe('undoPath', () => {
+  it('reads the restored path', () => {
+    expect(undoPath({ path: '/lib/in.mp4' })).toBe('/lib/in.mp4');
+  });
+  it('is empty when the result names no path', () => {
+    expect(undoPath({ editId: 'tedit-1' })).toBe('');
+  });
+});
+
+describe('<TranscriptEditor />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  async function mount(api?: MediaStudioApi): Promise<void> {
+    await act(async () => {
+      root.render(<TranscriptEditor videoId="v1" api={api} />);
+    });
+  }
+
+  const word = (id: string): HTMLButtonElement =>
+    container.querySelector<HTMLButtonElement>(`button[data-word-id="${id}"]`) as HTMLButtonElement;
+
+  const action = (name: string): HTMLButtonElement =>
+    container.querySelector<HTMLButtonElement>(
+      `button[data-action="${name}"]`,
+    ) as HTMLButtonElement;
+
+  async function click(el: HTMLButtonElement): Promise<void> {
+    await act(async () => {
+      el.click();
+      await Promise.resolve();
+    });
+  }
+
+  /** Click Apply, then deliver the job's terminal `job.done` payload. */
+  async function applyAndFinish(
+    fake: FakeApi,
+    result: unknown,
+    progress?: ProgressEvent,
+  ): Promise<void> {
+    await click(action('apply'));
+    if (progress) {
+      await act(async () => {
+        fake.fireProgress(progress);
+      });
+    }
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-t', result });
+    });
+  }
+
+  it('loads the transcript on mount and renders one button per word', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(fake.calls[0]).toEqual({ method: 'transcript.get', params: { videoId: 'v1' } });
+    expect(container.querySelectorAll('button[data-word-id]')).toHaveLength(4);
+    expect(word('w0-2').textContent).toBe('should');
+  });
+
+  it('falls back to the global api bridge when no prop is given', async () => {
+    const fake = makeFakeApi();
+    (globalThis as unknown as { api?: unknown }).api = fake.api;
+    await mount();
+    expect(container.querySelectorAll('button[data-word-id]')).toHaveLength(4);
+    (globalThis as unknown as { api?: unknown }).api = undefined;
+  });
+
+  it('shows an empty state (and disables Preview) when there is no transcript', async () => {
+    const fake = makeFakeApi({ 'transcript.get': { transcript: null } });
+    await mount(fake.api);
+    expect(container.querySelector('[data-state="empty"]')).not.toBeNull();
+    expect(action('preview').disabled).toBe(true);
+  });
+
+  it('surfaces a load failure', async () => {
+    const fake = makeFakeApi({ 'transcript.get': new Error('sidecar down') });
+    await mount(fake.api);
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('sidecar down');
+  });
+
+  it('strikes a word on click and restores it on a second click', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-1'));
+    expect(word('w0-1').dataset.deleted).toBe('true');
+    expect(container.querySelector('[data-section="editedText"]')?.textContent).toBe(
+      'we should ship',
+    );
+    expect(container.querySelector('[data-stat="removedSec"]')?.textContent).toBe('0.4');
+    await click(word('w0-1'));
+    expect(word('w0-1').dataset.deleted).toBe('false');
+    expect(container.querySelector('[data-section="editedText"]')?.textContent).toBe(
+      'we um should ship',
+    );
+  });
+
+  it('previews the cut with the exact EditSpans for the struck words', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    expect(fake.calls.at(-1)).toEqual({
+      method: 'transcript.previewEdit',
+      params: { videoId: 'v1', edits: [{ op: 'delete', wordId: 'w0-3' }] },
+    });
+    expect(container.querySelector('[data-stat="planRemovedSec"]')?.textContent).toBe('0.5');
+    expect(container.querySelector('[data-stat="keeps"]')?.textContent).toBe('2');
+  });
+
+  it('labels the Preview button in-flight while the plan is pending', async () => {
+    let release: (value: unknown) => void = () => {};
+    const pending = new Promise<unknown>((resolve) => {
+      release = resolve;
+    });
+    const fake = makeFakeApi({ 'transcript.previewEdit': pending });
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    expect(action('preview').textContent).toBe('Previewing…');
+    expect(action('preview').disabled).toBe(true);
+    await act(async () => {
+      release({ plan: PLAN });
+    });
+    expect(action('preview').textContent).toBe('Preview cut');
+  });
+
+  it('reports edits the sidecar dropped', async () => {
+    const rejected = {
+      ...PLAN,
+      rejected: [{ index: 0, op: 'reorder', reason: 'reorder-deferred' }],
+    };
+    const fake = makeFakeApi({ 'transcript.previewEdit': { plan: rejected } });
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    expect(container.querySelector('[data-stat="rejected"]')?.textContent).toContain(
+      'reorder-deferred',
+    );
+  });
+
+  it('surfaces a preview failure', async () => {
+    const fake = makeFakeApi({ 'transcript.previewEdit': new Error('no plan') });
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('no plan');
+  });
+
+  it('keeps Apply disabled until a preview exists, then applies and shows the cut file', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-3'));
+    expect(action('apply').disabled).toBe(true);
+    await click(action('preview'));
+    expect(action('apply').disabled).toBe(false);
+
+    await applyAndFinish(
+      fake,
+      { path: '/out/in.edited.mp4', editId: 'tedit-1' },
+      { jobId: 'job-t', pct: 40, message: 're-cutting' },
+    );
+
+    expect(container.querySelector('[data-section="result"] code')?.textContent).toBe(
+      '/out/in.edited.mp4',
+    );
+    expect(container.querySelector('[data-stat="editId"]')?.textContent).toBe('tedit-1');
+    expect(action('undo').disabled).toBe(false);
+  });
+
+  it('striking another word after a preview re-disables Apply', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    expect(action('apply').disabled).toBe(false);
+    await click(word('w0-1'));
+    expect(action('apply').disabled).toBe(true);
+  });
+
+  it('shows no result section when the apply job returns no path', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    await applyAndFinish(fake, {});
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+  });
+
+  it('surfaces an apply failure', async () => {
+    const fake = makeFakeApi({ 'transcript.applyEdit': new Error('ffmpeg exit 1') });
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    await click(action('apply'));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('ffmpeg exit 1');
+  });
+
+  it('treats a missing jobId as nothing to wait for', async () => {
+    const fake = makeFakeApi({ 'transcript.applyEdit': {} });
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    await click(action('apply'));
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('undo restores the previous path and clears the edit id', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    await applyAndFinish(fake, { path: '/out/in.edited.mp4', editId: 'tedit-1' });
+
+    await click(action('undo'));
+    expect(fake.calls.at(-1)).toEqual({
+      method: 'transcript.undoEdit',
+      params: { videoId: 'v1', editId: 'tedit-1' },
+    });
+    expect(container.querySelector('[data-section="result"] code')?.textContent).toBe(
+      '/lib/in.mp4',
+    );
+    expect(action('undo').disabled).toBe(true);
+  });
+
+  it('surfaces an undo failure', async () => {
+    const fake = makeFakeApi({ 'transcript.undoEdit': new Error('nothing to undo') });
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    await applyAndFinish(fake, { path: '/out/in.edited.mp4', editId: 'tedit-1' });
+    await click(action('undo'));
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('nothing to undo');
+  });
+
+  it('ignores progress for a different job', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await click(word('w0-3'));
+    await click(action('preview'));
+    await applyAndFinish(
+      fake,
+      { path: '/out/in.edited.mp4', editId: 'tedit-1' },
+      { jobId: 'someone-else', pct: 99, message: 'not mine' },
+    );
+    expect(container.textContent).not.toContain('not mine');
+  });
+});

--- a/app/renderer/src/features/TranscriptEditor.tsx
+++ b/app/renderer/src/features/TranscriptEditor.tsx
@@ -1,0 +1,324 @@
+// Transcript-native editing pane (v1.5 flagship #2) — "delete a word, the video cuts".
+//
+// The Descript-class inspector: the transcript renders as clickable word tokens;
+// striking a token marks it deleted, "Preview cut" asks the sidecar for the
+// resulting keep-list WITHOUT encoding, "Apply" renders it ONCE to a NEW
+// *.edited.mp4 (the source is never touched), and "Undo" pops that edit back off
+// the project's reversible ledger.
+//
+// Drives the four RPCs over the FROZEN window.api bridge:
+//   transcript.get({videoId})                -> {transcript}   (DIRECT)
+//   transcript.previewEdit({videoId, edits}) -> {plan}          (DIRECT)
+//   transcript.applyEdit({videoId, edits})   -> {jobId} -> job.done {path, editId, ...}
+//   transcript.undoEdit({videoId, editId})   -> {editId, path}  (DIRECT)
+//
+// ALL selection/΄what-does-this-cut΄ math lives in the pure `lib/transcriptEdit`
+// module (unit-tested standalone); this file is the thin view over it. Same
+// bridge shape as Refine.tsx (getApi / bridge.rpc / waitForJobDone / onProgress
+// / injectable `api?` prop for tests).
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import './panels.css';
+import {
+  buildEditSpans,
+  editedText,
+  flattenWords,
+  removedSeconds,
+  toggleWord,
+  type Transcript,
+} from '../lib/transcriptEdit';
+import { getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+
+/** The sidecar's TranscriptEditPlan (features/transcript_edit.py). */
+export interface TranscriptEditPlan {
+  keeps: number[][];
+  stats: {
+    wordsDeleted: number;
+    deletedSec: number;
+    fillersRemoved: number;
+    fillerSeconds: number;
+    silenceRemovedSec: number;
+    keptSec: number;
+    removedSec: number;
+  };
+  cues: unknown[];
+  rejected: Array<{ index: number; op: string; reason: string }>;
+}
+
+/** The applied-edit receipt (`transcript.applyEdit` job.done). */
+export interface ApplyReceipt {
+  path: string;
+  editId: string | null;
+}
+
+// --- pure helpers (exported for tests) -------------------------------------
+/** The transcript from a `transcript.get` result (null when absent/shapeless). */
+export function extractTranscript(result: unknown): Transcript | null {
+  const transcript = pickField<Transcript>(result, 'transcript');
+  if (transcript && Array.isArray(transcript.segments)) return transcript;
+  return null;
+}
+
+/** The plan from a `transcript.previewEdit` result (null when shapeless). */
+export function extractPlan(result: unknown): TranscriptEditPlan | null {
+  const plan = pickField<TranscriptEditPlan>(result, 'plan');
+  if (plan && Array.isArray(plan.keeps) && plan.stats && typeof plan.stats === 'object') {
+    return plan;
+  }
+  return null;
+}
+
+/** The `{path, editId}` receipt from an applyEdit job.done (null without a path). */
+export function extractApply(result: unknown): ApplyReceipt | null {
+  const path = pickField<string>(result, 'path');
+  if (typeof path !== 'string') return null;
+  const editId = pickField<string>(result, 'editId');
+  return { path, editId: typeof editId === 'string' ? editId : null };
+}
+
+/** A rejected RPC's human message — a non-Error throw still reads sensibly. */
+export function errMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/** The path a `transcript.undoEdit` result restores to ('' when it names none). */
+export function undoPath(result: unknown): string {
+  const path = pickField<string>(result, 'path');
+  return typeof path === 'string' ? path : '';
+}
+
+export interface TranscriptEditorProps {
+  videoId: string;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+
+export function TranscriptEditor({ videoId, api }: TranscriptEditorProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  const [loading, setLoading] = useState<boolean>(true);
+  const [transcript, setTranscript] = useState<Transcript | null>(null);
+  const [deleted, setDeleted] = useState<ReadonlySet<string>>(() => new Set<string>());
+  const [plan, setPlan] = useState<TranscriptEditPlan | null>(null);
+  const [previewing, setPreviewing] = useState<boolean>(false);
+  const [applying, setApplying] = useState<boolean>(false);
+  const [resultPath, setResultPath] = useState<string>('');
+  const [editId, setEditId] = useState<string | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  useEffect(() => {
+    let live = true;
+    void (async () => {
+      try {
+        const res = await bridge.rpc<unknown>('transcript.get', { videoId });
+        if (live) setTranscript(extractTranscript(res));
+      } catch (err) {
+        if (live) setError(errMessage(err));
+      } finally {
+        if (live) setLoading(false);
+      }
+    })();
+    return () => {
+      live = false;
+    };
+  }, [bridge, videoId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  const words = useMemo(() => flattenWords(transcript), [transcript]);
+  const edits = useMemo(() => buildEditSpans(words, deleted), [words, deleted]);
+
+  // "See before you cut": changing the selection makes the on-screen plan stale,
+  // so drop it — Apply is gated on `!plan`, which re-disables it until a fresh
+  // Preview runs. Apply can therefore never write a cut that differs from the
+  // numbers on screen.
+  const strike = useCallback((wordId: string): void => {
+    setDeleted((prev) => toggleWord(prev, wordId));
+    setPlan(null);
+  }, []);
+
+  const preview = useCallback(async (): Promise<void> => {
+    // defensive: the button is disabled while a preview is in flight.
+    /* v8 ignore next */
+    if (previewing) return;
+    setPreviewing(true);
+    setError('');
+    try {
+      const res = await bridge.rpc<unknown>('transcript.previewEdit', { videoId, edits });
+      setPlan(extractPlan(res));
+    } catch (err) {
+      setError(errMessage(err));
+    } finally {
+      setPreviewing(false);
+    }
+  }, [bridge, videoId, edits, previewing]);
+
+  const apply = useCallback(async (): Promise<void> => {
+    // defensive: Apply is disabled until a plan exists and while a job runs.
+    /* v8 ignore next */
+    if (applying || !plan) return;
+    setApplying(true);
+    setError('');
+    setResultPath('');
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      const res = await bridge.rpc<unknown>('transcript.applyEdit', { videoId, edits });
+      const id = pickField<string>(res, 'jobId');
+      setJobId(id);
+      const done = id ? await waitForJobDone<unknown>(bridge, id, (r) => r) : null;
+      const receipt = extractApply(done);
+      if (receipt) {
+        setResultPath(receipt.path);
+        setEditId(receipt.editId);
+        setPct(100);
+        setMessage('Done');
+      }
+    } catch (err) {
+      setError(errMessage(err));
+    } finally {
+      setApplying(false);
+      setJobId(null);
+    }
+  }, [bridge, videoId, edits, applying, plan]);
+
+  const undo = useCallback(async (): Promise<void> => {
+    // defensive: Undo renders disabled until an edit has been applied.
+    /* v8 ignore next */
+    if (!editId) return;
+    setError('');
+    try {
+      const res = await bridge.rpc<unknown>('transcript.undoEdit', { videoId, editId });
+      setResultPath(undoPath(res));
+      setEditId(null);
+      setMessage('Undone');
+    } catch (err) {
+      setError(errMessage(err));
+    }
+  }, [bridge, videoId, editId]);
+
+  return (
+    <section className="feature-panel transcript-panel" aria-label="Transcript">
+      <h2>Transcript Editing</h2>
+      <p className="assets-intro">
+        Strike a word and the video cuts there — fully local, nothing is changed until you Apply,
+        and the result is written to a new file so the original is never touched.
+      </p>
+
+      {loading && <p data-state="loading">Loading transcript…</p>}
+      {!loading && words.length === 0 && (
+        <p data-state="empty">No transcript yet — transcribe this video first.</p>
+      )}
+
+      {words.length > 0 && (
+        <>
+          <div className="transcript-tokens" data-section="tokens">
+            {words.map((w) => (
+              <button
+                key={w.wordId}
+                type="button"
+                className="transcript-token"
+                data-word-id={w.wordId}
+                data-deleted={deleted.has(w.wordId) ? 'true' : 'false'}
+                aria-pressed={deleted.has(w.wordId)}
+                onClick={() => strike(w.wordId)}
+              >
+                {w.text}
+              </button>
+            ))}
+          </div>
+          <dl className="transcript-summary">
+            <div>
+              <dt>Struck (s)</dt>
+              <dd data-stat="removedSec">{removedSeconds(words, deleted)}</dd>
+            </div>
+          </dl>
+          <p className="transcript-edited" data-section="editedText">
+            {editedText(words, deleted)}
+          </p>
+        </>
+      )}
+
+      <div className="actions">
+        <button
+          type="button"
+          data-action="preview"
+          onClick={() => void preview()}
+          disabled={previewing || edits.length === 0}
+        >
+          {previewing ? 'Previewing…' : 'Preview cut'}
+        </button>
+        <button
+          type="button"
+          data-action="apply"
+          onClick={() => void apply()}
+          disabled={applying || !plan}
+        >
+          {applying ? 'Applying…' : 'Apply'}
+        </button>
+        <button
+          type="button"
+          data-action="undo"
+          className="secondary"
+          onClick={() => void undo()}
+          disabled={!editId}
+        >
+          Undo
+        </button>
+      </div>
+
+      {applying && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          <span className="progress-message"> · {message}</span>
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {plan && (
+        <dl className="transcript-plan" data-section="plan">
+          <div>
+            <dt>Cut (s)</dt>
+            <dd data-stat="planRemovedSec">{plan.stats.removedSec}</dd>
+          </div>
+          <div>
+            <dt>Kept segments</dt>
+            <dd data-stat="keeps">{plan.keeps.length}</dd>
+          </div>
+          {plan.rejected.length > 0 && (
+            <div>
+              <dt>Ignored</dt>
+              <dd data-stat="rejected">{plan.rejected.map((r) => r.reason).join(', ')}</dd>
+            </div>
+          )}
+        </dl>
+      )}
+
+      {resultPath && (
+        <div className="output-done" data-section="result">
+          <span className="output-done-label">Current cut</span>
+          <code>{resultPath}</code>
+          {editId && <span data-stat="editId">{editId}</span>}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default TranscriptEditor;

--- a/app/renderer/src/features/TranscriptEditor.tsx
+++ b/app/renderer/src/features/TranscriptEditor.tsx
@@ -18,6 +18,7 @@
 // / injectable `api?` prop for tests).
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import './panels.css';
+import './transcriptEditor.css';
 import {
   buildEditSpans,
   editedText,

--- a/app/renderer/src/features/transcriptEditor.css
+++ b/app/renderer/src/features/transcriptEditor.css
@@ -32,15 +32,18 @@
 }
 
 .transcript-token:hover {
-  background: var(--surface-sunken, rgb(0 0 0 / 12%));
+  background: var(--surface-hover);
 }
 
 /* The one place a visible focus ring is non-negotiable: the tokens are the entire
- * keyboard surface of this pane. Never `:where()` this rule — a zero-specificity
- * focus style is how the v1.4 focus rings silently disappeared. */
+ * keyboard surface of this pane. `--focus-ring` is a two-stop BOX-SHADOW value
+ * (tokens.css), not a colour — so it is consumed the way the rest of the shell
+ * consumes it (library-cards.css / firstRunSetup.css), never as an `outline`
+ * colour. Never `:where()` this rule either — a zero-specificity focus style is
+ * how the v1.4 focus rings silently disappeared. */
 .transcript-token:focus-visible {
-  outline: 2px solid var(--focus-ring, currentcolor);
-  outline-offset: 1px;
+  outline: none;
+  box-shadow: var(--focus-ring);
 }
 
 .transcript-token[data-deleted="true"] {

--- a/app/renderer/src/features/transcriptEditor.css
+++ b/app/renderer/src/features/transcriptEditor.css
@@ -1,0 +1,86 @@
+/* transcriptEditor.css — the transcript-native editing pane. Tokens only.
+ *
+ * The load-bearing visual is the STRIKE: a struck word must read as removed at a
+ * glance, and the reading must survive a monochrome / forced-colors / colour-blind
+ * view. So deletion is carried by THREE redundant channels — line-through, reduced
+ * opacity, and `aria-pressed` for assistive tech — never by hue alone. */
+
+.transcript-tokens {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1, 4px);
+  align-items: baseline;
+  max-height: 22rem;
+  overflow-y: auto;
+  padding: var(--space-3, 12px);
+  background: var(--surface-raised);
+  border-radius: var(--radius-md);
+  line-height: 1.9;
+}
+
+/* A word token is a real <button> (keyboard-reachable, focusable) that must NOT
+ * look like a button — the transcript has to read as prose. */
+.transcript-token {
+  padding: 1px 3px;
+  margin: 0;
+  border: 0;
+  border-radius: var(--radius-sm, 3px);
+  background: transparent;
+  color: var(--text-primary);
+  font: inherit;
+  cursor: pointer;
+}
+
+.transcript-token:hover {
+  background: var(--surface-sunken, rgb(0 0 0 / 12%));
+}
+
+/* The one place a visible focus ring is non-negotiable: the tokens are the entire
+ * keyboard surface of this pane. Never `:where()` this rule — a zero-specificity
+ * focus style is how the v1.4 focus rings silently disappeared. */
+.transcript-token:focus-visible {
+  outline: 2px solid var(--focus-ring, currentcolor);
+  outline-offset: 1px;
+}
+
+.transcript-token[data-deleted="true"] {
+  text-decoration: line-through;
+  text-decoration-thickness: 2px;
+  opacity: 0.5;
+}
+
+.transcript-summary {
+  display: flex;
+  gap: var(--space-4, 16px);
+  margin: var(--space-3, 12px) 0 0;
+}
+
+.transcript-summary dt,
+.transcript-plan dt {
+  font-size: var(--type-caption-size, 0.8rem);
+  color: var(--text-secondary);
+}
+
+.transcript-summary dd,
+.transcript-plan dd {
+  margin: 0;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-primary);
+}
+
+/* The "how it will read after the cut" line — deliberately quiet: it is a
+ * consequence of the strikes above, not a second thing to act on. */
+.transcript-edited {
+  margin: var(--space-3, 12px) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--type-body-size);
+  line-height: var(--type-body-leading, 1.6);
+  max-width: 68ch;
+}
+
+.transcript-plan {
+  display: flex;
+  gap: var(--space-4, 16px);
+  flex-wrap: wrap;
+  margin: var(--space-3, 12px) 0 0;
+}

--- a/app/renderer/src/lib/transcriptEdit.test.ts
+++ b/app/renderer/src/lib/transcriptEdit.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildEditSpans,
+  editedText,
+  flattenWords,
+  keepSpansFor,
+  remapTime,
+  removedSeconds,
+  selectRange,
+  toggleWord,
+  wordAt,
+} from './transcriptEdit';
+import type { Transcript } from './transcriptEdit';
+
+// The §3 transcript shape `transcript.get` returns (wordIds stamped sidecar-side
+// by features/transcript_edit.address_transcript).
+const TRANSCRIPT: Transcript = {
+  language: 'en',
+  durationSec: 10,
+  segments: [
+    {
+      start: 0,
+      end: 3.5,
+      text: 'we um should ship',
+      words: [
+        { wordId: 'w0-0', segmentIndex: 0, wordIndex: 0, text: 'we', start: 0, end: 0.5 },
+        { wordId: 'w0-1', segmentIndex: 0, wordIndex: 1, text: 'um', start: 1, end: 1.4 },
+        { wordId: 'w0-2', segmentIndex: 0, wordIndex: 2, text: 'should', start: 2, end: 2.5 },
+        { wordId: 'w0-3', segmentIndex: 0, wordIndex: 3, text: 'ship', start: 3, end: 3.5 },
+      ],
+    },
+  ],
+};
+
+describe('flattenWords', () => {
+  it('flattens every stamped word in transcript order', () => {
+    expect(flattenWords(TRANSCRIPT).map((w) => w.wordId)).toEqual(['w0-0', 'w0-1', 'w0-2', 'w0-3']);
+  });
+
+  it('spans multiple segments', () => {
+    const t: Transcript = {
+      segments: [
+        { words: [{ wordId: 'w0-0', text: 'a', start: 0, end: 0.2 }] },
+        { words: [{ wordId: 'w1-0', text: 'b', start: 1, end: 1.2 }] },
+      ],
+    };
+    expect(flattenWords(t).map((w) => w.wordId)).toEqual(['w0-0', 'w1-0']);
+  });
+
+  it('derives a wordId when the sidecar did not stamp one', () => {
+    const t: Transcript = { segments: [{ words: [{ text: 'a', start: 0, end: 0.2 }] }] };
+    expect(flattenWords(t)[0]).toEqual({
+      wordId: 'w0-0',
+      segmentIndex: 0,
+      wordIndex: 0,
+      text: 'a',
+      start: 0,
+      end: 0.2,
+    });
+  });
+
+  it('returns [] for a null/undefined/empty transcript', () => {
+    expect(flattenWords(null)).toEqual([]);
+    expect(flattenWords(undefined)).toEqual([]);
+    expect(flattenWords({})).toEqual([]);
+    expect(flattenWords({ segments: [] })).toEqual([]);
+  });
+
+  it('skips malformed segments and words instead of throwing', () => {
+    const t = {
+      segments: [
+        null,
+        'nope',
+        { words: null },
+        { words: ['nope', 42, { text: 'ok', start: 1, end: 2 }] },
+      ],
+    } as unknown as Transcript;
+    expect(flattenWords(t).map((w) => w.text)).toEqual(['ok']);
+  });
+
+  it('drops a word whose timings are not finite numbers', () => {
+    const t = {
+      segments: [
+        {
+          words: [
+            { wordId: 'bad-1', text: 'x', start: 'a', end: 2 },
+            { wordId: 'bad-2', text: 'y', start: 1, end: Number.NaN },
+            { wordId: 'ok', text: 'z', start: 1, end: 2 },
+          ],
+        },
+      ],
+    } as unknown as Transcript;
+    expect(flattenWords(t).map((w) => w.wordId)).toEqual(['ok']);
+  });
+
+  it('coerces a missing text to the empty string', () => {
+    const t = { segments: [{ words: [{ start: 0, end: 1 }] }] } as unknown as Transcript;
+    expect(flattenWords(t)[0]?.text).toBe('');
+  });
+});
+
+describe('toggleWord', () => {
+  it('adds an id and returns a NEW set (the input is untouched)', () => {
+    const before = new Set<string>();
+    const after = toggleWord(before, 'w0-3');
+    expect([...after]).toEqual(['w0-3']);
+    expect(before.size).toBe(0);
+  });
+
+  it('removes an id that was already deleted', () => {
+    expect([...toggleWord(new Set(['w0-1', 'w0-3']), 'w0-3')]).toEqual(['w0-1']);
+  });
+});
+
+describe('selectRange', () => {
+  const words = flattenWords(TRANSCRIPT);
+
+  it('returns the inclusive ids between two anchors', () => {
+    expect(selectRange(words, 'w0-1', 'w0-3')).toEqual(['w0-1', 'w0-2', 'w0-3']);
+  });
+
+  it('is order-insensitive (drag backwards)', () => {
+    expect(selectRange(words, 'w0-3', 'w0-1')).toEqual(['w0-1', 'w0-2', 'w0-3']);
+  });
+
+  it('a single-word range is that word', () => {
+    expect(selectRange(words, 'w0-2', 'w0-2')).toEqual(['w0-2']);
+  });
+
+  it('returns [] when either anchor is unknown', () => {
+    expect(selectRange(words, 'ghost', 'w0-2')).toEqual([]);
+    expect(selectRange(words, 'w0-2', 'ghost')).toEqual([]);
+  });
+});
+
+describe('buildEditSpans', () => {
+  const words = flattenWords(TRANSCRIPT);
+
+  it('emits one delete span per deleted word, in transcript order', () => {
+    expect(buildEditSpans(words, new Set(['w0-3', 'w0-1']))).toEqual([
+      { op: 'delete', wordId: 'w0-1' },
+      { op: 'delete', wordId: 'w0-3' },
+    ]);
+  });
+
+  it('ignores ids that are not in the transcript', () => {
+    expect(buildEditSpans(words, new Set(['ghost']))).toEqual([]);
+  });
+
+  it('emits nothing when nothing is deleted', () => {
+    expect(buildEditSpans(words, new Set())).toEqual([]);
+  });
+});
+
+describe('removedSeconds', () => {
+  const words = flattenWords(TRANSCRIPT);
+
+  it('sums the deleted word durations', () => {
+    expect(removedSeconds(words, new Set(['w0-1', 'w0-3']))).toBe(0.9);
+  });
+
+  it('is 0 with no deletions', () => {
+    expect(removedSeconds(words, new Set())).toBe(0);
+  });
+
+  it('never counts a negative duration', () => {
+    const inverted = [{ wordId: 'x', segmentIndex: 0, wordIndex: 0, text: 'x', start: 5, end: 4 }];
+    expect(removedSeconds(inverted, new Set(['x']))).toBe(0);
+  });
+});
+
+describe('editedText', () => {
+  const words = flattenWords(TRANSCRIPT);
+
+  it('renders the transcript without the deleted tokens', () => {
+    expect(editedText(words, new Set(['w0-1']))).toBe('we should ship');
+  });
+
+  it('renders the full text when nothing is deleted', () => {
+    expect(editedText(words, new Set())).toBe('we um should ship');
+  });
+
+  it('trims stray whitespace from each token', () => {
+    const spaced = [{ wordId: 'a', segmentIndex: 0, wordIndex: 0, text: '  hi  ', start: 0, end: 1 }];
+    expect(editedText(spaced, new Set())).toBe('hi');
+  });
+});
+
+describe('keepSpansFor', () => {
+  const words = flattenWords(TRANSCRIPT);
+
+  it('inverts one deleted word into two keeps', () => {
+    expect(keepSpansFor(words, new Set(['w0-3']), 10)).toEqual([
+      [0, 3],
+      [3.5, 10],
+    ]);
+  });
+
+  it('merges adjacent/overlapping deletions into one gap', () => {
+    const overlapping = [
+      { wordId: 'a', segmentIndex: 0, wordIndex: 0, text: 'a', start: 1, end: 2.5 },
+      { wordId: 'b', segmentIndex: 0, wordIndex: 1, text: 'b', start: 2, end: 3 },
+    ];
+    expect(keepSpansFor(overlapping, new Set(['a', 'b']), 10)).toEqual([
+      [0, 1],
+      [3, 10],
+    ]);
+  });
+
+  it('keeps the whole clip when nothing is deleted', () => {
+    expect(keepSpansFor(words, new Set(), 10)).toEqual([[0, 10]]);
+  });
+
+  it('drops a leading keep when the first word starts at 0', () => {
+    expect(keepSpansFor(words, new Set(['w0-0']), 10)).toEqual([[0.5, 10]]);
+  });
+
+  it('drops the trailing keep when the deletion runs to the end', () => {
+    const tail = [{ wordId: 'a', segmentIndex: 0, wordIndex: 0, text: 'a', start: 8, end: 10 }];
+    expect(keepSpansFor(tail, new Set(['a']), 10)).toEqual([[0, 8]]);
+  });
+
+  it('clamps a deletion past the clip end', () => {
+    const over = [{ wordId: 'a', segmentIndex: 0, wordIndex: 0, text: 'a', start: 9, end: 99 }];
+    expect(keepSpansFor(over, new Set(['a']), 10)).toEqual([[0, 9]]);
+  });
+
+  it('returns [] for a non-positive duration', () => {
+    expect(keepSpansFor(words, new Set(['w0-3']), 0)).toEqual([]);
+  });
+
+  it('degrades a delete-everything to the whole clip (an empty keep-list is unrenderable)', () => {
+    const all = [{ wordId: 'a', segmentIndex: 0, wordIndex: 0, text: 'a', start: 0, end: 10 }];
+    expect(keepSpansFor(all, new Set(['a']), 10)).toEqual([[0, 10]]);
+  });
+});
+
+describe('remapTime', () => {
+  const keeps: ReadonlyArray<readonly [number, number]> = [
+    [0, 3],
+    [3.5, 10],
+  ];
+
+  it('maps a time inside the first keep to itself', () => {
+    expect(remapTime(1, keeps)).toBe(1);
+  });
+
+  it('slides a time after the cut earlier by the removed amount', () => {
+    expect(remapTime(4, keeps)).toBe(3.5);
+  });
+
+  it('collapses a time inside the removed span onto the cut point', () => {
+    expect(remapTime(3.2, keeps)).toBe(3);
+  });
+
+  it('clamps a time before the first keep to 0', () => {
+    expect(remapTime(-1, [[2, 5]])).toBe(0);
+  });
+
+  it('clamps a time past the last keep to the total kept duration', () => {
+    expect(remapTime(99, keeps)).toBe(9.5);
+  });
+
+  it('is 0 for an empty keep-list', () => {
+    expect(remapTime(5, [])).toBe(0);
+  });
+});
+
+describe('wordAt', () => {
+  const words = flattenWords(TRANSCRIPT);
+
+  it('finds the word containing the playhead', () => {
+    expect(wordAt(words, 2.2)?.text).toBe('should');
+  });
+
+  it('is inclusive of the word start and end', () => {
+    expect(wordAt(words, 2)?.wordId).toBe('w0-2');
+    expect(wordAt(words, 2.5)?.wordId).toBe('w0-2');
+  });
+
+  it('is null between words and outside the transcript', () => {
+    expect(wordAt(words, 1.7)).toBeNull();
+    expect(wordAt(words, 99)).toBeNull();
+  });
+});

--- a/app/renderer/src/lib/transcriptEdit.test.ts
+++ b/app/renderer/src/lib/transcriptEdit.test.ts
@@ -182,7 +182,9 @@ describe('editedText', () => {
   });
 
   it('trims stray whitespace from each token', () => {
-    const spaced = [{ wordId: 'a', segmentIndex: 0, wordIndex: 0, text: '  hi  ', start: 0, end: 1 }];
+    const spaced = [
+      { wordId: 'a', segmentIndex: 0, wordIndex: 0, text: '  hi  ', start: 0, end: 1 },
+    ];
     expect(editedText(spaced, new Set())).toBe('hi');
   });
 });

--- a/app/renderer/src/lib/transcriptEdit.ts
+++ b/app/renderer/src/lib/transcriptEdit.ts
@@ -75,7 +75,10 @@ export function flattenWords(transcript: Transcript | null | undefined): Transcr
       const start = finite(word.start);
       const end = finite(word.end);
       if (start === null || end === null) return;
-      const stamped = typeof word.wordId === 'string' && word.wordId ? word.wordId : `w${segmentIndex}-${wordIndex}`;
+      const stamped =
+        typeof word.wordId === 'string' && word.wordId
+          ? word.wordId
+          : `w${segmentIndex}-${wordIndex}`;
       out.push({
         wordId: stamped,
         segmentIndex,
@@ -122,7 +125,9 @@ export function buildEditSpans(
   words: readonly TranscriptWord[],
   deleted: ReadonlySet<string>,
 ): EditSpan[] {
-  return words.filter((w) => deleted.has(w.wordId)).map((w) => ({ op: 'delete' as const, wordId: w.wordId }));
+  return words
+    .filter((w) => deleted.has(w.wordId))
+    .map((w) => ({ op: 'delete' as const, wordId: w.wordId }));
 }
 
 /** The client-side estimate of how much time the current selection removes. */

--- a/app/renderer/src/lib/transcriptEdit.ts
+++ b/app/renderer/src/lib/transcriptEdit.ts
@@ -1,0 +1,193 @@
+/**
+ * Transcript-native editing — the PURE renderer half (v1.5 flagship #2, WU-T2).
+ *
+ * "Delete a word and the video cuts." This module owns the token model the
+ * Transcript inspector reasons over and the translation from a UI selection to
+ * the `transcript.previewEdit` / `transcript.applyEdit` wire payload. It is
+ * deliberately pure: no React, no RPC, no clock — so every branch is unit
+ * testable and the inspector pane stays a thin view over it.
+ *
+ * The sidecar (`media_studio/features/transcript_edit.py`) is the authority on
+ * the final cut: it re-resolves each `wordId`, unions the deletes with the
+ * shipped filler/silence math, and renders ONCE. `keepSpansFor` / `remapTime`
+ * here mirror that math ONLY so the UI can scrub an instant local preview
+ * before the round-trip — they are an ESTIMATE, never the applied edit.
+ *
+ * SCOPE: `delete` and `trim` (the monotonic half). `reorder` is deferred
+ * backend-side and is intentionally not expressible here — see the plan's C3.
+ */
+
+/** A word with the stable address `transcript.get` stamps on it. */
+export type TranscriptWord = {
+  readonly wordId: string;
+  readonly segmentIndex: number;
+  readonly wordIndex: number;
+  readonly text: string;
+  readonly start: number;
+  readonly end: number;
+};
+
+/** The §3 transcript as it arrives over the wire (fields are defensive). */
+export type Transcript = {
+  readonly language?: string | null;
+  readonly durationSec?: number;
+  readonly segments?: readonly unknown[];
+};
+
+/** The ops the sidecar translator applies; anything else it drops with a reason. */
+export type EditOp = 'delete' | 'trim';
+
+/** One entry of the `edits` array sent to `transcript.previewEdit`/`applyEdit`. */
+export type EditSpan = {
+  readonly op: EditOp;
+  readonly wordId?: string;
+  readonly startMs?: number;
+  readonly endMs?: number;
+};
+
+/** A `[start, end]` keep span in ORIGINAL-video seconds. */
+export type KeepSpan = readonly [number, number];
+
+const round3 = (n: number): number => Math.round(n * 1000) / 1000;
+
+const asArray = (value: unknown): readonly unknown[] => (Array.isArray(value) ? value : []);
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null;
+
+const finite = (value: unknown): number | null =>
+  typeof value === 'number' && Number.isFinite(value) ? value : null;
+
+/**
+ * Flatten a transcript into addressed words, in transcript order.
+ *
+ * Malformed input never throws: a non-object segment/word is skipped, a word
+ * without finite `start`/`end` is skipped (it cannot address a cut), and a word
+ * the sidecar did not stamp falls back to the same `w{seg}-{idx}` address the
+ * sidecar would have generated.
+ */
+export function flattenWords(transcript: Transcript | null | undefined): TranscriptWord[] {
+  const out: TranscriptWord[] = [];
+  asArray(transcript?.segments).forEach((segment, segmentIndex) => {
+    if (!isRecord(segment)) return;
+    asArray(segment.words).forEach((word, wordIndex) => {
+      if (!isRecord(word)) return;
+      const start = finite(word.start);
+      const end = finite(word.end);
+      if (start === null || end === null) return;
+      const stamped = typeof word.wordId === 'string' && word.wordId ? word.wordId : `w${segmentIndex}-${wordIndex}`;
+      out.push({
+        wordId: stamped,
+        segmentIndex,
+        wordIndex,
+        text: typeof word.text === 'string' ? word.text : '',
+        start,
+        end,
+      });
+    });
+  });
+  return out;
+}
+
+/** Immutably toggle a word's deleted state (strike-through in the inspector). */
+export function toggleWord(deleted: ReadonlySet<string>, wordId: string): Set<string> {
+  const next = new Set(deleted);
+  if (!next.delete(wordId)) next.add(wordId);
+  return next;
+}
+
+/**
+ * The inclusive word ids between two anchors (a shift-click / drag selection).
+ * Order-insensitive; `[]` when either anchor is not in `words`.
+ */
+export function selectRange(
+  words: readonly TranscriptWord[],
+  fromId: string,
+  toId: string,
+): string[] {
+  const from = words.findIndex((w) => w.wordId === fromId);
+  const to = words.findIndex((w) => w.wordId === toId);
+  if (from < 0 || to < 0) return [];
+  const lo = Math.min(from, to);
+  const hi = Math.max(from, to);
+  return words.slice(lo, hi + 1).map((w) => w.wordId);
+}
+
+/**
+ * The `edits` payload for the sidecar: one `delete` per deleted word, in
+ * transcript order. Ids that are not in `words` are dropped here so the wire
+ * payload can never carry an address the backend would only reject.
+ */
+export function buildEditSpans(
+  words: readonly TranscriptWord[],
+  deleted: ReadonlySet<string>,
+): EditSpan[] {
+  return words.filter((w) => deleted.has(w.wordId)).map((w) => ({ op: 'delete' as const, wordId: w.wordId }));
+}
+
+/** The client-side estimate of how much time the current selection removes. */
+export function removedSeconds(
+  words: readonly TranscriptWord[],
+  deleted: ReadonlySet<string>,
+): number {
+  const total = words
+    .filter((w) => deleted.has(w.wordId))
+    .reduce((sum, w) => sum + Math.max(0, w.end - w.start), 0);
+  return round3(total);
+}
+
+/** The transcript text as it will read after the cut (single-spaced). */
+export function editedText(words: readonly TranscriptWord[], deleted: ReadonlySet<string>): string {
+  return words
+    .filter((w) => !deleted.has(w.wordId))
+    .map((w) => w.text.trim())
+    .join(' ');
+}
+
+/**
+ * The keep-list the current selection implies, mirroring the sidecar's
+ * invert-the-union math. Overlapping deletions merge into one gap; a deletion
+ * that would remove the WHOLE clip degrades to the untouched clip (an empty
+ * keep-list is unrenderable — `build_segment_cut_argv` rejects it).
+ */
+export function keepSpansFor(
+  words: readonly TranscriptWord[],
+  deleted: ReadonlySet<string>,
+  durationSec: number,
+): KeepSpan[] {
+  if (durationSec <= 0) return [];
+  const removed = words
+    .filter((w) => deleted.has(w.wordId))
+    .map((w): KeepSpan => [w.start, Math.min(durationSec, w.end)])
+    .sort((a, b) => a[0] - b[0]);
+
+  const keeps: KeepSpan[] = [];
+  let cursor = 0;
+  for (const [start, end] of removed) {
+    if (start > cursor) keeps.push([round3(cursor), round3(start)]);
+    cursor = Math.max(cursor, end);
+  }
+  if (cursor < durationSec) keeps.push([round3(cursor), round3(durationSec)]);
+  return keeps.length > 0 ? keeps : [[0, round3(durationSec)]];
+}
+
+/**
+ * Map an ORIGINAL-video time onto the cut clip's local timeline — the renderer
+ * mirror of `fillers.remap_time`, used to drive the preview playhead. A time
+ * inside a removed span collapses onto the cut point; a time before the first
+ * keep clamps to 0.
+ */
+export function remapTime(t: number, keeps: readonly KeepSpan[]): number {
+  let elapsed = 0;
+  for (const [start, end] of keeps) {
+    if (t < start) return round3(elapsed);
+    if (t <= end) return round3(elapsed + (t - start));
+    elapsed += end - start;
+  }
+  return round3(elapsed);
+}
+
+/** The word under the playhead (karaoke highlight), or `null` between words. */
+export function wordAt(words: readonly TranscriptWord[], t: number): TranscriptWord | null {
+  return words.find((w) => t >= w.start && t <= w.end) ?? null;
+}

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -60,6 +60,16 @@ vi.mock('../lib/rpc', () => ({
 }));
 
 // NOTE: ../features/Subtitles is deliberately NOT mocked here.
+//
+// ../features/TranscriptEditor IS mocked: this suite pins the Subtitles seam, it
+// never selects the Transcript-edit tab, and leaving that panel real only adds
+// its module graph to the race this test is already timing. Measured: with the
+// panel real the case intermittently trips the 5s default (2/5 full-suite runs)
+// while passing in isolation at ~2.2s of test time, i.e. a transform-cost cliff
+// under parallel load, not a behaviour change. UNVERIFIED whether CI's Linux
+// runner ever crosses that cliff — settled by dropping this mock and reading the
+// gate-tests-coverage vitest step; the stub is correct either way.
+vi.mock('../features/TranscriptEditor', () => ({ default: () => <div /> }));
 
 import { Workspace } from './Workspace';
 import type { Project, SubtitleTrack, Video } from '../components/api';

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -70,6 +70,7 @@ vi.mock('../features/NleExport', () => stubPanel('NleExport'));
 vi.mock('../features/Diarize', () => stubPanel('Diarize'));
 vi.mock('../features/Refine', () => stubPanel('Refine'));
 vi.mock('../features/Stabilize', () => stubPanel('Stabilize'));
+vi.mock('../features/TranscriptEditor', () => stubPanel('TranscriptEditor'));
 vi.mock('../features/Recipes', () => stubPanel('Recipes'));
 vi.mock('../features/SemanticSearch', () => stubPanel('SemanticSearch'));
 
@@ -157,6 +158,7 @@ describe('Workspace', () => {
       'Transcribe',
       'Search',
       'Subtitles',
+      'Transcript edit',
       'Diarize',
       'Refine',
       'Tracks',
@@ -336,6 +338,7 @@ describe('Workspace', () => {
     ['transcribe', 'Transcribe'],
     ['search', 'SemanticSearch'],
     ['subtitles', 'Subtitles'],
+    ['transcriptEdit', 'TranscriptEditor'],
     ['diarize', 'Diarize'],
     ['refine', 'Refine'],
     ['tracks', 'Tracks'],

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -51,6 +51,8 @@ const Refine = lazy(() => import('../features/Refine'));
 // v1.5 expose-engines: per-video camera-shake removal. The `stabilize.run` RPC
 // and its output dir already existed; this tab is what makes them reachable.
 const Stabilize = lazy(() => import('../features/Stabilize'));
+// v1.5 flagship #2: transcript-native editing (strike a word -> the video cuts).
+const TranscriptEditor = lazy(() => import('../features/TranscriptEditor'));
 const Recipes = lazy(() => import('../features/Recipes'));
 // intelligence A: semantic transcript search (seeks the player on a hit).
 const SemanticSearch = lazy(() => import('../features/SemanticSearch'));
@@ -76,6 +78,7 @@ export const WORKSPACE_TABS: TabDef[] = [
   { id: 'transcribe', label: 'Transcribe' },
   { id: 'search', label: 'Search' },
   { id: 'subtitles', label: 'Subtitles' },
+  { id: 'transcriptEdit', label: 'Transcript edit' },
   { id: 'diarize', label: 'Diarize' },
   { id: 'refine', label: 'Refine' },
   { id: 'tracks', label: 'Tracks' },
@@ -104,7 +107,7 @@ export const WORKSPACE_TAB_GROUPS: TabGroup[] = [
   {
     id: 'speech',
     label: 'Speech & Text',
-    tabIds: ['transcribe', 'search', 'subtitles', 'diarize', 'refine'],
+    tabIds: ['transcribe', 'search', 'subtitles', 'transcriptEdit', 'diarize', 'refine'],
   },
   { id: 'frame', label: 'Frame & Cut', tabIds: ['shortmaker', 'timeline', 'stabilize', 'speed'] },
   { id: 'audio', label: 'Audio', tabIds: ['dub'] },
@@ -296,6 +299,8 @@ export function Workspace({
     switch (active) {
       case 'subtitles':
         return <Subtitles videoId={video.id} initialTrack={tracks[0] ?? null} />;
+      case 'transcriptEdit':
+        return <TranscriptEditor videoId={video.id} />;
       case 'diarize':
         return <Diarize videoId={video.id} />;
       case 'refine':

--- a/docs/plans/v1.5/flagship-transcript-editing.md
+++ b/docs/plans/v1.5/flagship-transcript-editing.md
@@ -1,6 +1,49 @@
 # Reframe v1.5 Flagship — Transcript-Native Editing: Implementation Plan + Go/No-Go
 
-> **Status:** DRAFT
+> **Status:** ACTIVE — partially executed: the DELETE vertical slice ships; see §0.
+
+## 0. Execution status (what is BUILT vs still DESIGN-ONLY)
+
+Branch `feat/v15-transcript-editing` landed a **working vertical slice**: strike a word →
+preview the cut → apply (ONE encode) → undo. The rest of this document remains the plan.
+
+**BUILT (tested, 100% line+branch on every new module):**
+
+| WU | State | Where |
+|---|---|---|
+| T1 (addressing half) | **BUILT** | `features/transcript_edit.py::address_transcript/addressed_words` stamp `wordId = w{seg}-{idx}` non-destructively at READ time, and `library.Project.open` now backfills the optional `transcriptEdits` ledger so it survives a manifest round-trip. |
+| T2 | **BUILT** | `app/renderer/src/lib/transcriptEdit.ts` — pure token model, `buildEditSpans`, local `keepSpansFor`/`remapTime` preview mirror. |
+| T3 | **BUILT (delete + trim)** | `features/transcript_edit.py::resolve_edits/plan_transcript_edit` + `TranscriptEditService`; word deletes UNION `refine.plan_refine`'s shipped filler/silence math into ONE keep-list → ONE `build_segment_cut_argv` encode → `*.edited.mp4` (source untouched). |
+| T5 (pane) | **BUILT (core)** | `app/renderer/src/features/TranscriptEditor.tsx`, mounted as the Workspace "Transcript edit" tab. |
+| — | **BUILT (net-new)** | `transcript.undoEdit` — a reversible per-project edit ledger (`transcriptEdits`), popped one edit at a time. |
+
+**NOT built (still design-only) — do not read the sections below as shipped:**
+
+- **T0** — the CC-BY-NC MMS aligner default is UNCHANGED. `ctc_align` was not touched, no
+  typed `ctcModelId`/`asrEngine`/`allowNonCommercialAligner` settings were added, and no
+  Parakeet NOTICE line was added. **The B1 commercial blocker is still open.**
+- **T4 (contract half)** — the three methods are registered at RUNTIME ONLY, via
+  `protocol.register` from `handlers/composition.py`. No `MethodSpec` entries were added to
+  `sidecar/contract/spec.py` and nothing was regenerated. §5's "dual registration is
+  mandatory" is a design aspiration, not the repo's current norm: only 6 of ~180 methods are
+  MethodSpec-migrated, and every other feature (including `refine.*`) is runtime-only. The
+  renderer calls `transcript.*` through the untyped `bridge.rpc` escape hatch, exactly like
+  `Refine.tsx`.
+- **T5 (rest)** — no waveform/karaoke playhead, no click-to-seek into the shared `Timeline`,
+  no filler underline, no NLE handoff button, no attribution surface. The pane is a word-token
+  list + preview/apply/undo.
+- **T6 (REORDER)** — untouched and still the ONE backend gap. `resolve_edits` DROPS a
+  `reorder` span with the typed reason `reorder-deferred` rather than mis-applying it, because
+  `fillers.remap_time` assumes monotonic keeps.
+- **T7** — no real-ffmpeg / re-transcribe functional tier. Every test is hermetic (injected
+  `run`/`duration`/`detect_run`/project-store fakes). **The unit suite therefore cannot
+  falsify "the rendered mp4 is actually cut"** — the argv values and keep-list are asserted,
+  the pixels are not. That is exactly the gap WU-T7 exists to close; it remains open.
+- Undo is a **project-ledger** undo (re-point to the previous path; the source file is never
+  touched), NOT the `apply_engine`/`director.undo` manifest walk §5 describes. Routing an
+  ordered EDL through `apply_engine` stays part of T6.
+
+---
 
 **Status:** RESEARCH + DESIGN + PLAN (no repo modified).
 **Grounding:** read from `origin/main` @ `7502e3a` (#288 Caption pilot) — local checkout is stale, every seam below was read via `git show origin/main:<path>`.

--- a/sidecar/media_studio/features/transcript_edit.py
+++ b/sidecar/media_studio/features/transcript_edit.py
@@ -210,7 +210,7 @@ def _ms_bounds(edit: Mapping[str, Any]) -> Span | None:
     return (start / 1000.0, end / 1000.0)
 
 
-def _word_bounds(edit: Mapping[str, Any], index: dict[str, Mapping[str, Any]]) -> tuple[Span | None, bool]:
+def _word_bounds(edit: Mapping[str, Any], index: Mapping[str, Mapping[str, Any]]) -> tuple[Span | None, bool]:
     """Resolve a word address to its ``[start, end]``.
 
     Returns ``(span, addressed)`` — ``addressed`` is ``True`` when the edit DID

--- a/sidecar/media_studio/features/transcript_edit.py
+++ b/sidecar/media_studio/features/transcript_edit.py
@@ -105,7 +105,12 @@ class AddressedWord(TypedDict):
 
 
 class TranscriptEditStats(TypedDict):
-    """Per-category stats. The filler/silence fields mirror ``RefineStats``."""
+    """Per-category stats. The filler/silence fields mirror ``RefineStats``.
+
+    ``wordsDeleted`` counts the edit spans that RESOLVED (a ``trim`` counts too,
+    since it also removes speech) — NOT the rejected ones, and not the words the
+    filler engine cut on its own (those stay in ``fillersRemoved``).
+    """
 
     wordsDeleted: int
     deletedSec: float

--- a/sidecar/media_studio/features/transcript_edit.py
+++ b/sidecar/media_studio/features/transcript_edit.py
@@ -1,0 +1,711 @@
+"""TRANSCRIPT-NATIVE EDITING — delete a word, the video cuts (v1.5 flagship #2).
+
+The Descript-class vertical slice from ``docs/plans/v1.5/flagship-transcript-editing.md``
+(WU-T1 addressing + WU-T3 translator/service). It adds **no new cut math**: every
+timeline operation below is the already-shipped, already-covered engine —
+
+* word timings come from ``features/transcribe.py`` (``word_timestamps=True``),
+  optionally tightened by ``features/ctc_align.py``;
+* filler + silence removal is ``features/refine.plan_refine`` (which itself
+  composes ``fillers.build_cutlist_with_stats`` + ``silencetrim.keep_spans``);
+* the frame-accurate, ORDER-PRESERVING render is
+  ``fillers.build_segment_cut_argv``;
+* caption re-timing is ``fillers.remap_cues``.
+
+What is genuinely new is three thin, PURE layers:
+
+1. **Addressing** — :func:`address_transcript` stamps a stable ``wordId``
+   (``w{segmentIndex}-{wordIndex}``) onto every word so the renderer can point at
+   a token and the backend can resolve it back to ``[start, end]`` seconds. It is
+   non-destructive: the input transcript is never mutated, and an already-stamped
+   ``wordId`` is preserved so a re-transcription can carry ids forward.
+2. **Translation** — :func:`resolve_edits` turns EditSpans into removed spans.
+   Like :func:`edit_validate.validate_and_reject` it **never raises**: an
+   impossible/unknown/deferred span is DROPPED with a typed reason so the caller
+   can surface exactly what was ignored.
+3. **Composition** — :func:`plan_transcript_edit` unions the word deletes with
+   the refine plan into ONE keep-list, so a delete + filler-strip + silence-trim
+   is a SINGLE encode (mirroring ``refine.apply``).
+
+SCOPE (honest): this module ships ``delete`` and ``trim`` — the monotonic
+keep-list half. ``reorder`` is DEFERRED (the design's C3 gap; see
+``director_op_engines.DEFERRED_KINDS``) and is rejected with
+:data:`REASON_REORDER_DEFERRED` rather than silently mis-applied, because the
+shipped cue remap (``fillers.remap_time``) assumes MONOTONIC keeps and would
+emit wrong times for a reordered span.
+
+REVERSIBILITY: ``applyEdit`` writes a NEW ``*.edited.mp4`` and never touches the
+source, then records the edit in ``project["transcriptEdits"]``. ``undoEdit``
+pops that record, so the project's current render walks back one edit at a time.
+This is a project-level ledger undo, NOT the ``apply_engine``/``director.undo``
+manifest walk — routing an ordered EDL through ``apply_engine`` is the deferred
+reorder work (WU-T6), and pretending otherwise here would be an overclaim.
+
+NO subprocess, NO model, NO real I/O in the pure half; every heavy seam
+(``run``/``duration``/``detect_run``/``load_project``/``save_project``) is
+injected exactly as ``RefineService`` does it.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any, TypedDict
+
+from .. import protocol
+from ..jobs import JobContext
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import get_logger
+from . import fillers as _fillers
+from . import refine as _refine
+from . import silencetrim as _silencetrim
+
+log = get_logger("media_studio.transcript_edit")
+
+# Injectable seams (identical to refine.RefineService — same shapes, same fakes).
+RunFn = Callable[..., int]
+ProbeFn = Callable[..., float]
+DetectRunner = Callable[..., Any]
+Resolver = Callable[[str], str | None]
+LoadProject = Callable[[str], dict[str, Any]]
+SaveProject = Callable[[str, dict[str, Any]], None]
+
+#: A removed/kept span in ORIGINAL-video seconds.
+Span = tuple[float, float]
+
+#: The project key holding the reversible edit ledger (see ``library.Project``).
+EDITS_KEY = "transcriptEdits"
+
+# --- typed drop reasons (mirrors edit_validate's "drop with a reason" contract) ---
+#: The op name is not one this module implements.
+REASON_UNKNOWN_OP = "unknown-op"
+#: ``reorder`` is the design's ONE deferred backend gap (C3 / WU-T6).
+REASON_REORDER_DEFERRED = "reorder-deferred"
+#: The addressed word does not exist in this transcript.
+REASON_UNKNOWN_WORD = "unknown-word"
+#: Neither a resolvable word address nor explicit ``startMs``/``endMs`` bounds.
+REASON_MISSING_SPAN = "missing-span"
+#: The span is empty, inverted, or entirely outside ``[0, totalSec]``.
+REASON_EMPTY_SPAN = "empty-span"
+
+#: The ops this module actually applies. Anything else is dropped with a reason.
+SUPPORTED_OPS = ("delete", "trim")
+
+
+class AddressedWord(TypedDict):
+    """A §3 Word plus its stable address."""
+
+    wordId: str
+    segmentIndex: int
+    wordIndex: int
+    text: str
+    start: float
+    end: float
+
+
+class TranscriptEditStats(TypedDict):
+    """Per-category stats. The filler/silence fields mirror ``RefineStats``."""
+
+    wordsDeleted: int
+    deletedSec: float
+    fillersRemoved: int
+    fillerSeconds: float
+    silenceRemovedSec: float
+    keptSec: float
+    removedSec: float
+
+
+class TranscriptEditPlan(TypedDict):
+    """The "see before you cut" plan: keep-list + stats + re-timed cues + drops."""
+
+    keeps: list[list[float]]
+    stats: TranscriptEditStats
+    cues: list[dict[str, Any]]
+    rejected: list[dict[str, Any]]
+
+
+# --------------------------------------------------------------------------- #
+# T1 — stable word addressing (pure, non-mutating)
+# --------------------------------------------------------------------------- #
+def word_id(segment_index: int, word_index: int) -> str:
+    """The stable address of a word: ``w{segmentIndex}-{wordIndex}``."""
+    return f"w{segment_index}-{word_index}"
+
+
+def _stamp(word: Mapping[str, Any], segment_index: int, word_index: int) -> dict[str, Any]:
+    """Return a COPY of ``word`` carrying its address (an existing id wins)."""
+    out = dict(word)
+    out["wordId"] = str(out.get("wordId") or word_id(segment_index, word_index))
+    out["segmentIndex"] = segment_index
+    out["wordIndex"] = word_index
+    return out
+
+
+def address_transcript(transcript: Mapping[str, Any] | None) -> dict[str, Any] | None:
+    """Return a COPY of ``transcript`` with a ``wordId`` stamped on every word.
+
+    Never mutates the input (the immutability rule) and never raises on a
+    malformed manifest: a non-mapping segment or word is passed through
+    untouched, so an old project always round-trips.
+    """
+    if not transcript:
+        return None
+    out = dict(transcript)
+    segments: list[Any] = []
+    for seg_i, seg in enumerate(transcript.get("segments") or []):
+        if not isinstance(seg, Mapping):
+            segments.append(seg)
+            continue
+        new_seg = dict(seg)
+        words = seg.get("words")
+        if isinstance(words, Sequence) and not isinstance(words, str | bytes):
+            new_seg["words"] = [
+                _stamp(word, seg_i, w_i) if isinstance(word, Mapping) else word for w_i, word in enumerate(words)
+            ]
+        segments.append(new_seg)
+    out["segments"] = segments
+    return out
+
+
+def addressed_words(transcript: Mapping[str, Any] | None) -> list[dict[str, Any]]:
+    """Flatten every addressed word across segments, in transcript order."""
+    addressed = address_transcript(transcript)
+    if addressed is None:
+        return []
+    words: list[dict[str, Any]] = []
+    for seg in addressed.get("segments") or []:
+        if not isinstance(seg, Mapping):
+            continue  # pragma: no cover - address_transcript preserves non-mappings verbatim
+        for word in seg.get("words") or []:
+            if isinstance(word, Mapping) and "wordId" in word:
+                words.append(dict(word))
+    return words
+
+
+# --------------------------------------------------------------------------- #
+# T3a — the pure EditSpan -> removed-span translator
+# --------------------------------------------------------------------------- #
+def _num(value: Any) -> float | None:
+    """Coerce a wire number, or ``None`` when it is not one."""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _ms_bounds(edit: Mapping[str, Any]) -> Span | None:
+    """The explicit ``[startMs, endMs]`` bounds in seconds, when both are given."""
+    start = _num(edit.get("startMs"))
+    end = _num(edit.get("endMs"))
+    if start is None or end is None:
+        return None
+    return (start / 1000.0, end / 1000.0)
+
+
+def _word_bounds(edit: Mapping[str, Any], index: dict[str, Mapping[str, Any]]) -> tuple[Span | None, bool]:
+    """Resolve a word address to its ``[start, end]``.
+
+    Returns ``(span, addressed)`` — ``addressed`` is ``True`` when the edit DID
+    name a word (so an unresolvable name is an ``unknown-word`` drop rather than
+    a ``missing-span`` one).
+    """
+    wid = edit.get("wordId")
+    if not isinstance(wid, str) or not wid:
+        seg_i = edit.get("segmentIndex")
+        w_i = edit.get("wordIndex")
+        if not isinstance(seg_i, int) or not isinstance(w_i, int) or isinstance(seg_i, bool) or isinstance(w_i, bool):
+            return None, False
+        wid = word_id(seg_i, w_i)
+    word = index.get(wid)
+    if word is None:
+        return None, True
+    start = _num(word.get("start"))
+    end = _num(word.get("end"))
+    if start is None or end is None:
+        return (0.0, 0.0), True  # junk timings -> an empty span, dropped below
+    return (start, end), True
+
+
+def resolve_edits(
+    edits: Sequence[Any] | None,
+    transcript: Mapping[str, Any] | None,
+    total_sec: float,
+) -> tuple[list[Span], list[dict[str, Any]]]:
+    """Translate EditSpans into removed spans, dropping the impossible ones.
+
+    Returns ``(removed_spans, rejected)`` in input order. NEVER raises — an
+    unknown op, an unresolvable address, or a degenerate span is reported in
+    ``rejected`` as ``{"index", "op", "reason"}`` (see the ``REASON_*``
+    constants) so the UI can say exactly what it ignored.
+    """
+    total = max(0.0, float(total_sec))
+    index = {word["wordId"]: word for word in addressed_words(transcript)}
+    removed: list[Span] = []
+    rejected: list[dict[str, Any]] = []
+
+    def drop(i: int, op: str, reason: str) -> None:
+        rejected.append({"index": i, "op": op, "reason": reason})
+
+    for i, edit in enumerate(edits or []):
+        if not isinstance(edit, Mapping):
+            drop(i, "", REASON_UNKNOWN_OP)
+            continue
+        op = str(edit.get("op") or "delete")
+        if op == "reorder":
+            drop(i, op, REASON_REORDER_DEFERRED)
+            continue
+        if op not in SUPPORTED_OPS:
+            drop(i, op, REASON_UNKNOWN_OP)
+            continue
+
+        span = _ms_bounds(edit)
+        addressed = False
+        if span is None and op == "delete":
+            span, addressed = _word_bounds(edit, index)
+        if span is None:
+            drop(i, op, REASON_UNKNOWN_WORD if addressed else REASON_MISSING_SPAN)
+            continue
+
+        start = min(max(span[0], 0.0), total)
+        end = min(max(span[1], 0.0), total)
+        if end - start <= 1e-9:
+            drop(i, op, REASON_EMPTY_SPAN)
+            continue
+        removed.append((start, end))
+    return removed, rejected
+
+
+# --------------------------------------------------------------------------- #
+# T3b — compose the deletes with the SHIPPED filler/silence math
+# --------------------------------------------------------------------------- #
+def plan_transcript_edit(
+    transcript: Mapping[str, Any] | None,
+    edits: Sequence[Any] | None,
+    total_sec: float,
+    silences: Sequence[Span],
+    *,
+    remove_fillers: bool,
+    remove_silence: bool,
+    lang: str | None = None,
+    merge_gap_ms: int = _fillers.DEFAULT_MERGE_GAP_MS,
+    pad_sec: float = _silencetrim.DEFAULT_PAD_SEC,
+    filler_sets: Mapping[str, Mapping[str, frozenset]] | None = None,
+    cues: Sequence[Mapping[str, Any]] | None = None,
+) -> TranscriptEditPlan:
+    """Union the word edits with :func:`refine.plan_refine` into ONE keep-list.
+
+    A word delete, a filler strip and a silence trim therefore render as a
+    SINGLE ``build_segment_cut_argv`` pass (mirroring ``refine.apply``), and the
+    removed regions are de-duplicated so an overlap is never double-counted.
+    A delete that would remove the WHOLE clip degrades to a no-op keep-list
+    (``build_segment_cut_argv`` requires at least one span).
+    """
+    total = max(0.0, float(total_sec))
+    words = addressed_words(transcript)
+    deleted, rejected = resolve_edits(edits, transcript, total)
+
+    refine_plan = _refine.plan_refine(
+        words,
+        lang,
+        total,
+        silences,
+        remove_fillers=remove_fillers,
+        remove_silence=remove_silence,
+        merge_gap_ms=merge_gap_ms,
+        pad_sec=pad_sec,
+        filler_sets=filler_sets,
+    )
+    refine_removed = _refine._removed_from_keeps(  # noqa: SLF001 - sibling module, same package
+        [(a, b) for a, b in refine_plan["keeps"]], 0.0, total
+    )
+
+    deleted_union = _refine._union_spans(deleted)  # noqa: SLF001 - sibling module, same package
+    deleted_sec = round(sum(b - a for a, b in deleted_union), 3)
+    removed_union = _refine._union_spans([*deleted_union, *refine_removed])  # noqa: SLF001 - sibling module
+
+    if total <= 0.0:
+        keeps: list[list[float]] = []
+    else:
+        keeps = _refine._keeps_from_removed(removed_union, total) or [  # noqa: SLF001 - sibling module
+            [0.0, round(total, 3)]
+        ]
+    kept_sec = round(sum(b - a for a, b in keeps), 3)
+
+    return TranscriptEditPlan(
+        keeps=keeps,
+        stats=TranscriptEditStats(
+            wordsDeleted=len(deleted),
+            deletedSec=deleted_sec,
+            fillersRemoved=refine_plan["stats"]["fillersRemoved"],
+            fillerSeconds=refine_plan["stats"]["fillerSeconds"],
+            silenceRemovedSec=refine_plan["stats"]["silenceRemovedSec"],
+            keptSec=kept_sec,
+            removedSec=round(total - kept_sec, 3),
+        ),
+        cues=_fillers.remap_cues(cues, [(a, b) for a, b in keeps]) if cues else [],
+        rejected=rejected,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# small param helpers (mirror refine's coercion seams)
+# --------------------------------------------------------------------------- #
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+def _require_str(params: Mapping[str, Any], key: str) -> str:
+    value = params.get(key)
+    if not isinstance(value, str) or not value:
+        raise _invalid(f"{key} (str) is required")
+    return value
+
+
+def _float(params: Mapping[str, Any], key: str, default: float) -> float:
+    value = _num(params.get(key, default))
+    return default if value is None else value
+
+
+def _bool(params: Mapping[str, Any], key: str, default: bool) -> bool:
+    value = params.get(key, default)
+    return default if value is None else bool(value)
+
+
+def _edit_history(project: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """The project's edit ledger, tolerating a missing/corrupt value."""
+    raw = project.get(EDITS_KEY)
+    if not isinstance(raw, list):
+        return []
+    return [dict(entry) for entry in raw if isinstance(entry, Mapping)]
+
+
+# --------------------------------------------------------------------------- #
+# T3c — the service (get/previewEdit = direct; applyEdit = job; undoEdit = direct)
+# --------------------------------------------------------------------------- #
+class TranscriptEditService:
+    """Owns the four ``transcript.*`` methods over injectable seams.
+
+    Seams are byte-identical to :class:`refine.RefineService` so the same fakes
+    drive both. ``previewEdit`` never encodes and never writes; ``applyEdit``
+    renders ONCE into ``out_dir`` (the source is never touched) and appends to
+    the reversible edit ledger; ``undoEdit`` pops it back.
+    """
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver,
+        out_dir: str | os.PathLike[str],
+        load_project: LoadProject,
+        save_project: SaveProject,
+        settings_provider: Callable[[], dict[str, Any]] | None = None,
+        run: RunFn | None = None,
+        duration: ProbeFn | None = None,
+        detect_run: DetectRunner | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._out_dir = Path(out_dir)
+        self._load_project = load_project
+        self._save_project = save_project
+        self._settings_provider = settings_provider or (lambda: {})
+        self._run = run
+        self._duration = duration
+        self._detect_run = detect_run
+
+    # ---- shared plumbing ---------------------------------------------------
+    def _settings(self) -> dict[str, Any]:
+        try:
+            return dict(self._settings_provider() or {})
+        except Exception:  # noqa: BLE001 - settings must never break an op
+            return {}
+
+    def _resolve(self, params: Mapping[str, Any]) -> str:
+        path = params.get("path")
+        if isinstance(path, str) and path:
+            return path
+        video_id = _require_str(params, "videoId")
+        resolved = self._resolver(video_id)
+        if not resolved:
+            raise _invalid(f"unknown video: {video_id}")
+        return str(resolved)
+
+    def _project(self, params: Mapping[str, Any]) -> dict[str, Any]:
+        video_id = params.get("videoId")
+        if not isinstance(video_id, str) or not video_id:
+            return {}
+        return dict(self._load_project(video_id) or {})
+
+    def _plan(self, params: Mapping[str, Any], in_path: str, settings: dict[str, Any], total: float):
+        """Detect silence + compose the plan (shared by previewEdit/applyEdit)."""
+        silences = _silencetrim.detect_silence_spans(
+            in_path,
+            settings=settings,
+            noise_db=_float(params, "noiseDb", _silencetrim.DEFAULT_NOISE_DB),
+            min_silence_sec=_float(params, "minSilenceSec", _silencetrim.DEFAULT_MIN_SILENCE_SEC),
+            run=self._detect_run,
+        )
+        return plan_transcript_edit(
+            self._project(params).get("transcript"),
+            params.get("edits"),
+            total,
+            silences,
+            remove_fillers=_bool(params, "removeFillers", False),
+            remove_silence=_bool(params, "removeSilence", False),
+            lang=params.get("lang"),
+            merge_gap_ms=int(_float(params, "mergeGapMs", float(_fillers.DEFAULT_MERGE_GAP_MS))),
+            pad_sec=_float(params, "padSec", _silencetrim.DEFAULT_PAD_SEC),
+            filler_sets=params.get("fillerSets"),
+            cues=params.get("cues"),
+        )
+
+    # ---- transcript.get ----------------------------------------------------
+    def get(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:  # noqa: ARG002 - RPC signature
+        """``transcript.get({videoId})`` -> ``{transcript}`` with stamped ids.
+
+        Returns ``{"transcript": None}`` when the project has not been
+        transcribed yet — the renderer distinguishes "no transcript" from an
+        empty one.
+        """
+        video_id = _require_str(params, "videoId")
+        project = self._load_project(video_id) or {}
+        return {"transcript": address_transcript(project.get("transcript"))}
+
+    # ---- transcript.previewEdit -------------------------------------------
+    def previewEdit(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:  # noqa: ARG002,N802 - wire name
+        """``transcript.previewEdit({videoId|path, edits, ...})`` -> ``{plan}``.
+
+        DIRECT: no encode, no file write — the "see before you cut" pass.
+        """
+        in_path = self._resolve(params)
+        settings = self._settings()
+        total = _float(params, "totalSec", 0.0)
+        if total <= 0.0:
+            total = _probe_total(self._duration, in_path, settings)
+        return {"plan": self._plan(params, in_path, settings, total)}
+
+    # ---- transcript.applyEdit ---------------------------------------------
+    def applyEdit(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:  # noqa: N802 - wire name
+        """``transcript.applyEdit({videoId|path, edits, ...})`` -> ``{jobId}``.
+
+        ``job.done.result`` = ``{path, removedSec, stats, plan, editId, cues?}``.
+        Renders ONCE via :func:`fillers.build_segment_cut_argv` into
+        ``out_dir/{stem}.edited.mp4`` — the source file is NEVER touched — then
+        appends ``{editId, path, sourcePath, removedSec, keeps}`` to the
+        project's ledger so :meth:`undoEdit` can walk it back. When nothing is
+        removed the original path passes straight through (no encode, no
+        ledger entry, ``editId=None``).
+        """
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        in_path = self._resolve(params)
+        settings = self._settings()
+        run = self._run if self._run is not None else _default_run()
+        duration = self._duration
+        out_dir = self._out_dir
+        video_id = params.get("videoId")
+        plan_params = dict(params)
+
+        def job_body(job_ctx: JobContext) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            job_ctx.progress(5, "planning transcript edit")
+            total = _probe_total(duration, in_path, settings)
+            if total <= 0.0:
+                job_ctx.progress(100, "nothing to edit")
+                return _passthrough(in_path, _empty_plan(0.0))
+            plan = self._plan(plan_params, in_path, settings, total)
+            keeps = [(float(a), float(b)) for a, b in plan["keeps"]]
+            removed = plan["stats"]["removedSec"]
+            if removed <= 1e-3 or len(keeps) <= 1:
+                job_ctx.progress(100, "nothing to edit")
+                return _passthrough(in_path, plan)
+            job_ctx.raise_if_cancelled()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            stem = Path(in_path).stem or "clip"
+            out_path = str(out_dir / f"{stem}.edited.mp4")
+            argv = _fillers.build_segment_cut_argv(in_path, out_path, keeps, settings)
+            job_ctx.progress(40, "re-cutting")
+            code = run(argv, total_sec=total)
+            if code != 0:
+                raise RpcError(f"transcript edit re-cut failed (ffmpeg exit {code})", ErrorCode.INTERNAL_ERROR)
+            edit_id = self._record(video_id, out_path, in_path, removed, plan["keeps"])
+            result: dict[str, Any] = {
+                "path": out_path,
+                "removedSec": removed,
+                "stats": plan["stats"],
+                "plan": plan,
+                "editId": edit_id,
+            }
+            if plan["cues"]:
+                result["cues"] = plan["cues"]
+            job_ctx.progress(100, f"removed {removed:.1f}s")
+            return result
+
+        job = ctx.jobs.start(job_body, feature="transcriptEdit", label="transcript edit", videoId=video_id)
+        return {"jobId": job.id}
+
+    def _record(
+        self,
+        video_id: Any,
+        out_path: str,
+        source_path: str,
+        removed: float,
+        keeps: list[list[float]],
+    ) -> str | None:
+        """Append the edit to the project ledger; returns its deterministic id."""
+        if not isinstance(video_id, str) or not video_id:
+            return None
+        project = dict(self._load_project(video_id) or {})
+        history = _edit_history(project)
+        edit_id = f"tedit-{len(history) + 1}"
+        history.append(
+            {
+                "editId": edit_id,
+                "path": out_path,
+                "sourcePath": source_path,
+                "removedSec": removed,
+                "keeps": keeps,
+            }
+        )
+        project[EDITS_KEY] = history
+        self._save_project(video_id, project)
+        return edit_id
+
+    # ---- transcript.undoEdit ----------------------------------------------
+    def undoEdit(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:  # noqa: ARG002,N802 - wire name
+        """``transcript.undoEdit({videoId, editId?})`` -> ``{editId, path, undone}``.
+
+        Pops the newest ledger entry (or asserts it is ``editId``) and returns
+        the path that becomes current again — the previous edit's output, or the
+        untouched original. The rendered file is left on disk (it is a sibling,
+        never the source), so an undo is cheap and re-doable by re-applying.
+        """
+        video_id = _require_str(params, "videoId")
+        project = dict(self._load_project(video_id) or {})
+        history = _edit_history(project)
+        if not history:
+            raise _invalid("nothing to undo for this video")
+        wanted = params.get("editId")
+        if isinstance(wanted, str) and wanted and wanted != history[-1]["editId"]:
+            raise _invalid(f"cannot undo {wanted}: the newest edit is {history[-1]['editId']}")
+        undone = history.pop()
+        project[EDITS_KEY] = history
+        self._save_project(video_id, project)
+        return {
+            "editId": undone["editId"],
+            "path": history[-1]["path"] if history else undone["sourcePath"],
+            "undone": undone,
+        }
+
+
+# --------------------------------------------------------------------------- #
+# module helpers
+# --------------------------------------------------------------------------- #
+def _default_run() -> RunFn:
+    """The real drained ffmpeg ``run`` seam (lazy import keeps the module light)."""
+    from .. import ffmpeg as _ffmpeg  # noqa: PLC0415 - lazy: avoids an import cycle
+
+    return _ffmpeg.run
+
+
+def _default_duration() -> ProbeFn:
+    """The real ffprobe duration seam (lazy import keeps the module light)."""
+    from .. import ffmpeg as _ffmpeg  # noqa: PLC0415 - lazy: avoids an import cycle
+
+    return _ffmpeg.ffprobe_duration
+
+
+def _probe_total(duration: ProbeFn | None, in_path: str, settings: dict[str, Any]) -> float:
+    """Probe the clip duration through the seam; a probe failure -> 0.0."""
+    probe = duration if duration is not None else _default_duration()
+    try:
+        return float(probe(in_path, settings))
+    except Exception:  # noqa: BLE001 - a probe failure means we can't cut safely
+        log.warning("duration probe failed for %s; skipping transcript edit", in_path)
+        return 0.0
+
+
+def _empty_plan(total: float) -> TranscriptEditPlan:
+    return TranscriptEditPlan(
+        keeps=[] if total <= 0.0 else [[0.0, round(total, 3)]],
+        stats=TranscriptEditStats(
+            wordsDeleted=0,
+            deletedSec=0.0,
+            fillersRemoved=0,
+            fillerSeconds=0.0,
+            silenceRemovedSec=0.0,
+            keptSec=round(total, 3),
+            removedSec=0.0,
+        ),
+        cues=[],
+        rejected=[],
+    )
+
+
+def _passthrough(in_path: str, plan: TranscriptEditPlan) -> dict[str, Any]:
+    """The no-encode result: the ORIGINAL path, nothing removed, nothing recorded."""
+    return {"path": in_path, "removedSec": 0.0, "stats": plan["stats"], "plan": plan, "editId": None}
+
+
+# --------------------------------------------------------------------------- #
+# registration (called from handlers.register_all — the ONE RPC site)
+# --------------------------------------------------------------------------- #
+def register(
+    *,
+    resolver: Resolver,
+    out_dir: str | os.PathLike[str],
+    load_project: LoadProject,
+    save_project: SaveProject,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+    run: RunFn | None = None,
+    duration: ProbeFn | None = None,
+    detect_run: DetectRunner | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> TranscriptEditService:
+    """Create the service and register the four ``transcript.*`` methods.
+
+    Mirrors :func:`refine.register`: ``register_fn`` defaults to
+    :func:`protocol.register` (duplicates fail loudly); tests inject a fake
+    registrar + fake seams. ``get``/``previewEdit``/``undoEdit`` are DIRECT
+    handlers; ``applyEdit`` runs as a job.
+    """
+    service = TranscriptEditService(
+        resolver=resolver,
+        out_dir=out_dir,
+        load_project=load_project,
+        save_project=save_project,
+        settings_provider=settings_provider,
+        run=run,
+        duration=duration,
+        detect_run=detect_run,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("transcript.get", service.get)
+    reg("transcript.previewEdit", service.previewEdit)
+    reg("transcript.applyEdit", service.applyEdit)
+    reg("transcript.undoEdit", service.undoEdit)
+    log.info("registered transcript.get + previewEdit + applyEdit + undoEdit")
+    return service
+
+
+__all__ = [
+    "EDITS_KEY",
+    "REASON_EMPTY_SPAN",
+    "REASON_MISSING_SPAN",
+    "REASON_REORDER_DEFERRED",
+    "REASON_UNKNOWN_OP",
+    "REASON_UNKNOWN_WORD",
+    "SUPPORTED_OPS",
+    "AddressedWord",
+    "TranscriptEditPlan",
+    "TranscriptEditService",
+    "TranscriptEditStats",
+    "address_transcript",
+    "addressed_words",
+    "plan_transcript_edit",
+    "register",
+    "resolve_edits",
+    "word_id",
+]

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -566,6 +566,28 @@ def register_all(
         register_fn=reg,
     )
 
+    # transcript.* (v1.5 flagship #2 — transcript-native editing): delete a word
+    # in the transcript and the video cuts. Registered immediately after refine
+    # because it COMPOSES refine.plan_refine (word deletes UNION the shipped
+    # filler/silence math) into ONE keep-list -> ONE build_segment_cut_argv
+    # encode, over the exact same project-store + ffmpeg seams. get/previewEdit/
+    # undoEdit are DIRECT handlers; applyEdit is a job (the module owns its
+    # register()). applyEdit writes a *.edited.mp4 sibling — the source video is
+    # never touched — and appends to the project's reversible `transcriptEdits`
+    # ledger that undoEdit walks back.
+    from ..features import transcript_edit as _transcript_edit  # local: import-light
+
+    _transcript_edit.register(
+        resolver=svc._resolve_video_path,
+        out_dir=svc.exports_dir / "edited",
+        load_project=_load_project_data,
+        save_project=_save_project_data,
+        settings_provider=svc.settings.get,
+        run=svc._ffmpeg_run,  # None -> the real drained ffmpeg.run
+        duration=svc._ffprobe_duration,
+        register_fn=reg,
+    )
+
     # assets.* (A2): registered via the assets package's own register() so the
     # manager binds to the services' data dir + settings (U4).
     from ..assets import rpc as _assets_rpc  # local import keeps handlers import-light

--- a/sidecar/media_studio/library.py
+++ b/sidecar/media_studio/library.py
@@ -575,6 +575,14 @@ class Project:
         # transcript is optional (only present once transcribed).
         if raw.get("transcript") is not None:
             data["transcript"] = raw["transcript"]
+        # transcriptEdits is the OPTIONAL reversible transcript-edit ledger
+        # (features/transcript_edit.py). Backfilled exactly like `transcript`:
+        # absent on an old project, and NEVER synthesised — a manifest that has
+        # never been transcript-edited must round-trip byte-identical. Without
+        # this passthrough the ledger written by `applyEdit` would be silently
+        # dropped on the next `open()`, and undo would lose its history.
+        if raw.get("transcriptEdits") is not None:
+            data["transcriptEdits"] = raw["transcriptEdits"]
         return cls(data, manifest_path=path)
 
     # ---- persistence -------------------------------------------------------

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -172,6 +172,11 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         "tracks.video.splitClip",
         "tracks.video.trimClip",
         "transcribe.start",
+        # v1.5 flagship #2 — transcript-native editing (features/transcript_edit.py).
+        "transcript.applyEdit",
+        "transcript.get",
+        "transcript.previewEdit",
+        "transcript.undoEdit",
         "tts.dub.start",
         "tts.sample.add",
         "tts.voices",

--- a/sidecar/tests/test_transcript_edit.py
+++ b/sidecar/tests/test_transcript_edit.py
@@ -185,9 +185,20 @@ class TestAddressing:
         src = {"segments": [None, {"words": None}, {"words": ["not-a-dict", w("ok", 1.0, 2.0)]}]}
         out = te.address_transcript(src)
         assert out is not None
-        assert [seg.get("words") for seg in out["segments"]][2] == [
-            {"text": "ok", "start": 1.0, "end": 2.0, "wordId": "w2-1", "segmentIndex": 2, "wordIndex": 1}
+        # a non-mapping segment passes through VERBATIM; a non-mapping word too;
+        # only the real word is stamped, and its index reflects its true slot.
+        assert out["segments"] == [
+            None,
+            {"words": None},
+            {
+                "words": [
+                    "not-a-dict",
+                    {"text": "ok", "start": 1.0, "end": 2.0, "wordId": "w2-1", "segmentIndex": 2, "wordIndex": 1},
+                ]
+            },
         ]
+        # ...and the flat view skips both junk entries
+        assert [x["wordId"] for x in te.addressed_words(src)] == ["w2-1"]
 
     def test_addressed_words_flattens_across_segments(self):
         src = {
@@ -636,6 +647,76 @@ class TestApplyEdit:
         result = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
         assert result["editId"] == "tedit-1"
         assert len(data["transcriptEdits"]) == 1
+
+
+    def test_apply_by_path_only_records_nothing_but_still_cuts(self, tmp_path, settings, registry):
+        # No videoId -> no project to write a ledger entry to. The cut STILL
+        # happens (silence removal needs no transcript) and editId is None, so a
+        # caller cannot later "undo" an edit that was never recorded.
+        run = RecordingRun()
+        svc, data = _service(tmp_path=tmp_path, settings=settings, run=run)
+        result = self._apply(
+            svc, registry, {"path": "/lib/in.mp4", "removeSilence": True, "padSec": 0.0}
+        )
+        assert result["path"].endswith(".edited.mp4")
+        assert result["removedSec"] > 0.0
+        assert result["editId"] is None
+        assert len(run.calls) == 1
+        assert te.EDITS_KEY not in data
+
+
+class TestDefaultSeams:
+    def test_default_run_is_ffmpeg_run(self):
+        from media_studio import ffmpeg as _ffmpeg
+
+        assert te._default_run() is _ffmpeg.run
+
+    def test_default_duration_is_ffprobe_duration(self):
+        from media_studio import ffmpeg as _ffmpeg
+
+        assert te._default_duration() is _ffmpeg.ffprobe_duration
+
+    def test_apply_uses_the_default_duration_seam_when_none(self, tmp_path, settings, registry):
+        # duration=None -> the REAL ffprobe seam runs on a bogus path, throws,
+        # _probe_total returns 0.0 -> pass-through (the fake run is never hit).
+        run = RecordingRun()
+        data = {"id": "p1", "transcript": _transcript()}
+        svc = te.TranscriptEditService(
+            resolver=lambda vid: "/no/such/clip.mp4",
+            out_dir=tmp_path / "edited",
+            load_project=lambda vid: data,
+            save_project=lambda vid, payload: None,
+            settings_provider=lambda: settings,
+            run=run,
+            duration=None,  # exercises _default_duration() + the probe-failure branch
+            detect_run=detect_with(SILENCE_STDERR),
+        )
+        out = svc.applyEdit({"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]}, _ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["path"] == "/no/such/clip.mp4"
+        assert job.result["removedSec"] == 0.0
+        assert run.calls == []
+
+    def test_apply_uses_the_default_run_seam_when_none(self, tmp_path, settings, registry):
+        # run=None -> _default_run() resolves the real ffmpeg.run; the duration
+        # probe returns 0.0 first, so the pass-through short-circuits BEFORE any
+        # subprocess is spawned (the seam is resolved, never invoked).
+        data = {"id": "p1", "transcript": _transcript()}
+        svc = te.TranscriptEditService(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "edited",
+            load_project=lambda vid: data,
+            save_project=lambda vid, payload: None,
+            settings_provider=lambda: settings,
+            run=None,  # exercises _default_run()
+            duration=lambda p, s=None: 0.0,
+            detect_run=detect_with(""),
+        )
+        out = svc.applyEdit({"videoId": "v1", "edits": []}, _ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.result["path"] == "/lib/in.mp4"
 
 
 class TestUndoEdit:

--- a/sidecar/tests/test_transcript_edit.py
+++ b/sidecar/tests/test_transcript_edit.py
@@ -223,9 +223,7 @@ class TestResolveEdits:
         assert rejected == []
 
     def test_delete_by_segment_and_word_index_resolves(self):
-        removed, rejected = te.resolve_edits(
-            [{"op": "delete", "segmentIndex": 0, "wordIndex": 1}], _transcript(), 10.0
-        )
+        removed, rejected = te.resolve_edits([{"op": "delete", "segmentIndex": 0, "wordIndex": 1}], _transcript(), 10.0)
         assert removed == [(1.0, 1.4)]
         assert rejected == []
 
@@ -234,9 +232,7 @@ class TestResolveEdits:
         assert removed == [(0.0, 0.5)]
 
     def test_trim_uses_explicit_millisecond_bounds(self):
-        removed, rejected = te.resolve_edits(
-            [{"op": "trim", "startMs": 3200, "endMs": 3400}], _transcript(), 10.0
-        )
+        removed, rejected = te.resolve_edits([{"op": "trim", "startMs": 3200, "endMs": 3400}], _transcript(), 10.0)
         assert removed == [(3.2, 3.4)]
         assert rejected == []
 
@@ -245,9 +241,7 @@ class TestResolveEdits:
         assert removed == [(0.0, 10.0)]
 
     def test_delete_with_explicit_bounds_beats_a_missing_address(self):
-        removed, rejected = te.resolve_edits(
-            [{"op": "delete", "startMs": 1000, "endMs": 1400}], _transcript(), 10.0
-        )
+        removed, rejected = te.resolve_edits([{"op": "delete", "startMs": 1000, "endMs": 1400}], _transcript(), 10.0)
         assert removed == [(1.0, 1.4)]
         assert rejected == []
 
@@ -279,16 +273,12 @@ class TestResolveEdits:
         assert rejected[0]["reason"] == te.REASON_EMPTY_SPAN
 
     def test_span_entirely_past_the_clip_end_is_dropped(self):
-        removed, rejected = te.resolve_edits(
-            [{"op": "trim", "startMs": 20000, "endMs": 21000}], _transcript(), 10.0
-        )
+        removed, rejected = te.resolve_edits([{"op": "trim", "startMs": 20000, "endMs": 21000}], _transcript(), 10.0)
         assert removed == []
         assert rejected[0]["reason"] == te.REASON_EMPTY_SPAN
 
     def test_reorder_is_dropped_as_deferred_not_silently_applied(self):
-        removed, rejected = te.resolve_edits(
-            [{"op": "reorder", "wordId": "w0-3", "toIndex": 0}], _transcript(), 10.0
-        )
+        removed, rejected = te.resolve_edits([{"op": "reorder", "wordId": "w0-3", "toIndex": 0}], _transcript(), 10.0)
         assert removed == []
         assert rejected == [{"index": 0, "op": "reorder", "reason": te.REASON_REORDER_DEFERRED}]
 
@@ -648,16 +638,13 @@ class TestApplyEdit:
         assert result["editId"] == "tedit-1"
         assert len(data["transcriptEdits"]) == 1
 
-
     def test_apply_by_path_only_records_nothing_but_still_cuts(self, tmp_path, settings, registry):
         # No videoId -> no project to write a ledger entry to. The cut STILL
         # happens (silence removal needs no transcript) and editId is None, so a
         # caller cannot later "undo" an edit that was never recorded.
         run = RecordingRun()
         svc, data = _service(tmp_path=tmp_path, settings=settings, run=run)
-        result = self._apply(
-            svc, registry, {"path": "/lib/in.mp4", "removeSilence": True, "padSec": 0.0}
-        )
+        result = self._apply(svc, registry, {"path": "/lib/in.mp4", "removeSilence": True, "padSec": 0.0})
         assert result["path"].endswith(".edited.mp4")
         assert result["removedSec"] > 0.0
         assert result["editId"] is None

--- a/sidecar/tests/test_transcript_edit.py
+++ b/sidecar/tests/test_transcript_edit.py
@@ -1,0 +1,756 @@
+"""Unit tests for transcript-native editing (features/transcript_edit.py, v1.5 T1/T3).
+
+The flagship "delete a word -> the video cuts" vertical slice. Three tiers, all
+hermetic (no ffmpeg, no model, no real I/O):
+
+1. **Addressing (T1, pure).** ``address_transcript`` stamps a stable ``wordId``
+   onto every word without mutating the input, so the renderer can address a
+   token and the backend can resolve it back to ``[start, end]`` seconds.
+2. **Translator (T3, pure).** ``resolve_edits`` turns EditSpans into removed
+   spans (dropping impossible/unknown ones with a TYPED reason, never raising --
+   mirroring ``edit_validate.validate_and_reject``), and
+   ``plan_transcript_edit`` unions them with the SHIPPED filler/silence math
+   (``refine.plan_refine``) into ONE keep-list + stats + re-timed cues.
+3. **Service (T3).** ``transcript.get`` / ``previewEdit`` / ``applyEdit`` /
+   ``undoEdit`` over fully-injected seams. ``applyEdit`` renders ONCE through the
+   fake ``run`` seam (writing ``*.edited.mp4`` -- the original is never touched)
+   and records a reversible edit entry; ``undoEdit`` pops it back.
+
+Assertions are on VALUES the real pure functions compute (the exact keep-list,
+the exact argv trim times, the exact remapped cue seconds) -- never on "was this
+called", which stays green even when the value is wrong.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import library as lib
+from media_studio import protocol
+from media_studio.features import refine as rf
+from media_studio.features import transcript_edit as te
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext, RpcError
+
+# --------------------------------------------------------------------------- #
+# fixtures / builders
+# --------------------------------------------------------------------------- #
+SILENCE_STDERR = (
+    "[silencedetect @ 0x1] silence_start: 5.0\n[silencedetect @ 0x1] silence_end: 7.0 | silence_duration: 2.0\n"
+)
+
+
+def w(text: str, start: float, end: float) -> dict[str, Any]:
+    return {"text": text, "start": start, "end": end}
+
+
+def _transcript(words: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    """A §3 transcript with ONE segment carrying ``words``."""
+    return {
+        "language": "en",
+        "durationSec": 10.0,
+        "segments": [
+            {
+                "start": 0.0,
+                "end": 3.5,
+                "text": "we um should ship",
+                "words": words
+                if words is not None
+                else [
+                    w("we", 0.0, 0.5),
+                    w("um", 1.0, 1.4),
+                    w("should", 2.0, 2.5),
+                    w("ship", 3.0, 3.5),
+                ],
+            }
+        ],
+    }
+
+
+class RecordingRun:
+    """A fake ffmpeg ``run`` seam recording every argv it is handed."""
+
+    def __init__(self, code: int = 0) -> None:
+        self.calls: list[list[str]] = []
+        self.code = code
+
+    def __call__(self, argv, **kw) -> int:
+        self.calls.append(list(argv))
+        return self.code
+
+
+def detect_with(stderr: str):
+    """A fake ``detect_run`` (subprocess.run-shaped) returning canned stderr."""
+
+    class Completed:
+        returncode = 0
+        stdout = ""
+
+    def runner(argv, **kw):
+        c = Completed()
+        c.stderr = stderr
+        return c
+
+    return runner
+
+
+@pytest.fixture()
+def bin_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "bin"
+    d.mkdir()
+    for name in ("ffmpeg", "ffprobe", "ffmpeg.exe", "ffprobe.exe"):
+        (d / name).write_text("", encoding="utf-8")
+    return d
+
+
+@pytest.fixture()
+def settings(bin_dir: Path) -> dict[str, Any]:
+    return {"ffmpegPath": str(bin_dir)}
+
+
+def _ctx(registry: JobRegistry | None) -> RpcContext:
+    return RpcContext(emit_notification=lambda obj: None, jobs=registry)
+
+
+def _service(
+    *,
+    tmp_path: Path,
+    settings: dict[str, Any],
+    project: dict[str, Any] | None = None,
+    resolver=None,
+    run=None,
+    duration=None,
+    detect_run=None,
+):
+    """A TranscriptEditService over fully-faked seams + the live project dict."""
+    data = project if project is not None else {"id": "p1", "transcript": _transcript()}
+
+    def load_project(video_id: str) -> dict[str, Any]:
+        return data
+
+    def save_project(video_id: str, payload: dict[str, Any]) -> None:
+        data.clear()
+        data.update(payload)
+
+    svc = te.TranscriptEditService(
+        resolver=resolver if resolver is not None else (lambda vid: "/lib/in.mp4"),
+        out_dir=tmp_path / "edited",
+        load_project=load_project,
+        save_project=save_project,
+        settings_provider=lambda: settings,
+        run=run if run is not None else RecordingRun(),
+        duration=duration if duration is not None else (lambda p, s=None: 10.0),
+        detect_run=detect_run if detect_run is not None else detect_with(SILENCE_STDERR),
+    )
+    return svc, data
+
+
+# --------------------------------------------------------------------------- #
+# T1 — stable word addressing (pure, immutable)
+# --------------------------------------------------------------------------- #
+class TestAddressing:
+    def test_word_id_is_segment_and_word_index(self):
+        assert te.word_id(0, 3) == "w0-3"
+        assert te.word_id(2, 11) == "w2-11"
+
+    def test_address_transcript_stamps_ids_without_mutating_input(self):
+        src = _transcript()
+        out = te.address_transcript(src)
+        assert out is not None
+        stamped = out["segments"][0]["words"]
+        assert [x["wordId"] for x in stamped] == ["w0-0", "w0-1", "w0-2", "w0-3"]
+        assert stamped[3] == {
+            "text": "ship",
+            "start": 3.0,
+            "end": 3.5,
+            "wordId": "w0-3",
+            "segmentIndex": 0,
+            "wordIndex": 3,
+        }
+        # the SOURCE transcript is untouched (immutability rule)
+        assert "wordId" not in src["segments"][0]["words"][3]
+
+    def test_address_transcript_preserves_an_existing_word_id(self):
+        src = _transcript([{"text": "hi", "start": 0.0, "end": 0.4, "wordId": "legacy-7"}])
+        out = te.address_transcript(src)
+        assert out is not None
+        assert out["segments"][0]["words"][0]["wordId"] == "legacy-7"
+
+    def test_address_transcript_of_none_is_none(self):
+        assert te.address_transcript(None) is None
+
+    def test_address_transcript_tolerates_junk_segments_and_words(self):
+        src = {"segments": [None, {"words": None}, {"words": ["not-a-dict", w("ok", 1.0, 2.0)]}]}
+        out = te.address_transcript(src)
+        assert out is not None
+        assert [seg.get("words") for seg in out["segments"]][2] == [
+            {"text": "ok", "start": 1.0, "end": 2.0, "wordId": "w2-1", "segmentIndex": 2, "wordIndex": 1}
+        ]
+
+    def test_addressed_words_flattens_across_segments(self):
+        src = {
+            "segments": [
+                {"words": [w("a", 0.0, 0.2)]},
+                {"words": [w("b", 1.0, 1.2), w("c", 2.0, 2.2)]},
+            ]
+        }
+        assert [x["wordId"] for x in te.addressed_words(src)] == ["w0-0", "w1-0", "w1-1"]
+
+    def test_addressed_words_of_empty_transcript_is_empty(self):
+        assert te.addressed_words(None) == []
+
+
+# --------------------------------------------------------------------------- #
+# T3a — the pure EditSpan -> removed-span translator
+# --------------------------------------------------------------------------- #
+class TestResolveEdits:
+    def test_delete_by_word_id_resolves_to_the_word_span(self):
+        removed, rejected = te.resolve_edits([{"op": "delete", "wordId": "w0-3"}], _transcript(), 10.0)
+        assert removed == [(3.0, 3.5)]
+        assert rejected == []
+
+    def test_delete_by_segment_and_word_index_resolves(self):
+        removed, rejected = te.resolve_edits(
+            [{"op": "delete", "segmentIndex": 0, "wordIndex": 1}], _transcript(), 10.0
+        )
+        assert removed == [(1.0, 1.4)]
+        assert rejected == []
+
+    def test_delete_defaults_the_op_when_absent(self):
+        removed, _ = te.resolve_edits([{"wordId": "w0-0"}], _transcript(), 10.0)
+        assert removed == [(0.0, 0.5)]
+
+    def test_trim_uses_explicit_millisecond_bounds(self):
+        removed, rejected = te.resolve_edits(
+            [{"op": "trim", "startMs": 3200, "endMs": 3400}], _transcript(), 10.0
+        )
+        assert removed == [(3.2, 3.4)]
+        assert rejected == []
+
+    def test_trim_clamps_to_the_clip_duration(self):
+        removed, _ = te.resolve_edits([{"op": "trim", "startMs": -500, "endMs": 99000}], _transcript(), 10.0)
+        assert removed == [(0.0, 10.0)]
+
+    def test_delete_with_explicit_bounds_beats_a_missing_address(self):
+        removed, rejected = te.resolve_edits(
+            [{"op": "delete", "startMs": 1000, "endMs": 1400}], _transcript(), 10.0
+        )
+        assert removed == [(1.0, 1.4)]
+        assert rejected == []
+
+    def test_unknown_word_id_is_dropped_with_a_typed_reason(self):
+        removed, rejected = te.resolve_edits([{"op": "delete", "wordId": "w9-9"}], _transcript(), 10.0)
+        assert removed == []
+        assert rejected == [{"index": 0, "op": "delete", "reason": te.REASON_UNKNOWN_WORD}]
+
+    def test_out_of_range_word_index_is_dropped(self):
+        removed, rejected = te.resolve_edits(
+            [{"op": "delete", "segmentIndex": 0, "wordIndex": 99}], _transcript(), 10.0
+        )
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_UNKNOWN_WORD
+
+    def test_delete_with_no_address_at_all_is_dropped(self):
+        removed, rejected = te.resolve_edits([{"op": "delete"}], _transcript(), 10.0)
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_MISSING_SPAN
+
+    def test_trim_without_bounds_is_dropped(self):
+        removed, rejected = te.resolve_edits([{"op": "trim", "wordId": "w0-0"}], _transcript(), 10.0)
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_MISSING_SPAN
+
+    def test_zero_length_span_is_dropped(self):
+        removed, rejected = te.resolve_edits([{"op": "trim", "startMs": 2000, "endMs": 2000}], _transcript(), 10.0)
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_EMPTY_SPAN
+
+    def test_span_entirely_past_the_clip_end_is_dropped(self):
+        removed, rejected = te.resolve_edits(
+            [{"op": "trim", "startMs": 20000, "endMs": 21000}], _transcript(), 10.0
+        )
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_EMPTY_SPAN
+
+    def test_reorder_is_dropped_as_deferred_not_silently_applied(self):
+        removed, rejected = te.resolve_edits(
+            [{"op": "reorder", "wordId": "w0-3", "toIndex": 0}], _transcript(), 10.0
+        )
+        assert removed == []
+        assert rejected == [{"index": 0, "op": "reorder", "reason": te.REASON_REORDER_DEFERRED}]
+
+    def test_unknown_op_is_dropped(self):
+        removed, rejected = te.resolve_edits([{"op": "teleport", "wordId": "w0-0"}], _transcript(), 10.0)
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_UNKNOWN_OP
+
+    def test_non_mapping_edit_is_dropped(self):
+        removed, rejected = te.resolve_edits(["nope"], _transcript(), 10.0)
+        assert removed == []
+        assert rejected == [{"index": 0, "op": "", "reason": te.REASON_UNKNOWN_OP}]
+
+    def test_non_numeric_bounds_are_dropped_not_raised(self):
+        removed, rejected = te.resolve_edits([{"op": "trim", "startMs": "x", "endMs": 500}], _transcript(), 10.0)
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_MISSING_SPAN
+
+    def test_no_edits_yields_no_spans(self):
+        assert te.resolve_edits(None, _transcript(), 10.0) == ([], [])
+
+    def test_word_with_junk_timings_is_dropped(self):
+        bad = _transcript([{"text": "ghost", "start": "a", "end": "b"}])
+        removed, rejected = te.resolve_edits([{"op": "delete", "wordId": "w0-0"}], bad, 10.0)
+        assert removed == []
+        assert rejected[0]["reason"] == te.REASON_EMPTY_SPAN
+
+
+# --------------------------------------------------------------------------- #
+# T3b — the composed plan (delete UNION shipped filler/silence math)
+# --------------------------------------------------------------------------- #
+class TestPlan:
+    def test_delete_one_word_cuts_exactly_that_span(self):
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            [{"op": "delete", "wordId": "w0-3"}],
+            10.0,
+            [],
+            remove_fillers=False,
+            remove_silence=False,
+        )
+        assert plan["keeps"] == [[0.0, 3.0], [3.5, 10.0]]
+        assert plan["stats"]["wordsDeleted"] == 1
+        assert plan["stats"]["deletedSec"] == 0.5
+        assert plan["stats"]["keptSec"] == 9.5
+        assert plan["stats"]["removedSec"] == 0.5
+        assert plan["rejected"] == []
+
+    def test_two_deletes_produce_three_keeps(self):
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            [{"op": "delete", "wordId": "w0-1"}, {"op": "delete", "wordId": "w0-3"}],
+            10.0,
+            [],
+            remove_fillers=False,
+            remove_silence=False,
+        )
+        assert plan["keeps"] == [[0.0, 1.0], [1.4, 3.0], [3.5, 10.0]]
+        assert plan["stats"]["wordsDeleted"] == 2
+
+    def test_overlapping_deletes_are_unioned_not_double_counted(self):
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            [
+                {"op": "delete", "wordId": "w0-3"},
+                {"op": "trim", "startMs": 3200, "endMs": 3800},
+            ],
+            10.0,
+            [],
+            remove_fillers=False,
+            remove_silence=False,
+        )
+        assert plan["keeps"] == [[0.0, 3.0], [3.8, 10.0]]
+        assert plan["stats"]["deletedSec"] == 0.8  # 3.0..3.8, NOT 0.5 + 0.6
+
+    def test_no_edits_and_no_toggles_keeps_the_whole_clip(self):
+        plan = te.plan_transcript_edit(_transcript(), [], 10.0, [], remove_fillers=False, remove_silence=False)
+        assert plan["keeps"] == [[0.0, 10.0]]
+        assert plan["stats"]["removedSec"] == 0.0
+
+    def test_zero_duration_yields_an_empty_plan(self):
+        plan = te.plan_transcript_edit(_transcript(), [], 0.0, [], remove_fillers=False, remove_silence=False)
+        assert plan["keeps"] == []
+        assert plan["stats"]["keptSec"] == 0.0
+
+    def test_delete_composes_with_the_shipped_filler_and_silence_math(self):
+        edits = [{"op": "delete", "wordId": "w0-3"}]
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            edits,
+            10.0,
+            [(5.0, 7.0)],
+            remove_fillers=True,
+            remove_silence=True,
+            lang="en",
+            pad_sec=0.0,
+        )
+        base = rf.plan_refine(
+            [w("we", 0.0, 0.5), w("um", 1.0, 1.4), w("should", 2.0, 2.5), w("ship", 3.0, 3.5)],
+            "en",
+            10.0,
+            [(5.0, 7.0)],
+            remove_fillers=True,
+            remove_silence=True,
+            pad_sec=0.0,
+        )
+        # the filler ("um") and silence stats are the SHIPPED numbers, unchanged
+        assert plan["stats"]["fillersRemoved"] == base["stats"]["fillersRemoved"] == 1
+        assert plan["stats"]["silenceRemovedSec"] == base["stats"]["silenceRemovedSec"]
+        # ...and the word delete removed 0.5s MORE than refine alone
+        assert plan["stats"]["keptSec"] == round(base["stats"]["keptSec"] - 0.5, 3)
+        assert [3.0, 3.5] not in plan["keeps"]
+
+    def test_cues_are_retimed_onto_the_cut_timeline(self):
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            [{"op": "delete", "wordId": "w0-3"}],
+            10.0,
+            [],
+            remove_fillers=False,
+            remove_silence=False,
+            cues=[
+                {"index": 1, "start": 0.0, "end": 1.0, "text": "we"},
+                {"index": 2, "start": 4.0, "end": 5.0, "text": "after"},
+            ],
+        )
+        # the second cue slides EARLIER by exactly the 0.5s that was cut
+        assert plan["cues"] == [
+            {"index": 1, "start": 0.0, "end": 1.0, "text": "we"},
+            {"index": 2, "start": 3.5, "end": 4.5, "text": "after"},
+        ]
+
+    def test_absent_cues_yields_an_empty_cue_list(self):
+        plan = te.plan_transcript_edit(_transcript(), [], 10.0, [], remove_fillers=False, remove_silence=False)
+        assert plan["cues"] == []
+
+    def test_rejections_survive_into_the_plan(self):
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            [{"op": "reorder", "wordId": "w0-0"}],
+            10.0,
+            [],
+            remove_fillers=False,
+            remove_silence=False,
+        )
+        assert plan["rejected"] == [{"index": 0, "op": "reorder", "reason": te.REASON_REORDER_DEFERRED}]
+        assert plan["keeps"] == [[0.0, 10.0]]  # nothing cut
+
+    def test_deleting_everything_still_leaves_a_legal_keep_list(self):
+        plan = te.plan_transcript_edit(
+            _transcript(),
+            [{"op": "trim", "startMs": 0, "endMs": 10000}],
+            10.0,
+            [],
+            remove_fillers=False,
+            remove_silence=False,
+        )
+        assert plan["keeps"] == [[0.0, 10.0]]  # a full-clip delete degrades to a no-op
+        assert plan["stats"]["removedSec"] == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# T3c — the service: get / previewEdit / applyEdit / undoEdit
+# --------------------------------------------------------------------------- #
+class TestGet:
+    def test_get_returns_the_addressed_transcript(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        out = svc.get({"videoId": "v1"}, _ctx(None))
+        assert out["transcript"]["segments"][0]["words"][2]["wordId"] == "w0-2"
+
+    def test_get_without_a_transcript_returns_none(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, project={"id": "p1"})
+        assert svc.get({"videoId": "v1"}, _ctx(None)) == {"transcript": None}
+
+    def test_get_requires_a_video_id(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        with pytest.raises(RpcError, match="videoId"):
+            svc.get({}, _ctx(None))
+
+
+class TestPreviewEdit:
+    def test_preview_plans_without_encoding(self, tmp_path, settings):
+        run = RecordingRun()
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run)
+        out = svc.previewEdit(
+            {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}], "totalSec": 10.0},
+            _ctx(None),
+        )
+        assert out["plan"]["keeps"] == [[0.0, 3.0], [3.5, 10.0]]
+        assert run.calls == []  # ZERO encodes
+
+    def test_preview_probes_the_duration_when_not_supplied(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, duration=lambda p, s=None: 12.0)
+        out = svc.previewEdit({"videoId": "v1", "edits": []}, _ctx(None))
+        assert out["plan"]["keeps"] == [[0.0, 12.0]]
+
+    def test_preview_accepts_an_explicit_path(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, resolver=lambda vid: None)
+        out = svc.previewEdit({"path": "/x/explicit.mp4", "videoId": "v1", "totalSec": 10.0}, _ctx(None))
+        assert out["plan"]["keeps"] == [[0.0, 10.0]]
+
+    def test_preview_unknown_video_raises(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, resolver=lambda vid: None)
+        with pytest.raises(RpcError, match="unknown video"):
+            svc.previewEdit({"videoId": "ghost"}, _ctx(None))
+
+    def test_preview_settings_provider_failure_is_swallowed(self, tmp_path, bin_dir):
+        def boom() -> dict[str, Any]:
+            raise RuntimeError("settings exploded")
+
+        data = {"id": "p1", "transcript": _transcript()}
+        svc = te.TranscriptEditService(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "edited",
+            load_project=lambda vid: data,
+            save_project=lambda vid, payload: None,
+            settings_provider=boom,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(SILENCE_STDERR),
+        )
+        out = svc.previewEdit({"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]}, _ctx(None))
+        assert out["plan"]["stats"]["wordsDeleted"] == 1
+
+    def test_preview_default_settings_provider_is_empty(self, tmp_path):
+        data = {"id": "p1", "transcript": _transcript()}
+        svc = te.TranscriptEditService(
+            resolver=lambda vid: "/lib/in.mp4",
+            out_dir=tmp_path / "edited",
+            load_project=lambda vid: data,
+            save_project=lambda vid, payload: None,
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(""),
+        )
+        out = svc.previewEdit({"videoId": "v1", "totalSec": 10.0}, _ctx(None))
+        assert out["plan"]["keeps"] == [[0.0, 10.0]]
+
+    def test_preview_missing_project_plans_on_an_empty_transcript(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, project={})
+        out = svc.previewEdit(
+            {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}], "totalSec": 10.0},
+            _ctx(None),
+        )
+        assert out["plan"]["rejected"][0]["reason"] == te.REASON_UNKNOWN_WORD
+
+    def test_preview_with_no_video_id_and_a_path_reads_no_project(self, tmp_path, settings):
+        def boom_load(video_id: str):  # pragma: no cover - must NOT be called
+            raise AssertionError("load_project must not run without a videoId")
+
+        svc = te.TranscriptEditService(
+            resolver=lambda vid: None,
+            out_dir=tmp_path / "edited",
+            load_project=boom_load,
+            save_project=lambda vid, payload: None,
+            settings_provider=lambda: settings,
+            run=RecordingRun(),
+            duration=lambda p, s=None: 10.0,
+            detect_run=detect_with(""),
+        )
+        out = svc.previewEdit({"path": "/x/explicit.mp4", "totalSec": 10.0}, _ctx(None))
+        assert out["plan"]["keeps"] == [[0.0, 10.0]]
+
+
+class TestApplyEdit:
+    def _apply(self, svc, registry, params):
+        out = svc.applyEdit(params, _ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.status.value == "done", job.error
+        return job.result
+
+    def test_apply_renders_once_and_writes_an_edited_sibling(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        svc, data = _service(tmp_path=tmp_path, settings=settings, run=run)
+        result = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+
+        assert result["path"].endswith(".edited.mp4")
+        assert result["path"] != "/lib/in.mp4"  # the ORIGINAL is never overwritten
+        assert result["removedSec"] == 0.5
+        assert result["editId"] == "tedit-1"
+        assert len(run.calls) == 1  # exactly ONE encode
+        argv = run.calls[0]
+        # the argv carries the REAL keep-list values, not a mock's say-so
+        assert "[0:v]trim=start=0.000:end=3.000,setpts=PTS-STARTPTS[v0]" in argv[argv.index("-filter_complex") + 1]
+        assert "[0:v]trim=start=3.500:end=10.000,setpts=PTS-STARTPTS[v1]" in argv[argv.index("-filter_complex") + 1]
+        # ...and the edit is recorded on the project for undo
+        assert data["transcriptEdits"] == [
+            {
+                "editId": "tedit-1",
+                "path": result["path"],
+                "sourcePath": "/lib/in.mp4",
+                "removedSec": 0.5,
+                "keeps": [[0.0, 3.0], [3.5, 10.0]],
+            }
+        ]
+
+    def test_apply_with_nothing_removed_passes_through_untouched(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        svc, data = _service(tmp_path=tmp_path, settings=settings, run=run)
+        result = self._apply(
+            svc, registry, {"videoId": "v1", "edits": [], "removeFillers": False, "removeSilence": False}
+        )
+        assert result["path"] == "/lib/in.mp4"
+        assert result["removedSec"] == 0.0
+        assert result["editId"] is None
+        assert run.calls == []  # NO re-encode
+        assert "transcriptEdits" not in data  # nothing recorded
+
+    def test_apply_on_a_zero_duration_clip_passes_through(self, tmp_path, settings, registry):
+        run = RecordingRun()
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=run, duration=lambda p, s=None: 0.0)
+        result = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        assert result["path"] == "/lib/in.mp4"
+        assert result["removedSec"] == 0.0
+        assert run.calls == []
+
+    def test_apply_surfaces_an_ffmpeg_failure(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings, run=RecordingRun(code=1))
+        out = svc.applyEdit({"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]}, _ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        assert job.status.value == "error"
+        assert "ffmpeg exit 1" in str(job.error)
+
+    def test_apply_remaps_cues_when_supplied(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        result = self._apply(
+            svc,
+            registry,
+            {
+                "videoId": "v1",
+                "edits": [{"op": "delete", "wordId": "w0-3"}],
+                "cues": [{"index": 1, "start": 4.0, "end": 5.0, "text": "after"}],
+            },
+        )
+        assert result["cues"] == [{"index": 1, "start": 3.5, "end": 4.5, "text": "after"}]
+
+    def test_apply_without_a_job_registry_raises(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        with pytest.raises(RpcError, match="no job registry"):
+            svc.applyEdit({"videoId": "v1"}, _ctx(None))
+
+    def test_second_apply_increments_the_edit_id(self, tmp_path, settings, registry):
+        svc, data = _service(tmp_path=tmp_path, settings=settings)
+        first = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        second = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-1"}]})
+        assert (first["editId"], second["editId"]) == ("tedit-1", "tedit-2")
+        assert [e["editId"] for e in data["transcriptEdits"]] == ["tedit-1", "tedit-2"]
+
+    def test_apply_ignores_a_corrupt_edit_history(self, tmp_path, settings, registry):
+        svc, data = _service(
+            tmp_path=tmp_path,
+            settings=settings,
+            project={"id": "p1", "transcript": _transcript(), "transcriptEdits": "not-a-list"},
+        )
+        result = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        assert result["editId"] == "tedit-1"
+        assert len(data["transcriptEdits"]) == 1
+
+
+class TestUndoEdit:
+    def _apply(self, svc, registry, params):
+        out = svc.applyEdit(params, _ctx(registry))
+        job = registry.get(out["jobId"])
+        job.wait(timeout=5)
+        return job.result
+
+    def test_undo_pops_the_last_edit_and_restores_the_source(self, tmp_path, settings, registry):
+        svc, data = _service(tmp_path=tmp_path, settings=settings)
+        applied = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        out = svc.undoEdit({"videoId": "v1"}, _ctx(None))
+        assert out["editId"] == "tedit-1"
+        assert out["path"] == "/lib/in.mp4"  # back to the untouched ORIGINAL
+        assert out["undone"]["path"] == applied["path"]
+        assert data["transcriptEdits"] == []
+
+    def test_undo_walks_back_one_edit_at_a_time(self, tmp_path, settings, registry):
+        svc, data = _service(tmp_path=tmp_path, settings=settings)
+        first = self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-1"}]})
+        out = svc.undoEdit({"videoId": "v1"}, _ctx(None))
+        assert out["editId"] == "tedit-2"
+        assert out["path"] == first["path"]  # the previous edit is now current
+        assert [e["editId"] for e in data["transcriptEdits"]] == ["tedit-1"]
+
+    def test_undo_of_a_named_edit_id_is_honoured(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        out = svc.undoEdit({"videoId": "v1", "editId": "tedit-1"}, _ctx(None))
+        assert out["editId"] == "tedit-1"
+
+    def test_undo_of_a_stale_edit_id_raises(self, tmp_path, settings, registry):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        self._apply(svc, registry, {"videoId": "v1", "edits": [{"op": "delete", "wordId": "w0-3"}]})
+        with pytest.raises(RpcError, match="tedit-9"):
+            svc.undoEdit({"videoId": "v1", "editId": "tedit-9"}, _ctx(None))
+
+    def test_undo_with_no_history_raises(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        with pytest.raises(RpcError, match="nothing to undo"):
+            svc.undoEdit({"videoId": "v1"}, _ctx(None))
+
+    def test_undo_requires_a_video_id(self, tmp_path, settings):
+        svc, _ = _service(tmp_path=tmp_path, settings=settings)
+        with pytest.raises(RpcError, match="videoId"):
+            svc.undoEdit({}, _ctx(None))
+
+
+# --------------------------------------------------------------------------- #
+# persistence — the edit ledger must SURVIVE a manifest round-trip
+# --------------------------------------------------------------------------- #
+def test_transcript_edits_survive_a_project_manifest_round_trip(tmp_path):
+    """A recorded edit is worthless if ``Project.open`` drops it on reload."""
+    manifest = tmp_path / "project.json"
+    project = lib.Project(
+        {
+            "id": "p1",
+            "video": {"id": "v1", "path": "/lib/in.mp4"},
+            "tracks": [],
+            "clips": [],
+            "settings": {},
+            "transcriptEdits": [{"editId": "tedit-1", "path": "/out/in.edited.mp4", "sourcePath": "/lib/in.mp4"}],
+        },
+        manifest_path=manifest,
+    )
+    project.save()
+    reopened = lib.Project.open(manifest)
+    assert reopened.data["transcriptEdits"] == [
+        {"editId": "tedit-1", "path": "/out/in.edited.mp4", "sourcePath": "/lib/in.mp4"}
+    ]
+
+
+def test_project_without_transcript_edits_omits_the_key(tmp_path):
+    manifest = tmp_path / "project.json"
+    lib.Project(
+        {"id": "p1", "video": {}, "tracks": [], "clips": [], "settings": {}},
+        manifest_path=manifest,
+    ).save()
+    assert "transcriptEdits" not in lib.Project.open(manifest).data
+
+
+# --------------------------------------------------------------------------- #
+# registration
+# --------------------------------------------------------------------------- #
+def test_register_binds_the_four_transcript_methods(tmp_path, settings):
+    seen: dict[str, Any] = {}
+    svc = te.register(
+        resolver=lambda vid: "/lib/in.mp4",
+        out_dir=tmp_path / "edited",
+        load_project=lambda vid: {"transcript": _transcript()},
+        save_project=lambda vid, payload: None,
+        settings_provider=lambda: settings,
+        run=RecordingRun(),
+        duration=lambda p, s=None: 10.0,
+        detect_run=detect_with(""),
+        register_fn=lambda name, fn: seen.__setitem__(name, fn),
+    )
+    assert sorted(seen) == [
+        "transcript.applyEdit",
+        "transcript.get",
+        "transcript.previewEdit",
+        "transcript.undoEdit",
+    ]
+    assert seen["transcript.get"].__self__ is svc
+
+
+def test_register_defaults_to_the_real_protocol_registrar(tmp_path, settings, monkeypatch):
+    calls: list[str] = []
+    monkeypatch.setattr(protocol, "register", lambda name, fn: calls.append(name))
+    te.register(
+        resolver=lambda vid: "/lib/in.mp4",
+        out_dir=tmp_path / "edited",
+        load_project=lambda vid: {},
+        save_project=lambda vid, payload: None,
+    )
+    assert "transcript.applyEdit" in calls

--- a/sidecar/tests/test_transcript_edit.py
+++ b/sidecar/tests/test_transcript_edit.py
@@ -245,6 +245,17 @@ class TestResolveEdits:
         assert removed == [(1.0, 1.4)]
         assert rejected == []
 
+    def test_explicit_bounds_win_over_the_word_address_on_the_same_edit(self):
+        # Precedence is deterministic: a caller that sends BOTH an address and
+        # explicit ms bounds is nudging a boundary, so the bounds are authoritative.
+        removed, rejected = te.resolve_edits(
+            [{"op": "delete", "wordId": "w0-3", "startMs": 3100, "endMs": 3300}],
+            _transcript(),
+            10.0,
+        )
+        assert removed == [(3.1, 3.3)]
+        assert rejected == []
+
     def test_unknown_word_id_is_dropped_with_a_typed_reason(self):
         removed, rejected = te.resolve_edits([{"op": "delete", "wordId": "w9-9"}], _transcript(), 10.0)
         assert removed == []


### PR DESCRIPTION
Edit the video by editing its transcript: strike a word, see the cut previewed
locally, apply it, undo it.

Built as a vertical slice under TDD (RED commit first). The word-addressing
layer and the `EditSpan` translator are pure; the service owns preview/apply/undo.
`transcript.*` joins the frozen RPC surface.

Two details worth review:
- explicit millisecond bounds **beat** a word address when both are supplied,
  and that precedence is pinned by a test rather than left to reading order;
- the strike treatment carries a redundant visual channel (not colour alone),
  so it survives a colour-blind or high-contrast reader.

`wordsDeleted` counts *words removed from the transcript*, not spans cut from
the timeline — stated in the docs because the two diverge on a multi-word span.

## Commits

- test(workspace): stub the Transcript-edit panel in the Subtitles seam suite
- fix(transcript-edit): widen the word index to Mapping so basedpyright is clean
- fix(transcript-edit): consume real shell tokens in the pane stylesheet
- style(transcript-edit): give the strike a visible, redundant-channel treatment
- docs(transcript-edit): state precisely what wordsDeleted counts
- test(transcript-edit): pin the explicit-ms-bounds-beat-a-word-address precedence
- docs(v1.5): mark the transcript-editing plan ACTIVE and enumerate BUILT vs design-only
- feat(transcript-edit): mount the Transcript edit tab in the Workspace
- feat(transcript-edit): Transcript inspector pane - strike a word, preview, apply, undo
- style(transcript-edit): biome 2.5.0 format the renderer module
- style(transcript-edit): ruff 0.15.17 format the test module
- feat(transcript-edit): renderer token model + EditSpan builder + local cut preview
- feat(transcript-edit): wire transcript.* into the composition root (RED->GREEN on the frozen RPC surface)
- feat(transcript-edit): GREEN - word addressing, EditSpan translator, and the preview/apply/undo service
- test(transcript-edit): RED - specify the delete-word vertical slice before any implementation

