### PR TITLE
fix(deps-gate): scan the shipped chatterbox + first-run sidecar envs for CVEs

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -137,10 +137,16 @@ jobs:
       # findings live in osv-scanner.toml (auto-loaded from the repo root).
       #
       # W23 — the last two arguments are the FIRST-RUN `pip --target` environments
-      # under sidecar/runtime_setup/. requirements-chatterbox.txt was scanned by
-      # NOTHING even though that environment ships (build/make-portable.ps1 stages
-      # a second, py3.14 embeddable CPython for it) and pins its own +cu128 torch
-      # build, which sidecar/requirements.lock.txt structurally cannot contain
+      # under sidecar/runtime_setup/. requirements-chatterbox.txt had NO coverage in
+      # THIS BLOCKING GATE (it was, and is, covered on the advisory Dependabot rail —
+      # 8 alerts on that manifest; an advisory rail cannot fail a PR) even though
+      # part of that environment ships: the dedicated py3.14 embeddable INTERPRETER
+      # is staged into the unpacked tree by build/make-portable.ps1, while torch and
+      # the weights are fetched on FIRST RUN and never enter the artifact
+      # (make-portable.ps1 fails the build on a torch package dir) — which is why
+      # osv-scanner.toml's SCOPE paragraph says "never ships inside the installer"
+      # about the same env without contradicting this line. It pins its own +cu128
+      # torch build, which sidecar/requirements.lock.txt structurally cannot contain
       # (sidecar/pyproject.toml forbids chatterbox-tts/torch in the main env).
       # Both files DO parse as requirements.txt under the pinned osv-scanner 2.3.8
       # and the +cu128 local version DOES match advisory ranges — measured against
@@ -153,8 +159,11 @@ jobs:
       # runtime_setup/generate_hashed_lock.py, whose output is generated rather
       # than committed; when such a lock IS staged beside a requirements file,
       # scanning either one satisfies the invariant asserted in section 5 of
-      # sidecar/tests/test_supply_chain_pins.py, which fails whenever a shipped
-      # environment has no argument here.
+      # sidecar/tests/test_supply_chain_pins.py, which fails whenever a DISCOVERED
+      # shipped environment has no argument here. "Discovered" is three globs, not a
+      # closure — a dependency set declared as a pyproject extra (the live
+      # `reframe-gpu` case) is not demanded. Scope + the assertions that pin it:
+      # osv-scanner.toml and TestDiscoveryScopeIsTheThreeGlobs.
       - name: gate-deps osv-scanner
         run: |
           osv-scanner scan source \

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -135,6 +135,26 @@ jobs:
       # transitive re-resolution is needed; this also keeps the scan deterministic
       # and offline-stable. Reasoned, dated per-CVE ignores for non-applicable
       # findings live in osv-scanner.toml (auto-loaded from the repo root).
+      #
+      # W23 — the last two arguments are the FIRST-RUN `pip --target` environments
+      # under sidecar/runtime_setup/. requirements-chatterbox.txt was scanned by
+      # NOTHING even though that environment ships (build/make-portable.ps1 stages
+      # a second, py3.14 embeddable CPython for it) and pins its own +cu128 torch
+      # build, which sidecar/requirements.lock.txt structurally cannot contain
+      # (sidecar/pyproject.toml forbids chatterbox-tts/torch in the main env).
+      # Both files DO parse as requirements.txt under the pinned osv-scanner 2.3.8
+      # and the +cu128 local version DOES match advisory ranges — measured against
+      # the same 2.3.8 build, not assumed: 3 packages found and one real finding
+      # raised for torch 2.10.0+cu128 (see osv-scanner.toml), 13 packages and zero
+      # findings for requirements-sidecar.txt.
+      # SCOPE OF THE COVERAGE THIS ADDS: under --no-resolve these two are read as
+      # FLAT pin lists, so the gate sees their DECLARED pins, not their transitive
+      # closure. The closure is hash-pinned separately at F1 build-prep by
+      # runtime_setup/generate_hashed_lock.py, whose output is generated rather
+      # than committed; when such a lock IS staged beside a requirements file,
+      # scanning either one satisfies the invariant asserted in section 5 of
+      # sidecar/tests/test_supply_chain_pins.py, which fails whenever a shipped
+      # environment has no argument here.
       - name: gate-deps osv-scanner
         run: |
           osv-scanner scan source \
@@ -142,7 +162,9 @@ jobs:
             --no-resolve \
             --lockfile=app/package-lock.json \
             --lockfile=app/render-cli/package-lock.json \
-            --lockfile=sidecar/requirements.lock.txt
+            --lockfile=sidecar/requirements.lock.txt \
+            --lockfile=sidecar/runtime_setup/requirements-sidecar.txt \
+            --lockfile=sidecar/runtime_setup/requirements-chatterbox.txt
 
       # charter ↔ workflow consistency
       - name: charter-check

--- a/QUALITY-CHARTER.md
+++ b/QUALITY-CHARTER.md
@@ -23,7 +23,7 @@ gates that exist in the source charter do not apply here and have been dropped.
 | 3 | tests-coverage | pytest 9 + pytest-cov (branch, `--cov-fail-under=100`) · vitest 3 (100% thresholds) | Strict 100% line+branch coverage **everywhere** — sidecar (`media_studio`) **and** the renderer (`renderer/src/**`). No hybrid/ratchet floor. Reasoned `# pragma: no cover — <reason>` / `/* v8 ignore — <reason> */` allowed only for genuinely-untestable platform/defensive branches. |
 | 4 | sast | opengrep 1.22.0 (CI) / semgrep 1.166.0 (local) | Static security analysis using the curated in-repo ruleset under `.quality/opengrep/` (NOT `--config auto`). Clean-zero lock: 0 findings, no baseline. |
 | 5 | secrets | gitleaks 8.30.1 | Secret scanning with the committed `.gitleaks.toml` allowlist (vendored deps + reasoned test fixtures only). Gate on 0. |
-| 6 | deps | osv-scanner 2.3.8 | Known-CVE scan of the lockfiles (`app` + `app/render-cli` npm, `sidecar` pyproject). Reasoned per-vuln ignores only in `osv-scanner.toml`; no baseline. Gate on 0. |
+| 6 | deps | osv-scanner 2.3.8 | Known-CVE scan of **every shipped dependency environment**: the `app` + `app/render-cli` npm lockfiles, the resolved `sidecar/requirements.lock.txt`, and both first-run `pip --target` environments (`sidecar/runtime_setup/requirements-sidecar.txt` plus `requirements-chatterbox.txt`, whose own `+cu128` torch build no other lockfile can contain). Read flat (`--no-resolve`), so declared pins rather than the transitive closure. Reasoned, dated per-vuln ignores only in `osv-scanner.toml`; no baseline. Gate on 0. |
 
 <!-- END GATES -->
 
@@ -57,6 +57,16 @@ tree, and github-actions); that is supply-chain hygiene, not part of the 6-gate 
 - **JS/TS formatter = Biome (format-only), not oxfmt.** As of the build date the OXC
   formatter (`oxfmt`) is still **beta** (no 1.0/GA), so the formatter gate uses
   Biome 2.5.0 `format --write` (linter disabled in `biome.json`; linting is oxlint's job).
+- **The deps gate scans environments, not just the two npm trees.** The isolated
+  py3.14 chatterbox voice-clone env is a *deliberate* separation — `sidecar/pyproject.toml`
+  forbids chatterbox-tts/torch in the main sidecar env, and the env exists at all because
+  chatterbox-tts 0.1.7 only accepts py3.14 — so the fix for its missing CVE coverage was to
+  add its requirements file to the EXISTING gate-6 lockfile set, never to unify the torch
+  pins. Adding a scanned lockfile is not a new gate and does not touch the one-in/one-out
+  rule (rule 2), which is about the closed list of six gates. Section 5 of
+  `sidecar/tests/test_supply_chain_pins.py` asserts the invariant that every shipped
+  environment has a `--lockfile` argument, discovering the environment set from disk so a
+  fourth one cannot be added unscanned.
 - **basedpyright mode = `standard`** (not `strict`) so "literal zero" stays achievable
   on partly-untyped code and untyped third-party libraries.
 - **react-hooks/exhaustive-deps = off** in oxlint: it is advisory and its auto-fix can

--- a/QUALITY-CHARTER.md
+++ b/QUALITY-CHARTER.md
@@ -23,7 +23,7 @@ gates that exist in the source charter do not apply here and have been dropped.
 | 3 | tests-coverage | pytest 9 + pytest-cov (branch, `--cov-fail-under=100`) · vitest 3 (100% thresholds) | Strict 100% line+branch coverage **everywhere** — sidecar (`media_studio`) **and** the renderer (`renderer/src/**`). No hybrid/ratchet floor. Reasoned `# pragma: no cover — <reason>` / `/* v8 ignore — <reason> */` allowed only for genuinely-untestable platform/defensive branches. |
 | 4 | sast | opengrep 1.22.0 (CI) / semgrep 1.166.0 (local) | Static security analysis using the curated in-repo ruleset under `.quality/opengrep/` (NOT `--config auto`). Clean-zero lock: 0 findings, no baseline. |
 | 5 | secrets | gitleaks 8.30.1 | Secret scanning with the committed `.gitleaks.toml` allowlist (vendored deps + reasoned test fixtures only). Gate on 0. |
-| 6 | deps | osv-scanner 2.3.8 | Known-CVE scan of **every shipped dependency environment**: the `app` + `app/render-cli` npm lockfiles, the resolved `sidecar/requirements.lock.txt`, and both first-run `pip --target` environments (`sidecar/runtime_setup/requirements-sidecar.txt` plus `requirements-chatterbox.txt`, whose own `+cu128` torch build no other lockfile can contain). Read flat (`--no-resolve`), so declared pins rather than the transitive closure. Reasoned, dated per-vuln ignores only in `osv-scanner.toml`; no baseline. Gate on 0. |
+| 6 | deps | osv-scanner 2.3.8 | Known-CVE scan of **five lockfiles**: the `app` + `app/render-cli` npm lockfiles, the resolved `sidecar/requirements.lock.txt`, and both first-run `pip --target` environments (`sidecar/runtime_setup/requirements-sidecar.txt` plus `requirements-chatterbox.txt`, whose own `+cu128` torch build no other lockfile can contain). Read flat (`--no-resolve`), so declared pins rather than the transitive closure. **NOT scanned by this gate:** the `reframe-gpu` extra in `sidecar/pyproject.toml` (`torch==2.6.0`, inside GHSA-rrmf-rvhw-rf47's range), which the shipped sidecar asks the user to install at runtime — an open item, covered today only by the advisory Dependabot rail. Reasoned, dated per-vuln ignores only in `osv-scanner.toml`; no baseline. Gate on 0. |
 
 <!-- END GATES -->
 
@@ -64,9 +64,20 @@ tree, and github-actions); that is supply-chain hygiene, not part of the 6-gate 
   add its requirements file to the EXISTING gate-6 lockfile set, never to unify the torch
   pins. Adding a scanned lockfile is not a new gate and does not touch the one-in/one-out
   rule (rule 2), which is about the closed list of six gates. Section 5 of
-  `sidecar/tests/test_supply_chain_pins.py` asserts the invariant that every shipped
-  environment has a `--lockfile` argument, discovering the environment set from disk so a
-  fourth one cannot be added unscanned.
+  `sidecar/tests/test_supply_chain_pins.py` asserts that every **discovered** shipped
+  environment has a `--lockfile` argument.
+  **Scope of that invariant, measured — it is three globs, not a closure.** An earlier
+  wording here claimed a fourth environment "cannot be added unscanned" full stop; three
+  reviewers refuted it by executing the discovery against synthetic trees. A new environment
+  is caught only if it arrives as `app/package-lock.json`,
+  `app/<immediate-subdir>/package-lock.json`, `sidecar/requirements*.txt`, or
+  `sidecar/runtime_setup/requirements*.txt`. One declared anywhere else is invisible to it —
+  a repo-root lockfile, two levels under `app/`, a sibling top-level tree, a `sidecar/envs/…`
+  tree, a pin list not named `requirements*`, or a dependency set declared as a `pyproject`
+  extra. The last is live, not hypothetical: it is exactly how `reframe-gpu` escapes gate 6.
+  Both directions are asserted by `TestDiscoveryScopeIsTheThreeGlobs` (4 discovered shapes as
+  a detector control, 6 undiscovered shapes as the boundary), so this paragraph cannot drift
+  away from the code silently. Widening a glob must update that test and this text together.
 - **basedpyright mode = `standard`** (not `strict`) so "literal zero" stays achievable
   on partly-untyped code and untyped third-party libraries.
 - **react-hooks/exhaustive-deps = off** in oxlint: it is advisory and its auto-fix can

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -246,11 +246,16 @@ picture, each item measured:
      the same version (2.10.0+cu128), and that lockstep is enforced upstream, not
      merely by convention: torchaudio==2.10.0's own metadata hard-pins
      `torch==2.10.0` (measured: pypi.org/pypi/torchaudio/2.10.0/json requires_dist
-     == ['torch==2.10.0']). And torchaudio has NO release above 2.11.0 ANYWHERE —
-     PyPI info.version == 2.11.0, and the cp314 listings on cu126, cu128, cu129
-     AND cu130 every one top out at torchaudio 2.11.0. There is therefore no
-     version of the pinned pair in which torch is >= 2.13.0 and torchaudio is a
-     released, index-published build.
+     == ['torch==2.10.0']). And torchaudio has no release above 2.11.0 on any
+     index probed — PyPI info.version == 2.11.0, and the cp314 listings on ALL
+     SEVEN download.pytorch.org indexes checked (cu126, cu128, cu129, cu130, cpu,
+     rocm7.0, xpu) top out at torchaudio 2.11.0. Scope of that stated exactly,
+     because over-generalising a wheel-index probe is the mistake this entry is
+     correcting: seven indexes plus PyPI were measured, not every index that
+     exists (the nightly channel was not probed and is not shippable anyway).
+     There is therefore no version of the pinned pair, on any index this env could
+     use, in which torch is >= 2.13.0 and torchaudio is a released,
+     index-published build.
      Adopting a fixed torch means either pairing torch 2.13.0 with torchaudio
      2.11.0 — a combination upstream has never shipped; pip would not refuse it on
      metadata grounds, because torchaudio 2.11.0 declares no requires_dist at all

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -15,6 +15,23 @@
 #                                        compile`. Scanned with --no-resolve so osv
 #                                        reads the flat pins directly. Re-generate
 #                                        on any sidecar dep change.)
+#   - sidecar/runtime_setup/requirements-sidecar.txt     (W23: the FIRST-RUN heavy
+#                                        sidecar env, installed by pip --target into
+#                                        %APPDATA%/media-studio/envs/sidecar)
+#   - sidecar/runtime_setup/requirements-chatterbox.txt  (W23: the ISOLATED py3.14
+#                                        voice-clone env. It pins its OWN +cu128
+#                                        torch build, which none of the lockfiles
+#                                        above can contain — sidecar/pyproject.toml
+#                                        forbids chatterbox-tts/torch in the main
+#                                        env — so before W23 it was scanned by
+#                                        nothing at all.)
+#
+# The two runtime_setup files are read as FLAT pin lists under --no-resolve, so the
+# gate covers their DECLARED pins, not their transitive closure. That closure is
+# hash-pinned separately at F1 build-prep by runtime_setup/generate_hashed_lock.py,
+# whose output is generated rather than committed. Section 5 of
+# sidecar/tests/test_supply_chain_pins.py asserts that every shipped environment
+# has an argument in the gate, so a fourth one cannot be added unscanned.
 #
 # ---------------------------------------------------------------------------
 # 2026-06-16 SECURITY UPGRADE — the electron/vite/esbuild/vitest/ws ignores that
@@ -62,6 +79,15 @@
 # Measured with the pinned osv-scanner 2.3.8 over blob-exact `git archive`
 # extracts: 18 vulnerabilities / 9 packages -> 2 / 2 (1 Critical -> 0 Critical).
 # The single remaining finding is the reasoned ignore below.
+# ---------------------------------------------------------------------------
+# 2026-08-10 COVERAGE FIX (W23) — the two sidecar/runtime_setup requirements files
+# joined the scanned set above. That did not change any dependency; it changed what
+# the gate can SEE. Measured with the pinned osv-scanner 2.3.8 in the worktree:
+# 3 lockfiles -> 495+209+76 = 780 packages, exit 0; 5 lockfiles -> +13+3 = 796
+# packages, exit 1 with exactly ONE new finding (torch 2.10.0+cu128 — the second
+# reasoned ignore below). The pre-existing "unused ignores: GHSA-mh99-v99m-4gvg"
+# notice appears in BOTH states, so it is not a consequence of this change and it
+# does not affect the exit code.
 # ---------------------------------------------------------------------------
 
 [[IgnoredVulns]]
@@ -115,5 +141,69 @@ RE-CHECK CONDITION — either one retires this entry outright:
       2.1.2 exists, then re-check that release against the advisory range.
 Re-review at ignoreUntil (2026-10-25) regardless. REMOVING the ignore is the
 default outcome; extending it requires re-measuring both paths above.
+"""
+
+[[IgnoredVulns]]
+id = "GHSA-rrmf-rvhw-rf47"
+ignoreUntil = 2026-11-10
+reason = """
+torch: memory corruption via `torch.jit.script` (aliases CVE-2025-3000,
+PYSEC-2025-194, BIT-pytorch-2025-3000). CVSS 5.3 Medium,
+AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L — a LOCAL, already-authenticated attacker
+only, no network vector. Surfaced 2026-08-10, the moment the W23 coverage fix
+added sidecar/runtime_setup/requirements-chatterbox.txt to the scanned set. It is
+NOT a regression: the pin did not change, only the gate's visibility did.
+Ignored per the POLICY at the top of this file as GENUINELY UNFIXABLE for THIS
+environment.
+
+WHY UNFIXABLE — measured 2026-08-10 by execution, from two mechanically
+independent sources, not assumed:
+  1. OSV record (api.osv.dev/v1/vulns/GHSA-rrmf-rvhw-rf47): the ECOSYSTEM range
+     is introduced 0 -> fixed 2.13.0, and database_specific
+     .last_known_affected_version_range is "<= 2.12.1". Every torch release up to
+     2.12.1 is affected; only 2.13.0 clears it.
+  2. The wheel index this env actually installs from
+     (download.pytorch.org/whl/cu128/torch/) tops out at torch 2.11.0 — and for
+     cp314, the DEDICATED py3.14 embeddable interpreter this env requires (see the
+     CONTRACT-NOTE in requirements-chatterbox.txt and build/python-embed-setup.ps1),
+     only 2.9.0, 2.9.1, 2.10.0 and 2.11.0 exist. There is no fixed +cu128 wheel to
+     upgrade to at all, so the "upgrade first" arm of the policy has nothing to
+     resolve to.
+  3. Counter-intuitive corollary, recorded so it is not re-derived: bumping to the
+     torch 2.11.0 an earlier sweep proposed would NOT clear this advisory. 2.11.0
+     is still inside the affected range.
+PyPI DOES publish a plain torch 2.13.0 (measured: pypi.org/pypi/torch/json
+info.version == 2.13.0). Adopting it means abandoning the cu128 per-index
+exception AND bumping the pinned trio (chatterbox-tts + torch + torchaudio)
+together, which requirements-chatterbox.txt states must be human-verified on a
+real GPU install. That is an environment-architecture change, deliberately NOT
+made by the coverage fix that merely revealed the finding.
+
+SCOPE: the isolated voice-clone env only. It is downloaded on FIRST RUN into
+%APPDATA%/media-studio/envs/chatterbox and never ships inside the installer
+(build/make-portable.ps1 forbids torch in the artifact); the sidecar drives it as
+a child process. NOT ASSESSED, and deliberately not claimed in either direction:
+whether chatterbox-tts 0.1.7 or its transitive closure ever reaches
+`torch.jit.script`. SETTLING EXPERIMENT for that: unpack the chatterbox-tts 0.1.7
+wheel plus its closure and search the call graph for jit.script / jit.trace. If it
+provably never does, re-scope this entry from unfixable to unreachable.
+
+CAVEAT — READ THIS BEFORE TRUSTING THIS ENTRY. An osv-scanner ignore is keyed by
+VULNERABILITY ID, not by package or version, so it suppresses this advisory
+everywhere in the scanned set. Measured blast radius today: nothing else — torch
+appears in NO other scanned lockfile (sidecar/requirements.lock.txt carries zero
+torch* pins). But sidecar/pyproject.toml's `reframe-gpu` extra pins torch==2.6.0,
+which is likewise inside the affected range; if that manifest is ever added to the
+gate, THIS entry silences it there too. Assess that env separately then rather
+than assuming this reason already covers it.
+
+RE-CHECK CONDITION — either one retires this entry outright:
+  (a) a torch >= 2.13.0 cp314 wheel appears on the cu128 index — verify with
+      `curl -sSL https://download.pytorch.org/whl/cu128/torch/` and grep for
+      cp314; or
+  (b) the env moves off the cu128 index onto a fixed PyPI torch, with the trio
+      re-verified on a GPU host.
+Re-review at ignoreUntil (2026-11-10) regardless. REMOVING the ignore is the
+default outcome; extending it requires re-measuring both probes above.
 """
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -23,15 +23,47 @@
 #                                        torch build, which none of the lockfiles
 #                                        above can contain — sidecar/pyproject.toml
 #                                        forbids chatterbox-tts/torch in the main
-#                                        env — so before W23 it was scanned by
-#                                        nothing at all.)
+#                                        env — so before W23 THIS GATE saw none of
+#                                        it. Scoped correction, see below: it was
+#                                        never "unscanned by everything".)
+#
+# WHAT W23 ADDED, SCOPED. An earlier wording here said the chatterbox env "was
+# scanned by nothing at all" before W23. That is FALSE and was refuted by one API
+# call this file had not made: GitHub's dependency graph HAS ingested
+# sidecar/runtime_setup/requirements-chatterbox.txt and has raised EIGHT CVE alerts
+# against it (measured 2026-08-10, `gh api repos/Prekzursil/Reframe/dependabot/
+# alerts --paginate`: seven now `fixed`, plus GHSA-rrmf-rvhw-rf47 `dismissed`).
+# The correct claim — and the one that actually justifies the fix — is that the env
+# had NO coverage in the BLOCKING `deps` gate; only the advisory Dependabot rail
+# saw it, and an advisory rail cannot fail a PR. Worth stating the corroboration
+# the two rails do give: osv-scanner reports exactly the one advisory Dependabot
+# has non-fixed on that manifest, so the two independent rails AGREE on today's
+# state.
 #
 # The two runtime_setup files are read as FLAT pin lists under --no-resolve, so the
 # gate covers their DECLARED pins, not their transitive closure. That closure is
 # hash-pinned separately at F1 build-prep by runtime_setup/generate_hashed_lock.py,
 # whose output is generated rather than committed. Section 5 of
-# sidecar/tests/test_supply_chain_pins.py asserts that every shipped environment
-# has an argument in the gate, so a fourth one cannot be added unscanned.
+# sidecar/tests/test_supply_chain_pins.py asserts that every DISCOVERED shipped
+# environment has an argument in the gate.
+#
+# SCOPE OF THAT INVARIANT — measured, not assumed, because an earlier wording here
+# claimed "a fourth one cannot be added unscanned" full stop and three reviewers
+# refuted it by executing the discovery against synthetic trees. Discovery is three
+# globs, and a new environment is caught ONLY if it arrives as one of these shapes:
+# app/package-lock.json · app/<immediate-subdir>/package-lock.json ·
+# sidecar/requirements*.txt · sidecar/runtime_setup/requirements*.txt. An
+# environment declared anywhere else is NOT discovered and therefore NOT demanded:
+# a repo-root lockfile, one two levels under app/, a sibling top-level tree (this
+# repo's own Dependabot history holds apps/web + apps/desktop lockfiles from an
+# earlier layout), a sidecar/envs/… tree, a pin list not named requirements*, or a
+# dependency set declared as a pyproject extra. That last one is live, not
+# hypothetical: sidecar/pyproject.toml's `reframe-gpu` extra is unscanned by this
+# gate today — see the CAVEAT on the torch ignore below.
+# Both directions are now asserted by
+# test_supply_chain_pins.py::TestDiscoveryScopeIsTheThreeGlobs (4 discovered shapes
+# as a detector control, 6 undiscovered shapes as the boundary), so this paragraph
+# and the code cannot drift apart silently.
 #
 # ---------------------------------------------------------------------------
 # 2026-06-16 SECURITY UPGRADE — the electron/vite/esbuild/vitest/ws ignores that
@@ -42,9 +74,15 @@
 #   - vitest 1.6.x -> 3.2.6        (clears the vitest UI-server file-read CVE)
 #   - esbuild pinned via overrides -> 0.28.1 (clears the dev-server + integrity CVEs)
 #   - ws (render-cli) via override -> 8.21.0  (clears the Remotion-transitive ws DoS)
-# osv-scanner now reports 0 issues across all three lockfiles with NO ignores, so
-# this file intentionally carries no IgnoredVulns. Add a dated, reasoned entry here
-# only for a future vuln that is genuinely unfixable or provably unreachable.
+# AS OF THAT DATE (2026-06-16) osv-scanner reported 0 issues across the three
+# lockfiles then scanned, with NO ignores, so this file carried no IgnoredVulns.
+# HISTORICAL — do not read this paragraph as the current state. It is kept as the
+# dated record of that upgrade; the live counts are the five lockfiles listed at the
+# top of this file and the TWO reasoned [[IgnoredVulns]] entries below. (Flagged by
+# a reviewer as a flat contradiction for anyone arriving here straight from the
+# lockfile list; it was already stale before W23 widened the scanned set.)
+# Add a dated, reasoned entry below only for a vuln that is genuinely unfixable or
+# provably unreachable.
 # ---------------------------------------------------------------------------
 # 2026-06-20 SECURITY UPGRADE — undici (dev/build transitive via node-gyp) bumped
 # 6.26.0 -> 6.27.0 to clear 4 new CVEs (GHSA-vxpw-j846-p89q HIGH, GHSA-p88m-4jfj-68fv,
@@ -150,60 +188,135 @@ reason = """
 torch: memory corruption via `torch.jit.script` (aliases CVE-2025-3000,
 PYSEC-2025-194, BIT-pytorch-2025-3000). CVSS 5.3 Medium,
 AV:L/AC:L/PR:L/UI:N/S:U/C:L/I:L/A:L — a LOCAL, already-authenticated attacker
-only, no network vector. Surfaced 2026-08-10, the moment the W23 coverage fix
-added sidecar/runtime_setup/requirements-chatterbox.txt to the scanned set. It is
-NOT a regression: the pin did not change, only the gate's visibility did.
-Ignored per the POLICY at the top of this file as GENUINELY UNFIXABLE for THIS
-environment.
+only, no network vector. Surfaced IN THIS GATE on 2026-08-10, the moment the W23
+coverage fix added sidecar/runtime_setup/requirements-chatterbox.txt to the
+scanned set. It is NOT a new exposure: the pin did not change, only this gate's
+visibility did — and the advisory was already known and already accepted on the
+Dependabot rail (see PRIOR TRIAGE). Ignored per the POLICY at the top of this file
+as GENUINELY UNFIXABLE for THIS environment.
 
-WHY UNFIXABLE — measured 2026-08-10 by execution, from two mechanically
-independent sources, not assumed:
-  1. OSV record (api.osv.dev/v1/vulns/GHSA-rrmf-rvhw-rf47): the ECOSYSTEM range
-     is introduced 0 -> fixed 2.13.0, and database_specific
+PRIOR TRIAGE — this advisory was ALREADY triaged and accepted by the owner. This
+entry RECONCILES with that decision; it does not re-decide it. The first version
+of this entry found neither record and so shipped a second, differently-reasoned
+triage of one advisory — refuted, and corrected here.
+  * Measured 2026-08-10, `gh api repos/Prekzursil/Reframe/dependabot/alerts
+    --paginate`: alert #272, manifest
+    sidecar/runtime_setup/requirements-chatterbox.txt, package torch, state
+    `dismissed`, dismissed_reason `tolerable_risk`, dismissed_at
+    2026-07-18T00:30:05Z. The same eight torch advisories are also dismissed
+    `tolerable_risk` against sidecar/pyproject.toml.
+  * .github/dependabot.yml:19-26 records the standing rationale in prose and names
+    CVE-2025-3000 (this advisory) explicitly: the torch advisories are "all LOCAL
+    attack-vector (AV:L), low/medium, several with no fixed version, and are not
+    reachable in a local desktop app processing the user's own media. Triaged +
+    alerts dismissed 2026-06-29".
+That is the OWNER'S threat-model risk acceptance, and it is cited as
+corroboration — NOT restated here as the ignore's ground. The POLICY above
+reserves the "provably not reachable" arm for a proof, and the owner's note is a
+threat-model judgement about attack VECTOR, not a call-graph analysis (see NOT
+ASSESSED below, which is a strictly narrower question and remains open). So this
+ignore rests on the unfixability measurement below, with the standing acceptance
+as evidence that the residual risk is understood rather than newly introduced.
+
+WHY UNFIXABLE — measured 2026-08-10 by execution. The FIRST version of this entry
+claimed "there is no fixed +cu128 wheel to upgrade to at all, so the 'upgrade
+first' arm of the policy has nothing to resolve to", and framed the only
+alternative as "abandoning the cu128 per-index exception". Both were REFUTED: that
+reasoning generalised a probe of ONE index to the whole per-index family. Recorded
+rather than deleted, so the next reader knows the premise was wrong. The corrected
+picture, each item measured:
+  1. OSV record (api.osv.dev/v1/vulns/GHSA-rrmf-rvhw-rf47): the ECOSYSTEM range is
+     introduced 0 -> fixed 2.13.0, and database_specific
      .last_known_affected_version_range is "<= 2.12.1". Every torch release up to
-     2.12.1 is affected; only 2.13.0 clears it.
-  2. The wheel index this env actually installs from
-     (download.pytorch.org/whl/cu128/torch/) tops out at torch 2.11.0 — and for
-     cp314, the DEDICATED py3.14 embeddable interpreter this env requires (see the
-     CONTRACT-NOTE in requirements-chatterbox.txt and build/python-embed-setup.ps1),
-     only 2.9.0, 2.9.1, 2.10.0 and 2.11.0 exist. There is no fixed +cu128 wheel to
-     upgrade to at all, so the "upgrade first" arm of the policy has nothing to
-     resolve to.
-  3. Counter-intuitive corollary, recorded so it is not re-derived: bumping to the
-     torch 2.11.0 an earlier sweep proposed would NOT clear this advisory. 2.11.0
-     is still inside the affected range.
-PyPI DOES publish a plain torch 2.13.0 (measured: pypi.org/pypi/torch/json
-info.version == 2.13.0). Adopting it means abandoning the cu128 per-index
-exception AND bumping the pinned trio (chatterbox-tts + torch + torchaudio)
-together, which requirements-chatterbox.txt states must be human-verified on a
-real GPU install. That is an environment-architecture change, deliberately NOT
-made by the coverage fix that merely revealed the finding.
+     2.12.1 is affected; only 2.13.0 clears it. Counter-intuitive corollary,
+     recorded so it is not re-derived: bumping to the torch 2.11.0 an earlier
+     sweep proposed would NOT clear this advisory — 2.11.0 is inside the range.
+  2. A FIXED CUDA WHEEL DOES EXIST for this interpreter. cp314 wheel listings,
+     measured the same day across the per-index family: cu128 (the index this env
+     names) tops out at torch 2.11.0 — 2.9.0 / 2.9.1 / 2.10.0 / 2.11.0 only, which
+     is exactly why a one-index probe read as "no fix anywhere" — but cu126, cu129
+     and cu130 all publish 2.13.0, and cu126 + cu130 publish it for cp314
+     win_amd64 (exact wheel: torch-2.13.0+cu130-cp314-cp314-win_amd64.whl; cu129
+     has 2.13.0 for manylinux only). Plain torch 2.13.0 is on PyPI too
+     (pypi.org/pypi/torch/json info.version == 2.13.0). So switching
+     --extra-index-url cu128 -> cu130 would reach a FIXED torch while KEEPING the
+     still-hashed per-index architecture, not abandoning it.
+  3. THE ACTUAL BLOCKER IS torchaudio — not torch, and not the index choice.
+     requirements-chatterbox.txt:36-37 pins torch and torchaudio in lockstep at
+     the same version (2.10.0+cu128), and that lockstep is enforced upstream, not
+     merely by convention: torchaudio==2.10.0's own metadata hard-pins
+     `torch==2.10.0` (measured: pypi.org/pypi/torchaudio/2.10.0/json requires_dist
+     == ['torch==2.10.0']). And torchaudio has NO release above 2.11.0 ANYWHERE —
+     PyPI info.version == 2.11.0, and the cp314 listings on cu126, cu128, cu129
+     AND cu130 every one top out at torchaudio 2.11.0. There is therefore no
+     version of the pinned pair in which torch is >= 2.13.0 and torchaudio is a
+     released, index-published build.
+     Adopting a fixed torch means either pairing torch 2.13.0 with torchaudio
+     2.11.0 — a combination upstream has never shipped; pip would not refuse it on
+     metadata grounds, because torchaudio 2.11.0 declares no requires_dist at all
+     (measured: null), but the ABI pairing is UNVERIFIED — or dropping torchaudio
+     outright. Either is an environment-architecture change that
+     requirements-chatterbox.txt:27-29 requires a human to verify on a real GPU
+     install, and is deliberately NOT made by a coverage fix that merely revealed
+     the finding.
+     For completeness: chatterbox-tts 0.1.7 itself does NOT block the upgrade.
+     Measured, its py>=3.14 constraints are torch>=2.9.0 and torchaudio>=2.9.0.
 
-SCOPE: the isolated voice-clone env only. It is downloaded on FIRST RUN into
-%APPDATA%/media-studio/envs/chatterbox and never ships inside the installer
-(build/make-portable.ps1 forbids torch in the artifact); the sidecar drives it as
-a child process. NOT ASSESSED, and deliberately not claimed in either direction:
-whether chatterbox-tts 0.1.7 or its transitive closure ever reaches
-`torch.jit.script`. SETTLING EXPERIMENT for that: unpack the chatterbox-tts 0.1.7
-wheel plus its closure and search the call graph for jit.script / jit.trace. If it
-provably never does, re-scope this entry from unfixable to unreachable.
+SCOPE: the isolated voice-clone env only. Reconciling two statements that a
+reviewer read as contradictory ("that environment ships" in quality.yml vs "never
+ships inside the installer" here) — both are true of DIFFERENT parts of it, so
+state the split explicitly: the dedicated py3.14 embeddable INTERPRETER does ship
+(build/make-portable.ps1:8 — the unpacked tree carries two embeddable CPythons,
+3.12 sidecar + 3.14 chatterbox), while torch and the model weights NEVER ship
+(build/make-portable.ps1:45-48 fails the build if a torch package dir is inside
+the artifact) and are downloaded on FIRST RUN into
+%APPDATA%/media-studio/envs/chatterbox, which the sidecar then drives as a child
+process. Interpreter ships; wheels are fetched on first run.
+NOT ASSESSED, and deliberately not claimed in either direction: whether
+chatterbox-tts 0.1.7 or its transitive closure ever reaches `torch.jit.script`.
+SETTLING EXPERIMENT: unpack the chatterbox-tts 0.1.7 wheel plus its closure and
+search the call graph for jit.script / jit.trace. If it provably never does,
+re-scope this entry from unfixable to unreachable — and the expiry can then go,
+because "provably unreachable" does not decay the way "no fixed release yet" does.
 
 CAVEAT — READ THIS BEFORE TRUSTING THIS ENTRY. An osv-scanner ignore is keyed by
 VULNERABILITY ID, not by package or version, so it suppresses this advisory
-everywhere in the scanned set. Measured blast radius today: nothing else — torch
-appears in NO other scanned lockfile (sidecar/requirements.lock.txt carries zero
-torch* pins). But sidecar/pyproject.toml's `reframe-gpu` extra pins torch==2.6.0,
-which is likewise inside the affected range; if that manifest is ever added to the
-gate, THIS entry silences it there too. Assess that env separately then rather
-than assuming this reason already covers it.
+everywhere in the scanned set. Measured blast radius INSIDE the scanned set today:
+nothing else — torch appears in no other scanned manifest
+(sidecar/requirements.lock.txt and runtime_setup/requirements-sidecar.txt both
+carry zero torch* pins, asserted by
+test_supply_chain_pins.py::TestDiscoveryScopeIsTheThreeGlobs).
+OUTSIDE the scanned set: sidecar/pyproject.toml's `reframe-gpu` extra pins
+torch==2.6.0, likewise inside the affected range, and the SHIPPED sidecar tells
+the user to install that extra at runtime
+(media_studio/features/diarize_backend.py:211-214 raises
+DiarizeBackendUnavailableError naming `pip install
+"media-studio-sidecar[reframe-gpu]"`). So the natural next step — adding
+sidecar/pyproject.toml to satisfy a wider reading of gate 6 — would SILENTLY PASS
+that torch instead of reporting it. Do not do that without assessing that env on
+its own terms; note its coverage today is the Dependabot rail, where its own eight
+torch alerts are dismissed `tolerable_risk`.
 
-RE-CHECK CONDITION — either one retires this entry outright:
-  (a) a torch >= 2.13.0 cp314 wheel appears on the cu128 index — verify with
-      `curl -sSL https://download.pytorch.org/whl/cu128/torch/` and grep for
-      cp314; or
-  (b) the env moves off the cu128 index onto a fixed PyPI torch, with the trio
-      re-verified on a GPU host.
-Re-review at ignoreUntil (2026-11-10) regardless. REMOVING the ignore is the
-default outcome; extending it requires re-measuring both probes above.
+RE-CHECK CONDITION — watch torchaudio, NOT the cu128 torch listing. The first
+version of this entry sent the reviewer to
+`curl https://download.pytorch.org/whl/cu128/torch/ | grep cp314` and to plain
+PyPI torch; both are the WRONG probe and were refuted — the cu128 torch listing is
+structurally blind to the cu126/cu130 fix path, and a fixed torch is not adoptable
+while torchaudio is the gating package. Either of these retires this entry:
+  (a) torchaudio publishes a release >= 2.12 for cp314 — verify with
+      `curl -sSL https://download.pytorch.org/whl/cu130/torchaudio/` (plus the
+      cu126 / cu129 siblings) and `pypi.org/pypi/torchaudio/json` info.version;
+      then move the env to a matching fixed torch on that index and human-verify
+      the trio on a real GPU install per requirements-chatterbox.txt:27-29; or
+  (b) the SETTLING EXPERIMENT above proves `torch.jit.script` unreachable, which
+      re-grounds this entry on the POLICY's "provably not reachable" arm.
+NOTHING WILL PROPOSE (a) AUTOMATICALLY, and that is deliberate:
+.github/dependabot.yml:27-29 ignores dependency-name torch / torchvision /
+torchaudio outright, because GPU-validated CUDA-wheel pins must never move via an
+unattended PR. The ignoreUntil date is therefore the ONLY scheduled prompt to
+re-run these probes — which is why it is KEPT rather than dropped in favour of the
+owner's standing acceptance. Re-review at ignoreUntil (2026-11-10) regardless.
+REMOVING the ignore is the default outcome; extending it requires re-measuring
+both probes above.
 """
 

--- a/sidecar/tests/test_supply_chain_pins.py
+++ b/sidecar/tests/test_supply_chain_pins.py
@@ -18,12 +18,21 @@ Three surfaces, all "an unverified artifact must never be EXECUTED":
   MUTABLE ``main`` branch and the scanner binary had no checksum at all.
 * ``.github/workflows/quality.yml`` again, W23 — the ``gate-deps`` osv-scanner
   invocation passed THREE ``--lockfile`` arguments and none of them was the
-  chatterbox environment, so a Python env that SHIPS (``build/make-portable.ps1``
-  ships a second, py3.14 embeddable CPython for it) and that carries its own
-  ``+cu128`` torch build had ZERO CVE scanning. Section 5 below turns "every
-  shipped dependency environment is in the deps gate" into an asserted
-  invariant, discovered from disk rather than from a hardcoded list, so a fourth
-  environment cannot be added unscanned later.
+  chatterbox environment, so a Python env that partly SHIPS (the dedicated py3.14
+  embeddable CPython is staged by ``build/make-portable.ps1``; torch and the
+  weights are fetched on first run and never enter the artifact) and that carries
+  its own ``+cu128`` torch build had NO coverage in the BLOCKING deps gate.
+  Scoped correction to the first wording, which said "ZERO CVE scanning": that is
+  false. GitHub's dependency graph HAS ingested
+  ``sidecar/runtime_setup/requirements-chatterbox.txt`` and has raised EIGHT CVE
+  alerts against it (measured 2026-08-10 via ``gh api …/dependabot/alerts``: seven
+  ``fixed``, one ``dismissed``). The env had real coverage on the ADVISORY rail;
+  what it lacked was a rail that can fail a PR. Section 5 below turns "every
+  DISCOVERED shipped environment is in the deps gate" into an asserted invariant,
+  read off disk rather than from a hardcoded list — and
+  :class:`TestDiscoveryScopeIsTheThreeGlobs` pins how far "discovered" reaches,
+  because three reviewers refuted the unqualified claim that a fourth environment
+  "cannot be added unscanned".
 
 The lockfile-mechanism tests live in ``test_env_lockfile.py``; this module only
 covers the WU-S10 pinning deltas.
@@ -317,7 +326,9 @@ class TestEmbedSetupPinIsMandatory:
 
 
 # --------------------------------------------------------------------------- #
-# 5. W23 — the deps gate must scan EVERY shipped dependency environment
+# 5. W23 — the deps gate must scan every DISCOVERED shipped dependency environment
+#    ("discovered" = the three globs in `shipped_dependency_manifests`, whose exact
+#     reach is asserted by TestDiscoveryScopeIsTheThreeGlobs — not a closure claim)
 # --------------------------------------------------------------------------- #
 #: `npm ci` / electron-builder create these; a manifest inside one is generated
 #: output, not a shipped environment, so discovery must not demand it be scanned.

--- a/sidecar/tests/test_supply_chain_pins.py
+++ b/sidecar/tests/test_supply_chain_pins.py
@@ -748,8 +748,17 @@ class TestDiscoveryScopeIsTheThreeGlobs:
         assert "reframe-gpu" in pyproject, "the reframe-gpu extra is gone; retire this test and the caveats"
         assert re.search(r"^\s*\"torch==", pyproject, flags=re.MULTILINE), "reframe-gpu no longer pins torch"
         assert "sidecar/pyproject.toml" not in gate_deps_lockfile_args(QUALITY_WORKFLOW.read_text(encoding="utf-8"))
-        assert "torch" not in _distribution_names(SIDECAR_DIR / "requirements.lock.txt")
-        assert "torch" not in _distribution_names(RUNTIME_SETUP_DIR / "requirements-sidecar.txt")
+        # The ID-keyed torch ignore in osv-scanner.toml claims a blast radius of
+        # "no OTHER scanned manifest pins torch*". Assert the whole family, not
+        # just the bare name, so the claim and the assertion have the same scope.
+        for manifest_path in (SIDECAR_DIR / "requirements.lock.txt", RUNTIME_SETUP_DIR / "requirements-sidecar.txt"):
+            pinned = _distribution_names(manifest_path)
+            assert pinned, f"{manifest_path.name} parsed to zero distributions — the parser is broken"
+            assert not {name for name in pinned if name.startswith("torch")}, (
+                f"{manifest_path.name} now pins a torch* distribution, so the ID-keyed "
+                f"GHSA-rrmf-rvhw-rf47 ignore in osv-scanner.toml silences it there too. "
+                f"Re-measure that entry's blast radius before this lands."
+            )
 
 
 class TestDepsGateChatterboxRationale:

--- a/sidecar/tests/test_supply_chain_pins.py
+++ b/sidecar/tests/test_supply_chain_pins.py
@@ -16,6 +16,14 @@ Three surfaces, all "an unverified artifact must never be EXECUTED":
   lock that ``runtime_setup.generate_hashed_lock`` produces.
 * ``.github/workflows/quality.yml`` — the CI installer was fetched from the
   MUTABLE ``main`` branch and the scanner binary had no checksum at all.
+* ``.github/workflows/quality.yml`` again, W23 — the ``gate-deps`` osv-scanner
+  invocation passed THREE ``--lockfile`` arguments and none of them was the
+  chatterbox environment, so a Python env that SHIPS (``build/make-portable.ps1``
+  ships a second, py3.14 embeddable CPython for it) and that carries its own
+  ``+cu128`` torch build had ZERO CVE scanning. Section 5 below turns "every
+  shipped dependency environment is in the deps gate" into an asserted
+  invariant, discovered from disk rather than from a hardcoded list, so a fourth
+  environment cannot be added unscanned later.
 
 The lockfile-mechanism tests live in ``test_env_lockfile.py``; this module only
 covers the WU-S10 pinning deltas.
@@ -27,6 +35,7 @@ import calendar
 import re
 from pathlib import Path
 
+import pytest
 from media_studio.assets import manifest
 from media_studio.assets.manager import (
     GET_PIP_SHA256,
@@ -40,6 +49,9 @@ from media_studio.features.tts import chatterbox as cb
 REPO_ROOT = Path(__file__).resolve().parents[2]
 QUALITY_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "quality.yml"
 EMBED_SETUP_PS1 = REPO_ROOT / "build" / "python-embed-setup.ps1"
+APP_DIR = REPO_ROOT / "app"
+SIDECAR_DIR = REPO_ROOT / "sidecar"
+RUNTIME_SETUP_DIR = SIDECAR_DIR / "runtime_setup"
 
 
 def _recording_manager(root: Path, **kwargs: object) -> tuple[AssetManager, list[list[str]]]:
@@ -302,3 +314,207 @@ class TestEmbedSetupPinIsMandatory:
         body = self._body()
         assert "[switch]$RecordHashes" in body
         assert "staged NOTHING by design" in body
+
+
+# --------------------------------------------------------------------------- #
+# 5. W23 — the deps gate must scan EVERY shipped dependency environment
+# --------------------------------------------------------------------------- #
+#: `npm ci` / electron-builder create these; a manifest inside one is generated
+#: output, not a shipped environment, so discovery must not demand it be scanned.
+GENERATED_APP_DIRS = frozenset({"node_modules", "dist", "out"})
+
+#: `name:` as the FIRST key of a sequence item — i.e. a real workflow STEP. Same
+#: shape `.quality/charter_check.py` matches on, and for the same reason: a
+#: job-level or `with:`-block `name:` is a plain mapping key, not a step.
+STEP_NAME_KEY = re.compile(r"^\s*-\s+name:\s*(?P<value>\S.*)$")
+#: `--lockfile=<path>`; the trailing `\` of a shell line continuation is excluded
+#: from the path by the character class.
+LOCKFILE_ARG = re.compile(r"--lockfile[=\s]+(?P<path>[^\s\\]+)")
+
+
+def _repo_rel(path: Path) -> str:
+    return path.relative_to(REPO_ROOT).as_posix()
+
+
+def gate_deps_lockfile_args(workflow_text: str) -> set[str]:
+    """The ``--lockfile`` paths the ``gate-deps`` STEP actually passes.
+
+    Measure the FIELD, not the document. Two shapes in this workflow would
+    otherwise let a deleted lockfile keep satisfying the invariant below: the
+    explanatory comment block directly above the step names all three original
+    lockfiles in prose, and a ``#``-disabled argument inside the ``run:`` body is
+    not an argument at all. So the scan is scoped to the lines that follow the
+    ``gate-deps`` step name (up to the next step) and skips comment lines.
+    """
+    inside = False
+    found: set[str] = set()
+    for line in workflow_text.splitlines():
+        step = STEP_NAME_KEY.match(line)
+        if step:
+            inside = step.group("value").startswith("gate-deps")
+            continue
+        if not inside or line.lstrip().startswith("#"):
+            continue
+        found.update(match.group("path") for match in LOCKFILE_ARG.finditer(line))
+    return found
+
+
+def shipped_dependency_manifests() -> dict[str, frozenset[str]]:
+    """``{environment -> the manifests that would cover it}``, read off disk.
+
+    Deliberately NOT a hardcoded list: the whole point of the invariant is that a
+    FOURTH environment cannot be introduced unscanned, and a literal list would
+    be edited by the very commit that introduces one.
+
+    * one environment per npm tree — ``app/`` plus every immediate subdirectory
+      that owns a committed ``package-lock.json``;
+    * one per ``sidecar/requirements*.txt`` (the resolved closure the gate has
+      read since it was written);
+    * one per ``sidecar/runtime_setup/requirements-<env>.txt`` — the first-run
+      ``pip --target`` environments. A sibling ``requirements-<env>.lock.txt`` is
+      an F1 build-prep artifact that is generated rather than committed, so
+      scanning EITHER file covers that environment; hence a SET per environment
+      instead of a single path.
+
+    Both globs are single-level on purpose: a recursive walk would descend into
+    ``sidecar/.venv`` and ``app/node_modules`` and pick up third-party
+    requirements files that this repo does not ship.
+    """
+    environments: dict[str, set[str]] = {}
+    npm_roots = [
+        APP_DIR,
+        *(d for d in sorted(APP_DIR.iterdir()) if d.is_dir() and d.name not in GENERATED_APP_DIRS),
+    ]
+    for root in npm_roots:
+        lock = root / "package-lock.json"
+        if lock.is_file():
+            environments[_repo_rel(lock)] = {_repo_rel(lock)}
+    for req in sorted(SIDECAR_DIR.glob("requirements*.txt")):
+        environments[_repo_rel(req)] = {_repo_rel(req)}
+    for req in sorted(RUNTIME_SETUP_DIR.glob("requirements*.txt")):
+        env = req.name.removesuffix(".txt").removesuffix(".lock")
+        environments.setdefault(env, set()).add(_repo_rel(req))
+    return {name: frozenset(paths) for name, paths in environments.items()}
+
+
+def _distribution_names(path: Path) -> set[str]:
+    """The normalized distribution names pinned in a requirements-style file."""
+    names: set[str] = set()
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith(("#", "-")):  # comment / `--extra-index-url` / `--hash`
+            continue
+        names.add(re.split(r"[=<>!~\[; ]", line, maxsplit=1)[0].strip().lower().replace("_", "-"))
+    return names
+
+
+class TestDepsGateCoversEveryShippedEnv:
+    @staticmethod
+    def _body() -> str:
+        return QUALITY_WORKFLOW.read_text(encoding="utf-8")
+
+    # --- detector control: both halves must find KNOWN-PRESENT items --------- #
+    def test_arg_parser_finds_the_three_long_standing_lockfiles(self):
+        """A zero read here would make every assertion below vacuously true.
+
+        These three have been in the ``gate-deps`` step since it was written, so
+        the parser must see them before its silence about a fourth means anything.
+        """
+        found = gate_deps_lockfile_args(self._body())
+        assert {
+            "app/package-lock.json",
+            "app/render-cli/package-lock.json",
+            "sidecar/requirements.lock.txt",
+        } <= found, f"the --lockfile parser is broken, it found {sorted(found)}"
+
+    def test_discovery_finds_the_known_environments(self):
+        environments = shipped_dependency_manifests()
+        assert "app/package-lock.json" in environments
+        assert "app/render-cli/package-lock.json" in environments
+        assert "sidecar/requirements.lock.txt" in environments
+        assert environments["requirements-chatterbox"] >= {"sidecar/runtime_setup/requirements-chatterbox.txt"}
+        assert environments["requirements-sidecar"] >= {"sidecar/runtime_setup/requirements-sidecar.txt"}
+
+    def test_arg_parser_ignores_lockfiles_outside_the_gate_deps_step(self):
+        text = "\n".join(
+            [
+                "      # --lockfile=prose/one.json is read by the deps gate",
+                "      - name: gate-sast opengrep",
+                "        run: echo --lockfile=other-step/two.json",
+                "      - name: gate-deps osv-scanner",
+                "        run: |",
+                "          osv-scanner scan source \\",
+                "            --lockfile=real/three.json \\",
+                "            # --lockfile=disabled/four.json",
+                "      - name: charter-check",
+                "        run: echo --lockfile=later-step/five.json",
+            ]
+        )
+        assert gate_deps_lockfile_args(text) == {"real/three.json"}
+
+    # --- the invariant ------------------------------------------------------- #
+    def test_every_shipped_environment_is_scanned_by_the_deps_gate(self):
+        scanned = gate_deps_lockfile_args(self._body())
+        missing = {env: sorted(paths) for env, paths in shipped_dependency_manifests().items() if not (paths & scanned)}
+        assert not missing, (
+            f"these dependency environments SHIP but no --lockfile in the gate-deps step scans them, "
+            f"so their known CVEs are invisible to the gate: {missing}. Add one manifest per "
+            f"environment to the osv-scanner invocation in .github/workflows/quality.yml (and, if a "
+            f"finding is genuinely unfixable, a dated + reasoned ignore in osv-scanner.toml)."
+        )
+
+    # --- MUTATION: the invariant must be able to FAIL ------------------------ #
+    @pytest.mark.parametrize(
+        "env",
+        [
+            "app/package-lock.json",
+            "app/render-cli/package-lock.json",
+            "sidecar/requirements.lock.txt",
+            "requirements-chatterbox",
+            "requirements-sidecar",
+        ],
+    )
+    def test_removing_one_environments_lockfile_arg_is_caught(self, env: str):
+        """Drop each environment's argument in turn; the invariant must name it.
+
+        A green invariant proves nothing on its own — this is the both-states
+        check that it goes RED in the known-broken state, run permanently rather
+        than once at authoring time.
+        """
+        body = self._body()
+        mutated = body
+        for path in shipped_dependency_manifests()[env]:
+            mutated = re.sub(rf"^.*--lockfile={re.escape(path)}.*$\n?", "", mutated, flags=re.MULTILINE)
+        assert mutated != body, f"no --lockfile argument for {env} was found to remove"
+        scanned = gate_deps_lockfile_args(mutated)
+        still_missing = sorted(name for name, paths in shipped_dependency_manifests().items() if not (paths & scanned))
+        assert still_missing == [env]
+
+    def test_a_commented_out_lockfile_arg_does_not_satisfy_the_invariant(self):
+        """use-vs-mention on the live file: a disabled argument is not passed."""
+        target = "sidecar/runtime_setup/requirements-chatterbox.txt"
+        body = self._body()
+        mutated = re.sub(rf"^(\s*)(--lockfile={re.escape(target)})", r"\1# \2", body, flags=re.MULTILINE)
+        assert mutated != body, f"no --lockfile argument for {target} was found to comment out"
+        assert target not in gate_deps_lockfile_args(mutated)
+
+    # --- WHY the chatterbox env needs its own argument ----------------------- #
+    def test_the_chatterbox_env_pins_distributions_no_other_manifest_covers(self):
+        """``sidecar/requirements.lock.txt`` structurally cannot cover this env.
+
+        ``sidecar/pyproject.toml`` states that chatterbox-tts/torch must NOT be
+        added to the main sidecar env (isolated env asset only), so the only
+        Python lockfile the gate read before W23 sees none of them. Measured at
+        this commit ALL THREE pins are absent from it (chatterbox-tts, torch,
+        torchaudio — the latter two a ``+cu128`` build the sidecar tree never
+        names); the assertion is the weaker "at least one", so a future dep
+        change cannot make it brittle while the load-bearing property holds.
+        """
+        chatterbox = _distribution_names(RUNTIME_SETUP_DIR / "requirements-chatterbox.txt")
+        sidecar_closure = _distribution_names(SIDECAR_DIR / "requirements.lock.txt")
+        assert chatterbox, "the chatterbox requirements file parsed to zero distributions"
+        assert len(sidecar_closure) > 1, "the sidecar closure parsed to nothing — the parser is broken"
+        assert chatterbox - sidecar_closure, (
+            "every chatterbox distribution is already pinned in sidecar/requirements.lock.txt; "
+            "re-check whether this environment still needs its own --lockfile argument"
+        )

--- a/sidecar/tests/test_supply_chain_pins.py
+++ b/sidecar/tests/test_supply_chain_pins.py
@@ -327,50 +327,128 @@ GENERATED_APP_DIRS = frozenset({"node_modules", "dist", "out"})
 #: shape `.quality/charter_check.py` matches on, and for the same reason: a
 #: job-level or `with:`-block `name:` is a plain mapping key, not a step.
 STEP_NAME_KEY = re.compile(r"^\s*-\s+name:\s*(?P<value>\S.*)$")
-#: `--lockfile=<path>`; the trailing `\` of a shell line continuation is excluded
-#: from the path by the character class.
-LOCKFILE_ARG = re.compile(r"--lockfile[=\s]+(?P<path>[^\s\\]+)")
+#: any other key of the step mapping (`run:`, `if:`, `env:`, `working-directory:`).
+STEP_MAPPING_KEY = re.compile(r"^\s*(?P<key>[A-Za-z][\w-]*):(?P<rest>.*)$")
+#: a shell comment marker: `#` at line start or after whitespace.
+SHELL_COMMENT = re.compile(r"(?:^|\s)#")
+#: the block-scalar indicators that mean "the body is on the FOLLOWING lines".
+BLOCK_SCALARS = frozenset({"|", ">", "|-", ">-", "|+", ">+", "|2", ">2"})
+#: `--lockfile=<path>`. Quote characters and the trailing `\` of a shell line
+#: continuation are excluded from the path by the character class.
+LOCKFILE_ARG = re.compile(r"--lockfile[=\s]+(?P<path>[^\s\\'\"]+)")
 
 
-def _repo_rel(path: Path) -> str:
-    return path.relative_to(REPO_ROOT).as_posix()
+def _repo_rel(path: Path, root: Path) -> str:
+    return path.relative_to(root).as_posix()
+
+
+def _strip_shell_comment(line: str) -> str:
+    """Everything from the first shell comment marker onward is not an argument."""
+    marker = SHELL_COMMENT.search(line)
+    return line[: marker.start()] if marker else line
+
+
+def gate_deps_run_script(workflow_text: str) -> str:
+    """The ``run:`` script of the ``gate-deps`` step, and nothing else.
+
+    Scoping to ``run:`` — rather than to "every line of the step" — is what keeps
+    a ``--lockfile`` named in a step-level ``if:``/``env:``/``with:`` value out of
+    the count. Both the inline (``run: osv-scanner …``) and block-scalar
+    (``run: |``) forms are handled.
+    """
+    in_step = in_run = False
+    script: list[str] = []
+    for raw in workflow_text.splitlines():
+        step = STEP_NAME_KEY.match(raw)
+        if step:
+            in_step = step.group("value").startswith("gate-deps")
+            in_run = False
+            continue
+        if not in_step:
+            continue
+        key = STEP_MAPPING_KEY.match(raw)
+        if key:
+            inline = key.group("rest").strip()
+            in_run = key.group("key") == "run" and inline in BLOCK_SCALARS
+            if key.group("key") == "run" and not in_run:
+                script.append(inline)
+            continue
+        if in_run:
+            script.append(raw)
+    return "\n".join(script)
+
+
+def shell_commands(script: str) -> list[str]:
+    """``script`` split into logical shell commands, comments removed.
+
+    Trailing ``\\`` continuations are joined so a multi-line invocation is ONE
+    command; that is what lets the caller ask "which command is this argument
+    actually on?" instead of trusting a bare line match.
+    """
+    commands: list[str] = []
+    pending = ""
+    for raw in script.splitlines():
+        line = _strip_shell_comment(raw).strip()
+        if not line:
+            continue
+        if line.endswith("\\"):
+            pending += line[:-1].rstrip() + " "
+            continue
+        commands.append((pending + line).strip())
+        pending = ""
+    if pending:
+        commands.append(pending.strip())
+    return commands
 
 
 def gate_deps_lockfile_args(workflow_text: str) -> set[str]:
-    """The ``--lockfile`` paths the ``gate-deps`` STEP actually passes.
+    """The ``--lockfile`` paths the ``gate-deps`` osv-scanner COMMAND passes.
 
-    Measure the FIELD, not the document. Two shapes in this workflow would
-    otherwise let a deleted lockfile keep satisfying the invariant below: the
-    explanatory comment block directly above the step names all three original
-    lockfiles in prose, and a ``#``-disabled argument inside the ``run:`` body is
-    not an argument at all. So the scan is scoped to the lines that follow the
-    ``gate-deps`` step name (up to the next step) and skips comment lines.
+    Measure the FIELD, not the document — and specifically, measure the COMMAND.
+    Four shapes in a workflow can name a lockfile without passing it, and all
+    four were counted by the first version of this function (each is now pinned
+    by :class:`TestArgParserMeasuresTheCommandNotTheDocument`): the explanatory
+    comment block above the step names lockfiles in prose; a ``#``-disabled
+    argument line; a *trailing* ``#`` mention on a live argument line; and an
+    ``echo`` of an argument inside the ``run:`` body. So the scan reads only the
+    step's ``run:`` script, strips shell comments, joins ``\\`` continuations
+    into logical commands, and accepts arguments ONLY from a command whose
+    executable is ``osv-scanner``.
+
+    Scope of that claim, measured rather than assumed (this is a line walker, not
+    a YAML+shell parser). NOT handled: a ``--lockfile`` inside a heredoc body, a
+    path built by variable expansion, an ``osv-scanner`` invoked through a
+    wrapper (``xargs``/``bash -c``/a script), and a flow-style ``- {name: …}``
+    step. Every one of those DROPS an argument, which makes the invariant report
+    the environment as unscanned and fails CI loudly; none can add a phantom
+    argument. That is the same fail-closed error direction
+    ``.quality/charter_check.py`` documents for its own parser, and it is the
+    direction that matters here — a false GREEN on a security gate is the
+    dangerous one.
     """
-    inside = False
     found: set[str] = set()
-    for line in workflow_text.splitlines():
-        step = STEP_NAME_KEY.match(line)
-        if step:
-            inside = step.group("value").startswith("gate-deps")
+    for command in shell_commands(gate_deps_run_script(workflow_text)):
+        if not command.startswith("osv-scanner"):
             continue
-        if not inside or line.lstrip().startswith("#"):
-            continue
-        found.update(match.group("path") for match in LOCKFILE_ARG.finditer(line))
+        found.update(match.group("path") for match in LOCKFILE_ARG.finditer(command))
     return found
 
 
-def shipped_dependency_manifests() -> dict[str, frozenset[str]]:
+def shipped_dependency_manifests(repo_root: Path | None = None) -> dict[str, frozenset[str]]:
     """``{environment -> the manifests that would cover it}``, read off disk.
 
-    Deliberately NOT a hardcoded list: the whole point of the invariant is that a
-    FOURTH environment cannot be introduced unscanned, and a literal list would
-    be edited by the very commit that introduces one.
+    Deliberately NOT a hardcoded list: a literal list would be edited by the very
+    commit that introduces a new environment, so discovery is the point.
 
-    * one environment per npm tree — ``app/`` plus every immediate subdirectory
-      that owns a committed ``package-lock.json``;
-    * one per ``sidecar/requirements*.txt`` (the resolved closure the gate has
-      read since it was written);
-    * one per ``sidecar/runtime_setup/requirements-<env>.txt`` — the first-run
+    Discovered shapes, and ONLY these (``repo_root`` defaults to this repo; it is
+    a parameter so :class:`TestDiscoveryScopeIsTheThreeGlobs` can plant manifests
+    in a throwaway tree and pin the boundary):
+
+    * ``app/package-lock.json`` and ``app/<immediate-subdir>/package-lock.json``
+      — one environment per npm tree;
+    * ``sidecar/requirements*.txt`` — the resolved closure the gate has read
+      since it was written;
+    * ``sidecar/runtime_setup/requirements*.txt`` — the first-run
       ``pip --target`` environments. A sibling ``requirements-<env>.lock.txt`` is
       an F1 build-prep artifact that is generated rather than committed, so
       scanning EITHER file covers that environment; hence a SET per environment
@@ -378,22 +456,30 @@ def shipped_dependency_manifests() -> dict[str, frozenset[str]]:
 
     Both globs are single-level on purpose: a recursive walk would descend into
     ``sidecar/.venv`` and ``app/node_modules`` and pick up third-party
-    requirements files that this repo does not ship.
+    requirements files that this repo does not ship. The cost of that choice is
+    stated, not hidden: a manifest anywhere ELSE — a repo-root lockfile, two
+    levels under ``app/``, a sibling top-level tree, a ``sidecar/envs/…`` tree, a
+    pin list not named ``requirements*``, or a dependency set declared as a
+    ``pyproject.toml`` extra (which is how the live ``reframe-gpu`` extra escapes
+    this gate) — is NOT discovered and therefore NOT demanded by the invariant.
     """
+    root = REPO_ROOT if repo_root is None else repo_root
+    app_dir = root / "app"
+    sidecar_dir = root / "sidecar"
     environments: dict[str, set[str]] = {}
     npm_roots = [
-        APP_DIR,
-        *(d for d in sorted(APP_DIR.iterdir()) if d.is_dir() and d.name not in GENERATED_APP_DIRS),
+        app_dir,
+        *(d for d in sorted(app_dir.iterdir()) if d.is_dir() and d.name not in GENERATED_APP_DIRS),
     ]
-    for root in npm_roots:
-        lock = root / "package-lock.json"
+    for npm_root in npm_roots:
+        lock = npm_root / "package-lock.json"
         if lock.is_file():
-            environments[_repo_rel(lock)] = {_repo_rel(lock)}
-    for req in sorted(SIDECAR_DIR.glob("requirements*.txt")):
-        environments[_repo_rel(req)] = {_repo_rel(req)}
-    for req in sorted(RUNTIME_SETUP_DIR.glob("requirements*.txt")):
+            environments[_repo_rel(lock, root)] = {_repo_rel(lock, root)}
+    for req in sorted(sidecar_dir.glob("requirements*.txt")):
+        environments[_repo_rel(req, root)] = {_repo_rel(req, root)}
+    for req in sorted((sidecar_dir / "runtime_setup").glob("requirements*.txt")):
         env = req.name.removesuffix(".txt").removesuffix(".lock")
-        environments.setdefault(env, set()).add(_repo_rel(req))
+        environments.setdefault(env, set()).add(_repo_rel(req, root))
     return {name: frozenset(paths) for name, paths in environments.items()}
 
 
@@ -498,6 +584,164 @@ class TestDepsGateCoversEveryShippedEnv:
         assert mutated != body, f"no --lockfile argument for {target} was found to comment out"
         assert target not in gate_deps_lockfile_args(mutated)
 
+
+class TestArgParserMeasuresTheCommandNotTheDocument:
+    """Only the osv-scanner COMMAND counts — a *mention* is not an argument.
+
+    Every case below was executed against the FIRST version of
+    :func:`gate_deps_lockfile_args`, which skipped a line only when its first
+    non-space character was ``#``. Three shapes leaked through it and were
+    counted as scanned lockfiles: a trailing ``#`` mention on a live argument
+    line, an ``echo`` inside the ``run:`` body, and an ``if:`` expression. The
+    last test is the dangerous one — with the chatterbox argument DELETED and
+    re-mentioned as a trailing comment, the invariant above reported
+    ``missing = {}`` (GREEN) while the gate no longer scanned the file at all.
+    False-GREEN on a security gate is the wrong error direction, so all four are
+    asserted permanently rather than measured once.
+    """
+
+    @staticmethod
+    def _run_block(*body: str) -> str:
+        return "\n".join(["      - name: gate-deps osv-scanner", "        run: |", *body])
+
+    @classmethod
+    def _osv_command(cls, *arg_lines: str) -> str:
+        """A ``gate-deps`` step whose run body is ONE continued osv-scanner call."""
+        return cls._run_block("          osv-scanner scan source \\", *arg_lines)
+
+    # --- detector control: the parser must SEE a known-present argument ------ #
+    def test_a_real_argument_is_seen(self):
+        assert gate_deps_lockfile_args(self._osv_command("            --lockfile=real/a.json")) == {"real/a.json"}
+
+    def test_an_inline_run_argument_is_seen(self):
+        text = "\n".join(
+            [
+                "      - name: gate-deps osv-scanner",
+                "        run: osv-scanner scan source --lockfile=real/a.json",
+            ]
+        )
+        assert gate_deps_lockfile_args(text) == {"real/a.json"}
+
+    # --- the four shapes that must NOT count -------------------------------- #
+    def test_a_whole_line_comment_argument_is_not_seen(self):
+        assert gate_deps_lockfile_args(self._osv_command("            # --lockfile=dead/b.json")) == set()
+
+    def test_a_trailing_comment_mention_is_not_seen(self):
+        text = self._osv_command("            --lockfile=real/a.json  # --lockfile=ghost/c.json")
+        assert gate_deps_lockfile_args(text) == {"real/a.json"}
+
+    def test_an_echoed_mention_inside_the_run_body_is_not_seen(self):
+        # A SEPARATE command in the same run body. (An `echo` glued on by a `\`
+        # continuation genuinely IS part of the osv-scanner argv, so that shape is
+        # not the hole — this one is.)
+        text = self._run_block(
+            "          echo '--lockfile=ghost/d.json'",
+            "          osv-scanner scan source --lockfile=real/a.json",
+        )
+        assert gate_deps_lockfile_args(text) == {"real/a.json"}
+
+    def test_a_mention_in_a_step_level_if_expression_is_not_seen(self):
+        text = "\n".join(
+            [
+                "      - name: gate-deps osv-scanner",
+                "        if: contains(github.event.head_commit.message, '--lockfile=ghost/e.json')",
+                "        run: osv-scanner scan source --lockfile=real/a.json",
+            ]
+        )
+        assert gate_deps_lockfile_args(text) == {"real/a.json"}
+
+    # --- end to end on the REAL committed workflow --------------------------- #
+    def test_a_deleted_argument_cannot_be_faked_by_a_trailing_comment(self):
+        target = "sidecar/runtime_setup/requirements-chatterbox.txt"
+        survivor = "--lockfile=sidecar/runtime_setup/requirements-sidecar.txt"
+        body = QUALITY_WORKFLOW.read_text(encoding="utf-8")
+        stripped = re.sub(rf"^.*--lockfile={re.escape(target)}.*$\n?", "", body, flags=re.MULTILINE)
+        assert f"--lockfile={target}" not in stripped, "the argument survived removal — this probe is broken"
+        assert survivor in stripped, "the surviving argument this case hangs the comment on is gone"
+        faked = stripped.replace(survivor, f"{survivor}  # dropped --lockfile={target}")
+        scanned = gate_deps_lockfile_args(faked)
+        assert target not in scanned, f"a commented-out mention was counted as an argument: {sorted(scanned)}"
+        still_missing = sorted(name for name, paths in shipped_dependency_manifests().items() if not (paths & scanned))
+        assert still_missing == ["requirements-chatterbox"]
+
+
+class TestDiscoveryScopeIsTheThreeGlobs:
+    """Pin exactly which manifest shapes discovery CAN and cannot see.
+
+    The W23 summary sentences originally said a fourth environment "cannot be
+    added unscanned" without qualification. Three independent reviewers REFUTED
+    that by executing :func:`shipped_dependency_manifests` against synthetic trees
+    with a manifest planted outside the three globs — a ``pyproject.toml`` extra,
+    a repo-root lockfile, one two levels under ``app/``, a sibling top-level tree,
+    a ``sidecar/envs/…`` tree, and a pin list not named ``requirements*``. The
+    code was right and the sentences were wider than the evidence, so the real
+    boundary is asserted here instead of merely described. Widening a glob is a
+    deliberate change that must update this test AND the prose in the same commit.
+    """
+
+    @staticmethod
+    def _tree(root: Path, *relative: str) -> Path:
+        (root / "app").mkdir(parents=True, exist_ok=True)
+        (root / "sidecar" / "runtime_setup").mkdir(parents=True, exist_ok=True)
+        for rel in relative:
+            target = root / rel
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text("# planted\n", encoding="utf-8")
+        return root
+
+    @pytest.mark.parametrize(
+        "planted",
+        [
+            "app/package-lock.json",
+            "app/render-cli/package-lock.json",
+            "sidecar/requirements.lock.txt",
+            "sidecar/runtime_setup/requirements-newenv.txt",
+        ],
+    )
+    def test_a_manifest_in_a_discovered_shape_is_found(self, tmp_path, planted: str):
+        """Detector control. Without this, every zero below would be meaningless."""
+        environments = shipped_dependency_manifests(self._tree(tmp_path, planted))
+        assert any(planted in paths for paths in environments.values()), (
+            f"discovery missed {planted}, which it is supposed to find: {environments}"
+        )
+
+    @pytest.mark.parametrize(
+        "planted",
+        [
+            "package-lock.json",  # repo root
+            "app/renderer/plugins/package-lock.json",  # two levels under app/
+            "tools/cli/package-lock.json",  # a sibling top-level tree
+            "sidecar/envs/whisperx/requirements.txt",  # nested under sidecar/
+            "sidecar/runtime_setup/gpu-pins.txt",  # not named requirements*
+            "sidecar/pyproject.toml",  # a dependency set declared as an extra
+        ],
+    )
+    def test_a_manifest_outside_the_three_globs_is_not_found(self, tmp_path, planted: str):
+        environments = shipped_dependency_manifests(self._tree(tmp_path, planted))
+        assert not any(planted in paths for paths in environments.values()), (
+            f"discovery now sees {planted}. That is an improvement, not a failure — but the "
+            f"claim in QUALITY-CHARTER.md, osv-scanner.toml and this module's docstring must be "
+            f"widened in the same commit, and this case moved to the discovered-shapes list."
+        )
+
+    def test_the_live_reframe_gpu_extra_is_a_real_instance_of_that_gap(self):
+        """The gap is not hypothetical: it is why ``reframe-gpu`` is unscanned.
+
+        ``sidecar/pyproject.toml`` declares a ``reframe-gpu`` extra with its own
+        pinned torch, and the SHIPPED sidecar tells the user to install it at
+        runtime — yet no scanned manifest contains those pins, and a pyproject
+        extra is not a shape discovery looks at. Asserted here so the honest scope
+        of gate 6 cannot silently drift back to "every shipped environment".
+        """
+        pyproject = (SIDECAR_DIR / "pyproject.toml").read_text(encoding="utf-8")
+        assert "reframe-gpu" in pyproject, "the reframe-gpu extra is gone; retire this test and the caveats"
+        assert re.search(r"^\s*\"torch==", pyproject, flags=re.MULTILINE), "reframe-gpu no longer pins torch"
+        assert "sidecar/pyproject.toml" not in gate_deps_lockfile_args(QUALITY_WORKFLOW.read_text(encoding="utf-8"))
+        assert "torch" not in _distribution_names(SIDECAR_DIR / "requirements.lock.txt")
+        assert "torch" not in _distribution_names(RUNTIME_SETUP_DIR / "requirements-sidecar.txt")
+
+
+class TestDepsGateChatterboxRationale:
     # --- WHY the chatterbox env needs its own argument ----------------------- #
     def test_the_chatterbox_env_pins_distributions_no_other_manifest_covers(self):
         """``sidecar/requirements.lock.txt`` structurally cannot cover this env.


### PR DESCRIPTION
## The hole

A shipped Python environment had **no coverage in the blocking `deps` gate**. `quality.yml` passed
exactly three `--lockfile` arguments; `sidecar/runtime_setup/requirements-chatterbox.txt` — which
pins its own `torch==2.10.0+cu128`, a build `sidecar/requirements.lock.txt` structurally cannot
contain because `pyproject.toml` forbids chatterbox torch in the main env — was not one of them.

**Scoped correctly, because the first wording was refuted:** an earlier draft said that environment
"was scanned by nothing at all". That is false. GitHub's dependency graph *has* ingested it and has
raised 8 CVE alerts against it. The true claim is that it had **no coverage in the BLOCKING gate** —
only the advisory Dependabot rail saw it, and an advisory rail cannot fail a PR.

## What changed

The `deps` gate went from **3 lockfiles / 780 packages → 5 / 796**, adding *both* first-run
`pip --target` environments (`requirements-sidecar.txt`: 13 packages, zero findings;
`requirements-chatterbox.txt`: 3 packages, one finding). No dependency moved — only what the gate
can **see**. `QUALITY-CHARTER.md` is updated in the same commit, since `.quality/charter_check.py`
enforces charter↔workflow parity in both directions. **No 7th gate was added** — the charter's
6-gate list is closed and stays closed.

A new invariant in `test_supply_chain_pins.py` fails whenever a discovered shipped environment has
no argument in the gate, so the lazy escape — deleting the new `--lockfile` line — now fails
closed. W23 cannot be silently undone.

## The lane refuted its own gate, twice

* **The lockfile-arg parser counted MENTIONS as arguments** — a false-GREEN. It now fails closed on
  a trailing-`#` mention, an `echo` in the run body, a step-level `if:`, a whole-line comment, and
  `if false; then osv-scanner …`, each verified with two working controls.
* **A wheel-index over-generalisation**: the claim "no fixed `+cu128` wheel exists" had generalised
  a probe of *one* index to the whole family. `cu126`/`cu129`/`cu130` all publish torch 2.13.0.
  (The verifier's own first probe was broken too — the listing URL-encodes `+` as `%2B` — and it
  said so rather than shipping the result.)

## The one ignore is load-bearing, not a convenience suppression

`GHSA-rrmf-rvhw-rf47` (torch, CVSS 5.3, local-only vector) is ignored with a dated expiry, and the
reasoning is measured rather than asserted:

* **torchaudio is the real blocker, not torch.** `torchaudio==2.10.0` hard-pins `torch==2.10.0`,
  and torchaudio tops out at **2.11.0** across seven probed indexes plus PyPI. So there is no
  adoptable pair in which torch is >= 2.13.0.
* It **reconciles with the owner's existing decision** rather than re-deciding it: alert #272 was
  already dismissed `tolerable_risk` on 2026-07-18, and `.github/dependabot.yml:19-26` names
  CVE-2025-3000 explicitly. That is cited as corroboration; the ignore itself rests on the
  unfixability measurement.
* It **declines to claim "provably unreachable"** — no call-graph analysis was done — and names the
  settling experiment (unpack the chatterbox-tts closure, search for `jit.script`/`jit.trace`).
* It **discloses its own blast radius**: an osv ignore is keyed by vulnerability ID, so adding
  `sidecar/pyproject.toml` to the gate later would silently pass that env's `torch==2.6.0`.

## Two things for the plan, not for this diff

1. **`docs/plans/v1.5/PROGRAM.md:19` should be updated, not scheduled.** It wants torch unified at
   **2.11**. Measured against the OSV record (introduced 0 → fixed 2.13.0, last-known-affected
   `<= 2.12.1`), **2.11.0 is inside the affected range** — that bump would not have cleared this
   advisory.
2. **A designed time bomb, disclosed on purpose:** on **2026-11-10** the ignore expires and gate 6
   goes RED. `.github/dependabot.yml:27-29` ignores torch outright, so nothing will auto-propose a
   fix — GPU-validated CUDA pins must never move via an unattended PR. The `ignoreUntil` date is
   the only scheduled prompt to re-run the probes.

## Residuals (non-blocking, disclosed)

* The parser's list of not-handled shapes is not proven exhaustive — three phantom-add shapes exist
  outside it, none present at HEAD, each needing a future careless workflow edit. It is still a net
  new defence over `origin/main`, which had no invariant at all.
* `charter_check.py` maps gate slugs to steps; it does not verify the charter's lockfile *list*, so
  that prose is not machine-enforced. Pre-existing shape, not introduced here.
* UNVERIFIED: that the linux osv-scanner build parses the two new files identically to the Windows
  build measured here — settled by the first CI `gate-deps` run.

Produced under the same adversarial pipeline: TDD → 3 refuters → remediation → fresh skeptic.
CI is the arbiter. This merges only if `quality` is green.
