### PR TITLE
fix(design-system): cap the editorial serif with an allowlist + fix the one real outlier (H7)

### DIFF
--- a/app/renderer/src/styles/tokens.conformance.test.ts
+++ b/app/renderer/src/styles/tokens.conformance.test.ts
@@ -697,3 +697,117 @@ describe('red status text clears AA — the DoD contrast floor (v1.5 shell-polis
     expect(consumed).toBe(true);
   });
 });
+
+// --- H7: the editorial serif is CAPPED to an enumerated allowlist -----------------
+//
+// docs/plans/v1.5/uiux-qol-audit-2026-08.md sec.3.1 measured `--font-editorial`
+// in 15 places against a documented limit of ONE, and named the real defect in
+// the same breath: "undetected by the conformance suite that already guards the
+// accent". The accent had a whole-tree guard; the second scarce typographic
+// channel had none, so it spread one reasonable-looking commit at a time.
+//
+// This is that guard. It is an ALLOWLIST, not a count: a 15th site fails until
+// someone adds the selector here, which turns silent drift into a reviewed
+// decision. A count alone would let a swap slip through unnoticed.
+//
+// The list is NOT a rubber-stamp of whatever was there. Every entry is a hook
+// pull-quote, an empty-state title, or a panel/modal display title — the
+// editorial voice. `.director-view__title` was REMOVED rather than admitted: it
+// was the only one of four `*-view__title` rules to take the serif, and the only
+// one at display size instead of title size (caption.css:39, deliver.css:39 and
+// export.css:39 are the three that agree). View chrome is the one place this
+// voice does not belong.
+//
+// Body text, labels, controls, data and timecode are never eligible.
+
+/** Every selector permitted to set `font-family: var(--font-editorial)`. */
+const EDITORIAL_SERIF_ALLOWLIST: readonly string[] = [
+  // hook pull-quotes — the original documented home
+  '.sm-hook',
+  '.shorts__hook',
+  '.caption-stage__hint',
+  // empty-state titles
+  '.caption-inspector__empty-title',
+  '.caption-view__empty-title',
+  '.export-view__empty-title',
+  // panel / modal / result display titles
+  '.shorts-modal__title',
+  '.director-handoff__title',
+  '.lineage-panel__title',
+  '.export-inspector__confirm-title',
+  '.export-result__title',
+  // identity / display moments
+  '.first-run-setup__brand',
+  '.profile-picker__legend',
+  '.caption-gallery__current',
+];
+
+/**
+ * Selectors that set `font-family: var(--font-editorial)` in one stylesheet.
+ *
+ * Reads the selector list immediately preceding each declaration's `{`. Comments
+ * are stripped FIRST so a selector quoted inside a comment cannot register as a
+ * real use (the use-vs-mention trap).
+ */
+function editorialSerifSelectors(css: string): readonly string[] {
+  const body = stripComments(css);
+  const out: string[] = [];
+  const rule = /([^{}]+)\{([^{}]*)\}/g;
+  for (let m = rule.exec(body); m !== null; m = rule.exec(body)) {
+    if (!/font-family\s*:\s*var\(--font-editorial\)/.test(m[2])) continue;
+    for (const sel of m[1].split(',')) {
+      const trimmed = sel.trim().replace(/\s+/g, ' ');
+      if (trimmed) out.push(trimmed);
+    }
+  }
+  return out;
+}
+
+describe('editorial serif stays inside its allowlist (H7)', () => {
+  const cssFiles = collectCssFiles(RENDERER_SRC);
+
+  it('finds the renderer stylesheets (guard is actually scanning something)', () => {
+    // A dead scan matching zero files would vacuously pass. Pin a floor, and pin
+    // that the detector CAN see a known-present use, before trusting its silence.
+    expect(cssFiles.length).toBeGreaterThan(20);
+    const anyUse = cssFiles.flatMap((f) => editorialSerifSelectors(readFileSync(f, 'utf8')));
+    expect(anyUse.length).toBeGreaterThan(0);
+  });
+
+  it('every --font-editorial site is on the allowlist', () => {
+    const offenders: string[] = [];
+    for (const file of cssFiles) {
+      for (const sel of editorialSerifSelectors(readFileSync(file, 'utf8'))) {
+        if (!EDITORIAL_SERIF_ALLOWLIST.includes(sel)) {
+          offenders.push(`${sel}  (${file.replace(RENDERER_SRC, '')})`);
+        }
+      }
+    }
+    // The message names the offender AND what to do, so the failure is actionable
+    // without opening this file.
+    expect(
+      offenders,
+      'New --font-editorial site(s). The editorial serif is a SCARCE channel ' +
+        '(docs/design-system.md): hook pull-quotes, empty-state titles and panel ' +
+        'display titles only — never body text, labels, controls or data. If this ' +
+        'use really is one of those, add the selector to EDITORIAL_SERIF_ALLOWLIST.',
+    ).toEqual([]);
+  });
+
+  it('the allowlist has no dead entries (it tracks the tree, not history)', () => {
+    // The other direction: an allowlisted selector that no longer sets the serif
+    // is stale permission, and stale permission is how an allowlist rots into a
+    // rubber stamp.
+    const live = new Set(cssFiles.flatMap((f) => editorialSerifSelectors(readFileSync(f, 'utf8'))));
+    expect(EDITORIAL_SERIF_ALLOWLIST.filter((s) => !live.has(s))).toEqual([]);
+  });
+
+  it('no VIEW header uses the serif — the four view titles agree', () => {
+    // The specific regression H7 named. Pinned separately from the allowlist so
+    // re-adding `.director-view__title` to the list cannot quietly re-open it.
+    const viewTitles = cssFiles.flatMap((f) =>
+      editorialSerifSelectors(readFileSync(f, 'utf8')).filter((s) => /view__title$/.test(s)),
+    );
+    expect(viewTitles).toEqual([]);
+  });
+});

--- a/app/renderer/src/views/director.css
+++ b/app/renderer/src/views/director.css
@@ -44,14 +44,27 @@
   box-shadow: var(--focus-ring);
 }
 
-/* The serif display voice with a real scale jump — the editorial moment. */
+/* H7 (docs/plans/v1.5/uiux-qol-audit-2026-08.md §3.1) — this was the serif at
+   display size, and the audit's "clearest case" of the editorial voice spreading
+   past its documented home.
+
+   It is an OUTLIER on both axes, not a style choice. Four views define a
+   `*-view__title`; the other three — caption.css:39, deliver.css:39,
+   export.css:39 — are all `--type-title-size` with NO `font-family`. Director
+   alone took `--font-editorial` AND `--type-display-size`, so the app's four view
+   headers rendered in two different typefaces at two different scales for no
+   reason a user could infer.
+
+   Aligned with its three siblings. The editorial serif is NOT deleted from the
+   product — it keeps the hook pull-quotes and the empty-state/panel display
+   titles it is actually for (see the allowlist in
+   `styles/tokens.conformance.test.ts`, which now caps it). A VIEW header is
+   chrome, and chrome is the one place it does not belong. */
 .director-view__title {
   margin: 0;
-  font-family: var(--font-editorial);
-  font-size: var(--type-display-size);
-  font-weight: var(--type-display-weight);
-  letter-spacing: var(--type-display-tracking);
-  line-height: var(--type-display-leading);
+  font-size: var(--type-title-size);
+  font-weight: var(--type-title-weight);
+  letter-spacing: var(--type-title-tracking);
   color: var(--text-primary);
 }
 

--- a/docs/design-system.md
+++ b/docs/design-system.md
@@ -45,8 +45,22 @@ Sanctioned off-ladder exception: abundance `--abundance #9b6cff` (never color-al
 | card-title 14 · hook 15 · rank 24 · chip 10 | — | — | role tokens |
 
 **Weight ramp:** `--weight-regular 400 / -medium 600 / -semibold 650 / -bold 700 / -heavy 800`.
-**Fonts:** `--font-ui` (system sans) · `--font-mono` (ui-monospace — timecode, tabular-nums) ·
-Georgia editorial serif (ShortMaker hook pull-quotes ONLY).
+**Fonts:** `--font-ui` (**Inter**, self-hosted) · `--font-mono` (**IBM Plex Mono** — timecode,
+tabular-nums) · `--font-editorial` (**Newsreader** — the editorial voice). All three are bundled
+OFL faces bound by `@font-face`, not system fallbacks; the binding is pinned by
+`styles/fonts.conformance.test.ts`.
+
+**The editorial serif is a SCARCE channel.** Permitted: hook pull-quotes, empty-state titles, and
+panel/modal display titles. Never: body text, labels, controls, data/timecode, or **VIEW headers**
+(all four `*-view__title` rules use `--type-title-size` in `--font-ui`; Director was the lone
+outlier until H7).
+
+This line previously read *"Georgia editorial serif (ShortMaker hook pull-quotes ONLY)"* — stale on
+both counts. The face is Newsreader, not Georgia, and the one-site limit had already been overtaken
+by 15 real uses that the conformance suite could not see, because it guarded the accent and not the
+serif (`docs/plans/v1.5/uiux-qol-audit-2026-08.md` §3.1). The rule above is the honest current one
+and is now **enforced by an allowlist** in `styles/tokens.conformance.test.ts`: a new site fails CI
+until its selector is added, so spreading the voice is a reviewed decision rather than drift.
 
 ## Spacing (4px base) & Radius
 Space: `2 / 4 / 8 / 12 / 16 / 24 / 32 / 48` (`--space-1…8`).


### PR DESCRIPTION
fix(design-system): cap the editorial serif with an allowlist, and fix the one real outlier (H7)

The audit measured `--font-editorial` in 15 places against a documented limit of
ONE, and named the actual defect in the same breath: "undetected by the
conformance suite that already guards the accent". The accent had a whole-tree
guard; the second scarce typographic channel had none, so the voice spread one
reasonable-looking commit at a time.

I did NOT strip the serif from 14 surfaces. Measured first, and the code is not
chaotic: every single site is a hook pull-quote, an empty-state title, or a
panel/modal display title. Never body text, never a control, never data. That is
a coherent editorial voice, and the DOC is the stale side of the disagreement —
it still said "Georgia" when the app self-hosts Newsreader.

ONE site is a genuine outlier, and it is the one the audit called the clearest
case. Four views define a `*-view__title`; caption.css:39, deliver.css:39 and
export.css:39 are all `--type-title-size` with NO font-family. Only
`.director-view__title` took `--font-editorial`, and only it used
`--type-display-size`. So the app's four view headers rendered in two typefaces at
two scales for no reason a user could infer. Aligned with its three siblings.
View chrome is the one place this voice does not belong.

THE GUARD (the audit's real ask)

`tokens.conformance.test.ts` now caps the serif with an ALLOWLIST, not a count:
a new site fails until its selector is added, which turns silent drift into a
reviewed decision. A count would let a swap through unnoticed.

Four tests, and the negative directions are covered deliberately:
  * a detector-control test — the scan finds >20 sheets AND at least one real
    use, so its silence cannot be vacuous;
  * every use is allowlisted, and the failure message names the offender, the
    file, and the rule;
  * NO DEAD ENTRIES — an allowlisted selector that no longer sets the serif is
    stale permission, and stale permission is how an allowlist rots into a rubber
    stamp;
  * no `*-view__title` uses it, pinned separately so re-adding
    `.director-view__title` to the allowlist cannot quietly re-open H7.

Comments are stripped before matching, so a selector quoted inside a comment
cannot register as a real use (use-vs-mention).

Mutation-tested rather than assumed: adding `font-family: var(--font-editorial)`
to `.deliver-view__title` fails BOTH the allowlist test and the view-header test,
each naming `.deliver-view__title`. Reverted after measuring.

DOC

`docs/design-system.md` now states the rule that is actually true and enforced,
and corrects the font names: Inter / IBM Plex Mono / Newsreader, all bundled OFL
faces, not the system-sans / ui-monospace / Georgia the line still claimed.

Verified: styles + Director suites 52 passed; tokens.conformance 36 passed;
tsc --noEmit clean; biome 2.5.0 clean.
