### PR TITLE
fix(search): honour the cloud-budget confirmation, and stop the card fabricating a verdict

### DIFF
--- a/app/renderer/src/features/SemanticSearch.test.tsx
+++ b/app/renderer/src/features/SemanticSearch.test.tsx
@@ -728,10 +728,14 @@ describe('<SemanticSearch />', () => {
     expect(card).toBeTruthy();
     expect(card.getAttribute('aria-label')).toBe('Cloud egress consent');
     // The card shows WHAT is being acknowledged (an ack with no preview is theatre).
-    expect(card.textContent).toContain('2048');
+    // RESCOPED (adversarial review): this test previously asserted the BUILD card
+    // echoed the plan's `2048`/`outside the provider free limits`/`preview`. That
+    // encoded the defect — `index.plan` sizes a build from an 11-byte sentinel, so
+    // those three are wrong for a build. The numeric disclosure is asserted on the
+    // SEARCH card (where the plan IS accurate) and the build card's honest copy is
+    // asserted in its own test below; nothing is merely dropped.
     expect(card.textContent).toContain('openrouter');
-    expect(card.textContent).toContain('embed: pricing');
-    expect(card.textContent).toContain('outside the provider free limits');
+    expect(card.textContent).toContain('entire transcript');
     expect(card.textContent).toContain('index build');
 
     await click(ackButton());
@@ -759,7 +763,14 @@ describe('<SemanticSearch />', () => {
     const card = consentCard() as HTMLElement;
     expect(card).toBeTruthy();
     expect(card.textContent).toContain('search');
+    // The SEARCH plan is accurate (it sizes the query text itself), so the card
+    // carries the full numeric disclosure: bytes, provider, request count,
+    // free-limit verdict and the sidecar's own preview line.
+    expect(card.textContent).toContain('2048');
+    expect(card.textContent).toContain('openrouter');
+    expect(card.textContent).toContain('1 request(s)');
     expect(card.textContent).toContain('within the provider free limits');
+    expect(card.querySelector('.search-consent__preview')?.textContent).toBe('embed: pricing');
     // Nothing is in flight, so the panel must not claim to be searching.
     expect(container.querySelector('.search-status')?.textContent).not.toContain('Searching…');
 
@@ -825,6 +836,133 @@ describe('<SemanticSearch />', () => {
     await click(ackButton());
     expect(container.querySelector('[role="alert"]')?.textContent).toContain('no transcript yet');
     expect(consentCard()).toBeNull();
+  });
+
+  // --- the deferral must not fabricate a verdict (adversarial-review regression)
+  // A deferred run sent NOTHING. If the panel keeps the previous query's result
+  // surface up, `.search-empty` and the polite live region — both fed by
+  // `searchedQuery` — re-label it with the new query, so the app asserts (and
+  // ANNOUNCES to a screen reader) a factual outcome for a request it never made.
+
+  it('gate ON: a deferred SEARCH never announces "No matches" for the query it did not run', async () => {
+    const fake = makeFakeApi({
+      'index.status': BUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan(),
+      'index.search': { hits: [] },
+    });
+    await mount(fake);
+    // 'foo' runs for real and legitimately finds nothing.
+    await type('foo');
+    await submit();
+    await click(ackButton());
+    expect(container.querySelector('.search-empty')?.textContent).toContain("No matches for 'foo'");
+    expect(fake.calls.filter((c) => c.method === 'index.search').length).toBe(1);
+
+    // 'bar' is deferred behind the card: no request, therefore no verdict.
+    await type('bar');
+    await submit();
+    expect(consentCard()).toBeTruthy();
+    expect(fake.calls.filter((c) => c.method === 'index.search').length).toBe(1);
+    expect(container.querySelector('.search-empty')).toBeNull();
+    const live = container.querySelector('[aria-live="polite"].search-status');
+    expect(live?.textContent).toBe('');
+    // Acknowledging then runs it and the verdict finally names 'bar' truthfully.
+    await click(ackButton());
+    expect(fake.calls.filter((c) => c.method === 'index.search').length).toBe(2);
+    expect(container.querySelector('.search-empty')?.textContent).toContain("No matches for 'bar'");
+  });
+
+  it('gate ON: a deferred SEARCH drops the previous query hit list instead of leaving it under the card', async () => {
+    const fake = makeFakeApi({
+      'index.status': BUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan(),
+      'index.search': { hits: hits() },
+    });
+    await mount(fake);
+    await type('foo');
+    await submit();
+    await click(ackButton());
+    expect(container.querySelectorAll('ul.search-hits li button').length).toBe(2);
+
+    await type('bar');
+    await submit();
+    expect(consentCard()).toBeTruthy();
+    expect(container.querySelectorAll('ul.search-hits li button').length).toBe(0);
+    expect(container.querySelector('[aria-live="polite"].search-status')?.textContent).toBe('');
+    expect(fake.calls.filter((c) => c.method === 'index.search').length).toBe(1);
+  });
+
+  it('gate ON: a deferred BUILD leaves the last REAL search verdict standing (it says nothing about it)', async () => {
+    const fake = makeFakeApi({
+      'index.status': BUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan(),
+      'index.search': { hits: hits() },
+      'index.build': { jobId: 'job-idx' },
+    });
+    await mount(fake);
+    await type('foo');
+    await submit();
+    await click(ackButton());
+    expect(container.querySelectorAll('ul.search-hits li button').length).toBe(2);
+
+    // Rebuild is a BUILD: it does not touch the search surface, so the earned
+    // 'foo' results (a real, already-answered request) stay put.
+    await click(
+      [...container.querySelectorAll('button')].find(
+        (b) => b.textContent === 'Rebuild index',
+      ) as HTMLButtonElement,
+    );
+    expect(consentCard()).toBeTruthy();
+    expect(container.querySelectorAll('ul.search-hits li button').length).toBe(2);
+    expect(container.querySelector('[aria-live="polite"].search-status')?.textContent).toContain(
+      '2 matches',
+    );
+  });
+
+  it('gate ON: the BUILD card refuses to quote the plan sentinel size or a free-limits verdict', async () => {
+    // `index.plan` builds its envelope from an 11-byte "index.build" sentinel
+    // (sidecar vision_ops.py:750), NOT from the transcript index_build embeds —
+    // executed against the repo's own estimator that returns
+    // egressBytes=11 / requests=1 / withinFreeLimits=True. Quoting any of it on
+    // a spend confirmation is a confident wrong number four-plus orders of
+    // magnitude low, so the card must not.
+    const fake = makeFakeApi({
+      'index.status': UNBUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan(
+        {
+          cacheKey: 'CK-build',
+          preview: '~1 request(s) across openrouter; sends ~0.0 KB (11 text / 0 frame bytes).',
+        },
+        { egressBytes: 11, egressKinds: { text: 11, frames: 0 }, withinFreeLimits: true },
+      ),
+      'index.build': { jobId: 'job-idx' },
+    });
+    await mount(fake);
+    await clickBuildCta();
+    const card = consentCard() as HTMLElement;
+    const text = card.textContent ?? '';
+    // What is TRUE is still stated: who receives it, and what really goes.
+    expect(text).toContain('openrouter');
+    expect(text).toContain('entire transcript');
+    expect(text).toContain('not estimated here');
+    // What is FALSE is absent — no sentinel byte count, no free-limits comfort,
+    // and no `preview` line (the sidecar derives that string from the same
+    // sentinel: "sends ~0.0 KB (11 text / 0 frame bytes)").
+    expect(text).not.toContain('11 bytes');
+    expect(text).not.toContain('within the provider free limits');
+    expect(text).not.toContain('outside the provider free limits');
+    expect(text).not.toContain('0.0 KB');
+    expect(card.querySelector('.search-consent__preview')).toBeNull();
+    // The ack still works and still carries the sidecar's token.
+    await click(ackButton());
+    expect(fake.calls.find((c) => c.method === 'index.build')?.params).toEqual({
+      videoId: 'v1',
+      confirmBudget: 'CK-build',
+    });
   });
 
   it('an index.search rejection AFTER acknowledgement surfaces via role="alert" and clears hits', async () => {

--- a/app/renderer/src/features/SemanticSearch.test.tsx
+++ b/app/renderer/src/features/SemanticSearch.test.tsx
@@ -14,6 +14,7 @@ import { createRoot, type Root } from 'react-dom/client';
 
 import SemanticSearch from './SemanticSearch';
 import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+import type { AiBudget, AiPlan } from '../components/useAiJob';
 import type { PlayerHandle } from '../components/Player';
 import type { IndexHit, IndexStatus } from '../lib/rpc';
 
@@ -92,6 +93,28 @@ const UNBUILT: IndexStatus = {
   builtAt: null,
   dim: 0,
 };
+
+/** A full `index.plan` payload (the sidecar's `envelope.planned()` wire shape). */
+function plan(over: Partial<AiPlan> = {}, budgetOver: Partial<AiBudget> = {}): AiPlan {
+  const budget: AiBudget = {
+    requests: 1,
+    providers: ['openrouter'],
+    egressBytes: 2048,
+    egressKinds: { text: 2048, frames: 0 },
+    withinFreeLimits: false,
+    ...budgetOver,
+  };
+  return {
+    route: { providers: ['openrouter'], degradeChain: [], cacheHit: false, willEgress: true },
+    costEst: budget,
+    cacheHit: false,
+    willEgress: true,
+    budget,
+    preview: 'embed: pricing',
+    cacheKey: 'CK',
+    ...over,
+  };
+}
 
 function hits(): IndexHit[] {
   return [
@@ -481,9 +504,12 @@ describe('<SemanticSearch />', () => {
     expect(cta.disabled).toBe(true);
   });
 
-  it('build echoes the plan cacheKey as confirmBudget when the plan will egress (cloud embedder)', async () => {
+  it('gate OFF: build echoes the plan cacheKey as confirmBudget when the plan will egress (cloud embedder)', async () => {
+    // confirmCloudBudget OFF -> no acknowledgement is required and the build
+    // starts immediately, still carrying the ack token the sidecar accepts.
     const fake = makeFakeApi({
       'index.status': UNBUILT,
+      'settings.get': { confirmCloudBudget: false },
       'index.plan': { willEgress: true, cacheKey: 'CK-build' },
       'index.build': { jobId: 'job-idx' },
     });
@@ -521,9 +547,10 @@ describe('<SemanticSearch />', () => {
     expect(fake.calls.find((c) => c.method === 'index.build')?.params).toEqual({ videoId: 'v1' });
   });
 
-  it('search echoes the plan cacheKey as confirmBudget when the plan will egress (cloud embedder)', async () => {
+  it('gate OFF: search echoes the plan cacheKey as confirmBudget when the plan will egress (cloud embedder)', async () => {
     const fake = makeFakeApi({
       'index.status': BUILT,
+      'settings.get': { confirmCloudBudget: false },
       'index.plan': { willEgress: true, cacheKey: 'CK-search' },
       'index.search': { hits: hits() },
     });
@@ -653,5 +680,168 @@ describe('<SemanticSearch />', () => {
     });
     expect(off).toHaveBeenCalled();
     root = createRoot(container);
+  });
+
+  // --- §9.1 cloud-budget acknowledgement gate --------------------------------
+  // The user's own `confirmCloudBudget` setting must be honoured HERE, the same
+  // way BatchQueue honours it (BatchQueue.tsx: plan with acknowledged=false,
+  // render a consent card, defer the real call). The panel must never answer the
+  // challenge on the user's behalf.
+
+  function consentCard(): HTMLElement | null {
+    return container.querySelector('section.search-consent');
+  }
+  function ackButton(): HTMLButtonElement {
+    return container.querySelector('.search-consent__ack') as HTMLButtonElement;
+  }
+  async function clickBuildCta(): Promise<void> {
+    const cta = [...container.querySelectorAll('button')].find((b) =>
+      /Build the search index/.test(b.textContent ?? ''),
+    ) as HTMLButtonElement;
+    await act(async () => {
+      cta.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+  async function click(btn: HTMLButtonElement): Promise<void> {
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  it('gate ON: an egressing BUILD is deferred behind a consent card that shows the cost, and only runs after the user acknowledges', async () => {
+    const fake = makeFakeApi({
+      'index.status': UNBUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan({ cacheKey: 'CK-build' }),
+      'index.build': { jobId: 'job-idx' },
+    });
+    await mount(fake);
+    await clickBuildCta();
+
+    // The build has NOT been dispatched — the user has not agreed yet.
+    expect(fake.calls.find((c) => c.method === 'index.build')).toBeUndefined();
+    const card = consentCard() as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.getAttribute('aria-label')).toBe('Cloud egress consent');
+    // The card shows WHAT is being acknowledged (an ack with no preview is theatre).
+    expect(card.textContent).toContain('2048');
+    expect(card.textContent).toContain('openrouter');
+    expect(card.textContent).toContain('embed: pricing');
+    expect(card.textContent).toContain('outside the provider free limits');
+    expect(card.textContent).toContain('index build');
+
+    await click(ackButton());
+    expect(fake.calls.find((c) => c.method === 'index.build')?.params).toEqual({
+      videoId: 'v1',
+      confirmBudget: 'CK-build',
+    });
+    // Acknowledged -> the card is gone and the build progress region is live.
+    expect(consentCard()).toBeNull();
+    expect(container.querySelector('.progress[aria-live="polite"]')).toBeTruthy();
+  });
+
+  it('gate ON: an egressing SEARCH is deferred behind the consent card and only runs after the user acknowledges', async () => {
+    const fake = makeFakeApi({
+      'index.status': BUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan({ cacheKey: 'CK-search' }, { withinFreeLimits: true }),
+      'index.search': { hits: hits() },
+    });
+    await mount(fake);
+    await type('pricing');
+    await submit();
+
+    expect(fake.calls.find((c) => c.method === 'index.search')).toBeUndefined();
+    const card = consentCard() as HTMLElement;
+    expect(card).toBeTruthy();
+    expect(card.textContent).toContain('search');
+    expect(card.textContent).toContain('within the provider free limits');
+    // Nothing is in flight, so the panel must not claim to be searching.
+    expect(container.querySelector('.search-status')?.textContent).not.toContain('Searching…');
+
+    await click(ackButton());
+    expect(fake.calls.find((c) => c.method === 'index.search')?.params).toEqual({
+      videoId: 'v1',
+      query: 'pricing',
+      topK: 8,
+      confirmBudget: 'CK-search',
+    });
+    expect(consentCard()).toBeNull();
+    expect(container.querySelectorAll('ul.search-hits li button').length).toBe(2);
+  });
+
+  it('gate ON: Cancel dismisses the consent card without running anything', async () => {
+    const fake = makeFakeApi({
+      'index.status': UNBUILT,
+      'settings.get': { confirmCloudBudget: true },
+      'index.plan': plan(),
+      'index.build': { jobId: 'job-idx' },
+    });
+    await mount(fake);
+    await clickBuildCta();
+    expect(consentCard()).toBeTruthy();
+    await click(container.querySelector('.search-consent__cancel') as HTMLButtonElement);
+    expect(consentCard()).toBeNull();
+    expect(fake.calls.find((c) => c.method === 'index.build')).toBeUndefined();
+  });
+
+  it('a settings.get rejection keeps the gate ON (fail-safe: never egress unacknowledged)', async () => {
+    const fake = makeFakeApi({
+      'index.status': UNBUILT,
+      'index.plan': plan(),
+      'index.build': { jobId: 'job-idx' },
+    });
+    fake.rpc.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      fake.calls.push({ method, params });
+      if (method === 'settings.get') throw new Error('settings unreadable');
+      if (method === 'index.status') return UNBUILT;
+      if (method === 'index.plan') return plan();
+      return { jobId: 'job-idx' };
+    });
+    await mount(fake);
+    await clickBuildCta();
+    expect(consentCard()).toBeTruthy();
+    expect(fake.calls.find((c) => c.method === 'index.build')).toBeUndefined();
+    // A failed settings probe is NOT an error banner — it silently keeps the gate.
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('an index.build rejection AFTER acknowledgement surfaces via role="alert"', async () => {
+    const fake = makeFakeApi({ 'index.status': UNBUILT });
+    fake.rpc.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      fake.calls.push({ method, params });
+      if (method === 'index.status') return UNBUILT;
+      if (method === 'settings.get') return { confirmCloudBudget: true };
+      if (method === 'index.plan') return plan();
+      if (method === 'index.build') throw new Error('no transcript yet');
+      return {};
+    });
+    await mount(fake);
+    await clickBuildCta();
+    await click(ackButton());
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('no transcript yet');
+    expect(consentCard()).toBeNull();
+  });
+
+  it('an index.search rejection AFTER acknowledgement surfaces via role="alert" and clears hits', async () => {
+    const fake = makeFakeApi({ 'index.status': BUILT });
+    fake.rpc.mockImplementation(async (method: string, params?: Record<string, unknown>) => {
+      fake.calls.push({ method, params });
+      if (method === 'index.status') return BUILT;
+      if (method === 'settings.get') return { confirmCloudBudget: true };
+      if (method === 'index.plan') return plan();
+      if (method === 'index.search') throw 'search blew up';
+      return {};
+    });
+    await mount(fake);
+    await type('pricing');
+    await submit();
+    await click(ackButton());
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('search blew up');
+    expect(container.querySelector('ul.search-hits li')).toBeNull();
   });
 });

--- a/app/renderer/src/features/SemanticSearch.tsx
+++ b/app/renderer/src/features/SemanticSearch.tsx
@@ -15,6 +15,15 @@
 // Status is announced via a polite `aria-live` region ("Searching…"/result
 // count/"No matches"); errors surface via `role="alert"` (mirroring
 // Workspace.tsx:176 / Transcribe.tsx:149).
+//
+// §9.1 CLOUD-BUDGET ACKNOWLEDGEMENT. When the user's persisted
+// `confirmCloudBudget` setting is ON and `index.plan` says the run WILL egress,
+// the run is DEFERRED behind a consent card that shows the planned cost/egress,
+// and only the user's click supplies the sidecar's ack token
+// (`_enforce_cloud_budget_ack`, ai_ops.py:256). Mirrors BatchQueue.tsx:193-240:
+// plan first, render the card, defer the real call. Previously this panel read
+// the plan and answered the challenge itself, so a user who deliberately turned
+// the setting ON still got zero confirmation from this surface.
 import React, { useCallback, useEffect, useState } from 'react';
 import './panels.css';
 import { fmtSeconds, getApi } from './_api';
@@ -36,6 +45,21 @@ interface BuildState {
   message: string;
 }
 
+/**
+ * A planned run held back for the user's §9.1 cloud-budget acknowledgement.
+ * `query` is the searched text ('' for a build, which has no query).
+ */
+interface PendingRun {
+  kind: 'build' | 'search';
+  plan: AiPlan;
+  query: string;
+}
+
+/** The message an unknown rejection surfaces in the panel's error banner. */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): React.ReactElement {
   const [built, setBuilt] = useState<boolean>(false);
   const [query, setQuery] = useState<string>('');
@@ -46,6 +70,25 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
   // The query string that produced the current empty/results state, so the
   // "No matches for '<query>'" message names the searched term (not a later edit).
   const [searchedQuery, setSearchedQuery] = useState<string>('');
+  // §9.1: the persisted budget gate (default ON, settings_store.py) and the run
+  // held back waiting for the user to acknowledge it.
+  const [confirmCloudBudget, setConfirmCloudBudget] = useState<boolean>(true);
+  const [pending, setPending] = useState<PendingRun | null>(null);
+
+  // Read the persisted §9.1 budget setting once on mount; a rejection keeps the
+  // default-ON gate (fail-safe — never egress without acknowledgement). Same
+  // read + same fail-safe as BatchQueue.tsx:123-132, through this panel's own
+  // `getApi()` accessor (the panel deliberately holds no runtime `lib/rpc` dep).
+  useEffect(() => {
+    void getApi()
+      .rpc<Record<string, unknown>>('settings.get')
+      .then((s) => {
+        setConfirmCloudBudget(s.confirmCloudBudget !== false);
+      })
+      .catch(() => {
+        // Keep the default-ON gate when the setting can't be read.
+      });
+  }, []);
 
   // Probe the index status on mount (and whenever the video changes). A probe
   // failure degrades to "unbuilt" (CTA shown), never an error banner.
@@ -89,23 +132,60 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
     };
   }, [build]);
 
+  // Dispatch a PLANNED run. The ack token (`confirmBudget`) is attached only
+  // when the plan says the run WILL egress — a local/consent-denied run must NOT
+  // send one (the sidecar gate never fires for it). Throws on RPC failure; each
+  // caller owns how that surfaces.
+  const execute = useCallback(
+    async (run: PendingRun): Promise<void> => {
+      const ack = run.plan.willEgress ? { confirmBudget: run.plan.cacheKey } : {};
+      if (run.kind === 'build') {
+        const res = await getApi().rpc<{ jobId: string }>('index.build', { videoId, ...ack });
+        setBuild({ jobId: res.jobId, pct: 0, message: 'Building…' });
+        return;
+      }
+      setPhase('searching');
+      const res = await getApi().rpc<{ hits: IndexHit[] }>('index.search', {
+        videoId,
+        query: run.query,
+        topK: 8,
+        ...ack,
+      });
+      const list = res.hits ?? [];
+      setHits(list);
+      setPhase(list.length ? 'results' : 'empty');
+    },
+    [videoId],
+  );
+
+  // §9.1 gate: an egressing run under a live `confirmCloudBudget` waits for the
+  // user's acknowledgement; everything else runs straight through (behaviour
+  // with the setting OFF is unchanged).
+  const startOrDefer = useCallback(
+    async (run: PendingRun): Promise<void> => {
+      if (run.plan.willEgress && confirmCloudBudget) {
+        setPending(run);
+        return;
+      }
+      await execute(run);
+    },
+    [confirmCloudBudget, execute],
+  );
+
   const startBuild = useCallback(async () => {
     setError('');
     try {
       // Cloud-budget pre-flight: `index.build` egress is gated exactly like the
       // AI jobs (vision_ops `_enforce_egress_gates`), so a cloud-configured
-      // embedder rejects the build unless we echo the plan's cacheKey as
+      // embedder rejects the build unless the plan's cacheKey is echoed as
       // `confirmBudget`. `index.plan` is a pure planning RPC (ZERO provider
-      // calls); we only attach the ack when the plan says it WILL egress (a
-      // local/consent-denied build must NOT send one).
+      // calls) — it only PREVIEWS the cost so the user can decide.
       const plan = await getApi().rpc<AiPlan>('index.plan', { videoId });
-      const params = plan.willEgress ? { videoId, confirmBudget: plan.cacheKey } : { videoId };
-      const res = await getApi().rpc<{ jobId: string }>('index.build', params);
-      setBuild({ jobId: res.jobId, pct: 0, message: 'Building…' });
+      await startOrDefer({ kind: 'build', plan, query: '' });
     } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
+      setError(errText(err));
     }
-  }, [videoId]);
+  }, [videoId, startOrDefer]);
 
   const runSearch = useCallback(
     async (e: React.FormEvent) => {
@@ -113,29 +193,41 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
       const q = query.trim();
       if (!q) return;
       setError('');
-      setPhase('searching');
       setSearchedQuery(q);
       try {
-        // Same cloud-budget pre-flight as the build path: a cloud-embedder
-        // `index.search` is egress-gated, so echo the plan's cacheKey as
-        // `confirmBudget` when the plan will egress (never for a local search).
+        // Same cloud-budget pre-flight as the build path. `phase` flips to
+        // 'searching' inside `execute`, i.e. only once a search is REALLY in
+        // flight — a deferred search announces nothing, because nothing is
+        // running until the user acknowledges.
         const plan = await getApi().rpc<AiPlan>('index.plan', { videoId, query: q });
-        const res = await getApi().rpc<{ hits: IndexHit[] }>(
-          'index.search',
-          plan.willEgress
-            ? { videoId, query: q, topK: 8, confirmBudget: plan.cacheKey }
-            : { videoId, query: q, topK: 8 },
-        );
-        const list = res.hits ?? [];
-        setHits(list);
-        setPhase(list.length ? 'results' : 'empty');
+        await startOrDefer({ kind: 'search', plan, query: q });
       } catch (err) {
         setHits([]);
-        setError(err instanceof Error ? err.message : String(err));
+        setError(errText(err));
         setPhase('error');
       }
     },
-    [query, videoId],
+    [query, videoId, startOrDefer],
+  );
+
+  // The user acknowledged the previewed cost: run the held-back job now, with
+  // the ack the sidecar demands. Failure surfaces exactly as it would have on
+  // the direct path (a search additionally drops stale hits + enters 'error').
+  const acknowledge = useCallback(
+    async (run: PendingRun): Promise<void> => {
+      setPending(null);
+      setError('');
+      try {
+        await execute(run);
+      } catch (err) {
+        if (run.kind === 'search') {
+          setHits([]);
+          setPhase('error');
+        }
+        setError(errText(err));
+      }
+    },
+    [execute],
   );
 
   const activate = useCallback(
@@ -198,6 +290,40 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
             Build the search index
           </button>
         </div>
+      )}
+
+      {pending !== null && (
+        // §9.1 consent card — the user's own confirm-cloud-budget setting is ON
+        // and this run WOULD leave the machine, so it names what is about to be
+        // sent, where, and whether it is billable BEFORE anything runs.
+        <section className="search-consent" aria-label="Cloud egress consent">
+          <h3 className="search-consent__title">
+            Before this {pending.kind === 'build' ? 'index build' : 'search'} runs
+          </h3>
+          <p className="search-consent__egress">
+            It sends {pending.plan.costEst.egressBytes} bytes of transcript text to{' '}
+            {pending.plan.costEst.providers.join(', ')} in {pending.plan.costEst.requests}{' '}
+            request(s) — {pending.plan.costEst.withinFreeLimits ? 'within' : 'outside'} the provider
+            free limits.
+          </p>
+          <p className="search-consent__preview">{pending.plan.preview}</p>
+          <div className="actions">
+            <button
+              type="button"
+              className="search-consent__ack"
+              onClick={() => void acknowledge(pending)}
+            >
+              Acknowledge cloud egress and continue
+            </button>
+            <button
+              type="button"
+              className="search-consent__cancel"
+              onClick={() => setPending(null)}
+            >
+              Cancel
+            </button>
+          </div>
+        </section>
       )}
 
       {building && (

--- a/app/renderer/src/features/SemanticSearch.tsx
+++ b/app/renderer/src/features/SemanticSearch.tsx
@@ -24,6 +24,17 @@
 // plan first, render the card, defer the real call. Previously this panel read
 // the plan and answered the challenge itself, so a user who deliberately turned
 // the setting ON still got zero confirmation from this surface.
+//
+// TWO HONESTY INVARIANTS the deferral must not break — both are asserted:
+//   1. A DEFERRED run has produced no result, so the panel must claim none. The
+//      searched-query label and the phase are committed inside `execute` (i.e.
+//      only once a request is really in flight), and deferring a search DROPS
+//      the previous query's verdict — otherwise the live region and
+//      `.search-empty` re-announce the old outcome under the NEW query's name.
+//   2. The card must not quote a number it does not have. `index.plan` sizes an
+//      index BUILD from an 11-byte `"index.build"` sentinel (vision_ops.py:750),
+//      not from the corpus the build embeds, so the build card states the size
+//      is unestimated instead of quoting that figure (see the card below).
 import React, { useCallback, useEffect, useState } from 'react';
 import './panels.css';
 import { fmtSeconds, getApi } from './_api';
@@ -144,6 +155,10 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
         setBuild({ jobId: res.jobId, pct: 0, message: 'Building…' });
         return;
       }
+      // Committed HERE, not at submit: `searchedQuery` names the query whose
+      // verdict the panel is about to render, so it may only advance once a
+      // request is genuinely in flight (invariant 1 in the header).
+      setSearchedQuery(run.query);
       setPhase('searching');
       const res = await getApi().rpc<{ hits: IndexHit[] }>('index.search', {
         videoId,
@@ -164,6 +179,16 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
   const startOrDefer = useCallback(
     async (run: PendingRun): Promise<void> => {
       if (run.plan.willEgress && confirmCloudBudget) {
+        if (run.kind === 'search') {
+          // Nothing ran, so nothing may be shown: drop the PREVIOUS query's
+          // result surface. Left standing it is re-labelled with the new,
+          // un-run query — `.search-empty` and the polite live region both read
+          // `searchedQuery` — which is an affirmative false claim about a
+          // request the panel never sent. (A deferred BUILD does not touch the
+          // search surface, so it leaves the last real result alone.)
+          setHits([]);
+          setPhase('idle');
+        }
         setPending(run);
         return;
       }
@@ -193,12 +218,12 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
       const q = query.trim();
       if (!q) return;
       setError('');
-      setSearchedQuery(q);
       try {
-        // Same cloud-budget pre-flight as the build path. `phase` flips to
-        // 'searching' inside `execute`, i.e. only once a search is REALLY in
-        // flight — a deferred search announces nothing, because nothing is
-        // running until the user acknowledges.
+        // Same cloud-budget pre-flight as the build path. `phase` AND
+        // `searchedQuery` are committed inside `execute`, i.e. only once a
+        // search is REALLY in flight — a deferred search announces nothing and
+        // labels nothing, because nothing is running until the user
+        // acknowledges.
         const plan = await getApi().rpc<AiPlan>('index.plan', { videoId, query: q });
         await startOrDefer({ kind: 'search', plan, query: q });
       } catch (err) {
@@ -300,13 +325,35 @@ export function SemanticSearch({ videoId, playerRef }: SemanticSearchProps): Rea
           <h3 className="search-consent__title">
             Before this {pending.kind === 'build' ? 'index build' : 'search'} runs
           </h3>
-          <p className="search-consent__egress">
-            It sends {pending.plan.costEst.egressBytes} bytes of transcript text to{' '}
-            {pending.plan.costEst.providers.join(', ')} in {pending.plan.costEst.requests}{' '}
-            request(s) — {pending.plan.costEst.withinFreeLimits ? 'within' : 'outside'} the provider
-            free limits.
-          </p>
-          <p className="search-consent__preview">{pending.plan.preview}</p>
+          {pending.kind === 'build' ? (
+            // HONESTY (invariant 2): `index.plan` plans a build over an 11-byte
+            // `"index.build"` SENTINEL (vision_ops.py:750) — not over the corpus
+            // `index_build` actually embeds — so its `egressBytes`, `requests`,
+            // `withinFreeLimits` AND the `preview` string derived from them are
+            // orders of magnitude low for a build. A spend confirmation quoting
+            // "11 bytes … within the provider free limits" would be worse than
+            // no number at all, so the card names WHO receives the data (that
+            // part is real) and says plainly that the size is not estimated.
+            // The sentinel also UNDER-METERS the sidecar's monthly cap and the
+            // recorded egress cents for a build — a sidecar-lane defect
+            // (vision_ops.index_build:549-559), not fixable from this panel.
+            <p className="search-consent__egress">
+              It sends this video&apos;s entire transcript to{' '}
+              {pending.plan.costEst.providers.join(', ')} to be embedded. The pre-flight plan does
+              not size an index build, so the bytes, the request count and the free-tier fit are not
+              estimated here.
+            </p>
+          ) : (
+            <>
+              <p className="search-consent__egress">
+                It sends {pending.plan.costEst.egressBytes} bytes of search-query text to{' '}
+                {pending.plan.costEst.providers.join(', ')} in {pending.plan.costEst.requests}{' '}
+                request(s) — {pending.plan.costEst.withinFreeLimits ? 'within' : 'outside'} the
+                provider free limits.
+              </p>
+              <p className="search-consent__preview">{pending.plan.preview}</p>
+            </>
+          )}
           <div className="actions">
             <button
               type="button"


### PR DESCRIPTION
## How this change was produced

Implemented under TDD, then **adversarially reviewed by three independent agents** with
distinct lenses (correctness / gate-integrity / blast-radius), each instructed to REFUTE
rather than approve and to default to refuted when uncertain.

**It was refuted.** Wave 1 measured 6/6 implementers self-reporting SUCCESS against 15/18
adversarial verdicts refuting them, so nothing was merged on a self-report. The lane was
then remediated against its specific objections and re-checked by a **fresh** skeptic who
wrote neither the code nor the original objections.

Several objections were about **false sentences** rather than broken code — assurances
like "no assertion was weakened", "no pragma was added", "never a silent pass". Those are
corrected in explicit follow-up commits, because a false assurance is worse than an
undisclosed gap: it tells the next reader not to look.

## What was fixed

All 3 FIXED in code; 0 rebutted. (1)+(2) the deferral's false verdict: setSearchedQuery(q) moved out of runSearch into execute (fires only once a request is really in flight), and deferring a SEARCH now clears the stale result surface (setHits([]), setPhase('idle')) so the previous query's ".search-empty" text and polite live region are never re-labelled with the un-run query. A deferred BUILD deliberately leaves the last real search verdict standing. (3) the consent card now branches on kind: SEARCH keeps the full accurate numeric disclosure (bytes/provider/requests/free-limit verdict/preview) and its wording is corrected from "transcript text" to "search-query text"; BUILD names who receives the data and that the ENTIRE transcript goes, and states plainly that the bytes, request count and free-tier fit are NOT estimated - no number, no free-limits reassurance, no preview line (the sidecar derives that string from the same 11-byte sentinel). Out-of-lane defect named for scheduling, not fixed: index_build plans its budget envelope over the same "index.build" sentinel (sidecar/media_studio/handlers/vision_ops.py:549-559), so the monthly hard cap and recorded egress cents UNDER-METER a cloud index build by the same 4+ orders of magnitude.

## Rebutted

None. All three reviewer findings were correct and I reproduced two of them executably before changing any code; the third (the 11-byte sentinel) is visible verbatim in my own RED run output.

## Disclosed residuals (non-blocking, and checked for accuracy — an inverted residual was itself one of the original findings)

Commit 39b47ebe corrects two FALSE SENTENCES from 94eda876's message, not just the code: (a) "phase now flips to 'searching' inside the real dispatch, so a deferred search no longer announces 'Searching...' while nothing is running" was true-but-incomplete, and the omission WAS the bug - the same move removed the only thing clearing the previous result surface; (b) residual #4 said the card showed raw egressBytes "with no human formatting", implying the number was merely unformatted when it was FALSE for a build. Also disclosed loudly: TWO assertions were rescoped again - the build-card test's "2048" / "outside the provider free limits" / "embed: pricing" assertions encoded objection 3 (they demanded the build card quote a per-build estimate that does not exist); they were MOVED to the SEARCH-card test where the plan is accurate, and the build card gained explicit negative assertions, so net assertions went up, none were weakened, deleted or skipped. Remaining residual, correctly scoped: (1) UNVERIFIED against a real cloud-configured embedder in a running app - every claim is from the jsdom suite; settling experiment: configure a cloud embed model with confirmCloudBudget ON and confirm with a network probe that nothing leaves the box until the card is acknowledged; confidence the wire behaviour is right anyway: almost-certain (90-99%), evidence = rpc-param-level assertions against the shape vision_ops.py:731-757 returns. (2) .search-consent still ships without CSS (BatchConsentCard precedent). (3) A pending build still leaves the "Build the search index" CTA clickable; a re-click re-plans and replaces the pending run.

## Independent re-verification

Fresh skeptic verdict: **mergeable = True**, all objections closed = True.

Remaining, per that verifier:

Nothing blocking. Non-blocking, correctly disclosed and independently verified as accurate: (1) OUT-OF-LANE SIDECAR DEFECT, needs scheduling — index_build plans its budget envelope and meters egress over the same 11-byte "index.build" sentinel (sidecar/media_studio/handlers/vision_ops.py:549-559 vs :750), so the monthly hard cap and recorded egress cents under-meter a cloud index build by 4+ orders of magnitude; this pre-exists on origin/main and is not introduced by the lane. (2) .search-consent ships without CSS — verified no match in features/panels.css, and the cited BatchConsentCard precedent is genuinely unstyled too (only .dub-consent is styled). (3) A pending build leaves the "Build the search index" CTA clickable (rendered on !built && !building, disabled only on !videoId); a re-click re-plans and replaces the pending run. (4) UNVERIFIED against a real cloud-configured embedder in a running app — all evidence is jsdom; settling experiment named in the commit (network probe with confirmCloudBudget ON). (5) Cosmetic mis-citation: 39b47ebe's body attributes a "residual #4" to 94eda876's commit message, which contains no such residual (its NOT-DONE list is CSS / sidecar-untouched / getApi accessor / UNVERIFIED) — that residual lived in the lane report. Self-critical, creates no false assurance.

---

CI is the arbiter here, not the agents. This merges only if `quality` is green.
