### PR TITLE
test(e2e): prove speech becomes a transcript and a caption through the real GUI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -211,12 +211,39 @@ jobs:
       # loudly on the macOS/Linux legs. Installing ~200 MB of ctranslate2 /
       # onnxruntime / tokenizers wheels for a spec that skips would be pure cost.
       #
-      # PINNED to the version in `sidecar/requirements.lock.txt` (== what the
-      # shipped app runs) per A6 lesson 5 — deliberately unlike the e2e-sidecar
+      # PINNED to `sidecar/requirements.lock.txt` (== what the shipped app runs),
+      # TRANSITIVES INCLUDED, per A6 lesson 5 — deliberately unlike the e2e-sidecar
       # job's unpinned `faster-whisper`, so a new upstream release cannot silently
-      # change this nightly's ASR behaviour. Its own pinned transitives
-      # (ctranslate2 4.8.1 / tokenizers 0.23.1 / onnxruntime 1.28.0 / av 17.1.0)
-      # come along as declared dependencies.
+      # change this nightly's ASR behaviour.
+      #
+      # REFUTED WORDING, recorded so it cannot be reintroduced: this comment used
+      # to claim faster-whisper's "own pinned transitives (ctranslate2 4.8.1 /
+      # tokenizers 0.23.1 / onnxruntime 1.28.0 / av 17.1.0) come along as declared
+      # dependencies". faster-whisper 1.2.1 pins NOTHING. MEASURED with
+      # `importlib.metadata.requires('faster-whisper')`: `ctranslate2<5,>=4.0`,
+      # `onnxruntime<2,>=1.14`, `tokenizers<1,>=0.13`, `av>=11` — all open ranges.
+      # And a bare `pip install "faster-whisper==1.2.1"` on this box resolved
+      # av 18.0.0 + numpy 2.5.2 against lock `av==17.1.0` (:17) and `numpy==2.5.1`
+      # (:107). So the reproducibility rationale was false exactly where it
+      # mattered: ctranslate2 IS the inference engine and onnxruntime IS the VAD
+      # runtime, and both floated freely inside their major bounds.
+      #
+      # `--constraint` makes that original claim TRUE rather than merely rewording
+      # it. MEASURED in a fresh venv (Windows, CPython 3.12) — every transitive
+      # lands lock-exact: faster-whisper 1.2.1 · ctranslate2 4.8.1 · tokenizers
+      # 0.23.1 · onnxruntime 1.28.0 · av 17.1.0 · numpy 2.5.1 · huggingface-hub
+      # 1.26.0 · tqdm 4.70.0, pip exit 0. `--constraint` and not `-r <lock>`
+      # because `-r` would install the WHOLE sidecar runtime and would fight the
+      # deliberate `opencv-python-headless==4.13.0.92` pin above (the lock carries
+      # `opencv-python==4.14.0.94`, a different distribution); a constraint only
+      # bounds packages already in faster-whisper's own resolution closure. The
+      # lock is constraint-safe: plain `==` lines plus pip-compile `# via`
+      # comments, and zero URLs / hashes / extras (which pip rejects in a
+      # constraints file).
+      # UNVERIFIED on a GitHub runner (measured here on the same OS family and the
+      # same CPython minor, so the wheel set should match — likely, 80%); the
+      # settling experiment is the next nightly, whose pip log prints every
+      # resolved version.
       #
       # NO `assets.ensure` step, on purpose. The spec pins whisper `tiny` via the
       # real `settings.set`, and `tiny` is NOT a registered manifest asset — so
@@ -228,7 +255,7 @@ jobs:
       # and is NOT an offline proof.
       - name: Install the ASR runtime for the speech-to-caption journey (Windows only)
         if: runner.os == 'Windows'
-        run: pip install "faster-whisper==1.2.1"
+        run: pip install "faster-whisper==1.2.1" --constraint sidecar/requirements.lock.txt
 
       - name: Install app deps
         working-directory: app
@@ -325,18 +352,34 @@ jobs:
       # (multi-minute, network) and cannot answer RPCs inside a CI window — a
       # documented packaged-runtime limitation, not a regression (see app/e2e/README).
       #
-      # transcribe-journey.spec (speech -> transcript -> caption) runs HERE and only
-      # here: it needs Windows SAPI for its speech fixture, so the macOS/Linux legs
-      # above self-skip it with a named reason. RF_E2E_DEV=1 puts it on the dev
-      # build, whose sidecar is the system python the ASR step above installed
-      # faster-whisper into.
+      # transcribe-journey.spec (speech -> transcript -> caption) is EXCLUDED here
+      # and runs in its OWN step AFTER the visual+a11y suite below. Why: a red
+      # Playwright step makes every LATER step inherit GitHub's implicit success()
+      # gate, and the BLOCKING visual/a11y diff step below deliberately does NOT
+      # carry always() (it must stay a real gate — see the comment there). This repo
+      # has already MEASURED that cascade on run 30612141716. A separate spec FILE
+      # is not separate CI exposure: playwright.config.ts testMatch is
+      # '**/*.spec.ts', so the new spec would otherwise join THIS one invocation —
+      # and by its own account it is the most fragile member (it needs an `en-*`
+      # SAPI voice on the runner and huggingface.co egress, both UNVERIFIED on a
+      # GitHub image), so its first red would silently drop visual+a11y coverage.
+      # Excluding it here keeps the pre-existing gate order intact and costs nothing.
+      #
+      # `--grep-invert` matches the spec's FILE PATH, verified with a detector
+      # control on this box: `--list` alone enumerates 27 tests including the 2
+      # transcribe-journey ones; with `--grep-invert transcribe-journey` it
+      # enumerates exactly those 25 others. Tripwire: rename the spec file and the
+      # exclusion silently stops matching (it would then run twice, restoring the
+      # cascade) — keep the pattern and the filename in sync.
+      # The macOS/Linux legs above need no exclusion: the spec self-skips there
+      # with a named reason (Windows SAPI).
       - name: E2E GUI — Playwright Electron (Windows packaged .exe + dev-build pipeline)
         if: runner.os == 'Windows'
         working-directory: app
         env:
           RF_PY: ${{ steps.setup-python.outputs.python-path }}
           RF_E2E_DEV: "1"
-        run: npm run test:e2e
+        run: npm run test:e2e -- --grep-invert "transcribe-journey"
 
       # WAVE-2b VISUAL + A11Y — Windows ONLY. The visual screenshot baselines are
       # platform-specific (committed as `*-win32.png`), so this suite runs on the
@@ -382,6 +425,26 @@ jobs:
           RF_PY: ${{ steps.setup-python.outputs.python-path }}
           RF_E2E_DEV: "1"
         run: npm run test:e2e:visual:update
+
+      # SPEECH -> TRANSCRIPT -> CAPTION, deliberately LAST of the test steps.
+      # It runs on Windows only (its fixture synthesises speech with Windows SAPI;
+      # the macOS/Linux legs self-skip it loudly), on the dev build, whose sidecar is
+      # the system python the ASR step above installed faster-whisper into.
+      #
+      # Placed after the visual/a11y gate ON PURPOSE: this is the leg with the most
+      # environmental dependencies (an `en-*` SAPI voice on the image, huggingface.co
+      # reachable for the 74.6 MB `tiny` snapshot), so if anything here goes red it
+      # must not be able to skip a suite that would otherwise have run. Everything
+      # after this point carries always(), so a red here suppresses no artifact.
+      #
+      # NO always() here: this IS a gate for the nightly, and a red must fail the leg.
+      - name: E2E GUI — Playwright Electron (speech -> transcript -> caption) [Windows only]
+        if: runner.os == 'Windows'
+        working-directory: app
+        env:
+          RF_PY: ${{ steps.setup-python.outputs.python-path }}
+          RF_E2E_DEV: "1"
+        run: npx playwright test --config playwright.config.ts transcribe-journey
 
       - name: Upload regenerated visual baselines
         if: always() && runner.os == 'Windows' && github.event.inputs.update_visual_baselines == 'true'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,13 @@ name: e2e
 #   * sidecar  : real_pipeline_smoke.py   (standalone real-ffmpeg + tiny-whisper
 #                                          short-making pipeline)
 #   * app      : npm run test:e2e         (Playwright Electron GUI E2E — preview +
-#                                          PACKAGED `app.isPackaged` proof)
+#                                          PACKAGED `app.isPackaged` proof + the
+#                                          golden Make-Shorts journey + the
+#                                          SPEECH-to-caption journey, which is
+#                                          WINDOWS-ONLY and self-skips loudly
+#                                          elsewhere — it synthesises its own
+#                                          speech with Windows SAPI, see
+#                                          app/e2e/transcribe-journey.spec.ts)
 #   * app      : npm run test:e2e:dom     (vitest DOM caption-over-video + nasty-
 #                                          caption proofs)
 #   * app      : npm run test:e2e:visual  (Wave-2b VISUAL screenshot-diff +
@@ -192,6 +198,38 @@ jobs:
         # the e2e-sidecar job's install.
         run: pip install "opencv-python-headless==4.13.0.92" numpy httpx huggingface_hub
 
+      # --- WINDOWS ONLY: the ASR runtime for the speech-to-caption journey. ---
+      # transcribe-journey.spec.ts drives the REAL `transcribe.start` through the
+      # GUI, so the sidecar must be able to load a whisper model. The
+      # `sidecar[dev] --no-deps` install above deliberately omits faster-whisper,
+      # and WITHOUT it the transcribe job dies with ModuleNotFoundError — which the
+      # spec would surface as a named UI error, but a named error is still a red
+      # leg, not a proof.
+      #
+      # WINDOWS-ONLY because the spec is: its speech fixture synthesises audio with
+      # Windows SAPI (`System.Speech.Synthesis.SpeechSynthesizer`) and `test.skip()`s
+      # loudly on the macOS/Linux legs. Installing ~200 MB of ctranslate2 /
+      # onnxruntime / tokenizers wheels for a spec that skips would be pure cost.
+      #
+      # PINNED to the version in `sidecar/requirements.lock.txt` (== what the
+      # shipped app runs) per A6 lesson 5 — deliberately unlike the e2e-sidecar
+      # job's unpinned `faster-whisper`, so a new upstream release cannot silently
+      # change this nightly's ASR behaviour. Its own pinned transitives
+      # (ctranslate2 4.8.1 / tokenizers 0.23.1 / onnxruntime 1.28.0 / av 17.1.0)
+      # come along as declared dependencies.
+      #
+      # NO `assets.ensure` step, on purpose. The spec pins whisper `tiny` via the
+      # real `settings.set`, and `tiny` is NOT a registered manifest asset — so
+      # `transcribe.resolve_model_source` hands faster-whisper the bare id and it
+      # fetches the ~75 MB snapshot from huggingface.co at run time. MEASURED
+      # alternative: provisioning the registered Default-profile asset instead
+      # (`whisper-large-v3-turbo`) is 1546.5 MB. This leg therefore carries the SAME
+      # network dependency the e2e-sidecar job's real_pipeline_smoke.py already has,
+      # and is NOT an offline proof.
+      - name: Install the ASR runtime for the speech-to-caption journey (Windows only)
+        if: runner.os == 'Windows'
+        run: pip install "faster-whisper==1.2.1"
+
       - name: Install app deps
         working-directory: app
         run: npm ci
@@ -286,6 +324,12 @@ jobs:
       # COLD packaged launch pip-installs the heavy sidecar runtime on first run
       # (multi-minute, network) and cannot answer RPCs inside a CI window — a
       # documented packaged-runtime limitation, not a regression (see app/e2e/README).
+      #
+      # transcribe-journey.spec (speech -> transcript -> caption) runs HERE and only
+      # here: it needs Windows SAPI for its speech fixture, so the macOS/Linux legs
+      # above self-skip it with a named reason. RF_E2E_DEV=1 puts it on the dev
+      # build, whose sidecar is the system python the ASR step above installed
+      # faster-whisper into.
       - name: E2E GUI — Playwright Electron (Windows packaged .exe + dev-build pipeline)
         if: runner.os == 'Windows'
         working-directory: app

--- a/app/e2e/README.md
+++ b/app/e2e/README.md
@@ -12,10 +12,65 @@ against the actual built Electron app and the live Python sidecar — no stubs.
 | `packaged.spec.ts` | Launches the **shipped electron-builder package** (the real `.exe`, resolved via `electron-playwright-helpers` `findLatestBuild`/`parseElectronApp`) and asserts `app.isPackaged === true`, that it runs out of `resources/app.asar`, that the packaged renderer boots with no console errors, and that the packaged main process inherits the seeded env + fires its first-run bootstrap. **WINDOWS-ONLY** (self-skips elsewhere — only the Windows CI leg builds a package). | **PACKAGED-SHELL-VERIFIED** (the shipped binary boots & is correctly wired). |
 | `confirm-scrim.hittest.spec.ts` | Loads the REAL `renderer/src/components/confirmDialog.css` (+ `styles/tokens.css`) into a plain Chromium page and asks `document.elementFromPoint` whether a click behind the themed confirm gate reaches the page — the pointer half of its `aria-modal="true"`, which jsdom cannot observe because it does no layout and no hit-testing. Carries a **detector control** (the oracle must see the background when nothing covers it) and a **both-states control** that mounts the pre-fix `::before`-on-a-transformed-card stylesheet and REQUIRES the click to get through, so a green run cannot come from a probe that is silent everywhere. No Electron app or sidecar needed — the question is a property of one stylesheet. | **HIT-TEST-VERIFIED** (real Chromium, real stylesheet). |
 | `nasty_captions.dom.test.tsx` | Feeds the real `CaptionOverlay` hostile caption data (unicode/RTL/emoji, empty/out-of-window cues, zero-duration/overlapping cues, a 10k-word timeline) and asserts graceful DOM output, never a crash. | **NASTY-INPUT-VERIFIED** (GUI leg). |
+| `transcribe-journey.spec.ts` | Synthesises **real speech** with Windows SAPI, muxes it over the same `testsrc` video, seeds it through the real `library.add`, pins whisper `tiny`/`cpu` through the real `settings.set`, then drives the GUI: the Transcribe panel's **empty** state → the real **Start transcription** → the rendered `.transcript-segments` must carry the spoken content words → the Subtitles panel's real **Generate subtitles** → a rendered cue must carry one of the same words. **WINDOWS-ONLY** (SAPI; self-skips loudly elsewhere). | **GUI-VERIFIED** (live app + live sidecar + real faster-whisper). |
 
 `DirectorPanel` is NOT mounted anywhere in the running renderer (only its own
 file + unit test exist), so it is covered by its existing
 `panels/DirectorPanel.test.tsx`, not by a GUI assertion.
+
+### Speech → transcript → caption: what `transcribe-journey.spec.ts` does and does NOT prove
+
+Until it existed, **no test in the repository proved that a spoken word becomes
+text or a caption.** The only media fixture was `testsrc` + a 440 Hz `sine`, so
+`golden-journey.spec.ts` deliberately takes the manual-range path (AI moment-pick
+emits "no candidates" on no-speech audio), `sidecar/tests/e2e/real_pipeline_smoke.py`
+*asserts an empty transcript* and says so in its own output, and
+`sidecar/tests/e2e/test_whisper_offline_e2e.py` proves model *resolution* with fake
+weights without ever transcribing audio. That was a **verification** hole, not
+necessarily a product defect — the new spec settles it in the affirmative.
+
+It **does** prove, through the live GUI: real audio → real faster-whisper →
+a transcript the user can SEE in the Transcribe panel → real `subtitles.generate`
+→ cues the user can SEE and edit in the Subtitles panel.
+
+It does **not** prove the *live `CaptionOverlay` painted over the video frame* —
+that surface (`CandidateReview`) still sits behind LLM clip selection, so the
+`caption.dom.test.tsx` row above remains the honest level for caption-over-video.
+
+Three deliberate design choices, each with its reason in the source:
+
+- **Keyword + threshold, never an exact phrase.** Measured with the shipped stack
+  (faster-whisper 1.2.1, `tiny`, cpu/int8) the word "Reframe" comes back as
+  "Refrain". An exact-sentence or product-name assertion would be flaky *by
+  construction*. The spec requires ≥ 2 of `fox` / `dog` / `landscape` / `vertical`
+  (`fixtures.SPEECH_KEYWORD_MIN_HITS`); do not "tighten" it to 4 — which specific
+  words survive depends on the machine's installed voice.
+- **No committed audio binary.** The repo tracks zero media binaries; Windows SAPI
+  synthesises the speech offline at test time. The cost is that the spec is
+  Windows-only, so it `test.skip()`s with a named reason *and prints it*.
+- **`tiny` pinned via `settings.set`.** Measured: the Default-profile whisper asset
+  (`whisper-large-v3-turbo`) is **1546.5 MB**; `Systran/faster-whisper-tiny` is
+  **74.6 MB**, and `tiny` is already what `real_pipeline_smoke.py` runs in the same
+  workflow. Because `tiny` is *not* a registered manifest asset,
+  `transcribe.resolve_model_source` hands faster-whisper the bare id and the
+  snapshot is fetched from huggingface.co at run time — measured on a cold, empty
+  `HF_HOME`: 13 files / 74.6 MB. **So this leg needs network; it is NOT an offline
+  proof** (the same dependency the `e2e-sidecar` leg already carries). Making it
+  offline would mean registering a pinned `tiny` asset, which adds a user-visible
+  component to `assets.list` for the sole benefit of a nightly test — deliberately
+  not done.
+
+**BOTH-STATES verified** (a test that passes in both states measures nothing).
+Same spec, same code, only the fixture's audio changed:
+
+| fixture audio | result |
+| --- | --- |
+| SAPI speech | **PASS** — keyword hits 4/4, 2 cues both carrying keywords |
+| speechless `sine` (the pre-existing fixture) | **FAIL** — "the transcription completed but produced ZERO segments" |
+
+**It gates nothing.** `e2e.yml` is `workflow_dispatch` + nightly `cron` only, so
+this proves the capability nightly and on demand; it cannot prevent a
+transcription regression from merging.
 
 ### Packaged data-pipeline: a documented CI limitation
 
@@ -82,13 +137,22 @@ npm run test:e2e:visual:update  # regenerate the `*-win32.png` baselines
 - Python 3.12 reachable as `py -3.12` (or set `RF_PY` to the interpreter path).
   The sidecar runs on the **standard library only** — no ML deps needed for the
   preview path (`library.add` / `library.list` / `media.playable` / `nle.export`).
+- `transcribe-journey.spec.ts` ONLY: `faster-whisper==1.2.1` in that interpreter
+  (`e2e.yml` installs it on the Windows leg), plus network access to
+  huggingface.co for the 74.6 MB `tiny` snapshot on the first run. Windows only —
+  the speech fixture needs SAPI. It needs no `assets.ensure` and no GPU (it pins
+  `transcribeDevice: 'cpu'`).
 
 ## Run
 
 ```sh
-npm run test:e2e        # Playwright Electron GUI E2E (preview.spec.ts)
+npm run test:e2e        # every Playwright Electron GUI spec
 npm run test:e2e:dom    # vitest DOM proof (caption.dom.test.tsx)
 npm run typecheck:e2e   # type-check the harness
+
+# one spec at a time (the arg is a regex over spec paths)
+npx playwright test --config playwright.config.ts preview
+npx playwright test --config playwright.config.ts transcribe-journey
 ```
 
 The harness seeds a fresh per-run `MEDIA_STUDIO_CONFIG_DIR` and registers the

--- a/app/e2e/README.md
+++ b/app/e2e/README.md
@@ -54,23 +54,67 @@ Three deliberate design choices, each with its reason in the source:
   workflow. Because `tiny` is *not* a registered manifest asset,
   `transcribe.resolve_model_source` hands faster-whisper the bare id and the
   snapshot is fetched from huggingface.co at run time — measured on a cold, empty
-  `HF_HOME`: 13 files / 74.6 MB. **So this leg needs network; it is NOT an offline
-  proof** (the same dependency the `e2e-sidecar` leg already carries). Making it
-  offline would mean registering a pinned `tiny` asset, which adds a user-visible
-  component to `assets.list` for the sole benefit of a nightly test — deliberately
-  not done.
+  `HF_HOME`: **6 model blobs / 78,207,087 B = 74.6 MB** (14 files in the repo dir
+  once the snapshot symlinks and `refs/` are counted). **So this leg needs network;
+  it is NOT an offline proof** (the same dependency the `e2e-sidecar` leg already
+  carries). Making it offline would mean registering a pinned `tiny` asset, which
+  adds a user-visible component to `assets.list` for the sole benefit of a nightly
+  test — deliberately not done.
+- **The fetch is forced ANONYMOUS** (`HF_HUB_DISABLE_IMPLICIT_TOKEN=1`, set on the
+  app env in the spec). `fixtures.definedEnv` copies the whole ambient environment
+  into the app env, so the sidecar inherits any `HF_TOKEN` the developer exported —
+  and huggingface_hub sends it implicitly *even for a public repo*, so a token that
+  no longer authenticates turns the public `tiny` fetch into
+  `RepositoryNotFoundError: 401` ("the model does not exist"). MEASURED on this box
+  end-to-end through the spec: **without** the override, a cold-`HF_HOME` run goes
+  red in 41 s carrying `User Access Token "Reframe" is expired`; **with** it, the
+  same cold cache and the same ambient token pass. Isolated four ways on a fresh
+  empty `HF_HOME` — huggingface_hub 1.27.0 and 1.26.0 (the lock pin), each with and
+  without the flag: ambient token → 401 (cache left at 5,698 B), flag → OK. The
+  credential is not touched (AGENTS.md §9); the consumer is fixed, which also
+  covers *any* `HF_TOKEN` that 401s (revoked / wrong org / insufficient scope).
+  A GitHub runner has no `HF_TOKEN`, so CI was already anonymous and is unchanged.
 
-**BOTH-STATES verified** (a test that passes in both states measures nothing).
-Same spec, same code, only the fixture's audio changed:
+**BOTH-STATES verified — for the TRANSCRIPT arm.** Same spec, same code, only the
+fixture's audio changed:
 
 | fixture audio | result |
 | --- | --- |
-| SAPI speech | **PASS** — keyword hits 4/4, 2 cues both carrying keywords |
-| speechless `sine` (the pre-existing fixture) | **FAIL** — "the transcription completed but produced ZERO segments" |
+| SAPI speech | **PASS** — keyword hits 4/4; 2 cues, both carrying keywords |
+| speechless `sine` (the repo's own 3 s fixture) | **FAIL** — "the transcription completed but produced ZERO segments" (failing test 12.6 s) |
+
+Two honest limits on that table — because a both-states claim that overreaches is
+worse than none — and one extra arm that IS measured:
+
+- **The CAPTION arm is not both-states controlled.** The broken run aborts at the
+  zero-segments assertion, so the caption half never executes with speechless
+  audio. Those assertions are fail-closed *by construction* (they require
+  `.cue-list .cue-row` to appear and then require cue text to be non-empty and to
+  carry a keyword), but "fail-closed by construction" is a code-reading, not a
+  measurement. The settling experiment is to seed a transcript with segments and
+  break `subtitles.generate`.
+- **The keyword THRESHOLD is controlled elsewhere.** With speechless audio there is
+  no transcript at all, so the `SPEECH_KEYWORD_MIN_HITS` comparison is never
+  evaluated in the broken state. `speechKeywords.test.ts` (vitest, every OS leg)
+  covers its failing direction directly — a 1-hit transcript must be below the
+  floor — and is mutation-checked: setting the floor to 1 turns that case red.
+- A THIRD arm is measured too: **ASR error**. A cold `HF_HOME` plus an ambient
+  `HF_TOKEN` that 401s lands on the panel's `p.error[role="alert"]` in 41 s with the
+  sidecar's own reason, rather than timing out anonymously.
 
 **It gates nothing.** `e2e.yml` is `workflow_dispatch` + nightly `cron` only, so
 this proves the capability nightly and on demand; it cannot prevent a
 transcription regression from merging.
+
+**It runs as its OWN, LAST CI step**, not inside the shared `npm run test:e2e`
+invocation (that step excludes it with `--grep-invert transcribe-journey`). A red
+Playwright step makes later steps inherit GitHub's implicit `success()` gate, and
+the blocking visual/a11y diff step deliberately has no `always()` — so folding the
+most environment-dependent spec in the repo (an `en-*` SAPI voice on the image plus
+huggingface.co egress) into that one invocation would let its first red silently
+drop visual + a11y coverage. This repo has already measured that cascade on run
+30612141716. Everything after the new step carries `always()`, so its own red
+suppresses no artifact.
 
 ### Packaged data-pipeline: a documented CI limitation
 
@@ -137,11 +181,19 @@ npm run test:e2e:visual:update  # regenerate the `*-win32.png` baselines
 - Python 3.12 reachable as `py -3.12` (or set `RF_PY` to the interpreter path).
   The sidecar runs on the **standard library only** — no ML deps needed for the
   preview path (`library.add` / `library.list` / `media.playable` / `nle.export`).
-- `transcribe-journey.spec.ts` ONLY: `faster-whisper==1.2.1` in that interpreter
-  (`e2e.yml` installs it on the Windows leg), plus network access to
-  huggingface.co for the 74.6 MB `tiny` snapshot on the first run. Windows only —
-  the speech fixture needs SAPI. It needs no `assets.ensure` and no GPU (it pins
-  `transcribeDevice: 'cpu'`).
+- `transcribe-journey.spec.ts` ONLY: `faster-whisper==1.2.1` in that interpreter,
+  plus network access to huggingface.co for the 74.6 MB `tiny` snapshot on the
+  first run. Windows only — the speech fixture needs SAPI. It needs no
+  `assets.ensure` and no GPU (it pins `transcribeDevice: 'cpu'`). Install it the
+  way `e2e.yml` does, so the transitives match the shipped stack instead of
+  floating (measured: unconstrained gives `av 18.0.0` against lock `av==17.1.0`):
+
+  ```sh
+  pip install "faster-whisper==1.2.1" --constraint sidecar/requirements.lock.txt
+  ```
+
+  A stale or mis-scoped `HF_TOKEN` in your environment does **not** break this —
+  the spec forces the HF fetch anonymous. You do not need to unset anything.
 
 ## Run
 

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -13,7 +13,7 @@
 // app lists + opens + plays the exact same library record either way.
 
 import { spawn, spawnSync } from 'node:child_process';
-import { mkdtempSync, existsSync, readdirSync, realpathSync } from 'node:fs';
+import { mkdtempSync, existsSync, readdirSync, realpathSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -184,6 +184,197 @@ function generateSample(samplePath: string): void {
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// SPEECH FIXTURE — a REAL spoken-word sample, synthesised at test time.
+//
+// WHY this exists: until it did, NO test in the repository proved that a spoken
+// word becomes text. The only media fixture was `generateSample` above
+// (`testsrc` + a 440 Hz `sine`), which carries no speech at all — so
+// `golden-journey.spec.ts` deliberately drives the manual-range path, and
+// `sidecar/tests/e2e/real_pipeline_smoke.py` asserts an EMPTY transcript and says
+// so in its own output. Transcription and captioning were therefore unproven in
+// BOTH directions: no evidence they worked, and none that they did not.
+//
+// WHY Windows-only SAPI and not a committed audio file: the repo tracks ZERO
+// audio/video binaries (verified: `git ls-tree -r --name-only origin/main` has no
+// media extensions), and adding a redistributable speech clip drags in a licence
+// question plus a binary in git. Windows ships a speech synthesiser in the OS
+// (`System.Speech.Synthesis.SpeechSynthesizer`, .NET), so the fixture GENERATES
+// its own speech offline, keeps nothing, and redistributes nothing. The cost is
+// that it only runs on Windows — the consuming spec must therefore `test.skip()`
+// LOUDLY elsewhere (see transcribe-journey.spec.ts) rather than pass vacuously.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The phrase the fixture speaks. Chosen for ASR-hostile-but-recoverable content:
+ * the pangram gives short, high-frequency, hard-to-mishear nouns, and the second
+ * sentence names the product's actual job.
+ *
+ * Measured (this box, `Microsoft David Desktop`): 22050 Hz mono `pcm_s16le`,
+ * 6.748 s, 297,640 bytes.
+ */
+export const SPEECH_PHRASE =
+  'The quick brown fox jumps over the lazy dog. Reframe converts landscape video to vertical.';
+
+/**
+ * The content words a transcript of :data:`SPEECH_PHRASE` must contain.
+ *
+ * DELIBERATELY NOT the product name. Measured with the shipped stack
+ * (faster_whisper 1.2.1, model `tiny`, cpu/int8) the transcript came back as
+ * "…lazy dog. **Refrain** converts landscape video to vertical." — "Reframe" was
+ * misheard. An exact-sentence or product-name assertion would therefore be flaky
+ * BY CONSTRUCTION, and a flaky keystone is a worse defect than the hole it closes.
+ */
+export const SPEECH_KEYWORDS: readonly string[] = ['fox', 'dog', 'landscape', 'vertical'];
+
+/**
+ * How many of :data:`SPEECH_KEYWORDS` a real transcript must carry.
+ *
+ * DO NOT "tighten" this to `SPEECH_KEYWORDS.length`. The synthesised voice is
+ * whatever the machine has installed (this box has 10 SAPI voices; a GitHub
+ * windows-latest image ships a different set), and `tiny` is the cheapest whisper
+ * model — so which individual words survive is machine-dependent. What is NOT
+ * machine-dependent is the difference between speech and no speech: the same
+ * assertion scores 0 hits on the speechless `sine` sample (measured), so a
+ * threshold of 2 still fails closed on a broken transcription while tolerating one
+ * mangled word. 4/4 was observed locally; 2 is the floor we are willing to defend.
+ */
+export const SPEECH_KEYWORD_MIN_HITS = 2;
+
+/** Which of :data:`SPEECH_KEYWORDS` appear in `text` (case-insensitive). */
+export function matchedSpeechKeywords(text: string): string[] {
+  const low = text.toLowerCase();
+  return SPEECH_KEYWORDS.filter((k) => low.includes(k));
+}
+
+/**
+ * The SAPI synthesiser, as a script rather than an inline `-Command`.
+ *
+ * Written to the per-run data root at test time (never committed) so it carries
+ * no `.gitattributes` end-of-line question and no shell-quoting hazard: the
+ * phrase and the output path arrive as bound `param()` values through argv, not
+ * spliced into a command line.
+ *
+ * Voice selection is by CULTURE (`en*`), not by name, so it works on any Windows
+ * image; it FAILS LOUD (exit 3) when no enabled English voice exists rather than
+ * silently producing a 0-byte file that would read as "transcription is broken".
+ */
+const SAPI_SCRIPT = [
+  '[CmdletBinding()]',
+  'param([Parameter(Mandatory=$true)][string]$Text,[Parameter(Mandatory=$true)][string]$Out)',
+  "$ErrorActionPreference = 'Stop'",
+  'Add-Type -AssemblyName System.Speech',
+  '$synth = New-Object System.Speech.Synthesis.SpeechSynthesizer',
+  'try {',
+  "  $voices = @($synth.GetInstalledVoices() | Where-Object { $_.Enabled -and $_.VoiceInfo.Culture.Name -like 'en*' })",
+  '  if ($voices.Count -eq 0) { Write-Error "no ENABLED en-* SAPI voice on this machine"; exit 3 }',
+  '  $pick = ($voices | Sort-Object { $_.VoiceInfo.Name } | Select-Object -First 1).VoiceInfo.Name',
+  '  $synth.SelectVoice($pick)',
+  '  $synth.Rate = 0',
+  '  $synth.SetOutputToWaveFile($Out)',
+  '  $synth.Speak($Text)',
+  '  $synth.SetOutputToNull()',
+  '  Write-Output "VOICE=$pick"',
+  '} finally { $synth.Dispose() }',
+  'if (-not (Test-Path -LiteralPath $Out)) { Write-Error "SAPI produced no file at $Out"; exit 4 }',
+  'Write-Output "BYTES=$((Get-Item -LiteralPath $Out).Length)"',
+  '',
+].join('\n');
+
+/** What the speech fixture produced — surfaced so a run self-documents. */
+export interface SpeechFixture {
+  /** Absolute path to the synthesised WAV (kept for diagnostics). */
+  wavPath: string;
+  /** The SAPI voice actually used (machine-dependent; logged, never asserted). */
+  voice: string;
+  /** Real duration of the synthesised speech, from ffprobe. */
+  speechDurationSec: number;
+}
+
+/** Duration in seconds of any media file, read with the spec's own ffprobe. */
+export function probeDurationSec(mediaPath: string): number {
+  const r = spawnSync(
+    resolveFfprobe(),
+    ['-v', 'error', '-show_entries', 'format=duration', '-of', 'default=nw=1:nk=1', mediaPath],
+    { encoding: 'utf8' },
+  );
+  if (r.status !== 0) {
+    throw new Error(`ffprobe duration failed (status ${r.status}) on ${mediaPath}: ${r.stderr ?? ''}`);
+  }
+  const seconds = Number((r.stdout ?? '').trim());
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    throw new Error(`ffprobe reported a non-positive duration (${r.stdout?.trim()}) for ${mediaPath}`);
+  }
+  return seconds;
+}
+
+/**
+ * Synthesise :data:`SPEECH_PHRASE` to `wavPath` via Windows SAPI. Windows-only.
+ *
+ * `scriptDir` is where the throwaway .ps1 lands (the per-run data root).
+ */
+export function synthesizeSpeechWav(wavPath: string, scriptDir: string, text = SPEECH_PHRASE): string {
+  if (process.platform !== 'win32') {
+    throw new Error('synthesizeSpeechWav requires Windows SAPI (System.Speech); guard with test.skip');
+  }
+  const scriptPath = join(scriptDir, 'sapi-speech.ps1');
+  writeFileSync(scriptPath, SAPI_SCRIPT, 'utf8');
+  const r = spawnSync(
+    'powershell.exe',
+    ['-NoProfile', '-NonInteractive', '-ExecutionPolicy', 'Bypass', '-File', scriptPath, '-Text', text, '-Out', wavPath],
+    { encoding: 'utf8' },
+  );
+  if (r.status !== 0 || !existsSync(wavPath)) {
+    throw new Error(
+      `SAPI speech synthesis failed (status ${r.status}) -> ${wavPath}\n` +
+        `stdout: ${r.stdout ?? ''}\nstderr: ${r.stderr ?? ''}`,
+    );
+  }
+  const voice = /VOICE=(.+)/.exec(r.stdout ?? '')?.[1]?.trim() ?? '';
+  if (!voice) throw new Error(`SAPI script did not report a voice; stdout: ${r.stdout ?? ''}`);
+  return voice;
+}
+
+/**
+ * Generate a real H.264/AAC MP4 that CARRIES SPEECH: the same `testsrc` video the
+ * silent fixture uses, muxed with a SAPI-synthesised speech track.
+ *
+ * The video is generated at `ceil(speech) + 2` s and the mux uses `-shortest`, so
+ * the output length equals the SPEECH length and the whole phrase is carried. The
+ * 3 s silent sample would truncate ~7 s of speech, which is precisely why this
+ * does not just reuse it.
+ */
+export function generateSpeechSample(samplePath: string, workDir: string): SpeechFixture {
+  const wavPath = join(workDir, 'speech.wav');
+  const voice = synthesizeSpeechWav(wavPath, workDir);
+  const speechDurationSec = probeDurationSec(wavPath);
+  const videoSec = Math.ceil(speechDurationSec) + 2;
+  const args = [
+    '-y',
+    '-f',
+    'lavfi',
+    '-i',
+    `testsrc=duration=${videoSec}:size=640x360:rate=24`,
+    '-i',
+    wavPath,
+    '-c:v',
+    'libx264',
+    '-pix_fmt',
+    'yuv420p',
+    '-movflags',
+    '+faststart',
+    '-c:a',
+    'aac',
+    '-shortest',
+    samplePath,
+  ];
+  const r = spawnSync(process.env.RF_FFMPEG?.trim() || 'ffmpeg', args, { encoding: 'utf8' });
+  if (r.status !== 0 || !existsSync(samplePath)) {
+    throw new Error(`ffmpeg speech-sample mux failed (status ${r.status}): ${r.stderr ?? ''}`);
+  }
+  return { wavPath, voice, speechDurationSec };
+}
+
 /** Run one JSON-RPC request against a one-shot sidecar process; return result. */
 function sidecarCall(python: string, dataRoot: string, method: string, params: unknown): unknown {
   const req = `${JSON.stringify({ jsonrpc: '2.0', id: 1, method, params })}\n`;
@@ -205,10 +396,21 @@ function sidecarCall(python: string, dataRoot: string, method: string, params: u
 }
 
 /**
+ * Writes the seeded sample media into `samplePath`. `workDir` is the per-run data
+ * root, for any intermediate the generator needs (e.g. the speech WAV).
+ */
+export type MediaGenerator = (samplePath: string, workDir: string) => void;
+
+/**
  * Build a fresh data root, generate a real sample MP4, register it through the
  * real sidecar `library.add`, and return everything the launched app needs.
+ *
+ * `generateMedia` defaults to the silent `testsrc`+`sine` sample, so every
+ * existing caller is byte-for-byte unchanged; the transcribe journey passes
+ * :func:`generateSpeechSample` to get a SPEECH-bearing sample through the exact
+ * same seeding path (same `library.add`, same thumbnail, same env).
  */
-export function seedEnvironment(): SeededEnv {
+export function seedEnvironment(generateMedia: MediaGenerator = generateSample): SeededEnv {
   const python = resolvePython();
   // realpathSync.NATIVE expands the tmp path's 8.3 SHORT name to its LONG form.
   // os.tmpdir() on Windows returns the SHORT name (C:\Users\PREKZU~1\...), which
@@ -219,7 +421,7 @@ export function seedEnvironment(): SeededEnv {
   // install's %APPDATA% root has no short/long split; canonicalising here matches it.
   const dataRoot = realpathSync.native(mkdtempSync(join(tmpdir(), 'reframe-e2e-data-')));
   const samplePath = join(dataRoot, 'sample.mp4');
-  generateSample(samplePath);
+  generateMedia(samplePath, dataRoot);
 
   const added = sidecarCall(python, dataRoot, 'library.add', { path: samplePath }) as {
     video: { id: string };
@@ -326,6 +528,28 @@ export function provisionAssets(python: string, dataRoot: string, names: string[
       `${JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'assets.ensure', params: { names } })}\n`,
     );
   });
+}
+
+/**
+ * Write settings into the per-run data root through the REAL `settings.set` RPC
+ * (the same one the Settings UI calls), returning the merged result.
+ *
+ * Used by the transcribe journey to PIN the ASR target before the app launches.
+ * Not a mock: `SettingsStore.set` merges + persists to `<dataRoot>/settings.json`,
+ * which is exactly where `_transcribe_and_persist` reads it from at job time.
+ *
+ * CONTRACT-NOTE: `settings.set`'s PARAMS OBJECT *is* the value map — the handler
+ * is `self.settings.set(dict(params))` (handlers/library_ops.py:382), with no
+ * `{values: …}` envelope. Wrapping it would silently persist a `values` key and
+ * leave `transcribeModel` unset, which is exactly the kind of no-op setup that
+ * makes a test measure nothing.
+ */
+export function applySettings(
+  python: string,
+  dataRoot: string,
+  values: Record<string, unknown>,
+): Record<string, unknown> {
+  return sidecarCall(python, dataRoot, 'settings.set', values) as Record<string, unknown>;
 }
 
 /** Direct `media.playable` probe (used to label the preview path honestly). */

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -440,6 +440,21 @@ export type MediaGenerator = (samplePath: string, workDir: string) => void;
  * existing caller is byte-for-byte unchanged; the transcribe journey passes
  * :func:`generateSpeechSample` to get a SPEECH-bearing sample through the exact
  * same seeding path (same `library.add`, same thumbnail, same env).
+ *
+ * The default is `generateSample`, which takes ONE parameter and therefore ignores
+ * the `workDir` second argument — that is WHY the zero-argument callers are
+ * unchanged rather than merely "probably fine". They are enumerated here so the
+ * count is checkable instead of asserted (a review of this branch put it at three
+ * by grepping only `e2e/*.spec.ts`; it is FOUR — the visual suite's helper is easy
+ * to miss because it lives under `e2e/visual/`, outside playwright.config.ts):
+ *   * `preview.spec.ts`               (executed on this branch: 9/9 green)
+ *   * `golden-journey.spec.ts`        (NOT executed here — UNVERIFIED)
+ *   * `packaged.spec.ts`              (NOT executed here — UNVERIFIED)
+ *   * `visual/_visualSetup.ts` `launchSeededApp()`, i.e. every visual + a11y spec
+ *                                     (NOT executed here — UNVERIFIED)
+ * The settling experiment for the three unexecuted ones is a full
+ * `npm run test:e2e` + `npm run test:e2e:visual`; the argument that they cannot
+ * have changed is the arity one above, not the test evidence.
  */
 export function seedEnvironment(generateMedia: MediaGenerator = generateSample): SeededEnv {
   const python = resolvePython();

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -231,13 +231,33 @@ export const SPEECH_KEYWORDS: readonly string[] = ['fox', 'dog', 'landscape', 'v
  * How many of :data:`SPEECH_KEYWORDS` a real transcript must carry.
  *
  * DO NOT "tighten" this to `SPEECH_KEYWORDS.length`. The synthesised voice is
- * whatever the machine has installed (this box has 10 SAPI voices; a GitHub
- * windows-latest image ships a different set), and `tiny` is the cheapest whisper
- * model — so which individual words survive is machine-dependent. What is NOT
- * machine-dependent is the difference between speech and no speech: the same
- * assertion scores 0 hits on the speechless `sine` sample (measured), so a
- * threshold of 2 still fails closed on a broken transcription while tolerating one
- * mangled word. 4/4 was observed locally; 2 is the floor we are willing to defend.
+ * whatever the machine has installed, and `tiny` is the cheapest whisper model —
+ * so which individual words survive is machine-dependent. (Voice-count
+ * correction: this comment used to say "10 SAPI voices". MEASURED through the
+ * SAME `System.Speech.Synthesis` enumeration the fixture uses, this box exposes
+ * **3** — all enabled, all `en-*`. The 10 counts the OneCore voices too:
+ * `HKLM:\SOFTWARE\Microsoft\Speech\Voices\Tokens` has 3 tokens and
+ * `…\Speech_OneCore\Voices\Tokens` has 7, and `System.Speech` enumerates only the
+ * former, so 3 is the fixture's real selection pool. A GitHub windows-latest
+ * image ships its own set — UNVERIFIED which; the settling experiment is the
+ * `VOICE=` line this fixture already prints on every CI run.)
+ *
+ * SCOPE CORRECTION. An earlier version of this comment claimed the both-states
+ * proof for the THRESHOLD: "the same assertion scores 0 hits on the speechless
+ * `sine` sample (measured)". That was REFUTED and is wrong about which assertion
+ * the sine run exercises: on speechless audio the spec dies EARLIER, at the
+ * zero-segments arm (`transcribe-journey.spec.ts`, `.not.toHaveCount(0)`), so the
+ * keyword arm is never evaluated there. What is actually measured:
+ *   * the ZERO-SEGMENTS arm is both-states verified (sine red / speech green);
+ *   * the threshold's own failing direction is covered by
+ *     `speechKeywords.test.ts` — a 1-hit transcript is BELOW this floor and a
+ *     2-hit one is at it, so the arm demonstrably fails closed;
+ *   * the margin is wide: MEASURED by synthesising SPEECH_PHRASE with EACH of the
+ *     3 enabled `en-*` voices, muxing each the way `generateSpeechSample` does and
+ *     transcribing with `tiny`/cpu/int8 — David 4/4, Hazel 4/4, Zira 4/4, the only
+ *     difference being the product name ("Refrain" / "Refrain" / "Reframed"),
+ *     while the CONTROL (the repo's own 3 s `sine`) transcribed to `''` = 0 hits.
+ * So 2 tolerates one mangled word without ever tolerating silence.
  */
 export const SPEECH_KEYWORD_MIN_HITS = 2;
 

--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -256,8 +256,19 @@ export function matchedSpeechKeywords(text: string): string[] {
  * spliced into a command line.
  *
  * Voice selection is by CULTURE (`en*`), not by name, so it works on any Windows
- * image; it FAILS LOUD (exit 3) when no enabled English voice exists rather than
- * silently producing a 0-byte file that would read as "transcription is broken".
+ * image; it FAILS LOUD when no enabled English voice exists rather than silently
+ * producing a 0-byte file that would read as "transcription is broken".
+ *
+ * MEASURED — the guard's exit code is 1, NOT the literal 3 in the script. Under
+ * `$ErrorActionPreference = 'Stop'` the `Write-Error` is TERMINATING, so it
+ * unwinds through `finally` and PowerShell exits 1 before `exit 3` is reached.
+ * The `exit 3` is therefore belt-and-braces, not the observed code, and this
+ * comment used to claim otherwise. Both states measured through the SAME
+ * `spawnSync` shape the caller below uses:
+ *   no en-* voice -> status=1, no file, stderr "no ENABLED … SAPI voice …"
+ *   en-* voice    -> status=0, file present, stdout "VOICE=…\nBYTES=…"
+ * which is why the caller's guard is `status !== 0 || !existsSync(...)`: the OR
+ * makes it fail closed regardless of which code PowerShell picks.
  */
 const SAPI_SCRIPT = [
   '[CmdletBinding()]',

--- a/app/e2e/speechKeywords.test.ts
+++ b/app/e2e/speechKeywords.test.ts
@@ -1,0 +1,76 @@
+// speechKeywords.test.ts — the SETTLING EXPERIMENT for the speech-keyword
+// threshold that `transcribe-journey.spec.ts` asserts on.
+//
+// ── WHY THIS FILE EXISTS ─────────────────────────────────────────────────────
+// `fixtures.SPEECH_KEYWORD_MIN_HITS` used to justify itself with "the same
+// assertion scores 0 hits on the speechless `sine` sample (measured)". That was
+// REFUTED: on speechless audio the GUI spec dies EARLIER, at the zero-segments
+// arm (`.transcript-segments li` `.not.toHaveCount(0)`), so the keyword arm is
+// never evaluated in the broken state. The zero-segments arm is genuinely
+// both-states verified; the THRESHOLD's failing direction was not observed at
+// all — the both-states proof belonged to a different assertion than the one
+// carrying the claim.
+//
+// This file closes that gap deterministically, with no audio, no model and no
+// GUI: it pins the FAILING direction (a 1-hit transcript must be BELOW the
+// floor) and the boundary (a 2-hit transcript must be AT it). Mutation-checked:
+// setting SPEECH_KEYWORD_MIN_HITS to 1 turns the "1 hit is below the floor" case
+// red, so this suite is actually protecting the constant rather than restating
+// it.
+//
+// It rides `vitest.e2e.config.ts` (`include: ['e2e/**/*.test.{ts,tsx}']`, run by
+// `npm run test:e2e:dom`), which every OS leg of e2e.yml already runs — so unlike
+// the Windows-only GUI journey, this check is OS-independent and always exercised.
+
+import { describe, expect, it } from 'vitest';
+
+import { SPEECH_KEYWORDS, SPEECH_KEYWORD_MIN_HITS, SPEECH_PHRASE, matchedSpeechKeywords } from './fixtures';
+
+describe('speech-keyword oracle', () => {
+  it('DETECTOR CONTROL — the phrase the fixture speaks scores every keyword', () => {
+    // If this ever fails, the keyword list and the phrase have drifted apart and
+    // every conclusion below is meaningless.
+    expect(matchedSpeechKeywords(SPEECH_PHRASE)).toEqual([...SPEECH_KEYWORDS]);
+  });
+
+  it('scores 0 on an EMPTY transcript — silence can never satisfy the floor', () => {
+    expect(matchedSpeechKeywords('')).toEqual([]);
+    // The load-bearing consequence: the floor is strictly positive, so a
+    // transcript with no recognised speech cannot pass the keyword arm even if
+    // the earlier zero-segments arm were ever removed.
+    expect(SPEECH_KEYWORD_MIN_HITS).toBeGreaterThan(0);
+  });
+
+  it('FAILS CLOSED at one hit — the arm the speechless run never reaches', () => {
+    const oneHit = 'the lazy dog sat still and nothing else was said';
+    expect(matchedSpeechKeywords(oneHit)).toEqual(['dog']);
+    // This is the assertion the sine fixture could NOT make: a transcript that
+    // carries a single keyword must be rejected by the threshold.
+    expect(matchedSpeechKeywords(oneHit).length).toBeLessThan(SPEECH_KEYWORD_MIN_HITS);
+  });
+
+  it('passes at two hits — the boundary is exactly where the constant says', () => {
+    const twoHits = 'a fox and a dog';
+    expect(matchedSpeechKeywords(twoHits)).toEqual(['fox', 'dog']);
+    expect(matchedSpeechKeywords(twoHits).length).toBeGreaterThanOrEqual(SPEECH_KEYWORD_MIN_HITS);
+  });
+
+  it('tolerates a mangled product name but not a mangled keyword', () => {
+    // MEASURED with the shipped stack (faster-whisper 1.2.1, `tiny`, cpu/int8) on
+    // all 3 enabled en-* SAPI voices of this box: "Reframe" came back as
+    // "Refrain" / "Refrain" / "Reframed" while all four keywords survived 4/4.
+    // That is exactly why the oracle is keyword-based and excludes the product
+    // name — this case pins the reason so a future edit cannot quietly re-add it.
+    const asHeard = 'The quick brown fox jumps over the lazy dog. Refrain converts landscape video to vertical.';
+    expect(matchedSpeechKeywords(asHeard).length).toBe(SPEECH_KEYWORDS.length);
+    expect(SPEECH_KEYWORDS).not.toContain('reframe');
+  });
+
+  it('matches case-insensitively and on inflected forms (deliberate substring match)', () => {
+    // The matcher is a lowercase `includes`, so "Dogs"/"vertically" count. That
+    // looseness is intended: whisper output is not word-normalised, and an exact
+    // word-boundary match would fail on plurals for no benefit.
+    expect(matchedSpeechKeywords('TWO DOGS and one FOX')).toEqual(['fox', 'dog']);
+    expect(matchedSpeechKeywords('rendered vertically')).toEqual(['vertical']);
+  });
+});

--- a/app/e2e/transcribe-journey.spec.ts
+++ b/app/e2e/transcribe-journey.spec.ts
@@ -1,0 +1,310 @@
+// transcribe-journey.spec.ts — the held-out proof that SPEECH becomes TEXT, and
+// then becomes CAPTIONS, through the real GUI against the real Python sidecar.
+//
+// ── THE HOLE THIS CLOSES ─────────────────────────────────────────────────────
+// Reframe's core purpose is: import landscape video → TRANSCRIBE → CAPTION →
+// reframe → export. Steps 2 and 3 had never been proven on speech ANYWHERE in the
+// repository, in either direction. Measured at origin/main 775a97ea:
+//   * `fixtures.ts` generateSample — the only media fixture — is `testsrc` +
+//     `sine=frequency=440`. No speech.
+//   * `golden-journey.spec.ts:18-19` deliberately drives the MANUAL-range path
+//     because "AI moment-pick would emit 'no candidates' on a 3s no-speech
+//     sample", so the GUI keystone bypasses transcription BY DESIGN.
+//   * `sidecar/tests/e2e/real_pipeline_smoke.py:294` runs a real tiny whisper and
+//     prints "sine-only audio has no speech, so 0 segments is the honest result"
+//     — it ASSERTS AN EMPTY TRANSCRIPT.
+//   * `sidecar/tests/e2e/test_whisper_offline_e2e.py` proves model RESOLUTION with
+//     fake weights (`write_bytes(b"ct2-weights")`); it never transcribes audio.
+//   * the repo tracks ZERO audio/video binaries.
+// So: no test proved a spoken word becomes text or a caption. That is a
+// VERIFICATION hole, not necessarily a product defect — this spec settles it.
+//
+// ── THE JOURNEY (nothing stubbed) ────────────────────────────────────────────
+//   synthesise real speech with Windows SAPI → mux it over the same `testsrc`
+//   video the silent fixture uses → seed it through the real `library.add`
+//   → PIN the ASR target via the real `settings.set`
+//   → launch the built app → open the video → Workspace
+//   → Transcribe tab: assert the panel's EMPTY state first (detector control),
+//     click the real "Start transcription", and assert the rendered
+//     `.transcript-segments` carries the spoken content words
+//   → Subtitles tab: click the real "Generate subtitles" and assert a rendered
+//     CUE carries one of those same words.
+//
+// Every assertion reads the UI, never the sidecar's return value: the point is
+// that the USER can see the transcript, not that an RPC returned one.
+//
+// ── WHAT THIS DOES *NOT* DO ──────────────────────────────────────────────────
+// It does NOT gate a PR. `e2e.yml` is `workflow_dispatch` + nightly `cron` only,
+// so this proves the capability NIGHTLY AND ON DEMAND; it cannot stop a
+// transcription regression from merging. Wiring it into `quality.yml` is not on
+// the table — that gate list is CLOSED at 6 by QUALITY-CHARTER.md rule 2. See the
+// PR body for the recommendation + its cost.
+
+import { test, expect, _electron as electron, type ElectronApplication } from '@playwright/test';
+import {
+  SPEECH_KEYWORDS,
+  SPEECH_KEYWORD_MIN_HITS,
+  SPEECH_PHRASE,
+  applySettings,
+  findBuiltApp,
+  generateSpeechSample,
+  matchedSpeechKeywords,
+  seedEnvironment,
+  type SeededEnv,
+  type SpeechFixture,
+} from './fixtures';
+
+// ── LOAD-BEARING SETUP VALUES ────────────────────────────────────────────────
+// The whisper model this journey pins, and WHY it is not the shipped default.
+//
+// `resolve_transcribe_target` (sidecar features/transcribe.py:353-392) would pick
+// `cpu_auto_model()` on a GPU-less runner, which today returns `large-v3-turbo`
+// (the only whisper snapshot the Default install profile registers). MEASURED on
+// this box, that snapshot is **1546.5 MB** across 11 files
+// (`mobiuslabsgmbh--faster-whisper-large-v3-turbo`, the exact commit
+// `manifest.WHISPER_HF_REVISION` pins) versus **74.6 MB** for
+// `Systran--faster-whisper-tiny`. Pulling 1.5 GB into a nightly leg to prove
+// "speech becomes text" buys nothing over 75 MB, so we pin `tiny` explicitly —
+// the SAME model `sidecar/tests/e2e/real_pipeline_smoke.py` already runs in this
+// very workflow, so no new CI contract is introduced.
+//
+// DISCLOSED RESIDUAL (inline, per the honesty rule): `tiny` is NOT a registered
+// manifest asset, so `transcribe.resolve_model_source('tiny')` logs
+// "no pinned local snapshot" and hands faster-whisper the bare id — a NETWORK
+// resolve. This leg therefore depends on huggingface.co being reachable, exactly
+// as `real_pipeline_smoke.py` already does. It is NOT an offline proof and must
+// not be described as one. Registering a pinned `tiny` asset would remove that
+// dependency but adds a user-visible component to `assets.list` / the Models &
+// System UI for the sole benefit of a nightly test, so it was deliberately NOT
+// done here; the settling experiment for the offline claim is a run with
+// HF_HUB_OFFLINE=1 after `assets.ensure(['whisper-tiny'])`, which needs that
+// registration first.
+const PIN_MODEL = 'tiny';
+// Force CPU too: `detect_device` probes `torch.cuda.is_available()`, and torch is
+// absent from the E2E runtime install — so the probe would ImportError-degrade to
+// CPU anyway. Pinning it makes the resolved target deterministic instead of a
+// side effect of which packages happen to be installed.
+const PIN_DEVICE = 'cpu';
+
+// Cold whisper: a ~75 MB model fetch on a fresh runner, then CPU/int8 inference
+// over ~7 s of audio. Measured locally (warm HF cache, 8-core): first transcript
+// in well under 30 s. 300 s is fetch-plus-slow-runner headroom, deliberately
+// generous — this is a nightly leg, not a PR gate.
+const TRANSCRIBE_WAIT_MS = 300_000;
+
+let seeded: SeededEnv;
+let speech: SpeechFixture;
+let app: ElectronApplication;
+const consoleErrors: string[] = [];
+// The sidecar's own stderr arrives on the MAIN process's pipes, not in
+// Playwright's error context. A failed transcribe job (no faster_whisper, a
+// blocked model download, a ctranslate2 load error) is only diagnosable from
+// here, so buffer it and fold the tail into any red repro.
+const mainLog: string[] = [];
+
+/** Loud, named reason for the platform gate — never a silent pass. */
+const SKIP_REASON =
+  'Windows-only: the speech fixture synthesises its audio with Windows SAPI ' +
+  '(System.Speech.Synthesis.SpeechSynthesizer). There is no committed speech ' +
+  'binary to fall back to, so this journey cannot run off-Windows — it is SKIPPED, ' +
+  'not silently satisfied.';
+
+test.beforeAll(async () => {
+  // Same reasoning as golden-journey.spec.ts:129-145: a beforeAll hook does NOT
+  // inherit a test's setTimeout and gets its own from the config (120 s). Speech
+  // synthesis + ffmpeg mux + library.add + thumbnail + app launch all live here.
+  test.setTimeout(240_000);
+
+  if (process.platform !== 'win32') {
+    // Print it as well as skipping: a `-` in the list reporter is easy to miss,
+    // and a gate that cannot fail must at least say so out loud.
+    console.log(`[transcribe-journey] SKIPPED — ${SKIP_REASON}`);
+  }
+  test.skip(process.platform !== 'win32', SKIP_REASON);
+
+  const built = findBuiltApp();
+  // The ONLY difference from every other spec's seeding: the sample carries real
+  // speech. Same data root, same `library.add`, same thumbnail, same app env.
+  seeded = seedEnvironment((samplePath, workDir) => {
+    speech = generateSpeechSample(samplePath, workDir);
+  });
+  console.log(
+    `[transcribe-journey] speech fixture: voice=${speech.voice} ` +
+      `speechDurationSec=${speech.speechDurationSec.toFixed(3)} phrase=${JSON.stringify(SPEECH_PHRASE)}`,
+  );
+
+  // PIN the ASR target before the app boots (see PIN_MODEL/PIN_DEVICE above), and
+  // VERIFY the write landed. `settings.set` returns the merged document, so an
+  // unabsorbed key (a param-shape mistake, a rejected write) fails HERE with a
+  // named error instead of surfacing as a mysterious 1.5 GB download later.
+  const merged = applySettings(seeded.python, seeded.dataRoot, {
+    transcribeModel: PIN_MODEL,
+    transcribeDevice: PIN_DEVICE,
+  });
+  if (merged.transcribeModel !== PIN_MODEL || merged.transcribeDevice !== PIN_DEVICE) {
+    throw new Error(
+      `settings.set did not persist the ASR pin — got transcribeModel=${JSON.stringify(merged.transcribeModel)} ` +
+        `transcribeDevice=${JSON.stringify(merged.transcribeDevice)}`,
+    );
+  }
+
+  app = await electron.launch({
+    args: [built.main, '--autoplay-policy=no-user-gesture-required', '--no-sandbox'],
+    ...(built.executablePath ? { executablePath: built.executablePath } : {}),
+    env: seeded.appEnv,
+  });
+
+  const proc = app.process();
+  proc.stdout?.on('data', (d: Buffer) => mainLog.push(d.toString()));
+  proc.stderr?.on('data', (d: Buffer) => mainLog.push(d.toString()));
+
+  const win = await app.firstWindow();
+  win.on('console', (m) => {
+    if (m.type() === 'error') consoleErrors.push(m.text());
+  });
+  win.on('pageerror', (e) => consoleErrors.push(`PAGEERROR: ${e.message}`));
+  await win.waitForLoadState('domcontentloaded');
+});
+
+test.afterAll(async () => {
+  await app?.close();
+});
+
+/** The lines of the sidecar's log that explain a failed ASR job. */
+function asrErrorTail(): string {
+  return mainLog
+    .join('')
+    .split(/\r?\n/)
+    .filter((l) =>
+      /error|traceback|whisper|ctranslate|faster_whisper|transcribe|huggingface|offline|snapshot|tokenizer/i.test(l),
+    )
+    .slice(-30)
+    .join('\n');
+}
+
+test('spoken words become a visible transcript and then a caption cue (real GUI + real sidecar)', async () => {
+  // Whisper cold-start dominates; give the whole journey room above the 120 s
+  // config default. Kept as ONE test on purpose: a caption assertion is
+  // meaningless without the transcript that feeds it, so splitting them would
+  // create a silent inter-test ordering dependency instead of a visible one.
+  test.setTimeout(TRANSCRIBE_WAIT_MS + 120_000);
+  const win = await app.firstWindow();
+
+  // A — the shell is up and the speech-bearing sample is imported + listed.
+  await expect(win.locator('.app__brand')).toHaveText('Reframe');
+  await expect(win.locator('.library__item-title').first()).toHaveText('sample');
+
+  // B — open it and take the "Advanced / all tools" escape into the full
+  // Workspace (opening a video lands on the per-video Task Hub first; the same
+  // route preview.spec.ts:142-144 drives).
+  await win.locator('.library__item-title', { hasText: 'sample' }).click();
+  await win.locator('button.task-hub__advanced').click();
+  await expect(win.locator('.workspace__title')).toHaveText('sample');
+
+  // C — Transcribe tab. The Workspace lands on Subtitles by default
+  // (`DEFAULT_WORKSPACE_TAB`, Workspace.tsx:158), so select Transcribe explicitly.
+  // Both tabs live in the VISIBLE "Speech & Text" cluster, so no Advanced
+  // disclosure is involved.
+  await win.locator('[role="tab"][data-tab-id="transcribe"]').click();
+  const panel = win.locator('section.transcribe-panel');
+  await expect(panel).toBeVisible();
+
+  // DETECTOR CONTROL — assert the ABSENCE first. A fresh data root has no
+  // transcript, so the panel must render its empty state and offer "Start
+  // transcription". This is what makes the post-run assertion meaningful: it
+  // proves the selectors resolve, that nothing pre-seeded a transcript, and that
+  // the keyword-bearing text below genuinely arrived from THIS run. Without it a
+  // green could come from a stale fixture and would measure nothing.
+  await expect(panel.locator('[data-state="empty"]')).toBeVisible();
+  await expect(panel.locator('.transcript-segments')).toHaveCount(0);
+  const startButton = panel.locator('button', { hasText: 'Start transcription' });
+  await expect(startButton).toBeEnabled();
+
+  // D — run the REAL transcription (transcribe.start → live faster-whisper).
+  await startButton.click();
+
+  // A panel-level error is a NAMED failure; race it against the transcript so a
+  // broken ASR install reports "no module named faster_whisper" instead of an
+  // anonymous timeout.
+  const segments = panel.locator('.transcript-segments li');
+  const panelError = panel.locator('p.error[role="alert"]');
+  await Promise.race([
+    segments.first().waitFor({ state: 'visible', timeout: TRANSCRIBE_WAIT_MS }),
+    panelError.waitFor({ state: 'visible', timeout: TRANSCRIBE_WAIT_MS }),
+  ]).catch(() => undefined);
+  if (await panelError.isVisible()) {
+    throw new Error(
+      `transcription failed in the UI: ${(await panelError.textContent())?.trim()}\n` +
+        `--- sidecar log tail ---\n${asrErrorTail()}`,
+    );
+  }
+  await expect(
+    segments.first(),
+    `no transcript segment ever rendered within ${TRANSCRIBE_WAIT_MS}ms\n` +
+      `--- sidecar log tail ---\n${asrErrorTail()}`,
+  ).toBeVisible({ timeout: 5_000 });
+
+  // E — THE PRIMARY DONE-SIGNAL: the words the user can SEE.
+  const transcriptText = ((await panel.locator('.transcript-segments').textContent()) ?? '').trim();
+  const summary = ((await panel.locator('.transcript-summary p').textContent()) ?? '').trim();
+  const hits = matchedSpeechKeywords(transcriptText);
+  // Self-document on green AND red — an oracle nobody can read is an oracle
+  // nobody trusts, and this line is the evidence for the whole lane.
+  console.log(`[transcribe-journey] summary: ${summary}`);
+  console.log(`[transcribe-journey] transcript-as-rendered: ${JSON.stringify(transcriptText)}`);
+  console.log(`[transcribe-journey] keyword hits: ${hits.length}/${SPEECH_KEYWORDS.length} -> ${JSON.stringify(hits)}`);
+
+  expect(
+    hits.length,
+    `the rendered transcript must carry at least ${SPEECH_KEYWORD_MIN_HITS} of ` +
+      `${JSON.stringify(SPEECH_KEYWORDS)} (NOT an exact-phrase match — see ` +
+      `fixtures.SPEECH_KEYWORD_MIN_HITS for why). rendered: ${JSON.stringify(transcriptText)}\n` +
+      `--- sidecar log tail ---\n${asrErrorTail()}`,
+  ).toBeGreaterThanOrEqual(SPEECH_KEYWORD_MIN_HITS);
+
+  // F — CAPTIONS. `subtitles.generate` reads the transcript the run above just
+  // persisted onto the project manifest, so this is the second half of the chain:
+  // transcript → cues the user can see and edit.
+  await win.locator('[role="tab"][data-tab-id="subtitles"]').click();
+  const subs = win.locator('section.subtitles-panel');
+  await expect(subs).toBeVisible();
+  // Detector control again: no track yet ⇒ no cue rows.
+  await expect(subs.locator('.cue-list .cue-row')).toHaveCount(0);
+
+  await subs.locator('button', { hasText: 'Generate subtitles' }).click();
+  const subsError = subs.locator('p.error[role="alert"]');
+  await Promise.race([
+    subs.locator('.cue-list .cue-row').first().waitFor({ state: 'visible', timeout: 60_000 }),
+    subsError.waitFor({ state: 'visible', timeout: 60_000 }),
+  ]).catch(() => undefined);
+  if (await subsError.isVisible()) {
+    throw new Error(
+      `subtitles.generate failed in the UI: ${(await subsError.textContent())?.trim()}\n` +
+        `--- sidecar log tail ---\n${asrErrorTail()}`,
+    );
+  }
+  await expect(subs.locator('.cue-list .cue-row').first()).toBeVisible({ timeout: 5_000 });
+
+  // A cue's TEXT lives in its editable input's value, not in textContent.
+  const cueTexts = await subs.locator('.cue-list .cue-row input.cue-text').evaluateAll((els) =>
+    els.map((el) => (el as HTMLInputElement).value),
+  );
+  const cueHits = matchedSpeechKeywords(cueTexts.join(' '));
+  console.log(`[transcribe-journey] cues: ${JSON.stringify(cueTexts)}`);
+  console.log(`[transcribe-journey] cue keyword hits: ${cueHits.length} -> ${JSON.stringify(cueHits)}`);
+
+  expect(cueTexts.length, 'at least one caption cue was generated from the transcript').toBeGreaterThan(0);
+  expect(
+    cueHits.length,
+    `a generated CUE must carry at least one of ${JSON.stringify(SPEECH_KEYWORDS)} — ` +
+      `otherwise captions are not carrying the spoken words. cues: ${JSON.stringify(cueTexts)}`,
+  ).toBeGreaterThan(0);
+});
+
+test('no console errors across the transcribe-journey session', async () => {
+  // Bound in beforeAll, so this covers load, navigation, the transcription run and
+  // the caption generation. Kept SEPARATE from — and after — the speech-to-text
+  // done-signal so a renderer console error never masks the primary verdict
+  // (same split as golden-journey.spec.ts:318).
+  expect(consoleErrors, `console errors across session: ${JSON.stringify(consoleErrors)}`).toEqual([]);
+});

--- a/app/e2e/transcribe-journey.spec.ts
+++ b/app/e2e/transcribe-journey.spec.ts
@@ -23,15 +23,26 @@
 //   synthesise real speech with Windows SAPI → mux it over the same `testsrc`
 //   video the silent fixture uses → seed it through the real `library.add`
 //   → PIN the ASR target via the real `settings.set`
-//   → launch the built app → open the video → Workspace
+//   → launch the built app (with the HF model fetch forced ANONYMOUS — see
+//     HF_ANONYMOUS_ENV; an ambient HF_TOKEN that 401s otherwise reads as
+//     "the model does not exist") → open the video → Workspace
 //   → Transcribe tab: assert the panel's EMPTY state first (detector control),
 //     click the real "Start transcription", and assert the rendered
 //     `.transcript-segments` carries the spoken content words
 //   → Subtitles tab: click the real "Generate subtitles" and assert a rendered
 //     CUE carries one of those same words.
 //
-// Every assertion reads the UI, never the sidecar's return value: the point is
+// Every assertion about the TRANSCRIPT and the CUES reads the UI: the point is
 // that the USER can see the transcript, not that an RPC returned one.
+//
+// SCOPE CORRECTION — the earlier wording here ("every assertion reads the UI,
+// never the sidecar's return value") was REFUTED and is wrong. There is exactly
+// ONE assertion on an RPC return value: the `settings.set` pin in `beforeAll`
+// below, which checks the MERGED settings document it returns. That is a setup
+// PRECONDITION that no UI surface exposes, and it is deliberate — without it a
+// param-shape mistake becomes a mysterious 1.5 GB download instead of a named
+// setup failure. Every done-signal (transcript text, cue text) is still read
+// from the rendered DOM.
 //
 // ── WHAT THIS DOES *NOT* DO ──────────────────────────────────────────────────
 // It does NOT gate a PR. `e2e.yml` is `workflow_dispatch` + nightly `cron` only,
@@ -85,6 +96,31 @@ const PIN_MODEL = 'tiny';
 // CPU anyway. Pinning it makes the resolved target deterministic instead of a
 // side effect of which packages happen to be installed.
 const PIN_DEVICE = 'cpu';
+
+// ── THE ONE ENV OVERRIDE, AND THE DEFECT IT CLOSES ───────────────────────────
+// `fixtures.definedEnv` copies the WHOLE ambient environment into the app env, so
+// the sidecar inherits any `HF_TOKEN` the developer has exported. huggingface_hub
+// sends that token IMPLICITLY on every request — including requests for a PUBLIC
+// repo — and a token that no longer authenticates turns a public fetch into
+// `RepositoryNotFoundError: 401`, which reads as "the model does not exist", not
+// "your token is bad". MEASURED on this box, four arms, each on a FRESH empty
+// HF_HOME against the public `Systran/faster-whisper-tiny`:
+//   huggingface_hub 1.27.0, ambient token -> RepositoryNotFoundError 401, cache 5,698 B
+//   huggingface_hub 1.27.0, this override -> OK, 6 blobs / 78,207,087 B (74.6 MB)
+//   huggingface_hub 1.26.0 (the lock pin), ambient token -> RepositoryNotFoundError 401
+//   huggingface_hub 1.26.0 (the lock pin), this override -> OK, the same 6 blobs
+// and END-TO-END through this spec: WITHOUT the override, a cold-HF_HOME run goes
+// red in 41 s at the panel-error arm below, carrying the sidecar's
+// `User Access Token "Reframe" is expired`.
+//
+// The credential itself is NOT touched — AGENTS.md §9 reserves credential
+// lifecycle to the owner — so the CONSUMER is fixed instead, which is also the
+// durable half: ANY HF_TOKEN that 401s (revoked, wrong org, insufficient scope)
+// breaks the cold-cache path identically. A GitHub runner carries no HF_TOKEN and
+// was therefore already anonymous, so this changes nothing in CI and only makes a
+// developer's cold-cache run deterministic. It does NOT make the leg offline (see
+// PIN_MODEL's disclosed residual) — it makes the network fetch unauthenticated.
+const HF_ANONYMOUS_ENV: Record<string, string> = { HF_HUB_DISABLE_IMPLICIT_TOKEN: '1' };
 
 // Cold whisper: a ~75 MB model fetch on a fresh runner, then CPU/int8 inference
 // over ~7 s of audio. Measured locally (warm HF cache, 8-core): first transcript
@@ -151,7 +187,8 @@ test.beforeAll(async () => {
   app = await electron.launch({
     args: [built.main, '--autoplay-policy=no-user-gesture-required', '--no-sandbox'],
     ...(built.executablePath ? { executablePath: built.executablePath } : {}),
-    env: seeded.appEnv,
+    // HF_ANONYMOUS_ENV last so it wins over anything the ambient env carried.
+    env: { ...seeded.appEnv, ...HF_ANONYMOUS_ENV },
   });
 
   const proc = app.process();
@@ -229,9 +266,27 @@ test('spoken words become a visible transcript and then a caption cue (real GUI 
   // (Transcribe.tsx:318), INCLUDING one with zero segments. Waiting on
   // `.transcript-segments li` instead means an honest empty transcript (what the
   // speechless `sine` sample produces) burns the whole TRANSCRIBE_WAIT_MS budget
-  // before reporting an anonymous "element not found" — measured: 5.1 minutes.
-  // Racing the summary and the panel error gives three distinct, fast verdicts:
-  // ASR blew up / ASR finished empty / ASR finished with content.
+  // before reporting an anonymous "element not found" — measured at 5.1 minutes
+  // on the PRE-SHARPENING shape of this block against a ~6.7 s speechless sine
+  // (i.e. a sine stretched to the speech fixture's length, NOT the repo's own
+  // 3 s `sine=frequency=440:duration=3`). UNVERIFIED here: that 5.1-minute figure
+  // has not been re-measured, because the shape it describes no longer exists;
+  // the settling experiment is to revert to `segments.first().waitFor(...)` and
+  // re-run the sine arm. What IS re-measured is the sharpened shape below.
+  //
+  // Racing the summary and the panel error gives three distinct, fast verdicts —
+  // and all THREE are now measured, not two:
+  //   ASR blew up            -> panel error, 41 s wall clock: a cold HF_HOME plus
+  //                             an ambient HF_TOKEN that 401s (see HF_ANONYMOUS_ENV)
+  //                             lands here carrying the sidecar's own reason.
+  //   ASR finished EMPTY     -> the zero-segments arm below, RE-MEASURED against
+  //                             the repo's OWN 3 s speechless `sine` fixture:
+  //                             failing test 12.6 s, whole invocation 56.3 s
+  //                             (it includes Playwright's worker restart). Seconds,
+  //                             not the pre-sharpening minutes — worth stating
+  //                             because the cost of the red state is the only
+  //                             argument against keeping this arm strict.
+  //   ASR finished with content -> the green path.
   const segments = panel.locator('.transcript-segments li');
   const summaryLoc = panel.locator('.transcript-summary');
   const panelError = panel.locator('p.error[role="alert"]');
@@ -321,9 +376,20 @@ test('spoken words become a visible transcript and then a caption cue (real GUI 
 });
 
 test('no console errors across the transcribe-journey session', async () => {
-  // Bound in beforeAll, so this covers load, navigation, the transcription run and
-  // the caption generation. Kept SEPARATE from — and after — the speech-to-text
+  // Bound in beforeAll. Kept SEPARATE from — and after — the speech-to-text
   // done-signal so a renderer console error never masks the primary verdict
   // (same split as golden-journey.spec.ts:318).
+  //
+  // SCOPE — this covers load, navigation, the transcription run and the caption
+  // generation ONLY WHEN THE PRIMARY TEST PASSES. After a primary failure
+  // Playwright restarts the worker, `beforeAll` re-runs, and this test then
+  // observes a FRESH app that never transcribed. MEASURED both states in one
+  // spec: the red run prints the `[transcribe-journey] speech fixture: …` line
+  // TWICE (once per beforeAll) and this test finishes in tens of ms against that
+  // fresh launch, while the green run prints it ONCE. So on a red run this is a
+  // launch-only console check, not session coverage. Not lane-introduced —
+  // golden-journey.spec.ts:318 has the identical split — and left as-is
+  // deliberately: merging it into the primary test would let a console error mask
+  // the speech verdict, which is the worse failure.
   expect(consoleErrors, `console errors across session: ${JSON.stringify(consoleErrors)}`).toEqual([]);
 });

--- a/app/e2e/transcribe-journey.spec.ts
+++ b/app/e2e/transcribe-journey.spec.ts
@@ -223,13 +223,20 @@ test('spoken words become a visible transcript and then a caption cue (real GUI 
   // D — run the REAL transcription (transcribe.start → live faster-whisper).
   await startButton.click();
 
-  // A panel-level error is a NAMED failure; race it against the transcript so a
-  // broken ASR install reports "no module named faster_whisper" instead of an
-  // anonymous timeout.
+  // Wait for the JOB to land, not for the segments — the two are different states
+  // and conflating them costs five minutes on the most interesting failure.
+  // `.transcript-summary` renders as soon as a Transcript object arrives
+  // (Transcribe.tsx:318), INCLUDING one with zero segments. Waiting on
+  // `.transcript-segments li` instead means an honest empty transcript (what the
+  // speechless `sine` sample produces) burns the whole TRANSCRIBE_WAIT_MS budget
+  // before reporting an anonymous "element not found" — measured: 5.1 minutes.
+  // Racing the summary and the panel error gives three distinct, fast verdicts:
+  // ASR blew up / ASR finished empty / ASR finished with content.
   const segments = panel.locator('.transcript-segments li');
+  const summaryLoc = panel.locator('.transcript-summary');
   const panelError = panel.locator('p.error[role="alert"]');
   await Promise.race([
-    segments.first().waitFor({ state: 'visible', timeout: TRANSCRIBE_WAIT_MS }),
+    summaryLoc.waitFor({ state: 'visible', timeout: TRANSCRIBE_WAIT_MS }),
     panelError.waitFor({ state: 'visible', timeout: TRANSCRIBE_WAIT_MS }),
   ]).catch(() => undefined);
   if (await panelError.isVisible()) {
@@ -239,10 +246,22 @@ test('spoken words become a visible transcript and then a caption cue (real GUI 
     );
   }
   await expect(
-    segments.first(),
-    `no transcript segment ever rendered within ${TRANSCRIBE_WAIT_MS}ms\n` +
+    summaryLoc,
+    `the transcription never completed within ${TRANSCRIBE_WAIT_MS}ms (no transcript reached the UI)\n` +
       `--- sidecar log tail ---\n${asrErrorTail()}`,
   ).toBeVisible({ timeout: 5_000 });
+  // A transcript OBJECT arrived. An EMPTY one is the signature of "the audio
+  // carried no recognisable speech" — precisely the pre-existing state this spec
+  // exists to distinguish from working transcription, so name it.
+  await expect(
+    segments,
+    'the transcription completed but produced ZERO segments — the audio reaching whisper ' +
+      'carried no recognisable speech (this is exactly what the speechless `sine` fixture does)',
+    // Short timeout on purpose: the summary above proves the job is TERMINAL, and
+    // Transcribe.tsx renders every segment in the same commit as the summary — so
+    // the count cannot change. Polling it for the config's 30 s only lengthens the
+    // red repro. MEASURED against the sine fixture: this arm fires.
+  ).not.toHaveCount(0, { timeout: 5_000 });
 
   // E — THE PRIMARY DONE-SIGNAL: the words the user can SEE.
   const transcriptText = ((await panel.locator('.transcript-segments').textContent()) ?? '').trim();


### PR DESCRIPTION
## The hole this closes

Reframe's core purpose is import → **transcribe** → caption → reframe → export. Until this PR,
**no test anywhere in the repository proved that a spoken word becomes text.** Not a product
defect necessarily — but there was no evidence either way, which is the problem.

Measured at `origin/main` before this change:

* `app/e2e/fixtures.ts` — the only media fixture is `testsrc` + `sine=frequency=440`. No speech.
* `golden-journey.spec.ts:18-19` — deliberately takes the manual-range path because
  *"AI moment-pick would emit 'no candidates' on a 3s no-speech sample"*. The GUI journey bypasses
  transcription **by design**.
* `sidecar/tests/e2e/real_pipeline_smoke.py` runs a **real** tiny/cpu/int8 whisper — and its own
  output says *"sine-only audio has no speech, so 0 segments is the honest result"*. It asserts an
  **empty** transcript.
* `test_whisper_offline_e2e.py` proves model *resolution* with fake weights
  (`model.bin` = `b"ct2-weights"`). It never transcribes audio.

## What this adds

A new Windows-only Playwright spec driving the **real Electron GUI** against the **real Python
sidecar**. `golden-journey.spec.ts` is untouched — it is currently the only proof that
cut → reframe → export works on real media, and a slower model-dependent assertion inside it would
put that proof at risk.

Speech is synthesised at test time via Windows SAPI and muxed over the existing `testsrc` video —
**no audio binary is committed and nothing is redistributed.** Every assertion reads the UI
(`.transcript-segments`, then `.cue-list input.cue-text`), never an RPC return value: the point is
that the *user* can see it.

`seedEnvironment()` gained an optional media generator that **defaults to the existing silent
sample**, so all four existing callers are behaviourally unchanged (`preview.spec` — the one
runnable shared caller — is 9/9 green on the branch).

### The assertion is keyword + threshold, and must not be "tightened"

The phrase says *"Reframe converts landscape video to vertical"*; whisper returns **"Refrain"**.
So an exact-string match would be flaky **by construction**. The spec asserts >= 2 of
{fox, dog, landscape, vertical}, with the reasoning in-source and an explicit do-not-tighten
warning. A vitest oracle pins the threshold constant, and is **mutation-verified**: floor=2 → 6
passed; floor=1 → fails closed.

## Both-states proof — run by the implementer AND re-run independently by a fresh skeptic

Same spec (SHA256-verified byte-identical), same code, **only the fixture audio differs**:

| arm | result |
|---|---|
| real SAPI speech | **2 passed**, 4/4 keywords, `Segments: 2 · Words: 15` |
| the repo's own speechless `sine` | **RED** — *"the transcription completed but produced ZERO segments"* |
| real speech, no `faster_whisper` installed | **RED in 2.1s** — panel shows `No module named 'faster_whisper'` |

The third arm was added by the skeptic; nobody had run it before. All three failure modes are now
distinguishable rather than collapsing into one timeout.

Transcript as rendered in the UI: `0.0–2.7s The quick brown fox jumps over the lazy dog.` /
`3.7–5.8s Refrain converts landscape video to vertical.` — the *mis-hearing reproduces exactly*,
which is the strongest available attribution of the text to the audio.

An early version of the red path was useless: it waited on a segment element, so an honest empty
transcript burned the full 300s and reported "element not found". Fixed by racing the summary
element against the panel error.

## Scope — stated plainly, because it is easy to overstate

* **This gates NOTHING.** `e2e.yml` triggers are exactly `['schedule','workflow_dispatch']`
  (parsed from the stored blob). `quality.yml` is untouched and its 6-gate list is unchanged. This
  proves the capability nightly and on demand; it does **not** prevent a regression from merging.
* **Not an offline proof.** `tiny` is deliberately unregistered, so the 74.6 MB snapshot is fetched
  at run time (cold-cache fetch measured: 0 → 78,247,329 B).
* **`manifest.py` was NOT modified**, and the reason is measured: the registered
  `whisper-large-v3-turbo` is **1546.5 MB** vs **74.6 MB** for tiny — 20× for zero extra proof, and
  registering a pinned tiny asset would add a user-visible component to `assets.list` for the sole
  benefit of a nightly test.
* The caption arm is fail-closed by construction but **not** both-states controlled (the broken run
  aborts at the zero-segments arm first).
* This does not prove the live `CaptionOverlay` painted over the video frame — still behind LLM
  clip selection. The README says so.

## Owner action — a credential finding, reported not acted on

The ambient **User-scope `HF_TOKEN` does not authenticate**: with it, a metadata call to the
*public* `Systran/faster-whisper-tiny` returns **401 RepositoryNotFoundError**; anonymous succeeds.
Reproduced read-only in both directions; the value was never read or printed and **nothing was
rotated or modified** (AGENTS.md §9 — credential lifecycle is the owner's).

The spec is unaffected because it sets `HF_HUB_DISABLE_IMPLICIT_TOKEN=1`, proven load-bearing
against a fresh empty `HF_HOME` with the invalid token present: 2 passed, 4/4 keywords.

## Residuals (disclosed, non-blocking)

* The **CI leg itself is UNVERIFIED** on a `windows-latest` runner — an enabled `en-*` voice,
  huggingface egress, and identical `--constraint` resolution. Settling experiment: one
  `workflow_dispatch` of `e2e.yml`.
* Nightly step ordering: the speech step carries no `always()`, so a red in the earlier Playwright
  or visual step makes it **skip**. No false green (the leg is red regardless), but the speech
  proof is the lowest-priority thing in the nightly.
* `speechKeywords.test.ts` runs under `vitest.e2e.config.ts` only, so the oracle is in no PR gate.
* The non-Windows `test.skip()` path could not be run from this box; an independent refuter
  controlled it in a temp project (2 skipped; control 2 failed).

CI is the arbiter. This merges only if `quality` is green.
