### PR TITLE
fix(e2e): tab-strip counts went stale four times because no gate could see them

### DIFF
--- a/app/e2e/preview.spec.ts
+++ b/app/e2e/preview.spec.ts
@@ -211,14 +211,23 @@ test('Advanced disclosure actually COLLAPSES the Deliver cluster (F17)', async (
   // ...so the cluster it owns must not paint. It does today: the author-origin
   // `display: flex` on `.tabbar--grouped .tabbar__advanced-panel` outranks the
   // UA `[hidden] { display: none }`, and no `[hidden]` selector anywhere under
-  // app/ restores it — so all 13 tabs paint instead of 8 and `aria-expanded`
+  // app/ restores it — so all 17 tabs paint instead of 12 and `aria-expanded`
   // lies about what is on screen.
   await expect(panel).toBeHidden();
   await expect(deliverTab).toBeHidden();
-  // The user-visible consequence: the default view paints the 8 primary tabs,
-  // not all 13. (`.tab` is exclusive to this strip — measured 13 total.)
-  await expect(win.locator('.tab')).toHaveCount(13);
-  await expect(win.locator('.tab:visible')).toHaveCount(8);
+  // The user-visible consequence: the default view paints the 12 primary tabs,
+  // not all 17. (`.tab` is exclusive to this strip.)
+  //
+  // These two numbers are DERIVED, not observed — they are `WORKSPACE_TABS.length`
+  // and that minus the `advanced: true` group's `tabIds.length`
+  // (`Workspace.tsx:80-124`): 17 tabs total; Deliver holds 5 (convert, nle,
+  // recipes, assets, tracks), so 12 paint while it is collapsed. They were 13/8
+  // until the v1.5 wave added `transcriptEdit`, `timeline`, `speed` and
+  // `audiomix`; e2e is opt-in and nightly, so it never gated those PRs and the
+  // stale pair merged four times over. Re-derive from the source when the tab
+  // list changes — do NOT read a number off a failing run and paste it back.
+  await expect(win.locator('.tab')).toHaveCount(17);
+  await expect(win.locator('.tab:visible')).toHaveCount(12);
   // ...and the disclosure's own toggle is reachable WITHOUT horizontally
   // scrolling `.workspace .tabbar` (workspace.css `overflow-x: auto`). With the
   // cluster always painted the strip overflowed its 1064px track by 587px and

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -687,12 +687,37 @@ describe('Workspace tab clusters (WU-3a2)', () => {
     expect(groupLabels()).toEqual(['Speech & Text', 'Frame & Cut', 'Audio', 'Deliver']);
   });
 
-  it('keeps every tab reachable: all 13 ids stay in the tablist across clusters', async () => {
+  it('keeps every tab reachable: every id stays in the tablist across clusters', async () => {
     await mount();
     const ids = Array.from(container.querySelectorAll('[role="tab"]'))
       .map((t) => t.getAttribute('data-tab-id'))
       .sort();
     expect(ids).toEqual(WORKSPACE_TABS.map((t) => t.id).sort());
+  });
+
+  // GATE LINK — deliberately LITERAL, and NOT a tautology.
+  //
+  // Every other tab assertion in this file compares the DOM against
+  // WORKSPACE_TABS, so all of them stay green when a tab is added. The nightly
+  // e2e strip assertions (`app/e2e/preview.spec.ts`, "Advanced disclosure
+  // actually COLLAPSES the Deliver cluster") hardcode these same two counts —
+  // and e2e is opt-in + nightly, so it gates no PR. The v1.5 wave added
+  // `transcriptEdit`, `timeline`, `speed` and `audiomix` and shipped that spec
+  // stale four times over; the strip had been 13/8 and was 17/12 before anyone
+  // measured it.
+  //
+  // These literals are the missing link: adding or regrouping a tab now fails
+  // HERE, in the suite `quality` actually runs on every PR, and says which file
+  // to update. Update both together, or the nightly goes red again.
+  it('pins the strip counts that the nightly e2e spec hardcodes', () => {
+    expect(WORKSPACE_TABS).toHaveLength(17);
+    const hiddenWhenCollapsed = WORKSPACE_TAB_GROUPS.filter((g) => g.advanced).reduce(
+      (n, g) => n + g.tabIds.length,
+      0,
+    );
+    expect(hiddenWhenCollapsed).toBe(5);
+    // What actually paints while the Advanced cluster is collapsed.
+    expect(WORKSPACE_TABS.length - hiddenWhenCollapsed).toBe(12);
   });
 
   it('collapses the Deliver cluster behind Advanced by default and toggles it open/closed', async () => {

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -101,7 +101,7 @@ export const WORKSPACE_TABS: TabDef[] = [
 ];
 
 /**
- * WU-3a2: the 13 flat tabs regrouped into 4 NAMED clusters for progressive
+ * WU-3a2: the flat tab list regrouped into 4 NAMED clusters for progressive
  * disclosure. This is an ADDITIVE VISUAL layer over WORKSPACE_TABS — every tab
  * id above appears in exactly one group and every panel stays reachable; the
  * ids/labels/behaviour are unchanged. "Deliver" is flagged `advanced` so it


### PR DESCRIPTION
The nightly e2e on `main` is RED, identically on **windows, macos and ubuntu** — so a real regression, not flake, and **not** the visual baselines:

```
preview.spec.ts:220  expect(win.locator('.tab')).toHaveCount(13)
Expected: 13   Received: 17
```

The v1.5 wave added four tabs (`transcriptEdit`, `timeline`, `speed`, `audiomix`): the strip went 13 -> 17, and collapsed 8 -> 12.

Numbers are **derived** from `Workspace.tsx:80-124`, not read off the failing run — 17 tabs, and the single `advanced: true` group (Deliver: convert/nle/recipes/assets/tracks) holds 5, so 12 paint while collapsed. The live run independently resolved 17, which is the corroborating second signal.

## Why it shipped stale four times

Nothing could catch it. Every tab assertion in `Workspace.test.tsx` compares the DOM **against** `WORKSPACE_TABS` (`[role=tab].length === WORKSPACE_TABS.length`), so they all stay green no matter how many tabs exist. The only literal copy lives in the e2e spec — and e2e is `workflow_dispatch` + nightly cron, so it **gates no PR**. Four lanes each added a tab, each passed `quality`, each left the nightly a little more broken.

So this adds the missing link: `pins the strip counts that the nightly e2e spec hardcodes`, asserting both numbers as literals **in the suite `quality` runs on every PR**, naming the file to update.

**Mutation-tested, not assumed** (a gate that has never gone red is indistinguishable from a no-op): adding an 18th tab fails it with `expected [...] to have a length of 17 but got 18`. Reverted after measuring.

## Deliberately not touched

`await expect(toggle).toBeInViewport()` at `:227` stays exactly as-is. The counts were a stale **fact**; that is a live **invariant**. Going 8 -> 12 painted tabs may genuinely push the Advanced toggle off-screen again — the exact defect F17 exists to prevent. Relaxing it would hide a real regression. **If it fails on the re-run, that is a finding.**

The two sibling failures in the same spec (`Workspace tabs mount`, `export action yields a real file` — both losing `.workspace`) are **not** diagnosed here. Test 20 "no console errors across the whole session" **passed** in the same run, so they are not a render crash. Re-running with the count fixed is the cheapest way to tell whether they cascaded from the 30s timeout or are independent.

## Verification

- `Workspace.test.tsx` — 55 passed
- mutation: 18th tab -> gate goes red, then reverted
- `tsc --noEmit` clean; `@biomejs/biome@2.5.0 check` clean
