### PR TITLE
feat(tts): make voice-clone consent a blocking, fail-closed gate

### DIFF
--- a/CONTRACTS.md
+++ b/CONTRACTS.md
@@ -305,3 +305,32 @@ built here — the translation flow was owned by a concurrent lane, and coupling
 keys across lanes would have created a cross-lane dependency. If the unified glossary is
 wanted later, the translation side can read this same key (or merge a second one); no
 migration is needed because `asrVocabulary` is additive and defaults to empty.
+---
+
+# v1.5 ADDENDUM — WU-A2 voice-clone consent (2026-08-08; ADDITIVE, extends A2 + A3)
+
+Source: [`docs/plans/v1.5/flagship-lip-sync-dub.md`](docs/plans/v1.5/flagship-lip-sync-dub.md)
+§4 WU-A2 + §5.1 (the LEGAL keystone — EU AI Act Art. 50 transparency). Additive
+in the A3a sense: **every previously-frozen field keeps its name and meaning**;
+`tts.sample.add` gains a REQUIRED param and `VoiceSample` gains three fields.
+
+## A2 (amended) — `tts.sample.add`
+- `tts.sample.add({path, name?, consentAttested, consentNote?})` -> `{sample: VoiceSample}`
+  - `consentAttested` is REQUIRED and must be exactly `true`. Anything else
+    (absent, `false`, `"true"`, `1`) is a typed `INVALID_PARAMS` refusal and
+    **nothing is written** — no copied audio, no index row.
+- `tts.dub.start` is UNCHANGED on the wire, but a `sampleId` whose stored row
+  carries no attestation is refused with the same typed error, synchronously,
+  before the job is spawned. This closes the LEGACY-row back door.
+
+## A3 (amended) — `VoiceSample`
+- `VoiceSample {id, name, path, durationSec, consentAttested:bool, consentAt:str|null, consentNote:str|null}`
+  - `consentAt` is UTC ISO-8601 (`YYYY-MM-DDTHH:MM:SSZ`).
+  - A row written before this addendum backfills to `consentAttested:false`,
+    `consentAt:null` — it still LISTS (with a `consent required` label on its
+    `tts.voices` row) but cannot be cloned until the user re-attests.
+- The A2 `Voice` row (`{id,engine,lang,name}`) stays FROZEN at four keys.
+
+## Scope
+The gate is unconditional: there is no settings opt-out in this addendum. A
+`requireVoiceConsent` setting is WU-A4's, and may only ever be *stricter*.

--- a/app/renderer/src/features/Dub.test.tsx
+++ b/app/renderer/src/features/Dub.test.tsx
@@ -10,10 +10,12 @@ import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
 import Dub, {
+  CONSENT_ATTESTATION_TEXT,
   ENGINES,
   type AudioTrack,
   type TtsVoice,
   buildDubParams,
+  buildSampleAddParams,
   dubMediaUrl,
   voicesForEngine,
 } from './Dub';
@@ -128,6 +130,36 @@ describe('buildDubParams', () => {
         targetLang: '   ',
       }),
     ).not.toHaveProperty('targetLang');
+  });
+});
+
+describe('buildSampleAddParams', () => {
+  it('always carries consentAttested:true and trims the path', () => {
+    expect(buildSampleAddParams({ path: '  C:/me.wav  ' })).toEqual({
+      path: 'C:/me.wav',
+      consentAttested: true,
+    });
+  });
+
+  it('includes a trimmed note and omits a blank one', () => {
+    expect(buildSampleAddParams({ path: 'p', consentNote: '  ok  ' })).toEqual({
+      path: 'p',
+      consentAttested: true,
+      consentNote: 'ok',
+    });
+    expect(buildSampleAddParams({ path: 'p', consentNote: '   ' })).not.toHaveProperty(
+      'consentNote',
+    );
+  });
+});
+
+describe('CONSENT_ATTESTATION_TEXT', () => {
+  it('is the exact sentence the sidecar records and quotes back on refusal', () => {
+    // Mirrors voices.CONSENT_ATTESTATION_TEXT — a drift here would promise the
+    // user something different from what the backend enforces.
+    expect(CONSENT_ATTESTATION_TEXT).toBe(
+      "I own this voice or have the speaker's documented permission to clone it.",
+    );
   });
 });
 
@@ -305,6 +337,14 @@ describe('<Dub />', () => {
       root.render(<Dub videoId={videoId} api={api} />);
     });
     await flush();
+  }
+
+  /** Toggle the WU-A2 blocking consent checkbox (a real click, as a user would). */
+  function attest() {
+    const box = container.querySelector('[data-input="consent-attest"]') as HTMLInputElement;
+    act(() => {
+      box.click();
+    });
   }
 
   function pick(selector: string, value: string) {
@@ -598,6 +638,7 @@ describe('<Dub />', () => {
     });
     await mount(api);
     pick('[data-input="sample-path"]', 'C:/x.wav');
+    attest();
     await act(async () => {
       (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
       await Promise.resolve();
@@ -623,6 +664,7 @@ describe('<Dub />', () => {
       (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).disabled,
     ).toBe(true);
     pick('[data-input="sample-path"]', 'C:/bad.wav');
+    attest();
     await act(async () => {
       (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
       await Promise.resolve();
@@ -636,7 +678,15 @@ describe('<Dub />', () => {
   it('adds a voice sample through tts.sample.add', async () => {
     const { api, calls } = makeBridge({
       'tts.sample.add': {
-        sample: { id: 's9', name: 'me', path: 'C:/voices/s9.wav', durationSec: 4 },
+        sample: {
+          id: 's9',
+          name: 'me',
+          path: 'C:/voices/s9.wav',
+          durationSec: 4,
+          consentAttested: true,
+          consentAt: '2026-08-08T10:20:30Z',
+          consentNote: null,
+        },
       },
     });
     await act(async () => {
@@ -650,12 +700,155 @@ describe('<Dub />', () => {
       setter.call(input, 'C:/me.wav');
       input.dispatchEvent(new Event('input', { bubbles: true }));
     });
+    attest();
     await act(async () => {
       (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
     });
     await flush();
     const call = calls.find((c) => c.method === 'tts.sample.add');
-    expect(call?.params).toEqual({ path: 'C:/me.wav' });
+    expect(call?.params).toEqual({ path: 'C:/me.wav', consentAttested: true });
     expect(container.textContent).toContain('Added sample "me"');
+  });
+
+  // ------------------------------------------------------------------------
+  // WU-A2 — the voice-clone consent gate in the UI (the BLOCKING attestation).
+  // docs/plans/v1.5/flagship-lip-sync-dub.md §4 WU-A2 / §5.1: "the checkbox is
+  // a first-class gate; add is refused without it".
+  // ------------------------------------------------------------------------
+  it('keeps add-sample disabled until the consent box is ticked, even with a path', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    const button = () => container.querySelector('[data-action="add-sample"]') as HTMLButtonElement;
+    pick('[data-input="sample-path"]', 'C:/me.wav');
+    // path alone is NOT enough — the attestation is the gate
+    expect(button().disabled).toBe(true);
+    attest();
+    expect(button().disabled).toBe(false);
+    // untick -> refused again (the gate is not one-way)
+    attest();
+    expect(button().disabled).toBe(true);
+  });
+
+  it('shows the same attestation sentence the sidecar enforces', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    const label = container.querySelector('[data-testid="consent-attest-label"]');
+    expect(label?.textContent).toContain(
+      "I own this voice or have the speaker's documented permission to clone it.",
+    );
+  });
+
+  it('forwards consentAttested + a trimmed consentNote to tts.sample.add', async () => {
+    const { api, calls } = makeBridge({
+      'tts.sample.add': {
+        sample: {
+          id: 's1',
+          name: 'ann',
+          path: 'C:/voices/s1.wav',
+          durationSec: 3,
+          consentAttested: true,
+          consentAt: '2026-08-08T10:20:30Z',
+          consentNote: 'signed release',
+        },
+      },
+    });
+    await mount(api);
+    pick('[data-input="sample-path"]', '  C:/ann.wav  ');
+    pick('[data-input="consent-note"]', '  signed release  ');
+    attest();
+    await act(async () => {
+      (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    expect(calls.find((c) => c.method === 'tts.sample.add')?.params).toEqual({
+      path: 'C:/ann.wav',
+      consentAttested: true,
+      consentNote: 'signed release',
+    });
+  });
+
+  it('omits a whitespace-only consentNote', async () => {
+    const { api, calls } = makeBridge({
+      'tts.sample.add': {
+        sample: {
+          id: 's2',
+          name: 'bo',
+          path: 'C:/voices/s2.wav',
+          durationSec: 3,
+          consentAttested: true,
+          consentAt: '2026-08-08T10:20:30Z',
+          consentNote: null,
+        },
+      },
+    });
+    await mount(api);
+    pick('[data-input="sample-path"]', 'C:/bo.wav');
+    pick('[data-input="consent-note"]', '    ');
+    attest();
+    await act(async () => {
+      (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    expect(calls.find((c) => c.method === 'tts.sample.add')?.params).toEqual({
+      path: 'C:/bo.wav',
+      consentAttested: true,
+    });
+  });
+
+  it('clears the attestation after a successful add (a fresh tick per clone)', async () => {
+    const { api } = makeBridge({
+      'tts.sample.add': {
+        sample: {
+          id: 's3',
+          name: 'cy',
+          path: 'C:/voices/s3.wav',
+          durationSec: 3,
+          consentAttested: true,
+          consentAt: '2026-08-08T10:20:30Z',
+          consentNote: 'note',
+        },
+      },
+    });
+    await mount(api);
+    pick('[data-input="sample-path"]', 'C:/cy.wav');
+    pick('[data-input="consent-note"]', 'note');
+    attest();
+    await act(async () => {
+      (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    const box = container.querySelector('[data-input="consent-attest"]') as HTMLInputElement;
+    const note = container.querySelector('[data-input="consent-note"]') as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    expect(note.value).toBe('');
+    // and the button is disabled again — one tick can never cover a second clone
+    expect(
+      (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it('keeps the attestation ticked when the add FAILS so the user can retry', async () => {
+    const { api } = makeBridge();
+    (api.rpc as ReturnType<typeof vi.fn>).mockImplementation(async (method: string) => {
+      if (method === 'tts.sample.add') throw new Error('unsupported sample format');
+      if (method === 'tts.voices') return { voices: VOICES };
+      if (method === 'tracks.list') return { tracks: [] };
+      if (method === 'tracks.audio.list') return { audioTracks: [] };
+      return {};
+    });
+    await mount(api);
+    pick('[data-input="sample-path"]', 'C:/bad.txt');
+    attest();
+    await act(async () => {
+      (container.querySelector('[data-action="add-sample"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(
+      (container.querySelector('[data-input="consent-attest"]') as HTMLInputElement).checked,
+    ).toBe(true);
+    expect(container.querySelector('.dub-sample-message')?.textContent).toContain(
+      'unsupported sample format',
+    );
   });
 });

--- a/app/renderer/src/features/Dub.tsx
+++ b/app/renderer/src/features/Dub.tsx
@@ -36,6 +36,34 @@ export interface VoiceSample {
   name: string;
   path: string;
   durationSec: number;
+  /** WU-A2 consent record — the sidecar refuses to store a clone without it. */
+  consentAttested?: boolean;
+  consentAt?: string | null;
+  consentNote?: string | null;
+}
+
+/**
+ * WU-A2 (docs/plans/v1.5/flagship-lip-sync-dub.md §4/§5.1) — the exact
+ * attestation the user makes. It MUST match
+ * `voices.CONSENT_ATTESTATION_TEXT` in the sidecar: the backend quotes this
+ * sentence in its refusal, so a drifting UI copy would promise the user
+ * something different from what is actually enforced and recorded.
+ */
+export const CONSENT_ATTESTATION_TEXT =
+  "I own this voice or have the speaker's documented permission to clone it.";
+
+/** Build the WU-A2 `tts.sample.add` params. `consentAttested` is never optional. */
+export function buildSampleAddParams(args: {
+  path: string;
+  consentNote?: string;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    path: args.path.trim(),
+    consentAttested: true,
+  };
+  const note = (args.consentNote ?? '').trim();
+  if (note) params.consentNote = note;
+  return params;
 }
 
 export interface AudioTrack {
@@ -124,9 +152,11 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
   const [voice, setVoice] = useState<string>('');
   const [trackId, setTrackId] = useState<string>('');
   const [targetLang, setTargetLang] = useState<string>('');
-  // sample upload (voice clone)
+  // sample upload (voice clone) + the WU-A2 blocking consent attestation
   const [samplePath, setSamplePath] = useState<string>('');
   const [sampleMessage, setSampleMessage] = useState<string>('');
+  const [consentAttested, setConsentAttested] = useState<boolean>(false);
+  const [consentNote, setConsentNote] = useState<string>('');
   // job state
   const [busy, setBusy] = useState<boolean>(false);
   const [jobId, setJobId] = useState<string | null>(null);
@@ -185,20 +215,29 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
 
   const addSample = useCallback(async (): Promise<void> => {
     const path = samplePath.trim();
-    // The Add-sample button is disabled when the path is blank, so this guard is
-    // defensive.
+    // The Add-sample button is disabled when the path is blank OR the consent
+    // box is unticked, so this guard is defensive.
     /* v8 ignore next */
-    if (!path) return;
+    if (!path || !consentAttested) return;
     setSampleMessage('');
     try {
-      const res = await bridge.rpc<{ sample: VoiceSample }>('tts.sample.add', { path });
+      const res = await bridge.rpc<{ sample: VoiceSample }>(
+        'tts.sample.add',
+        buildSampleAddParams({ path, consentNote }),
+      );
       setSampleMessage(`Added sample "${res.sample.name}"`);
       setSamplePath('');
+      // A fresh attestation is required per clone: one tick must never carry
+      // over to the NEXT voice the user adds.
+      setConsentNote('');
+      setConsentAttested(false);
       await refresh(); // samples surface as chatterbox voices
     } catch (err) {
+      // On FAILURE the tick stays, so a retry after fixing the path does not
+      // force the user to re-attest for the same voice.
       setSampleMessage(err instanceof Error ? err.message : String(err));
     }
-  }, [bridge, samplePath, refresh]);
+  }, [bridge, samplePath, consentAttested, consentNote, refresh]);
 
   const startDub = useCallback(async (): Promise<void> => {
     // The Start-dub button is disabled while busy and without a video/track/voice,
@@ -345,12 +384,45 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
             disabled={busy}
           />
         </label>
+        {/* WU-A2 — BLOCKING consent attestation. Cloning a person's voice
+            without the right to do so is the flagship's headline legal
+            exposure (EU AI Act Art. 50), so this is a first-class gate, not a
+            notice: the button stays disabled until it is ticked, and the
+            sidecar refuses the add independently even if it were bypassed. */}
+        <fieldset className="dub-consent" data-testid="dub-consent">
+          <legend>Voice-clone consent (required)</legend>
+          <label className="dub-consent-attest" data-testid="consent-attest-label">
+            <input
+              data-input="consent-attest"
+              type="checkbox"
+              checked={consentAttested}
+              onChange={(e) => setConsentAttested(e.target.checked)}
+              disabled={busy}
+            />{' '}
+            {CONSENT_ATTESTATION_TEXT}
+          </label>
+          <label className="dub-consent-note">
+            Note (optional — e.g. where the written permission is filed){' '}
+            <input
+              data-input="consent-note"
+              type="text"
+              placeholder="signed release 2026-08-01"
+              value={consentNote}
+              onChange={(e) => setConsentNote(e.target.value)}
+              disabled={busy}
+            />
+          </label>
+          <p className="dub-consent-hint">
+            Recorded locally with the sample — the attestation and its timestamp never leave this
+            machine.
+          </p>
+        </fieldset>
         <button
           type="button"
           data-action="add-sample"
           className="secondary"
           onClick={() => void addSample()}
-          disabled={busy || !samplePath.trim()}
+          disabled={busy || !samplePath.trim() || !consentAttested}
         >
           Add sample
         </button>

--- a/app/renderer/src/features/panels.css
+++ b/app/renderer/src/features/panels.css
@@ -255,6 +255,55 @@
   color: var(--text-muted);
 }
 
+/* WU-A2 voice-clone consent — a GATE, so it reads as a bordered commitment
+   block rather than fine print: full-row, warning rail, attestation first. */
+.dub-panel .dub-consent {
+  flex: 1 1 100%;
+  order: -1;
+  margin: 0;
+  padding: var(--space-3) var(--space-4) var(--space-4);
+  border: 1px solid var(--status-warn, var(--text-faint));
+  border-left-width: 3px;
+  border-radius: var(--radius-sm);
+  background: var(--surface-deep);
+}
+
+.dub-panel .dub-consent legend {
+  padding: 0 var(--space-2);
+  font-size: var(--type-caption-size);
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--status-warn, var(--text-secondary));
+}
+
+/* the attestation itself is the loudest line in the block: body voice, inline
+   checkbox — it is a statement the user makes, not a field label */
+.dub-panel .dub-consent .dub-consent-attest {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: var(--space-3);
+  font-size: var(--type-body-size);
+  font-weight: var(--type-body-weight);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.dub-panel .dub-consent .dub-consent-attest input {
+  margin-top: 0.15em;
+  flex: 0 0 auto;
+}
+
+.dub-panel .dub-consent .dub-consent-note {
+  margin-top: var(--space-3);
+}
+
+.dub-panel .dub-consent-hint {
+  margin: var(--space-3) 0 0;
+  font-size: var(--type-caption-size);
+  color: var(--text-faint);
+}
+
 /* a finished dub is a DONE status: success rail + auditioning player */
 .dub-panel .dub-result {
   margin: var(--space-5) 0;

--- a/app/renderer/src/lib/rpc.test.ts
+++ b/app/renderer/src/lib/rpc.test.ts
@@ -592,8 +592,18 @@ describe('client.feedback / media / timeline / tts', () => {
     const r = installApi();
     await client.tts.voices();
     expect(r).toHaveBeenCalledWith('tts.voices', undefined);
-    await client.tts.sampleAdd('/sample.wav');
-    expect(r).toHaveBeenCalledWith('tts.sample.add', { path: '/sample.wav' });
+    // WU-A2: the attestation is a required argument and always reaches the wire.
+    await client.tts.sampleAdd('/sample.wav', true);
+    expect(r).toHaveBeenCalledWith('tts.sample.add', {
+      path: '/sample.wav',
+      consentAttested: true,
+    });
+    await client.tts.sampleAdd('/sample.wav', true, 'written release on file');
+    expect(r).toHaveBeenCalledWith('tts.sample.add', {
+      path: '/sample.wav',
+      consentAttested: true,
+      consentNote: 'written release on file',
+    });
     await client.tts.dubStart({ videoId: 'v1', trackId: 't1', engine: 'xtts', voice: 'a' });
     expect(r).toHaveBeenCalledWith('tts.dub.start', {
       videoId: 'v1',

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -408,7 +408,19 @@ export const client = {
     voices: (): Promise<{
       voices: { id: string; engine: string; lang: string; name: string }[];
     }> => rpc('tts.voices'),
-    sampleAdd: (path: string): Promise<{ sample: VoiceSample }> => rpc('tts.sample.add', { path }),
+    // WU-A2: `consentAttested` is REQUIRED by the sidecar and must be `true`;
+    // it is a positional argument here (not an options bag with a default) so
+    // a caller cannot omit the attestation by accident.
+    sampleAdd: (
+      path: string,
+      consentAttested: true,
+      consentNote?: string,
+    ): Promise<{ sample: VoiceSample }> =>
+      rpc('tts.sample.add', {
+        path,
+        consentAttested,
+        ...(consentNote ? { consentNote } : {}),
+      }),
     dubStart: (p: {
       videoId: string;
       trackId: string;

--- a/app/renderer/src/lib/rpc/schemas.ts
+++ b/app/renderer/src/lib/rpc/schemas.ts
@@ -1251,12 +1251,21 @@ export interface BatchConsent {
   budget: Record<string, unknown>;
 }
 
-/** A3 VoiceSample — a stored voice-clone reference sample. */
+/**
+ * A3 VoiceSample — a stored voice-clone reference sample, plus the WU-A2
+ * consent record (`docs/plans/v1.5/flagship-lip-sync-dub.md` §4 WU-A2).
+ * `consentAttested` is always present on a row the sidecar wrote; it is
+ * `false` only on a LEGACY row backfilled by `voices.normalize_sample`, and
+ * such a row is refused at clone time.
+ */
 export interface VoiceSample {
   id: string;
   name: string;
   path: string;
   durationSec: number;
+  consentAttested: boolean;
+  consentAt: string | null;
+  consentNote: string | null;
 }
 
 /** A2 media.playable result (codec-driven: remux-safe vs proxy). */

--- a/docs/wiring/WIRING-T2.md
+++ b/docs/wiring/WIRING-T2.md
@@ -190,8 +190,12 @@ If the canonical client is being extended this round, the T2 methods are:
 tts: {
   voices: (): Promise<{ voices: { id: string; engine: string; lang: string; name: string }[] }> =>
     rpc('tts.voices'),
-  sampleAdd: (path: string): Promise<{ sample: { id: string; name: string; path: string; durationSec: number } }> =>
-    rpc('tts.sample.add', { path }),
+  // v1.5 WU-A2: `consentAttested` is REQUIRED and must be `true` (CONTRACTS.md
+  // "v1.5 ADDENDUM"); the sidecar refuses the add otherwise and stores nothing.
+  sampleAdd: (path: string, consentAttested: true, consentNote?: string):
+    Promise<{ sample: { id: string; name: string; path: string; durationSec: number;
+                        consentAttested: boolean; consentAt: string | null; consentNote: string | null } }> =>
+    rpc('tts.sample.add', { path, consentAttested, ...(consentNote ? { consentNote } : {}) }),
   dubStart: (p: { videoId: string; trackId: string; engine: string; voice?: string; sampleId?: string; targetLang?: string }):
     Promise<{ jobId: string }> => rpc('tts.dub.start', { ...p }),
 },

--- a/sidecar/media_studio/features/tts/dub.py
+++ b/sidecar/media_studio/features/tts/dub.py
@@ -47,7 +47,7 @@ from ...util import get_logger
 from .. import offline as _offline
 from . import align as _align
 from .engine import Cue, TtsEngine, TtsError, wav_duration_sec
-from .voices import VoiceStore
+from .voices import VoiceConsentError, VoiceStore, require_consent
 
 log = get_logger("media_studio.tts.dub")
 
@@ -289,6 +289,14 @@ class DubService:
             sample = self._voice_store.get(sample_id)
             if sample is None:
                 raise RpcError(f"unknown sampleId: {sample_id}", ErrorCode.INVALID_PARAMS)
+            # WU-A2 clone-time gate: gating tts.sample.add alone leaves a back
+            # door — rows written BEFORE the gate existed backfill to
+            # consentAttested:False and would still reach the clone engine.
+            # Refuse here, synchronously, before any job is spawned.
+            try:
+                require_consent(sample, sample_id)
+            except VoiceConsentError as exc:
+                raise RpcError(str(exc), ErrorCode.INVALID_PARAMS) from exc
             return str(sample["path"])
         if not voice or not isinstance(voice, str):
             raise RpcError(

--- a/sidecar/media_studio/features/tts/voices.py
+++ b/sidecar/media_studio/features/tts/voices.py
@@ -10,7 +10,30 @@ Owns two frozen A2 methods (registered via the package ``register()``):
     given audio file into ``%APPDATA%/media-studio/voices/`` (A2: samples
     live there) and persists it in a small JSON index.
 
-``VoiceSample`` (A3, field names FROZEN): ``{id, name, path, durationSec}``.
+``VoiceSample`` (A3, field names FROZEN): ``{id, name, path, durationSec}``,
+EXTENDED by WU-A2 with the consent record ``{consentAttested, consentAt,
+consentNote}``.
+
+WU-A2 — the voice-clone CONSENT gate (the LEGAL keystone;
+``docs/plans/v1.5/flagship-lip-sync-dub.md`` §4 WU-A2 + §5.1). Cloning a
+person's voice without an attested right to do so is the flagship's headline
+legal exposure (EU AI Act Art. 50 transparency duties), so:
+
+  * ``tts.sample.add`` REQUIRES ``consentAttested is True`` and refuses
+    otherwise with a typed ``INVALID_PARAMS``;
+  * :meth:`VoiceStore.add` re-checks the attestation BEFORE it touches the
+    filesystem, so no code path can persist a clone reference without one;
+  * :func:`require_consent` is the clone-time gate (``tts.dub.start`` calls it
+    through ``dub.DubService._resolve_voice``) so a LEGACY row backfilled as
+    ``consentAttested: False`` cannot be cloned either;
+  * the attestation timestamp ``consentAt`` is UTC ISO-8601 and the clock is
+    injectable, so the record is deterministic under test.
+
+CONTRACT-NOTE: this is a SEPARATE gate from :mod:`media_studio.models.consent`,
+which is a per-provider text/frames EGRESS gate. That module is the *idiom*
+mirrored here (typed refusal + default-deny), not the mechanism — see
+``flagship-lip-sync-dub.md:57``. This gate has NO settings opt-out in this
+lane; ``requireVoiceConsent`` belongs to WU-A4 (settings surface).
 
 Pure logic + filesystem I/O; the duration probe is injectable (defaults to
 the lazy ffprobe seam) so tests never spawn a process.
@@ -23,7 +46,8 @@ import json
 import os
 import shutil
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -35,17 +59,25 @@ from .engine import TtsEngine, TtsError, Voice
 
 log = get_logger("media_studio.tts.voices")
 
-#: A3 VoiceSample (frozen field names)
+#: A3 VoiceSample (frozen field names) + the WU-A2 consent record.
 VoiceSample = dict[str, Any]
 
 # Injectable duration probe: (path) -> seconds.
 DurationProber = Callable[[str], float]
+# Injectable UTC ISO-8601 clock for the consent record.
+ConsentClock = Callable[[], str]
 
 _INDEX_FILENAME = "voices.json"
 _INDEX_VERSION = 1
 
 #: sample formats we accept for cloning references.
 _SAMPLE_SUFFIXES = (".wav", ".mp3", ".m4a", ".flac", ".ogg", ".opus")
+
+#: The exact attestation the user makes. The renderer's blocking checkbox
+#: (``app/renderer/src/features/Dub.tsx``) shows this same sentence — keep the
+#: two in step; the refusal message quotes it so the UI can never claim a
+#: weaker promise than the one the backend enforces.
+CONSENT_ATTESTATION_TEXT = "I own this voice or have the speaker's documented permission to clone it."
 
 
 def default_voices_dir() -> Path:
@@ -60,17 +92,82 @@ def _default_probe(path: str) -> float:
     return ffmpeg.ffprobe_duration(path)
 
 
+def _utc_now_iso() -> str:
+    """``YYYY-MM-DDTHH:MM:SSZ`` — UTC, so a consent record has no local-time ambiguity."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def _new_id() -> str:
     return uuid.uuid4().hex[:12]
 
 
+# --------------------------------------------------------------------------- #
+# WU-A2 consent primitives (pure; mirrors models.consent's default-deny idiom)
+# --------------------------------------------------------------------------- #
+class VoiceConsentError(TtsError):
+    """Typed refusal: a voice-clone act with no consent attestation on record.
+
+    A :class:`~.engine.TtsError` so the existing RPC boundaries (which already
+    convert ``TtsError`` to a typed ``INVALID_PARAMS``) surface it correctly
+    instead of leaking a 500.
+    """
+
+    def __init__(self, sample_id: str | None = None) -> None:
+        self.sample_id = sample_id
+        subject = f"voice sample {sample_id!r}" if sample_id else "this voice sample"
+        super().__init__(
+            f"voice clone refused: no consent attestation on record for {subject} — "
+            f"{CONSENT_ATTESTATION_TEXT}"
+        )
+
+
+def consent_attested(sample: Mapping[str, Any] | Any) -> bool:
+    """Default-deny predicate: ONLY an explicit stored ``True`` is an attestation.
+
+    A missing row, a malformed row, ``False``, ``None`` and truthy-but-not-``True``
+    values (``"true"``, ``1``) all read as NOT attested — consent must be an
+    explicit, present ``True``, never an absence or a coincidence of truthiness.
+    """
+    if not isinstance(sample, Mapping):
+        return False
+    return sample.get("consentAttested") is True
+
+
+def require_consent(sample: Mapping[str, Any] | Any, sample_id: str | None = None) -> None:
+    """Raise :class:`VoiceConsentError` unless ``sample`` carries an attestation.
+
+    The single clone-time enforcement point: called BEFORE a stored sample's
+    audio path is handed to a voice-clone engine, so a legacy row (backfilled
+    ``consentAttested: False``) is refused just like a consent-less add.
+    """
+    if not consent_attested(sample):
+        raise VoiceConsentError(sample_id)
+
+
+def _clean_note(note: Any) -> str | None:
+    """A consent note is free text; blank / non-string normalizes to ``None``."""
+    if not isinstance(note, str):
+        return None
+    return note.strip() or None
+
+
 def normalize_sample(raw: dict[str, Any]) -> VoiceSample:
-    """Backfill a stored row to the full A3 VoiceSample shape."""
+    """Backfill a stored row to the full A3 VoiceSample + WU-A2 consent shape.
+
+    A pre-WU-A2 row has no consent fields; it backfills to ``consentAttested:
+    False`` (default-deny) so an existing library keeps listing but can no
+    longer be cloned until the user re-attests.
+    """
+    attested = consent_attested(raw)
+    consent_at = raw.get("consentAt")
     return {
         "id": str(raw.get("id") or _new_id()),
         "name": str(raw.get("name") or "sample"),
         "path": str(raw.get("path") or ""),
         "durationSec": float(raw.get("durationSec") or 0.0),
+        "consentAttested": attested,
+        "consentAt": consent_at if attested and isinstance(consent_at, str) and consent_at else None,
+        "consentNote": _clean_note(raw.get("consentNote")),
     }
 
 
@@ -82,6 +179,7 @@ class VoiceStore:
         samples_dir: str | os.PathLike | None = None,
         *,
         duration_probe: DurationProber | None = None,
+        now: ConsentClock | None = None,
     ) -> None:
         raw_dir = Path(samples_dir) if samples_dir is not None else default_voices_dir()
         # Canonicalise the voices base through the ensure_within barrier so the
@@ -90,6 +188,7 @@ class VoiceStore:
         self.samples_dir = Path(ensure_within(raw_dir))
         self.index_path = Path(ensure_within(self.samples_dir, _INDEX_FILENAME))
         self._probe = duration_probe or _default_probe
+        self._now = now or _utc_now_iso
 
     # -- index I/O -----------------------------------------------------------
     def _load(self) -> builtins.list[VoiceSample]:
@@ -127,13 +226,27 @@ class VoiceStore:
                 return sample
         return None
 
-    def add(self, path: str, name: str | None = None) -> VoiceSample:
+    def add(
+        self,
+        path: str,
+        name: str | None = None,
+        *,
+        consent_attested: bool = False,
+        consent_note: Any = None,
+    ) -> VoiceSample:
         """Copy ``path`` into the voices dir and persist a VoiceSample row.
+
+        WU-A2: ``consent_attested`` must be exactly ``True`` — the check runs
+        FIRST, before the file is even stat'd, so a consent-less add leaves the
+        store byte-identical (no copied audio, no index row). The attestation
+        default is ``False`` so a caller must opt IN, never out.
 
         The source file is COPIED (the store owns its bytes — a user moving
         the original later cannot break cloning). Duration is probed through
         the injectable seam; a probe failure stores 0.0 rather than blocking.
         """
+        if consent_attested is not True:
+            raise VoiceConsentError()
         src = Path(path)
         if not src.is_file():
             raise TtsError(f"voice sample not found: {path}")
@@ -152,6 +265,9 @@ class VoiceStore:
             "name": name or src.stem,
             "path": str(dest),
             "durationSec": duration,
+            "consentAttested": True,
+            "consentAt": self._now(),
+            "consentNote": _clean_note(consent_note),
         }
         samples = self._load()
         samples.append(sample)
@@ -166,13 +282,20 @@ def samples_as_voices(samples: Sequence[VoiceSample]) -> list[Voice]:
     sample as ``{id: <sampleId>, engine: "chatterbox", lang: "und", name}``
     gives the picker one uniform list. The id doubles as the ``sampleId``
     param of ``tts.dub.start``.
+
+    WU-A2: a row with NO attestation (a legacy sample) still LISTS — hiding a
+    user's own data would be worse — but its label says so, because picking it
+    will be refused by :func:`require_consent` at dub time. The A2 ``Voice``
+    shape stays frozen at four keys, so the label is the only channel.
     """
     return [
         {
             "id": s["id"],
             "engine": "chatterbox",
             "lang": "und",
-            "name": f"{s['name']} (cloned sample)",
+            "name": f"{s['name']} (cloned sample)"
+            if consent_attested(s)
+            else f"{s['name']} (cloned sample — consent required)",
         }
         for s in samples
     ]
@@ -202,15 +325,30 @@ def make_voices_handler(
 def make_sample_add_handler(
     store: VoiceStore,
 ) -> Callable[[dict[str, Any], RpcContext], dict[str, Any]]:
-    """Build ``tts.sample.add({path})`` -> ``{sample: VoiceSample}`` (A2)."""
+    """Build ``tts.sample.add({path, name?, consentAttested, consentNote?})`` (A2 + WU-A2).
+
+    ``consentAttested`` is REQUIRED and must be exactly ``True``; anything else
+    (absent, ``False``, ``"true"``, ``1``) is a typed ``INVALID_PARAMS``
+    refusal and NOTHING is stored. ``consentNote`` is optional free text.
+    """
 
     def handler(params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
         path = params.get("path")
         if not isinstance(path, str) or not path:
             raise RpcError("path (str) is required", ErrorCode.INVALID_PARAMS)
+        if params.get("consentAttested") is not True:
+            raise RpcError(
+                f"consentAttested (true) is required to store a voice clone — {CONSENT_ATTESTATION_TEXT}",
+                ErrorCode.INVALID_PARAMS,
+            )
         name = params.get("name")
         try:
-            sample = store.add(path, name if isinstance(name, str) else None)
+            sample = store.add(
+                path,
+                name if isinstance(name, str) else None,
+                consent_attested=True,
+                consent_note=params.get("consentNote"),
+            )
         except TtsError as exc:
             raise RpcError(str(exc), ErrorCode.INVALID_PARAMS) from exc
         return {"sample": sample}
@@ -219,11 +357,15 @@ def make_sample_add_handler(
 
 
 __all__ = [
+    "CONSENT_ATTESTATION_TEXT",
+    "VoiceConsentError",
     "VoiceSample",
     "VoiceStore",
+    "consent_attested",
     "default_voices_dir",
     "make_sample_add_handler",
     "make_voices_handler",
     "normalize_sample",
+    "require_consent",
     "samples_as_voices",
 ]

--- a/sidecar/media_studio/features/tts/voices.py
+++ b/sidecar/media_studio/features/tts/voices.py
@@ -120,7 +120,7 @@ class VoiceConsentError(TtsError):
         )
 
 
-def consent_attested(sample: Mapping[str, Any] | Any) -> bool:
+def consent_attested(sample: object) -> bool:
     """Default-deny predicate: ONLY an explicit stored ``True`` is an attestation.
 
     A missing row, a malformed row, ``False``, ``None`` and truthy-but-not-``True``
@@ -132,7 +132,7 @@ def consent_attested(sample: Mapping[str, Any] | Any) -> bool:
     return sample.get("consentAttested") is True
 
 
-def require_consent(sample: Mapping[str, Any] | Any, sample_id: str | None = None) -> None:
+def require_consent(sample: object, sample_id: str | None = None) -> None:
     """Raise :class:`VoiceConsentError` unless ``sample`` carries an attestation.
 
     The single clone-time enforcement point: called BEFORE a stored sample's
@@ -143,7 +143,7 @@ def require_consent(sample: Mapping[str, Any] | Any, sample_id: str | None = Non
         raise VoiceConsentError(sample_id)
 
 
-def _clean_note(note: Any) -> str | None:
+def _clean_note(note: object) -> str | None:
     """A consent note is free text; blank / non-string normalizes to ``None``."""
     if not isinstance(note, str):
         return None
@@ -231,7 +231,7 @@ class VoiceStore:
         name: str | None = None,
         *,
         consent_attested: bool = False,
-        consent_note: Any = None,
+        consent_note: object = None,
     ) -> VoiceSample:
         """Copy ``path`` into the voices dir and persist a VoiceSample row.
 

--- a/sidecar/media_studio/features/tts/voices.py
+++ b/sidecar/media_studio/features/tts/voices.py
@@ -32,7 +32,7 @@ legal exposure (EU AI Act Art. 50 transparency duties), so:
 CONTRACT-NOTE: this is a SEPARATE gate from :mod:`media_studio.models.consent`,
 which is a per-provider text/frames EGRESS gate. That module is the *idiom*
 mirrored here (typed refusal + default-deny), not the mechanism — see
-``flagship-lip-sync-dub.md:57``. This gate has NO settings opt-out in this
+``docs/plans/v1.5/flagship-lip-sync-dub.md:57``. This gate has NO settings opt-out in this
 lane; ``requireVoiceConsent`` belongs to WU-A4 (settings surface).
 
 Pure logic + filesystem I/O; the duration probe is injectable (defaults to
@@ -116,8 +116,7 @@ class VoiceConsentError(TtsError):
         self.sample_id = sample_id
         subject = f"voice sample {sample_id!r}" if sample_id else "this voice sample"
         super().__init__(
-            f"voice clone refused: no consent attestation on record for {subject} — "
-            f"{CONSENT_ATTESTATION_TEXT}"
+            f"voice clone refused: no consent attestation on record for {subject} — {CONSENT_ATTESTATION_TEXT}"
         )
 
 

--- a/sidecar/tests/test_tts_dub.py
+++ b/sidecar/tests/test_tts_dub.py
@@ -11,6 +11,7 @@ DONE criteria covered:
 
 from __future__ import annotations
 
+import json
 import threading
 import wave
 from pathlib import Path
@@ -414,6 +415,38 @@ class TestDubStartHandler:
                 ctx,
             )
 
+    def test_chatterbox_refuses_a_sample_with_no_consent_attestation(self, tmp_path, registry):
+        """WU-A2 clone-time gate: a LEGACY (pre-consent) row must not be clonable.
+
+        Gating only ``tts.sample.add`` would leave the back door open — rows
+        written before the gate existed backfill to ``consentAttested: False``
+        and would still reach the clone engine. ``_resolve_voice`` closes it.
+        """
+        voices_dir = tmp_path / "voices"
+        voices_dir.mkdir()
+        legacy = tmp_path / "legacy.wav"
+        legacy.write_bytes(b"RIFF0000WAVEfake")
+        (voices_dir / "voices.json").write_text(
+            json.dumps(
+                {
+                    "version": 1,
+                    "samples": [{"id": "old1", "name": "n", "path": str(legacy), "durationSec": 2.0}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        service = make_service(
+            tmp_path,
+            engines={"chatterbox": lambda: RecordingEngine([])},
+            voice_store=VoiceStore(voices_dir, duration_probe=lambda p: 1.0),
+        )
+        ctx = RpcContext(emit_notification=lambda o: None, jobs=registry)
+        with pytest.raises(RpcError, match="consent"):
+            service.dub_start(
+                {"videoId": "v1", "trackId": "t1", "engine": "chatterbox", "sampleId": "old1"},
+                ctx,
+            )
+
     def test_voice_required_for_named_voice_engines(self, tmp_path, registry):
         service = make_service(tmp_path)
         ctx = RpcContext(emit_notification=lambda o: None, jobs=registry)
@@ -478,10 +511,13 @@ class TestDubStartHandler:
             )
 
     def test_chatterbox_valid_sample_id_resolves_path(self, tmp_path, registry, collected):
+        # The healthy-state half of the WU-A2 both-states pair: an ATTESTED
+        # sample must still clone end-to-end (the refusal above is the broken
+        # half). A gate that fired in both states would measure nothing.
         store = VoiceStore(tmp_path / "voices", duration_probe=lambda p: 1.0)
         sample_src = tmp_path / "ref.wav"
         sample_src.write_bytes(b"RIFF0000WAVEfake")
-        sample = store.add(str(sample_src))
+        sample = store.add(str(sample_src), consent_attested=True)
         seen_voice: list[str] = []
 
         class SampleEngine(RecordingEngine):

--- a/sidecar/tests/test_tts_voices.py
+++ b/sidecar/tests/test_tts_voices.py
@@ -33,9 +33,17 @@ def sample_file(tmp_path):
 # --------------------------------------------------------------------------- #
 class TestVoiceStore:
     def test_add_copies_and_persists(self, store, sample_file, tmp_path):
-        sample = store.add(str(sample_file))
-        # A3 VoiceSample shape (frozen field names)
-        assert set(sample) == {"id", "name", "path", "durationSec"}
+        sample = store.add(str(sample_file), consent_attested=True)
+        # A3 VoiceSample shape (frozen field names) + the WU-A2 consent record
+        assert set(sample) == {
+            "id",
+            "name",
+            "path",
+            "durationSec",
+            "consentAttested",
+            "consentAt",
+            "consentNote",
+        }
         assert sample["name"] == "my voice"
         assert sample["durationSec"] == 3.5
         copied = Path(sample["path"])
@@ -48,20 +56,20 @@ class TestVoiceStore:
 
     def test_add_missing_file_raises(self, store, tmp_path):
         with pytest.raises(TtsError, match="not found"):
-            store.add(str(tmp_path / "ghost.wav"))
+            store.add(str(tmp_path / "ghost.wav"), consent_attested=True)
 
     def test_add_unsupported_format_raises(self, store, tmp_path):
         bad = tmp_path / "notes.txt"
         bad.write_text("hi", encoding="utf-8")
         with pytest.raises(TtsError, match="unsupported"):
-            store.add(str(bad))
+            store.add(str(bad), consent_attested=True)
 
     def test_probe_failure_stores_zero(self, tmp_path, sample_file):
         def boom(path):
             raise RuntimeError("no ffprobe")
 
         store = v.VoiceStore(tmp_path / "voices", duration_probe=boom)
-        assert store.add(str(sample_file))["durationSec"] == 0.0
+        assert store.add(str(sample_file), consent_attested=True)["durationSec"] == 0.0
 
     def test_corrupt_index_starts_empty(self, tmp_path):
         d = tmp_path / "voices"
@@ -78,8 +86,8 @@ class TestVoiceStore:
         first.write_bytes(b"RIFF0000WAVEa")
         second = tmp_path / "second.wav"
         second.write_bytes(b"RIFF0000WAVEb")
-        s1 = store.add(str(first))
-        s2 = store.add(str(second))
+        s1 = store.add(str(first), consent_attested=True)
+        s2 = store.add(str(second), consent_attested=True)
         # the SECOND id forces the loop to skip s1 before matching s2.
         assert s1["id"] != s2["id"]
         assert store.get(s2["id"])["path"] == s2["path"]
@@ -104,7 +112,7 @@ class StaticEngine(TtsEngine):
 
 class TestHandlers:
     def test_voices_aggregates_engines_and_samples(self, store, sample_file):
-        sample = store.add(str(sample_file))
+        sample = store.add(str(sample_file), consent_attested=True)
         rows = [{"id": "af_x", "engine": "kokoro", "lang": "en-us", "name": "X"}]
         handler = v.make_voices_handler([StaticEngine(rows)], store)
         result = handler({}, ctx())
@@ -134,13 +142,21 @@ class TestHandlers:
 
     def test_sample_add_handler_shape_and_validation(self, store, sample_file):
         handler = v.make_sample_add_handler(store)
-        result = handler({"path": str(sample_file)}, ctx())
+        result = handler({"path": str(sample_file), "consentAttested": True}, ctx())
         assert set(result) == {"sample"}
-        assert set(result["sample"]) == {"id", "name", "path", "durationSec"}
+        assert set(result["sample"]) == {
+            "id",
+            "name",
+            "path",
+            "durationSec",
+            "consentAttested",
+            "consentAt",
+            "consentNote",
+        }
         with pytest.raises(RpcError):
             handler({}, ctx())
         with pytest.raises(RpcError):
-            handler({"path": "C:/nope.wav"}, ctx())
+            handler({"path": "C:/nope.wav", "consentAttested": True}, ctx())
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_tts_voices.py
+++ b/sidecar/tests/test_tts_voices.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
@@ -176,3 +177,205 @@ class TestRegister:
         # kokoro + edgetts ship static catalogs; chatterbox rows appear once
         # samples exist (none here).
         assert {"kokoro", "edgetts"} <= engines
+
+
+# --------------------------------------------------------------------------- #
+# WU-A2 — the voice-clone CONSENT gate (docs/plans/v1.5/flagship-lip-sync-dub.md
+# §4 WU-A2 + §5.1, the legal keystone). Mirrors models/consent.py's typed-refusal
+# / default-deny idiom for the SEPARATE voice-clone act.
+# --------------------------------------------------------------------------- #
+FROZEN_ISO = "2026-08-08T10:20:30Z"
+
+
+@pytest.fixture()
+def consenting_store(tmp_path):
+    """A store with a FROZEN consent clock so ``consentAt`` is deterministic."""
+    return v.VoiceStore(
+        tmp_path / "voices",
+        duration_probe=lambda p: 3.5,
+        now=lambda: FROZEN_ISO,
+    )
+
+
+class TestConsentPredicate:
+    @pytest.mark.parametrize(
+        "row",
+        [
+            None,
+            {},
+            "not-a-mapping",
+            {"consentAttested": False},
+            {"consentAttested": None},
+            # default-deny: a TRUTHY non-True value is NOT an attestation
+            {"consentAttested": "true"},
+            {"consentAttested": 1},
+        ],
+    )
+    def test_default_deny(self, row):
+        assert v.consent_attested(row) is False
+
+    def test_explicit_true_is_the_only_grant(self):
+        assert v.consent_attested({"consentAttested": True}) is True
+
+    def test_require_consent_raises_typed_error_naming_the_sample(self):
+        with pytest.raises(v.VoiceConsentError) as excinfo:
+            v.require_consent({"consentAttested": False}, "abc123")
+        assert "abc123" in str(excinfo.value)
+        assert excinfo.value.sample_id == "abc123"
+
+    def test_require_consent_without_an_id_still_refuses(self):
+        with pytest.raises(v.VoiceConsentError) as excinfo:
+            v.require_consent(None)
+        assert excinfo.value.sample_id is None
+        assert "consent" in str(excinfo.value).lower()
+
+    def test_require_consent_passes_on_an_attested_row(self):
+        assert v.require_consent({"consentAttested": True}, "ok") is None
+
+    def test_is_a_tts_error_so_rpc_boundaries_convert_it(self):
+        assert issubclass(v.VoiceConsentError, TtsError)
+
+
+class TestStoreConsentGate:
+    def test_add_without_attestation_refuses_and_stores_NOTHING(self, consenting_store, sample_file, tmp_path):
+        """The gate is real: no file is copied and no index row is written."""
+        with pytest.raises(v.VoiceConsentError):
+            consenting_store.add(str(sample_file))
+        assert consenting_store.list() == []
+        voices_dir = tmp_path / "voices"
+        assert not voices_dir.exists() or list(voices_dir.iterdir()) == []
+
+    def test_consent_is_checked_before_ANY_filesystem_touch(self, consenting_store, tmp_path):
+        """A missing path + no consent reports CONSENT, not 'not found' (deny-first)."""
+        with pytest.raises(v.VoiceConsentError):
+            consenting_store.add(str(tmp_path / "ghost.wav"))
+
+    def test_add_with_attestation_persists_the_consent_record(self, consenting_store, sample_file, tmp_path):
+        sample = consenting_store.add(
+            str(sample_file),
+            consent_attested=True,
+            consent_note="signed release 2026-08-01",
+        )
+        assert set(sample) == {
+            "id",
+            "name",
+            "path",
+            "durationSec",
+            "consentAttested",
+            "consentAt",
+            "consentNote",
+        }
+        assert sample["consentAttested"] is True
+        assert sample["consentAt"] == FROZEN_ISO
+        assert sample["consentNote"] == "signed release 2026-08-01"
+        # the record survives a round-trip through voices.json
+        again = v.VoiceStore(tmp_path / "voices", duration_probe=lambda p: 0.0)
+        stored = again.get(sample["id"])
+        assert stored["consentAttested"] is True
+        assert stored["consentAt"] == FROZEN_ISO
+        assert stored["consentNote"] == "signed release 2026-08-01"
+
+    @pytest.mark.parametrize("note", [None, "", "   ", 42])
+    def test_blank_or_non_string_note_normalizes_to_None(self, consenting_store, sample_file, note):
+        sample = consenting_store.add(str(sample_file), consent_attested=True, consent_note=note)
+        assert sample["consentNote"] is None
+
+    def test_default_clock_emits_an_iso8601_utc_stamp(self, tmp_path, sample_file):
+        store = v.VoiceStore(tmp_path / "voices", duration_probe=lambda p: 0.0)
+        stamp = store.add(str(sample_file), consent_attested=True)["consentAt"]
+        # YYYY-MM-DDTHH:MM:SSZ — UTC, no local-time ambiguity in a legal record
+        assert re.fullmatch(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z", stamp)
+
+
+class TestLegacyRowBackfill:
+    def test_normalize_backfills_a_pre_consent_row_as_NOT_attested(self):
+        row = v.normalize_sample({"id": "old", "name": "n", "path": "p", "durationSec": 1.0})
+        assert row["consentAttested"] is False
+        assert row["consentAt"] is None
+        assert row["consentNote"] is None
+
+    def test_normalize_preserves_a_stored_consent_record(self):
+        row = v.normalize_sample(
+            {
+                "id": "new",
+                "name": "n",
+                "path": "p",
+                "durationSec": 1.0,
+                "consentAttested": True,
+                "consentAt": FROZEN_ISO,
+                "consentNote": "note",
+            }
+        )
+        assert (row["consentAttested"], row["consentAt"], row["consentNote"]) == (True, FROZEN_ISO, "note")
+
+    def test_normalize_rejects_a_non_string_consentAt(self):
+        row = v.normalize_sample({"id": "x", "consentAttested": True, "consentAt": 1723106430})
+        assert row["consentAt"] is None
+
+    def test_a_legacy_row_on_disk_is_read_back_as_unattested(self, tmp_path):
+        d = tmp_path / "voices"
+        d.mkdir()
+        (d / "voices.json").write_text(
+            '{"version": 1, "samples": [{"id": "old", "name": "n", "path": "p", "durationSec": 2.0}]}',
+            encoding="utf-8",
+        )
+        store = v.VoiceStore(d, duration_probe=lambda p: 0.0)
+        assert store.get("old")["consentAttested"] is False
+
+
+class TestCatalogMarksUnattestedSamples:
+    def test_attested_and_legacy_rows_are_labelled_differently(self):
+        rows = v.samples_as_voices(
+            [
+                {"id": "a", "name": "Ann", "path": "p", "durationSec": 1.0, "consentAttested": True},
+                {"id": "b", "name": "Bob", "path": "p", "durationSec": 1.0, "consentAttested": False},
+            ]
+        )
+        by_id = {row["id"]: row for row in rows}
+        assert by_id["a"]["name"] == "Ann (cloned sample)"
+        assert "consent required" in by_id["b"]["name"]
+        # the A2 Voice shape stays FROZEN at exactly four keys
+        for row in rows:
+            assert set(row) == {"id", "engine", "lang", "name"}
+
+
+class TestSampleAddHandlerConsent:
+    @pytest.mark.parametrize("attested", [None, False, "true", 1])
+    def test_add_without_a_true_attestation_is_refused(self, consenting_store, sample_file, attested):
+        handler = v.make_sample_add_handler(consenting_store)
+        params = {"path": str(sample_file)}
+        if attested is not None:
+            params["consentAttested"] = attested
+        with pytest.raises(RpcError, match="consentAttested"):
+            handler(params, ctx())
+        assert consenting_store.list() == []
+
+    def test_add_with_attestation_returns_the_consent_record(self, consenting_store, sample_file):
+        handler = v.make_sample_add_handler(consenting_store)
+        result = handler(
+            {
+                "path": str(sample_file),
+                "name": "Ann",
+                "consentAttested": True,
+                "consentNote": "written permission on file",
+            },
+            ctx(),
+        )
+        sample = result["sample"]
+        assert sample["name"] == "Ann"
+        assert sample["consentAttested"] is True
+        assert sample["consentAt"] == FROZEN_ISO
+        assert sample["consentNote"] == "written permission on file"
+
+    def test_a_non_string_note_is_dropped_not_rejected(self, consenting_store, sample_file):
+        handler = v.make_sample_add_handler(consenting_store)
+        result = handler(
+            {"path": str(sample_file), "consentAttested": True, "consentNote": 7},
+            ctx(),
+        )
+        assert result["sample"]["consentNote"] is None
+
+    def test_the_path_check_still_runs_first(self, consenting_store):
+        handler = v.make_sample_add_handler(consenting_store)
+        with pytest.raises(RpcError, match="path"):
+            handler({"consentAttested": True}, ctx())


### PR DESCRIPTION
Cloning a person's voice without an attested right to do so is the flagship's
headline legal exposure (EU AI Act Art. 50 transparency duties). This lane makes
the attestation structural rather than advisory.

Three enforcement points, all default-deny:
- `tts.sample.add` requires `consentAttested is True`, typed `INVALID_PARAMS` otherwise;
- `VoiceStore.add` re-checks **before touching the filesystem**, so no path can
  persist a clone reference without one;
- `require_consent` is the clone-time gate reached via `tts.dub.start`, so a
  legacy row backfilled as `consentAttested: False` cannot be cloned either.

That third gate is the non-obvious one: gating `sample.add` alone leaves a back
door for rows written before the gate existed.

The renderer shows a **blocking** checkbox carrying the same sentence the backend
quotes in its refusal, so the UI can never promise something weaker than what is
enforced. `consentAt` is UTC ISO-8601 with an injectable clock.

`CONTRACTS.md` updated — the SSOT was previously silent on this extension.

## Commits

- refactor(tts): type the consent predicates as `object`, not `X | Any`
- docs(contracts): record the WU-A2 consent extension so the SSOT stops lying
- feat(dub): make the voice-clone consent attestation a blocking UI gate
- feat(tts): refuse to store or clone a voice with no consent attestation
- test(tts): RED — the voice-clone consent gate does not exist yet

