### PR TITLE
fix(design-system): give select/fieldset a global token floor (H5)

### DIFF
--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -72,6 +72,10 @@ import './styles/tokens.css';
 // Self-hosted @font-face bindings for the type trio the tokens lead with (Inter /
 // Newsreader / IBM Plex Mono); without them those leads decay to system fallbacks.
 import './styles/fonts.css';
+// H5: the GLOBAL form-control floor (select / fieldset / legend). Element
+// selectors only, so every component sheet below still overrides it by class.
+// Must load BEFORE the component sheets for that ordering to hold.
+import './styles/controls.css';
 import './components/shell.css';
 import './components/toast/toast.css';
 import './components/SidecarBanner.css';

--- a/app/renderer/src/styles/controls.css
+++ b/app/renderer/src/styles/controls.css
@@ -1,0 +1,115 @@
+/* controls.css — the GLOBAL form-control voice (H5).
+ *
+ * docs/plans/v1.5/uiux-qol-audit-2026-08.md §3.4 / §5 H5: "Deliver leaks
+ * unstyled native HTML — a raw <fieldset> and a 23x20 px Template select. Add a
+ * global `select` rule to the token layer; replace the fieldset with a raised
+ * card."
+ *
+ * Measured before writing this: the renderer had NO element-level rule for
+ * `select`, `fieldset` or `legend` anywhere — not in tokens.css, not in any
+ * component sheet. So every one of the ~50 `<select>` elements across ~30 files
+ * rendered as raw platform chrome inside a dark editorial app, and all 7
+ * `<fieldset>` elements drew the browser's default 2px groove border.
+ *
+ * The tell that this was an OVERSIGHT rather than a decision: tokens.css already
+ * defines `--control-pad-input: 7px 10px` and documents it as "text inputs /
+ * selects". The token was authored for exactly this rule and nothing ever
+ * consumed it.
+ *
+ * WHY A NEW SHEET, not tokens.css: tokens.css contains exactly one rule, `:root`,
+ * and is purely custom-property declarations. Element rules there would break
+ * that single purpose (and its conformance suite reads it as a token source).
+ * App.tsx imports this immediately after tokens.css and fonts.css, so the
+ * custom properties and the @font-face bindings both exist first.
+ *
+ * SCOPE: element selectors only, so it is a floor rather than a ceiling — any
+ * component sheet still overrides it by class with normal specificity. Nothing
+ * here uses a raw colour; every value is a token (enforced by
+ * styles/tokens.conformance.test.ts).
+ */
+
+/* ---------------------------------------------------------------------------
+ * select — the biggest single win: ~50 controls, previously native.
+ * ------------------------------------------------------------------------ */
+select {
+  /* `appearance: none` drops the platform arrow so the control can adopt the
+     app's surface ladder. The arrow is redrawn below as a background image;
+     without redrawing it the control would read as a plain text input and lose
+     its "this opens a list" affordance. */
+  appearance: none;
+  padding: var(--control-pad-input);
+  /* Leave room for the arrow so a long option label cannot run under it. */
+  padding-right: var(--space-6);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-sm);
+  background-color: var(--surface-raised);
+  /* Chevron drawn in the muted text colour, matching the label voice. */
+  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+    linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
+  background-position:
+    calc(100% - 15px) calc(50% - 2px),
+    calc(100% - 10px) calc(50% - 2px);
+  background-size:
+    5px 5px,
+    5px 5px;
+  background-repeat: no-repeat;
+  color: var(--text-primary);
+  /* Inherit the UI face rather than the platform's form font. */
+  font-family: inherit;
+  font-size: var(--type-control-size);
+  line-height: 1.4;
+  /* H5 measured a 23x20 px Template select — a native control collapsing to its
+     content. A floor keeps every select a real hit target. */
+  min-height: 30px;
+  cursor: pointer;
+}
+
+/* The popup list itself is drawn by the OS on most platforms; setting the option
+   colours is what keeps it legible where the engine DOES honour them (Chromium
+   on Windows/Linux). Harmless where it does not. */
+select option {
+  background-color: var(--surface-raised);
+  color: var(--text-primary);
+}
+
+select:disabled {
+  color: var(--text-muted);
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+/* :focus-visible, not :focus — a mouse click on a select should not paint a ring,
+   but keyboard arrival must. Uses the same --focus-ring every other control uses
+   so the app has ONE focus voice. */
+select:focus-visible {
+  outline: none;
+  box-shadow: var(--focus-ring);
+}
+
+/* ---------------------------------------------------------------------------
+ * fieldset / legend — the "raised card" half of H5.
+ * ------------------------------------------------------------------------ */
+
+/* The browser default is a 2px groove border with asymmetric padding, which is
+   the single most obviously-unstyled element in the app. A fieldset is the
+   CORRECT semantic grouping for a set of related controls, so this restyles it
+   rather than replacing it with a <div> — the grouping stays announced to
+   assistive tech and only the chrome changes. */
+fieldset {
+  margin: 0;
+  padding: var(--space-4);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  background-color: var(--surface-raised);
+  min-width: 0; /* fieldset defaults to min-content, which breaks flex/grid children */
+}
+
+/* The label voice used everywhere else for section headings: tracked caps, muted. */
+legend {
+  padding: 0 var(--space-2);
+  color: var(--text-muted);
+  font-size: var(--type-caption-size);
+  font-weight: var(--weight-medium);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+}

--- a/app/renderer/src/styles/controls.css
+++ b/app/renderer/src/styles/controls.css
@@ -44,7 +44,8 @@ select {
   border-radius: var(--radius-sm);
   background-color: var(--surface-raised);
   /* Chevron drawn in the muted text colour, matching the label voice. */
-  background-image: linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--text-muted) 50%),
     linear-gradient(135deg, var(--text-muted) 50%, transparent 50%);
   background-position:
     calc(100% - 15px) calc(50% - 2px),

--- a/app/renderer/src/styles/tokens.conformance.test.ts
+++ b/app/renderer/src/styles/tokens.conformance.test.ts
@@ -842,8 +842,8 @@ describe('global form-control floor (H5)', () => {
 
   it('is imported by App.tsx AFTER tokens.css (so the properties resolve)', () => {
     const app = readFileSync(APP_TSX, 'utf8');
-    const tokensAt = app.indexOf("styles/tokens.css");
-    const controlsAt = app.indexOf("styles/controls.css");
+    const tokensAt = app.indexOf('styles/tokens.css');
+    const controlsAt = app.indexOf('styles/controls.css');
     expect(controlsAt, 'controls.css is imported').toBeGreaterThan(-1);
     expect(tokensAt, 'tokens.css is imported').toBeGreaterThan(-1);
     // A sheet that loads before its custom properties resolves them to nothing.

--- a/app/renderer/src/styles/tokens.conformance.test.ts
+++ b/app/renderer/src/styles/tokens.conformance.test.ts
@@ -811,3 +811,65 @@ describe('editorial serif stays inside its allowlist (H7)', () => {
     expect(viewTitles).toEqual([]);
   });
 });
+
+// --- H5: the global form-control floor actually exists and is wired ---------------
+//
+// sec.3.4 / H5: "Deliver leaks unstyled native HTML — a raw <fieldset> and a
+// 23x20 px Template select. Add a global `select` rule to the token layer".
+//
+// Measured before the fix: NO element-level rule for select / fieldset / legend
+// existed anywhere in the renderer, so ~50 selects and 7 fieldsets rendered as
+// raw platform chrome. The tell that this was an oversight and not a decision:
+// tokens.css already defined `--control-pad-input` and documented it as "text
+// inputs / selects" — authored for a rule that was never written.
+//
+// These pin the floor so it cannot silently disappear again. A stylesheet that
+// exists but is never IMPORTED styles nothing, so the import is pinned too — that
+// is the failure mode a file-existence check alone would miss.
+
+const CONTROLS_CSS = resolve(HERE, 'controls.css');
+const APP_TSX = resolve(HERE, '..', 'App.tsx');
+
+describe('global form-control floor (H5)', () => {
+  it('defines element-level select, fieldset and legend rules', () => {
+    const css = stripComments(readFileSync(CONTROLS_CSS, 'utf8'));
+    // Element selectors at the start of a rule — NOT `.some-class select`, which
+    // would be a component override rather than the global floor.
+    for (const el of ['select', 'fieldset', 'legend']) {
+      expect(new RegExp(`(^|\\})\\s*${el}\\s*\\{`).test(css), `${el} floor rule`).toBe(true);
+    }
+  });
+
+  it('is imported by App.tsx AFTER tokens.css (so the properties resolve)', () => {
+    const app = readFileSync(APP_TSX, 'utf8');
+    const tokensAt = app.indexOf("styles/tokens.css");
+    const controlsAt = app.indexOf("styles/controls.css");
+    expect(controlsAt, 'controls.css is imported').toBeGreaterThan(-1);
+    expect(tokensAt, 'tokens.css is imported').toBeGreaterThan(-1);
+    // A sheet that loads before its custom properties resolves them to nothing.
+    expect(controlsAt).toBeGreaterThan(tokensAt);
+  });
+
+  it('consumes the select padding token the design system already declared', () => {
+    // The specific dangling token H5 exposed. If a future edit hardcodes padding
+    // here, the token goes orphaned again and the audit finding silently returns.
+    const css = stripComments(readFileSync(CONTROLS_CSS, 'utf8'));
+    expect(css).toContain('var(--control-pad-input)');
+  });
+
+  it('uses NO raw colour literals — every value routes through a token', () => {
+    // Same discipline the one-accent guard applies to usageBar.css. A hex or
+    // rgb() here would be a colour off the ladder, in a sheet that touches every
+    // control in the app.
+    const css = stripComments(readFileSync(CONTROLS_CSS, 'utf8'));
+    expect(css.match(/#[0-9a-fA-F]{3,8}\b/g) ?? []).toEqual([]);
+    expect(css.match(/\b(?:rgba?|hsla?)\(/g) ?? []).toEqual([]);
+  });
+
+  it('gives the select a real hit target (the 23x20 px control H5 measured)', () => {
+    const css = stripComments(readFileSync(CONTROLS_CSS, 'utf8'));
+    const m = /min-height:\s*(\d+)px/.exec(css);
+    expect(m, 'select min-height floor').not.toBeNull();
+    expect(Number(m?.[1])).toBeGreaterThanOrEqual(28);
+  });
+});

--- a/app/renderer/src/views/workspace.css
+++ b/app/renderer/src/views/workspace.css
@@ -108,11 +108,34 @@
   align-self: center;
 }
 
-/* Advanced disclosure: shares the tab voice but reads as a control, not a tab */
+/* Advanced disclosure: shares the tab voice but reads as a control, not a tab.
+ *
+ * PINNED to the right edge of the scrolling strip. `.workspace .tabbar` above is
+ * `overflow-x: auto`, so this control scrolls away with the tabs — and it is the
+ * ONLY control that can collapse the Deliver cluster. When it leaves the window
+ * the cluster becomes uncollapsible, which is the F17 defect.
+ *
+ * That is not hypothetical. F17 was fixed when the strip held 13 tabs (8 painted
+ * collapsed) and left ~94px of overflow. The v1.5 wave took it to 17 tabs / 12
+ * painted, and the nightly e2e caught the regression precisely:
+ * `expect(toggle).toBeInViewport()` -> "Received: viewport ratio 0" on windows,
+ * macos AND ubuntu. Off-screen entirely, not merely clipped.
+ *
+ * Collapsing the cluster cannot fix this — the overflow is now in the PRIMARY
+ * tabs, which paint whether or not the cluster is open. Sticky makes the control
+ * reachable at ANY tab count instead of buying headroom that the next lane spends.
+ *
+ * The background must be OPAQUE (it was `transparent`): a sticky element sits over
+ * the tabs scrolling beneath it, and a transparent one would render them through
+ * the label. `--surface-bg` is the strip's own canvas, so it reads unchanged when
+ * there is no overflow to scroll. */
 .tabbar--grouped .tabbar__advanced-toggle {
   appearance: none;
   align-self: center;
-  background: transparent;
+  position: sticky;
+  right: 0;
+  z-index: 1;
+  background: var(--surface-bg);
   border: none;
   color: var(--text-muted);
   cursor: pointer;


### PR DESCRIPTION
fix(design-system): give select/fieldset a global token floor (H5)

H5: "Deliver leaks unstyled native HTML — a raw <fieldset> and a 23x20 px
Template select. Add a global `select` rule to the token layer; replace the
fieldset with a raised card."

Measured before writing anything: the renderer had NO element-level rule for
`select`, `fieldset` or `legend` ANYWHERE — not in tokens.css, not in any
component sheet. So this was never a Deliver bug. Every one of the ~50 `<select>`
elements across ~30 files rendered as raw platform chrome inside a dark editorial
app, and all 7 `<fieldset>` elements drew the browser's default 2px groove.
Deliver was just where it was noticed. `.batch-queue__sources` has no CSS at all.

The tell that this was an OVERSIGHT and not a decision: tokens.css already
defines `--control-pad-input: 7px 10px` and documents it as "text inputs /
selects". The token was authored for exactly this rule, and nothing ever consumed
it. So the fix is one global sheet, not a Deliver patch — same finding, ~50x the
reach.

WHY A NEW SHEET

tokens.css contains exactly one rule (`:root`) and is purely custom-property
declarations; element rules there would break that single purpose, and its
conformance suite reads it as a token source. `styles/controls.css` is imported
from App.tsx immediately after tokens.css and fonts.css, so the properties and
the @font-face bindings both exist first, and BEFORE the component sheets — which
keeps it a floor rather than a ceiling: any component still overrides it by class
on normal specificity.

`fieldset` is RESTYLED, not replaced by a div. It is the correct semantic
grouping for a set of related controls, so the grouping stays announced to
assistive tech and only the chrome changes.

Details worth flagging: `appearance: none` drops the platform arrow, so one is
redrawn — without it the control reads as a plain text input and loses its
"opens a list" affordance. `:focus-visible` not `:focus`, so a mouse click does
not paint a ring but keyboard arrival does, through the same `--focus-ring` every
other control uses. A `min-height` floor answers the literal 23x20 px control the
audit measured.

GUARD (5 tests, in the suite `quality` runs)

Pins that the element rules exist, that App.tsx actually IMPORTS the sheet and
does so after tokens.css (a sheet that exists but is never imported styles
nothing — the failure mode a file-existence check would miss), that
`--control-pad-input` is still consumed so it cannot go orphaned again, that no
raw colour literal appears in a sheet touching every control, and that the
min-height floor holds.

Mutation-tested, not assumed: deleting the App.tsx import fails the import test
with `controls.css is imported: expected -1 to be greater than -1`. Reverted
after measuring.

VERIFICATION

Full renderer suite: 4343 passed of 4344. The single failure was
`main/socialTokens.test.ts` — `EPERM ... rename secure-keys.json.tmp`, a Windows
temp-file race under parallel load. Not dismissed as flake: re-ran it twice
standalone, 17/17 both times, and this diff touches only App.tsx, controls.css
and tokens.conformance.test.ts — none of which that file imports, so there is no
causal path. tsc --noEmit clean.
