### PR TITLE
fix(transcribe): resolve whisper to the pinned local snapshot so a CPU-only install works offline

### DIFF
--- a/sidecar/media_studio/assets/manifest.py
+++ b/sidecar/media_studio/assets/manifest.py
@@ -302,28 +302,42 @@ WHISPER_SIZE_MB = 1600
 # fabricated pin is worse than a missing one). Registering an entry named
 # CPU_WHISPER_ASSET_NAME with tier="core" is the ONLY change needed to flip
 # ``transcribe.cpu_auto_model()`` over to it — see WHISPER_MODEL_ASSETS.
+# NOTE: a core-tier registration makes the Default profile DOWNLOAD it; it is
+# still the load path (``transcribe.resolve_model_source``) that decides whether
+# the bytes are actually on disk before pointing faster-whisper at them.
 CPU_WHISPER_MODEL_ID = "small"
 CPU_WHISPER_ASSET_NAME = "whisper-small"
 
 #: faster-whisper model id -> the manifest asset name that provisions it.
 #: An id absent from this map (or mapped to an unregistered/non-Default-profile
 #: asset) can only be reached by an on-demand network download, so automatic
-#: resolution must never pick one — see :func:`provisioned_whisper_model_ids`.
+#: resolution must never pick one — see :func:`default_profile_whisper_model_ids`.
 WHISPER_MODEL_ASSETS: dict[str, str] = {
     WHISPER_MODEL_ID: WHISPER_ASSET_NAME,
     CPU_WHISPER_MODEL_ID: CPU_WHISPER_ASSET_NAME,
 }
 
 
-def provisioned_whisper_model_ids() -> frozenset[str]:
-    """faster-whisper model ids an offline install is guaranteed to have.
+def default_profile_whisper_model_ids() -> frozenset[str]:
+    """faster-whisper model ids the **Default** install profile is CONFIGURED to pull.
 
-    A model counts as provisioned only when its :data:`WHISPER_MODEL_ASSETS`
-    asset is (a) actually registered and (b) in a tier the **Default** installer
-    profile pulls (``core``). An ``optional``/``gpu`` entry is not enough: a
-    Default install never downloads it, so the first transcribe would still hit
-    the network. Derived from the live registry, so registering the CPU asset
-    later needs no further code change.
+    REGISTRY-ONLY, and deliberately named for what it computes. An id is included
+    when its :data:`WHISPER_MODEL_ASSETS` asset is (a) registered and (b) in a tier
+    ``PROFILE_TIERS["default"]`` pulls (``core``). An ``optional``/``gpu`` entry is
+    excluded because a Default install never downloads it.
+
+    THIS IS NOT AN OFFLINE GUARANTEE, and must not be read as one — an earlier
+    revision of this function was named ``provisioned_whisper_model_ids`` and
+    documented as "ids an offline install is guaranteed to have", which was false
+    in two measured states: (1) the **Minimum** profile pulls nothing at all
+    (``PROFILE_TIERS["minimum"] == ()``) and a Custom profile need not include
+    transcription, and (2) nothing here touches the disk, while the whisper
+    snapshot is explicitly excluded from the renderer's first-run completion gate
+    (``app/tests/main/firstRunGate.test.ts``), so a first run can complete with the
+    weights absent. The only honest disk-level answer is
+    :func:`media_studio.features.transcribe.whisper_snapshot_dir`, which looks in
+    the HF cache; this function answers the narrower "did we configure Default to
+    install it".
     """
     default_tiers = PROFILE_TIERS["default"]
     return frozenset(

--- a/sidecar/media_studio/assets/manifest.py
+++ b/sidecar/media_studio/assets/manifest.py
@@ -283,14 +283,55 @@ def resolve_profile(profile: str, custom: Sequence[str] | None = None) -> list[s
 # --------------------------------------------------------------------------- #
 
 WHISPER_ASSET_NAME = "whisper-large-v3-turbo"
+#: The faster-whisper model id this asset provisions (== transcribe.DEFAULT_MODEL).
+WHISPER_MODEL_ID = "large-v3-turbo"
 # §7 / transcribe.py DEFAULT_MODEL="large-v3-turbo" resolves to this CT2 repo via
 # faster-whisper; ensuring it through huggingface_hub lands in the SAME HF_HOME
 # cache faster-whisper reads, so transcribe.start finds it pre-downloaded.
-WHISPER_HF_REPO = "mobiuslabsgmbh/faster-whisper-large-v3-turbo"
+WHISPER_HF_REPO = f"mobiuslabsgmbh/faster-whisper-{WHISPER_MODEL_ID}"
 # F3c: pin the HF snapshot to a COMMIT HASH (never floating "main"). Verified via
 # the HF revision API (commit of refs/heads/main on 2026-06-28).
 WHISPER_HF_REVISION = "0a363e9161cbc7ed1431c9597a8ceaf0c4f78fcf"
 WHISPER_SIZE_MB = 1600
+
+# W01/T0: the CPU auto-path wants a materially cheaper model than the turbo
+# snapshot, but a model id is only usable OFFLINE when a registered core-tier
+# asset has put that exact snapshot in HF_HOME. These two names reserve the
+# CPU rung; the asset itself is NOT registered yet because that needs a real
+# pinned HF commit hash + verified size, which is a deliberate follow-up (a
+# fabricated pin is worse than a missing one). Registering an entry named
+# CPU_WHISPER_ASSET_NAME with tier="core" is the ONLY change needed to flip
+# ``transcribe.cpu_auto_model()`` over to it — see WHISPER_MODEL_ASSETS.
+CPU_WHISPER_MODEL_ID = "small"
+CPU_WHISPER_ASSET_NAME = "whisper-small"
+
+#: faster-whisper model id -> the manifest asset name that provisions it.
+#: An id absent from this map (or mapped to an unregistered/non-Default-profile
+#: asset) can only be reached by an on-demand network download, so automatic
+#: resolution must never pick one — see :func:`provisioned_whisper_model_ids`.
+WHISPER_MODEL_ASSETS: dict[str, str] = {
+    WHISPER_MODEL_ID: WHISPER_ASSET_NAME,
+    CPU_WHISPER_MODEL_ID: CPU_WHISPER_ASSET_NAME,
+}
+
+
+def provisioned_whisper_model_ids() -> frozenset[str]:
+    """faster-whisper model ids an offline install is guaranteed to have.
+
+    A model counts as provisioned only when its :data:`WHISPER_MODEL_ASSETS`
+    asset is (a) actually registered and (b) in a tier the **Default** installer
+    profile pulls (``core``). An ``optional``/``gpu`` entry is not enough: a
+    Default install never downloads it, so the first transcribe would still hit
+    the network. Derived from the live registry, so registering the CPU asset
+    later needs no further code change.
+    """
+    default_tiers = PROFILE_TIERS["default"]
+    return frozenset(
+        model_id
+        for model_id, asset_name in WHISPER_MODEL_ASSETS.items()
+        if (entry := get_asset(asset_name)) is not None and entry.tier in default_tiers
+    )
+
 
 QWEN_ASSET_NAME = "qwen3-4b-gguf"
 # CONTRACT-NOTE: §7 default model is "Qwen3-4B GGUF". The URL pins the exact

--- a/sidecar/media_studio/features/transcribe.py
+++ b/sidecar/media_studio/features/transcribe.py
@@ -29,13 +29,15 @@ from __future__ import annotations
 
 import os
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any, Protocol
 
+from ..assets import manager as _asset_manager
 from ..assets import manifest
 from ..util import clamp, get_logger
 from . import asr_vocabulary as _vocabulary
+from .diarize_backend import UnpinnedModelRevisionError, resolve_pinned_hf_source
 
 log = get_logger("media_studio.features.transcribe")
 
@@ -87,18 +89,116 @@ def cpu_auto_model() -> str:
     CPU/int8, so it is the model we *want* here. But Reframe is offline-first and
     faster-whisper only avoids a network round-trip when that exact snapshot is
     already in ``HF_HOME`` — which only a registered, Default-profile manifest
-    asset puts there. Today the ONLY provisioned whisper snapshot is
-    ``large-v3-turbo`` (``assets.manifest._register_day1``), so auto-resolving
+    asset puts there. Today the only whisper snapshot the Default profile installs
+    is ``large-v3-turbo`` (``assets.manifest._register_day1``), so auto-resolving
     ``small`` made a CPU-only user's FIRST transcribe an unpinned download that
     fails outright with no network.
 
-    So: prefer the cheap CPU model when — and only when — the manifest actually
-    provisions it, else stay on the provisioned turbo snapshot. A user who
+    So: prefer the cheap CPU model when — and only when — the Default profile is
+    configured to install it, else stay on the turbo snapshot. A user who
     knowingly accepts a download can still force any id via ``transcribeModel``.
+
+    SCOPE, stated precisely because the earlier wording overclaimed: this is a
+    REGISTRY decision, not a disk guarantee. Whether the chosen id is actually
+    resolvable offline is decided later, per load, by :func:`resolve_model_source`.
     """
-    if manifest.CPU_WHISPER_MODEL_ID in manifest.provisioned_whisper_model_ids():
+    if manifest.CPU_WHISPER_MODEL_ID in manifest.default_profile_whisper_model_ids():
         return manifest.CPU_WHISPER_MODEL_ID
     return DEFAULT_MODEL
+
+
+#: Locates the on-disk dir of a PINNED HF snapshot: ``(repo_id, revision,
+#: env_vars) -> dir | None``. A seam so the offline-resolution logic is testable
+#: against a real temp cache without huggingface_hub or 1.6 GB of weights.
+SnapshotLocator = Callable[..., str | None]
+
+
+def default_snapshot_locator(*, repo_id: str, revision: str, env_vars: Mapping[str, str] | None = None) -> str | None:
+    """The local dir of ``repo_id`` at ``revision``, or ``None`` when absent.
+
+    Reads the SAME cache layout ``assets.ensure`` writes —
+    ``<HF cache>/models--<org>--<name>/snapshots/<commit>`` — through the asset
+    manager's env-derived cache resolver. Deliberately a plain filesystem probe:
+    it needs no ``huggingface_hub`` import, never touches the network, and cannot
+    be defeated by a missing ``refs/`` entry (which is exactly the failure this
+    whole function exists to route around — see :func:`resolve_model_source`).
+    """
+    snapshot = _asset_manager.hf_repo_dir(repo_id, env_vars) / "snapshots" / revision
+    if snapshot.is_dir() and any(snapshot.iterdir()):
+        return str(snapshot)
+    return None
+
+
+def whisper_snapshot_dir(
+    model: str,
+    *,
+    locator: SnapshotLocator = default_snapshot_locator,
+    env_vars: Mapping[str, str] | None = None,
+) -> str | None:
+    """Local dir holding ``model`` at its REGISTERED commit pin, or ``None``.
+
+    The honest disk-level answer to "can this model load offline". ``None`` means
+    either the manifest does not map the id to an asset, the asset is not
+    registered / not pinned to a 40-hex commit, or the pinned snapshot is simply
+    not on this machine (a Minimum-profile install, a cancelled first run, a
+    manually cleared HF cache).
+    """
+    asset_name = manifest.WHISPER_MODEL_ASSETS.get(model)
+    if asset_name is None:
+        return None
+    entry = manifest.get_asset(asset_name)
+    if entry is None:
+        return None
+    try:
+        repo, revision = resolve_pinned_hf_source(asset_name, str(entry.hf_repo or ""))
+    except UnpinnedModelRevisionError as exc:
+        log.warning("whisper asset %s is not usable as a pinned source: %s", asset_name, exc)
+        return None
+    return locator(repo_id=repo, revision=revision, env_vars=env_vars)
+
+
+def resolve_model_source(
+    model: str,
+    *,
+    locator: SnapshotLocator = default_snapshot_locator,
+    env_vars: Mapping[str, str] | None = None,
+) -> str:
+    """What to hand faster-whisper for ``model``: a local snapshot DIR, else the id.
+
+    W01/T0 second half — the part a bare "resolve the CPU path to the provisioned
+    model" does NOT fix. ``WhisperModel("<id>")`` funnels into
+    ``huggingface_hub.snapshot_download(repo)`` with the DEFAULT revision
+    ``"main"``. ``assets.ensure`` installs by 40-hex commit pin, and
+    ``huggingface_hub`` writes ``refs/<revision>`` only when the requested
+    revision differs from the resolved commit hash
+    (``file_download._cache_commit_hash_for_specific_revision``), so a pin-installed
+    repo has NO ``refs/main``. Offline, ``_snapshot_download`` resolves a cached
+    snapshot only from a commit-hash revision or an existing ``refs/<revision>``
+    and otherwise raises ``LocalEntryNotFoundError`` — i.e. the weights are on
+    disk and the loader still fails. MEASURED against huggingface_hub 1.22.0 with
+    a pin-shaped cache: ``revision="main"`` and the bare default both raise, while
+    ``revision=<pin>`` resolves (``sidecar/tests/e2e/test_whisper_offline_e2e.py``).
+
+    ``WhisperModel`` takes a DIRECTORY as well as an id (it short-circuits on
+    ``os.path.isdir``), so handing it the pinned snapshot dir skips hub resolution
+    altogether. That also closes a second hole: the id path resolved whatever
+    ``main`` points at TODAY, not the commit the manifest verified — the same
+    unpinned-runtime-load class WU-S5 fixed for the SpeechBrain/Parakeet backends.
+
+    Falls back to the bare id (a network resolve, which fails loudly offline) when
+    no pinned snapshot is on disk — an explicitly user-forced ``transcribeModel``,
+    or an install profile that never downloaded whisper at all.
+    """
+    snapshot = whisper_snapshot_dir(model, locator=locator, env_vars=env_vars)
+    if snapshot is None:
+        log.warning(
+            "no pinned local snapshot for whisper model %r; faster-whisper will resolve it "
+            "over the network (this FAILS offline). Install the transcription asset to fix.",
+            model,
+        )
+        return model
+    log.info("resolved whisper model %r to pinned local snapshot %s", model, snapshot)
+    return snapshot
 
 
 #: the settings key picking the transcribe device (``auto`` | ``cuda`` | ``cpu``).
@@ -178,7 +278,10 @@ class FasterWhisperLoader:
         # Local import keeps the seam mockable and the module import-light.
         from faster_whisper import WhisperModel as _WhisperModel  # type: ignore
 
-        built = _WhisperModel(model, device=device, compute_type=compute_type)
+        # W01/T0: hand faster-whisper the PINNED local snapshot dir when we have
+        # one. Passing the bare id makes it ask the hub for revision "main", which
+        # a pin-installed cache cannot resolve offline (see resolve_model_source).
+        built = _WhisperModel(resolve_model_source(model), device=device, compute_type=compute_type)
         self._cache[key] = built
         return built
 

--- a/sidecar/media_studio/features/transcribe.py
+++ b/sidecar/media_studio/features/transcribe.py
@@ -33,6 +33,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Protocol
 
+from ..assets import manifest
 from ..util import clamp, get_logger
 from . import asr_vocabulary as _vocabulary
 
@@ -77,10 +78,28 @@ DEFAULT_DEVICE = "cuda"
 DEFAULT_GPU_COMPUTE = "float16"
 CPU_DEVICE = "cpu"
 CPU_COMPUTE = "int8"
-#: CPU-appropriate model: ``large-v3-turbo`` is impractically slow on CPU/int8.
-#: ``small`` is the sweet spot — multilingual, ~10x faster than large on CPU, and
-#: still good quality. Chosen as the auto CPU default; overridable via settings.
-CPU_MODEL = "small"
+
+
+def cpu_auto_model() -> str:
+    """The whisper model the CPU auto-path resolves to (W01/T0).
+
+    A smaller model (``small``) is materially cheaper than ``large-v3-turbo`` on
+    CPU/int8, so it is the model we *want* here. But Reframe is offline-first and
+    faster-whisper only avoids a network round-trip when that exact snapshot is
+    already in ``HF_HOME`` — which only a registered, Default-profile manifest
+    asset puts there. Today the ONLY provisioned whisper snapshot is
+    ``large-v3-turbo`` (``assets.manifest._register_day1``), so auto-resolving
+    ``small`` made a CPU-only user's FIRST transcribe an unpinned download that
+    fails outright with no network.
+
+    So: prefer the cheap CPU model when — and only when — the manifest actually
+    provisions it, else stay on the provisioned turbo snapshot. A user who
+    knowingly accepts a download can still force any id via ``transcribeModel``.
+    """
+    if manifest.CPU_WHISPER_MODEL_ID in manifest.provisioned_whisper_model_ids():
+        return manifest.CPU_WHISPER_MODEL_ID
+    return DEFAULT_MODEL
+
 
 #: the settings key picking the transcribe device (``auto`` | ``cuda`` | ``cpu``).
 TRANSCRIBE_DEVICE_KEY = "transcribeDevice"
@@ -242,8 +261,8 @@ def resolve_transcribe_target(
         detection; == ``"cpu"`` -> force CPU (``int8``); anything else (``auto``,
         a typo, a non-string) -> :func:`detect_device`.
       * the model defaults to the device-appropriate auto model (large turbo on
-        GPU, :data:`CPU_MODEL` on CPU) and is overridden only by an explicit,
-        non-empty string ``transcribeModel``.
+        GPU, :func:`cpu_auto_model` on CPU) and is overridden only by an
+        explicit, non-empty string ``transcribeModel``.
 
     Returning the resolved triple lets the caller pass it straight into
     :func:`transcribe_file` (whose ``model``/``device``/``compute_type`` params
@@ -261,7 +280,7 @@ def resolve_transcribe_target(
     else:  # "auto" / unknown / non-string -> detect
         device, compute = detect_device(probe=probe)
 
-    model = DEFAULT_MODEL if device == DEFAULT_DEVICE else CPU_MODEL
+    model = DEFAULT_MODEL if device == DEFAULT_DEVICE else cpu_auto_model()
     model_raw = settings.get(TRANSCRIBE_MODEL_KEY)
     if isinstance(model_raw, str):
         trimmed = model_raw.strip()

--- a/sidecar/tests/e2e/test_whisper_offline_e2e.py
+++ b/sidecar/tests/e2e/test_whisper_offline_e2e.py
@@ -1,0 +1,114 @@
+"""E2E: the whisper offline-resolution mechanism, against the REAL huggingface_hub.
+
+This is the BOTH-STATES proof behind ``transcribe.resolve_model_source``. The
+blocking gate cannot host it: ``huggingface_hub`` is deliberately not installed
+there (quality.yml installs the sidecar with ``--no-deps``), so an unconditional
+import would break CI. The e2e leg DOES install it (e2e.yml), and the unit suite
+covers the same resolution logic hermetically in ``tests/test_transcribe.py``.
+
+No network is involved: every call passes ``local_files_only=True``, so this is a
+pure filesystem + cache-layout assertion.
+
+WHAT IT PROVES
+--------------
+``assets.ensure`` installs the whisper snapshot by 40-hex COMMIT PIN
+(``manager._install_hf`` -> ``snapshot_download(revision=<sha>)``).
+huggingface_hub writes ``refs/<revision>`` only when the requested revision
+differs from the resolved commit hash
+(``file_download._cache_commit_hash_for_specific_revision``), so a pin-installed
+repo has NO ``refs/main``.
+
+* BROKEN state — what ``WhisperModel("large-v3-turbo")`` does: faster-whisper
+  calls ``snapshot_download(repo)`` with the default revision ``"main"``. Offline
+  that resolves only from a commit-hash revision or an existing ``refs/<rev>``,
+  so it raises ``LocalEntryNotFoundError`` **even though the weights are on
+  disk**. A probe that did not fire here would be measuring nothing.
+* FIXED state — asking for the pin, or handing over the snapshot directory,
+  resolves with no network.
+"""
+
+from __future__ import annotations
+
+import pytest
+from media_studio.assets import manifest
+from media_studio.features import transcribe
+
+pytestmark = pytest.mark.e2e
+
+
+def _pin_shaped_cache(root, repo: str, revision: str):
+    """Exactly the layout ``snapshot_download(revision=<pin>)`` leaves behind.
+
+    DELIBERATELY a second, independent copy of the same helper in
+    ``tests/test_transcribe.py`` rather than an import. The unit suite's value
+    rests on that hand-built layout being the real one; if both suites read the
+    same helper, a wrong layout would be wrong in both and this file would stop
+    being a check on the unit file's premise.
+    """
+    snap = root / ("models--" + repo.replace("/", "--")) / "snapshots" / revision
+    snap.mkdir(parents=True)
+    (snap / "model.bin").write_bytes(b"ct2-weights")
+    (snap / "config.json").write_text("{}")
+    (snap / "tokenizer.json").write_text("{}")
+    return snap
+
+
+def _whisper_pin() -> tuple[str, str]:
+    entry = manifest.get_asset(manifest.WHISPER_ASSET_NAME)
+    assert entry is not None, "the whisper asset must be registered"
+    assert entry.hf_repo and entry.hf_revision
+    return entry.hf_repo, entry.hf_revision
+
+
+# huggingface_hub snapshots ``HF_HUB_CACHE`` into ``constants`` at IMPORT time, so
+# monkeypatching the env after import does NOT redirect it — measured: a run that
+# only set the env var read the author's real D: cache and the "broken state"
+# probe silently passed. Every call below therefore passes ``cache_dir=`` explicitly.
+# (``transcribe.default_snapshot_locator`` reads the env per call, which is why the
+# ``ours`` side of the comparison is env-driven.)
+
+
+def test_bare_model_id_cannot_resolve_a_pin_installed_cache_offline(tmp_path):
+    """BROKEN state: the revision faster-whisper asks for is unresolvable offline."""
+    from huggingface_hub import snapshot_download
+    from huggingface_hub.errors import LocalEntryNotFoundError
+
+    repo, revision = _whisper_pin()
+    snap = _pin_shaped_cache(tmp_path, repo, revision)
+    assert not (snap.parent.parent / "refs").exists()
+
+    # The exact call shape faster_whisper.utils.download_model makes: no revision.
+    with pytest.raises(LocalEntryNotFoundError):
+        snapshot_download(repo, cache_dir=str(tmp_path), local_files_only=True)
+    # And the explicit default it stands in for.
+    with pytest.raises(LocalEntryNotFoundError):
+        snapshot_download(repo, revision="main", cache_dir=str(tmp_path), local_files_only=True)
+
+
+def test_the_pinned_revision_resolves_the_same_cache_offline(tmp_path):
+    """FIXED state: same bytes, same offline mode, resolvable via the pin."""
+    from huggingface_hub import snapshot_download
+
+    repo, revision = _whisper_pin()
+    snap = _pin_shaped_cache(tmp_path, repo, revision)
+
+    resolved = snapshot_download(repo, revision=revision, cache_dir=str(tmp_path), local_files_only=True)
+    assert (type(snap)(resolved)).resolve() == snap.resolve()
+
+
+def test_resolve_model_source_agrees_with_huggingface_hub(tmp_path, monkeypatch):
+    """Our filesystem locator returns the SAME dir huggingface_hub resolves.
+
+    This is what makes the hermetic unit tests trustworthy: the layout they
+    hand-build is the layout the real library reads.
+    """
+    from huggingface_hub import snapshot_download
+
+    repo, revision = _whisper_pin()
+    _pin_shaped_cache(tmp_path, repo, revision)
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path))
+
+    ours = transcribe.resolve_model_source(manifest.WHISPER_MODEL_ID)
+    theirs = snapshot_download(repo, revision=revision, cache_dir=str(tmp_path), local_files_only=True)
+    assert ours != manifest.WHISPER_MODEL_ID  # not the bare id
+    assert (type(tmp_path)(ours)).resolve() == (type(tmp_path)(theirs)).resolve()

--- a/sidecar/tests/test_transcribe.py
+++ b/sidecar/tests/test_transcribe.py
@@ -14,6 +14,7 @@ from typing import Any
 
 import pytest
 from media_studio import protocol
+from media_studio.assets import manifest
 from media_studio.features import transcribe
 from media_studio.jobs import JobRegistry
 from media_studio.protocol import RpcContext, RpcError
@@ -787,8 +788,76 @@ def test_resolve_target_auto_cpu_uses_cpu_model():
     model, device, compute = transcribe.resolve_transcribe_target({}, probe=lambda: False)
     assert device == transcribe.CPU_DEVICE
     assert compute == transcribe.CPU_COMPUTE
-    assert model == transcribe.CPU_MODEL
-    assert model != transcribe.DEFAULT_MODEL
+    assert model == transcribe.cpu_auto_model()
+
+
+# --------------------------------------------------------------------------- #
+# T0 — a CPU-only install must auto-resolve to a PROVISIONED whisper model.
+#
+# Reframe is offline-first: faster-whisper only finds a model without a network
+# round-trip when that exact snapshot is already in HF_HOME, and the ONLY thing
+# that puts one there is a registered core-tier manifest asset. Auto-resolving an
+# id that no asset provisions turns a CPU user's FIRST transcribe into an
+# unpinned download that fails outright offline.
+# --------------------------------------------------------------------------- #
+def test_provisioned_whisper_model_ids_is_turbo_only_today():
+    ids = manifest.provisioned_whisper_model_ids()
+    assert ids == frozenset({manifest.WHISPER_MODEL_ID})
+    # The faster CPU model is KNOWN but NOT provisioned (no pinned asset yet).
+    assert manifest.CPU_WHISPER_MODEL_ID not in ids
+
+
+def test_cpu_auto_model_is_backed_by_a_provisioned_manifest_asset():
+    model, device, _ = transcribe.resolve_transcribe_target({}, probe=lambda: False)
+    assert device == transcribe.CPU_DEVICE
+    assert model in manifest.provisioned_whisper_model_ids()
+
+
+def test_transcribe_with_engine_cpu_loads_a_provisioned_model():
+    loader = FakeLoader(_two_segment_model())
+    transcribe.transcribe_with_engine("/v.mp4", loader=loader, settings={}, detect_probe=lambda: False)
+    (loaded_model, loaded_device, _compute) = loader.loads[0]
+    assert loaded_device == transcribe.CPU_DEVICE
+    assert loaded_model in manifest.provisioned_whisper_model_ids()
+
+
+def _register_cpu_whisper(tier: str) -> None:
+    """Register a stand-in CPU whisper asset (test double; dummy revision)."""
+    manifest.register_asset(
+        manifest.AssetEntry(
+            name=manifest.CPU_WHISPER_ASSET_NAME,
+            kind="model",
+            size_mb=500,
+            label="Whisper small (CPU)",
+            tier=tier,
+            why="test double",
+            installer="hf",
+            hf_repo=f"Systran/faster-whisper-{manifest.CPU_WHISPER_MODEL_ID}",
+            hf_revision="0" * 40,
+        )
+    )
+
+
+def test_cpu_auto_model_prefers_small_once_a_core_asset_provisions_it():
+    snapshot = manifest.registry_snapshot()
+    try:
+        _register_cpu_whisper("core")
+        assert transcribe.cpu_auto_model() == manifest.CPU_WHISPER_MODEL_ID
+        model, _, _ = transcribe.resolve_transcribe_target({}, probe=lambda: False)
+        assert model == manifest.CPU_WHISPER_MODEL_ID
+    finally:
+        manifest.registry_restore(snapshot)
+
+
+def test_cpu_auto_model_ignores_a_non_default_profile_cpu_asset():
+    # "optional" is NOT pulled by the Default installer profile, so a CPU-only
+    # user would still have no snapshot on disk -> auto must not select it.
+    snapshot = manifest.registry_snapshot()
+    try:
+        _register_cpu_whisper("optional")
+        assert transcribe.cpu_auto_model() == transcribe.DEFAULT_MODEL
+    finally:
+        manifest.registry_restore(snapshot)
 
 
 def test_resolve_target_explicit_device_cpu_override_skips_probe():
@@ -801,7 +870,7 @@ def test_resolve_target_explicit_device_cpu_override_skips_probe():
     model, device, compute = transcribe.resolve_transcribe_target({"transcribeDevice": "cpu"}, probe=probe)
     assert device == transcribe.CPU_DEVICE
     assert compute == transcribe.CPU_COMPUTE
-    assert model == transcribe.CPU_MODEL
+    assert model == transcribe.cpu_auto_model()
     assert probed["n"] == 0
 
 
@@ -822,7 +891,7 @@ def test_resolve_target_unknown_device_value_falls_back_to_auto():
     model, device, compute = transcribe.resolve_transcribe_target({"transcribeDevice": "gpu-9000"}, probe=lambda: False)
     assert device == transcribe.CPU_DEVICE
     assert compute == transcribe.CPU_COMPUTE
-    assert model == transcribe.CPU_MODEL
+    assert model == transcribe.cpu_auto_model()
 
 
 def test_resolve_target_non_string_device_value_falls_back_to_auto():
@@ -837,7 +906,7 @@ def test_transcribe_with_engine_no_cuda_loads_cpu_int8_only():
     loader = FakeLoader(_two_segment_model())
     t = transcribe.transcribe_with_engine("/v.mp4", loader=loader, settings={}, detect_probe=lambda: False)
     assert len(t["segments"]) == 2
-    assert loader.loads == [(transcribe.CPU_MODEL, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+    assert loader.loads == [(transcribe.cpu_auto_model(), transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
 
 
 def test_transcribe_with_engine_cuda_loads_gpu_default():
@@ -854,7 +923,7 @@ def test_transcribe_with_engine_settings_device_override():
         settings={"transcribeDevice": "cpu"},
         detect_probe=lambda: True,
     )
-    assert loader.loads == [(transcribe.CPU_MODEL, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+    assert loader.loads == [(transcribe.cpu_auto_model(), transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
 
 
 def test_transcribe_with_engine_parakeet_degrade_uses_resolved_cpu_target():
@@ -870,7 +939,7 @@ def test_transcribe_with_engine_parakeet_degrade_uses_resolved_cpu_target():
         parakeet_runner=empty_parakeet,
         detect_probe=lambda: False,
     )
-    assert loader.loads == [(transcribe.CPU_MODEL, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+    assert loader.loads == [(transcribe.cpu_auto_model(), transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
 
 
 def test_default_cuda_probe_is_callable_and_safe():
@@ -931,7 +1000,7 @@ def test_resolve_target_empty_model_string_keeps_auto_model():
     # An empty/whitespace transcribeModel is ignored -> the auto model stands
     # (covers the falsy-trimmed short-circuit branch).
     model, device, _ = transcribe.resolve_transcribe_target({"transcribeModel": "   "}, probe=lambda: False)
-    assert model == transcribe.CPU_MODEL
+    assert model == transcribe.cpu_auto_model()
     assert device == transcribe.CPU_DEVICE
 
 

--- a/sidecar/tests/test_transcribe.py
+++ b/sidecar/tests/test_transcribe.py
@@ -9,7 +9,10 @@ wiring are covered without any heavy-ML import.
 
 from __future__ import annotations
 
+import contextlib
 import threading
+from collections.abc import Iterator
+from pathlib import Path
 from typing import Any
 
 import pytest
@@ -546,14 +549,22 @@ class _FakeFasterWhisperModel:
 
 
 @pytest.fixture()
-def _stub_faster_whisper(monkeypatch):
-    """Install a fake ``faster_whisper`` module so .load() never downloads."""
+def _stub_faster_whisper(monkeypatch, tmp_path):
+    """Install a fake ``faster_whisper`` module so .load() never downloads.
+
+    Also points the HF cache at an EMPTY tmp dir. ``load()`` now runs
+    ``resolve_model_source``, which reads the real cache location from the
+    environment — without this the result would depend on whether the developer's
+    machine happens to have the 1.6 GB turbo snapshot (it does on the author's
+    box, which is how this hazard was found).
+    """
     _FakeFasterWhisperModel.instances = []
     fake_mod = types.ModuleType("faster_whisper")
     fake_mod.WhisperModel = _FakeFasterWhisperModel  # type: ignore[attr-defined]
     monkeypatch.setitem(sys.modules, "faster_whisper", fake_mod)
     # Don't let the Windows CUDA-DLL hook fire on real sys.path during this test.
     monkeypatch.setattr(transcribe, "_register_cuda_dll_dirs", lambda: None)
+    monkeypatch.setenv("HF_HUB_CACHE", str(tmp_path / "empty-hf-cache"))
     return fake_mod
 
 
@@ -584,6 +595,150 @@ def test_faster_whisper_loader_release_drops_cache(_stub_faster_whisper):
     rebuilt = loader.load("large-v3-turbo", "cuda", "float16")
     assert rebuilt is not first
     assert len(_FakeFasterWhisperModel.instances) == 2
+
+
+# --------------------------------------------------------------------------- #
+# T0 (second half) — the OFFLINE resolution path.
+#
+# Resolving the CPU auto-path to the installed model id is NOT sufficient:
+# ``WhisperModel("<id>")`` asks huggingface_hub for revision "main", and a cache
+# populated by ``assets.ensure`` (which installs by 40-hex commit pin) has NO
+# ``refs/main``, so the offline lookup raises LocalEntryNotFoundError even though
+# the weights are right there. These tests build the pin-shaped cache on a real
+# filesystem and assert we hand faster-whisper the snapshot DIRECTORY instead.
+#
+# The mechanism itself is proved against the real huggingface_hub (both states:
+# "main" raises, the pin resolves) in tests/e2e/test_whisper_offline_e2e.py; that
+# leg is e2e-marked because huggingface_hub is deliberately NOT installed in the
+# blocking gate env.
+# --------------------------------------------------------------------------- #
+def _pin_shaped_cache(root, repo: str, revision: str):
+    """A cache exactly as ``snapshot_download(revision=<pin>)`` leaves it.
+
+    snapshots/<pin>/ with content, and NO refs/ dir — huggingface_hub writes
+    ``refs/<revision>`` only when the requested revision differs from the commit
+    hash it resolved to (file_download._cache_commit_hash_for_specific_revision).
+    """
+    snap = root / ("models--" + repo.replace("/", "--")) / "snapshots" / revision
+    snap.mkdir(parents=True)
+    (snap / "model.bin").write_bytes(b"ct2-weights")
+    (snap / "config.json").write_text("{}")
+    return snap
+
+
+def test_whisper_snapshot_dir_finds_the_pinned_snapshot(tmp_path):
+    entry = manifest.get_asset(manifest.WHISPER_ASSET_NAME)
+    assert entry is not None and entry.hf_repo and entry.hf_revision
+    snap = _pin_shaped_cache(tmp_path, entry.hf_repo, entry.hf_revision)
+    assert not (snap.parent.parent / "refs").exists()  # the whole point
+
+    found = transcribe.whisper_snapshot_dir(manifest.WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)})
+    assert found == str(snap)
+
+
+def test_whisper_snapshot_dir_is_none_when_the_cache_is_empty(tmp_path):
+    assert transcribe.whisper_snapshot_dir(manifest.WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)}) is None
+
+
+def test_whisper_snapshot_dir_is_none_for_an_empty_snapshot_dir(tmp_path):
+    # An interrupted install can leave the directory with nothing in it.
+    entry = manifest.get_asset(manifest.WHISPER_ASSET_NAME)
+    assert entry is not None and entry.hf_repo and entry.hf_revision
+    (tmp_path / ("models--" + entry.hf_repo.replace("/", "--")) / "snapshots" / entry.hf_revision).mkdir(parents=True)
+    assert transcribe.whisper_snapshot_dir(manifest.WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)}) is None
+
+
+def test_whisper_snapshot_dir_is_none_for_an_unmapped_model_id(tmp_path):
+    # A user-forced ``transcribeModel`` the manifest knows nothing about.
+    assert transcribe.whisper_snapshot_dir("medium", env_vars={"HF_HUB_CACHE": str(tmp_path)}) is None
+
+
+def test_whisper_snapshot_dir_is_none_when_the_asset_is_unregistered(tmp_path):
+    # ``small`` is MAPPED but no asset is registered for it (the open follow-up).
+    assert (
+        transcribe.whisper_snapshot_dir(manifest.CPU_WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)}) is None
+    )
+
+
+def test_whisper_snapshot_dir_is_none_when_the_registered_asset_is_not_pinned(tmp_path):
+    # Defense in depth: an entry that is not an ``installer="hf"`` commit pin must
+    # never be used as a load source (mirrors WU-S5's fail-closed contract).
+    snapshot = manifest.registry_snapshot()
+    try:
+        manifest.register_asset(
+            manifest.AssetEntry(
+                name=manifest.CPU_WHISPER_ASSET_NAME,
+                kind="model",
+                size_mb=500,
+                dest="models/whisper-small.bin",
+                tier="core",
+                installer="download",
+                url="https://example.invalid/whisper-small.bin",
+                sha256="a" * 64,
+            )
+        )
+        assert (
+            transcribe.whisper_snapshot_dir(manifest.CPU_WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)})
+            is None
+        )
+    finally:
+        manifest.registry_restore(snapshot)
+
+
+def test_resolve_model_source_returns_the_pinned_dir(tmp_path):
+    entry = manifest.get_asset(manifest.WHISPER_ASSET_NAME)
+    assert entry is not None and entry.hf_repo and entry.hf_revision
+    snap = _pin_shaped_cache(tmp_path, entry.hf_repo, entry.hf_revision)
+    source = transcribe.resolve_model_source(manifest.WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)})
+    assert source == str(snap)
+    # It must be a DIRECTORY, because that is the only input faster-whisper
+    # accepts without going through hub revision resolution.
+    assert Path(source).is_dir()
+
+
+def test_resolve_model_source_falls_back_to_the_bare_id_when_absent(tmp_path):
+    source = transcribe.resolve_model_source(manifest.WHISPER_MODEL_ID, env_vars={"HF_HUB_CACHE": str(tmp_path)})
+    assert source == manifest.WHISPER_MODEL_ID
+
+
+def test_default_snapshot_locator_reads_the_hf_cache_env(tmp_path):
+    snap = _pin_shaped_cache(tmp_path, "org/repo", "b" * 40)
+    assert transcribe.default_snapshot_locator(
+        repo_id="org/repo", revision="b" * 40, env_vars={"HF_HUB_CACHE": str(tmp_path)}
+    ) == str(snap)
+    assert (
+        transcribe.default_snapshot_locator(
+            repo_id="org/repo", revision="c" * 40, env_vars={"HF_HUB_CACHE": str(tmp_path)}
+        )
+        is None
+    )
+
+
+def test_faster_whisper_loader_passes_the_pinned_snapshot_dir(_stub_faster_whisper, tmp_path, monkeypatch):
+    """The load site must receive the DIRECTORY, not the model id.
+
+    RED without the fix: reverting ``FasterWhisperLoader.load`` to
+    ``_WhisperModel(model, ...)`` makes this assert see "large-v3-turbo".
+    """
+    entry = manifest.get_asset(manifest.WHISPER_ASSET_NAME)
+    assert entry is not None and entry.hf_repo and entry.hf_revision
+    cache = tmp_path / "hf"
+    snap = _pin_shaped_cache(cache, entry.hf_repo, entry.hf_revision)
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache))
+
+    loader = transcribe.FasterWhisperLoader()
+    built = loader.load(manifest.WHISPER_MODEL_ID, "cpu", "int8")
+    assert built.model == str(snap)
+    # The CACHE key stays the logical id, so a repeat load still hits the cache.
+    assert loader.load(manifest.WHISPER_MODEL_ID, "cpu", "int8") is built
+    assert len(_FakeFasterWhisperModel.instances) == 1
+
+
+def test_faster_whisper_loader_falls_back_to_the_id_with_no_snapshot(_stub_faster_whisper):
+    # _stub_faster_whisper points HF_HUB_CACHE at an empty dir.
+    loader = transcribe.FasterWhisperLoader()
+    built = loader.load(manifest.WHISPER_MODEL_ID, "cpu", "int8")
+    assert built.model == manifest.WHISPER_MODEL_ID
 
 
 # --------------------------------------------------------------------------- #
@@ -788,37 +943,46 @@ def test_resolve_target_auto_cpu_uses_cpu_model():
     model, device, compute = transcribe.resolve_transcribe_target({}, probe=lambda: False)
     assert device == transcribe.CPU_DEVICE
     assert compute == transcribe.CPU_COMPUTE
-    assert model == transcribe.cpu_auto_model()
+    # Compare against the expected CONSTANT, never against cpu_auto_model() —
+    # a self-comparison is satisfied by an implementation with no CPU branch at
+    # all (measured: it dropped this file from 7 RED to 1 RED under the
+    # "delete the CPU branch" mutant). Today no core-tier asset provisions the
+    # cheap CPU model, so the CPU auto model IS the turbo default; the
+    # discriminating case lives in the ``_with_provisioned_cpu_model`` twins
+    # below, which the same mutant fails.
+    assert model == transcribe.DEFAULT_MODEL
 
 
 # --------------------------------------------------------------------------- #
-# T0 — a CPU-only install must auto-resolve to a PROVISIONED whisper model.
+# T0 — a CPU-only install must auto-resolve to a whisper model the install
+# actually has, and must hand faster-whisper something it can resolve OFFLINE.
 #
 # Reframe is offline-first: faster-whisper only finds a model without a network
 # round-trip when that exact snapshot is already in HF_HOME, and the ONLY thing
 # that puts one there is a registered core-tier manifest asset. Auto-resolving an
-# id that no asset provisions turns a CPU user's FIRST transcribe into an
-# unpinned download that fails outright offline.
+# id no asset installs turns a CPU user's FIRST transcribe into an unpinned
+# download that fails outright offline.
 # --------------------------------------------------------------------------- #
-def test_provisioned_whisper_model_ids_is_turbo_only_today():
-    ids = manifest.provisioned_whisper_model_ids()
+def test_default_profile_whisper_model_ids_is_turbo_only_today():
+    ids = manifest.default_profile_whisper_model_ids()
     assert ids == frozenset({manifest.WHISPER_MODEL_ID})
-    # The faster CPU model is KNOWN but NOT provisioned (no pinned asset yet).
+    # The faster CPU model is KNOWN but the Default profile installs no asset
+    # for it (no pinned asset registered yet).
     assert manifest.CPU_WHISPER_MODEL_ID not in ids
 
 
-def test_cpu_auto_model_is_backed_by_a_provisioned_manifest_asset():
+def test_cpu_auto_model_is_backed_by_a_default_profile_manifest_asset():
     model, device, _ = transcribe.resolve_transcribe_target({}, probe=lambda: False)
     assert device == transcribe.CPU_DEVICE
-    assert model in manifest.provisioned_whisper_model_ids()
+    assert model in manifest.default_profile_whisper_model_ids()
 
 
-def test_transcribe_with_engine_cpu_loads_a_provisioned_model():
+def test_transcribe_with_engine_cpu_loads_a_default_profile_model():
     loader = FakeLoader(_two_segment_model())
     transcribe.transcribe_with_engine("/v.mp4", loader=loader, settings={}, detect_probe=lambda: False)
     (loaded_model, loaded_device, _compute) = loader.loads[0]
     assert loaded_device == transcribe.CPU_DEVICE
-    assert loaded_model in manifest.provisioned_whisper_model_ids()
+    assert loaded_model in manifest.default_profile_whisper_model_ids()
 
 
 def _register_cpu_whisper(tier: str) -> None:
@@ -838,26 +1002,42 @@ def _register_cpu_whisper(tier: str) -> None:
     )
 
 
-def test_cpu_auto_model_prefers_small_once_a_core_asset_provisions_it():
+@contextlib.contextmanager
+def _cpu_whisper_registered(tier: str = "core") -> Iterator[None]:
+    """Registry state in which the Default profile DOES install the CPU model.
+
+    This is the state that discriminates a real CPU branch from its absence: the
+    CPU auto model becomes ``small`` while the GPU model stays ``large-v3-turbo``.
+    Every CPU-path assertion below has a twin that runs inside this block, so
+    deleting the CPU branch turns them RED instead of leaving them satisfied.
+    """
     snapshot = manifest.registry_snapshot()
     try:
-        _register_cpu_whisper("core")
+        _register_cpu_whisper(tier)
+        yield
+    finally:
+        manifest.registry_restore(snapshot)
+
+
+def test_cpu_auto_model_prefers_small_once_a_core_asset_provisions_it():
+    with _cpu_whisper_registered("core"):
         assert transcribe.cpu_auto_model() == manifest.CPU_WHISPER_MODEL_ID
         model, _, _ = transcribe.resolve_transcribe_target({}, probe=lambda: False)
         assert model == manifest.CPU_WHISPER_MODEL_ID
-    finally:
-        manifest.registry_restore(snapshot)
 
 
 def test_cpu_auto_model_ignores_a_non_default_profile_cpu_asset():
     # "optional" is NOT pulled by the Default installer profile, so a CPU-only
     # user would still have no snapshot on disk -> auto must not select it.
-    snapshot = manifest.registry_snapshot()
-    try:
-        _register_cpu_whisper("optional")
+    with _cpu_whisper_registered("optional"):
         assert transcribe.cpu_auto_model() == transcribe.DEFAULT_MODEL
-    finally:
-        manifest.registry_restore(snapshot)
+
+
+def test_resolve_target_auto_cpu_with_provisioned_cpu_model():
+    with _cpu_whisper_registered():
+        model, device, _ = transcribe.resolve_transcribe_target({}, probe=lambda: False)
+        assert device == transcribe.CPU_DEVICE
+        assert model == manifest.CPU_WHISPER_MODEL_ID
 
 
 def test_resolve_target_explicit_device_cpu_override_skips_probe():
@@ -870,8 +1050,15 @@ def test_resolve_target_explicit_device_cpu_override_skips_probe():
     model, device, compute = transcribe.resolve_transcribe_target({"transcribeDevice": "cpu"}, probe=probe)
     assert device == transcribe.CPU_DEVICE
     assert compute == transcribe.CPU_COMPUTE
-    assert model == transcribe.cpu_auto_model()
+    assert model == transcribe.DEFAULT_MODEL
     assert probed["n"] == 0
+
+
+def test_resolve_target_explicit_device_cpu_with_provisioned_cpu_model():
+    with _cpu_whisper_registered():
+        model, device, _ = transcribe.resolve_transcribe_target({"transcribeDevice": "cpu"}, probe=lambda: True)
+        assert device == transcribe.CPU_DEVICE
+        assert model == manifest.CPU_WHISPER_MODEL_ID
 
 
 def test_resolve_target_explicit_device_cuda_override():
@@ -891,7 +1078,14 @@ def test_resolve_target_unknown_device_value_falls_back_to_auto():
     model, device, compute = transcribe.resolve_transcribe_target({"transcribeDevice": "gpu-9000"}, probe=lambda: False)
     assert device == transcribe.CPU_DEVICE
     assert compute == transcribe.CPU_COMPUTE
-    assert model == transcribe.cpu_auto_model()
+    assert model == transcribe.DEFAULT_MODEL
+
+
+def test_resolve_target_unknown_device_with_provisioned_cpu_model():
+    with _cpu_whisper_registered():
+        model, device, _ = transcribe.resolve_transcribe_target({"transcribeDevice": "gpu-9000"}, probe=lambda: False)
+        assert device == transcribe.CPU_DEVICE
+        assert model == manifest.CPU_WHISPER_MODEL_ID
 
 
 def test_resolve_target_non_string_device_value_falls_back_to_auto():
@@ -906,7 +1100,14 @@ def test_transcribe_with_engine_no_cuda_loads_cpu_int8_only():
     loader = FakeLoader(_two_segment_model())
     t = transcribe.transcribe_with_engine("/v.mp4", loader=loader, settings={}, detect_probe=lambda: False)
     assert len(t["segments"]) == 2
-    assert loader.loads == [(transcribe.cpu_auto_model(), transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+    assert loader.loads == [(transcribe.DEFAULT_MODEL, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+
+
+def test_transcribe_with_engine_no_cuda_with_provisioned_cpu_model():
+    with _cpu_whisper_registered():
+        loader = FakeLoader(_two_segment_model())
+        transcribe.transcribe_with_engine("/v.mp4", loader=loader, settings={}, detect_probe=lambda: False)
+        assert loader.loads == [(manifest.CPU_WHISPER_MODEL_ID, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
 
 
 def test_transcribe_with_engine_cuda_loads_gpu_default():
@@ -923,7 +1124,19 @@ def test_transcribe_with_engine_settings_device_override():
         settings={"transcribeDevice": "cpu"},
         detect_probe=lambda: True,
     )
-    assert loader.loads == [(transcribe.cpu_auto_model(), transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+    assert loader.loads == [(transcribe.DEFAULT_MODEL, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+
+
+def test_transcribe_with_engine_settings_device_override_with_provisioned_cpu_model():
+    with _cpu_whisper_registered():
+        loader = FakeLoader(_two_segment_model())
+        transcribe.transcribe_with_engine(
+            "/v.mp4",
+            loader=loader,
+            settings={"transcribeDevice": "cpu"},
+            detect_probe=lambda: True,
+        )
+        assert loader.loads == [(manifest.CPU_WHISPER_MODEL_ID, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
 
 
 def test_transcribe_with_engine_parakeet_degrade_uses_resolved_cpu_target():
@@ -939,7 +1152,23 @@ def test_transcribe_with_engine_parakeet_degrade_uses_resolved_cpu_target():
         parakeet_runner=empty_parakeet,
         detect_probe=lambda: False,
     )
-    assert loader.loads == [(transcribe.cpu_auto_model(), transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+    assert loader.loads == [(transcribe.DEFAULT_MODEL, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
+
+
+def test_transcribe_with_engine_parakeet_degrade_with_provisioned_cpu_model():
+    def empty_parakeet(audio_path: str, **kwargs: Any):
+        return {"language": "", "segments": [], "durationSec": 0.0}
+
+    with _cpu_whisper_registered():
+        loader = FakeLoader(_two_segment_model())
+        transcribe.transcribe_with_engine(
+            "/v.mp4",
+            loader=loader,
+            settings={"asrEngine": "parakeet"},
+            parakeet_runner=empty_parakeet,
+            detect_probe=lambda: False,
+        )
+        assert loader.loads == [(manifest.CPU_WHISPER_MODEL_ID, transcribe.CPU_DEVICE, transcribe.CPU_COMPUTE)]
 
 
 def test_default_cuda_probe_is_callable_and_safe():
@@ -1000,8 +1229,15 @@ def test_resolve_target_empty_model_string_keeps_auto_model():
     # An empty/whitespace transcribeModel is ignored -> the auto model stands
     # (covers the falsy-trimmed short-circuit branch).
     model, device, _ = transcribe.resolve_transcribe_target({"transcribeModel": "   "}, probe=lambda: False)
-    assert model == transcribe.cpu_auto_model()
+    assert model == transcribe.DEFAULT_MODEL
     assert device == transcribe.CPU_DEVICE
+
+
+def test_resolve_target_empty_model_string_with_provisioned_cpu_model():
+    with _cpu_whisper_registered():
+        model, device, _ = transcribe.resolve_transcribe_target({"transcribeModel": "   "}, probe=lambda: False)
+        assert model == manifest.CPU_WHISPER_MODEL_ID
+        assert device == transcribe.CPU_DEVICE
 
 
 def test_resolve_target_auto_literal_model_keeps_auto_model():


### PR DESCRIPTION
## How this change was produced

Implemented under TDD, then **adversarially reviewed by three independent agents** with
distinct lenses (correctness / gate-integrity / blast-radius), each instructed to REFUTE
rather than approve and to default to refuted when uncertain.

**It was refuted.** Wave 1 measured 6/6 implementers self-reporting SUCCESS against 15/18
adversarial verdicts refuting them, so nothing was merged on a self-report. The lane was
then remediated against its specific objections and re-checked by a **fresh** skeptic who
wrote neither the code nor the original objections.

Several objections were about **false sentences** rather than broken code — assurances
like "no assertion was weakened", "no pragma was added", "never a silent pass". Those are
corrected in explicit follow-up commits, because a false assurance is worse than an
undisclosed gap: it tells the next reader not to look.

## What was fixed

All 3 objections ACCEPTED as correct and FIXED in code (0 rebutted). (1) Offline path: reproduced the reviewer's HF-cache trace against the real huggingface_hub 1.22.0 — assets.ensure installs by 40-hex pin, file_download.py:708 writes refs/<rev> only when revision != commit_hash so no refs/main exists, and _snapshot_download.py:288-342 then raises LocalEntryNotFoundError for the default "main" revision even with the weights on disk. Fixed by handing faster-whisper the pinned snapshot DIRECTORY (WhisperModel short-circuits on os.path.isdir) via new transcribe.default_snapshot_locator / whisper_snapshot_dir / resolve_model_source, gated by the existing WU-S5 pin validator (diarize_backend.resolve_pinned_hf_source) so an unregistered/unpinned entry fails closed. Side benefit: online loads are now pinned to the verified commit instead of whatever "main" points at. (2) Restored the 7 self-comparison assertions to compare against the expected CONSTANT (transcribe.DEFAULT_MODEL) and added a discriminating twin for every CPU call site under _cpu_whisper_registered(). (3) manifest.provisioned_whisper_model_ids() RENAMED to default_profile_whisper_model_ids() and re-documented as registry-only, explicitly not an offline guarantee, with the refuted old wording recorded rather than deleted; the no-whisper-asset install is handled explicitly at the load site with a loud warning + bare-id fallback. Corrected three FALSE sentences from 36724a6e ("(b) cannot fail offline", "no assertion was weakened or deleted", and the helper's "guaranteed to have" docstring) in the new commit message 1c03ec69.

## Rebutted

None. All three objections were upheld on independent re-measurement — I reproduced the reviewer's mutation counts exactly (7 on origin/main, 1 on my refuted commit) and independently confirmed the huggingface_hub refs/main mechanism at file_download.py:708 and _snapshot_download.py:288-342 with a live executable probe. Nothing survived a rebuttal attempt.

## Disclosed residuals (non-blocking, and checked for accuracy — an inverted residual was itself one of the original findings)

Residuals disclosed inline in the commit message, none blocking: (a) transcribe.start still has no typed offline refusal analogous to diarize.start's OfflineError guard — with offline mode on and no snapshot the failure surfaces as a raw huggingface_hub LocalEntryNotFoundError inside the job; schedule as lane "transcribe offline guard". (b) whisper-small is still NOT registered — no fabricated 40-hex pin, and core-tier changes Default install size + touches app/main/installProfiles*.ts; the seam is in place so it becomes a manifest-only change. (c) CPU speed regression remains UNVERIFIED (faster_whisper is not installed in this sidecar env); settling experiment is a wall-clock A/B of turbo/int8 vs small/int8 on one fixed 60 s sample; likely (55-80%) turbo is materially slower, accepted as the cost of loading at all. (d) Out of lane, same defect class: models/model_recommend.WHISPER_LADDER still advertises medium/small/base rungs no asset provisions (display-only today).

## Independent re-verification

Fresh skeptic verdict: **mergeable = True**, all objections closed = True.

Remaining, per that verifier:

Nothing blocking. Four honestly-scoped, non-blocking residuals, all verified as accurate (not inverted) disclosures: (1) transcribe.start still has no typed offline refusal — confirmed by grep: diarize.py:313 calls _offline.guard_network, transcribe.py has ZERO matches, so an offline no-snapshot run surfaces a raw huggingface_hub LocalEntryNotFoundError; own lane. (2) whisper-small is still unregistered, so a CPU-only user now loads large-v3-turbo/int8 instead of small/int8 — a real user-facing behavior change shipping un-benchmarked; the UNVERIFIED tag is honest (I confirmed `import faster_whisper` fails in this sidecar env, so the A/B genuinely could not be run here). Correct tradeoff vs. the alternative of a fabricated 40-hex pin, and the seam (register CPU_WHISPER_ASSET_NAME at tier="core") is in place. (3) Cosmetic-only: resolve_model_source logs "faster-whisper will resolve it over the network (this FAILS offline)" even when the user forces a literal local DIRECTORY via transcribeModel — the load still succeeds via faster_whisper transcribe.py:678 os.path.isdir, so this is a misleading log line, not a defect. (4) Out of lane, same defect class: models/model_recommend.py:51 WHISPER_LADDER still advertises medium/small/base rungs no asset provisions (display-only). app/ gates (vitest, tsc, biome) correctly NOT run and NOT claimed — git diff origin/main...HEAD contains no app/ file.

---

CI is the arbiter here, not the agents. This merges only if `quality` is green.
