### PR TITLE
fix(cues): stop merge/translate silently dropping the speaker label

### DIFF
--- a/app/renderer/src/components/api.ts
+++ b/app/renderer/src/components/api.ts
@@ -33,6 +33,13 @@ export interface Cue {
   start: number;
   end: number;
   text: string;
+  /**
+   * Diarized speaker label — OPTIONAL, additive (CONTRACTS.md §A3a:166-169).
+   * Declared on all THREE copies of this wire shape (here, `features/_api.ts`,
+   * `lib/rpc/schemas.ts`) so a consumer of this module's `SubtitleTrack` cannot
+   * silently re-introduce the drop the timeline editor just had.
+   */
+  speaker?: string;
 }
 
 export interface SubtitleTrack {

--- a/app/renderer/src/features/_api.ts
+++ b/app/renderer/src/features/_api.ts
@@ -124,6 +124,13 @@ export interface Cue {
   start: number;
   end: number;
   text: string;
+  /**
+   * Diarized speaker label — OPTIONAL, additive (CONTRACTS.md §A3a:166-169).
+   * Absent (not `undefined`) on a non-diarized cue. This is the `Cue` the
+   * timeline editor operates on (`lib/timelineOps.ts` re-exports it), so the
+   * field must be declared here for the editor ops to carry it honestly.
+   */
+  speaker?: string;
 }
 
 export type SubtitleFormat = 'srt' | 'ass' | 'vtt';

--- a/app/renderer/src/lib/rpc/schemas.ts
+++ b/app/renderer/src/lib/rpc/schemas.ts
@@ -31,6 +31,17 @@ export interface Cue {
   start: number;
   end: number;
   text: string;
+  /**
+   * The diarized speaker label — OPTIONAL and ADDITIVE (CONTRACTS.md §A3a:166-169:
+   * "Cue gains OPTIONAL `speaker?: string` … Frozen index/start/end/text are
+   * unchanged"). The sidecar has always emitted it (`features/subtitles.py`
+   * `make_cue`:102-113) and preserves it across `subtitles.edit`
+   * (`reindex`:116-133), but this declaration omitted it, so the renderer could
+   * neither read nor deliberately carry the field — which is how `mergeCues`
+   * came to drop it unnoticed. The key is ABSENT (never `undefined`) on a
+   * non-diarized cue, mirroring the sidecar's "no speaker: None leakage" rule.
+   */
+  speaker?: string;
 }
 
 export type SubtitleFormat = 'srt' | 'ass' | 'vtt';

--- a/app/renderer/src/lib/timelineOps.test.ts
+++ b/app/renderer/src/lib/timelineOps.test.ts
@@ -176,6 +176,12 @@ describe('mergeCues', () => {
   it('emits NO speaker key when the earlier cue is not diarized', () => {
     // A `speaker: undefined` key would leak into the wire shape the sidecar
     // deliberately keeps clean (`make_cue`: "no speaker: None leakage").
+    //
+    // SCOPE (measured): this case is GREEN in BOTH states — reverting `mergeCues`
+    // to its pre-fix `{index,start,end,text}` literal reddens the other three
+    // speaker assertions and NOT this one. It is therefore not evidence FOR the
+    // spread fix; it pins the plausible alternative `speaker: first.speaker`,
+    // which `toEqual` would silently accept because it ignores undefined keys.
     const merged = mergeCues(cue(1, 0, 2, 'plain'), diarized(2, 3, 5, 'later', 'B'));
     expect('speaker' in merged).toBe(false);
   });
@@ -203,6 +209,62 @@ describe('mergeAt', () => {
     expect(mergeAt(input, 2)).toBe(input);
     expect(mergeAt(input, -1)).toBe(input);
     expect(mergeAt(input, 99)).toBe(input);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// speaker preservation across the REST of the op surface (regression guard)
+//
+// `mergeCues` was the one op that returned a fresh `{index,start,end,text}`
+// literal and so destroyed `speaker`; its siblings are correct today only
+// because each happens to spread. Nothing pinned that, so a future refactor
+// could re-introduce the exact same shape in `splitCue` or `dragEdge` and no
+// test would notice. These assertions are the pin.
+//
+// PROVEN RED per op: replacing that op's spread with an explicit
+// `{ index, start, end, text }` literal makes ITS case here fail and no other.
+// ---------------------------------------------------------------------------
+
+describe('speaker survives every cue op (regression guard)', () => {
+  /** Two diarized cues at [0,2] and [3,5], plus a plain third at [6,8]. */
+  function diarizedList(): Cue[] {
+    return [
+      diarized(1, 0, 2, 'hello world', 'A'),
+      diarized(2, 3, 5, 'second cue', 'B'),
+      cue(3, 6, 8, 'third one'),
+    ];
+  }
+
+  it('renumber', () => {
+    expect(renumber(diarizedList()).map((c) => c.speaker)).toEqual(['A', 'B', undefined]);
+  });
+
+  it('splitCue puts the speaker on BOTH halves', () => {
+    const halves = splitCue(diarized(1, 0, 2, 'hello world', 'A'), 1);
+    expect(halves).not.toBeNull();
+    expect(halves?.[0].speaker).toBe('A');
+    expect(halves?.[1].speaker).toBe('A');
+  });
+
+  it('splitAt keeps the speaker through the list-level split + renumber', () => {
+    expect(splitAt(diarizedList(), 0, 1).map((c) => c.speaker)).toEqual(['A', 'A', 'B', undefined]);
+  });
+
+  it('retimeCue', () => {
+    expect(retimeCue(diarized(1, 0, 2, 'a', 'A'), 1, 4).speaker).toBe('A');
+  });
+
+  it('retimeAt', () => {
+    expect(retimeAt(diarizedList(), 1, 2.5, 5.5)[1].speaker).toBe('B');
+  });
+
+  it('nudgeAt', () => {
+    expect(nudgeAt(diarizedList(), 1, 0.5)[1].speaker).toBe('B');
+  });
+
+  it('dragEdge on both edges', () => {
+    expect(dragEdge(diarizedList(), 1, 'start', 2.5)[1].speaker).toBe('B');
+    expect(dragEdge(diarizedList(), 1, 'end', 5.5)[1].speaker).toBe('B');
   });
 });
 

--- a/app/renderer/src/lib/timelineOps.test.ts
+++ b/app/renderer/src/lib/timelineOps.test.ts
@@ -35,6 +35,15 @@ function cue(index: number, start: number, end: number, text: string): Cue {
   return { index, start, end, text };
 }
 
+/**
+ * A DIARIZED cue — `speaker` is the OPTIONAL §A3a `Cue` field (CONTRACTS.md:166-169),
+ * emitted by the sidecar (`features/subtitles.py:102-113` `make_cue`) and round-tripped
+ * by `subtitles.edit` (`reindex`, :116-133). Every op here must carry it through.
+ */
+function diarized(index: number, start: number, end: number, text: string, speaker: string): Cue {
+  return { index, start, end, text, speaker };
+}
+
 /** Three well-spaced cues: [0,2] [3,5] [6,8]. */
 function threeCues(): Cue[] {
   return [cue(1, 0, 2, 'hello world'), cue(2, 3, 5, 'second cue'), cue(3, 6, 8, 'third one')];
@@ -150,6 +159,26 @@ describe('mergeCues', () => {
     expect(mergeCues(cue(1, 0, 1, '  '), cue(2, 1, 2, 'kept')).text).toBe('kept');
     expect(mergeCues(cue(1, 0, 1, 'kept'), cue(2, 1, 2, '')).text).toBe('kept');
   });
+
+  it('preserves the diarized speaker label (§A3a optional Cue field)', () => {
+    const merged = mergeCues(
+      diarized(1, 0, 2, 'hello world', 'SPEAKER_00'),
+      diarized(2, 3, 5, 'second cue', 'SPEAKER_00'),
+    );
+    expect(merged.speaker).toBe('SPEAKER_00');
+  });
+
+  it('takes the speaker from the EARLIER cue, not the argument order', () => {
+    const merged = mergeCues(diarized(2, 3, 5, 'later', 'B'), diarized(1, 0, 2, 'earlier', 'A'));
+    expect(merged.speaker).toBe('A');
+  });
+
+  it('emits NO speaker key when the earlier cue is not diarized', () => {
+    // A `speaker: undefined` key would leak into the wire shape the sidecar
+    // deliberately keeps clean (`make_cue`: "no speaker: None leakage").
+    const merged = mergeCues(cue(1, 0, 2, 'plain'), diarized(2, 3, 5, 'later', 'B'));
+    expect('speaker' in merged).toBe(false);
+  });
 });
 
 describe('mergeAt', () => {
@@ -158,6 +187,15 @@ describe('mergeAt', () => {
     expect(out).toHaveLength(2);
     expect(out[0]).toEqual({ index: 1, start: 0, end: 5, text: 'hello world second cue' });
     expect(out[1].index).toBe(2);
+  });
+
+  it('carries the diarized speaker through the list-level merge + renumber', () => {
+    const out = mergeAt(
+      [diarized(1, 0, 2, 'a', 'S0'), diarized(2, 3, 5, 'b', 'S0'), cue(3, 6, 8, 'c')],
+      0,
+    );
+    expect(out[0].speaker).toBe('S0');
+    expect(out.map((c) => c.index)).toEqual([1, 2]);
   });
 
   it('returns the SAME array when pos is the last cue or invalid', () => {

--- a/app/renderer/src/lib/timelineOps.ts
+++ b/app/renderer/src/lib/timelineOps.ts
@@ -68,14 +68,28 @@ export function splitCue(cue: Cue, t: number): [Cue, Cue] | null {
 
 /**
  * Merge two cues into one spanning both: `[min(start), max(end)]`, texts
- * joined in time order with a single space (empty halves dropped). Keeps the
- * earlier cue's `index` (list-level callers renumber anyway).
+ * joined in time order with a single space (empty halves dropped).
+ *
+ * SPREADS the earlier cue, exactly like `splitCue` / `retimeCue` / `renumber`
+ * do — so the earlier cue's `index` survives (list-level callers renumber
+ * anyway) AND so do the fields this module does not name. That is not a
+ * stylistic choice: the §A3a `Cue` carries an OPTIONAL `speaker`
+ * (CONTRACTS.md:166-169) that the sidecar emits and round-trips
+ * (`features/subtitles.py` `make_cue`:102-113, `reindex`:116-133). The former
+ * fresh `{index,start,end,text}` literal silently DROPPED it, so merging two
+ * diarized cues erased the speaker label on the next `subtitles.edit` save.
+ *
+ * The earlier cue wins for the same reason it wins for `index`: a merge across
+ * a speaker change is inherently lossy and there is no correct second label to
+ * keep. When the earlier cue is NOT diarized the key is simply absent — never
+ * `speaker: undefined`, which would leak a null into the wire shape the sidecar
+ * deliberately keeps clean.
  */
 export function mergeCues(a: Cue, b: Cue): Cue {
   const [first, second] = a.start <= b.start ? [a, b] : [b, a];
   const text = [first.text.trim(), second.text.trim()].filter(Boolean).join(' ');
   return {
-    index: first.index,
+    ...first,
     start: Math.min(a.start, b.start),
     end: Math.max(a.end, b.end),
     text,

--- a/sidecar/media_studio/features/fillers.py
+++ b/sidecar/media_studio/features/fillers.py
@@ -327,6 +327,11 @@ def remap_cues(cues: Sequence[Mapping[str, Any]], keeps: Sequence[KeepSpan]) -> 
     Cues that collapse to zero length (they lived entirely inside a removed
     filler span) are dropped; indexes are renumbered 1..N. The result is
     clip-local — callers pass ``source_start=0`` to the caption stage.
+
+    The source cue is SPREAD, not re-listed field by field: re-timing moves a cue
+    and must not silently destroy any other key it carries (``speaker`` is the one
+    that costs — a bare literal here erased the diarized label on every de-fill,
+    silence-trim and transcript-edit pass).
     """
     out: list[dict[str, Any]] = []
     for cue in cues or []:
@@ -336,6 +341,7 @@ def remap_cues(cues: Sequence[Mapping[str, Any]], keeps: Sequence[KeepSpan]) -> 
             continue
         out.append(
             {
+                **cue,
                 "index": len(out) + 1,
                 "start": round(start, 3),
                 "end": round(end, 3),

--- a/sidecar/media_studio/features/shortmaker.py
+++ b/sidecar/media_studio/features/shortmaker.py
@@ -719,6 +719,10 @@ def _rebase_cues(cues: list[Cue], source_start: float) -> list[Cue]:
     Used only on the filler path: the de-fill stage works in clip-local time, so
     the cues handed to ``remap_cues`` must already be clip-local. Cues that end
     at/before the clip in-point are dropped; indexes renumbered 1..N.
+
+    The source cue is SPREAD, not re-listed field by field: re-basing moves a cue
+    in time and must not silently destroy any other key it carries (``speaker``
+    is the one that costs — a bare literal here erased the diarized label).
     """
     out: list[Cue] = []
     for cue in cues or []:
@@ -726,7 +730,7 @@ def _rebase_cues(cues: list[Cue], source_start: float) -> list[Cue]:
         end = max(0.0, float(cue.get("end", 0.0)) - source_start)
         if end <= start:
             continue
-        out.append({"index": len(out) + 1, "start": start, "end": end, "text": str(cue.get("text", "") or "")})
+        out.append({**cue, "index": len(out) + 1, "start": start, "end": end, "text": str(cue.get("text", "") or "")})
     return out
 
 

--- a/sidecar/media_studio/features/subtitles.py
+++ b/sidecar/media_studio/features/subtitles.py
@@ -381,7 +381,15 @@ def translate(
             break
         new_text = translator(str(cue.get("text", "")))
         out_cues.append(
-            make_cue(int(cue.get("index", i + 1)), float(cue.get("start", 0.0)), float(cue.get("end", 0.0)), new_text)
+            make_cue(
+                int(cue.get("index", i + 1)),
+                float(cue.get("start", 0.0)),
+                float(cue.get("end", 0.0)),
+                new_text,
+                # Translating changes the WORDS, never who said them: an absent
+                # ``speaker=`` here silently erased every diarized label.
+                speaker=cue.get("speaker"),
+            )
         )
         if progress is not None and total:
             progress(int(round((i + 1) / total * 100)), f"translated {i + 1}/{total}")
@@ -454,6 +462,10 @@ def stack_bilingual(
                 float(cue.get("start", 0.0)),
                 float(cue.get("end", 0.0)),
                 stack_cue_text(str(cue.get("text", "")), translated_text, order=order),
+                # The stacked cue is the ORIGINAL cue with a second line added, so
+                # it keeps the original's diarized label (the translation carries
+                # the same one; both sides agree by construction).
+                speaker=cue.get("speaker"),
             )
         )
 

--- a/sidecar/media_studio/models/translation.py
+++ b/sidecar/media_studio/models/translation.py
@@ -438,9 +438,20 @@ def group_cues_for_translation(
     return groups
 
 
-def _make_cue(index: int, start: float, end: float, text: str) -> Cue:
-    """A §3 Cue dict (field names frozen; mirrors features.subtitles.make_cue)."""
-    return {"index": int(index), "start": float(start), "end": float(end), "text": text}
+def _make_cue(index: int, start: float, end: float, text: str, *, speaker: str | None = None) -> Cue:
+    """A §3 Cue dict (field names frozen; mirrors features.subtitles.make_cue).
+
+    The optional diarized ``speaker`` is ADDITIVE and only set when non-empty, so
+    an undiarized cue stays byte-identical to the frozen §3 shape (no
+    ``speaker: None`` leakage) — the same rule ``subtitles.make_cue`` follows.
+    Carrying it matters here because this module already READS ``speaker`` (see
+    ``_breaks_continuity``) to break sentence groups on a speaker change; a
+    bare literal on the way out used the label and then destroyed it.
+    """
+    cue: Cue = {"index": int(index), "start": float(start), "end": float(end), "text": text}
+    if speaker:
+        cue["speaker"] = str(speaker)
+    return cue
 
 
 # --------------------------------------------------------------------------- #
@@ -670,6 +681,7 @@ class TieredTranslator:
                         float(cue.get("start", 0.0)),
                         float(cue.get("end", 0.0)),
                         str(cue.get("text", "")),
+                        speaker=cue.get("speaker"),
                     )
                 )
             if progress is not None and total:

--- a/sidecar/tests/test_fillers.py
+++ b/sidecar/tests/test_fillers.py
@@ -260,6 +260,26 @@ def test_remap_cues_drops_cues_inside_removed_spans():
     assert [c["index"] for c in out] == [1, 2]
 
 
+def test_remap_cues_preserves_the_diarized_speaker_label():
+    """Re-timing cues onto the cut clip must not erase who was speaking.
+
+    ``remap_cues`` rebuilt a bare ``{index,start,end,text}`` literal, so every
+    de-fill / silence-trim / transcript-edit pass dropped the diarized label.
+    It sits directly downstream of ``shortmaker._rebase_cues``, so fixing only
+    that one would have been a no-op on the filler path. Mutation that must turn
+    this RED: rebuild the literal without the ``**cue`` spread.
+    """
+    keeps = [(0.0, 1.0), (2.0, 3.0)]
+    cues = [
+        {"index": 1, "start": 0.2, "end": 0.8, "text": "kept", "speaker": "A"},
+        {"index": 2, "start": 2.2, "end": 2.8, "text": "shifted"},  # not diarized
+    ]
+    out = fl.remap_cues(cues, keeps)
+    assert [c["text"] for c in out] == ["kept", "shifted"]
+    assert out[0]["speaker"] == "A"
+    assert "speaker" not in out[1]
+
+
 def test_remap_cues_clips_straddling_cue():
     keeps = [(0.0, 1.0), (2.0, 3.0)]
     cues = [{"index": 1, "start": 0.5, "end": 2.5, "text": "straddle"}]

--- a/sidecar/tests/test_shortmaker.py
+++ b/sidecar/tests/test_shortmaker.py
@@ -2999,6 +2999,24 @@ def test_rebase_cues_drops_cues_ending_before_in_point():
     assert out[0]["start"] == pytest.approx(5.0)  # 25 - 20
 
 
+def test_rebase_cues_preserves_the_diarized_speaker_label():
+    """Re-basing a clip's cues must not erase who was speaking.
+
+    ``_rebase_cues`` rebuilt a bare ``{index,start,end,text}`` literal, so the
+    shortmaker filler path dropped every diarized label before the captions were
+    rendered. Mutation that must turn this RED: rebuild the literal without the
+    ``**cue`` spread.
+    """
+    cues = [
+        {"start": 25.0, "end": 28.0, "text": "kept", "speaker": "A"},
+        {"start": 28.0, "end": 30.0, "text": "plain"},  # not diarized
+    ]
+    out = sm._rebase_cues(cues, source_start=20.0)
+    assert [c["text"] for c in out] == ["kept", "plain"]
+    assert out[0]["speaker"] == "A"
+    assert "speaker" not in out[1]
+
+
 def test_candidate_virality_non_numeric_returns_none():
     # A non-numeric calibratedPct/viralityPct -> None (never crashes export).
     assert sm._candidate_virality({"viralityPct": "junk"}) is None

--- a/sidecar/tests/test_subtitles.py
+++ b/sidecar/tests/test_subtitles.py
@@ -257,6 +257,27 @@ def test_translate_honors_cancellation(simple_track):
     assert out["cues"] == []
 
 
+def test_translate_preserves_the_diarized_speaker_label():
+    """Translating a diarized track must NOT erase who was speaking.
+
+    Regression guard for the fresh-literal drop class: ``translate`` rebuilt
+    every cue via ``make_cue(index, start, end, new_text)`` with no ``speaker=``,
+    so translating a diarized track silently deleted every label. Mutation that
+    must turn this RED: drop the ``speaker=`` argument at the ``make_cue`` call.
+    """
+    track = S.new_track(
+        [
+            S.make_cue(1, 0.0, 1.0, "Hello.", speaker="SPEAKER_00"),
+            S.make_cue(2, 1.0, 2.0, "Bye."),  # not diarized
+        ],
+        lang="en",
+    )
+    out = S.translate(track, "es", translator=lambda t: t.upper())
+    assert out["cues"][0]["speaker"] == "SPEAKER_00"
+    # no ``speaker: None`` leakage onto the non-diarized cue (make_cue's rule)
+    assert "speaker" not in out["cues"][1]
+
+
 def test_make_provider_translator_blank_short_circuits():
     provider = FakeProvider()
     tr = S.make_provider_translator(provider, "fr")

--- a/sidecar/tests/test_subtitles_bilingual.py
+++ b/sidecar/tests/test_subtitles_bilingual.py
@@ -102,6 +102,25 @@ def test_stack_bilingual_new_id_each_call() -> None:
     assert a["id"] != b["id"]
 
 
+def test_stack_bilingual_preserves_the_diarized_speaker_label() -> None:
+    """Stacking a diarized original must carry its speaker onto the stacked cue.
+
+    Regression guard for the fresh-literal drop class: ``stack_bilingual`` built
+    each output cue with ``make_cue(idx, start, end, stacked_text)`` and no
+    ``speaker=``. Mutation that must turn this RED: drop that ``speaker=``.
+    """
+    orig = subs.new_track(
+        [
+            subs.make_cue(1, 0.0, 2.0, "Hello", speaker="A"),
+            subs.make_cue(2, 2.0, 4.0, "World"),  # not diarized
+        ],
+        lang="en",
+    )
+    out = subs.stack_bilingual(orig, _trans())
+    assert out["cues"][0]["speaker"] == "A"
+    assert "speaker" not in out["cues"][1]
+
+
 def test_bilingual_orders_constant() -> None:
     assert "original-first" in subs.BILINGUAL_ORDERS
     assert "translation-first" in subs.BILINGUAL_ORDERS

--- a/sidecar/tests/test_translation.py
+++ b/sidecar/tests/test_translation.py
@@ -650,6 +650,25 @@ def test_cancelled_mid_batch_returns_partial():
     assert len(provider.chats) == 1
 
 
+def test_translate_preserves_the_diarized_speaker_label():
+    """The tiered batch must NOT erase the speaker it is demonstrably aware of.
+
+    ``group_cues_for_translation`` reads ``cue["speaker"]`` to break sentence
+    groups on a speaker change, yet ``_make_cue`` rebuilt a bare
+    ``{index,start,end,text}`` on the way out — so the module used the label and
+    then threw it away. Mutation that must turn this RED: drop the ``speaker``
+    argument from the ``_make_cue`` call in ``_translate_batch``.
+    """
+    cues = [
+        {"index": 1, "start": 0.0, "end": 1.5, "text": "Hello there.", "speaker": "A"},
+        {"index": 2, "start": 1.5, "end": 3.0, "text": "Good night."},  # not diarized
+    ]
+    out = make_translator(runner=FakeRunner(), local=[FakeProvider()]).translate(cues, "es")
+    assert [c["text"] for c in out] == ["XX:Hello there.", "XX:Good night."]
+    assert out[0]["speaker"] == "A"
+    assert "speaker" not in out[1]  # no ``speaker: None`` leakage
+
+
 def test_cancelled_before_start_returns_empty():
     runner = FakeRunner()
     provider = FakeProvider()


### PR DESCRIPTION
## How this change was produced

Implemented under TDD, then **adversarially reviewed by three independent agents** with
distinct lenses (correctness / gate-integrity / blast-radius), each instructed to REFUTE
rather than approve and to default to refuted when uncertain.

**It was refuted.** Wave 1 measured 6/6 implementers self-reporting SUCCESS against 15/18
adversarial verdicts refuting them, so nothing was merged on a self-report. The lane was
then remediated against its specific objections and re-checked by a **fresh** skeptic who
wrote neither the code nor the original objections.

Several objections were about **false sentences** rather than broken code — assurances
like "no assertion was weakened", "no pragma was added", "never a silent pass". Those are
corrected in explicit follow-up commits, because a false assurance is worse than an
undisclosed gap: it tells the next reader not to look.

## What was fixed

ALL THREE ANSWERED — 2 FIXED IN CODE, 1 ACCEPTED-AND-DISCLOSED (plus 3 false sentences corrected).

[REFUTED objection — FIXED] "no sidecar change — it was already correct on both emit and preserve; the renderer was the sole drop point." Reviewer is CORRECT; sentence RETRACTED in commit 3e5f90c5 and replaced with a correctly-scoped version. All four named sites fixed, each with a per-site test proven RED first:
 * sidecar/media_studio/features/subtitles.py translate() — now passes speaker= to make_cue.
 * sidecar/media_studio/features/subtitles.py stack_bilingual() — same.
 * sidecar/media_studio/models/translation.py _make_cue() + its _translate_batch call site — _make_cue gained `*, speaker: str | None = None` mirroring subtitles.make_cue including the "no speaker: None leakage" rule.
 * sidecar/media_studio/features/shortmaker.py _rebase_cues() — now spreads the source cue.
 * FIFTH SITE, deliberately added: sidecar/media_studio/features/fillers.py remap_cues(). The objection named "remap_cues()" but pinned it to shortmaker.py:723-730, which is _rebase_cues; the function actually called remap_cues lives in fillers.py:324. shortmaker.py:1010-1011 calls _rebase_cues THEN _fillers.remap_cues, so fixing only _rebase_cues would have been a literal no-op — remap_cues dropped the key again one line later. This also closes the drop on refine.py:376, transcript_edit.py:353 and the silencetrim path.
Counter-check reproduced: caption_polish.py:343-351 and redistribute_cue_text:500 use {**cue, ...} and DO preserve — the spread is the house idiom and these five were genuine outliers.

[stands objection #1 — FIXED] "no regression guard pins speaker-preservation on the other ops." Added `describe('speaker survives every cue op (regression guard)')` in app/renderer/src/lib/timelineOps.test.ts covering renumber, splitCue, splitAt, retimeCue, retimeAt, nudgeAt, dragEdge (both edges).

[stands objection #2 — ACCEPTED AND DISCLOSED, independently reproduced] The fourth mergeCues test ("emits NO speaker key when the earlier cue is not diarized") IS green in both states. I re-ran the reviewer's experiment rather than taking it on trust: reverting mergeCues to its pre-fix {index,start,end,text} literal reddens exactly 3 of the 4 and leaves that one green. It is now labelled INLINE at timelineOps.test.ts:180-184 as not-evidence-for-the-fix (it pins the plausible alternative `speaker: first.speaker`, which toEqual would accept since toEqual ignores undefined keys), and 3e5f90c5 says so too.

FALSE SENTENCES CORRECTED (the point of this pass):
 1. "no sidecar change — it was already correct" → RETRACTED (3e5f90c5).
 2. "I audited all seven ops" → the module exports nine; substantive sole-offender claim holds and is now pinned (3e5f90c5).
 3. "a wire field that has ALWAYS been sent" → false universal: make_cue:111 is `if speaker:`, so the key is emitted only when the transcript is diarized. Corrected in a separate empty commit a578c516, which also carries a one-place ledger of all four corrections.

RESIDUALS, honestly scoped (not fixed, stated so they can be scheduled):
 * features/caption/* and renderer lib/editorState.ts not audited for the same shape. editorState.ts constructs no cue literals — READ, not executed → UNVERIFIED, band unlikely (20-45%).
 * The three renderer copies of the Cue interface are still not deduplicated (out of lane; a merge of three declarations is a reviewed refactor). A fourth copy can silently re-introduce the declaration gap.
 * No UI reads `speaker` anywhere; the visible label is baked into cue TEXT by format_speaker_prefix (subtitles.py:210-226). All of this closes silent DATA loss, not a visible regression.
 * "Earlier cue wins" on a cross-speaker merge is still a judgement call pinned by a test, not a documented contract.

## Rebutted

NONE REBUTTED — every objection was upheld as written. Two nuances I add rather than dispute, both stated in the commits:

1. SCOPE WIDENED, NOT DISPUTED. The objection listed four sites; I fixed five. The fourth pointer ("shortmaker.py:723-730 — remap_cues()") conflates two functions: lines 723-730 are shortmaker._rebase_cues, while the function named remap_cues is fillers.py:324. shortmaker.py:1010-1011 runs _rebase_cues then _fillers.remap_cues, so fixing only the named lines would have left the filler path still dropping speaker — the fix would have measured zero. Both are fixed. Evidence: the fillers test I wrote was RED against the current tree, which cannot be true if remap_cues already preserved.

2. The reviewer's own hedge on residual #1 ("no UI reads speaker today") was checked and is accurate — no renderer component reads cue.speaker; the visible label is baked into cue TEXT by format_speaker_prefix (subtitles.py:210-226). So the whole class is silent DATA loss.

NOT CHECKED / OUT OF LANE, named so they can be scheduled elsewhere:
 * The three-copy renderer Cue duplication (structural hazard, needs a reviewed refactor).
 * features/caption/* and lib/editorState.ts fresh-literal audit.
 * I did not re-run W10's original sidecar round-trip probe from 1ca3729b; the five new committed tests supersede it as standing evidence.

## Disclosed residuals (non-blocking, and checked for accuracy — an inverted residual was itself one of the original findings)

_None._

## Independent re-verification

Fresh skeptic verdict: **mergeable = True**, all objections closed = True.

Remaining, per that verifier:

Nothing blocking. Non-blocking, already disclosed in-commit: (1) caption_remotion.py:431 still rebuilds a bare {index,start,end,text} cue, but it is a terminal Remotion render-job payload against a frozen zod schema (no persisted data loss) and falls inside the declared-unaudited features/caption* family; (2) the three renderer Cue interface copies remain undeduplicated - all three now declare speaker?, but a fourth copy could re-open the declaration gap; (3) "earlier cue wins" on a cross-speaker merge is pinned by a test, not by CONTRACTS.md. One process gap I closed myself rather than leaving open: the remediator's gate list omitted basedpyright (CI quality.yml gate:2) despite 4 changed .py files - I ran it, 0 errors / 11 pre-existing missing-import warnings. The false sentence survives in the historical commit 1ca3729b by design, retracted and ledgered in 3e5f90c5 + a578c516, which is what the objection asked for.

---

CI is the arbiter here, not the agents. This merges only if `quality` is green.
