### PR TITLE
fix(licence): disclose the CC-BY-NC aligner and build the allowNonCommercialAligner opt-in

### DIFF
--- a/app/renderer/src/components/AlignModelSelect.test.tsx
+++ b/app/renderer/src/components/AlignModelSelect.test.tsx
@@ -202,4 +202,38 @@ describe('AlignModelSelect — non-commercial gate', () => {
     mount({ value: '' });
     expect(container.textContent).toContain('non-commercial');
   });
+
+  // --- the shape three reviewers proved was uncovered: opted IN, nothing chosen.
+  // The sidecar used to fall back to MMS in exactly this state while this select
+  // kept rendering the commercial-safe row as chosen. The backend fallback is
+  // gone (ctc_align._resolve_model_id); these pin the UI half of that contract.
+  it('keeps the commercial-safe default selected when opted in with no choice', () => {
+    mount({ value: '', allowNonCommercial: true });
+    expect(select().value).toBe('');
+    const chosen = select().selectedOptions[0];
+    expect(chosen.textContent).toContain('Apache-2.0');
+    expect(chosen.textContent).toContain('commercial-safe');
+  });
+
+  it('offers MMS but does not preselect it once the opt-in is on', () => {
+    mount({ value: '', allowNonCommercial: true });
+    expect(mmsOption().disabled).toBe(false);
+    expect(mmsOption().selected).toBe(false);
+  });
+
+  it('re-picking the default row after trying MMS persists the empty id', () => {
+    // The exact user story: opt in, try MMS, go back to the row labelled
+    // commercial-safe. `''` is what gets persisted, and `''` must mean Apache.
+    const onChange = vi.fn();
+    mount({ value: MMS_ALIGNER_ALIAS, allowNonCommercial: true, onChange });
+    setValue(select(), '');
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('says the opt-in only unlocks MMS rather than switching to it', () => {
+    mount({ value: '' });
+    const copy = container.textContent ?? '';
+    expect(copy).toContain('UNLOCKS');
+    expect(copy).toContain('does not switch to it');
+  });
 });

--- a/app/renderer/src/components/AlignModelSelect.test.tsx
+++ b/app/renderer/src/components/AlignModelSelect.test.tsx
@@ -7,6 +7,8 @@ import { createRoot, type Root } from 'react-dom/client';
 import {
   AlignModelSelect,
   ALIGN_MODEL_CHOICES,
+  MMS_ALIGNER_ALIAS,
+  MMS_ALIGNER_MODEL_ID,
   type AlignModelSelectProps,
 } from './AlignModelSelect';
 
@@ -24,14 +26,38 @@ afterEach(() => {
   container.remove();
 });
 
-function mount(props: AlignModelSelectProps): void {
+// The non-commercial opt-in props are REQUIRED (a licence gate must not be
+// silently omittable), so the helper supplies inert defaults and each test
+// overrides only what it exercises.
+function mount(props: Partial<AlignModelSelectProps> & { value: string }): void {
+  const full: AlignModelSelectProps = {
+    onChange: () => {},
+    allowNonCommercial: false,
+    onAllowNonCommercialChange: () => {},
+    ...props,
+  };
   act(() => {
-    root.render(<AlignModelSelect {...props} />);
+    root.render(<AlignModelSelect {...full} />);
   });
 }
 
 function select(): HTMLSelectElement {
   return container.querySelector('select[data-action="align-model"]') as HTMLSelectElement;
+}
+
+function ncToggle(): HTMLInputElement {
+  return container.querySelector(
+    'input[data-action="allow-non-commercial-aligner"]',
+  ) as HTMLInputElement;
+}
+
+// A real `.click()` so React's own value-tracker sees the flip; assigning
+// `.checked` by hand and dispatching a synthetic event makes React treat it as
+// a no-change and the handler never fires.
+function toggleNc(el: HTMLInputElement): void {
+  act(() => {
+    el.click();
+  });
 }
 
 function setValue(el: HTMLSelectElement, value: string): void {
@@ -42,20 +68,21 @@ function setValue(el: HTMLSelectElement, value: string): void {
 }
 
 describe('AlignModelSelect', () => {
-  it('exposes the MMS default + the Romanian and MIT opt-ins', () => {
+  it('exposes the permissive default + the Romanian and MMS opt-ins', () => {
     const ids = ALIGN_MODEL_CHOICES.map((c) => c.id);
     expect(ids).toContain('');
     expect(ids).toContain('romanian-wav2vec2');
     expect(ids).toContain('wav2vec2-960h-lv60');
+    expect(ids).toContain(MMS_ALIGNER_ALIAS);
   });
 
-  it('shows the default (MMS) when value is blank', () => {
-    mount({ value: '', onChange: () => {} });
+  it('shows the packaged default when value is blank', () => {
+    mount({ value: '' });
     expect(select().value).toBe('');
   });
 
   it('reflects the Romanian opt-in selection', () => {
-    mount({ value: 'romanian-wav2vec2', onChange: () => {} });
+    mount({ value: 'romanian-wav2vec2' });
     expect(select().value).toBe('romanian-wav2vec2');
   });
 
@@ -74,25 +101,105 @@ describe('AlignModelSelect', () => {
   });
 
   it('keeps an unknown custom id without losing it (shows default row + a badge)', () => {
-    mount({ value: 'gigant/romanian-wav2vec2', onChange: () => {} });
+    mount({ value: 'facebook/some-other-ctc' });
     expect(select().value).toBe('');
     expect(container.querySelector('[data-testid="align-model-custom"]')?.textContent).toContain(
-      'gigant/romanian-wav2vec2',
+      'facebook/some-other-ctc',
     );
   });
 
   it('shows no custom badge for a blank value', () => {
-    mount({ value: '', onChange: () => {} });
+    mount({ value: '' });
     expect(container.querySelector('[data-testid="align-model-custom"]')).toBeNull();
   });
 
   it('disables the control while busy', () => {
-    mount({ value: '', onChange: () => {}, busy: true });
+    mount({ value: '', busy: true });
     expect(select().disabled).toBe(true);
+    expect(ncToggle().disabled).toBe(true);
   });
 
   it('is enabled by default', () => {
-    mount({ value: '', onChange: () => {} });
+    mount({ value: '' });
     expect(select().disabled).toBe(false);
+    expect(ncToggle().disabled).toBe(false);
+  });
+});
+
+// --- WU-T0/B1: the CC-BY-NC MMS aligner is an explicit opt-in ------------------
+// The sidecar `ctc_align._resolve_model_id` refuses the MMS model unless
+// `allowNonCommercialAligner` is on, so the picker must not offer it as if it
+// were free to choose — an option the backend silently downgrades is worse than
+// no option at all. This block is the UI half of that gate.
+describe('AlignModelSelect — non-commercial gate', () => {
+  function mmsOption(): HTMLOptionElement {
+    return container.querySelector(`option[value="${MMS_ALIGNER_ALIAS}"]`) as HTMLOptionElement;
+  }
+
+  it('names the packaged default as Apache-2.0, never MIT', () => {
+    const def = ALIGN_MODEL_CHOICES.find((c) => c.id === '');
+    expect(def?.label).toContain('Apache-2.0');
+    expect(ALIGN_MODEL_CHOICES.every((c) => !c.label.includes('MIT'))).toBe(true);
+  });
+
+  it('labels the MMS row with its CC-BY-NC licence', () => {
+    mount({ value: '' });
+    expect(mmsOption().textContent).toContain('CC-BY-NC');
+  });
+
+  it('disables the MMS row until the opt-in is on', () => {
+    mount({ value: '' });
+    expect(mmsOption().disabled).toBe(true);
+  });
+
+  it('enables the MMS row once the opt-in is on', () => {
+    mount({ value: '', allowNonCommercial: true });
+    expect(mmsOption().disabled).toBe(false);
+  });
+
+  it('reflects the opt-in state on the toggle', () => {
+    mount({ value: '', allowNonCommercial: true });
+    expect(ncToggle().checked).toBe(true);
+  });
+
+  it('persists turning the opt-in on', () => {
+    const onAllowNonCommercialChange = vi.fn();
+    mount({ value: '', onAllowNonCommercialChange });
+    toggleNc(ncToggle());
+    expect(onAllowNonCommercialChange).toHaveBeenCalledWith(true);
+  });
+
+  it('clears an MMS selection when the opt-in is turned back off', () => {
+    const onChange = vi.fn();
+    const onAllowNonCommercialChange = vi.fn();
+    mount({
+      value: MMS_ALIGNER_ALIAS,
+      allowNonCommercial: true,
+      onChange,
+      onAllowNonCommercialChange,
+    });
+    toggleNc(ncToggle());
+    expect(onAllowNonCommercialChange).toHaveBeenCalledWith(false);
+    // Leaving `ctcModelId` on a model the sidecar will refuse is a lie in the UI.
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('clears a full-HF-id MMS selection too, not just the alias', () => {
+    const onChange = vi.fn();
+    mount({ value: MMS_ALIGNER_MODEL_ID, allowNonCommercial: true, onChange });
+    toggleNc(ncToggle());
+    expect(onChange).toHaveBeenCalledWith('');
+  });
+
+  it('leaves a permissive selection alone when the opt-in is turned off', () => {
+    const onChange = vi.fn();
+    mount({ value: 'romanian-wav2vec2', allowNonCommercial: true, onChange });
+    toggleNc(ncToggle());
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('warns that turning it on makes the output non-commercial', () => {
+    mount({ value: '' });
+    expect(container.textContent).toContain('non-commercial');
   });
 });

--- a/app/renderer/src/components/AlignModelSelect.tsx
+++ b/app/renderer/src/components/AlignModelSelect.tsx
@@ -1,31 +1,54 @@
-// AlignModelSelect.tsx — M5 word-timing alignment model opt-in (incl. Romanian).
+// AlignModelSelect.tsx — word-timing alignment model picker + the WU-T0 licence gate.
 //
-// The CTC forced-aligner default is MMS-300M (CC-BY-NC, 158 languages); this
-// control exposes the opt-in overrides the sidecar `ctc_align._resolve_model_id`
-// understands via `settings['ctcModelId']`: the Romanian wav2vec2
-// (gigant/romanian-wav2vec2) for RO-language alignment, plus the MIT English
-// wav2vec2 for a commercial build. Selecting the default persists an EMPTY
-// `ctcModelId` so the package default applies (no silent override).
+// The picker exposes the overrides the sidecar `ctc_align._resolve_model_id`
+// understands via `settings['ctcModelId']`. Since WU-T0/B1 the PACKAGED default
+// is the Apache-2.0 English wav2vec2 (`facebook/wav2vec2-large-960h-lv60-self`),
+// NOT the CC-BY-NC-4.0 MMS model it used to be, and MMS is reachable only when
+// `settings['allowNonCommercialAligner']` is on. Selecting the default persists
+// an EMPTY `ctcModelId` so the package default applies (no silent override).
+//
+// The MMS row is rendered but DISABLED until the opt-in is on: the sidecar
+// silently downgrades an MMS request when the flag is off, and an option whose
+// effect the backend discards is worse than one that visibly cannot be chosen.
+// Licence facts: HF Hub metadata probe, 2026-08-09 (the previous "MIT" label on
+// the wav2vec2 row was wrong — the Hub reports apache-2.0).
 import React from 'react';
 
 /** One selectable alignment model. `id` is the `ctcModelId` value ('' = default). */
 export interface AlignModelChoice {
   id: string;
   label: string;
+  /** True when picking it requires the non-commercial opt-in (CC-BY-NC weights). */
+  nonCommercial?: boolean;
 }
 
-/** The default MMS pick + the M5 opt-ins (aliases the sidecar resolves). */
+/** The `ctcModelId` alias for the CC-BY-NC MMS aligner (sidecar `_MODEL_ALIASES`). */
+export const MMS_ALIGNER_ALIAS = 'mms-300m';
+/** Its full HF id — a hand-typed `ctcModelId` can carry this instead of the alias. */
+export const MMS_ALIGNER_MODEL_ID = 'MahmoudAshraf/mms-300m-1130-forced-aligner';
+
+/** The permissive default + the opt-ins (aliases the sidecar resolves). */
 export const ALIGN_MODEL_CHOICES: AlignModelChoice[] = [
-  { id: '', label: 'MMS-300M — default (158 languages)' },
-  { id: 'romanian-wav2vec2', label: 'Romanian — gigant/romanian-wav2vec2' },
-  { id: 'wav2vec2-960h-lv60', label: 'English wav2vec2 (MIT, commercial)' },
+  { id: '', label: 'English wav2vec2 — default (Apache-2.0, commercial-safe)' },
+  { id: 'romanian-wav2vec2', label: 'Romanian — gigant/romanian-wav2vec2 (Apache-2.0)' },
+  { id: 'wav2vec2-960h-lv60', label: 'English wav2vec2 lv60-self (Apache-2.0)' },
+  { id: 'hubert-large', label: 'English HuBERT-Large (Apache-2.0)' },
+  {
+    id: MMS_ALIGNER_ALIAS,
+    label: 'MMS-300M — 158 languages (CC-BY-NC-4.0, non-commercial)',
+    nonCommercial: true,
+  },
 ];
 
 export interface AlignModelSelectProps {
-  /** Current persisted `ctcModelId` ('' / undefined = the MMS default). */
+  /** Current persisted `ctcModelId` ('' / undefined = the packaged default). */
   value: string;
   /** Persist the chosen alignment model id (the parent writes `ctcModelId`). */
   onChange: (ctcModelId: string) => void;
+  /** Current persisted `allowNonCommercialAligner`. */
+  allowNonCommercial: boolean;
+  /** Persist the opt-in (the parent writes `allowNonCommercialAligner`). */
+  onAllowNonCommercialChange: (allow: boolean) => void;
   /** Disable the control while a write is in flight. */
   busy?: boolean;
 }
@@ -33,11 +56,24 @@ export interface AlignModelSelectProps {
 export function AlignModelSelect({
   value,
   onChange,
+  allowNonCommercial,
+  onAllowNonCommercialChange,
   busy,
 }: AlignModelSelectProps): React.ReactElement {
   // An unknown persisted id (e.g. a hand-typed full HF id) shows as the default
   // row visually but is NOT lost — we only overwrite it when the user picks a row.
   const known = ALIGN_MODEL_CHOICES.some((c) => c.id === value);
+  const disabled = Boolean(busy);
+  const mmsSelected = value === MMS_ALIGNER_ALIAS || value === MMS_ALIGNER_MODEL_ID;
+
+  function handleAllowChange(next: boolean): void {
+    onAllowNonCommercialChange(next);
+    // Withdrawing the opt-in must also drop an MMS selection: the sidecar would
+    // refuse it and silently align with the permissive default, so leaving it
+    // persisted would leave the UI stating something untrue about the next job.
+    if (!next && mmsSelected) onChange('');
+  }
+
   return (
     <div className="align-model" data-section="align-model">
       <label htmlFor="align-model-select">Word-timing alignment model</label>
@@ -45,11 +81,15 @@ export function AlignModelSelect({
         id="align-model-select"
         data-action="align-model"
         value={known ? value : ''}
-        disabled={Boolean(busy)}
+        disabled={disabled}
         onChange={(e) => onChange(e.target.value)}
       >
         {ALIGN_MODEL_CHOICES.map((choice) => (
-          <option key={choice.id || 'default'} value={choice.id}>
+          <option
+            key={choice.id || 'default'}
+            value={choice.id}
+            disabled={Boolean(choice.nonCommercial) && !allowNonCommercial}
+          >
             {choice.label}
           </option>
         ))}
@@ -59,6 +99,21 @@ export function AlignModelSelect({
           custom: {value}
         </span>
       )}
+      <label className="align-model__nc" htmlFor="align-model-allow-nc">
+        <input
+          id="align-model-allow-nc"
+          type="checkbox"
+          data-action="allow-non-commercial-aligner"
+          checked={allowNonCommercial}
+          disabled={disabled}
+          onChange={(e) => handleAllowChange(e.target.checked)}
+        />
+        <span>
+          Allow non-commercial alignment models (CC-BY-NC-4.0). Off by default. Turning this on
+          unlocks MMS-300M and its 158 languages, and makes anything you align with it
+          non-commercial.
+        </span>
+      </label>
     </div>
   );
 }

--- a/app/renderer/src/components/AlignModelSelect.tsx
+++ b/app/renderer/src/components/AlignModelSelect.tsx
@@ -4,12 +4,20 @@
 // understands via `settings['ctcModelId']`. Since WU-T0/B1 the PACKAGED default
 // is the Apache-2.0 English wav2vec2 (`facebook/wav2vec2-large-960h-lv60-self`),
 // NOT the CC-BY-NC-4.0 MMS model it used to be, and MMS is reachable only when
-// `settings['allowNonCommercialAligner']` is on. Selecting the default persists
-// an EMPTY `ctcModelId` so the package default applies (no silent override).
+// `settings['allowNonCommercialAligner']` is on AND MMS is explicitly selected.
+// Selecting the default persists an EMPTY `ctcModelId` so the package default
+// applies (no silent override).
 //
 // The MMS row is rendered but DISABLED until the opt-in is on: the sidecar
 // silently downgrades an MMS request when the flag is off, and an option whose
 // effect the backend discards is worse than one that visibly cannot be chosen.
+//
+// The opt-in is an UNLOCK, never a selection. It briefly was both — the sidecar
+// fell back to MMS whenever the flag was on and nothing was chosen — so this
+// dropdown showed "Apache-2.0, commercial-safe" as the selected row over a
+// CC-BY-NC job. The sidecar fallback is gone; the label is now true in every
+// state, and `ctc_align`'s cross-file test joins these two halves so neither can
+// drift again (a comment saying they cannot drift is not a gate).
 // Licence facts: HF Hub metadata probe, 2026-08-09 (the previous "MIT" label on
 // the wav2vec2 row was wrong — the Hub reports apache-2.0).
 import React from 'react';
@@ -109,9 +117,9 @@ export function AlignModelSelect({
           onChange={(e) => handleAllowChange(e.target.checked)}
         />
         <span>
-          Allow non-commercial alignment models (CC-BY-NC-4.0). Off by default. Turning this on
-          unlocks MMS-300M and its 158 languages, and makes anything you align with it
-          non-commercial.
+          Allow non-commercial alignment models (CC-BY-NC-4.0). Off by default. Turning this on only
+          UNLOCKS MMS-300M and its 158 languages in the list above — it does not switch to it. Pick
+          it there to use it; anything you then align with it is non-commercial.
         </span>
       </label>
     </div>

--- a/app/renderer/src/components/advisorMeta.test.ts
+++ b/app/renderer/src/components/advisorMeta.test.ts
@@ -126,6 +126,14 @@ describe('prettyName', () => {
       expect(prettyName(id)).not.toMatch(codename);
     }
   });
+  // WU-T0/B1: the word-timing component's proposed download must be the model
+  // the sidecar actually resolves to. It pointed at the CC-BY-NC MMS asset,
+  // which `ctc_align._resolve_model_id` now refuses unless the user opts in —
+  // so installing it would have burned 1.2 GB on a model that never runs.
+  it('proposes the Apache-2.0 aligner asset, not the opt-in CC-BY-NC one', () => {
+    expect(componentAsset('ctc_aligner')).toBe('ctc-forced-aligner-wav2vec2');
+  });
+
   it('title-cases + de-snakes unknowns', () => {
     expect(prettyName('foo_bar')).toBe('Foo bar');
     expect(prettyName('zeta')).toBe('Zeta');

--- a/app/renderer/src/components/advisorMeta.ts
+++ b/app/renderer/src/components/advisorMeta.ts
@@ -150,7 +150,9 @@ export const COMPONENT_ASSET: Record<string, string> = {
   emotion: 'hsemotion-onnx',
   ocr: 'rapidocr-onnx',
   parakeet: 'parakeet-tdt-0.6b-v3',
-  ctc_aligner: 'ctc-forced-aligner-mms',
+  // WU-T0/B1: the packaged default is the Apache-2.0 wav2vec2 aligner; the
+  // CC-BY-NC MMS asset is only used when `allowNonCommercialAligner` is on.
+  ctc_aligner: 'ctc-forced-aligner-wav2vec2',
   pyannote: 'pyannote-speaker-diarization-31',
   smolvlm2: 'smolvlm2-2.2b',
 };

--- a/app/renderer/src/features/ThirdPartyNotices.test.tsx
+++ b/app/renderer/src/features/ThirdPartyNotices.test.tsx
@@ -16,6 +16,7 @@ import {
   FONT_LICENSE_FILE,
   FFMPEG_NOTICE,
   OPT_IN_MODEL_NOTICES,
+  ALIGNER_MODEL_NOTICES,
 } from './ThirdPartyNotices';
 
 let container: HTMLDivElement;
@@ -282,5 +283,85 @@ describe('ThirdPartyNotices — opt-in OpenRAIL models (WU-B1 lip-sync)', () => 
     expect(items).toHaveLength(2);
     expect(items[0]?.querySelector('.tpn__paper')?.textContent).toContain('arXiv:2412.09262');
     expect(items[1]?.querySelector('.tpn__paper')).toBeNull();
+  });
+});
+
+// --- Word-timing CTC aligners (v1.5 WU-T0 / B1) --------------------------------
+// The CC-BY-NC-4.0 MMS aligner shipped from Phase-8 with NO user-facing notice at
+// all — searching this file for `mms-300m`, `forced-aligner` or `MahmoudAshraf`
+// returned nothing before this block existed. CC-BY-NC REQUIRES attribution, so
+// the absence was a live licence breach independent of the commercial question.
+// It gets its OWN list because neither existing list can hold it: adding it to
+// THIRD_PARTY_NOTICES breaks the asserted "exactly one non-commercial model
+// (ViNet-S)" invariant and the `.tpn__chip--nc` count, and adding it to
+// OPT_IN_MODEL_NOTICES would be false — that list is OpenRAIL, commercial-OK by
+// construction, and asserts `every(n => n.commercial)`.
+describe('ThirdPartyNotices — word-timing aligners (WU-T0)', () => {
+  it('discloses the CC-BY-NC MMS aligner that previously appeared nowhere', async () => {
+    await mount();
+    const text = container.querySelector('.tpn__aligners')?.textContent ?? '';
+    expect(text).toContain('MMS-300M');
+    expect(text).toContain('MahmoudAshraf/mms-300m-1130-forced-aligner');
+    expect(text).toContain('CC-BY-NC-4.0');
+    // Attribution is the actual CC-BY-NC obligation — the author must be named.
+    expect(text).toContain('Mahmoud Ashraf');
+    expect(
+      container.querySelector('a[href="https://creativecommons.org/licenses/by-nc/4.0/"]'),
+    ).not.toBeNull();
+  });
+
+  it('names the setting that gates the non-commercial model and says it is off', async () => {
+    await mount();
+    const text = container.querySelector('.tpn__aligners')?.textContent ?? '';
+    expect(text).toContain('allowNonCommercialAligner');
+    expect(text).toContain('off by default');
+    const mms = ALIGNER_MODEL_NOTICES.find((n) => n.name.includes('MMS-300M'));
+    expect(mms?.commercial).toBe(false);
+    expect(mms?.gatedBy).toBe('allowNonCommercialAligner');
+  });
+
+  it('names the Apache-2.0 packaged default and never calls it MIT', async () => {
+    const def = ALIGNER_MODEL_NOTICES.find((n) => n.packagedDefault);
+    expect(def?.modelId).toBe('facebook/wav2vec2-large-960h-lv60-self');
+    expect(def?.license).toBe('Apache-2.0');
+    // The code called these three "MIT_MODEL_IDS"; the HF Hub says apache-2.0
+    // for all of them (probed 2026-08-09). A licence claim must not be restated
+    // from a neighbouring comment.
+    expect(ALIGNER_MODEL_NOTICES.every((n) => n.license !== 'MIT')).toBe(true);
+    expect(ALIGNER_MODEL_NOTICES.filter((n) => n.packagedDefault)).toHaveLength(1);
+  });
+
+  it('chips aligners as their own state, leaving every existing count intact', async () => {
+    await mount();
+    expect(container.querySelectorAll('.tpn__chip--aligner').length).toBe(
+      ALIGNER_MODEL_NOTICES.length,
+    );
+    // The pre-existing counts are load-bearing assertions elsewhere in this file.
+    expect(container.querySelectorAll('.tpn__chip--ok')).toHaveLength(4);
+    expect(container.querySelectorAll('.tpn__chip--nc')).toHaveLength(1);
+    expect(container.querySelectorAll('.tpn__chip--ofl')).toHaveLength(3);
+    expect(container.querySelectorAll('.tpn__chip--copyleft')).toHaveLength(1);
+    expect(container.querySelectorAll('.tpn__chip--userestricted')).toHaveLength(2);
+  });
+
+  it('keeps aligners out of the bundled and OpenRAIL lists', () => {
+    const bundled = THIRD_PARTY_NOTICES.map((n) => n.name);
+    const optIn = OPT_IN_MODEL_NOTICES.map((n) => n.name);
+    for (const n of ALIGNER_MODEL_NOTICES) {
+      expect(bundled).not.toContain(n.name);
+      expect(optIn).not.toContain(n.name);
+    }
+    // ...and the "exactly one non-commercial bundled model" invariant survives.
+    expect(THIRD_PARTY_NOTICES.filter((n) => !n.commercial)).toHaveLength(1);
+  });
+
+  it('renders the optional gate/note branches for the gated model only', async () => {
+    await mount();
+    const items = Array.from(container.querySelectorAll('.tpn__aligners .tpn__item'));
+    expect(items).toHaveLength(ALIGNER_MODEL_NOTICES.length);
+    // The permissive entries carry no gate chip text and no obligation note.
+    const permissive = items.filter((i) => i.querySelector('.tpn__note') === null);
+    expect(permissive.length).toBe(ALIGNER_MODEL_NOTICES.filter((n) => !n.note).length);
+    expect(permissive.length).toBeGreaterThan(0);
   });
 });

--- a/app/renderer/src/features/ThirdPartyNotices.tsx
+++ b/app/renderer/src/features/ThirdPartyNotices.tsx
@@ -328,6 +328,122 @@ export const OPT_IN_MODEL_NOTICES: readonly OptInModelNotice[] = [
   },
 ];
 
+/**
+ * A word-timing CTC forced-alignment model (v1.5 WU-T0). Its own record type
+ * because the axis that matters here is neither "bundled vs downloaded" nor
+ * "OpenRAIL", but WHICH ONE THE BUILD DEFAULTS TO and whether reaching a given
+ * one needs an explicit opt-in.
+ */
+export interface AlignerModelNotice {
+  /** Display name. */
+  name: string;
+  /** The exact Hugging Face repo id the sidecar resolves to. */
+  modelId: string;
+  /** What selecting it gets you, in one line. */
+  role: string;
+  /** SPDX id of the WEIGHTS licence, as the Hub reports it. */
+  license: string;
+  /** Canonical URL of that licence text. */
+  licenseUrl: string;
+  /** True when the licence permits commercial use. */
+  commercial: boolean;
+  /** Copyright / authors attribution line. */
+  attribution: string;
+  /** Upstream weights coordinates. */
+  source: string;
+  /** True for the ONE model the shipped build uses when nothing is selected. */
+  packagedDefault?: boolean;
+  /** The setting that must be turned on before this model can be selected. */
+  gatedBy?: string;
+  /** Extra obligation / scope callout (only where there is one). */
+  note?: string;
+}
+
+/**
+ * The selectable word-timing aligners, and the licence position of each.
+ *
+ * WHY THIS BLOCK EXISTS: the CC-BY-NC-4.0 MMS aligner has been in the product
+ * since Phase-8 and was disclosed NOWHERE — not here, not in
+ * `docs/THIRD-PARTY-LICENSES.md`. CC-BY-NC's attribution condition is
+ * independent of the commercial question (Reframe is already non-commercial
+ * while ViNet-S is bundled), so shipping it uncredited was a breach on its own.
+ *
+ * LICENCE FACTS VERIFIED 2026-08-09 by a Hugging Face Hub metadata probe — a
+ * source mechanically independent of the sidecar's own comments, which is how
+ * the pre-existing mislabel was caught: `ctc_align.py` called the three
+ * permissive models `MIT_MODEL_IDS` and labelled the wav2vec2 asset "MIT
+ * commercial", and the Hub reports `license:apache-2.0` for all three. Kept in
+ * lockstep with `sidecar/media_studio/features/ctc_align.py`
+ * (`DEFAULT_MODEL_ID` / `PERMISSIVE_MODEL_IDS` / `NON_COMMERCIAL_MODEL_ID`).
+ *
+ * WHY ITS OWN CHIP CLASS: an aligner is neither a bundled weight nor an OpenRAIL
+ * download, and both existing lists carry asserted invariants this entry would
+ * violate — `THIRD_PARTY_NOTICES` asserts exactly one non-commercial model
+ * (ViNet-S), `OPT_IN_MODEL_NOTICES` asserts every member is commercial-OK.
+ */
+export const ALIGNER_MODEL_NOTICES: readonly AlignerModelNotice[] = [
+  {
+    name: 'wav2vec2 (960h lv60-self)',
+    modelId: 'facebook/wav2vec2-large-960h-lv60-self',
+    role: 'word-timing forced alignment — English, the packaged default',
+    license: 'Apache-2.0',
+    licenseUrl: 'https://www.apache.org/licenses/LICENSE-2.0',
+    commercial: true,
+    attribution: '© Meta Platforms, Inc. (facebook/wav2vec2-large-960h-lv60-self)',
+    source: 'https://huggingface.co/facebook/wav2vec2-large-960h-lv60-self',
+    packagedDefault: true,
+  },
+  {
+    name: 'wav2vec2 (960h)',
+    modelId: 'facebook/wav2vec2-large-960h',
+    role: 'word-timing forced alignment — English, alternative',
+    license: 'Apache-2.0',
+    licenseUrl: 'https://www.apache.org/licenses/LICENSE-2.0',
+    commercial: true,
+    attribution: '© Meta Platforms, Inc. (facebook/wav2vec2-large-960h)',
+    source: 'https://huggingface.co/facebook/wav2vec2-large-960h',
+  },
+  {
+    name: 'HuBERT-Large (ls960-ft)',
+    modelId: 'facebook/hubert-large-ls960-ft',
+    role: 'word-timing forced alignment — English, alternative',
+    license: 'Apache-2.0',
+    licenseUrl: 'https://www.apache.org/licenses/LICENSE-2.0',
+    commercial: true,
+    attribution: '© Meta Platforms, Inc. (facebook/hubert-large-ls960-ft)',
+    source: 'https://huggingface.co/facebook/hubert-large-ls960-ft',
+  },
+  {
+    name: 'Romanian wav2vec2',
+    modelId: 'gigant/romanian-wav2vec2',
+    role: 'word-timing forced alignment — Romanian',
+    license: 'Apache-2.0',
+    licenseUrl: 'https://www.apache.org/licenses/LICENSE-2.0',
+    commercial: true,
+    attribution:
+      '© gigant (gigant/romanian-wav2vec2), fine-tuned from facebook/wav2vec2-xls-r-300m',
+    source: 'https://huggingface.co/gigant/romanian-wav2vec2',
+  },
+  {
+    name: 'MMS-300M forced aligner',
+    modelId: 'MahmoudAshraf/mms-300m-1130-forced-aligner',
+    role: 'word-timing forced alignment — 158 languages',
+    license: 'CC-BY-NC-4.0',
+    licenseUrl: 'https://creativecommons.org/licenses/by-nc/4.0/',
+    commercial: false,
+    attribution:
+      '© Mahmoud Ashraf (MahmoudAshraf/mms-300m-1130-forced-aligner), an MMS-300M derivative',
+    source: 'https://huggingface.co/MahmoudAshraf/mms-300m-1130-forced-aligner',
+    gatedBy: 'allowNonCommercialAligner',
+    note:
+      'NON-COMMERCIAL: this model may not be used for commercial purposes, and it requires ' +
+      'attribution — which is what this entry is. It is off by default: Reframe aligns with the ' +
+      'Apache-2.0 wav2vec2 model above unless you turn this one on in Settings, and turning it on ' +
+      'is what makes your alignment output non-commercial. It covers far more languages than the ' +
+      'permissive alternatives, which is the whole trade-off.',
+  },
+];
+
 /** The Settings → Licenses surface: bundled third-party model attributions. */
 export function ThirdPartyNotices(): React.ReactElement {
   return (
@@ -473,6 +589,54 @@ export function ThirdPartyNotices(): React.ReactElement {
               <p className="tpn__note" role="note">
                 {n.note}
               </p>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <div className="tpn__aligners">
+        <h3 className="tpn__subtitle">Word-timing alignment models</h3>
+        <p className="tpn__intro">
+          Karaoke-accurate word timings come from a forced-alignment model, downloaded on demand.
+          Reframe defaults to a permissive Apache-2.0 model. One alternative covers far more
+          languages but is licensed for non-commercial use only — it is off unless you turn it on,
+          and this list says which is which.
+        </p>
+        <ul className="tpn__list">
+          {ALIGNER_MODEL_NOTICES.map((n) => (
+            <li key={n.modelId} className="tpn__item" data-aligner-license={n.license}>
+              <header className="tpn__head">
+                <span className="tpn__name">{n.name}</span>
+                <span
+                  className="tpn__chip tpn__chip--aligner"
+                  data-commercial={n.commercial ? 'yes' : 'no'}
+                  data-packaged-default={n.packagedDefault ? 'yes' : 'no'}
+                >
+                  {n.license} · {n.commercial ? 'commercial OK' : 'non-commercial only'}
+                  {n.packagedDefault ? ' · default' : ''}
+                </span>
+              </header>
+              <p className="tpn__role">{n.role}</p>
+              <p className="tpn__attr">{n.attribution}</p>
+              <p className="tpn__license">
+                License:{' '}
+                <a href={n.licenseUrl} target="_blank" rel="noreferrer">
+                  {n.license}
+                </a>{' '}
+                · Source:{' '}
+                <a href={n.source} target="_blank" rel="noreferrer">
+                  {n.modelId}
+                </a>
+              </p>
+              {n.gatedBy ? (
+                <p className="tpn__gate">
+                  Off unless <code>{n.gatedBy}</code> is enabled.
+                </p>
+              ) : null}
+              {n.note ? (
+                <p className="tpn__note" role="note">
+                  {n.note}
+                </p>
+              ) : null}
             </li>
           ))}
         </ul>

--- a/app/renderer/src/features/ThirdPartyNotices.tsx
+++ b/app/renderer/src/features/ThirdPartyNotices.tsx
@@ -437,10 +437,11 @@ export const ALIGNER_MODEL_NOTICES: readonly AlignerModelNotice[] = [
     gatedBy: 'allowNonCommercialAligner',
     note:
       'NON-COMMERCIAL: this model may not be used for commercial purposes, and it requires ' +
-      'attribution — which is what this entry is. It is off by default: Reframe aligns with the ' +
-      'Apache-2.0 wav2vec2 model above unless you turn this one on in Settings, and turning it on ' +
-      'is what makes your alignment output non-commercial. It covers far more languages than the ' +
-      'permissive alternatives, which is the whole trade-off.',
+      'attribution — which is what this entry is. It is off by default, and the opt-in only ' +
+      'UNLOCKS it: Reframe keeps aligning with the Apache-2.0 wav2vec2 model above until you ' +
+      'also pick this one in Settings, so the licence the dropdown shows is always the licence ' +
+      'your jobs run under. Choosing it is what makes your alignment output non-commercial. It ' +
+      'covers far more languages than the permissive alternatives, which is the whole trade-off.',
   },
 ];
 

--- a/app/renderer/src/features/thirdPartyNotices.css
+++ b/app/renderer/src/features/thirdPartyNotices.css
@@ -24,11 +24,13 @@
 }
 
 /* The sub-blocks below the model list — bundled programs, optional downloads,
- * bundled fonts — each sit behind a hairline so the license categories read as
- * distinct groups under one heading. (`.tpn__binaries` was added without a rule
- * and rendered as an unseparated block; folded in here so all three match.) */
+ * word-timing aligners, bundled fonts — each sit behind a hairline so the license
+ * categories read as distinct groups under one heading. (`.tpn__binaries` was
+ * added without a rule and rendered as an unseparated block; folded in here so
+ * all of them match.) */
 .tpn__binaries,
 .tpn__optin,
+.tpn__aligners,
 .tpn__fonts {
   display: flex;
   flex-direction: column;
@@ -125,6 +127,29 @@
   background: var(--status-warn-soft);
   color: var(--status-warn);
   white-space: normal;
+}
+
+/* Word-timing aligners are a CHOICE, not a fixed fact about the build: the same
+ * list holds permissive models and one non-commercial one. A single neutral chip
+ * class keeps the model/font/binary chip counts independent, and the chip TEXT
+ * carries the licence id plus "commercial OK" / "non-commercial only", so the
+ * meaning never rides on hue. The non-commercial member is additionally tinted
+ * by its data attribute rather than by a second class. */
+.tpn__chip--aligner {
+  background: var(--surface-hover);
+  color: var(--text-secondary);
+  white-space: normal;
+}
+
+.tpn__chip--aligner[data-commercial="no"] {
+  background: var(--status-error-soft);
+  color: var(--status-error);
+}
+
+.tpn__gate {
+  margin: 0;
+  font-size: var(--type-caption-size);
+  color: var(--text-secondary);
 }
 
 .tpn__role {

--- a/app/renderer/src/panels/ModelsSystemPanel.test.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.test.tsx
@@ -1018,6 +1018,38 @@ describe('<ModelsSystemPanel />', () => {
     });
   });
 
+  // WU-T0/B1: the CC-BY-NC MMS aligner is unlocked by its own persisted setting.
+  it('persists allowNonCommercialAligner from the aligner opt-in toggle', async () => {
+    const c = makeClient({ initialSettings: { modelsOnboardingSeen: true } });
+    await mount(c);
+    await analyze();
+    const toggle = container.querySelector(
+      'input[data-action="allow-non-commercial-aligner"]',
+    ) as HTMLInputElement;
+    expect(toggle).not.toBeNull();
+    // Default-off is the licence-safe state, and it is what the sidecar assumes.
+    expect(toggle.checked).toBe(false);
+    await act(async () => {
+      toggle.click();
+      await Promise.resolve();
+    });
+    expect(c.calls.find((x) => x.method === 'settings.set')?.args[0]).toEqual({
+      allowNonCommercialAligner: true,
+    });
+  });
+
+  it('reflects a persisted allowNonCommercialAligner opt-in', async () => {
+    const c = makeClient({
+      initialSettings: { modelsOnboardingSeen: true, allowNonCommercialAligner: true },
+    });
+    await mount(c);
+    await analyze();
+    const toggle = container.querySelector(
+      'input[data-action="allow-non-commercial-aligner"]',
+    ) as HTMLInputElement;
+    expect(toggle.checked).toBe(true);
+  });
+
   it('mergeOverviewRoutingPolicy folds the policy in (and passes null through) (M5)', () => {
     expect(mergeOverviewRoutingPolicy(null, { global: 'cloud', overrides: {} })).toBeNull();
     const ov = modelsOverview({ routingPolicy: { global: 'local', overrides: {} } });

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -315,8 +315,12 @@ interface SettingsShape {
   // M3 POINT: non-default local-runner base URLs the detector probes.
   ollamaBaseUrl?: string;
   lmStudioBaseUrl?: string;
-  // M5 RO alignment opt-in: the word-timing CTC model id ('' = MMS default).
+  // M5 RO alignment opt-in: the word-timing CTC model id ('' = the packaged
+  // Apache-2.0 default; WU-T0/B1 flipped that away from the CC-BY-NC MMS model).
   ctcModelId?: string;
+  // WU-T0/B1: unlocks the CC-BY-NC-4.0 MMS aligner. The sidecar refuses that
+  // model unless this is truthy, so the picker must read the SAME key.
+  allowNonCommercialAligner?: boolean;
 }
 
 export function ModelsSystemPanel({
@@ -902,12 +906,18 @@ export function ModelsSystemPanel({
         />
       )}
 
-      {/* M5: RO alignment opt-in — exposes gigant/romanian-wav2vec2 (and the MIT
-          English wav2vec2) over the MMS-300m default via settings.ctcModelId. */}
+      {/* M5 + WU-T0/B1: the alignment-model picker over settings.ctcModelId,
+          plus the allowNonCommercialAligner opt-in that unlocks the CC-BY-NC
+          MMS model. Both keys are read by the sidecar's single
+          `ctc_align._resolve_model_id`, so the UI cannot drift from the gate. */}
       {analyzed && (
         <AlignModelSelect
           value={settings.ctcModelId ?? ''}
           onChange={(ctcModelId) => void patchSettings({ ctcModelId })}
+          allowNonCommercial={settings.allowNonCommercialAligner ?? false}
+          onAllowNonCommercialChange={(allowNonCommercialAligner) =>
+            void patchSettings({ allowNonCommercialAligner })
+          }
         />
       )}
 

--- a/app/renderer/src/panels/ModelsSystemPanel.tsx
+++ b/app/renderer/src/panels/ModelsSystemPanel.tsx
@@ -907,9 +907,15 @@ export function ModelsSystemPanel({
       )}
 
       {/* M5 + WU-T0/B1: the alignment-model picker over settings.ctcModelId,
-          plus the allowNonCommercialAligner opt-in that unlocks the CC-BY-NC
-          MMS model. Both keys are read by the sidecar's single
-          `ctc_align._resolve_model_id`, so the UI cannot drift from the gate. */}
+          plus the allowNonCommercialAligner opt-in that unlocks (never selects)
+          the CC-BY-NC MMS model. Both keys are read by the sidecar's single
+          `ctc_align._resolve_model_id`.
+          This comment used to claim "so the UI cannot drift from the gate" — it
+          could, and it did: sharing an input says nothing about agreeing on the
+          output, and the drift shipped green because each suite only checked its
+          own side. The actual guard is the cross-file
+          test_the_settings_dropdown_label_matches_the_model_that_will_actually_run
+          in sidecar/tests/test_ctc_align.py. */}
       {analyzed && (
         <AlignModelSelect
           value={settings.ctcModelId ?? ''}

--- a/docs/THIRD-PARTY-LICENSES.md
+++ b/docs/THIRD-PARTY-LICENSES.md
@@ -217,5 +217,19 @@ cross-file test that reads both plus this table's in-app twin:
   `allowNonCommercialAligner`) in `sidecar/contract/spec.py` are **not added**;
   both keys stay stringly-accessed as before. Regenerating the contract
   artifacts was out of scope here.
+- The `ctc_aligner` readiness signal is **not selection-aware**. The
+  component→asset maps (`handlers/_wire.py`, `features/recommender.py`,
+  `components/advisorMeta.ts`) statically name `ctc-forced-aligner-wav2vec2`, so
+  a user who has opted in *and picked MMS* sees the word-timing card report
+  readiness off the wav2vec2 asset rather than the MMS one they will actually
+  use. Both assets remain installable by name via `assets.list` / `assets.ensure`,
+  so this is a wrong *signal*, not an unreachable model. Raised by a reviewer who
+  flagged it as their own weakest point (INFERRED from the two `_COMPONENT_ASSETS`
+  maps plus `_asset_for_model`, ~75-85%; the readiness path was not executed
+  end-to-end by them or by me). Left as-is deliberately: making three mirrored
+  static maps settings-aware is a change to the readiness architecture, not to
+  licence disclosure. Settling experiment: drive `assets.status` for
+  `ctc_aligner` with `{allowNonCommercialAligner: true, ctcModelId: 'mms-300m'}`
+  and MMS absent from disk, and check whether the card claims ready.
 - Nothing was checked with licence counsel. The claims above are licence *tags*
   and licence *text*, not legal advice.

--- a/docs/THIRD-PARTY-LICENSES.md
+++ b/docs/THIRD-PARTY-LICENSES.md
@@ -143,3 +143,65 @@ Two corrections to the v1.5 plan (`docs/plans/v1.5/flagship-lip-sync-dub.md`
 wall: its README states "any form of commercial use is strictly prohibited".
 It is named in `lipsync.DENIED_ENGINES` so a request for it is refused with that
 reason rather than falling through to a generic "unknown engine".
+
+## 5. Word-timing CTC forced aligners — one CC-BY-NC model, now opt-in
+
+Karaoke-grade word timings come from a CTC forced-alignment model
+(`sidecar/media_studio/features/ctc_align.py`), downloaded on demand. The
+attributions render in-app as `ALIGNER_MODEL_NOTICES` in
+`app/renderer/src/features/ThirdPartyNotices.tsx`; this section records the two
+things an attribution block does not: **what was previously wrong, and how it was
+measured.**
+
+| Model | Licence | Commercial | Role |
+|---|---|---|---|
+| `facebook/wav2vec2-large-960h-lv60-self` | Apache-2.0 | yes | **packaged default** (English) |
+| `facebook/wav2vec2-large-960h` | Apache-2.0 | yes | English alternative |
+| `facebook/hubert-large-ls960-ft` | Apache-2.0 | yes | English alternative |
+| `gigant/romanian-wav2vec2` | Apache-2.0 | yes | Romanian |
+| `MahmoudAshraf/mms-300m-1130-forced-aligner` | **CC-BY-NC-4.0** | **no** | 158 languages, opt-in only |
+
+Licences verified 2026-08-09 by a Hugging Face Hub metadata probe — a source
+mechanically independent of the repo's own comments, which is exactly why it was
+worth running.
+
+**Two defects this closed.**
+
+1. **The MMS model was disclosed nowhere.** It had been the packaged default
+   since Phase-8, and searching `ThirdPartyNotices.tsx` and this file for
+   `mms-300m`, `forced-aligner` or `MahmoudAshraf` returned nothing. CC-BY-NC-4.0
+   requires **attribution**, and that obligation is independent of the commercial
+   question — Reframe is already non-commercial while ViNet-S (CC-BY-NC-SA-4.0)
+   is bundled, so this was not a *new* commercial breach, but it was a live
+   attribution breach on its own.
+2. **The permissive alternatives were mislabelled MIT.** The code called them
+   `MIT_MODEL_IDS` and the asset label read "wav2vec2 (word timing, MIT
+   commercial)". The Hub reports `license:apache-2.0` for all three. Both are
+   permissive, so nothing shipped under a wrong grant, but Apache-2.0 carries a
+   NOTICE/attribution condition MIT does not, and a licence claim restated from a
+   neighbouring comment is how that kind of error survives. Renamed
+   `PERMISSIVE_MODEL_IDS`.
+
+**The gate.** `ctc_align._resolve_model_id` applies the licence check LAST, to
+the *resolved* id, so no request shape routes around it: the packaged default,
+the `ctcModelId` alias, a hand-typed full HF id and the per-job `model_id`
+argument all pass through one check, and a `NON_COMMERCIAL_MODEL_IDS` member is
+downgraded to the Apache-2.0 default unless `settings['allowNonCommercialAligner']`
+is truthy. This implements
+`docs/plans/v1.5/flagship-transcript-editing.md:94` ("must NOT be the packaged
+default") and `:150` ("gate MMS behind `allowNonCommercialAligner`").
+
+**What this does NOT do, stated so it is not assumed:**
+
+- The per-language permissive-CTC map the same plan line asks for (the XLSR-53
+  family) is **not built**. A non-English clip whose language has no permissive
+  aligner now falls back to the ASR's own word timings — measurably looser
+  (~100–500 ms Whisper DTW vs ~20–120 ms CTC) — unless the user picks the
+  Romanian model or accepts the non-commercial terms. That is a real quality
+  regression for non-English users and it is the deliberate price of the flip.
+- The typed `Settings` keys (`ctcModelId`, `asrEngine`,
+  `allowNonCommercialAligner`) in `sidecar/contract/spec.py` are **not added**;
+  both keys stay stringly-accessed as before. Regenerating the contract
+  artifacts was out of scope here.
+- Nothing was checked with licence counsel. The claims above are licence *tags*
+  and licence *text*, not legal advice.

--- a/docs/THIRD-PARTY-LICENSES.md
+++ b/docs/THIRD-PARTY-LICENSES.md
@@ -191,6 +191,20 @@ is truthy. This implements
 `docs/plans/v1.5/flagship-transcript-editing.md:94` ("must NOT be the packaged
 default") and `:150` ("gate MMS behind `allowNonCommercialAligner`").
 
+**The opt-in UNLOCKS the MMS model; it never selects it.** Reaching CC-BY-NC
+weights takes the flag *and* an explicit choice in Settings. The first cut of
+this section did not say that because the code did not do it: with the flag on
+and nothing chosen, `_resolve_model_id` fell back to MMS while the Settings
+dropdown still rendered "English wav2vec2 — default (Apache-2.0,
+commercial-safe)" as the selected row — a screen asserting the wrong licence for
+the model actually running, which is worse than the undisclosed dependency this
+section was written to close. Three independent reviewers reproduced it with the
+same probe. The fallback is removed. It shipped green because the sidecar suite
+and the renderer suite each only checked their own half, so the guard is now a
+cross-file test that reads both plus this table's in-app twin:
+`test_the_settings_dropdown_label_matches_the_model_that_will_actually_run` in
+`sidecar/tests/test_ctc_align.py`.
+
 **What this does NOT do, stated so it is not assumed:**
 
 - The per-language permissive-CTC map the same plan line asks for (the XLSR-53

--- a/sidecar/media_studio/features/ctc_align.py
+++ b/sidecar/media_studio/features/ctc_align.py
@@ -22,12 +22,29 @@ Design (the canonical Phase-8 seam pattern — see ``diarize`` / ``audio_salienc
     fake :class:`CtcAlignBackend` returning canned word spans and a fake loader
     returning synthetic samples — no torch, no aligner, no ffmpeg.
 
-Decision #1 (license): the package DEFAULT model
-``MahmoudAshraf/mms-300m-1130-forced-aligner`` is **CC-BY-NC-4.0** (non-commercial
-only) — fine for the local desktop tool. A commercial build overrides it with an
-**MIT** wav2vec2 model id via ``settings['ctcModelId']`` or the ``model_id`` arg
-(see :data:`MIT_MODEL_IDS`). The default + override flow through one
-``_resolve_model_id`` so a single switch picks the model everywhere.
+Decision #1 (license), as REVISED by v1.5 WU-T0/B1: the *upstream package* default
+``MahmoudAshraf/mms-300m-1130-forced-aligner`` is **CC-BY-NC-4.0**, so it is NO
+LONGER Reframe's packaged default — ``docs/plans/v1.5/flagship-transcript-editing.md:94``
+("must NOT be the packaged default") and ``:150`` ("gate MMS behind
+``allowNonCommercialAligner``"). Reframe now defaults to
+``facebook/wav2vec2-large-960h-lv60-self`` (**Apache-2.0**, English) and reaches the
+MMS model ONLY when ``settings['allowNonCommercialAligner']`` is truthy — an explicit
+opt-in that also has to be set before an explicit ``ctcModelId``/``model_id`` naming
+MMS is honoured. Everything flows through one :func:`_resolve_model_id`, so a single
+switch picks the model everywhere and the gate cannot be routed around.
+
+LICENCE FACTS VERIFIED 2026-08-09 by an HF Hub metadata probe (a probe mechanically
+independent of this file's own comments, which is how the pre-existing "MIT"
+mislabel — plan B3 — was caught): MMS = ``cc-by-nc-4.0``; all three of
+:data:`PERMISSIVE_MODEL_IDS` and ``gigant/romanian-wav2vec2`` = ``apache-2.0``,
+NOT MIT. The user-facing attribution lives in
+``app/renderer/src/features/ThirdPartyNotices.tsx`` (``ALIGNER_MODEL_NOTICES``) and
+``docs/THIRD-PARTY-LICENSES.md``.
+
+NOT done here (disclosed, not silently skipped): the per-language permissive-CTC
+map (XLSR-53 family) and the typed ``spec.py`` Settings keys that the same plan
+section asks for. Non-English alignment therefore degrades to the ASR's own word
+timings unless the user picks RO or opts into MMS.
 
 Missing-modality / degrade contract: when the model is unavailable (offline AND
 the asset is not installed) — or any backend failure occurs — :func:`align_words`
@@ -95,38 +112,62 @@ def _decode_pcm_or_raise(
 
 
 # --------------------------------------------------------------------------- #
-# model ids + asset (Decision #1: CC-BY-NC default, MIT override available)
+# model ids + assets (Decision #1 as revised by WU-T0/B1: permissive default,
+# CC-BY-NC MMS behind an explicit opt-in)
 # --------------------------------------------------------------------------- #
-#: the package default — CC-BY-NC-4.0, 158-language, ungated. Local-tool default.
-DEFAULT_MODEL_ID = "MahmoudAshraf/mms-300m-1130-forced-aligner"
+#: The 158-language MMS forced aligner — **CC-BY-NC-4.0**, so NON-COMMERCIAL only
+#: (HF Hub tag ``license:cc-by-nc-4.0``, probed 2026-08-09). It is the upstream
+#: ``ctc-forced-aligner`` package default but NOT Reframe's: it is reachable only
+#: via ``settings['allowNonCommercialAligner']``. Attribution: © Mahmoud Ashraf
+#: (MahmoudAshraf/mms-300m-1130-forced-aligner), built on Meta AI's MMS-300M.
+NON_COMMERCIAL_MODEL_ID = "MahmoudAshraf/mms-300m-1130-forced-aligner"
+#: The settings key that gates :data:`NON_COMMERCIAL_MODEL_IDS`. Absent/falsy =
+#: commercial-safe; a user must turn it on knowing what it means.
+ALLOW_NON_COMMERCIAL_SETTING = "allowNonCommercialAligner"
+#: Every model id this module refuses to use without that opt-in. A frozenset so
+#: adding a second NC model is a one-line change that the gate picks up for free.
+NON_COMMERCIAL_MODEL_IDS: frozenset[str] = frozenset({NON_COMMERCIAL_MODEL_ID})
+
 # F3c: pin the HF snapshot revisions to commit hashes (verified 2026-06-28).
-DEFAULT_MODEL_REVISION = "49402e9577b1158620820667c218cd494cc44486"
+NON_COMMERCIAL_MODEL_REVISION = "49402e9577b1158620820667c218cd494cc44486"
 WAV2VEC2_REVISION = "54074b1c16f4de6a5ad59affb4caa8f2ea03a119"
 
-#: commercial-safe MIT wav2vec2/HuBERT alternatives (the Decision #1 swap).
-#: Keyed by a short alias the UI/settings can surface; values are the model ids.
-MIT_MODEL_IDS: dict[str, str] = {
+#: Commercial-safe **Apache-2.0** wav2vec2/HuBERT alternatives, keyed by the short
+#: alias the UI/settings surface. Named ``MIT_MODEL_IDS`` until 2026-08-09: an HF
+#: Hub probe showed all three carry ``license:apache-2.0``, never MIT (plan B3).
+PERMISSIVE_MODEL_IDS: dict[str, str] = {
     "wav2vec2-960h-lv60": "facebook/wav2vec2-large-960h-lv60-self",
     "wav2vec2-960h": "facebook/wav2vec2-large-960h",
     "hubert-large": "facebook/hubert-large-ls960-ft",
 }
 
+#: Reframe's PACKAGED default aligner (WU-T0/B1 flip): Apache-2.0, English.
+#: Non-English clips degrade to the ASR's own word timings unless the user picks
+#: the RO model or opts into MMS — the per-language permissive map is NOT built.
+DEFAULT_MODEL_ID = PERMISSIVE_MODEL_IDS["wav2vec2-960h-lv60"]
+
 #: M5 — Romanian-language alignment opt-in. A wav2vec2 CTC model fine-tuned on
-#: Romanian (Apache-2.0); the MMS-300m default stays unless ``settings['ctcModelId']``
-#: selects this alias (or its full HF id). Keyed by the alias the UI surfaces.
+#: Romanian (Apache-2.0, HF-probed 2026-08-09); selected via ``settings['ctcModelId']``
+#: (this alias or its full HF id). Keyed by the alias the UI surfaces.
 RO_MODEL_IDS: dict[str, str] = {
     "romanian-wav2vec2": "gigant/romanian-wav2vec2",
 }
 # F3c: pin the HF snapshot revision to a commit hash (git ls-remote, 2026-06-29).
 RO_MODEL_REVISION = "79cf603aac59501d02bfeb37f615efc3ac4ce1b3"
 
-#: every short alias -> full HF id (the package default + MIT swaps + RO opt-in).
-_MODEL_ALIASES: dict[str, str] = {**MIT_MODEL_IDS, **RO_MODEL_IDS}
+#: every short alias -> full HF id (permissive swaps + RO opt-in + the gated MMS).
+#: ``mms-300m`` is listed so the UI can name the NC model explicitly rather than
+#: reaching it by an unlabelled fallback — the gate still governs whether it wins.
+_MODEL_ALIASES: dict[str, str] = {
+    **PERMISSIVE_MODEL_IDS,
+    **RO_MODEL_IDS,
+    "mms-300m": NON_COMMERCIAL_MODEL_ID,
+}
 
-#: the on-demand asset name for the DEFAULT model (Wave-2 manifest entry).
+#: the on-demand asset name for the gated CC-BY-NC MMS model (Wave-2 manifest).
 ASSET_NAME = "ctc-forced-aligner-mms"
-#: the on-demand asset name for the MIT commercial-override model.
-MIT_ASSET_NAME = "ctc-forced-aligner-wav2vec2"
+#: the on-demand asset name for the Apache-2.0 wav2vec2 packaged default.
+WAV2VEC2_ASSET_NAME = "ctc-forced-aligner-wav2vec2"
 #: the on-demand asset name for the Romanian (M5) alignment opt-in.
 RO_ASSET_NAME = "ctc-forced-aligner-romanian"
 
@@ -189,28 +230,51 @@ ModelsPresent = Callable[[dict[str, Any], str], bool]
 # pure: model-id resolution (Decision #1 switch)
 # --------------------------------------------------------------------------- #
 def _resolve_model_id(settings: dict[str, Any], model_id: str | None) -> str:
-    """Pick the alignment model id: explicit arg > settings > package default.
+    """Pick the alignment model id: explicit arg > settings > packaged default.
 
     ``model_id`` (the call arg) wins so a caller can force a model per-job. Next
     is ``settings['ctcModelId']`` — which may be a full HF id OR one of the
-    :data:`MIT_MODEL_IDS` / :data:`RO_MODEL_IDS` aliases (resolved to its id).
-    Absent both, the CC-BY-NC package default is used (fine for the local tool).
+    :data:`PERMISSIVE_MODEL_IDS` / :data:`RO_MODEL_IDS` aliases (resolved to its
+    id), or ``mms-300m``. Absent both, the packaged Apache-2.0
+    :data:`DEFAULT_MODEL_ID` is used.
+
+    **The licence gate is applied LAST, to the resolved id**, so no request shape
+    can route around it: a :data:`NON_COMMERCIAL_MODEL_IDS` member is downgraded
+    to :data:`DEFAULT_MODEL_ID` unless ``settings['allowNonCommercialAligner']``
+    is truthy. Placing it after resolution (rather than only on the fallback) is
+    what makes the alias, the full-id and the per-job-arg paths all covered by one
+    check — the flaw in gating only the default would be an explicit
+    ``ctcModelId`` silently re-enabling a CC-BY-NC model in a commercial build.
     """
-    if model_id:
-        return _MODEL_ALIASES.get(model_id, model_id)
+    allow_non_commercial = bool(settings.get(ALLOW_NON_COMMERCIAL_SETTING))
     configured = settings.get("ctcModelId")
-    if isinstance(configured, str) and configured:
-        return _MODEL_ALIASES.get(configured, configured)
-    return DEFAULT_MODEL_ID
+    requested = model_id or (configured if isinstance(configured, str) and configured else None)
+    if requested:
+        resolved = _MODEL_ALIASES.get(requested, requested)
+    elif allow_non_commercial:
+        # Explicitly opted in and nothing selected: the 158-language MMS model is
+        # the best default available, and it is what pre-T0 builds used.
+        resolved = NON_COMMERCIAL_MODEL_ID
+    else:
+        resolved = DEFAULT_MODEL_ID
+    if resolved in NON_COMMERCIAL_MODEL_IDS and not allow_non_commercial:
+        log.warning(
+            "ctc_align: %s is non-commercial (CC-BY-NC-4.0) and %s is off — using %s instead",
+            resolved,
+            ALLOW_NON_COMMERCIAL_SETTING,
+            DEFAULT_MODEL_ID,
+        )
+        return DEFAULT_MODEL_ID
+    return resolved
 
 
 def _asset_for_model(model_id: str) -> str:
-    """The asset name guarding a model id (default MMS / RO opt-in / MIT override)."""
-    if model_id == DEFAULT_MODEL_ID:
+    """The asset name guarding a model id (gated MMS / RO opt-in / wav2vec2)."""
+    if model_id == NON_COMMERCIAL_MODEL_ID:
         return ASSET_NAME
     if model_id == RO_MODEL_IDS["romanian-wav2vec2"]:
         return RO_ASSET_NAME
-    return MIT_ASSET_NAME
+    return WAV2VEC2_ASSET_NAME
 
 
 # --------------------------------------------------------------------------- #
@@ -408,9 +472,10 @@ def align_words(
     """Refine the word timings of ``transcript`` by force-aligning to ``audio_path``.
 
     Returns a NEW transcript with karaoke-grade word ``start``/``end`` (and a
-    per-word ``score``); the input is never mutated. The CC-BY-NC default model is
-    used unless ``model_id`` / ``settings['ctcModelId']`` selects an MIT override
-    (Decision #1).
+    per-word ``score``); the input is never mutated. The Apache-2.0
+    :data:`DEFAULT_MODEL_ID` is used unless ``model_id`` /
+    ``settings['ctcModelId']`` selects another; the CC-BY-NC MMS model is reached
+    only with ``settings['allowNonCommercialAligner']`` (WU-T0/B1).
 
     Degrade rules (never raises for a missing modality, never drops text):
       * **Empty transcript** (no word tokens) -> the input is returned unchanged.
@@ -486,11 +551,12 @@ def align_words(
 # asset registration (mirrors diarize.register_diarize_assets)
 # --------------------------------------------------------------------------- #
 def register_ctc_align_assets() -> None:
-    """Register the default (CC-BY-NC) + MIT-override models as on-demand assets.
+    """Register the packaged Apache-2.0 default + the gated MMS model as assets.
 
-    Idempotent (identical re-register is a no-op). The default MMS model is the
-    local-tool default; the wav2vec2 entry is the commercial override (Decision
-    #1). Both resolve from the standard HF cache.
+    Idempotent (identical re-register is a no-op). The wav2vec2 entry is the
+    PACKAGED default (Apache-2.0); the MMS entry stays registered because a user
+    who sets ``allowNonCommercialAligner`` must still be able to install it.
+    Both resolve from the standard HF cache.
     """
     from ..assets import manifest  # noqa: PLC0415 - lazy: avoids a cycle
 
@@ -499,20 +565,20 @@ def register_ctc_align_assets() -> None:
             name=ASSET_NAME,
             kind="model",
             size_mb=1200,
-            label="CTC forced aligner — MMS-300M (word timing, CC-BY-NC)",
+            label="CTC forced aligner — MMS-300M (word timing, CC-BY-NC-4.0, opt-in)",
             installer="hf",
-            hf_repo=DEFAULT_MODEL_ID,
-            hf_revision=DEFAULT_MODEL_REVISION,
+            hf_repo=NON_COMMERCIAL_MODEL_ID,
+            hf_revision=NON_COMMERCIAL_MODEL_REVISION,
         )
     )
     manifest.register_asset(
         manifest.AssetEntry(
-            name=MIT_ASSET_NAME,
+            name=WAV2VEC2_ASSET_NAME,
             kind="model",
             size_mb=1300,
-            label="CTC forced aligner — wav2vec2 (word timing, MIT commercial)",
+            label="CTC forced aligner — wav2vec2 (word timing, Apache-2.0, default)",
             installer="hf",
-            hf_repo=MIT_MODEL_IDS["wav2vec2-960h-lv60"],
+            hf_repo=DEFAULT_MODEL_ID,
             hf_revision=WAV2VEC2_REVISION,
         )
     )
@@ -534,12 +600,15 @@ register_ctc_align_assets()
 
 
 __all__ = [
+    "ALLOW_NON_COMMERCIAL_SETTING",
     "ASSET_NAME",
     "DEFAULT_MODEL_ID",
-    "MIT_ASSET_NAME",
-    "MIT_MODEL_IDS",
+    "NON_COMMERCIAL_MODEL_ID",
+    "NON_COMMERCIAL_MODEL_IDS",
+    "PERMISSIVE_MODEL_IDS",
     "RO_ASSET_NAME",
     "RO_MODEL_IDS",
+    "WAV2VEC2_ASSET_NAME",
     "AudioLoader",
     "BackendFactory",
     "CtcAlignBackend",

--- a/sidecar/media_studio/features/ctc_align.py
+++ b/sidecar/media_studio/features/ctc_align.py
@@ -28,10 +28,13 @@ LONGER Reframe's packaged default — ``docs/plans/v1.5/flagship-transcript-edit
 ("must NOT be the packaged default") and ``:150`` ("gate MMS behind
 ``allowNonCommercialAligner``"). Reframe now defaults to
 ``facebook/wav2vec2-large-960h-lv60-self`` (**Apache-2.0**, English) and reaches the
-MMS model ONLY when ``settings['allowNonCommercialAligner']`` is truthy — an explicit
-opt-in that also has to be set before an explicit ``ctcModelId``/``model_id`` naming
-MMS is honoured. Everything flows through one :func:`_resolve_model_id`, so a single
-switch picks the model everywhere and the gate cannot be routed around.
+MMS model ONLY when BOTH hold: ``settings['allowNonCommercialAligner']`` is truthy
+AND a ``ctcModelId``/``model_id`` explicitly names MMS. The opt-in on its own is an
+UNLOCK, never a selection — with nothing chosen the packaged Apache-2.0 default
+still runs, because otherwise the Settings dropdown would keep showing
+"commercial-safe" over a CC-BY-NC job. Everything flows through one
+:func:`_resolve_model_id`, so a single switch picks the model everywhere and the
+gate cannot be routed around.
 
 LICENCE FACTS VERIFIED 2026-08-09 by an HF Hub metadata probe (a probe mechanically
 independent of this file's own comments, which is how the pre-existing "MIT"
@@ -118,7 +121,8 @@ def _decode_pcm_or_raise(
 #: The 158-language MMS forced aligner — **CC-BY-NC-4.0**, so NON-COMMERCIAL only
 #: (HF Hub tag ``license:cc-by-nc-4.0``, probed 2026-08-09). It is the upstream
 #: ``ctc-forced-aligner`` package default but NOT Reframe's: it is reachable only
-#: via ``settings['allowNonCommercialAligner']``. Attribution: © Mahmoud Ashraf
+#: by explicitly SELECTING it with ``settings['allowNonCommercialAligner']`` on —
+#: the flag alone unlocks it, it never selects it. Attribution: © Mahmoud Ashraf
 #: (MahmoudAshraf/mms-300m-1130-forced-aligner), built on Meta AI's MMS-300M.
 NON_COMMERCIAL_MODEL_ID = "MahmoudAshraf/mms-300m-1130-forced-aligner"
 #: The settings key that gates :data:`NON_COMMERCIAL_MODEL_IDS`. Absent/falsy =
@@ -245,18 +249,24 @@ def _resolve_model_id(settings: dict[str, Any], model_id: str | None) -> str:
     what makes the alias, the full-id and the per-job-arg paths all covered by one
     check — the flaw in gating only the default would be an explicit
     ``ctcModelId`` silently re-enabling a CC-BY-NC model in a commercial build.
+
+    **The opt-in UNLOCKS the MMS model; it does not select it.** The first cut of
+    this function had an ``elif allow_non_commercial: resolved =
+    NON_COMMERCIAL_MODEL_ID`` fallback, so turning the checkbox on silently made
+    CC-BY-NC weights the effective default while the Settings dropdown kept
+    rendering "English wav2vec2 — default (Apache-2.0, commercial-safe)" as the
+    chosen row — a screen stating the wrong licence for the model that would
+    actually run, in the very lane meant to make aligner licensing honest. It
+    also contradicted plan line 94 ("must NOT be the packaged default"), the
+    checkbox copy ("unlocks MMS-300M"), and the Licences copy. Reaching MMS now
+    takes the opt-in AND an explicit selection, which is what all three promised.
+    Cross-checked against the UI text by
+    ``test_the_settings_dropdown_label_matches_the_model_that_will_actually_run``.
     """
     allow_non_commercial = bool(settings.get(ALLOW_NON_COMMERCIAL_SETTING))
     configured = settings.get("ctcModelId")
     requested = model_id or (configured if isinstance(configured, str) and configured else None)
-    if requested:
-        resolved = _MODEL_ALIASES.get(requested, requested)
-    elif allow_non_commercial:
-        # Explicitly opted in and nothing selected: the 158-language MMS model is
-        # the best default available, and it is what pre-T0 builds used.
-        resolved = NON_COMMERCIAL_MODEL_ID
-    else:
-        resolved = DEFAULT_MODEL_ID
+    resolved = _MODEL_ALIASES.get(requested, requested) if requested else DEFAULT_MODEL_ID
     if resolved in NON_COMMERCIAL_MODEL_IDS and not allow_non_commercial:
         log.warning(
             "ctc_align: %s is non-commercial (CC-BY-NC-4.0) and %s is off — using %s instead",

--- a/sidecar/media_studio/features/recommender.py
+++ b/sidecar/media_studio/features/recommender.py
@@ -89,7 +89,9 @@ _COMPONENT_ASSETS: dict[str, str] = {
     "emotion": "hsemotion-onnx",
     "ocr": "rapidocr-onnx",
     "parakeet": "parakeet-tdt-0.6b-v3",
-    "ctc_aligner": "ctc-forced-aligner-mms",
+    # WU-T0/B1: mirrors _wire — the packaged default is the Apache-2.0 wav2vec2
+    # aligner, not the opt-in CC-BY-NC MMS one.
+    "ctc_aligner": "ctc-forced-aligner-wav2vec2",
     "pyannote": "pyannote-speaker-diarization-31",
     "smolvlm2": "smolvlm2-2.2b",
 }

--- a/sidecar/media_studio/features/system_advisor.py
+++ b/sidecar/media_studio/features/system_advisor.py
@@ -240,11 +240,17 @@ COMPONENTS: tuple[ComponentSpec, ...] = (
         model_backed=True,
         vram_mb=2000,
         size_mb=1200,
-        license_commercial_ok=False,
+        # WU-T0/B1: commercial-OK since the packaged default flipped from the
+        # CC-BY-NC MMS model to Apache-2.0 wav2vec2 (ctc_align.DEFAULT_MODEL_ID).
+        # The CC-BY-NC model is still reachable, but only when the user turns on
+        # `allowNonCommercialAligner` — an explicit choice this static component
+        # spec cannot see, and one the Settings copy warns about at the point of
+        # opt-in. Describing the DEFAULT here is what makes the verdict truthful.
+        license_commercial_ok=True,
         improves="karaoke word-timing 2nd pass (ctc-forced-aligner)",
         speed="GPU/CPU ~1-2GB; ONNX + PyTorch backends",
-        reason_ok="BSD code; commercial via MIT wav2vec2 model override",
-        reason_block="default mms-300m model CC-BY-NC-4.0; override with MIT wav2vec2 for commercial",
+        reason_ok="BSD code; Apache-2.0 wav2vec2 default (MMS CC-BY-NC is opt-in only)",
+        reason_block="",
     ),
     ComponentSpec(
         name="pyannote",

--- a/sidecar/media_studio/features/system_advisor.py
+++ b/sidecar/media_studio/features/system_advisor.py
@@ -243,9 +243,12 @@ COMPONENTS: tuple[ComponentSpec, ...] = (
         # WU-T0/B1: commercial-OK since the packaged default flipped from the
         # CC-BY-NC MMS model to Apache-2.0 wav2vec2 (ctc_align.DEFAULT_MODEL_ID).
         # The CC-BY-NC model is still reachable, but only when the user turns on
-        # `allowNonCommercialAligner` — an explicit choice this static component
-        # spec cannot see, and one the Settings copy warns about at the point of
-        # opt-in. Describing the DEFAULT here is what makes the verdict truthful.
+        # `allowNonCommercialAligner` AND picks it — the flag alone unlocks it and
+        # leaves the Apache-2.0 default running. That is an explicit choice this
+        # static component spec cannot see, and one the Settings copy warns about
+        # at the point of opt-in. Describing the DEFAULT here is what makes the
+        # verdict truthful — and since the flag no longer changes the default,
+        # the default really is Apache-2.0 in EVERY settings state.
         license_commercial_ok=True,
         improves="karaoke word-timing 2nd pass (ctc-forced-aligner)",
         speed="GPU/CPU ~1-2GB; ONNX + PyTorch backends",

--- a/sidecar/media_studio/handlers/_wire.py
+++ b/sidecar/media_studio/handlers/_wire.py
@@ -69,7 +69,11 @@ _COMPONENT_ASSETS: dict[str, str] = {
     "emotion": "hsemotion-onnx",
     "ocr": "rapidocr-onnx",
     "parakeet": "parakeet-tdt-0.6b-v3",
-    "ctc_aligner": "ctc-forced-aligner-mms",
+    # WU-T0/B1: the packaged default is the Apache-2.0 wav2vec2 aligner, so THAT
+    # is the download to propose. Pointing this at the CC-BY-NC MMS asset would
+    # install a model `ctc_align._resolve_model_id` refuses unless the user has
+    # turned on `allowNonCommercialAligner`.
+    "ctc_aligner": "ctc-forced-aligner-wav2vec2",
     "pyannote": "pyannote-speaker-diarization-31",
     "smolvlm2": "smolvlm2-2.2b",
 }

--- a/sidecar/tests/test_ctc_align.py
+++ b/sidecar/tests/test_ctc_align.py
@@ -10,6 +10,8 @@ audio_loader returning synthetic numpy samples, plus the offline / empty / cance
 
 from __future__ import annotations
 
+import re
+from pathlib import Path
 from typing import Any
 
 import numpy as np
@@ -317,6 +319,22 @@ class TestResolveModelId:
 _MMS = "MahmoudAshraf/mms-300m-1130-forced-aligner"
 _W2V2 = "facebook/wav2vec2-large-960h-lv60-self"
 
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+#: the Settings dropdown whose row labels state a licence per model.
+_ALIGN_SELECT_TSX = _REPO_ROOT / "app" / "renderer" / "src" / "components" / "AlignModelSelect.tsx"
+#: the Licenses surface whose ``ALIGNER_MODEL_NOTICES`` states the licence per model id.
+_NOTICES_TSX = _REPO_ROOT / "app" / "renderer" / "src" / "features" / "ThirdPartyNotices.tsx"
+
+#: Every settings shape that means "the user has NOT chosen a model". ``''`` is
+#: not hypothetical: it is what ``AlignModelSelect`` persists for its first row
+#: AND what its opt-in-withdrawal handler writes (AlignModelSelect.tsx:74).
+_DEFAULT_ROW_SETTINGS: tuple[dict[str, Any], ...] = (
+    {},
+    {"ctcModelId": ""},
+    {"allowNonCommercialAligner": True},
+    {"allowNonCommercialAligner": True, "ctcModelId": ""},
+)
+
 
 class TestNonCommercialAlignerGate:
     def test_constants_name_the_two_sides_of_the_gate(self):
@@ -327,8 +345,34 @@ class TestNonCommercialAlignerGate:
     def test_packaged_default_is_not_the_cc_by_nc_model(self):
         assert ca._resolve_model_id({}, None) == _W2V2
 
-    def test_opt_in_restores_the_mms_default(self):
-        assert ca._resolve_model_id({"allowNonCommercialAligner": True}, None) == _MMS
+    def test_the_opt_in_unlocks_mms_it_does_not_make_it_the_default(self):
+        """The opt-in is an UNLOCK, not a default-switch. REFUTED-AND-CORRECTED.
+
+        This test used to be named ``test_opt_in_restores_the_mms_default`` and
+        asserted the OPPOSITE — that ``{'allowNonCommercialAligner': True}`` with
+        no selection resolves to the CC-BY-NC id. Three independent reviewers
+        refuted that with the same executed probe, and they were right: the
+        Settings dropdown renders the selected row as "English wav2vec2 —
+        default (Apache-2.0, commercial-safe)" in exactly that state, so the
+        screen asserted the wrong licence for the model that would actually run.
+
+        Nothing here is weakened: MMS is still reachable, and every test that
+        pins it as reachable-with-an-explicit-selection is untouched below. What
+        changed is that reaching it now requires the SELECTION as well as the
+        opt-in — which is what the checkbox copy ("unlocks MMS-300M"), the
+        Licenses copy, and plan line 94 ("must NOT be the packaged default") all
+        already promised.
+        """
+        assert ca._resolve_model_id({"allowNonCommercialAligner": True}, None) == _W2V2
+
+    def test_the_opt_in_plus_the_empty_selection_is_still_the_permissive_default(self):
+        """``ctcModelId: ''`` is what the default row and the withdrawal handler write.
+
+        The uncovered shape: opt in, try MMS, then re-pick the row labelled
+        commercial-safe. Before the fix that still resolved to CC-BY-NC weights.
+        """
+        settings = {"allowNonCommercialAligner": True, "ctcModelId": ""}
+        assert ca._resolve_model_id(settings, None) == _W2V2
 
     def test_falsy_opt_in_keeps_the_permissive_default(self):
         assert ca._resolve_model_id({"allowNonCommercialAligner": False}, None) == _W2V2
@@ -367,6 +411,50 @@ class TestNonCommercialAlignerGate:
 
         assert _wire._COMPONENT_ASSETS["ctc_aligner"] == ca.WAV2VEC2_ASSET_NAME
         assert recommender._COMPONENT_ASSETS["ctc_aligner"] == ca.WAV2VEC2_ASSET_NAME
+
+    def test_the_settings_dropdown_label_matches_the_model_that_will_actually_run(self):
+        """CROSS-CUTTING: the label the UI shows vs the id the sidecar resolves.
+
+        This is the test whose ABSENCE let the defect ship green. The renderer
+        suite asserted the row label; this suite asserted the resolved id; each
+        was internally consistent, so 239 sidecar + 188 renderer tests passed
+        while the two halves contradicted each other. Nothing that reads only one
+        side can see that — so this reads BOTH, plus the Licenses surface that
+        states the licence per model id, and joins them on the resolved id.
+
+        It spans three files on purpose (same pattern as
+        ``test_transition_ts_parity`` / the ``ThirdPartyNotices`` read in
+        ``test_tts_lipsync``): a comment claiming "the UI cannot drift from the
+        gate" (ModelsSystemPanel.tsx:912) is not a gate, it is a wish.
+        """
+        select_src = _ALIGN_SELECT_TSX.read_text(encoding="utf-8")
+        notices_src = _NOTICES_TSX.read_text(encoding="utf-8")
+
+        # 1. the label of the row whose persisted value is '' (the default row).
+        row = re.search(r"\{\s*id:\s*''\s*,\s*label:\s*'([^']*)'", select_src)
+        assert row is not None, f"no `id: ''` row in ALIGN_MODEL_CHOICES ({_ALIGN_SELECT_TSX})"
+        label = row.group(1)
+
+        for settings in _DEFAULT_ROW_SETTINGS:
+            # 2. what the sidecar will ACTUALLY align with in that state.
+            resolved = ca._resolve_model_id(settings, None)
+            # 3. the licence that surface #3 declares for that exact model id.
+            notice = re.search(
+                rf"modelId: '{re.escape(resolved)}',.*?license: '([^']*)'",
+                notices_src,
+                re.S,
+            )
+            assert notice is not None, f"{resolved} has no ALIGNER_MODEL_NOTICES entry"
+            declared = notice.group(1)
+            assert declared in label, (
+                f"settings={settings!r} resolves to {resolved} ({declared}), but the "
+                f"default row still reads {label!r} — the screen states the wrong "
+                f"licence for the model the job will use"
+            )
+            assert resolved not in ca.NON_COMMERCIAL_MODEL_IDS, (
+                f"settings={settings!r} resolves to the CC-BY-NC {resolved} while the "
+                f"row the user sees selected reads {label!r}"
+            )
 
     def test_every_permissive_id_is_a_real_hf_repo_path(self):
         # HF Hub metadata probe, 2026-08-09: all three are license:apache-2.0.

--- a/sidecar/tests/test_ctc_align.py
+++ b/sidecar/tests/test_ctc_align.py
@@ -263,10 +263,10 @@ class TestResolveModelId:
         assert ca._resolve_model_id({"ctcModelId": "x"}, "facebook/custom") == "facebook/custom"
 
     def test_explicit_arg_alias_resolved(self):
-        assert ca._resolve_model_id({}, "wav2vec2-960h-lv60") == ca.MIT_MODEL_IDS["wav2vec2-960h-lv60"]
+        assert ca._resolve_model_id({}, "wav2vec2-960h-lv60") == ca.PERMISSIVE_MODEL_IDS["wav2vec2-960h-lv60"]
 
     def test_settings_alias_resolved(self):
-        assert ca._resolve_model_id({"ctcModelId": "hubert-large"}, None) == ca.MIT_MODEL_IDS["hubert-large"]
+        assert ca._resolve_model_id({"ctcModelId": "hubert-large"}, None) == ca.PERMISSIVE_MODEL_IDS["hubert-large"]
 
     def test_settings_full_id(self):
         assert ca._resolve_model_id({"ctcModelId": "my/model"}, None) == "my/model"
@@ -277,16 +277,16 @@ class TestResolveModelId:
     def test_settings_empty_string_ignored(self):
         assert ca._resolve_model_id({"ctcModelId": ""}, None) == ca.DEFAULT_MODEL_ID
 
-    def test_asset_for_default_model(self):
-        assert ca._asset_for_model(ca.DEFAULT_MODEL_ID) == ca.ASSET_NAME
+    def test_asset_for_non_commercial_model(self):
+        assert ca._asset_for_model(ca.NON_COMMERCIAL_MODEL_ID) == ca.ASSET_NAME
 
-    def test_asset_for_mit_model(self):
-        assert ca._asset_for_model("facebook/anything") == ca.MIT_ASSET_NAME
+    def test_asset_for_permissive_model(self):
+        assert ca._asset_for_model("facebook/anything") == ca.WAV2VEC2_ASSET_NAME
 
-    # M5 — RO alignment opt-in (gigant/romanian-wav2vec2); MMS-300m stays default.
+    # M5 — RO alignment opt-in (gigant/romanian-wav2vec2) over the packaged default.
     def test_default_path_unchanged_when_no_ctc_model(self):
         assert ca._resolve_model_id({}, None) == ca.DEFAULT_MODEL_ID
-        assert ca._asset_for_model(ca.DEFAULT_MODEL_ID) == ca.ASSET_NAME
+        assert ca._asset_for_model(ca.DEFAULT_MODEL_ID) == ca.WAV2VEC2_ASSET_NAME
 
     def test_ro_settings_alias_resolved(self):
         resolved = ca._resolve_model_id({"ctcModelId": "romanian-wav2vec2"}, None)
@@ -302,8 +302,79 @@ class TestResolveModelId:
     def test_asset_for_ro_model_is_its_own_asset(self):
         ro_id = ca.RO_MODEL_IDS["romanian-wav2vec2"]
         assert ca._asset_for_model(ro_id) == ca.RO_ASSET_NAME
-        # the RO asset is distinct from BOTH the default MMS and the MIT wav2vec2.
-        assert ca.RO_ASSET_NAME not in {ca.ASSET_NAME, ca.MIT_ASSET_NAME}
+        # the RO asset is distinct from BOTH the MMS and the wav2vec2 assets.
+        assert ca.RO_ASSET_NAME not in {ca.ASSET_NAME, ca.WAV2VEC2_ASSET_NAME}
+
+
+# --------------------------------------------------------------------------- #
+# T0/B1 — the CC-BY-NC MMS aligner is OPT-IN, never the packaged default
+# (docs/plans/v1.5/flagship-transcript-editing.md:94 + :150).
+#
+# These assert the LITERAL model ids, not the module constants: a rename that
+# re-points ``DEFAULT_MODEL_ID`` must not be able to make the gate pass by
+# tautology. The MMS id may only ever be reached with the explicit opt-in.
+# --------------------------------------------------------------------------- #
+_MMS = "MahmoudAshraf/mms-300m-1130-forced-aligner"
+_W2V2 = "facebook/wav2vec2-large-960h-lv60-self"
+
+
+class TestNonCommercialAlignerGate:
+    def test_constants_name_the_two_sides_of_the_gate(self):
+        assert ca.NON_COMMERCIAL_MODEL_ID == _MMS
+        assert ca.DEFAULT_MODEL_ID == _W2V2
+        assert set(ca.NON_COMMERCIAL_MODEL_IDS) == {_MMS}
+
+    def test_packaged_default_is_not_the_cc_by_nc_model(self):
+        assert ca._resolve_model_id({}, None) == _W2V2
+
+    def test_opt_in_restores_the_mms_default(self):
+        assert ca._resolve_model_id({"allowNonCommercialAligner": True}, None) == _MMS
+
+    def test_falsy_opt_in_keeps_the_permissive_default(self):
+        assert ca._resolve_model_id({"allowNonCommercialAligner": False}, None) == _W2V2
+
+    def test_explicit_mms_full_id_is_refused_without_the_opt_in(self):
+        assert ca._resolve_model_id({"ctcModelId": _MMS}, None) == _W2V2
+
+    def test_explicit_mms_alias_is_refused_without_the_opt_in(self):
+        assert ca._resolve_model_id({}, "mms-300m") == _W2V2
+
+    def test_explicit_mms_alias_is_honoured_with_the_opt_in(self):
+        assert ca._resolve_model_id({"allowNonCommercialAligner": True}, "mms-300m") == _MMS
+
+    def test_explicit_mms_full_id_is_honoured_with_the_opt_in(self):
+        settings = {"allowNonCommercialAligner": True, "ctcModelId": _MMS}
+        assert ca._resolve_model_id(settings, None) == _MMS
+
+    def test_permissive_override_is_unaffected_by_the_gate(self):
+        assert ca._resolve_model_id({}, "hubert-large") == ca.PERMISSIVE_MODEL_IDS["hubert-large"]
+
+    def test_mms_still_maps_to_its_own_asset(self):
+        assert ca._asset_for_model(_MMS) == ca.ASSET_NAME
+        assert ca._asset_for_model(_W2V2) == ca.WAV2VEC2_ASSET_NAME
+
+    def test_the_component_asset_maps_point_at_the_packaged_default(self):
+        """The download the UI proposes must be the model the sidecar will USE.
+
+        Both maps named the MMS asset. Left alone after the default flip, a user
+        clicking "install" on the word-timing component would fetch 1.2 GB of a
+        CC-BY-NC model that `_resolve_model_id` then refuses — installed, unused,
+        and silently so. These are hand-mirrored copies of one fact, so the test
+        reads BOTH rather than trusting the "mirrors ..." comment on each.
+        """
+        from media_studio.features import recommender
+        from media_studio.handlers import _wire
+
+        assert _wire._COMPONENT_ASSETS["ctc_aligner"] == ca.WAV2VEC2_ASSET_NAME
+        assert recommender._COMPONENT_ASSETS["ctc_aligner"] == ca.WAV2VEC2_ASSET_NAME
+
+    def test_every_permissive_id_is_a_real_hf_repo_path(self):
+        # HF Hub metadata probe, 2026-08-09: all three are license:apache-2.0.
+        assert set(ca.PERMISSIVE_MODEL_IDS.values()) == {
+            "facebook/wav2vec2-large-960h-lv60-self",
+            "facebook/wav2vec2-large-960h",
+            "facebook/hubert-large-ls960-ft",
+        }
 
 
 # --------------------------------------------------------------------------- #
@@ -375,7 +446,7 @@ class TestAlignWordsHappyPath:
             models_present=present,
             model_id="wav2vec2-960h-lv60",
         )
-        assert seen["model_id"] == ca.MIT_MODEL_IDS["wav2vec2-960h-lv60"]
+        assert seen["model_id"] == ca.PERMISSIVE_MODEL_IDS["wav2vec2-960h-lv60"]
 
     def test_duration_from_samples_when_no_duration_sec(self):
         # transcript without durationSec -> duration derived from samples/sr.
@@ -579,11 +650,17 @@ class TestAssetRegistration:
     def test_registers_both_models(self):
         manifest.registry_restore({})
         ca.register_ctc_align_assets()
-        default = manifest.get_asset(ca.ASSET_NAME)
-        mit = manifest.get_asset(ca.MIT_ASSET_NAME)
-        assert default is not None and default.hf_repo == ca.DEFAULT_MODEL_ID
-        assert mit is not None and mit.hf_repo == ca.MIT_MODEL_IDS["wav2vec2-960h-lv60"]
-        assert default.installer == "hf"
+        mms = manifest.get_asset(ca.ASSET_NAME)
+        wav2vec2 = manifest.get_asset(ca.WAV2VEC2_ASSET_NAME)
+        assert mms is not None and mms.hf_repo == ca.NON_COMMERCIAL_MODEL_ID
+        assert wav2vec2 is not None and wav2vec2.hf_repo == ca.DEFAULT_MODEL_ID
+        assert mms.installer == "hf"
+        # The user-facing label has to state the licence, both ways round: the
+        # gated model says CC-BY-NC and the packaged default says Apache-2.0
+        # (it read "MIT commercial" until 2026-08-09 — plan B3, HF-refuted).
+        assert "CC-BY-NC-4.0" in mms.label
+        assert "Apache-2.0" in wav2vec2.label
+        assert "MIT" not in wav2vec2.label
 
     def test_idempotent(self):
         manifest.registry_restore({})

--- a/sidecar/tests/test_system_advisor.py
+++ b/sidecar/tests/test_system_advisor.py
@@ -178,7 +178,7 @@ def test_missing_probe_key_defaults_to_absent() -> None:
 
 def test_commercial_flips_non_commercial_components_unavailable() -> None:
     report = sa.advise(probes=ALL_DEPS, vram_mb=6144, commercial=True)
-    for nc in ("saliency", "quality_gate", "aesthetic", "ctc_aligner"):
+    for nc in ("saliency", "quality_gate", "aesthetic"):
         st = _status(report, nc)
         assert st.verdict == "unavailable"
         assert st.license_commercial_ok is False
@@ -186,6 +186,22 @@ def test_commercial_flips_non_commercial_components_unavailable() -> None:
     # commercial-OK ones still run.
     assert _status(report, "vlm_backbone").verdict in ("ok", "degraded")
     assert _status(report, "audio_saliency").verdict == "ok"
+
+
+def test_ctc_aligner_is_commercial_ok_after_the_permissive_default_flip() -> None:
+    """WU-T0/B1: ``ctc_aligner`` used to be pinned here as non-commercial.
+
+    That was TRUE while ``ctc_align.DEFAULT_MODEL_ID`` was the CC-BY-NC-4.0 MMS
+    model. The packaged default is now Apache-2.0 wav2vec2 and MMS is reachable
+    only via ``allowNonCommercialAligner``, so blocking the whole component in a
+    commercial build became a FALSE block. Moving it out of the list above is a
+    deliberate, reviewed change of a fact-pinning assertion, not a loosened test:
+    the replacement below is strictly more specific about what is now true.
+    """
+    report = sa.advise(probes=ALL_DEPS, vram_mb=6144, commercial=True)
+    st = _status(report, "ctc_aligner")
+    assert st.license_commercial_ok is True
+    assert st.verdict != "unavailable"
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## How this change was produced

Implemented under TDD, then **adversarially reviewed by three independent agents** with
distinct lenses (correctness / gate-integrity / blast-radius), each instructed to REFUTE
rather than approve and to default to refuted when uncertain.

**It was refuted.** Wave 1 measured 6/6 implementers self-reporting SUCCESS against 15/18
adversarial verdicts refuting them, so nothing was merged on a self-report. The lane was
then remediated against its specific objections and re-checked by a **fresh** skeptic who
wrote neither the code nor the original objections.

Several objections were about **false sentences** rather than broken code — assurances
like "no assertion was weakened", "no pragma was added", "never a silent pass". Those are
corrected in explicit follow-up commits, because a false assurance is worse than an
undisclosed gap: it tells the next reader not to look.

## What was fixed

3 of 3 objections were about ONE defect and it is FIXED in code, not rebutted.

REPRODUCED FIRST (executed, before any edit, same probe the reviewers ran):
  _resolve_model_id({'allowNonCommercialAligner': True}, None)                    -> MahmoudAshraf/mms-300m-1130-forced-aligner
  _resolve_model_id({'allowNonCommercialAligner': True, 'ctcModelId': ''}, None)  -> MahmoudAshraf/mms-300m-1130-forced-aligner
  _resolve_model_id({}, None)                                                     -> facebook/wav2vec2-large-960h-lv60-self

FIX (ctc_align.py:252-259 -> one line): deleted the
`elif allow_non_commercial: resolved = NON_COMMERCIAL_MODEL_ID` fallback. The opt-in now
UNLOCKS MMS and never selects it. The licence check still runs LAST on the resolved id, so
the alias / full-HF-id / per-job-arg paths remain covered by one check.

WHY THIS REPAIR AND NOT "make the label conditional" (reviewer 2 fairly offered both):
three user-facing promises already stated unlock semantics and only the code disagreed —
the checkbox copy ("unlocks MMS-300M"), the ThirdPartyNotices copy, and plan line 94
("must NOT be the packaged default"), which the fallback actively violated by making MMS
the effective default whenever the flag was on. One code branch was wrong; three promises
were right. COST stated plainly in the commit: an opted-in user wanting 158-language
alignment now needs the tick AND the dropdown pick; the dropdown then truthfully reads
CC-BY-NC.

FALSE SENTENCES CORRECTED (the part that matters more than the code):
 * commit 8036f1ca said "the packaged default moves ... to wav2vec2" — true ONLY with the
   opt-in OFF. Corrected in the new commit message, which states the old sentence was wider
   than the code.
 * ModelsSystemPanel.tsx:912 asserted "the UI cannot drift from the gate" — it could and it
   did; sharing an INPUT says nothing about agreeing on the OUTPUT. Rewritten to say so and
   to point at the test that actually enforces it.
 * ThirdPartyNotices MMS note said Reframe aligns with wav2vec2 "unless you turn this one on
   in Settings" — that described the defect. Rewritten: the opt-in unlocks, you must also
   pick it.
 * ctc_align module docstring + NON_COMMERCIAL_MODEL_ID comment + system_advisor comment all
   tightened to "flag AND explicit selection".
 * docs/THIRD-PARTY-LICENSES.md §5 gained a paragraph RECORDING that the earlier wording was
   refuted, rather than silently editing it away.

TEST RENAMED AND INVERTED, DISCLOSED: test_opt_in_restores_the_mms_default asserted the
defect as correct. Now test_the_opt_in_unlocks_mms_it_does_not_make_it_the_default, with the
refutation history in its docstring. NOT a weakening — every test pinning MMS as
reachable-with-explicit-selection (alias, full id, per-job arg) is untouched and green, and
the covered state space is strictly larger. Zero tests skipped, zero assertions loosened,
zero pragmas added.

ADDED: sidecar test_the_opt_in_plus_the_empty_selection_is_still_the_permissive_default
(the uncovered {allowNonCommercial: true, ctcModelId: ''} shape); four renderer
AlignModelSelect tests for the opted-in-nothing-chosen state (default row stays selected and
reads Apache-2.0/commercial-safe, MMS enabled but NOT preselected, re-picking default after
MMS persists '', checkbox copy states unlock semantics).

Commits: f3abd2c8 (fix + tests + sentence corrections), 0c4f8692 (residual disclosure).

## Rebutted

NONE. I rebutted nothing — every objection was correct on the evidence and I reproduced the
reviewers' probe before touching a line. Reviewer 2's self-offered counter (that the
opt-in->MMS behaviour might be INTENTIONAL, being named in a test and justified at
ctc_align.py:255-256) was the one genuinely arguable point; I did not accept it, because the
justification comment contradicted plan line 94 that the same commit cites as its authority,
and because the checkbox and Licences copy both already promised "unlocks". That is a
disagreement with a code comment, not a rebuttal of a reviewer.

## Disclosed residuals (non-blocking, and checked for accuracy — an inverted residual was itself one of the original findings)

ONE accepted-and-disclosed residual, from objection 2's own weakest sub-point (its author
graded it INFERRED ~75-85% and said they had NOT executed the readiness path end-to-end):

`ctc_aligner` readiness is NOT selection-aware. The component->asset maps (_wire.py,
recommender.py, advisorMeta.ts) statically name ctc-forced-aligner-wav2vec2, so a user who
has opted in AND explicitly picked MMS sees readiness computed off the wav2vec2 asset. Both
assets stay installable by name via assets.list / assets.ensure, so it is a wrong SIGNAL,
not an unreachable model.

Note the scope shrank because of this pass: with the opt-in->MMS fallback gone, resolved
model and mapped asset now agree in EVERY "user chose nothing" state, which they did not
before. Only the explicit-MMS-selection case remains.

Left as-is deliberately — making three hand-mirrored static maps settings-aware is a change
to the readiness architecture, not to licence disclosure, and would be scope expansion past
this lane. Disclosed durably (not just in this report) in docs/THIRD-PARTY-LICENSES.md §5's
"what this does NOT do" list, with the confidence band, the fact that neither reviewer nor I
executed the path, and the settling experiment: drive assets.status for ctc_aligner with
{allowNonCommercialAligner: true, ctcModelId: 'mms-300m'} and MMS absent from disk, and check
whether the card claims ready. Schedulable as its own work unit.

Unchanged pre-existing residuals, still disclosed and not re-litigated here: no per-language
permissive-CTC map (non-English degrades to ASR word timings), no typed spec.py keys, no
licence-counsel review.

## Independent re-verification

Fresh skeptic verdict: **mergeable = True**, all objections closed = True.

Remaining, per that verifier:

Nothing blocking. Two cosmetic nits and one accepted residual, all verified non-blocking: (1) sidecar/tests/test_ctc_align.py:331 cites AlignModelSelect.tsx:74 for the opt-in-withdrawal handler, which actually lives at line 82 (the commit message cites 82 correctly) - a stale line reference in a comment, no behavioural claim depends on it. (2) The report states renderer branches 7517/7517; I measure 7519/7519 - both 100%, so this is v8 run-to-run branch-counting variance, not a coverage gap. (3) The disclosed residual is REAL and ACCURATE (I verified it, not just read it): the ctc_aligner readiness signal is not selection-aware - handlers/_wire.py:76, features/recommender.py:94 and components/advisorMeta.ts:155 all statically name ctc-forced-aligner-wav2vec2, so an opted-in user who has explicitly picked MMS sees readiness computed off the wav2vec2 asset. The JOB path is unaffected: ctc_align.py:457 calls _asset_for_model(resolved), which returns ctc-forced-aligner-mms (ctc_align.py:283-284) for an MMS selection, so this is a wrong signal, not an unreachable model. It is disclosed durably in docs/THIRD-PARTY-LICENSES.md section 5 with its confidence band, the admission that neither reviewer nor remediator executed the path, and a named settling experiment. Schedulable as its own work unit; making three hand-mirrored static maps settings-aware is readiness architecture, not licence disclosure. Pre-existing residuals also still disclosed and unchanged: no per-language permissive-CTC map (non-English degrades to ASR word timings), no typed spec.py keys, no licence-counsel review.

---

CI is the arbiter here, not the agents. This merges only if `quality` is green.
