### PR TITLE
docs(v1.5): close two decisions the plan still reads as outstanding

### DIFF
--- a/docs/plans/v1.5/PROGRAM.md
+++ b/docs/plans/v1.5/PROGRAM.md
@@ -21,9 +21,13 @@ Synthesized from: 15-agent audit + competitor redo + live visual audit. Owner gr
 - Split the 3 worst god-modules (main.ts, Services, _export_one).
 
 ### Wave 1 — Trust / distribution
-- Authenticode-signed + attested CI release pipeline (tag-triggered release.yml, pin 4 build SHA-256s, SBOM/provenance, release depends on `quality`).
-- Electron 39 (EOL) → 43 + ASAR-integrity fuses + Electronegativity CI.
+- ~~Authenticode-signed + attested CI release pipeline (tag-triggered release.yml, pin 4 build SHA-256s, SBOM/provenance, release depends on `quality`).~~
+  **REVERSED 2026-08-09 by `docs/plans/v1.5/GRILL-DECISION-QUEUE.md` §F-1:** *"Signing stays NONE (already by design). No SmartScreen concern to solve."* The absent `release.yml` is therefore CORRECT, not an outstanding item. Design docs marked SUPERSEDED.
+- Electron 39 (EOL) → 43 + ASAR-integrity fuses + Electronegativity CI. **SHIPPED** — the app runs Electron 43.
 - **Licensing swaps (mandatory per decision 1):** ViNet-S (CC-BY-NC-SA) → UNISAL (Apache-2.0); NLLB/Seamless (NC) → MADLAD-400; verify Parakeet/EdgeTAM permissive. Behind existing backend seams.
+  - **Translator: DONE, by a different model than planned.** The NC translator was replaced with **Apache-2.0 Qwen3** (tier1 Qwen3-4B / tier2 Qwen3-8B), not MADLAD-400 — the licence objective was met, the named model was not used. Recorded here so the plan stops reading as outstanding. If MADLAD-400 was wanted *specifically*, that is a new decision.
+  - **ViNet-S → UNISAL: NOT DONE, and the current state inverts the decision's purpose.** UNISAL was never integrated; instead the tree gates ViNet-S OFF for a commercial build, so a commercial build silently ships **worse crop quality** — the exact outcome decision 1 exists to prevent. Still open; the tests currently assert the un-swapped state as correct, so the suite is green *because* the swap did not happen.
+  - **Forced aligner (not in the original list):** `MahmoudAshraf/mms-300m-1130-forced-aligner` is CC-BY-NC-4.0 and was shipping **undisclosed**. Owner ruling 2026-08-09: disclose it + implement the `allowNonCommercialAligner` opt-in; do NOT swap the default.
 - **Commercialization scaffolding, BUILD-BUT-DON'T-WIRE:** licence/edition model, feature-flag gates, edition config — all dormant, no live paywall.
 
 ### Wave 2 — Full pro-shell redesign (design track, runs parallel from now)

--- a/docs/plans/v1.5/signed-release-ci.md
+++ b/docs/plans/v1.5/signed-release-ci.md
@@ -1,6 +1,15 @@
 # Reframe — Signed Release CI Pipeline Design
 
-> **Status:** DRAFT
+> **Status:** SUPERSEDED BY docs/plans/v1.5/GRILL-DECISION-QUEUE.md (2026-08-09)
+
+> **Why this is closed, not pending.** `GRILL-DECISION-QUEUE.md` §F-1 ruled
+> *"**Signing** stays NONE (already by design). No SmartScreen concern to solve."*
+> That ruling post-dates this design and reverses its premise, so the absent
+> `release.yml` is **correct** — it is not an unfinished item.
+>
+> Left in the tree deliberately rather than deleted: the threat model, the pinning
+> scheme and the SBOM/provenance work are reusable if signing is ever revisited.
+> Nothing here should be scheduled without first reversing F-1.
 
 **Repo:** `Prekzursil/Reframe` · **Verified against:** `origin/main @ 7502e3a` (fetched 2026-07-12)
 **Scope:** READ-ONLY design. No repo files changed. The owner decides local-vs-CI builds.

--- a/docs/plans/v1.5/signed-release-trust-options.md
+++ b/docs/plans/v1.5/signed-release-trust-options.md
@@ -1,6 +1,16 @@
 # Reframe Trust-Wave Plan — Auto-Updater Authenticity + Electron 39→43
 
-> **Status:** DRAFT
+> **Status:** SUPERSEDED BY docs/plans/v1.5/GRILL-DECISION-QUEUE.md (2026-08-09)
+
+> **Partly shipped, partly reversed — read before reviving either half.**
+>
+> * The **Electron 39→43** half SHIPPED. The app runs Electron 43 today.
+> * The **signing / trust** half is CLOSED by `GRILL-DECISION-QUEUE.md` §F-1:
+>   *"**Signing** stays NONE (already by design). No SmartScreen concern to solve."*
+>
+> Because the two halves diverged, this document as a whole is neither done nor
+> pending, which is exactly the state that makes a reader re-open dead work. Treat
+> the updater-authenticity sections as requiring an F-1 reversal first.
 
 **Date:** 2026-07-11
 **Repo:** `Prekzursil/Reframe` (local `C:/Users/Prekzursil/Documents/GitHub/Reframe`)


### PR DESCRIPTION
docs(v1.5): close two decisions the plan still reads as outstanding

Both are cases where PROGRAM.md promises work that a LATER ruling reversed or that
shipped by another route. Neither is a code change; both exist so the next reader does
not re-open finished or cancelled work. This is the "no drafts left unimplemented"
sweep, and the honest answer for these two is "already closed, badly recorded".

1. SIGNED RELEASE PIPELINE — reversed, not pending.

PROGRAM.md:24 lists an Authenticode-signed + attested CI release pipeline with a
tag-triggered release.yml. GRILL-DECISION-QUEUE.md:146 (F-1), which post-dates it, rules
"Signing stays NONE (already by design). No SmartScreen concern to solve."

So the MISSING release.yml is CORRECT. Verified both lines directly rather than
inheriting the claim.

signed-release-ci.md and signed-release-trust-options.md (~61 KB of design) both still
read Status: DRAFT, which is what makes them look schedulable. Both are now SUPERSEDED BY
the GRILL queue, using the closed status vocabulary docs/INDEX.md R2 defines.

Deliberately NOT deleted: the threat model, pinning scheme and SBOM/provenance work are
reusable if signing is ever revisited. The header says what would have to change first
(reverse F-1) instead of leaving a reader to guess.

signed-release-trust-options.md needed a two-part note because its halves diverged: the
Electron 39->43 half SHIPPED (the app runs 43) while the signing half was cancelled. A
document that is half-done and half-cancelled is exactly the state that gets re-opened.

2. LICENSING SWAPS — one done by another model, one NOT done and now inverted.

PROGRAM.md:26 bundles three swaps under "mandatory per decision 1". Their real states
differ sharply and the line hid that:

  * Translator: DONE, but with Apache-2.0 Qwen3 (tier1 4B / tier2 8B), NOT MADLAD-400.
    The LICENCE objective was met; the named model was not used. If MADLAD-400 was wanted
    specifically, that is a new decision, not an unfinished one.
  * ViNet-S -> UNISAL: NOT done, and the current state inverts the decision's PURPOSE.
    UNISAL was never integrated; the tree instead gates ViNet-S off for a commercial
    build, so a commercial build silently ships WORSE crop quality — precisely what
    decision 1 exists to prevent. Flagged inline as still open. Note the suite is green
    BECAUSE the swap did not happen: the tests assert the un-swapped state as correct.
  * Forced aligner: not in the original list at all, and was shipping an undisclosed
    CC-BY-NC-4.0 dependency. Owner ruling 2026-08-09: disclose + build the
    allowNonCommercialAligner opt-in, do NOT swap the default. Recorded so the licence
    programme is complete on one page.

Also marked the Electron 39->43 item SHIPPED, since it is.

VERIFIED: .quality/docs_check.py -> SUCCESS:docscheck, r1=0 r2=0 r3=0 r4=0 r5=0 across 93
authority docs and 1080 citing files. The SUPERSEDED BY status strings use the closed
vocabulary from docs/INDEX.md R2 and cite repo-relative paths per R1.
