### PR TITLE
fix(asr): report whisper installed-state from the LOADER's pinned-snapshot probe (W25)

### DIFF
--- a/sidecar/media_studio/handlers/_wire.py
+++ b/sidecar/media_studio/handlers/_wire.py
@@ -56,9 +56,17 @@ def _js_number(value: Any) -> str:
 # --------------------------------------------------------------------------- #
 # Phase-8 wiring helpers (pure; the heavy runner stays pragma-excluded)
 # --------------------------------------------------------------------------- #
-#: advisor component name -> its registered manifest asset name (the installed
-#: -state probe key). Components with no own asset (motion/diversity/ranker are
-#: zero-download floors) are absent; ``aesthetic`` shares the SigLIP-2 backbone.
+#: component name -> its registered manifest asset name (the installed-state
+#: probe key ``_models_present_map`` iterates). Components with no own asset
+#: (motion/diversity/ranker are zero-download floors) are absent; ``aesthetic``
+#: shares the SigLIP-2 backbone.
+#:
+#: Every key EXCEPT ``whisper`` is also a ``system_advisor.COMPONENTS`` spec name.
+#: ``whisper`` is a probe-only key (W25): it is not an advisor component and never
+#: reaches a tier/verdict roll-up (``advise`` iterates ``COMPONENTS``, and
+#: ``_READINESS_TIERS`` / ``recommender._COMPONENT_ASSETS`` do not name it), but
+#: ``asr.engines`` needs its installed-state from the SAME probe parakeet uses
+#: rather than a second, independent guess.
 _COMPONENT_ASSETS: dict[str, str] = {
     "saliency": "vinet-s-saliency",
     "audio_saliency": "panns-cnn14",
@@ -69,6 +77,10 @@ _COMPONENT_ASSETS: dict[str, str] = {
     "emotion": "hsemotion-onnx",
     "ocr": "rapidocr-onnx",
     "parakeet": "parakeet-tdt-0.6b-v3",
+    # W25: the day-1 transcription asset (``manifest.WHISPER_ASSET_NAME``) — the
+    # snapshot ``transcribe.resolve_model_source`` hands faster-whisper for the
+    # default ``large-v3-turbo`` id. Probe-only key; see the note above.
+    "whisper": "whisper-large-v3-turbo",
     # WU-T0/B1: the packaged default is the Apache-2.0 wav2vec2 aligner, so THAT
     # is the download to propose. Pointing this at the CC-BY-NC MMS asset would
     # install a model `ctc_align._resolve_model_id` refuses unless the user has

--- a/sidecar/media_studio/handlers/_wire.py
+++ b/sidecar/media_studio/handlers/_wire.py
@@ -56,17 +56,16 @@ def _js_number(value: Any) -> str:
 # --------------------------------------------------------------------------- #
 # Phase-8 wiring helpers (pure; the heavy runner stays pragma-excluded)
 # --------------------------------------------------------------------------- #
-#: component name -> its registered manifest asset name (the installed-state
-#: probe key ``_models_present_map`` iterates). Components with no own asset
-#: (motion/diversity/ranker are zero-download floors) are absent; ``aesthetic``
-#: shares the SigLIP-2 backbone.
+#: advisor component name -> its registered manifest asset name (the installed
+#: -state probe key). Components with no own asset (motion/diversity/ranker are
+#: zero-download floors) are absent; ``aesthetic`` shares the SigLIP-2 backbone.
 #:
-#: Every key EXCEPT ``whisper`` is also a ``system_advisor.COMPONENTS`` spec name.
-#: ``whisper`` is a probe-only key (W25): it is not an advisor component and never
-#: reaches a tier/verdict roll-up (``advise`` iterates ``COMPONENTS``, and
-#: ``_READINESS_TIERS`` / ``recommender._COMPONENT_ASSETS`` do not name it), but
-#: ``asr.engines`` needs its installed-state from the SAME probe parakeet uses
-#: rather than a second, independent guess.
+#: EVERY key is a ``system_advisor.COMPONENTS`` spec name — the invariant the
+#: tier/verdict roll-ups rely on. W25 briefly added a probe-only ``whisper`` key
+#: here; that was reverted, because an asset-presence probe is the WRONG oracle
+#: for whisper (see :func:`~media_studio.handlers.system_ops.asr_engines`: it
+#: answers "any snapshot of the repo is cached", while the loader needs the
+#: PINNED revision). ``asr.engines`` asks ``transcribe`` directly instead.
 _COMPONENT_ASSETS: dict[str, str] = {
     "saliency": "vinet-s-saliency",
     "audio_saliency": "panns-cnn14",
@@ -77,10 +76,6 @@ _COMPONENT_ASSETS: dict[str, str] = {
     "emotion": "hsemotion-onnx",
     "ocr": "rapidocr-onnx",
     "parakeet": "parakeet-tdt-0.6b-v3",
-    # W25: the day-1 transcription asset (``manifest.WHISPER_ASSET_NAME``) — the
-    # snapshot ``transcribe.resolve_model_source`` hands faster-whisper for the
-    # default ``large-v3-turbo`` id. Probe-only key; see the note above.
-    "whisper": "whisper-large-v3-turbo",
     # WU-T0/B1: the packaged default is the Apache-2.0 wav2vec2 aligner, so THAT
     # is the download to propose. Pointing this at the CC-BY-NC MMS asset would
     # install a model `ctc_align._resolve_model_id` refuses unless the user has

--- a/sidecar/media_studio/handlers/system_ops.py
+++ b/sidecar/media_studio/handlers/system_ops.py
@@ -84,9 +84,7 @@ def asr_engines(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict
     """``asr.engines()`` -> ``{engines:[{id, label, installed}]}``. Direct-return.
 
     Lists the selectable ASR engines (whisper default / parakeet opt-in) with
-    an installed flag per engine (drives the ASR picker UI). BOTH flags come
-    from the SAME :meth:`_models_present_map` probe — the asset manager's
-    installed-state for each engine's registered manifest asset.
+    an installed flag per engine (drives the ASR picker UI).
 
     W25: whisper's flag used to be a hardcoded ``True`` ("the always-installed
     default"), which was false on every install that did not download the
@@ -96,16 +94,33 @@ def asr_engines(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict
     that the model the user is about to need is absent, and
     ``recommender._pick_asr_engine`` always found "an installed engine".
 
-    SCOPE, stated precisely: the probe answers "are whisper weights cached"
-    (``AssetManager.installed_path`` -> ``hf_snapshot_present``: ANY non-empty
-    snapshot of the pinned repo), which is one step weaker than the loader's
-    ``transcribe.whisper_snapshot_dir`` (the pinned REVISION specifically).
-    They diverge only when the cache holds a different revision of the same
-    repo — in that state faster-whisper can still resolve it via its own
-    ``refs/`` entry, so reporting installed is the accurate answer there too.
-    UNVERIFIED: that divergent state has not been exercised end-to-end here;
-    the settling experiment is an e2e that seeds a non-pinned snapshot and runs
-    ``transcribe.start`` with egress blocked.
+    Whisper's flag is the LOADER's own answer, not a second guess about it:
+    :func:`transcribe.resolve_transcribe_target` decides which model id this
+    machine + these settings would actually load (device auto-detect,
+    :func:`transcribe.cpu_auto_model`, an explicit ``transcribeModel``
+    override), and :func:`transcribe.whisper_snapshot_dir` — the same call
+    ``resolve_model_source`` makes on the load path — reports whether that id's
+    PINNED snapshot is on disk. So ``installed: True`` means exactly "a
+    ``transcribe.start`` right now resolves locally".
+
+    CORRECTION (W25 review): the first cut of this fix read whisper's flag out
+    of :meth:`_models_present_map` instead. That probe answers "does the HF
+    cache hold ANY non-empty snapshot of the repo"
+    (``AssetManager.installed_path`` -> ``hf_snapshot_present``), and the
+    accompanying comment claimed the two agree because faster-whisper would
+    resolve a non-pinned snapshot through its own ``refs/`` entry. That claim
+    was FALSE, and this repo had already measured it false:
+    :func:`transcribe.resolve_model_source` documents (against huggingface_hub
+    1.22.0) that a pin-installed repo has NO ``refs/main``, so an offline load
+    of the bare id raises ``LocalEntryNotFoundError``. The divergent state is
+    also routine, not exotic — bumping ``manifest.WHISPER_HF_REVISION`` puts
+    every existing install into it — so the weaker probe would have re-created
+    the very "reports installed, then fails to load" lie W25 exists to kill.
+
+    Parakeet keeps the :meth:`_models_present_map` probe: its backend loads by
+    asset (``parakeet_asr.ASSET_NAME``), so asset-presence IS its loader's
+    question. Fail-open per engine — a probe error reports not-installed (a
+    picker warning), never a crashed RPC.
     """
     settings = self.settings.get()
     installed = self._models_present_map(settings)
@@ -114,7 +129,7 @@ def asr_engines(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict
             {
                 "id": "whisper",
                 "label": "Whisper large-v3-turbo",
-                "installed": bool(installed.get("whisper", False)),
+                "installed": _whisper_snapshot_present(settings),
             },
             {
                 "id": "parakeet",
@@ -123,6 +138,43 @@ def asr_engines(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict
             },
         ]
     }
+
+
+def _whisper_snapshot_present(settings: dict[str, Any]) -> bool:
+    """Is the whisper model THIS machine would load already on disk (W25)?
+
+    Asks ``transcribe`` both halves of the question rather than re-deriving
+    either: :func:`~media_studio.features.transcribe.resolve_transcribe_target`
+    for WHICH model id would be loaded (device auto-detect / ``cpu_auto_model``
+    / an explicit ``transcribeModel``), then
+    :func:`~media_studio.features.transcribe.whisper_snapshot_dir` for whether
+    that id's PINNED snapshot is cached — the same call the load path makes.
+
+    ``False`` therefore covers every way a load would have to hit the network:
+    no snapshot, only a NON-pinned revision of the repo (a stale install after a
+    ``WHISPER_HF_REVISION`` bump), or a forced ``transcribeModel`` id the
+    manifest does not map to a registered, pinned asset.
+
+    Fail-open like :meth:`_models_present_map`: any probe error reports
+    not-installed (the picker warns) instead of sinking the RPC.
+
+    PERF, MEASURED (not a guess): ``resolve_transcribe_target`` with
+    ``transcribeDevice`` unset runs ``detect_device`` -> the lazy ``import
+    torch`` CUDA probe. On this box that cost **3.2 s once per process** and
+    **0.000 s** on every later call (module cache); with ``transcribeDevice``
+    set to ``cpu``/``cuda`` it is skipped entirely. Accepted deliberately: any
+    cheaper stand-in (e.g. the advisor's ``gpu_present``) answers a DIFFERENT
+    question than ``torch.cuda.is_available()``, which is what the loader
+    actually branches on — and a flag derived from a different question is the
+    second-guess class this fix exists to remove.
+    """
+    from ..features import transcribe as _transcribe  # local: import-light (faster_whisper stays deferred)
+
+    try:
+        model, _device, _compute = _transcribe.resolve_transcribe_target(settings)
+        return _transcribe.whisper_snapshot_dir(model) is not None
+    except Exception:  # noqa: BLE001 - a bad probe must not sink the picker
+        return False
 
 
 def _detect_local_servers(self: Services, settings: dict[str, Any]) -> list[dict[str, Any]]:
@@ -478,15 +530,17 @@ def phase8_select(self: Services, params: dict[str, Any], ctx: RpcContext) -> di
 
 
 def _models_present_map(self: Services, settings: dict[str, Any]) -> dict[str, bool]:
-    """Map each model-backed component -> is its weight installed.
+    """Map each model-backed advisor component -> is its weight installed.
 
-    Probes the asset manager for each :data:`_COMPONENT_ASSETS` entry's pinned
-    asset so the advisor (and the ASR picker) can report installed-state +
-    degrade an offline-missing model. Most keys are advisor components; the
-    probe-only ``whisper`` key exists purely so ``asr.engines`` reads its flag
-    from THIS map instead of guessing (W25). Components with no registered asset are omitted
-    (the advisor then treats them as not-installed). Fail-open: a probe error
-    for one component marks it absent, never crashes the report.
+    Probes the asset manager for each Phase-8 component's pinned asset so the
+    advisor (and the parakeet row of the ASR picker) can report installed-state
+    + degrade an offline-missing model. Components with no registered asset are
+    omitted (the advisor then treats them as not-installed). Fail-open: a probe
+    error for one component marks it absent, never crashes the report.
+
+    NOT the right probe for whisper (W25 review): ``installed_path`` is true for
+    ANY cached snapshot of the repo, while the whisper loader needs the pinned
+    revision — ``asr.engines`` uses :func:`_whisper_snapshot_present` instead.
     """
     from ..assets import manifest as _manifest  # local: import-light
     from ..assets.manager import AssetManager  # local: import-light

--- a/sidecar/media_studio/handlers/system_ops.py
+++ b/sidecar/media_studio/handlers/system_ops.py
@@ -84,15 +84,38 @@ def asr_engines(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict
     """``asr.engines()`` -> ``{engines:[{id, label, installed}]}``. Direct-return.
 
     Lists the selectable ASR engines (whisper default / parakeet opt-in) with
-    an installed flag per engine (drives the ASR picker UI). Whisper is treated
-    as always available (the always-installed default); parakeet's installed
-    flag reflects whether its weights are cached.
+    an installed flag per engine (drives the ASR picker UI). BOTH flags come
+    from the SAME :meth:`_models_present_map` probe — the asset manager's
+    installed-state for each engine's registered manifest asset.
+
+    W25: whisper's flag used to be a hardcoded ``True`` ("the always-installed
+    default"), which was false on every install that did not download the
+    weights — the Minimum profile pulls nothing, a Custom profile need not
+    include transcription, and the whisper snapshot is excluded from the
+    renderer's first-run completion gate. The picker therefore could not warn
+    that the model the user is about to need is absent, and
+    ``recommender._pick_asr_engine`` always found "an installed engine".
+
+    SCOPE, stated precisely: the probe answers "are whisper weights cached"
+    (``AssetManager.installed_path`` -> ``hf_snapshot_present``: ANY non-empty
+    snapshot of the pinned repo), which is one step weaker than the loader's
+    ``transcribe.whisper_snapshot_dir`` (the pinned REVISION specifically).
+    They diverge only when the cache holds a different revision of the same
+    repo — in that state faster-whisper can still resolve it via its own
+    ``refs/`` entry, so reporting installed is the accurate answer there too.
+    UNVERIFIED: that divergent state has not been exercised end-to-end here;
+    the settling experiment is an e2e that seeds a non-pinned snapshot and runs
+    ``transcribe.start`` with egress blocked.
     """
     settings = self.settings.get()
     installed = self._models_present_map(settings)
     return {
         "engines": [
-            {"id": "whisper", "label": "Whisper large-v3-turbo", "installed": True},
+            {
+                "id": "whisper",
+                "label": "Whisper large-v3-turbo",
+                "installed": bool(installed.get("whisper", False)),
+            },
             {
                 "id": "parakeet",
                 "label": "Parakeet-TDT-0.6b-v3 (multilingual)",
@@ -455,11 +478,13 @@ def phase8_select(self: Services, params: dict[str, Any], ctx: RpcContext) -> di
 
 
 def _models_present_map(self: Services, settings: dict[str, Any]) -> dict[str, bool]:
-    """Map each model-backed advisor component -> is its weight installed.
+    """Map each model-backed component -> is its weight installed.
 
-    Probes the asset manager for each Phase-8 component's pinned asset so the
-    advisor (and the ASR picker) can report installed-state + degrade an
-    offline-missing model. Components with no registered asset are omitted
+    Probes the asset manager for each :data:`_COMPONENT_ASSETS` entry's pinned
+    asset so the advisor (and the ASR picker) can report installed-state +
+    degrade an offline-missing model. Most keys are advisor components; the
+    probe-only ``whisper`` key exists purely so ``asr.engines`` reads its flag
+    from THIS map instead of guessing (W25). Components with no registered asset are omitted
     (the advisor then treats them as not-installed). Fail-open: a probe error
     for one component marks it absent, never crashes the report.
     """

--- a/sidecar/tests/test_e2e_ai2_intel_repurpose.py
+++ b/sidecar/tests/test_e2e_ai2_intel_repurpose.py
@@ -448,7 +448,20 @@ def test_intel_recommender_real_device_detect(tmp_path: Path) -> None:
     per_function = rec.get("routing", {}).get("perFunction", {})
     assert per_function, f"no per-function routing recommended: {rec!r}"
     assert all("provider" in slot for slot in per_function.values()), f"routing slot missing provider: {per_function!r}"
-    assert isinstance(rec.get("asrEngine"), str) and rec["asrEngine"], f"no ASR engine recommended: {rec!r}"
+    # W25 (REVIEWED CHANGE): this used to assert a non-empty asrEngine string
+    # unconditionally. That only held because ``asr.engines`` hardcoded whisper
+    # ``installed: True``; with the flag now derived from the installed-weight
+    # probe, a runner with NO ASR weights on disk correctly recommends ``None``.
+    # Asserting "always a string" would re-pin the very defect W25 removed, so the
+    # check becomes a cross-RPC consistency one: the recommender must pick exactly
+    # the last INSTALLED engine ``asr.engines`` reports (``_pick_asr_engine``), and
+    # ``None`` only when nothing is installed. That still fails loudly if the
+    # recommender ever proposes an engine whose weights are absent.
+    engines = rpc.call("asr.engines", {})["engines"]
+    installed_ids = [e["id"] for e in engines if e["installed"]]
+    assert rec.get("asrEngine") == (installed_ids[-1] if installed_ids else None), (
+        f"asrEngine does not match the installed engines {engines!r}: {rec!r}"
+    )
 
 
 # ========================================================================== #

--- a/sidecar/tests/test_e2e_ai2_intel_repurpose.py
+++ b/sidecar/tests/test_e2e_ai2_intel_repurpose.py
@@ -450,18 +450,40 @@ def test_intel_recommender_real_device_detect(tmp_path: Path) -> None:
     assert all("provider" in slot for slot in per_function.values()), f"routing slot missing provider: {per_function!r}"
     # W25 (REVIEWED CHANGE): this used to assert a non-empty asrEngine string
     # unconditionally. That only held because ``asr.engines`` hardcoded whisper
-    # ``installed: True``; with the flag now derived from the installed-weight
-    # probe, a runner with NO ASR weights on disk correctly recommends ``None``.
-    # Asserting "always a string" would re-pin the very defect W25 removed, so the
-    # check becomes a cross-RPC consistency one: the recommender must pick exactly
-    # the last INSTALLED engine ``asr.engines`` reports (``_pick_asr_engine``), and
-    # ``None`` only when nothing is installed. That still fails loudly if the
-    # recommender ever proposes an engine whose weights are absent.
-    engines = rpc.call("asr.engines", {})["engines"]
-    installed_ids = [e["id"] for e in engines if e["installed"]]
-    assert rec.get("asrEngine") == (installed_ids[-1] if installed_ids else None), (
-        f"asrEngine does not match the installed engines {engines!r}: {rec!r}"
+    # ``installed: True``; with the flag derived from a real weight probe, a
+    # runner with NO ASR weights on disk correctly recommends ``None``, so
+    # "always a string" would re-pin the very defect W25 removed.
+    #
+    # The first replacement compared the recommendation against ``asr.engines``
+    # — the SAME payload ``_pick_asr_engine`` consumed — i.e. a tautology that
+    # PASSED against the defective handler (reviewer-proven: `asrEngine`
+    # 'whisper' + an empty HF cache + `1 passed`). The oracle below is instead
+    # INDEPENDENT of the recommender's input: it asks the LOADERS whether the
+    # recommended engine's weights are actually on this disk. Verified RED
+    # against origin/main's hardcoded ``installed: True`` with an empty cache.
+    from media_studio.assets import manifest
+    from media_studio.assets.manager import AssetManager
+    from media_studio.features import parakeet_asr, transcribe
+
+    engine = rec.get("asrEngine")
+    settings = svc.settings.get()
+    whisper_model, _device, _compute = transcribe.resolve_transcribe_target(settings)
+    whisper_on_disk = transcribe.whisper_snapshot_dir(whisper_model) is not None
+    parakeet_entry = manifest.get_asset(parakeet_asr.ASSET_NAME)
+    parakeet_on_disk = (
+        parakeet_entry is not None
+        and AssetManager(root=svc.data_dir, settings_provider=lambda: settings).installed_path(parakeet_entry)
+        is not None
     )
+    if engine == "whisper":
+        assert whisper_on_disk, f"recommended whisper but its pinned snapshot is absent ({whisper_model!r}): {rec!r}"
+    elif engine == "parakeet":
+        assert parakeet_on_disk, f"recommended parakeet but its weights are absent: {rec!r}"
+    else:
+        assert engine is None and not whisper_on_disk and not parakeet_on_disk, (
+            f"asrEngine {engine!r} is neither a known engine nor a justified None "
+            f"(whisper_on_disk={whisper_on_disk}, parakeet_on_disk={parakeet_on_disk}): {rec!r}"
+        )
 
 
 # ========================================================================== #

--- a/sidecar/tests/test_handlers_phase8.py
+++ b/sidecar/tests/test_handlers_phase8.py
@@ -249,7 +249,34 @@ def test_system_advisor_commercial_flag_drops_noncommercial(tmp_path: Path) -> N
     assert by_name["saliency"]["licenseCommercialOk"] is False
 
 
-def test_asr_engines_lists_whisper_and_parakeet(tmp_path: Path) -> None:
+def _isolate_hf_cache(tmp_path: Path, monkeypatch: Any) -> Path:
+    """Point the HF cache at an EMPTY tmp dir and return it.
+
+    ``whisper-large-v3-turbo`` is an ``installer="hf"`` asset, so its
+    installed-probe reads the REAL HF cache. Without this a dev box that already
+    has the snapshot cached reports it installed and the absent-weights arm below
+    becomes host-dependent (the same flake ``test_models_present_map_omits_missing
+    _and_fails_open`` isolates for smolvlm2).
+    """
+    cache = tmp_path / "hf-cache"
+    cache.mkdir()
+    monkeypatch.setenv("HF_HUB_CACHE", str(cache))
+    monkeypatch.setenv("HF_HOME", str(tmp_path / "hf-home"))
+    monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+    return cache
+
+
+def test_asr_engines_lists_whisper_and_parakeet(tmp_path: Path, monkeypatch: Any) -> None:
+    """W25 (REVIEWED CHANGE): whisper's flag was pinned ``is True`` here.
+
+    The old assertion asserted the DEFECT: ``asr_engines`` hardcoded
+    ``installed: True`` for whisper while its weights were demonstrably absent
+    from this tmp dir, so the ASR picker could never warn that the model the user
+    is about to need is missing. The flag now derives from the same
+    ``_models_present_map`` probe parakeet already used, so with no weights on
+    disk BOTH engines report ``False``.
+    """
+    _isolate_hf_cache(tmp_path, monkeypatch)
     svc = _phase8_services(tmp_path)
     direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
     out = svc.asr_engines({}, direct)
@@ -257,8 +284,64 @@ def test_asr_engines_lists_whisper_and_parakeet(tmp_path: Path) -> None:
     assert ids == {"whisper", "parakeet"}
     whisper = next(e for e in out["engines"] if e["id"] == "whisper")
     parakeet = next(e for e in out["engines"] if e["id"] == "parakeet")
-    assert whisper["installed"] is True
+    assert whisper["installed"] is False  # weights not installed in the tmp dir
     assert parakeet["installed"] is False  # weights not installed in the tmp dir
+
+
+def test_asr_engines_whisper_installed_true_when_the_pinned_snapshot_is_cached(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """The TRUE arm: a cached whisper snapshot flips the reported flag to True.
+
+    Paired with the False arm above so a mutation that hardcodes EITHER constant
+    goes red (a one-sided test would stay green against ``installed: False``).
+    """
+    from media_studio.assets import manifest as _manifest
+
+    cache = _isolate_hf_cache(tmp_path, monkeypatch)
+    snapshot = (
+        cache
+        / ("models--" + _manifest.WHISPER_HF_REPO.replace("/", "--"))
+        / "snapshots"
+        / _manifest.WHISPER_HF_REVISION
+    )
+    snapshot.mkdir(parents=True)
+    (snapshot / "model.bin").write_bytes(b"weights")
+    svc = _phase8_services(tmp_path)
+    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
+    out = svc.asr_engines({}, direct)
+    whisper = next(e for e in out["engines"] if e["id"] == "whisper")
+    assert whisper["installed"] is True
+
+
+@pytest.mark.parametrize("flag", [True, False])
+def test_asr_engines_both_flags_track_the_presence_map(tmp_path: Path, flag: bool) -> None:
+    """Both engine rows are DERIVED from ``_models_present_map``, not hardcoded.
+
+    Overriding the seam (rather than the disk) pins the wiring itself: the handler
+    must read the map key it computed one line earlier. Parametrised over both
+    values so neither a hardcoded ``True`` nor a hardcoded ``False`` survives.
+    """
+    svc = _phase8_services(tmp_path)
+    svc._models_present_map = lambda _s: {"whisper": flag, "parakeet": flag}  # type: ignore[method-assign]
+    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
+    out = svc.asr_engines({}, direct)
+    assert {e["id"]: e["installed"] for e in out["engines"]} == {"whisper": flag, "parakeet": flag}
+
+
+def test_component_assets_maps_whisper_to_the_registered_day1_asset(tmp_path: Path) -> None:
+    """The probe key ``asr.engines`` reads must name the asset the loader uses.
+
+    ``_models_present_map`` is keyed by ``_COMPONENT_ASSETS``; if whisper's entry
+    named a different (or de-registered) asset the flag would silently be absent
+    -> reported False forever. Reads BOTH ends rather than trusting the mapping.
+    """
+    from media_studio.assets import manifest as _manifest
+    from media_studio.handlers import _wire
+
+    assert _wire._COMPONENT_ASSETS["whisper"] == _manifest.WHISPER_ASSET_NAME
+    assert _manifest.get_asset(_manifest.WHISPER_ASSET_NAME) is not None
+    assert _manifest.WHISPER_MODEL_ASSETS[_manifest.WHISPER_MODEL_ID] == _manifest.WHISPER_ASSET_NAME
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_handlers_phase8.py
+++ b/sidecar/tests/test_handlers_phase8.py
@@ -252,11 +252,11 @@ def test_system_advisor_commercial_flag_drops_noncommercial(tmp_path: Path) -> N
 def _isolate_hf_cache(tmp_path: Path, monkeypatch: Any) -> Path:
     """Point the HF cache at an EMPTY tmp dir and return it.
 
-    ``whisper-large-v3-turbo`` is an ``installer="hf"`` asset, so its
-    installed-probe reads the REAL HF cache. Without this a dev box that already
-    has the snapshot cached reports it installed and the absent-weights arm below
-    becomes host-dependent (the same flake ``test_models_present_map_omits_missing
-    _and_fails_open`` isolates for smolvlm2).
+    Whisper's installed-probe (``transcribe.whisper_snapshot_dir``) reads the
+    REAL HF cache. Without this a dev box that already has the snapshot cached
+    reports it installed and the absent-weights arm below becomes host-dependent
+    (the same flake ``test_models_present_map_omits_missing_and_fails_open``
+    isolates for smolvlm2).
     """
     cache = tmp_path / "hf-cache"
     cache.mkdir()
@@ -266,18 +266,38 @@ def _isolate_hf_cache(tmp_path: Path, monkeypatch: Any) -> Path:
     return cache
 
 
+def _seed_whisper_snapshot(cache: Path, revision: str) -> Path:
+    """Create a non-empty snapshot dir for the whisper repo at ``revision``."""
+    from media_studio.assets import manifest as _manifest
+
+    snapshot = cache / ("models--" + _manifest.WHISPER_HF_REPO.replace("/", "--")) / "snapshots" / revision
+    snapshot.mkdir(parents=True)
+    (snapshot / "model.bin").write_bytes(b"weights")
+    return snapshot
+
+
+def _asr_flags(svc: Services) -> dict[str, bool]:
+    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
+    return {e["id"]: e["installed"] for e in svc.asr_engines({}, direct)["engines"]}
+
+
+#: pin the device so these stay hermetic (no torch/CUDA probe in ``detect_device``).
+_CPU: dict[str, Any] = {"transcribeDevice": "cpu"}
+
+
 def test_asr_engines_lists_whisper_and_parakeet(tmp_path: Path, monkeypatch: Any) -> None:
     """W25 (REVIEWED CHANGE): whisper's flag was pinned ``is True`` here.
 
     The old assertion asserted the DEFECT: ``asr_engines`` hardcoded
     ``installed: True`` for whisper while its weights were demonstrably absent
     from this tmp dir, so the ASR picker could never warn that the model the user
-    is about to need is missing. The flag now derives from the same
-    ``_models_present_map`` probe parakeet already used, so with no weights on
-    disk BOTH engines report ``False``.
+    is about to need is missing. The flag now comes from the loader's own
+    ``transcribe.whisper_snapshot_dir``, so with no weights on disk BOTH engines
+    report ``False``.
     """
     _isolate_hf_cache(tmp_path, monkeypatch)
     svc = _phase8_services(tmp_path)
+    svc.settings.set(_CPU)
     direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
     out = svc.asr_engines({}, direct)
     ids = {e["id"] for e in out["engines"]}
@@ -291,7 +311,7 @@ def test_asr_engines_lists_whisper_and_parakeet(tmp_path: Path, monkeypatch: Any
 def test_asr_engines_whisper_installed_true_when_the_pinned_snapshot_is_cached(
     tmp_path: Path, monkeypatch: Any
 ) -> None:
-    """The TRUE arm: a cached whisper snapshot flips the reported flag to True.
+    """The TRUE arm: a cached PINNED whisper snapshot flips the flag to True.
 
     Paired with the False arm above so a mutation that hardcodes EITHER constant
     goes red (a one-sided test would stay green against ``installed: False``).
@@ -299,47 +319,107 @@ def test_asr_engines_whisper_installed_true_when_the_pinned_snapshot_is_cached(
     from media_studio.assets import manifest as _manifest
 
     cache = _isolate_hf_cache(tmp_path, monkeypatch)
-    snapshot = (
-        cache
-        / ("models--" + _manifest.WHISPER_HF_REPO.replace("/", "--"))
-        / "snapshots"
-        / _manifest.WHISPER_HF_REVISION
-    )
-    snapshot.mkdir(parents=True)
-    (snapshot / "model.bin").write_bytes(b"weights")
+    _seed_whisper_snapshot(cache, _manifest.WHISPER_HF_REVISION)
     svc = _phase8_services(tmp_path)
-    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
-    out = svc.asr_engines({}, direct)
-    whisper = next(e for e in out["engines"] if e["id"] == "whisper")
-    assert whisper["installed"] is True
+    svc.settings.set({**_CPU, "transcribeModel": _manifest.WHISPER_MODEL_ID})
+    assert _asr_flags(svc)["whisper"] is True
+
+
+def test_asr_engines_whisper_installed_false_for_a_NON_pinned_cached_snapshot(tmp_path: Path, monkeypatch: Any) -> None:
+    """W25 REVIEW REGRESSION: a stale revision on disk must NOT read as installed.
+
+    The first cut of W25 read the flag from ``_models_present_map``, whose
+    ``AssetManager.installed_path`` -> ``hf_snapshot_present`` probe is true for
+    ANY non-empty snapshot of the repo. This test seeds exactly that state — a
+    snapshot under a DIFFERENT commit, which is what every existing install looks
+    like the moment ``WHISPER_HF_REVISION`` is bumped — and pins the honest
+    answer: the loader (``resolve_model_source`` -> ``whisper_snapshot_dir``)
+    finds no pinned dir, falls back to the bare id and raises
+    ``LocalEntryNotFoundError`` offline, so the picker must report NOT installed.
+
+    Both halves are asserted here so the test cannot silently degrade into
+    "nothing is cached": the asset-presence probe says True, the reported flag
+    says False. It is RED against the presence-map implementation.
+    """
+    from media_studio.assets import manifest as _manifest
+    from media_studio.assets.manager import AssetManager
+
+    cache = _isolate_hf_cache(tmp_path, monkeypatch)
+    stale = "0" * 40  # a valid-looking commit that is NOT the pin
+    assert stale != _manifest.WHISPER_HF_REVISION
+    _seed_whisper_snapshot(cache, stale)
+    svc = _phase8_services(tmp_path)
+    svc.settings.set({**_CPU, "transcribeModel": _manifest.WHISPER_MODEL_ID})
+
+    entry = _manifest.get_asset(_manifest.WHISPER_ASSET_NAME)
+    assert entry is not None
+    mgr = AssetManager(root=tmp_path / "data", settings_provider=dict)
+    assert mgr.installed_path(entry) is not None, "control: the weaker asset probe DOES see this snapshot"
+    assert _asr_flags(svc)["whisper"] is False
+
+
+def test_asr_engines_whisper_flag_follows_the_resolved_model_id(tmp_path: Path, monkeypatch: Any) -> None:
+    """The flag tracks the id ``transcribe`` would LOAD, not a fixed asset name.
+
+    With the default model's pinned snapshot cached, forcing ``transcribeModel``
+    to an id the manifest does not map to a registered pinned asset must report
+    NOT installed — that load would have to hit the network. A probe hardcoded to
+    the ``whisper-large-v3-turbo`` asset stays green here.
+    """
+    from media_studio.assets import manifest as _manifest
+
+    cache = _isolate_hf_cache(tmp_path, monkeypatch)
+    _seed_whisper_snapshot(cache, _manifest.WHISPER_HF_REVISION)
+    svc = _phase8_services(tmp_path)
+    svc.settings.set({**_CPU, "transcribeModel": _manifest.WHISPER_MODEL_ID})
+    assert _asr_flags(svc)["whisper"] is True  # control: the default id IS resolvable
+    svc.settings.set({**_CPU, "transcribeModel": "medium"})
+    assert _asr_flags(svc)["whisper"] is False
+
+
+def test_asr_engines_whisper_flag_fails_open_when_the_probe_raises(tmp_path: Path, monkeypatch: Any) -> None:
+    """A broken probe reports not-installed (a picker warning), never a 500."""
+    from media_studio.features import transcribe as _transcribe
+
+    def _boom(*_a: Any, **_k: Any) -> str | None:
+        raise RuntimeError("probe exploded")
+
+    monkeypatch.setattr(_transcribe, "whisper_snapshot_dir", _boom)
+    svc = _phase8_services(tmp_path)
+    svc.settings.set(_CPU)
+    assert _asr_flags(svc)["whisper"] is False
 
 
 @pytest.mark.parametrize("flag", [True, False])
-def test_asr_engines_both_flags_track_the_presence_map(tmp_path: Path, flag: bool) -> None:
-    """Both engine rows are DERIVED from ``_models_present_map``, not hardcoded.
+def test_asr_engines_parakeet_flag_tracks_the_presence_map(tmp_path: Path, flag: bool) -> None:
+    """Parakeet's row is DERIVED from ``_models_present_map``, not hardcoded.
 
-    Overriding the seam (rather than the disk) pins the wiring itself: the handler
-    must read the map key it computed one line earlier. Parametrised over both
-    values so neither a hardcoded ``True`` nor a hardcoded ``False`` survives.
+    Its backend loads by manifest asset, so asset-presence IS its loader's
+    question (unlike whisper — see the non-pinned-snapshot test above).
+    Overriding the seam pins the wiring itself: the handler must read the map key
+    it computed one line earlier. Parametrised over both values so neither a
+    hardcoded ``True`` nor a hardcoded ``False`` survives.
     """
     svc = _phase8_services(tmp_path)
-    svc._models_present_map = lambda _s: {"whisper": flag, "parakeet": flag}  # type: ignore[method-assign]
-    direct = RpcContext(emit_notification=lambda obj: None, jobs=None)
-    out = svc.asr_engines({}, direct)
-    assert {e["id"]: e["installed"] for e in out["engines"]} == {"whisper": flag, "parakeet": flag}
+    svc.settings.set(_CPU)
+    svc._models_present_map = lambda _s: {"parakeet": flag}  # type: ignore[method-assign]
+    assert _asr_flags(svc)["parakeet"] is flag
 
 
-def test_component_assets_maps_whisper_to_the_registered_day1_asset(tmp_path: Path) -> None:
-    """The probe key ``asr.engines`` reads must name the asset the loader uses.
+def test_component_assets_holds_only_advisor_components() -> None:
+    """``_COMPONENT_ASSETS`` keys stay a subset of the advisor's component specs.
 
-    ``_models_present_map`` is keyed by ``_COMPONENT_ASSETS``; if whisper's entry
-    named a different (or de-registered) asset the flag would silently be absent
-    -> reported False forever. Reads BOTH ends rather than trusting the mapping.
+    W25's first cut added a probe-only ``whisper`` key here; the review reverted
+    it (an asset-presence probe is the wrong oracle for whisper). This pins the
+    invariant so it cannot drift back in silently, and checks the whisper asset
+    the LOADER uses is still registered + mapped from the default model id.
     """
     from media_studio.assets import manifest as _manifest
+    from media_studio.features import system_advisor as _sa
     from media_studio.handlers import _wire
 
-    assert _wire._COMPONENT_ASSETS["whisper"] == _manifest.WHISPER_ASSET_NAME
+    assert set(_wire._COMPONENT_ASSETS) <= {spec.name for spec in _sa.COMPONENTS}
+    assert "whisper" not in _wire._COMPONENT_ASSETS
     assert _manifest.get_asset(_manifest.WHISPER_ASSET_NAME) is not None
     assert _manifest.WHISPER_MODEL_ASSETS[_manifest.WHISPER_MODEL_ID] == _manifest.WHISPER_ASSET_NAME
 


### PR DESCRIPTION
## W25 — `asr.engines` reported whisper as installed unconditionally

`asr_engines` emitted a hardcoded `"installed": True` for whisper ("the always-installed
default"), which is false on every install that did not download the weights: the Minimum
profile pulls nothing, a Custom profile need not include transcription, and the whisper
snapshot is excluded from the renderer's first-run completion gate. The picker could
therefore never warn that the model the user is about to need is absent, and
`recommender._pick_asr_engine` always found "an installed engine" to recommend.

## What changed (after adversarial review — the first cut was refuted)

Whisper's flag is now the **loader's own answer**, not a second guess about it:

* `transcribe.resolve_transcribe_target(settings)` decides **which** model id this machine +
  these settings would actually load (device auto-detect, `cpu_auto_model`, an explicit
  `transcribeModel` override), and
* `transcribe.whisper_snapshot_dir(id)` — the same call `resolve_model_source` makes on the
  load path — reports whether that id's **pinned** snapshot is cached.

So `installed: True` now means exactly *"a `transcribe.start` right now resolves locally"*.
Parakeet keeps the `_models_present_map` asset probe, because its backend loads **by manifest
asset** — asset-presence IS its loader's question.

Fail-open per engine: a probe error reports not-installed (a picker warning), never a 500.

## Corrections forced by review (both were false sentences, one also forced a code change)

1. **The first cut read the flag from `_models_present_map`, and the docstring claimed that
   probe agreed with the loader.** It said the two "diverge only when the cache holds a
   different revision of the same repo — in that state faster-whisper can still resolve it via
   its own `refs/` entry, so reporting installed is the accurate answer there too."
   **That was false, and this repo had already measured it false**:
   `transcribe.resolve_model_source` documents (against huggingface_hub 1.22.0) that a
   pin-installed repo has **no** `refs/main`, so an offline load of the bare id raises
   `LocalEntryNotFoundError`. An `UNVERIFIED` tag does not cover a claim the codebase has
   already refuted elsewhere.
   Disclosure alone was not enough either: the divergent state is **routine**, not exotic —
   bumping `manifest.WHISPER_HF_REVISION` puts every existing install into it — so the weaker
   probe would have re-created the exact "reports installed, then fails to load" lie W25
   exists to kill. Hence the probe change above.

2. **The replacement e2e assertion was vacuous.** It compared `system.recommend`'s `asrEngine`
   against `asr.engines` — the *same payload* `_pick_asr_engine` consumed — i.e. a
   re-derivation of the rule under test. The reviewer ran it against `origin/main`'s defective
   handler with a proven-empty HF cache and got `1 passed`. The commit body's claim that it
   "still fails loudly if the recommender ever proposes an engine whose weights are absent"
   was false. Replaced with an oracle **independent of the recommender's input**: ask the
   loaders whether the recommended engine's weights are on this disk, and require a `None`
   recommendation to be justified by both being absent.

3. **Reverted** the probe-only `_COMPONENT_ASSETS["whisper"]` key the first cut added,
   restoring the "every key is a `system_advisor.COMPONENTS` spec" invariant — now pinned by a
   test rather than by a comment (this was my own disclosed residual #3).

4. The reviewer's third finding — the flag was blind to the **resolved** model id, so a
   `transcribeModel` override or a future `whisper-small` registration would silently
   mis-report — is closed **mechanically** by the change above, not by prose.

## RED proofs (both-states, per single-signal-verification §3b)

Run in a **temp copy** of the tree, never in a sibling worktree.

| probe | fixed state | known-broken state |
|---|---|---|
| `test_intel_recommender_real_device_detect` (empty HF cache) | `1 passed` | `origin/main`'s hardcoded `installed: True` → `1 failed`: *"recommended whisper but its pinned snapshot is absent ('large-v3-turbo')"*, report shows `'asrEngine': 'whisper'` |
| same test, real HF cache (pinned snapshot present) | `1 passed` | — |
| the changed/new unit tests | `8 passed` | first-cut presence-map handler → **4 failed**, 4 passed |

The four reds are exactly the new guarantees: non-pinned cached snapshot → `False` (with a
control asserting the weaker asset probe *does* see that snapshot, so the test cannot decay
into "nothing is cached"); the flag follows the resolved model id; fail-open on a raising
probe; `_COMPONENT_ASSETS` ⊆ advisor components.

No test was weakened, skipped or deleted.

## Residuals (correctly scoped)

* **PERF, measured not guessed.** With `transcribeDevice` unset, the new probe pays
  `detect_device`'s lazy `import torch`: **3.2 s once per process**, **0.000 s** thereafter,
  skipped entirely when the device is pinned. Accepted deliberately — any cheaper stand-in
  (e.g. the advisor's `gpu_present`) answers a *different* question than
  `torch.cuda.is_available()`, which is what the loader branches on, and a flag derived from a
  different question is the second-guess class this fix removes.
* **Behaviour change on a second RPC:** `system.recommend` can now return `asrEngine: null`
  where it previously always returned `"whisper"`. That is the intended truthful outcome. The
  renderer already types it `string | null` (`app/renderer/src/lib/rpc/schemas.ts`) and already
  tests the null arm (`ModelsSystemPanel.test.tsx:2393/2420/2428`). Confidence no renderer
  regression: **almost certain (90-99%)** — but the renderer gates are **NOT-RUN** here (no
  `app/` file changed), not "passing".
* **Pre-existing, out of lane:** `test_phase8_select_runs_job_and_caches` in the same file is
  order-dependent on a box with SmolVLM2 cached (green in the full suite; proven not mine by
  reverting my source and reproducing).

## Gates

* `sidecar`: `pytest -q -m "not e2e" --cov=media_studio --cov-branch --cov-fail-under=100`
* `sidecar`: `ruff check` + `ruff format --check` on all four changed files
* `app`: **NOT-RUN** — no renderer file changed.
