### PR TITLE
fix(models-system): one analyze control, not two (H3)

### DIFF
--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -658,8 +658,18 @@ function downloadBtn(model: string): HTMLButtonElement {
   ) as HTMLButtonElement;
 }
 
+// "The control that starts analysis", wherever it currently lives. Before H3 the
+// toolbar copy and the empty-state CTA both existed pre-analysis; now the CTA owns
+// that state and the toolbar owns the other two, so a single hard-coded selector
+// would silently resolve to null depending on when it is called.
+function analyzeStarter(): HTMLButtonElement {
+  return container.querySelector(
+    'button[data-action="analyze"], button[data-action="analyze-cta"]',
+  ) as HTMLButtonElement;
+}
+
 async function analyze(): Promise<void> {
-  const btn = container.querySelector('button[data-action="analyze"]') as HTMLButtonElement;
+  const btn = analyzeStarter();
   await act(async () => {
     btn.click();
   });
@@ -691,6 +701,63 @@ describe('<ModelsSystemPanel />', () => {
       await Promise.resolve();
       await Promise.resolve();
     });
+    expect(container.querySelector('[data-section="hardware"]')).not.toBeNull();
+  });
+
+  // H3 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5). The toolbar button and the
+  // empty-state CTA both read "Analyze my system" and both call `analyze()`, so an
+  // un-analyzed panel shipped the SAME control twice — measured live at 552,161 and
+  // 576,326. The audit records C1 and H3 as masking each other: C1's landing-scrolled
+  // bug hid the toolbar copy, so fixing C1 is what made the pair visible together.
+  // Two buttons carrying an identical accessible name is also an ambiguous target for
+  // anyone navigating by name rather than by position.
+  it('offers exactly ONE analyze control while the empty-state prompt is showing', async () => {
+    const c = makeClient();
+    await mount(c);
+    expect(container.querySelector('[data-section="prompt"]')).not.toBeNull();
+    const starters = container.querySelectorAll(
+      'button[data-action="analyze"], button[data-action="analyze-cta"]',
+    );
+    expect(starters.length).toBe(1);
+    // The survivor is the CTA, not the toolbar copy: it is the one carrying the
+    // explanation, and dropping it instead would leave the empty state a paragraph
+    // with no way forward (the shape audit M2 flags on Edit).
+    expect((starters[0] as HTMLElement).dataset.action).toBe('analyze-cta');
+  });
+
+  // The other half of H3: suppressing the toolbar copy must not lose the control.
+  // It is the ONLY affordance once the prompt is gone, in both remaining states.
+  it('restores the toolbar analyze control as Re-analyze once analysis has run', async () => {
+    const c = makeClient();
+    await mount(c);
+    await analyze();
+    expect(container.querySelector('[data-section="prompt"]')).toBeNull();
+    const toolbar = container.querySelector('button[data-action="analyze"]') as HTMLButtonElement;
+    expect(toolbar).not.toBeNull();
+    expect(toolbar.textContent).toContain('Re-analyze');
+  });
+
+  // …and clicking it must actually re-run the analysis. Nothing exercised the
+  // TOOLBAR button's own handler before H3: every test reached analysis through
+  // the pre-analysis copy of it, so the post-analysis "Re-analyze" path shipped
+  // unproven. Removing the duplicate made that hole measurable — the file went to
+  // 97.05% functions with this handler as the only uncovered one.
+  it('Re-analyze re-runs the probe from the toolbar control', async () => {
+    const c = makeClient();
+    await mount(c);
+    await analyze();
+    const probe = c.client.system.probe as ReturnType<typeof vi.fn>;
+    const callsAfterFirst = probe.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+    const toolbar = container.querySelector('button[data-action="analyze"]') as HTMLButtonElement;
+    await act(async () => {
+      toolbar.click();
+    });
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(probe.mock.calls.length).toBeGreaterThan(callsAfterFirst);
     expect(container.querySelector('[data-section="hardware"]')).not.toBeNull();
   });
 
@@ -1557,19 +1624,25 @@ describe('<ModelsSystemPanel />', () => {
         }),
     );
     await mount(c);
-    const btn = container.querySelector('button[data-action="analyze"]') as HTMLButtonElement;
     await act(async () => {
-      btn.click();
+      analyzeStarter().click();
     });
-    expect(btn.disabled).toBe(true);
-    expect(btn.textContent).toContain('Analyzing');
+    // RE-QUERY each phase rather than holding one node. Since H3 the control that
+    // starts analysis (the empty-state CTA) is NOT the control that reports progress
+    // (the toolbar button) — the first unmounts as `busy` flips. A captured
+    // reference would go detached and every assertion below would read a stale,
+    // off-DOM node, which is a vacuous pass rather than a real one.
+    const during = analyzeStarter();
+    expect(during.dataset.action).toBe('analyze');
+    expect(during.disabled).toBe(true);
+    expect(during.textContent).toContain('Analyzing');
     await act(async () => {
       release();
       await Promise.resolve();
       await Promise.resolve();
     });
     // After resolution the busy label clears.
-    expect(btn.textContent).not.toContain('Analyzing');
+    expect(analyzeStarter().textContent).not.toContain('Analyzing');
   });
 
   it('download tolerates a non-array asset list and a null advisor refresh', async () => {
@@ -2361,7 +2434,7 @@ describe('<ModelsSystemPanel /> WU-B3 card', () => {
         }),
     );
     await mount(c);
-    const btn = container.querySelector('button[data-action="analyze"]') as HTMLButtonElement;
+    const btn = analyzeStarter();
     await act(async () => btn.click());
     const loading = container.querySelector('[data-section="recommend-loading"]') as HTMLElement;
     expect(loading).not.toBeNull();

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -778,6 +778,11 @@ export function ModelsSystemPanel({
     ? 'Your settings already match the recommendation'
     : 'Apply recommended settings';
 
+  // H3: the ONE predicate the empty-state prompt and the toolbar analyze button
+  // both read, so they can never render together again. Previously each site
+  // spelled `!analyzed && !busy` for itself, which is what let the duplicate exist.
+  const showPrompt = !analyzed && !busy;
+
   return (
     <section className="feature-panel models-system-panel" aria-label="Models and System">
       <h2>Models &amp; System</h2>
@@ -793,15 +798,30 @@ export function ModelsSystemPanel({
       />
 
       <div className="actions">
-        <button
-          type="button"
-          data-action="analyze"
-          onClick={() => void analyze()}
-          disabled={busy}
-          title={busy ? 'Analysis is already running…' : undefined}
-        >
-          {busy ? 'Analyzing…' : analyzed ? 'Re-analyze' : 'Analyze my system'}
-        </button>
+        {/* H3 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5) — this button and the
+            empty-state CTA below both read "Analyze my system" and both call
+            `analyze()`, so an un-analyzed panel rendered the SAME control twice
+            (measured live at 552,161 and 576,326). The audit records C1 and H3 as
+            masking each other: C1's landing-scrolled bug kept this copy off-screen,
+            so fixing C1 is what made the pair visible together.
+
+            The CTA wins the un-analyzed state because it is the one carrying the
+            explanation; suppressing IT instead would leave the empty state a
+            paragraph with no way forward. This button owns the other two states,
+            where it is the only affordance — hence `Analyzing…` / `Re-analyze` and
+            no third label: `!showPrompt` means `analyzed || busy`, so a bare
+            "Analyze my system" here is unreachable, not merely unused. */}
+        {!showPrompt && (
+          <button
+            type="button"
+            data-action="analyze"
+            onClick={() => void analyze()}
+            disabled={busy}
+            title={busy ? 'Analysis is already running…' : undefined}
+          >
+            {busy ? 'Analyzing…' : 'Re-analyze'}
+          </button>
+        )}
         {analyzed && (
           <button
             type="button"
@@ -829,7 +849,7 @@ export function ModelsSystemPanel({
         </p>
       )}
 
-      {!analyzed && !busy && (
+      {showPrompt && (
         <div className="empty-state" data-section="prompt">
           <p className="empty-state__title">See what your machine can run</p>
           <p className="empty-state__body">

--- a/app/renderer/src/views/Edit.tsx
+++ b/app/renderer/src/views/Edit.tsx
@@ -179,7 +179,7 @@ export function Edit({
           <span className="edit__empty-timecode">--:--</span>
         </div>
         <p className="edit__empty-title">No video open</p>
-        {/* C3 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §5) — this used to read
+        {/* docs/plans/v1.5/editing-surface-audit-2026-08.md:52 — this used to read
             "trim, cut, join, reframe, caption, and more — every edit tool lives
             here". Three of those verbs are not reachable from this section, and
             the "every tool lives here" clause was the widest part of the claim:


### PR DESCRIPTION
Closes **H3** from `docs/plans/v1.5/uiux-qol-audit-2026-08.md` §5.

## The defect

The toolbar button (`ModelsSystemPanel.tsx:796`) and the empty-state CTA (`:840`)
both read **"Analyze my system"** and both call `analyze()`. They coexist in
exactly one state — `!analyzed && !busy` — which is the **first screen a new user
sees**. The audit measured them live at `552,161` and `576,326`.

The audit records C1 and H3 as **masking each other**: C1's landing-scrolled bug
kept the toolbar copy off-screen, so landing C1 is what made the pair visible
together. C1 is now on main, so this is unmasked.

Two buttons with an identical accessible name on one panel is also an ambiguous
target for anyone navigating by name rather than by position.

## Which one to drop

The audit does not prescribe one, so — from the state machine:

| state | empty-state CTA | toolbar button |
|---|---|---|
| `!analyzed && !busy` | present | present — **the duplicate** |
| `busy` | gone | `Analyzing…`, disabled |
| `analyzed` | gone | `Re-analyze` |

The toolbar button is the only affordance in two of three states, so it stays.
The CTA wins the contested state because it is the one carrying the explanation —
dropping it instead would leave the empty state a paragraph with no way forward,
which is the shape audit **M2** flags on Edit.

Both sites now read one `showPrompt` predicate. Each previously spelled
`!analyzed && !busy` for itself, and that duplication is what let them drift into
rendering together.

Dropping the third label is not tidying: `!showPrompt` means `analyzed || busy`,
so a bare `"Analyze my system"` on the toolbar became **unreachable**, not merely
unused. Leaving it would have broken the 100% branch gate.

## This exposed a real coverage hole

Every test reached analysis through the *pre-analysis* copy of the button, so the
**toolbar button's own handler was never invoked** — the post-analysis
`Re-analyze` path shipped unproven.

Measured both directions rather than assumed:

| | % Stmts | % Branch | % Funcs | % Lines |
|---|---|---|---|---|
| `origin/main` (control) | 100 | 100 | **100** | 100 |
| this branch, before the new test | 100 | 100 | **97.05** | 100 |
| this branch, after | 100 | 100 | **100** | 100 |

`Re-analyze re-runs the probe from the toolbar control` closes it by asserting the
probe call count actually increases. 122 tests, up from 119.

## Two test changes are consequences, not accommodations

Both follow from the element *identity* changing, not the behaviour:

- **`analyzeStarter()`** resolves "the control that starts analysis" wherever it
  currently lives. A hard-coded toolbar selector now resolves to `null` depending
  on when it is called.
- **the busy-label test re-queries each phase** instead of holding one node. The
  control that *starts* analysis is no longer the control that *reports* progress,
  so a captured reference goes detached and every later assertion reads an off-DOM
  node — a vacuous pass, not a real one. This assertion is now stronger than
  before, not weaker.

## Also in here (one line)

`Edit.tsx` labelled its empty-state comment `C3 (uiux-qol-audit-2026-08.md §5)`.
**That audit has no C3** — it runs C1, C2, H1–H7, M1–M9, verified by enumerating
every `**C<n>.` heading. The defect it addresses lives in a different document,
`editing-surface-audit-2026-08.md:52`. The comment body already cites that file
correctly at `:44` and `:45-48`; only the heading was wrong, so a reader following
the label landed in the wrong document.

Worth noting for the gate: **r5 checks that a cited PATH exists, not that the
ANCHOR within it does**, so this class of dangling citation passes CI today.

## Verification

- `ModelsSystemPanel.test.tsx` — 122 passed, 100/100/100/100 on the file
- full renderer suite — 225 files / 4171 tests passed
- `tsc --noEmit` clean; `@biomejs/biome@2.5.0 check` clean (note: bare `npx biome`
  resolves an unrelated package at 0.3.3)
