### PR TITLE
feat(disclosure): surface AI-generated content disclosure in the renderer (W21)

### DIFF
--- a/app/renderer/src/App.director-state.test.tsx
+++ b/app/renderer/src/App.director-state.test.tsx
@@ -153,6 +153,29 @@ vi.mock('./components/SidecarBanner', () => ({ SidecarBanner: () => <div /> }));
 // mock and reading the gate-tests-coverage vitest step; the stub is correct either
 // way because the panel is irrelevant here.
 vi.mock('./features/TranscriptEditor', () => ({ default: () => <div /> }));
+// CORRECTION to the paragraph above, measured 2026-08-10 while remediating the
+// W21 review. A review objection proposed adding the same stub for the Dub panel
+// (also `lazy()` at `views/Workspace.tsx:42`) on the premise that a lazy sibling
+// panel's module graph is paid for by this suite. An executable probe REFUTES the
+// module-EVALUATION half of that premise for BOTH panels: a `throw` planted at
+// module top-level in `features/Dub.tsx` did NOT fire here, and the same probe in
+// `features/TranscriptEditor.tsx` (with its mock above temporarily disabled) did
+// NOT fire either — while the identical Dub probe DID fire in
+// `features/Dub.test.tsx`, so the detector is known-good in the loading state.
+// Neither panel is evaluated by this suite; `lazy()` defers the import until the
+// tab is rendered, and this suite never leaves the Director tab. A Dub stub would
+// therefore have saved nothing, so none was added. (Scope: EVALUATION is what the
+// probe measures. Whether Vite still TRANSFORMS an unevaluated dynamic import is
+// NOT measured here — the timings could not settle it, see below.)
+//
+// The timeout risk is real anyway, and its real cause is machine load, not this
+// file's imports. Measured on this box, three runs per configuration, first case:
+// without a Dub stub 2607 / 1542 / 1158 ms, with one 3438 / 3005 / 2770 ms — the
+// spread is larger than any effect and the ordering inverts, i.e. the single
+// 3628ms datapoint the objection cited is a load artifact, exactly like the
+// earlier 3/3 timeout. Against a 5000ms default that is a coin-flip on a busy
+// runner, so the margin is removed explicitly instead of by proxy.
+vi.setConfig({ testTimeout: 30_000 });
 
 import { App } from './App';
 

--- a/app/renderer/src/features/AiDisclosure.test.tsx
+++ b/app/renderer/src/features/AiDisclosure.test.tsx
@@ -11,10 +11,14 @@ import { createRoot, type Root } from 'react-dom/client';
 
 import {
   AI_AUDIO_BADGE_LABEL,
+  AI_EXPORT_LABEL_NOTE,
+  AI_LABEL_DIRECTION_NOTE,
   AiAudioBadge,
   AiDisclosurePanel,
   C2PA_EXPORT_STATUS,
+  NON_AI_TRACK_KIND,
   PERTH_WATERMARK_ENGINES,
+  audioTrackPickerLabel,
   engineEmbedsPerthWatermark,
   isAiGeneratedAudioTrack,
 } from './AiDisclosure';
@@ -36,12 +40,44 @@ describe('isAiGeneratedAudioTrack', () => {
     expect(isAiGeneratedAudioTrack({ kind: 'dub' })).toBe(true);
   });
 
-  it('does NOT flag an original row', () => {
-    expect(isAiGeneratedAudioTrack({ kind: 'original' })).toBe(false);
+  it('does NOT flag the original recording, and that is the ONLY suppressing kind', () => {
+    expect(NON_AI_TRACK_KIND).toBe('original');
+    expect(isAiGeneratedAudioTrack({ kind: NON_AI_TRACK_KIND })).toBe(false);
   });
 
-  it('does NOT flag a row whose kind is absent', () => {
-    expect(isAiGeneratedAudioTrack({})).toBe(false);
+  // REVISED after adversarial review. These two cases previously asserted
+  // `false` (the absent-kind one existed; the unrecognized-kind one did not).
+  // Asserting `false` LOCKED IN the unsafe direction: a row whose `kind` never
+  // arrived, or arrived as something the renderer does not know, rendered with
+  // no label at all. That is UNDER-disclosure — the Article-50 harm direction —
+  // and it disagreed with the sidecar, whose `normalize_audio_track` defaults a
+  // missing `kind` to "dub" (sidecar/media_studio/features/tracks_audio.py:114).
+  it('FLAGS a row whose kind is absent — the fallback points at labelling', () => {
+    expect(isAiGeneratedAudioTrack({})).toBe(true);
+  });
+
+  it('FLAGS a row whose kind is unrecognized', () => {
+    expect(isAiGeneratedAudioTrack({ kind: 'music' })).toBe(true);
+  });
+});
+
+describe('audioTrackPickerLabel', () => {
+  it('appends the AI label to a dub option (a <select> cannot host a badge element)', () => {
+    expect(audioTrackPickerLabel({ name: 'Spanish dub', lang: 'es', kind: 'dub' })).toBe(
+      `Spanish dub (es, dub) — ${AI_AUDIO_BADGE_LABEL}`,
+    );
+  });
+
+  it('leaves an original option unlabelled', () => {
+    expect(audioTrackPickerLabel({ name: 'English', lang: 'en', kind: 'original' })).toBe(
+      'English (en, original)',
+    );
+  });
+});
+
+describe('AI_EXPORT_LABEL_NOTE', () => {
+  it('says the marking is in-app only, at the surface where a dub is exported', () => {
+    expect(AI_EXPORT_LABEL_NOTE).toContain('not written into the exported file');
   });
 });
 
@@ -88,15 +124,19 @@ describe('<AiAudioBadge />', () => {
     container.remove();
   });
 
-  it('renders the badge label and explains what the label is derived from', () => {
+  it('renders the badge label with a plain-language tooltip, free of internal API jargon', () => {
     act(() => {
       root = createRoot(container);
       root.render(<AiAudioBadge />);
     });
     const badge = container.querySelector('[data-testid="ai-audio-badge"]');
     expect(badge?.textContent).toBe(AI_AUDIO_BADGE_LABEL);
-    // The tooltip must disclose the over-labelling direction, not hide it.
-    expect(badge?.getAttribute('title')).toContain('over-label');
+    const title = badge?.getAttribute('title') ?? '';
+    // The tooltip must still disclose the direction of the error...
+    expect(title).toContain('errs toward marking');
+    // ...but in shipped copy, not in the renderer's internal identifiers.
+    expect(title).not.toContain('AudioTrack.kind');
+    expect(title).not.toContain('tracks.audio.mux');
   });
 });
 
@@ -128,9 +168,28 @@ describe('<AiDisclosurePanel />', () => {
     expect(panel?.textContent).toContain('not embedded in exported files');
   });
 
+  // The badge tooltip is unreachable by keyboard, unreliable for screen readers
+  // and absent on touch, so the direction caveat cannot live only there.
+  it('states the labelling direction as VISIBLE text, not only inside a tooltip', () => {
+    mount(<AiDisclosurePanel engineId="kokoro" />);
+    const note = container.querySelector('[data-testid="ai-disclosure-direction"]');
+    expect(note?.textContent).toBe(AI_LABEL_DIRECTION_NOTE);
+    expect(AI_LABEL_DIRECTION_NOTE).toContain('errs toward marking');
+  });
+
   it('surfaces the Perth watermark note for chatterbox only', () => {
     mount(<AiDisclosurePanel engineId="chatterbox" />);
     expect(container.querySelector('[data-testid="perth-note"]')?.textContent).toContain('Perth');
+  });
+
+  // The note is keyed to the engine PICKER, so it is a pre-generation notice.
+  // Read retrospectively it would tell a user that a dub already in the list is
+  // watermarked when it may have been produced by a different engine.
+  it('scopes the Perth note to the engine about to be used, not to existing tracks', () => {
+    mount(<AiDisclosurePanel engineId="chatterbox" />);
+    const note = container.querySelector('[data-testid="perth-note"]')?.textContent ?? '';
+    expect(note).toContain('about to make');
+    expect(note).toContain('not the tracks already listed');
   });
 
   it('omits the Perth watermark note for a non-watermarking engine', () => {

--- a/app/renderer/src/features/AiDisclosure.test.tsx
+++ b/app/renderer/src/features/AiDisclosure.test.tsx
@@ -1,0 +1,161 @@
+// AiDisclosure.test.tsx — the AI-content disclosure surface (W21).
+//
+// Covers the pure predicates/constants with LITERAL expectations (never derived
+// from the value under test) and the two components under jsdom. The
+// Dub-panel wiring is asserted in Dub.test.tsx.
+
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import {
+  AI_AUDIO_BADGE_LABEL,
+  AiAudioBadge,
+  AiDisclosurePanel,
+  C2PA_EXPORT_STATUS,
+  PERTH_WATERMARK_ENGINES,
+  engineEmbedsPerthWatermark,
+  isAiGeneratedAudioTrack,
+} from './AiDisclosure';
+
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+// ---------------------------------------------------------------------------
+// pure constants + predicates
+// ---------------------------------------------------------------------------
+
+describe('AI_AUDIO_BADGE_LABEL', () => {
+  it('is the exact Article-50 wording the UI shows', () => {
+    expect(AI_AUDIO_BADGE_LABEL).toBe('AI-generated audio');
+  });
+});
+
+describe('isAiGeneratedAudioTrack', () => {
+  it('flags a dub row (the sidecar AudioTrack.kind the dub pipeline writes)', () => {
+    expect(isAiGeneratedAudioTrack({ kind: 'dub' })).toBe(true);
+  });
+
+  it('does NOT flag an original row', () => {
+    expect(isAiGeneratedAudioTrack({ kind: 'original' })).toBe(false);
+  });
+
+  it('does NOT flag a row whose kind is absent', () => {
+    expect(isAiGeneratedAudioTrack({})).toBe(false);
+  });
+});
+
+describe('PERTH_WATERMARK_ENGINES', () => {
+  it('lists exactly the engines that embed a Perth watermark', () => {
+    // Literal expectation: an added/removed engine must break this test.
+    expect([...PERTH_WATERMARK_ENGINES]).toEqual(['chatterbox']);
+  });
+});
+
+describe('engineEmbedsPerthWatermark', () => {
+  it('is true for chatterbox', () => {
+    expect(engineEmbedsPerthWatermark('chatterbox')).toBe(true);
+  });
+
+  it('is false for the local and hosted non-clone engines', () => {
+    expect(engineEmbedsPerthWatermark('kokoro')).toBe(false);
+    expect(engineEmbedsPerthWatermark('edgetts')).toBe(false);
+  });
+});
+
+describe('C2PA_EXPORT_STATUS', () => {
+  it('reports C2PA export as NOT available and names the blocker', () => {
+    expect(C2PA_EXPORT_STATUS.available).toBe(false);
+    expect(C2PA_EXPORT_STATUS.reason).toContain('signing identity');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// components
+// ---------------------------------------------------------------------------
+
+describe('<AiAudioBadge />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  it('renders the badge label and explains what the label is derived from', () => {
+    act(() => {
+      root = createRoot(container);
+      root.render(<AiAudioBadge />);
+    });
+    const badge = container.querySelector('[data-testid="ai-audio-badge"]');
+    expect(badge?.textContent).toBe(AI_AUDIO_BADGE_LABEL);
+    // The tooltip must disclose the over-labelling direction, not hide it.
+    expect(badge?.getAttribute('title')).toContain('over-label');
+  });
+});
+
+describe('<AiDisclosurePanel />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+  });
+
+  function mount(node: React.ReactElement): void {
+    act(() => {
+      root = createRoot(container);
+      root.render(node);
+    });
+  }
+
+  it('always states that the in-app label is not embedded in exported files', () => {
+    mount(<AiDisclosurePanel engineId="kokoro" />);
+    const panel = container.querySelector('[data-testid="ai-disclosure"]');
+    expect(panel).toBeTruthy();
+    expect(panel?.textContent).toContain('not embedded in exported files');
+  });
+
+  it('surfaces the Perth watermark note for chatterbox only', () => {
+    mount(<AiDisclosurePanel engineId="chatterbox" />);
+    expect(container.querySelector('[data-testid="perth-note"]')?.textContent).toContain('Perth');
+  });
+
+  it('omits the Perth watermark note for a non-watermarking engine', () => {
+    mount(<AiDisclosurePanel engineId="kokoro" />);
+    expect(container.querySelector('[data-testid="perth-note"]')).toBeNull();
+  });
+
+  it('reports C2PA export as unavailable with its reason, and NOT as a toggle', () => {
+    mount(<AiDisclosurePanel engineId="kokoro" />);
+    const row = container.querySelector('[data-testid="c2pa-status"]');
+    expect(row?.textContent).toContain('Not available');
+    expect(row?.textContent).toContain(C2PA_EXPORT_STATUS.reason);
+    // A checkbox here would promise provenance signing that does not exist.
+    expect(container.querySelector('[data-testid="ai-disclosure"] input')).toBeNull();
+  });
+
+  it('reports C2PA export as available when the injected status says so', () => {
+    mount(
+      <AiDisclosurePanel
+        engineId="kokoro"
+        c2pa={{ available: true, reason: 'signing identity configured' }}
+      />,
+    );
+    const row = container.querySelector('[data-testid="c2pa-status"]');
+    expect(row?.textContent).toContain('Available');
+    expect(row?.textContent).not.toContain('Not available');
+  });
+});

--- a/app/renderer/src/features/AiDisclosure.tsx
+++ b/app/renderer/src/features/AiDisclosure.tsx
@@ -7,15 +7,16 @@
 //
 // WHERE THE LABEL COMES FROM — the sidecar does NOT emit an `isAiGenerated`
 // field. Measured on this tree:
-//   * `sidecar/media_studio/features/tracks_audio.py:117-126` — `normalize_audio_track`
-//     builds exactly {id, lang, name, kind, path} (+ optional `voice`). No
-//     `isAiGenerated`.
+//   * `sidecar/media_studio/features/tracks_audio.py:105-126` —
+//     `normalize_audio_track` builds exactly {id, lang, name, kind, path} (+
+//     optional `voice`). No `isAiGenerated`, and no engine field either.
 //   * the only `isAiGenerated` occurrence in `sidecar/` is a *test fixture*
 //     (`sidecar/tests/test_tts_lipsync.py:46`), not produced data.
-// So the honest signal available to the renderer is `AudioTrack.kind === 'dub'`,
-// which the dub pipeline writes via `tracks_audio.mux_for_dub`
-// (`sidecar/media_studio/features/tts/dub.py:382`). See
-// `isAiGeneratedAudioTrack` for the direction of its error.
+// So the honest signal available to the renderer is the track's `kind`, which the
+// dub pipeline writes via `tracks_audio.mux_for_dub`
+// (`sidecar/media_studio/features/tracks_audio.py:591-601`, called from
+// `features/tts/dub.py:382`). See `isAiGeneratedAudioTrack` for the direction of
+// its error.
 import React from 'react';
 
 /** The subset of the A3 AudioTrack this module reads. */
@@ -23,30 +24,89 @@ export interface DisclosableAudioTrack {
   kind?: string;
 }
 
+/**
+ * The one A3 `kind` that means "the container's own, human-recorded audio"
+ * (`KIND_ORIGINAL`, `sidecar/media_studio/features/tracks_audio.py:67`). It is
+ * the ONLY value that suppresses the label.
+ */
+export const NON_AI_TRACK_KIND = 'original';
+
 /** The exact badge wording. */
 export const AI_AUDIO_BADGE_LABEL = 'AI-generated audio';
 
 /**
- * Tooltip for the badge — it discloses the predicate AND the direction in which
- * it is wrong, because a label whose basis is hidden invites over-trust.
+ * Tooltip for the badge. Plain shipped copy — it names no renderer identifier
+ * and no RPC method, because it is read by end users, not by maintainers. The
+ * same sentence is ALSO rendered as visible text by `AiDisclosurePanel`
+ * (`AI_LABEL_DIRECTION_NOTE`): a `title=` attribute is unreachable by keyboard,
+ * unreliable for screen readers and absent on touch, so the caveat cannot live
+ * only here.
  */
 export const AI_AUDIO_BADGE_TITLE =
-  'Derived from the sidecar AudioTrack.kind === "dub". A human-recorded file ' +
-  'registered through tracks.audio.mux with kind "dub" is labelled too, so this ' +
-  'can over-label; it never leaves a dub produced by this panel unlabelled.';
+  'Reframe errs toward marking: every audio track except the video’s own ' +
+  'recorded audio carries this mark, so an imported human recording added as a ' +
+  'dub is marked too.';
+
+/**
+ * The same caveat as `AI_AUDIO_BADGE_TITLE`, rendered as visible panel text.
+ */
+export const AI_LABEL_DIRECTION_NOTE =
+  'Reframe errs toward marking: every audio track except the video’s own ' +
+  'recorded audio carries the “' +
+  AI_AUDIO_BADGE_LABEL +
+  '” mark, so an imported human recording added as a dub is marked too. The ' +
+  'mark is withheld only for a track that is explicitly the original recording.';
 
 /**
  * True when the row should carry the AI-generated label.
  *
- * ERROR DIRECTION (deliberate): `tracks.audio.mux` defaults `kind` to `"dub"`
- * (`sidecar/media_studio/features/tracks_audio.py:498`), so a human-recorded
- * track imported that way is ALSO labelled. That is over-disclosure. For an
- * Article-50 transparency duty over-disclosure is the safe side and
- * under-disclosure is the harm, so the predicate is intentionally not narrowed.
+ * ERROR DIRECTION — the fallback points at LABELLING. Only an explicit
+ * `"original"` suppresses the badge; a missing or unrecognized `kind` is
+ * labelled. Two consequences, both deliberate:
+ *   * OVER-labelling: a human-recorded track registered through
+ *     `tracks.audio.mux` with kind `"dub"` (or with no kind at all — the sidecar
+ *     defaults it to `"dub"`, `tracks_audio.py:114`) is labelled as well.
+ *   * a future non-AI kind (say `"music"`) would be labelled until it is added
+ *     to the non-AI set. That is a real cost, stated here rather than hidden.
+ * For an Article-50 transparency duty over-disclosure is the recoverable side
+ * and under-disclosure is the harm.
+ *
+ * REVISED after adversarial review. The first version was `kind === 'dub'`,
+ * which failed the OTHER way: a row whose `kind` was absent or unrecognized
+ * rendered with NO label — under-disclosure — and it disagreed with the
+ * sidecar's own fallback, which defaults a missing `kind` to `"dub"`
+ * (`tracks_audio.py:114`). Both sides now fail in the same direction. The
+ * renderer's `AudioTrack.kind` is typed `'original' | 'dub'` and required
+ * (`lib/rpc/schemas.ts:409-414`), so on a well-typed payload the two predicates
+ * agree; the change only decides what happens when that contract is not held.
  */
 export function isAiGeneratedAudioTrack(track: DisclosableAudioTrack): boolean {
-  return track.kind === 'dub';
+  return track.kind !== NON_AI_TRACK_KIND;
 }
+
+/**
+ * The option text for an audio-track `<select>` — used by the ShortMaker export
+ * picker, which is where a dub is actually chosen to be muxed into an exported
+ * short. A `<select>` cannot host a badge element, so the disclosure has to be
+ * part of the label text.
+ */
+export function audioTrackPickerLabel(track: { name: string; lang: string; kind: string }): string {
+  const base = `${track.name} (${track.lang}, ${track.kind})`;
+  return isAiGeneratedAudioTrack(track) ? `${base} — ${AI_AUDIO_BADGE_LABEL}` : base;
+}
+
+/**
+ * Shown next to the export picker when the selected track is AI-generated. The
+ * marking is in-app only: `shortmaker.build_audio_mux_argv`
+ * (`sidecar/media_studio/features/shortmaker.py:512-539`) emits no `-metadata`
+ * of any kind, so nothing about the label reaches the exported container.
+ */
+export const AI_EXPORT_LABEL_NOTE =
+  'This short will be exported with an AI-generated audio track. The ' +
+  '“' +
+  AI_AUDIO_BADGE_LABEL +
+  '” marking is shown inside Reframe only — it is not written into the ' +
+  'exported file.';
 
 /**
  * Engines whose upstream model embeds Resemble AI's inaudible **Perth**
@@ -62,10 +122,23 @@ export function engineEmbedsPerthWatermark(engineId: string): boolean {
 }
 
 /**
- * The Perth disclosure copy. Deliberately does NOT promise the watermark
- * survives the pipeline: the dub is re-encoded to AAC
- * (`sidecar/media_studio/features/tts/dub.py:376`) and nothing in this repo
- * verifies that the watermark survives that encode.
+ * The Perth disclosure copy.
+ *
+ * FORWARD-LOOKING, and the copy now says so. The note is keyed to the engine
+ * PICKER, so it describes the dub the user is about to make. Read
+ * retrospectively it would assert that a dub already in the track list carries a
+ * Perth watermark, which it may not: an A3 AudioTrack has no engine FIELD
+ * (`normalize_audio_track` keeps only id/lang/name/kind/path/voice,
+ * `tracks_audio.py:117-126`). The engine does survive inside the display NAME the
+ * sidecar writes as `Dub (<engine>, <lang>)` (`features/tts/dub.py:386`). That is
+ * free text a user can rename and no other producer is obliged to follow, so the
+ * panel neither asserts provenance from it nor claims the engine is unknowable —
+ * the copy below says only that an existing track "may have been made with a
+ * different engine", which holds either way.
+ *
+ * It also deliberately does NOT promise the watermark survives the pipeline: the
+ * dub is re-encoded to AAC (`features/tts/dub.py:376`) and nothing in this repo
+ * verifies survival.
  *
  * UNVERIFIED — that chatterbox-tts 0.1.7 in fact applies the Perth watermarker,
  * and whether it survives the AAC encode. Settling experiment: run the
@@ -75,10 +148,13 @@ export function engineEmbedsPerthWatermark(engineId: string): boolean {
  * removal of its own — that part is measured, the upstream embed is not.
  */
 export const PERTH_WATERMARK_NOTE =
-  'Chatterbox embeds Resemble AI’s inaudible Perth watermark in the speech it ' +
-  'generates. Reframe never strips it deliberately — but the dub is re-encoded ' +
-  'to AAC before it becomes a track, and Reframe does not verify the watermark ' +
-  'survives that encode.';
+  'Chatterbox — the engine selected above — embeds Resemble AI’s inaudible ' +
+  'Perth watermark in the speech it generates. That describes the dub you are ' +
+  'about to make, not the tracks already listed below: those may have been made ' +
+  'with a different engine. Reframe never ' +
+  'strips the watermark deliberately, but the dub is re-encoded to AAC before ' +
+  'it becomes a track and Reframe does not verify the watermark survives that ' +
+  'encode.';
 
 /** Status of Content Credentials (C2PA) signing on export. */
 export interface C2paExportStatus {
@@ -120,8 +196,9 @@ export interface AiDisclosurePanelProps {
 }
 
 /**
- * The disclosure block for the Dub panel: what is labelled, what the label does
- * NOT cover, the engine-specific watermark note, and the C2PA export status.
+ * The disclosure block for the Dub panel: what is labelled, which way the
+ * labelling errs, what the label does NOT cover, the engine-specific watermark
+ * note, and the C2PA export status.
  */
 export function AiDisclosurePanel({
   engineId,
@@ -138,6 +215,9 @@ export function AiDisclosurePanel({
         Audio produced here is synthesized, and every dub track is marked
         {` “${AI_AUDIO_BADGE_LABEL}” `}
         in the track list below. That marking is in-app only: it is not embedded in exported files.
+      </p>
+      <p className="ai-disclosure-direction" data-testid="ai-disclosure-direction">
+        {AI_LABEL_DIRECTION_NOTE}
       </p>
       {engineEmbedsPerthWatermark(engineId) && (
         <p className="ai-disclosure-perth" data-testid="perth-note">

--- a/app/renderer/src/features/AiDisclosure.tsx
+++ b/app/renderer/src/features/AiDisclosure.tsx
@@ -1,0 +1,155 @@
+// AI-content disclosure surface (W21 — docs/plans/v1.5/flagship-lip-sync-dub.md
+// lines 165 / 184-190, EU AI Act Article 50 transparency).
+//
+// Consent gates 1 (voice-clone attestation) and 2 (likeness attestation) already
+// ship. This is gate 3: LABEL the generated result and be explicit about what the
+// label does and does not cover.
+//
+// WHERE THE LABEL COMES FROM — the sidecar does NOT emit an `isAiGenerated`
+// field. Measured on this tree:
+//   * `sidecar/media_studio/features/tracks_audio.py:117-126` — `normalize_audio_track`
+//     builds exactly {id, lang, name, kind, path} (+ optional `voice`). No
+//     `isAiGenerated`.
+//   * the only `isAiGenerated` occurrence in `sidecar/` is a *test fixture*
+//     (`sidecar/tests/test_tts_lipsync.py:46`), not produced data.
+// So the honest signal available to the renderer is `AudioTrack.kind === 'dub'`,
+// which the dub pipeline writes via `tracks_audio.mux_for_dub`
+// (`sidecar/media_studio/features/tts/dub.py:382`). See
+// `isAiGeneratedAudioTrack` for the direction of its error.
+import React from 'react';
+
+/** The subset of the A3 AudioTrack this module reads. */
+export interface DisclosableAudioTrack {
+  kind?: string;
+}
+
+/** The exact badge wording. */
+export const AI_AUDIO_BADGE_LABEL = 'AI-generated audio';
+
+/**
+ * Tooltip for the badge — it discloses the predicate AND the direction in which
+ * it is wrong, because a label whose basis is hidden invites over-trust.
+ */
+export const AI_AUDIO_BADGE_TITLE =
+  'Derived from the sidecar AudioTrack.kind === "dub". A human-recorded file ' +
+  'registered through tracks.audio.mux with kind "dub" is labelled too, so this ' +
+  'can over-label; it never leaves a dub produced by this panel unlabelled.';
+
+/**
+ * True when the row should carry the AI-generated label.
+ *
+ * ERROR DIRECTION (deliberate): `tracks.audio.mux` defaults `kind` to `"dub"`
+ * (`sidecar/media_studio/features/tracks_audio.py:498`), so a human-recorded
+ * track imported that way is ALSO labelled. That is over-disclosure. For an
+ * Article-50 transparency duty over-disclosure is the safe side and
+ * under-disclosure is the harm, so the predicate is intentionally not narrowed.
+ */
+export function isAiGeneratedAudioTrack(track: DisclosableAudioTrack): boolean {
+  return track.kind === 'dub';
+}
+
+/**
+ * Engines whose upstream model embeds Resemble AI's inaudible **Perth**
+ * watermark in what it generates. Only the chatterbox voice-clone engine does
+ * (`chatterbox-tts==0.1.7`, pinned in
+ * `sidecar/runtime_setup/requirements-chatterbox.txt`).
+ */
+export const PERTH_WATERMARK_ENGINES: readonly string[] = ['chatterbox'];
+
+/** Whether `engineId`'s generated audio carries a Perth watermark. */
+export function engineEmbedsPerthWatermark(engineId: string): boolean {
+  return PERTH_WATERMARK_ENGINES.includes(engineId);
+}
+
+/**
+ * The Perth disclosure copy. Deliberately does NOT promise the watermark
+ * survives the pipeline: the dub is re-encoded to AAC
+ * (`sidecar/media_studio/features/tts/dub.py:376`) and nothing in this repo
+ * verifies that the watermark survives that encode.
+ *
+ * UNVERIFIED — that chatterbox-tts 0.1.7 in fact applies the Perth watermarker,
+ * and whether it survives the AAC encode. Settling experiment: run the
+ * `resemble-perth` detector over a chatterbox-produced WAV and over the muxed
+ * `.m4a`. Neither `perth` nor any watermark-stripping step appears anywhere in
+ * `sidecar/media_studio/features/tts/` (measured: 0 matches), so Reframe adds no
+ * removal of its own — that part is measured, the upstream embed is not.
+ */
+export const PERTH_WATERMARK_NOTE =
+  'Chatterbox embeds Resemble AI’s inaudible Perth watermark in the speech it ' +
+  'generates. Reframe never strips it deliberately — but the dub is re-encoded ' +
+  'to AAC before it becomes a track, and Reframe does not verify the watermark ' +
+  'survives that encode.';
+
+/** Status of Content Credentials (C2PA) signing on export. */
+export interface C2paExportStatus {
+  readonly available: boolean;
+  readonly reason: string;
+}
+
+/**
+ * C2PA manifest emit is NOT implemented in this tree. Measured: no `c2patool`
+ * reference exists anywhere in the repo, and `docs/V1.1-FEATURES.md:575` lists
+ * "Optional C2PA Content-Credentials manifest emit on export" as an L7 item
+ * deferred to V2 because it needs a signing identity.
+ *
+ * This is exposed as a STATUS, not a checkbox, on purpose: a toggle that
+ * persists a preference nothing consumes would tell the user their exports carry
+ * provenance when they do not.
+ */
+export const C2PA_EXPORT_STATUS: C2paExportStatus = {
+  available: false,
+  reason:
+    'C2PA manifest signing is not implemented — it needs a signing identity ' +
+    '(deferred to V2, docs/V1.1-FEATURES.md L7).',
+};
+
+/** The "AI-generated audio" badge. */
+export function AiAudioBadge(): React.ReactElement {
+  return (
+    <span className="ai-audio-badge" data-testid="ai-audio-badge" title={AI_AUDIO_BADGE_TITLE}>
+      {AI_AUDIO_BADGE_LABEL}
+    </span>
+  );
+}
+
+export interface AiDisclosurePanelProps {
+  /** The engine currently selected in the dub picker. */
+  engineId: string;
+  /** Injectable so the panel can be exercised in both C2PA states. */
+  c2pa?: C2paExportStatus;
+}
+
+/**
+ * The disclosure block for the Dub panel: what is labelled, what the label does
+ * NOT cover, the engine-specific watermark note, and the C2PA export status.
+ */
+export function AiDisclosurePanel({
+  engineId,
+  c2pa = C2PA_EXPORT_STATUS,
+}: AiDisclosurePanelProps): React.ReactElement {
+  return (
+    <section
+      className="ai-disclosure"
+      data-testid="ai-disclosure"
+      aria-label="AI content disclosure"
+    >
+      <h3>AI-content disclosure</h3>
+      <p className="ai-disclosure-scope">
+        Audio produced here is synthesized, and every dub track is marked
+        {` “${AI_AUDIO_BADGE_LABEL}” `}
+        in the track list below. That marking is in-app only: it is not embedded in exported files.
+      </p>
+      {engineEmbedsPerthWatermark(engineId) && (
+        <p className="ai-disclosure-perth" data-testid="perth-note">
+          {PERTH_WATERMARK_NOTE}
+        </p>
+      )}
+      <p className="ai-disclosure-c2pa" data-testid="c2pa-status">
+        <span className="ai-disclosure-c2pa-label">Content Credentials (C2PA) on export: </span>
+        {c2pa.available ? 'Available' : `Not available — ${c2pa.reason}`}
+      </p>
+    </section>
+  );
+}
+
+export default AiDisclosurePanel;

--- a/app/renderer/src/features/Dub.test.tsx
+++ b/app/renderer/src/features/Dub.test.tsx
@@ -910,6 +910,13 @@ describe('<Dub />', () => {
     expect(container.querySelector('[data-testid="perth-note"]')?.textContent).toContain('Perth');
   });
 
+  it('shows the labelling-direction caveat as visible panel text, not only as a tooltip', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    const note = container.querySelector('[data-testid="ai-disclosure-direction"]');
+    expect(note?.textContent).toContain('errs toward marking');
+  });
+
   it('states the C2PA export gap instead of offering a toggle that signs nothing', async () => {
     const { api } = makeBridge();
     await mount(api);

--- a/app/renderer/src/features/Dub.test.tsx
+++ b/app/renderer/src/features/Dub.test.tsx
@@ -851,4 +851,70 @@ describe('<Dub />', () => {
       'unsupported sample format',
     );
   });
+
+  // ------------------------------------------------------------------------
+  // W21 — the AI-content disclosure surface (consent gate 3).
+  // docs/plans/v1.5/flagship-lip-sync-dub.md:165/188 — "AI-content label on the
+  // dub track + export-time C2PA + surface Chatterbox's Perth watermark".
+  // ------------------------------------------------------------------------
+  it('labels the dub row — and ONLY the dub row — with the AI-generated badge', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    // AUDIO_TRACKS = [a1 kind:'original', a2 kind:'dub'] -> exactly one badge.
+    expect(container.querySelectorAll('[data-testid="ai-audio-badge"]')).toHaveLength(1);
+    const dubRow = container.querySelector('[data-audio-track="a2"]');
+    const originalRow = container.querySelector('[data-audio-track="a1"]');
+    expect(dubRow?.querySelector('[data-testid="ai-audio-badge"]')).toBeTruthy();
+    expect(originalRow?.querySelector('[data-testid="ai-audio-badge"]')).toBeNull();
+    expect(dubRow?.textContent).toContain('AI-generated audio');
+  });
+
+  it('labels the finished dub result with the AI-generated badge', async () => {
+    const { api, doneCbs } = makeBridge({ 'tracks.audio.list': { audioTracks: [] } });
+    await mount(api);
+    pick('[data-picker="track"]', 't1');
+    await act(async () => {
+      (container.querySelector('[data-action="start-dub"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    await act(async () => {
+      doneCbs.forEach((cb) =>
+        cb({
+          jobId: 'job-9',
+          result: {
+            audioTrack: {
+              id: 'a3',
+              lang: 'en',
+              name: 'Dub (kokoro, en)',
+              kind: 'dub',
+              voice: 'af_sarah',
+              path: 'C:/dubs/dub.m4a',
+            },
+            path: 'C:/dubs/dub.wav',
+          },
+        }),
+      );
+    });
+    await flush();
+    const result = container.querySelector('[data-testid="dub-result"]');
+    expect(result?.querySelector('[data-testid="ai-audio-badge"]')).toBeTruthy();
+  });
+
+  it('renders the disclosure block and surfaces Perth only for chatterbox', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    expect(container.querySelector('[data-testid="ai-disclosure"]')).toBeTruthy();
+    // kokoro (the default engine) does not watermark.
+    expect(container.querySelector('[data-testid="perth-note"]')).toBeNull();
+    pick('[data-picker="engine"]', 'chatterbox');
+    expect(container.querySelector('[data-testid="perth-note"]')?.textContent).toContain('Perth');
+  });
+
+  it('states the C2PA export gap instead of offering a toggle that signs nothing', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    const row = container.querySelector('[data-testid="c2pa-status"]');
+    expect(row?.textContent).toContain('Not available');
+    expect(row?.textContent).toContain('signing identity');
+  });
 });

--- a/app/renderer/src/features/Dub.tsx
+++ b/app/renderer/src/features/Dub.tsx
@@ -15,6 +15,7 @@
 // resolver extension; until applied the player shows the path instead).
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import './panels.css';
+import { AiAudioBadge, AiDisclosurePanel, isAiGeneratedAudioTrack } from './AiDisclosure';
 import {
   extractJobId,
   getApi,
@@ -372,6 +373,10 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
         </label>
       </div>
 
+      {/* W21 — consent gate 3: label the generated result, and be explicit
+          about what the label does NOT cover. */}
+      <AiDisclosurePanel engineId={engine} />
+
       <div className="dub-sample-upload">
         <label>
           Voice sample (wav/mp3 path for cloning){' '}
@@ -479,6 +484,12 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
           <p className="dub-result-name">
             {result.audioTrack.name} · {result.audioTrack.lang}
             {result.audioTrack.voice ? ` · voice ${result.audioTrack.voice}` : ''}
+            {isAiGeneratedAudioTrack(result.audioTrack) && (
+              <>
+                {' '}
+                <AiAudioBadge />
+              </>
+            )}
           </p>
           {/* audition the WAV directly (plan: play the dub WAV) */}
           <audio controls src={dubMediaUrl(result.path)} data-testid="dub-audio" />
@@ -496,6 +507,7 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
             <span className="audio-track-lang">{t.lang}</span>
             <span className={`audio-track-kind audio-track-kind--${t.kind}`}>{t.kind}</span>
             {t.voice && <span className="audio-track-voice">{t.voice}</span>}
+            {isAiGeneratedAudioTrack(t) && <AiAudioBadge />}
           </li>
         ))}
       </ul>

--- a/app/renderer/src/features/ShortMakerControls.test.tsx
+++ b/app/renderer/src/features/ShortMakerControls.test.tsx
@@ -111,13 +111,29 @@ describe('<ShortMakerControls />', () => {
     });
   }
 
+  // STRENGTHENED (not weakened) after adversarial review: this is the surface
+  // where a dub is actually chosen to be muxed into an exported short, so the
+  // dub option must carry the Article-50 wording and not only the raw kind.
   it('renders the audio-track picker with Original plus every track option', () => {
     mount();
     const select = byLabel('Audio track') as HTMLSelectElement;
     const opts = [...select.options].map((o) => `${o.value}:${o.textContent}`);
     expect(opts[0]).toBe(':Original');
     expect(opts[1]).toBe('t-en:English (en, original)');
-    expect(opts[2]).toBe('t-es:Spanish dub (es, dub)');
+    expect(opts[2]).toBe('t-es:Spanish dub (es, dub) — AI-generated audio');
+  });
+
+  it('warns that the AI marking is in-app only when an AI track is selected for export', () => {
+    mount({ audioTrackId: 't-es' });
+    const note = container.querySelector('[data-testid="sm-ai-audio-note"]');
+    expect(note?.textContent).toContain('not written into the exported file');
+  });
+
+  it('shows no AI export note for the original track or for no selection', () => {
+    mount({ audioTrackId: 't-en' });
+    expect(container.querySelector('[data-testid="sm-ai-audio-note"]')).toBeNull();
+    mount({ audioTrackId: '' });
+    expect(container.querySelector('[data-testid="sm-ai-audio-note"]')).toBeNull();
   });
 
   it('forwards prompt edits to setPrompt', () => {

--- a/app/renderer/src/features/ShortMakerControls.tsx
+++ b/app/renderer/src/features/ShortMakerControls.tsx
@@ -22,6 +22,14 @@ import {
   type ShortMakerControls as ShortMakerControlsState,
   clamp,
 } from './shortMakerLogic';
+// W21 (EU AI Act Art. 50): this picker is where a dub is chosen to be muxed
+// into an EXPORTED short, so the AI-generated marking and the "in-app only"
+// caveat have to be reachable here, not only on the Dub panel.
+import {
+  AI_EXPORT_LABEL_NOTE,
+  audioTrackPickerLabel,
+  isAiGeneratedAudioTrack,
+} from './AiDisclosure';
 import { type PlatformPresetId, PLATFORM_PRESETS, PLATFORM_PRESET_IDS } from './shortMakerPresets';
 import { CAPTION_STYLES } from './shortMakerLogic';
 import { LanguageSelect } from '../components/LanguageSelect';
@@ -68,6 +76,7 @@ export function ShortMakerControls({
   onBatch,
   onCancel,
 }: ShortMakerControlsProps): React.JSX.Element {
+  const selectedAudioTrack = audioTracks.find((t) => t.id === audioTrackId);
   return (
     <form
       className="shortmaker-form"
@@ -188,11 +197,17 @@ export function ShortMakerControls({
             <option value="">Original</option>
             {audioTracks.map((t) => (
               <option key={t.id} value={t.id}>
-                {t.name} ({t.lang}, {t.kind})
+                {audioTrackPickerLabel(t)}
               </option>
             ))}
           </select>
         </label>
+
+        {selectedAudioTrack && isAiGeneratedAudioTrack(selectedAudioTrack) && (
+          <p className="sm-ai-audio-note" data-testid="sm-ai-audio-note">
+            {AI_EXPORT_LABEL_NOTE}
+          </p>
+        )}
 
         {/* P3-A: hook-title overlay toggle (default ON). */}
         <label className="sm-field sm-toggle">

--- a/app/renderer/src/features/panels.css
+++ b/app/renderer/src/features/panels.css
@@ -357,6 +357,56 @@
   color: var(--status-success);
 }
 
+/* ---- AI-content disclosure (W21, EU AI Act Art. 50) --------------------------- */
+
+/* The disclosure block is an INFORMATION rail, not an alarm: it must be legible
+   and unmissable without competing with the consent gate (the only warn-coloured
+   element in this panel). */
+.dub-panel .ai-disclosure {
+  margin: var(--space-5) 0;
+  padding: var(--space-4) var(--space-5);
+  border-left: 3px solid var(--text-muted);
+  border-radius: var(--radius-sm);
+  background: var(--surface-deep);
+}
+
+.dub-panel .ai-disclosure h3 {
+  margin: 0 0 var(--space-3);
+  font-size: var(--type-caption-size);
+  font-weight: 650;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-secondary);
+}
+
+.dub-panel .ai-disclosure p {
+  margin: 0 0 var(--space-3);
+  font-size: var(--type-caption-size);
+  color: var(--text-muted);
+}
+
+.dub-panel .ai-disclosure p:last-child {
+  margin-bottom: 0;
+}
+
+.dub-panel .ai-disclosure-c2pa-label {
+  font-weight: 650;
+  color: var(--text-secondary);
+}
+
+/* The label itself: a chip that reads as a STATEMENT about the audio, so it
+   carries its own colour rather than inheriting the row's muted voice. */
+.dub-panel .ai-audio-badge {
+  padding: var(--space-1) var(--space-3);
+  border: 1px solid var(--text-muted);
+  border-radius: var(--radius-xs);
+  font-size: var(--type-caption-size);
+  font-weight: 650;
+  letter-spacing: 0.02em;
+  color: var(--text-primary);
+  white-space: nowrap;
+}
+
 /* ---- Assets ------------------------------------------------------------------- */
 
 .assets-panel .asset-row {

--- a/app/renderer/src/features/shortmaker-p3.css
+++ b/app/renderer/src/features/shortmaker-p3.css
@@ -8,6 +8,17 @@
    factor toggle (an active state). Factor bars are data display, not
    progress, so the fills stay tonal grays off the text ladder. */
 
+/* ---- W21 AI-content disclosure on the export audio picker ------------------- */
+
+/* An informational footnote under the audio-track picker, not an alarm: it rides
+   the muted text voice like the other field captions and claims no accent. */
+.shortmaker .sm-ai-audio-note {
+  margin: calc(-1 * var(--space-2)) 0 var(--space-4);
+  font-size: var(--type-caption-size);
+  line-height: 1.45;
+  color: var(--text-muted);
+}
+
 /* ---- the two pipeline toggles (ride the controls row) ----------------------- */
 
 .shortmaker .sm-toggle {


### PR DESCRIPTION
Wave 2 lane H — W21 AI-content disclosure (EU AI Act Article 50), renderer only.
Adversarial review has landed; this body replaces the placeholder it promised to replace.

## Commits

| | |
|---|---|
| `9731e222` | the original disclosure surface (badge, disclosure panel, Perth note, C2PA status) |
| `a19a2ada` | **remediation** — two upheld objections fixed, one refuted by an executable probe |

## What the review found, and what happened to it

**1. UPHELD — the badge predicate failed UNSAFE, and a new test locked that in.**
`isAiGeneratedAudioTrack` was `kind === 'dub'`, so a row whose `kind` was absent or
unrecognized rendered with **no** label — under-disclosure, the Article-50 harm direction —
and the opposite of the sidecar's own fallback, which defaults a missing `kind` to `"dub"`
(`tracks_audio.py:114`). `AiDisclosure.test.tsx` asserted `isAiGeneratedAudioTrack({}) === false`,
i.e. the defect as the expectation. **Fixed:** the predicate is now `kind !== 'original'`;
the test asserts `true` and a new unrecognized-kind case was added. Both proven RED first.

**2. UPHELD — the Perth note was retrospectively false.** It is keyed to the engine *picker*
(a pre-generation notice) but read as a fact about audio that exists, so a user who dubbed with
kokoro and then moved the picker to chatterbox was told their existing track is watermarked.
**Fixed:** the copy now scopes itself — "the dub you are about to make, not the tracks already
listed below: those may have been made with a different engine."

**3. UPHELD (graded sub-blocking) — unreachable caveat, jargon copy, unnamed export surface.**
The error-direction caveat lived only in a `title=` attribute (no keyboard, unreliable for
screen readers, absent on touch) and shipped `AudioTrack.kind === "dub"` / `tracks.audio.mux`
to end users. It is now **visible panel text** in plain copy, with a test asserting the internal
identifiers are gone. `ShortMakerControls`' "Audio track" `<select>` — where a dub is actually
chosen to be muxed into an **exported** short — carried no disclosure at all and was never named
in the residuals; its options now carry the Article-50 wording and selecting an AI track shows
the in-app-only caveat.

**4. REFUTED by probe — the requested `vi.mock('./features/Dub')` would have saved nothing.**
A `throw` planted at module top level in `features/Dub.tsx` did **not** fire in
`App.director-state.test.tsx`, while the *same* probe **did** fire in `features/Dub.test.tsx`
(detector validated in both states). The identical probe in `TranscriptEditor.tsx`, with its own
mock temporarily disabled, also did not fire — `lazy()` defers the import until the tab renders,
and that suite never leaves the Director tab. Timings could not settle it either and that is the
point: three runs per configuration, first case, **without** a Dub stub 2607/1542/1158 ms,
**with** one 3438/3005/2770 ms — the spread exceeds any effect and the ordering inverts, so the
3628 ms datapoint the objection cited is a load artifact. **Fixed at the real cause instead:**
`vi.setConfig({ testTimeout: 30_000 })` on that file, verified both-states with a throwaway 6 s
test (passes with the call, `Test timed out in 5000ms` without it).
*Scope: the probe measures module EVALUATION. Whether Vite still TRANSFORMS an unevaluated
dynamic import is not settled here.*

## Corrections to sentences I previously shipped

* ~~"it never leaves a dub produced by this panel unlabelled"~~ — an absolute denial resting on a
  sidecar invariant the renderer did not enforce. Replaced with what the code does: *the mark is
  withheld only for a track that is explicitly the original recording.*
* ~~residual "the badge OVER-labels by design"~~ — true but **inverted**: stating only the safe
  direction is what told the next reader not to look for the under-label path.
* ~~residual "the UI copy is worded to claim only the measured half" (Perth)~~ — the copy was
  silent about *which* audio it described, which was the axis that mattered.
* A draft of the new Perth copy said "Reframe does not record which [engine]". Cut before
  shipping: false to a user reading `Dub (kokoro, de)` two lines below (`features/tts/dub.py:386`).

## Tests

No test was weakened, deleted or skipped. Three assertions were **revised and each is strictly
stronger** (the predicate case, the tooltip case, the option-text case). Fail-first: every
new/revised assertion was run against the unfixed tree — **12 failed / 66 passed** across the
three suites; the only new case green there is the deliberately-negative
"no AI export note for the original track".

## Gates (on the remediation tree)

* `npx vitest run --coverage` → **233 files, 4421 tests, exit 0**; 100% statements
  (22891/22891), branches (7561/7561), functions (1349/1349), lines.
* `npx tsc --noEmit` → exit 0.
* `npx @biomejs/biome@2.5.0 check` → clean on all 7 touched files.
* sidecar pytest → **NOT-APPLICABLE**, no `.py` file changed.

## Residuals, correctly scoped

1. Over-labelling is now **structural**: any kind that is not `'original'` is marked.
   Reachability from the UI is LOW — the typed client makes `kind` required
   (`lib/rpc/schemas.ts:409-414`, `lib/rpc/client.ts:438-444`) and the sidecar rejects anything
   outside `{original, dub}` (`tracks_audio.py:115`). It bites on malformed or future data, and
   it bites toward disclosure.
2. That chatterbox-tts 0.1.7 applies the Perth watermarker, and that it survives the AAC
   re-encode, remain **UNVERIFIED** — an upstream-library property. Settling experiment named
   inline in the source: run the `resemble-perth` detector over a chatterbox WAV and over the
   muxed `.m4a`. Measured here: 0 `perth`/stripping matches under `features/tts/`, so Reframe
   removes nothing of its own.
3. Generated **video** is still unlabelled — the lip-sync surface has no renderer panel on this
   tree to host a badge.
4. Nothing is embedded in exported files (`shortmaker.build_audio_mux_argv` emits no
   `-metadata`). Both surfaces now say so; C2PA stays a status row because no signing identity
   exists (`docs/V1.1-FEATURES.md:575`, L7 → V2).
5. **Not verified visually** — no app launch, no screenshot. The new paragraph reuses the existing
   `.ai-disclosure p` rule and the new `.sm-ai-audio-note` rule is token-only. Confidence it
   renders as intended: *likely* (55-80%), evidence = CSS reuse only.
