### PR TITLE
fix(shortmaker): guard settle-time writes against a mid-flight videoId switch

### DIFF
--- a/app/renderer/src/features/ShortMaker.test.tsx
+++ b/app/renderer/src/features/ShortMaker.test.tsx
@@ -3696,9 +3696,22 @@ describe('<ShortMaker /> component', () => {
   // re-subscribe: the emit never reaches the wait, the job never settles, and "no
   // stale write" gets measured for entirely the wrong reason. `jobDoneBus` fans
   // every event out to ALL live subscribers, and each switch test asserts the
-  // multi-subscriber condition was really present at emit time. Every switch case
-  // is ALSO paired with a NO-SWITCH control arm that must still show the write —
-  // a guard that simply suppressed everything would pass the switch arm alone.
+  // multi-subscriber condition was really present at emit time.
+  //
+  // CONTROL ARMS — corrected count (the earlier wording here claimed every switch
+  // case was paired with a control arm written below; that was wider than the
+  // evidence). 5 of the 8 switch probes have a NO-SWITCH control arm written here;
+  // the other 3 are covered by PRE-EXISTING controls in this file, which assert
+  // exactly the write each probe expects to be suppressed:
+  //   * runSelect-catch          -> 'a select failure shows a DISTINCT error +
+  //                                 Retry that re-runs select' (:2711)
+  //   * runBatch-stale-select    -> '"Make N shorts" runs select -> auto-approve
+  //                                 top N by virality -> export unattended' (:2253)
+  //   * runBatch-zero-candidate  -> 'batch shows the empty state (not an error) and
+  //                                 does NOT export when no candidates are
+  //                                 proposed' (:2291)
+  // Either way no probe stands alone, so a guard that simply suppressed everything
+  // could not pass — but only 5 of those controls are new here.
   // -------------------------------------------------------------------------
 
   /** A `job.done` bridge double that fans each event out to EVERY subscriber. */
@@ -4111,5 +4124,334 @@ describe('<ShortMaker /> component', () => {
     // Back on v1 the receipt describes the selected video again — truthful, so it
     // is admitted (this is what makes the guard an id comparison, not a latch).
     expect(container.querySelector('.sm-exported')?.textContent).toContain('/out/v1-clip.mp4');
+  });
+
+  // -------------------------------------------------------------------------
+  // Item SM (remediation) — LANE OWNERSHIP.
+  //
+  // `activeJobRef`, `abortRef` and `progress` are ONE slot each, shared by all
+  // three run loops, and the reset effect leaves `phase` at 'idle' after a video
+  // switch — so the user really can start a SECOND job while the first is still
+  // in flight. On the runBatch path the videoId guard above is what makes that
+  // reachable: pre-guard, runBatch ran `setPhase('exporting')` unconditionally, so
+  // video 2 was falsely busy and its start controls stayed disabled for the whole
+  // export wait. Measured two-state, same script, only the source swapped —
+  // origin/main: batchDisabled=true cancelVisible=true exportFired=true; with the
+  // guard: batchDisabled=false cancelVisible=false exportFired=true. Un-blocking
+  // video 2 is correct — it has no job of its own, and the export still runs — but
+  // video 1 then settles into a lane video 2 owns, and its teardown cleared all
+  // three slots.
+  //
+  // Measured consequences, each RED against the previous commit:
+  //   * v2's progress bar never returns for the REST of its job — the relay is
+  //     keyed on `activeJobRef`, which v1's `finally` nulled.
+  //   * v2's Cancel emits ZERO `job.cancel` calls — `cancel()` reads the same
+  //     nulled handle, so the "cancelled" job is never aborted.
+  //   * v1's own in-flight events are relayed onto v2's bar once v1's late handle
+  //     wins the single slot (`resolveJobResult` writes it unconditionally, and it
+  //     was handed the real ref).
+  // Scope of "pre-existing": the CLASS is — on runSelect/runExport the reset
+  // already left phase='idle' before the guard, so a second job was always
+  // startable there. On the runBatch path it is the guard that opened it (the
+  // two-state probe above). Either way it is fixed here, not merely disclosed.
+  //
+  // Every probe below drives TWO real jobs and asserts BOTH directions: video 2's
+  // own lane keeps working, and video 1's events never render as video 2's. In the
+  // first five, "v2's progress relays BEFORE v1 settles" is a state-invariant
+  // control arm — it holds in the broken state too (verified: the pre-fix failure
+  // is the POST-settle assertion, never the control), so a fix that simply muted
+  // the bar could not pass. The sixth (pre-handle window) is two-DIRECTIONAL
+  // instead: both of its assertions are RED pre-fix, and its accept-path control
+  // is the pre-existing 'renders progress with an empty message …' test above.
+  // -------------------------------------------------------------------------
+
+  /** A promise plus its resolver, so an rpc can be held in flight on purpose. */
+  function deferred<T>() {
+    let settle!: (v: T) => void;
+    const promise = new Promise<T>((r) => {
+      settle = r;
+    });
+    return { promise, settle };
+  }
+
+  /**
+   * Method-keyed rpc fake whose handler is a QUEUE — one entry per call, the last
+   * entry repeating. These probes drive TWO real jobs through the SAME method
+   * (video 1's, then video 2's), so each call needs its own jobId; an entry may be
+   * a pending promise to hold that call in flight. `media.playable` answers FALSE
+   * by default for the same reason `staleRpc` does (the second job.done subscriber).
+   */
+  function laneRpc(over: Record<string, unknown[]>) {
+    const seen: Record<string, number> = {};
+    return vi.fn(async (method: string) => {
+      const q = over[method];
+      if (!q) return method === 'media.playable' ? { playable: false } : {};
+      const i = seen[method] ?? 0;
+      seen[method] = i + 1;
+      return q[Math.min(i, q.length - 1)];
+    }) as unknown as Api['rpc'] & ReturnType<typeof vi.fn>;
+  }
+
+  function bar() {
+    return container.querySelector('.sm-progress')?.textContent ?? null;
+  }
+
+  function cancelButton() {
+    return [...container.querySelectorAll('button')].find((b) => b.textContent === 'Cancel') as
+      | HTMLButtonElement
+      | undefined;
+  }
+
+  async function emitProgress(fn: (p: JobProgress) => void, p: JobProgress) {
+    await act(async () => {
+      fn(p);
+      await Promise.resolve();
+    });
+  }
+
+  /** Let a resumed run loop drain its remaining awaits. */
+  async function drain() {
+    await flush();
+    await flush();
+    await flush();
+  }
+
+  /** Switch the prop to v2 (same instance) and start v2's OWN deferred select. */
+  async function startV2Select(el: React.ReactElement) {
+    render(el);
+    await flush();
+    await submitForm();
+  }
+
+  const V2_SELECT = { jobId: 'sel-v2' };
+
+  it('lane: a v1 export settling while a v2 job runs leaves v2 progress relaying', async () => {
+    const bus = jobDoneBus();
+    let onP: ((p: JobProgress) => void) | null = null;
+    const rpc = laneRpc({
+      'shortmaker.select': [{ candidates: THREE }, V2_SELECT],
+      'shortmaker.export': [EXPORTED_JOB],
+    });
+    const api = makeApi({
+      rpc,
+      onJobDone: bus.onJobDone,
+      onProgress: (fn) => {
+        onP = fn;
+        return () => undefined;
+      },
+    });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved(); // v1: exp-1 in flight
+    await startV2Select(<ShortMaker videoId="v2" api={api} />);
+    expect(bus.count()).toBeGreaterThanOrEqual(2);
+
+    // CONTROL (must hold in the broken state too): v2's own progress relays.
+    await emitProgress(onP!, { jobId: 'sel-v2', pct: 33, message: 'v2 working' });
+    expect(bar()).toContain('33% v2 working');
+
+    await emitDone(bus, { jobId: 'exp-1', result: V1_CLIPS });
+
+    // v1's teardown must not clear the bar v2 owns...
+    expect(bar()).toContain('33% v2 working');
+    // ...and v2's LATER progress must still reach it (the relay needs the handle).
+    await emitProgress(onP!, { jobId: 'sel-v2', pct: 66, message: 'v2 still working' });
+    expect(bar()).toContain('66% v2 still working');
+    // ...while v1's receipt is still dropped (the videoId guard, unchanged).
+    expect(container.querySelector('.sm-exported')).toBeNull();
+  });
+
+  it('lane: a v1 export settling while a v2 job runs leaves v2 Cancel able to cancel v2', async () => {
+    const bus = jobDoneBus();
+    const rpc = laneRpc({
+      'shortmaker.select': [{ candidates: THREE }, V2_SELECT],
+      'shortmaker.export': [EXPORTED_JOB],
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+    await startV2Select(<ShortMaker videoId="v2" api={api} />);
+    // CONTROL: v2 is busy on its own job, so Cancel is on screen before AND after.
+    expect(cancelButton()).toBeTruthy();
+
+    await emitDone(bus, { jobId: 'exp-1', result: V1_CLIPS });
+
+    expect(cancelButton()).toBeTruthy();
+    await act(async () => {
+      cancelButton()!.click();
+      await Promise.resolve();
+    });
+    // v2's handle survived, so Cancel really aborts v2's job (not v1's, not none).
+    expect(rpc).toHaveBeenCalledWith('job.cancel', { jobId: 'sel-v2' });
+  });
+
+  it('lane: a v1 select handle resolving after v2 started never claims v2 lane', async () => {
+    const bus = jobDoneBus();
+    let onP: ((p: JobProgress) => void) | null = null;
+    const held = deferred<unknown>();
+    const rpc = laneRpc({ 'shortmaker.select': [held.promise, V2_SELECT] });
+    const api = makeApi({
+      rpc,
+      onJobDone: bus.onJobDone,
+      onProgress: (fn) => {
+        onP = fn;
+        return () => undefined;
+      },
+    });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await submitForm(); // v1's select rpc is HELD — no handle yet
+    await startV2Select(<ShortMaker videoId="v2" api={api} />);
+    await emitProgress(onP!, { jobId: 'sel-v2', pct: 33, message: 'v2 working' });
+    expect(bar()).toContain('33% v2 working'); // control
+
+    await act(async () => {
+      held.settle({ jobId: 'sel-v1' });
+      await Promise.resolve();
+    });
+    await drain();
+
+    // v1's handle must not hijack the relay...
+    await emitProgress(onP!, { jobId: 'sel-v1', pct: 99, message: 'v1 select running' });
+    expect(bar()).not.toContain('v1 select running');
+    expect(bar()).toContain('33% v2 working');
+    // ...and v1's job settling must not clear v2's progress.
+    await emitDone(bus, { jobId: 'sel-v1', result: { candidates: THREE } });
+    expect(bar()).toContain('33% v2 working');
+    expect(container.querySelector('.sm-candidate')).toBeNull();
+  });
+
+  it('lane: a v1 export handle resolving after v2 started never claims v2 lane', async () => {
+    let onP: ((p: JobProgress) => void) | null = null;
+    const held = deferred<unknown>();
+    const rpc = laneRpc({
+      'shortmaker.select': [{ candidates: THREE }, V2_SELECT],
+      'shortmaker.export': [held.promise],
+    });
+    const api = makeApi({
+      rpc,
+      onJobDone: jobDoneBus().onJobDone,
+      onProgress: (fn) => {
+        onP = fn;
+        return () => undefined;
+      },
+    });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved(); // v1's export rpc is HELD — no handle yet
+    await startV2Select(<ShortMaker videoId="v2" api={api} />);
+    await emitProgress(onP!, { jobId: 'sel-v2', pct: 33, message: 'v2 working' });
+    expect(bar()).toContain('33% v2 working'); // control
+
+    await act(async () => {
+      held.settle({ jobId: 'exp-1' });
+      await Promise.resolve();
+    });
+    await drain();
+
+    await emitProgress(onP!, { jobId: 'exp-1', pct: 42, message: 'v1 export running' });
+    expect(bar()).not.toContain('v1 export running');
+    expect(bar()).toContain('33% v2 working');
+  });
+
+  it('lane: neither runBatch stage claims a lane a second video owns', async () => {
+    const bus = jobDoneBus();
+    let onP: ((p: JobProgress) => void) | null = null;
+    const heldSel = deferred<unknown>();
+    const rpc = laneRpc({
+      'shortmaker.select': [heldSel.promise, V2_SELECT],
+      'shortmaker.export': [{ jobId: 'bexp-1' }],
+    });
+    const api = makeApi({
+      rpc,
+      onJobDone: bus.onJobDone,
+      onProgress: (fn) => {
+        onP = fn;
+        return () => undefined;
+      },
+    });
+    render(<ShortMaker videoId="v1" api={api} initialControls={{ count: 1 }} />);
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await startV2Select(<ShortMaker videoId="v2" api={api} initialControls={{ count: 1 }} />);
+    await emitProgress(onP!, { jobId: 'sel-v2', pct: 33, message: 'v2 working' });
+    expect(bar()).toContain('33% v2 working'); // control
+
+    // Stage 1 — v1's batch SELECT handle arrives late.
+    await act(async () => {
+      heldSel.settle({ jobId: 'bsel-1' });
+      await Promise.resolve();
+    });
+    await drain();
+    await emitProgress(onP!, { jobId: 'bsel-1', pct: 11, message: 'v1 batch select' });
+    expect(bar()).not.toContain('v1 batch select');
+
+    // Stage 2 — nor may its EXPORT handle claim the lane.
+    await emitDone(bus, { jobId: 'bsel-1', result: { candidates: THREE } });
+    await emitProgress(onP!, { jobId: 'bexp-1', pct: 42, message: 'v1 batch export' });
+    expect(bar()).not.toContain('v1 batch export');
+
+    // And the batch settling must not clear v2's progress.
+    await emitDone(bus, { jobId: 'bexp-1', result: V1_CLIPS });
+    expect(bar()).toContain('33% v2 working');
+    expect(container.querySelector('.sm-exported')).toBeNull();
+  });
+
+  it('lane: a previous run handle cannot paint the bar in the new pre-handle window', async () => {
+    // The relay documents (ShortMaker.tsx:239-242) that BEFORE the handle is known
+    // it accepts ONLY jobId-less early progress — which holds only while the slot is
+    // empty, i.e. only because a new run clears the previous owner's handle. Both
+    // assertions below are RED without that clear: the empty-jobId event is REJECTED
+    // (the slot still holds 'exp-1') and v1's event is ACCEPTED. The accept path
+    // itself is also pinned by the pre-existing 'renders progress with an empty
+    // message when the notification omits one' test above.
+    let onP: ((p: JobProgress) => void) | null = null;
+    const heldV2 = deferred<unknown>();
+    const rpc = laneRpc({
+      'shortmaker.select': [{ candidates: THREE }, heldV2.promise],
+      'shortmaker.export': [EXPORTED_JOB],
+    });
+    const api = makeApi({
+      rpc,
+      onJobDone: jobDoneBus().onJobDone,
+      onProgress: (fn) => {
+        onP = fn;
+        return () => undefined;
+      },
+    });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved(); // v1's exp-1 handle IS registered
+    // v2 takes the lane, but its select rpc is HELD: the pre-handle window is open.
+    await startV2Select(<ShortMaker videoId="v2" api={api} />);
+
+    await emitProgress(onP!, { jobId: '', pct: 5, message: 'v2 starting' });
+    expect(bar()).toContain('5% v2 starting');
+    await emitProgress(onP!, { jobId: 'exp-1', pct: 77, message: 'v1 export running' });
+    expect(bar()).not.toContain('v1 export running');
+    expect(bar()).toContain('5% v2 starting');
+  });
+
+  it('Cancel before the deferred handle arrives resets the UI and sends no job.cancel', async () => {
+    // NOT a fail-first probe — a regression pin for the pre-handle window, which
+    // was previously hidden behind a `/* v8 ignore */` on a two-operand guard whose
+    // `!jobId` half is REACHABLE: Cancel renders on `busy` ALONE
+    // (ShortMakerControls.tsx:349), i.e. before the handle exists.
+    const held = deferred<unknown>();
+    const rpc = laneRpc({ 'shortmaker.select': [held.promise] });
+    render(<ShortMaker videoId="v1" api={makeApi({ rpc })} />);
+    await submitForm();
+    expect(cancelButton()).toBeTruthy();
+
+    await act(async () => {
+      cancelButton()!.click();
+      await Promise.resolve();
+    });
+
+    expect(callsTo(rpc, 'job.cancel')).toHaveLength(0);
+    expect(bar()).toBeNull();
+    expect(cancelButton()).toBeUndefined();
   });
 });

--- a/app/renderer/src/features/ShortMaker.test.tsx
+++ b/app/renderer/src/features/ShortMaker.test.tsx
@@ -3675,4 +3675,441 @@ describe('<ShortMaker /> component', () => {
     expect(container.querySelector('.sm-exported')).toBeNull();
     expect(container.querySelector('[role="alert"]')).toBeNull();
   });
+
+  // -------------------------------------------------------------------------
+  // Item SM — a DEFERRED job that settles AFTER the parent swapped `videoId`
+  // must not write video 1's outcome as video 2's status.
+  //
+  // views/MakeShorts.tsx:358-366 renders <ShortMaker videoId={selectedId}>
+  // UNKEYED, so the picker swaps the prop instead of remounting, and
+  // shortmaker.select / shortmaker.export are deferred jobs awaited for up to
+  // EXPORT_JOB_TIMEOUT_MS (35 min). The reset effect (ShortMaker.tsx:255-266)
+  // clears per-video state on the switch but does NOT abort the in-flight wait,
+  // so the OLD video's settle-time writes land AFTER that reset.
+  //
+  // DETECTOR CONTROL — this is a measured false-pass trap, not a hypothetical.
+  // ShortMaker installs TWO job.done subscribers: the run loop's own
+  // `waitForJobDone` AND the media.playable preview watcher (ShortMaker.tsx:433),
+  // which is torn down and RE-subscribed on every videoId change. A double with a
+  // single callback slot (`doneCb = fn`, as the older tests above use) therefore
+  // has the in-flight wait's callback OVERWRITTEN by that post-switch
+  // re-subscribe: the emit never reaches the wait, the job never settles, and "no
+  // stale write" gets measured for entirely the wrong reason. `jobDoneBus` fans
+  // every event out to ALL live subscribers, and each switch test asserts the
+  // multi-subscriber condition was really present at emit time. Every switch case
+  // is ALSO paired with a NO-SWITCH control arm that must still show the write —
+  // a guard that simply suppressed everything would pass the switch arm alone.
+  // -------------------------------------------------------------------------
+
+  /** A `job.done` bridge double that fans each event out to EVERY subscriber. */
+  function jobDoneBus() {
+    const subs = new Set<(d: JobDone) => void>();
+    return {
+      onJobDone: (fn: (d: JobDone) => void) => {
+        subs.add(fn);
+        return () => {
+          subs.delete(fn);
+        };
+      },
+      emit: (d: JobDone) => {
+        for (const fn of [...subs]) fn(d);
+      },
+      /** Live subscriber count — the detector control for the note above. */
+      count: () => subs.size,
+    };
+  }
+
+  /**
+   * Method-aware rpc fake for the stale-write tests. `media.playable` answers
+   * FALSE by default so the preview watcher really does install the SECOND
+   * job.done subscriber that `jobDoneBus` exists for.
+   */
+  function staleRpc(over: Record<string, unknown> = {}) {
+    return vi.fn(async (method: string) => {
+      const h = over[method];
+      if (h instanceof Error) throw h;
+      if (h !== undefined) return h;
+      if (method === 'media.playable') return { playable: false };
+      return {};
+    }) as unknown as Api['rpc'] & ReturnType<typeof vi.fn>;
+  }
+
+  /** Select (sync) then approve rank 1, leaving Export approved enabled. */
+  async function selectAndApproveOne() {
+    await submitForm();
+    const row = container.querySelector('.sm-candidate[data-id="1@97"]')!;
+    act(() => (row.querySelector('[aria-label="Approve"]') as HTMLButtonElement).click());
+  }
+
+  async function clickExportApproved() {
+    const btn = [...container.querySelectorAll('button')].find(
+      (b) => b.textContent === 'Export approved',
+    ) as HTMLButtonElement;
+    await act(async () => {
+      btn.click();
+      await Promise.resolve();
+    });
+  }
+
+  async function emitDone(bus: ReturnType<typeof jobDoneBus>, d: JobDone) {
+    await act(async () => {
+      bus.emit(d);
+      await Promise.resolve();
+    });
+    await flush();
+  }
+
+  function callsTo(rpc: ReturnType<typeof vi.fn>, method: string) {
+    return rpc.mock.calls.filter((c) => c[0] === method);
+  }
+
+  const EXPORTED_JOB = { jobId: 'exp-1' };
+  const V1_CLIPS = { clips: [{ path: '/out/v1-clip.mp4' }] };
+
+  // ---- runExport ----------------------------------------------------------
+
+  it('runExport: a job settling AFTER a videoId switch writes no clips and no shorts.list', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': EXPORTED_JOB,
+      'shorts.list': { shorts: [{ path: '/out/v1-clip.mp4' }] },
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+
+    // The parent swaps the prop only (UNKEYED child) — same instance, new video.
+    render(<ShortMaker videoId="v2" api={api} />);
+    await flush();
+    // Detector control: the wait AND the re-subscribed preview watcher are both
+    // live, which is exactly what a single-slot double would silently break.
+    expect(bus.count()).toBeGreaterThanOrEqual(2);
+
+    await emitDone(bus, { jobId: 'exp-1', result: V1_CLIPS });
+
+    // v1's receipt must not be presented as v2's status...
+    expect(container.querySelector('.sm-exported')).toBeNull();
+    // ...and the gallery reload for the OLD video must not fire: its result is
+    // rendered as the CURRENTLY selected video's produced-shorts list.
+    expect(callsTo(rpc, 'shorts.list')).toHaveLength(0);
+  });
+
+  it('runExport control (no switch): the same deferred job DOES write clips + reload shorts.list', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': EXPORTED_JOB,
+      'shorts.list': { shorts: [{ path: '/out/v1-clip.mp4' }] },
+    });
+    render(<ShortMaker videoId="v1" api={makeApi({ rpc, onJobDone: bus.onJobDone })} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+    await emitDone(bus, { jobId: 'exp-1', result: V1_CLIPS });
+
+    expect(container.querySelector('.sm-exported')?.textContent).toContain('Exported 1 clip(s)');
+    expect(container.querySelector('.sm-exported')?.textContent).toContain('/out/v1-clip.mp4');
+    expect(callsTo(rpc, 'shorts.list')).toHaveLength(1);
+    expect(rpc).toHaveBeenCalledWith('shorts.list', { videoId: 'v1' });
+  });
+
+  it('runExport: the exported-label feedback still fires after a switch, attributed to v1', async () => {
+    // DELIBERATE and NOT guarded: `videoId`/`items` in the feedback loop are the
+    // CLOSURE's (frozen at export start), so the label is correctly attributed to
+    // the video that was actually exported and it writes no component state.
+    // Suppressing it would drop a true label, not prevent a false claim.
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': EXPORTED_JOB,
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+    render(<ShortMaker videoId="v2" api={api} />);
+    await flush();
+    await emitDone(bus, { jobId: 'exp-1', result: V1_CLIPS });
+
+    const exported = rpc.mock.calls.filter(
+      (c) => c[0] === 'feedback.record' && (c[1] as { action?: string }).action === 'exported',
+    );
+    expect(exported).toHaveLength(1);
+    expect((exported[0][1] as { videoId: string }).videoId).toBe('v1');
+  });
+
+  it('runExport: a job FAILING after a videoId switch raises no error banner', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': EXPORTED_JOB,
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+    render(<ShortMaker videoId="v2" api={api} />);
+    await flush();
+    await emitDone(bus, {
+      jobId: 'exp-1',
+      result: { error: { message: 'v1 export blew up', type: 'RuntimeError' } },
+    });
+
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('runExport control (no switch): the same failure DOES raise the error banner', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': EXPORTED_JOB,
+    });
+    render(<ShortMaker videoId="v1" api={makeApi({ rpc, onJobDone: bus.onJobDone })} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+    await emitDone(bus, {
+      jobId: 'exp-1',
+      result: { error: { message: 'v1 export blew up', type: 'RuntimeError' } },
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('v1 export blew up');
+  });
+
+  // ---- runSelect ----------------------------------------------------------
+  // The worst case in this family: v1's candidates loaded into v2's review list
+  // means "Export approved" would carve the NEW video at the OLD video's
+  // timestamps — the exact hazard the reset effect's own comment names.
+
+  it('runSelect: candidates arriving after a videoId switch are NOT loaded for the new video', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({ 'shortmaker.select': { jobId: 'sel-1' } });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await act(async () => {
+      container
+        .querySelector('form')!
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    render(<ShortMaker videoId="v2" api={api} />);
+    await flush();
+    expect(bus.count()).toBeGreaterThanOrEqual(2);
+
+    await emitDone(bus, { jobId: 'sel-1', result: { candidates: THREE } });
+
+    expect(container.querySelector('.sm-candidate')).toBeNull();
+    // Still the idle prompt form for v2 — no phantom 'reviewing' phase.
+    expect(byLabel('Prompt')).toBeTruthy();
+  });
+
+  it('runSelect control (no switch): the same deferred job DOES load the candidates', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({ 'shortmaker.select': { jobId: 'sel-1' } });
+    render(<ShortMaker videoId="v1" api={makeApi({ rpc, onJobDone: bus.onJobDone })} />);
+    await act(async () => {
+      container
+        .querySelector('form')!
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    await emitDone(bus, { jobId: 'sel-1', result: { candidates: THREE } });
+
+    expect(container.querySelectorAll('.sm-candidate').length).toBe(3);
+  });
+
+  it('runSelect: a select FAILING after a videoId switch raises no error banner', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({ 'shortmaker.select': { jobId: 'sel-1' } });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await act(async () => {
+      container
+        .querySelector('form')!
+        .dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+      await Promise.resolve();
+    });
+    render(<ShortMaker videoId="v2" api={api} />);
+    await flush();
+    await emitDone(bus, {
+      jobId: 'sel-1',
+      result: { error: { message: 'v1 select blew up', type: 'RuntimeError' } },
+    });
+
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  // ---- runBatch -----------------------------------------------------------
+
+  it('runBatch: a select settling after a switch loads no candidates but STILL exports v1', async () => {
+    // Guard-the-WRITE, not the work: the batch the user asked for still runs (its
+    // params carry the closure's videoId), only the on-screen receipt is dropped.
+    const bus = jobDoneBus();
+    const rpc = staleRpc({ 'shortmaker.select': { jobId: 'bsel-1' } });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} initialControls={{ count: 1 }} />);
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    render(<ShortMaker videoId="v2" api={api} initialControls={{ count: 1 }} />);
+    await flush();
+    expect(bus.count()).toBeGreaterThanOrEqual(2);
+
+    await emitDone(bus, { jobId: 'bsel-1', result: { candidates: THREE } });
+
+    // No v1 candidates in v2's review list, and v2 is not falsely busy.
+    expect(container.querySelector('.sm-candidate')).toBeNull();
+    expect(
+      [...container.querySelectorAll('button')].find((b) => b.textContent === 'Cancel'),
+    ).toBeUndefined();
+    // The requested export still ran, attributed to v1.
+    expect(rpc).toHaveBeenCalledWith(
+      'shortmaker.export',
+      expect.objectContaining({ videoId: 'v1' }),
+    );
+  });
+
+  it('runBatch: a ZERO-candidate select settling after a switch shows no empty state', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({ 'shortmaker.select': { jobId: 'bsel-1' } });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} initialControls={{ count: 1 }} />);
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    render(<ShortMaker videoId="v2" api={api} initialControls={{ count: 1 }} />);
+    await flush();
+
+    await emitDone(bus, { jobId: 'bsel-1', result: { candidates: [] } });
+
+    // "No candidates were proposed" would be a claim about v2, which was never
+    // asked. The control arm for the same assertion is the existing
+    // "batch shows the empty state ..." test above.
+    expect(container.querySelector('.sm-empty')).toBeNull();
+    expect(callsTo(rpc, 'shortmaker.export')).toHaveLength(0);
+  });
+
+  it('runBatch: an export settling after a switch writes no clips and no shorts.list', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': { jobId: 'bexp-1' },
+      'shorts.list': { shorts: [{ path: '/out/v1-clip.mp4' }] },
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} initialControls={{ count: 1 }} />);
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+    // select resolved synchronously -> the export job is now in flight for v1.
+    render(<ShortMaker videoId="v2" api={api} initialControls={{ count: 1 }} />);
+    await flush();
+    expect(bus.count()).toBeGreaterThanOrEqual(2);
+
+    await emitDone(bus, { jobId: 'bexp-1', result: V1_CLIPS });
+
+    expect(container.querySelector('.sm-exported')).toBeNull();
+    expect(callsTo(rpc, 'shorts.list')).toHaveLength(0);
+  });
+
+  it('runBatch control (no switch): the same deferred export DOES write clips + shorts.list', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': { jobId: 'bexp-1' },
+      'shorts.list': { shorts: [{ path: '/out/v1-clip.mp4' }] },
+    });
+    render(
+      <ShortMaker
+        videoId="v1"
+        api={makeApi({ rpc, onJobDone: bus.onJobDone })}
+        initialControls={{ count: 1 }}
+      />,
+    );
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+    await emitDone(bus, { jobId: 'bexp-1', result: V1_CLIPS });
+
+    expect(container.querySelector('.sm-exported')?.textContent).toContain('Exported 1 clip(s)');
+    expect(callsTo(rpc, 'shorts.list')).toHaveLength(1);
+  });
+
+  it('runBatch: an export FAILING after a videoId switch raises no error banner', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': { jobId: 'bexp-1' },
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} initialControls={{ count: 1 }} />);
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+    render(<ShortMaker videoId="v2" api={api} initialControls={{ count: 1 }} />);
+    await flush();
+    await emitDone(bus, {
+      jobId: 'bexp-1',
+      result: { error: { message: 'v1 batch blew up', type: 'RuntimeError' } },
+    });
+
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('runBatch control (no switch): the same failure DOES raise the error banner', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': { jobId: 'bexp-1' },
+    });
+    render(
+      <ShortMaker
+        videoId="v1"
+        api={makeApi({ rpc, onJobDone: bus.onJobDone })}
+        initialControls={{ count: 1 }}
+      />,
+    );
+    await act(async () => {
+      (byLabel('Make N shorts') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+    await emitDone(bus, {
+      jobId: 'bexp-1',
+      result: { error: { message: 'v1 batch blew up', type: 'RuntimeError' } },
+    });
+
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('v1 batch blew up');
+  });
+
+  it('switching AWAY and BACK re-admits the receipt (the guard is not a permanent mute)', async () => {
+    const bus = jobDoneBus();
+    const rpc = staleRpc({
+      'shortmaker.select': { candidates: THREE },
+      'shortmaker.export': EXPORTED_JOB,
+      'shorts.list': { shorts: [] },
+    });
+    const api = makeApi({ rpc, onJobDone: bus.onJobDone });
+    render(<ShortMaker videoId="v1" api={api} />);
+    await selectAndApproveOne();
+    await clickExportApproved();
+    render(<ShortMaker videoId="v2" api={api} />);
+    await flush();
+    render(<ShortMaker videoId="v1" api={api} />);
+    await flush();
+
+    await emitDone(bus, { jobId: 'exp-1', result: V1_CLIPS });
+
+    // Back on v1 the receipt describes the selected video again — truthful, so it
+    // is admitted (this is what makes the guard an id comparison, not a latch).
+    expect(container.querySelector('.sm-exported')?.textContent).toContain('/out/v1-clip.mp4');
+  });
 });

--- a/app/renderer/src/features/ShortMaker.tsx
+++ b/app/renderer/src/features/ShortMaker.tsx
@@ -226,6 +226,32 @@ export function ShortMaker({
   // (JobAbortedError) and the subscription/timer tear down instead of leaking.
   const abortRef = useRef<AbortController | null>(null);
 
+  // ---- LANE OWNERSHIP ------------------------------------------------------
+  // `activeJobRef`, `abortRef` and `progress` are ONE slot each, shared by all
+  // three run loops — a single visible lane. The reset effect below leaves
+  // `phase` at 'idle' after a video switch, so the user CAN start a second job
+  // while the first is still in flight (up to EXPORT_JOB_TIMEOUT_MS = 35 min),
+  // and the first job then settles into a lane the second one owns.
+  //
+  // So every lane write is scoped to its owner: `abortRef` holds exactly one
+  // controller — the current owner's — which makes `abortRef.current === ctrl`
+  // the ownership test. Without it, video 1's settle-time teardown cleared all
+  // three slots and (measured) video 2's progress bar never returned for the
+  // rest of its job, its Cancel emitted no `job.cancel` because the handle it
+  // reads had been nulled, and video 1's own in-flight events were relayed onto
+  // video 2's bar once video 1's late handle won the single slot.
+  //
+  // A non-owning `finally` may safely skip the teardown because the handle slot
+  // is re-initialised by whichever run takes the lane NEXT, and while no run owns
+  // the lane nothing can read it: both the progress relay and the Cancel button
+  // are gated on `busy`, which is false outside a run.
+  //
+  // Not closed by this (single-lane by design, disclosed rather than widened):
+  // a job for a video that is NOT on screen is invisible — its progress fails
+  // the relay filter and `busy` is false — and it cannot be cancelled from the
+  // UI, because Cancel addresses the visible lane. The work still completes
+  // sidecar-side and its files still land; only the on-screen receipt is
+  // dropped (see the guard-the-write-not-the-work note in runBatch).
   const busy = phase === 'selecting' || phase === 'exporting';
 
   // ---- progress wiring ----------------------------------------------------
@@ -556,6 +582,10 @@ export function ShortMaker({
     const clean = sanitizeControls(controls);
     const ctrl = new AbortController();
     abortRef.current = ctrl;
+    // This run is the new lane owner and has no handle yet, so drop any previous
+    // owner's. The relay's documented pre-handle rule ("accept ONLY jobId-less
+    // early progress") only actually holds while this slot is null.
+    activeJobRef.current = null;
     try {
       const res = await resolvedApi.rpc<SelectResult | JobHandle>('shortmaker.select', {
         videoId,
@@ -564,7 +594,10 @@ export function ShortMaker({
       });
       let candidates = extractCandidates(res);
       if (candidates === null && isJobHandle(res)) {
-        activeJobRef.current = res.jobId;
+        // LANE OWNERSHIP (see above): a second job may have started during this
+        // rpc. Claiming the handle then would point the progress relay and Cancel
+        // at THIS job instead of the visible one.
+        if (abortRef.current === ctrl) activeJobRef.current = res.jobId;
         // Deferred job: wait for job.done if a hook exists, else the rpc already
         // resolved above with the handle — fall through with empty list. F2: the
         // wait carries a timeout + the cancel/unmount AbortSignal.
@@ -600,15 +633,28 @@ export function ShortMaker({
       setRetryAction('select');
       setPhase('idle');
     } finally {
-      activeJobRef.current = null;
-      abortRef.current = null;
-      setProgress(null);
+      // LANE OWNERSHIP (see above): only the current owner tears the lane down.
+      if (abortRef.current === ctrl) {
+        activeJobRef.current = null;
+        abortRef.current = null;
+        setProgress(null);
+      }
     }
   }, [resolvedApi, busy, controls, videoId, prompt]);
 
   // ---- review actions (all non-destructive) -------------------------------
   // P3-D: each decision doubles as an implicit taste label — fire-and-forget
   // feedback.record with the candidate AS REVIEWED (current, possibly nudged).
+  //
+  // These three send the CURRENT `videoId` prop with the CURRENT `items` entry, so
+  // unlike the export label below they are only correct while `items` belongs to
+  // the selected video. On main they were genuinely MIS-ATTRIBUTABLE: the
+  // stale-select path loaded v1's candidates into v2's review list, and clicking
+  // Approve then sent `feedback.record {videoId: 'v2'}` carrying v1's `start`
+  // (measured on main; silent post-fix). Nothing here changed — the fix is
+  // UPSTREAM, in runSelect/runBatch, which now never load another video's
+  // candidates. Do not "fix" this by freezing videoId in the closure: that would
+  // paper over a stale list instead of preventing it.
   const approve = useCallback(
     (id: string) => {
       dispatch({ type: 'approve', id });
@@ -684,6 +730,8 @@ export function ShortMaker({
     const clean = sanitizeControls(controls);
     const ctrl = new AbortController();
     abortRef.current = ctrl;
+    // See runSelect: the new owner starts with no handle (LANE OWNERSHIP above).
+    activeJobRef.current = null;
     try {
       // §2 sends `candidateIds`; the sidecar resolves them against its cached
       // select result. We ALSO forward the full approved `candidates` objects
@@ -706,7 +754,9 @@ export function ShortMaker({
       );
       let clips = extractClips(res);
       if (clips === null && isJobHandle(res)) {
-        activeJobRef.current = res.jobId;
+        // LANE OWNERSHIP (see above): mirror runSelect — a handle that arrives
+        // after a second job started must not claim the visible lane.
+        if (abortRef.current === ctrl) activeJobRef.current = res.jobId;
         // F2: race the wait against a timeout (and the cancel/unmount signal) so a
         // dead sidecar surfaces a user-facing error instead of hanging the UI.
         clips = await waitForJobDone(
@@ -734,6 +784,10 @@ export function ShortMaker({
       // guard leaves the RPC order unchanged: export -> feedback.record ->
       // shorts.list.) This is the honest counterpart to the single-lane busy flag
       // that views/MakeShorts.tsx:293-297 leaves unguarded for the same reason.
+      //
+      // SCOPE: that holds for THIS label only, because its arguments are frozen.
+      // It is NOT a claim that feedback.record was never mis-attributed — the
+      // review-action labels (see the note at `approve` above) were, on main.
       for (const c of approvedCandidates(items)) {
         recordFeedback(resolvedApi, videoId, c, 'exported');
       }
@@ -757,9 +811,12 @@ export function ShortMaker({
       setRetryAction('export');
       setPhase('reviewing');
     } finally {
-      activeJobRef.current = null;
-      abortRef.current = null;
-      setProgress(null);
+      // LANE OWNERSHIP (see above): only the current owner tears the lane down.
+      if (abortRef.current === ctrl) {
+        activeJobRef.current = null;
+        abortRef.current = null;
+        setProgress(null);
+      }
     }
   }, [resolvedApi, busy, items, videoId, controls, audioTrackId, output, reloadVideoShorts]);
 
@@ -783,6 +840,8 @@ export function ShortMaker({
     setProgress({ jobId: '', pct: 0, message: `Finding the top ${clean.count} clips…` });
     const ctrl = new AbortController();
     abortRef.current = ctrl;
+    // See runSelect: the new owner starts with no handle (LANE OWNERSHIP above).
+    activeJobRef.current = null;
     try {
       const selRes = await resolvedApi.rpc<SelectResult | JobHandle>('shortmaker.select', {
         videoId,
@@ -790,11 +849,16 @@ export function ShortMaker({
         controls: clean,
       });
       // F2: select also carries a timeout + the cancel/unmount AbortSignal.
+      // LANE OWNERSHIP (see above): `resolveJobResult` records the deferred handle
+      // on the ref it is handed, and does so SYNCHRONOUSLY (no await precedes the
+      // write), so choosing the ref here is equivalent to gating that write. A
+      // non-owner gets a throwaway sink: its job is real and still awaited, it
+      // just must not claim the visible lane's progress/cancel handle.
       const found = await resolveJobResult(
         resolvedApi,
         selRes,
         extractCandidates,
-        activeJobRef,
+        abortRef.current === ctrl ? activeJobRef : { current: null },
         EXPORT_JOB_TIMEOUT_MS,
         ctrl.signal,
       );
@@ -840,7 +904,11 @@ export function ShortMaker({
         resolvedApi,
         expRes,
         extractClips,
-        activeJobRef,
+        // Same lane-ownership choice as the select stage above — and this is the
+        // one the videoId guard made newly reachable: with `setPhase('exporting')`
+        // now skipped for a non-owner, video 2 is idle and startable, so video 1's
+        // export handle can arrive while video 2 owns the lane.
+        abortRef.current === ctrl ? activeJobRef : { current: null },
         EXPORT_JOB_TIMEOUT_MS,
         ctrl.signal,
       );
@@ -863,14 +931,23 @@ export function ShortMaker({
       setRetryAction('batch');
       setPhase('reviewing');
     } finally {
-      activeJobRef.current = null;
-      abortRef.current = null;
-      setProgress(null);
+      // LANE OWNERSHIP (see above): only the current owner tears the lane down.
+      if (abortRef.current === ctrl) {
+        activeJobRef.current = null;
+        abortRef.current = null;
+        setProgress(null);
+      }
     }
   }, [resolvedApi, busy, videoId, prompt, controls, audioTrackId, output, reloadVideoShorts]);
 
   // F2: abort any in-flight job.done wait (cancel/unmount) so the wait rejects
   // with JobAbortedError and its subscription/timer tear down instead of leaking.
+  // It releases the CONTROLLER only: after a cancel the aborted run's `finally` is
+  // no longer the owner and skips the teardown, so the handle slot stays set until
+  // the next run takes the lane and re-initialises it. Nulling it here as well was
+  // tried and REMOVED — no test could distinguish it (the mutation survived),
+  // because the handle is unreadable while `phase` is idle: the relay renders only
+  // when `busy`, and Cancel renders only when `busy`.
   const tearDownWait = useCallback(() => {
     abortRef.current?.abort();
     abortRef.current = null;
@@ -886,9 +963,16 @@ export function ShortMaker({
     tearDownWait();
     setPhase('idle');
     setProgress(null);
-    // The Cancel button renders only while busy with an active job; defensive guard.
+    // Cancel renders on `busy` ALONE (ShortMakerControls.tsx:349), NOT on "busy
+    // with a known handle" — so this half is a REAL path, not a defensive one: a
+    // cancel in the pre-handle window (the rpc that returns the handle is still in
+    // flight) has nothing to cancel server-side, and resetting the UI is the whole
+    // job. It used to share a `v8 ignore` with the guard below, which hid a
+    // reachable branch behind an unreachable one; it is covered by its own test now.
+    if (!jobId) return;
+    // resolvedApi is always present (prop or window.api); defensive guard.
     /* v8 ignore next */
-    if (!resolvedApi || !jobId) return;
+    if (!resolvedApi) return;
     try {
       await resolvedApi.rpc('job.cancel', { jobId });
     } catch (e) {

--- a/app/renderer/src/features/ShortMaker.tsx
+++ b/app/renderer/src/features/ShortMaker.tsx
@@ -252,7 +252,24 @@ export function ShortMaker({
   // would carve the NEW video at the OLD video's timestamps. Clear ONLY per-video
   // review state (NOT app-level controls/brand/data-folder). Every reset is
   // idempotent against the initial state, so it is a harmless no-op on first mount.
+  //
+  // The reset alone is NOT sufficient. It closes the AFTER case (a job settles,
+  // THEN the user switches) but not the IN-FLIGHT one: shortmaker.select and
+  // shortmaker.export are DEFERRED jobs awaited for up to EXPORT_JOB_TIMEOUT_MS
+  // (35 min, _api.ts:62), this effect does NOT abort `abortRef.current` (only
+  // Cancel/unmount does), and each run loop closes over the videoId it started
+  // on. So a switch during those 35 minutes runs this reset FIRST and the
+  // in-flight job's own writes land AFTER it — re-creating the defect one seam
+  // over (measured: v1's clip paths rendered as v2's `.sm-exported` receipt, v1's
+  // candidates loaded into v2's review list, and `shorts.list {videoId:v1}`
+  // populating the gallery shown under v2). `videoIdRef` is the other half: it
+  // mirrors the COMMITTED prop so a settled job can ask "am I still the selected
+  // video?" before writing. Kept as a ref rather than read from the closure
+  // because the closure is frozen at start-of-job. This mirrors the same
+  // guard-the-write fix in views/MakeShorts.tsx:184-191 for the manual path.
+  const videoIdRef = useRef(videoId);
   useEffect(() => {
+    videoIdRef.current = videoId;
     dispatch({ type: 'clear' });
     setExportedClips(null);
     setPhase('idle');
@@ -525,6 +542,12 @@ export function ShortMaker({
     // resolvedApi is always present; the submit button is disabled while busy.
     /* v8 ignore next */
     if (!resolvedApi || busy) return;
+    // The video this run is FOR. Every settle-time write below is a factual claim
+    // about THIS id, so each is gated on the selection still being it when the job
+    // finishes (see `videoIdRef` above). Switching away and back re-admits the
+    // writes — by then they describe the selected video again, which is the
+    // truthful outcome, not a stale one.
+    const startedFor = videoId;
     setError(null);
     setRetryAction(null);
     setExportedClips(null);
@@ -559,11 +582,20 @@ export function ShortMaker({
       // this a cancel during the (non-job) sync path would still load results and
       // override the idle reset. Treat it as a clean cancel (the catch returns).
       if (ctrl.signal.aborted) throw new JobAbortedError();
+      // The user may have switched the picker during the wait. Loading v1's
+      // candidates into v2's review list is the WORST case in this family: the
+      // list is what "Export approved" carves from, so it would export the NEW
+      // video at the OLD video's timestamps — the exact hazard the reset effect's
+      // own comment names. Drop the load rather than mis-attribute it.
+      if (videoIdRef.current !== startedFor) return;
       dispatch({ type: 'load', candidates });
       setPhase('reviewing');
     } catch (e) {
       // F2: an aborted wait is a clean cancel — cancel() already reset to idle.
       if (e instanceof JobAbortedError) return;
+      // Same rule for the failure half — v1's error is not v2's, and its Retry
+      // would re-run against the newly selected video.
+      if (videoIdRef.current !== startedFor) return;
       setError(errMsg(e));
       setRetryAction('select');
       setPhase('idle');
@@ -643,6 +675,8 @@ export function ShortMaker({
       setError('Approve at least one clip before exporting.');
       return;
     }
+    // See `runSelect` above: the video this export is a receipt FOR.
+    const startedFor = videoId;
     setError(null);
     setRetryAction(null);
     setProgress({ jobId: '', pct: 0, message: 'Exporting approved clips…' });
@@ -689,12 +723,27 @@ export function ShortMaker({
       // the sync path would still load clips and record 'exported' feedback,
       // overriding the idle reset. Treat it as a clean cancel (the catch returns).
       if (ctrl.signal.aborted) throw new JobAbortedError();
-      setExportedClips(clips ?? []);
       // P3-D: a successful export is the strongest implicit label — record
       // one 'exported' action per exported candidate (fire-and-forget).
+      //
+      // DELIBERATELY ABOVE the stale guard, and NOT gated by it: `videoId` and
+      // `items` here are the CLOSURE's (frozen at export start), so each label is
+      // correctly attributed to the video that was actually exported, and this
+      // writes no component state. Dropping it after a mid-flight switch would
+      // lose a TRUE label rather than prevent a false claim. (Moving it above the
+      // guard leaves the RPC order unchanged: export -> feedback.record ->
+      // shorts.list.) This is the honest counterpart to the single-lane busy flag
+      // that views/MakeShorts.tsx:293-297 leaves unguarded for the same reason.
       for (const c of approvedCandidates(items)) {
         recordFeedback(resolvedApi, videoId, c, 'exported');
       }
+      // The user may have switched the picker during the wait: this receipt then
+      // describes a video that is no longer on screen. Both writes below are
+      // claims about the CURRENTLY selected video — `exportedClips` renders as its
+      // `.sm-exported` file list, and `reloadVideoShorts` resolves `shorts.list`
+      // for the OLD id into the produced-shorts gallery shown under the NEW one.
+      if (videoIdRef.current !== startedFor) return;
+      setExportedClips(clips ?? []);
       // P4 §6 / C11: reload the produced-shorts list for this video so the
       // exported clips gain the gallery card actions (fire-and-forget).
       void reloadVideoShorts();
@@ -702,6 +751,8 @@ export function ShortMaker({
     } catch (e) {
       // F2: an aborted wait is a clean cancel — cancel() already reset to idle.
       if (e instanceof JobAbortedError) return;
+      // Same rule for the failure half — v1's error is not v2's.
+      if (videoIdRef.current !== startedFor) return;
       setError(errMsg(e));
       setRetryAction('export');
       setPhase('reviewing');
@@ -722,6 +773,8 @@ export function ShortMaker({
     // resolvedApi/videoId are always present; the batch button is disabled while busy.
     /* v8 ignore next */
     if (!resolvedApi || busy || !videoId) return;
+    // See `runSelect` above: the video this batch is a receipt FOR.
+    const startedFor = videoId;
     setError(null);
     setRetryAction(null);
     setExportedClips(null);
@@ -750,17 +803,34 @@ export function ShortMaker({
       // orphaned-export window without extra job.cancel plumbing).
       if (ctrl.signal.aborted) throw new JobAbortedError();
       const candidates = found ?? [];
-      dispatch({ type: 'load', candidates }); // surface for post-hoc review
       const top = topByVirality(candidates, clean.count);
+      // The user may have switched the picker during the select wait. GUARD THE
+      // WRITES, NOT THE WORK: every component-state write below is a factual claim
+      // about the CURRENTLY selected video, but the export itself is the batch the
+      // user asked for, and `buildExportParams` uses the CLOSURE's `videoId`, so it
+      // still produces the requested clips for the right video. Suppressing only
+      // the on-screen receipt is the smaller cost — abandoning the export would
+      // trade a false-status defect for silently dropped work. Re-checked after the
+      // export wait, because the switch can land during THAT wait instead.
+      const mine = videoIdRef.current === startedFor;
+      if (mine) {
+        dispatch({ type: 'load', candidates }); // surface for post-hoc review
+        // A no-op when `top` is empty, so hoisting it above the zero-result return
+        // below is behaviour-identical to approving after that check.
+        for (const c of top) dispatch({ type: 'approve', id: candidateId(c) });
+      }
       if (top.length === 0) {
         // F1: a confirmed zero-result is NOT an error — fall through to the
         // "No candidates were proposed" empty state (no error/Retry surfaced).
-        setPhase('reviewing');
+        // Guarded too: that empty state would be a claim about a video this batch
+        // never asked about.
+        if (mine) setPhase('reviewing');
         return;
       }
-      for (const c of top) dispatch({ type: 'approve', id: candidateId(c) });
-      setPhase('exporting');
-      setProgress({ jobId: '', pct: 0, message: `Exporting ${top.length} clips…` });
+      if (mine) {
+        setPhase('exporting');
+        setProgress({ jobId: '', pct: 0, message: `Exporting ${top.length} clips…` });
+      }
       const expRes = await resolvedApi.rpc<ExportResult | JobHandle>(
         'shortmaker.export',
         // F45: same `output` slice as the review path (see runExport).
@@ -776,13 +846,19 @@ export function ShortMaker({
       );
       // Bug-sweep: honor a mid-flight Cancel before loading the exported clips.
       if (ctrl.signal.aborted) throw new JobAbortedError();
-      setExportedClips(clips ?? []);
+      // Unguarded for the same reason as runExport's copy: correctly attributed to
+      // the closure's video, and no component state is written.
       for (const c of top) recordFeedback(resolvedApi, videoId, c, 'exported');
+      // Re-read (not `mine`): the switch may have landed during the export wait.
+      if (videoIdRef.current !== startedFor) return;
+      setExportedClips(clips ?? []);
       void reloadVideoShorts();
       setPhase('reviewing');
     } catch (e) {
       // F2: an aborted wait is a clean cancel — cancel() already reset to idle.
       if (e instanceof JobAbortedError) return;
+      // Same rule for the failure half — v1's error is not v2's.
+      if (videoIdRef.current !== startedFor) return;
       setError(errMsg(e));
       setRetryAction('batch');
       setPhase('reviewing');


### PR DESCRIPTION
## The defect

`ShortMaker.tsx`'s `runExport` and `runBatch` close over `videoId`, await `waitForJobDone(...)` for
up to **35 minutes**, then write results. The reset effect clears state on a `videoId` change but
does not abort the in-flight handle, and `MakeShorts` renders `<ShortMaker videoId={selectedId}>`
**unkeyed** — so the picker swaps the prop instead of remounting.

Measured consequence: switch video mid-export and `.sm-exported` renders **video 1's clips** under
video 2, and `shorts.list` fires for the **wrong video**.

**Scope correction, and it is mine to own:** my orchestrator brief said `feedback.record` was
mis-attributed too. That was wrong and the lane's correctness reviewer refuted it —
`recordFeedback` sends the *closure's* videoId (`shortMakerLogic.ts:596-610`), so it was never
mis-attributed. `shorts.list` was the only wrong-video RPC.

## The fix

Guard-the-write, matching the pattern already merged for the sibling `MakeShorts` case in #387:
capture `startedFor` at start, mirror the committed selection in a ref updated inside the **same**
effect that resets state, and gate every settle-time write on `ref.current === startedFor`.

The picker is deliberately **not** disabled during export — a 35-minute lockout would trade a
false-status defect for a worse usability one.

## Verification

Three adversarial refuters (correctness / gate-integrity / blast-radius), each told to default to
refuted; then a fresh skeptic who wrote neither the code nor the objections. **8 objections raised,
all closed.** Every code-level objection was killed by the skeptic's own mutation, and all 6 gates
were re-run on the final tree.

Both-states: **8 new tests RED pre-fix** (exactly the 8 named) / **214 GREEN** post-fix. Two source
mutations each kill exactly the named tests. 242 files / 4584 tests at 100% coverage; `tsc` exit 0.
The test file is **437 insertions / 0 deletions**, so "no assertion was weakened" is mechanically
true rather than asserted.

The harness fans the job event to **all** subscribers and keeps a no-switch control arm — a
single-slot test double gives a false pass here, because the videoId change installs a second
subscriber that overwrites the slot.

### Two reviewers withdrew their own findings rather than ship them

* The correctness refuter suspected a commit-before-effect race and its first probe appeared to
  reproduce it — a decisive ordering probe showed React had not committed at all, so the emit
  simply landed *before* the switch, which is legitimate. Withdrawn, with the residual scoped: the
  `act()`/vitest case is settled; a production concurrent root is UNVERIFIED, settling experiment
  named.
* The skeptic's `SKEPTIC-EXPORT` probe failed in all three states, so it measured nothing. It
  withdrew it and said so, to stop the next reviewer re-walking it.

## Residuals (disclosed, non-blocking)

1. **An untested-but-load-bearing line** — the skeptic's own finding. Of three
   `activeJobRef.current = null` clears, only one is protected: deleting the `runBatch` one leaves
   the suite 221/221 GREEN at 100% coverage, yet a three-state probe shows it is reachable and
   load-bearing. The code is correct; the *assertion* is missing. Cheapest close is ~20 lines of
   test, no source change.
2. Its `runExport` twin survived mutation and reachability could not be established — likely inert
   defensive symmetry, unlikely (20-45%) to be observable. Settling experiment named.
3. **Pre-existing, out of scope:** the produced-shorts gallery is never cleared on a videoId
   switch, so v1's shorts keep rendering under v2 independently of any job.
   `useShortsGallery.ts` has zero `useEffect` (control: 12 in `ShortMaker.tsx`).
4. `ShortMaker.tsx` is now 1214 lines against the 800-line guideline. Pre-existing (1054 on main);
   this branch adds 182 lines of which 135 are comments. **No gate enforces file length** — the
   charter's 6-gate set has no length check — so this is a guideline breach, not a gate failure.
5. `sast`/opengrep **NOT RUN** — the binary is absent on this box (detector controlled: node,
   semgrep, osv-scanner, gitleaks, biome all resolve; opengrep does not). Proxy: all 10 rule
   patterns from `.quality/opengrep/*.yaml` across the 963 added lines → 0 hits, detector
   controlled on two synthetic positives.

CI is the arbiter. This merges only if `quality` is green.
