### PR TITLE
feat(sidecar): BR1 b-roll asset registry — the registration door (auto-B-roll still not user-reachable)

### DIFF
--- a/docs/plans/v1.5/flagship-auto-broll.md
+++ b/docs/plans/v1.5/flagship-auto-broll.md
@@ -158,7 +158,7 @@ append models to `DATA_MODELS`):
 
 ```python
 @dataclass
-class BrollAsset:        id: str; path: str; kind: str; addedAt: str; thumbPath: str
+class BrollAsset:        assetId: str; path: str; kind: str; addedAt: str; thumbnailPath: str
 @dataclass
 class BrollSuggestion:   segmentIndex: int; start: float; end: float; assetId: str; score: float; reason: str; layout: str
 @dataclass
@@ -184,9 +184,22 @@ privacy guarantee):
 | `broll.suggest` | job | NAMED | `BrollSuggestParams` | `JobHandle & { suggestions?: BrollSuggestion[] }` (import `BrollSuggestion` from `_OWN`) | threshold-gated, ranked |
 | `broll.apply` | job | NAMED | `BrollApplyParams` | `JobHandle` | reversible composite |
 | `broll.status` | direct | NAMED | `BrollSuggestParams`→`{videoId}` (or a slim `BrollStatusParams{videoId}`) | `BrollStatus` | pure freshness read |
-| `broll.assets` | direct | NONE | — | `{ assets: BrollAsset[] }` | list |
+| `broll.assets` | direct | NONE | — | `{ assets: BrollAsset[], missing: BrollAsset[] }` | list + loud missing |
 | `broll.addAsset` | direct | NAMED | `BrollAssetParams` | `{ asset: BrollAsset }` | mirror of `library.add` |
-| `broll.removeAsset` | direct | NAMED | `BrollAssetParams`→`{id}` | `{ removed: bool }` | — |
+| `broll.removeAsset` | direct | NAMED | `BrollAssetParams`→`{id}` | `{ ok: bool }` | — |
+
+> **BR1 wire-shape correction (implemented 2026-08-10, branch `feat/v15-w16-broll-registry`).**
+> Four keys above were CHANGED from this doc's first draft to match the already-running
+> engine, and the doc is the shape a renderer lane will code against — so the deviation is
+> recorded here rather than left to be discovered:
+> `id` → **`assetId`** and `thumbPath` → **`thumbnailPath`** (the names `broll_ops.scan_assets`
+> and the `Video` row already use, so a scanned and a registered asset need no branch);
+> `broll.assets` returns **`{assets, missing}`** (registered assets whose file has vanished are
+> reported, never silently dropped); `broll.removeAsset` returns **`{ok}`** (every other
+> boolean-ack handler in `handlers/library_ops.py` uses `ok`). A row additionally carries
+> `entityKind`, `title`, `durationSec`, `contentHash`, `sizeBytes`, `mtime`, `exists`,
+> `registered`. `thumbnailPath` is present but **unconditionally `""`** — no b-roll poster
+> extractor exists yet, so BR-thumbnail reuse is NOT implemented.
 
 **Regenerate + guard:**
 - Run `python -m contract.generate` from `sidecar/` (emits `contract.schema.json`, `schemas.generated.ts`,

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -15,6 +15,7 @@ from ..features import timeline as _timeline
 from ..features import tracks as _tracks
 from ..protocol import Handler, RpcContext
 from ..settings_store import INJECTED_KEYS_FIELD
+from . import library_ops as _library_ops
 from ._services import Services
 from ._shared import _invalid, log
 from ._wire import _self_ffprobe
@@ -464,8 +465,8 @@ def register_all(
     )
 
     # broll.* (v1.5 flagship #3): LOCAL auto-b-roll over the user's OWN library.
-    # The asset list is a scan of the ``brollDir`` setting and the vector index is
-    # a sidecar next to the data dir (never the project manifest — the same
+    # The asset list is the ``brollDir`` scan UNION the BR1 registry, and the vector
+    # index is a sidecar next to the data dir (never the project manifest — the same
     # decision index.build made for its embeddings). Both SigLIP-2 towers come
     # from ONE factory so the image and text vectors share a joint space.
     from ..features import broll_ops as _broll_ops  # local: import-light
@@ -474,7 +475,11 @@ def register_all(
         return svc.data_dir / _broll_ops.INDEX_FILENAME
 
     def _list_broll_assets() -> list[dict[str, Any]]:
-        return _broll_ops.scan_assets(str(svc.settings.get().get(_broll_ops.BROLL_DIR_KEY) or ""))
+        # BR1: the SAME seam as before, now delegating to the union lister so a
+        # REGISTERED asset (one that lives outside brollDir) is indexed and
+        # suggestible too. Kept as this one closure rather than a second lister:
+        # the panel and the engine must never see two different libraries.
+        return _library_ops.broll_asset_rows(svc)
 
     def _load_broll_index() -> Any:
         return _broll_ops.load_index_file(_broll_index_path())
@@ -499,6 +504,16 @@ def register_all(
         duration=svc._ffprobe_duration,
         register_fn=reg,
     )
+
+    # BR1: the b-roll ASSET REGISTRY door. broll_ops owns the four engine methods
+    # (status/index/suggest/apply) via its own register(); these three are Library
+    # CRUD over the ``role='broll'`` entity rows, so they live with the other
+    # library.* handlers in library_ops and are wired here. Registered through a
+    # closure rather than a bound ``svc.`` method because the Services binding table
+    # (_services.py) is outside this lane's declared file scope.
+    reg("broll.assets", lambda params, ctx: _library_ops.broll_assets(svc, params, ctx))
+    reg("broll.addAsset", lambda params, ctx: _library_ops.broll_add_asset(svc, params, ctx))
+    reg("broll.removeAsset", lambda params, ctx: _library_ops.broll_remove_asset(svc, params, ctx))
 
     # ---------------------------------------------------------------------- #
     # system-advanced group (this build) — health / recipes / diarize.

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -475,10 +475,15 @@ def register_all(
         return svc.data_dir / _broll_ops.INDEX_FILENAME
 
     def _list_broll_assets() -> list[dict[str, Any]]:
-        # BR1: the SAME seam as before, now delegating to the union lister so a
-        # REGISTERED asset (one that lives outside brollDir) is indexed and
+        # BR1: the same seam POSITION as before, now delegating to the union lister so
+        # a REGISTERED asset (one that lives outside brollDir) is indexed and
         # suggestible too. Kept as this one closure rather than a second lister:
         # the panel and the engine must never see two different libraries.
+        #
+        # Not a drop-in equal of the old scan-only closure, in two measured ways, both
+        # documented at broll_asset_rows: it costs one realpath per DIRECTORY on top of
+        # the scan, and it now reads the Library, so a corrupt library.json fails
+        # broll.status/assets/index where before those could not fail on library state.
         return _library_ops.broll_asset_rows(svc)
 
     def _load_broll_index() -> Any:

--- a/sidecar/media_studio/handlers/library_ops.py
+++ b/sidecar/media_studio/handlers/library_ops.py
@@ -382,8 +382,11 @@ def broll_asset_rows(self: Services, registered: list[dict[str, Any]] | None = N
 def broll_assets(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
     """``broll.assets()`` -> ``{assets, missing}`` (BR1). Direct-return, read-only.
 
-    ``assets`` is exactly what ``broll.index`` would embed (:func:`broll_asset_rows`),
-    so the panel cannot show one library while the engine indexes another.
+    ``assets`` is exactly the library ``broll.index`` works from — the same
+    :func:`broll_asset_rows` seam, so the panel cannot show one library while the
+    engine indexes another. (It is not the list the tower receives: ``broll.index``
+    then embeds only the STALE subset of it, whose size ``broll.status`` reports as
+    ``staleCount``.)
     ``missing`` lists REGISTERED assets whose file has moved or been deleted — they
     are reported rather than silently dropped, so the UI can offer a re-register or
     an unregister instead of leaving a phantom in the grid. No model, no provider,

--- a/sidecar/media_studio/handlers/library_ops.py
+++ b/sidecar/media_studio/handlers/library_ops.py
@@ -10,12 +10,14 @@ in services.py). Behaviour + the RPC surface are byte-identical to pre-split.
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from .. import keepcopy as _keepcopy
 from .. import library as _library
 from .. import relink as _relink
+from ..features import broll_ops as _broll_ops
 from ..features import offline as _offline
 from ..features import shorts as _shorts_meta
 from ..protocol import ErrorCode, RpcContext, RpcError
@@ -323,6 +325,94 @@ def library_managed_clear(self: Services, params: dict[str, Any], ctx: RpcContex
         return self.library.managed_clear(force=force)
     except _keepcopy.KeepCopyError as exc:
         raise _invalid(str(exc)) from exc
+
+
+# --------------------------------------------------------------------------- #
+# BR1 — the b-roll asset registry surface (broll.assets / addAsset / removeAsset)
+# --------------------------------------------------------------------------- #
+def _real_key(path: str) -> str:
+    """A spelling-insensitive identity for a file path (the union's dedup key).
+
+    ``broll_ops.scan_assets`` reports each file as the CONFIGURED folder with the
+    relative parts joined on, verbatim, while ``Library.add_broll`` stores
+    ``Path.resolve()``'d text — so the same file can arrive at the two halves of the
+    union under two different strings: a ``..`` segment or a trailing separator in
+    ``brollDir``, a relative folder, a symlinked folder, letter case, or an 8.3 short
+    component on Windows. ``normcase(realpath(...))`` collapses all of those. Keying
+    the union on the raw string would count that file twice and embed it twice.
+    """
+    return os.path.normcase(os.path.realpath(path))
+
+
+def broll_asset_rows(self: Services) -> list[dict[str, Any]]:
+    """The b-roll library the index/planner see: the folder scan UNION the registry.
+
+    ``brollDir`` stays the bulk source (a recursive scan) and the BR1 registry adds
+    individual assets from anywhere on disk, so ONE list feeds ``broll.status`` /
+    ``broll.index`` / ``broll.suggest`` and there is no second scanner. This is the
+    ``list_assets`` seam the composition root hands to ``broll_ops.register``.
+
+    Two rules, both load-bearing:
+
+    * **Dedup on the REAL path** (:func:`_real_key`), not on the path string or the
+      ``assetId`` derived from it — see that helper for the measured reason. A
+      REGISTERED row WINS the collision because it carries the title/thumbnail the
+      UI shows; it keeps the scanned row's position so the list stays deterministic.
+    * **A registered asset whose file is gone is EXCLUDED.** It must not reach
+      ``broll.index``, which would hand a vanished path to the image tower and fail
+      the whole job. It is surfaced as ``broll.assets``' ``missing`` instead — loud,
+      the same way ``library.reveal`` reports a missing source.
+    """
+    scanned = _broll_ops.scan_assets(str(self.settings.get().get(_broll_ops.BROLL_DIR_KEY) or ""))
+    rows: dict[str, dict[str, Any]] = {_real_key(str(row["path"])): {**row, "registered": False} for row in scanned}
+    for asset in self.library.list_broll():
+        if asset["exists"]:
+            rows[_real_key(str(asset["path"]))] = asset
+    return list(rows.values())
+
+
+def broll_assets(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+    """``broll.assets()`` -> ``{assets, missing}`` (BR1). Direct-return, read-only.
+
+    ``assets`` is exactly what ``broll.index`` would embed (:func:`broll_asset_rows`),
+    so the panel cannot show one library while the engine indexes another.
+    ``missing`` lists REGISTERED assets whose file has moved or been deleted — they
+    are reported rather than silently dropped, so the UI can offer a re-register or
+    an unregister instead of leaving a phantom in the grid. No model, no provider,
+    no network: a scan plus one SQLite read.
+    """
+    return {
+        "assets": broll_asset_rows(self),
+        "missing": [asset for asset in self.library.list_broll() if not asset["exists"]],
+    }
+
+
+def broll_add_asset(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+    """``broll.addAsset({path, title?})`` -> ``{asset}`` (BR1). Direct-return.
+
+    THE missing door: before this method the b-roll library could only ever be a
+    folder scan, so nothing in the app could put a specific asset into it. Registers
+    the file by path (no copy, no move) as a ``role='broll'`` entity. A missing file
+    or a non-b-roll extension is INVALID_PARAMS (loud).
+    """
+    path = _require_str(params, "path")
+    title = params.get("title")
+    try:
+        asset = self.library.add_broll(path, title if isinstance(title, str) else None)
+    except _library.BrollAssetError as exc:
+        raise _invalid(str(exc)) from exc
+    return {"asset": asset}
+
+
+def broll_remove_asset(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+    """``broll.removeAsset({id})`` -> ``{ok}`` (BR1). Direct-return.
+
+    UNREGISTERS the asset. The USER's file on disk is never deleted (the registry
+    holds a path, not bytes) — the same rule ``library.remove`` follows for a source
+    video. Idempotent: an id that is not registered returns ``{ok: false}`` rather
+    than an error, so a double-click cannot fail.
+    """
+    return {"ok": self.library.remove_broll(_require_str(params, "id"))}
 
 
 def project_open(self: Services, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:

--- a/sidecar/media_studio/handlers/library_ops.py
+++ b/sidecar/media_studio/handlers/library_ops.py
@@ -330,7 +330,7 @@ def library_managed_clear(self: Services, params: dict[str, Any], ctx: RpcContex
 # --------------------------------------------------------------------------- #
 # BR1 — the b-roll asset registry surface (broll.assets / addAsset / removeAsset)
 # --------------------------------------------------------------------------- #
-def _real_key(path: str) -> str:
+def _real_key(path: str, dir_cache: dict[str, str] | None = None) -> str:
     """A spelling-insensitive identity for a file path (the union's dedup key).
 
     ``broll_ops.scan_assets`` reports each file as the CONFIGURED folder with the
@@ -340,8 +340,34 @@ def _real_key(path: str) -> str:
     ``brollDir``, a relative folder, a symlinked folder, letter case, or an 8.3 short
     component on Windows. ``normcase(realpath(...))`` collapses all of those. Keying
     the union on the raw string would count that file twice and embed it twice.
+
+    PERF: ``realpath`` is a SYSCALL PER PATH (on Windows it opens the file to ask for
+    its final name), and the union calls this once per scanned asset. Measured on this
+    box with 2000 assets in one folder and an EMPTY registry: ``scan_assets`` alone
+    94 ms vs the union lister 479 ms (x5.1) — paid synchronously on the RPC loop,
+    because ``broll.status`` is a direct-return handler. So when ``dir_cache`` is
+    supplied the DIRECTORY is resolved once per distinct directory and the basename is
+    ``normcase``d onto it (2000 assets -> 1 syscall). Equivalence with the uncached
+    form is asserted, not assumed, for every spelling above.
+
+    Residual of the memo, disclosed: the final component is no longer passed through
+    ``realpath``, so a per-FILE symlink (or an 8.3 short BASENAME) is not expanded.
+    Neither is reachable through the two producers — ``rglob`` yields real long
+    basenames and ``Path.resolve()`` expands them — and the failure direction if it
+    ever were would be an asset embedded twice, never an asset dropped. UNVERIFIED:
+    whether any platform's ``rglob`` can yield a short basename; the settling
+    experiment is to create ``LONGFILENAME.png`` and scan a ``brollDir`` spelled with
+    the ``LONGFI~1.PNG`` form and compare the two keys.
     """
-    return os.path.normcase(os.path.realpath(path))
+    if dir_cache is None:
+        return os.path.normcase(os.path.realpath(path))
+    head, tail = os.path.split(path)
+    if not tail:  # a trailing-separator (bare directory) spelling has nothing to join
+        return os.path.normcase(os.path.realpath(path))
+    real_head = dir_cache.get(head)
+    if real_head is None:
+        real_head = dir_cache[head] = os.path.realpath(head)
+    return os.path.normcase(os.path.join(real_head, tail))
 
 
 def broll_asset_rows(self: Services, registered: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
@@ -363,19 +389,63 @@ def broll_asset_rows(self: Services, registered: list[dict[str, Any]] | None = N
 
     * **Dedup on the REAL path** (:func:`_real_key`), not on the path string or the
       ``assetId`` derived from it — see that helper for the measured reason. A
-      REGISTERED row WINS the collision because it carries the title/thumbnail the
-      UI shows; it keeps the scanned row's position so the list stays deterministic.
+      REGISTERED row WINS the collision because it carries the ``title`` the UI shows;
+      it keeps the scanned row's position so the list stays deterministic. (It also
+      carries ``thumbnailPath``, but that field is UNCONDITIONALLY ``""`` on this
+      branch: ``add_broll`` writes ``""`` and the only poster writer,
+      ``Library.set_thumbnail``, is ``role='source'``-scoped — measured,
+      ``set_thumbnail(<brollAssetId>, ...)`` returns ``None`` and changes nothing. So
+      the thumbnail half of this rationale is aspiration, not fact: BR1 surfaces the
+      column, no b-roll poster extractor exists yet. Do not cite it as a reason.)
     * **A registered asset whose file is gone is EXCLUDED.** It must not reach
       ``broll.index``, which would hand a vanished path to the image tower and fail
       the whole job. It is surfaced as ``broll.assets``' ``missing`` instead — loud,
-      the same way ``library.reveal`` reports a missing source.
+      the same way ``library.reveal`` reports a missing source. Note the filter checks
+      LIVENESS, not usability: the "is it a usable file at all" question is answered at
+      the registry door (``Library.add_broll``' ``is_file`` gate), because ``os.stat``
+      of a directory succeeds and would sail through here.
+
+    Two consequences worth naming, because neither is obvious from the signature:
+
+    * **The dedup is NOT skippable when the registry is empty.** Measured with
+      ``mklink /J``: ``os.path.islink`` returns False for a Windows junction and
+      ``Path.rglob`` descends into it, so a junction inside ``brollDir`` makes
+      ``scan_assets`` emit two spellings of ONE file. An "if nothing is registered,
+      return the scan verbatim" short-circuit would embed that file twice. The
+      per-directory memo in :func:`_real_key` is the cheap fix instead.
+    * **Registering a file that is ALREADY scanned can cost one re-embed.** The
+      registered row wins, and it spells the path ``Path.resolve()``'d, so when
+      ``brollDir`` is spelled non-canonically the surviving row's ``path`` — and
+      therefore its ``assetId`` and its ``broll_index.fingerprint`` — differ from the
+      scanned row's. Measured on one file with three ``brollDir`` spellings: resolved
+      absolute -> both equal; with a ``..`` segment or an upper-cased directory -> both
+      differ. The asset is re-embedded ONCE and then stable; nothing is lost, because
+      ``broll.apply`` composites from ``path`` + ``kind`` (not ``assetId``) and
+      ``broll_plan``'s id lookup is validated inside a single ``suggest`` call, so an
+      already-accepted suggestion is not invalidated by the id flip. And
+      ``tempfile.gettempdir()`` on this box IS an 8.3 short form, so a non-canonical
+      ``brollDir`` is not hypothetical.
+    * **This seam now depends on library state.** Reading the registry runs
+      ``Library._open`` -> ``_migrate``, which raises ``LibraryMigrationError`` on a
+      corrupt/wrong-shape ``library.json``. Measured: at 775a97ea ``broll.status`` /
+      ``broll.assets`` / ``broll.index`` could not fail on library state; now they can,
+      and ``LibraryMigrationError`` is NOT an ``RpcError``, so it surfaces as an untyped
+      internal error. That is deliberate rather than swallowed: ``library.list`` fails
+      in exactly that state too, and degrading to "empty registry" would show the user
+      a b-roll panel with their registered assets silently absent — the failure
+      ``missing`` exists to prevent. UNVERIFIED whether the renderer renders that error
+      usefully; the settling experiment is to corrupt ``data/library.json`` and drive
+      the b-roll panel.
     """
     known = self.library.list_broll() if registered is None else registered
     scanned = _broll_ops.scan_assets(str(self.settings.get().get(_broll_ops.BROLL_DIR_KEY) or ""))
-    rows: dict[str, dict[str, Any]] = {_real_key(str(row["path"])): {**row, "registered": False} for row in scanned}
+    dir_cache: dict[str, str] = {}  # one realpath per DIRECTORY, not per asset
+    rows: dict[str, dict[str, Any]] = {
+        _real_key(str(row["path"]), dir_cache): {**row, "registered": False} for row in scanned
+    }
     for asset in known:
         if asset["exists"]:
-            rows[_real_key(str(asset["path"]))] = asset
+            rows[_real_key(str(asset["path"]), dir_cache)] = asset
     return list(rows.values())
 
 
@@ -391,6 +461,12 @@ def broll_assets(self: Services, params: dict[str, Any], ctx: RpcContext) -> dic
     are reported rather than silently dropped, so the UI can offer a re-register or
     an unregister instead of leaving a phantom in the grid. No model, no provider,
     no network: a scan plus ONE SQLite read.
+
+    DEVIATION from ``docs/plans/v1.5/flagship-auto-broll.md`` §5, which declared
+    ``{assets}`` only: this returns ``{assets, missing}``, and each row is the
+    scan/registry shape (``assetId``, ``thumbnailPath``), not the doc's first-draft
+    ``BrollAsset`` (``id``, ``thumbPath``). The doc has been corrected; a renderer lane
+    reading an older copy of it will write ``asset.id`` and break.
 
     The registry is read ONCE and the two halves are a partition of that single
     snapshot, so every registered asset lands in exactly one of them. Reading twice
@@ -410,8 +486,19 @@ def broll_add_asset(self: Services, params: dict[str, Any], ctx: RpcContext) -> 
 
     THE missing door: before this method the b-roll library could only ever be a
     folder scan, so nothing in the app could put a specific asset into it. Registers
-    the file by path (no copy, no move) as a ``role='broll'`` entity. A missing file
-    or a non-b-roll extension is INVALID_PARAMS (loud).
+    the file by path (no copy, no move) as a ``role='broll'`` entity. A path that is
+    missing, is not a FILE (a directory with a media extension is the case that used
+    to slip through), or carries a non-b-roll extension is INVALID_PARAMS (loud) —
+    ``Library.add_broll`` owns those three gates and they mirror the folder scan's.
+
+    CONTRACT-NOTE: ``title`` applies on FIRST registration only. Re-posting the same
+    path returns the existing row unchanged and the new ``title`` is dropped without a
+    signal (``Library.add_broll`` mirrors ``Library.add`` here). BR1 ships no rename
+    door; the renderer's own path to a new title is ``removeAsset`` + ``addAsset``.
+
+    The wire shape is ``{asset}`` where the asset row carries ``assetId`` and
+    ``thumbnailPath`` — NOT the ``id`` / ``thumbPath`` the design doc's first draft
+    named. See the deviation note in ``docs/plans/v1.5/flagship-auto-broll.md`` §5.
     """
     path = _require_str(params, "path")
     title = params.get("title")
@@ -429,6 +516,10 @@ def broll_remove_asset(self: Services, params: dict[str, Any], ctx: RpcContext) 
     holds a path, not bytes) — the same rule ``library.remove`` follows for a source
     video. Idempotent: an id that is not registered returns ``{ok: false}`` rather
     than an error, so a double-click cannot fail.
+
+    DEVIATION from ``docs/plans/v1.5/flagship-auto-broll.md`` §5, which declared
+    ``{removed: bool}``: the key is ``ok``, matching every other boolean-ack handler in
+    this module. The doc has been corrected.
     """
     return {"ok": self.library.remove_broll(_require_str(params, "id"))}
 

--- a/sidecar/media_studio/handlers/library_ops.py
+++ b/sidecar/media_studio/handlers/library_ops.py
@@ -344,13 +344,20 @@ def _real_key(path: str) -> str:
     return os.path.normcase(os.path.realpath(path))
 
 
-def broll_asset_rows(self: Services) -> list[dict[str, Any]]:
+def broll_asset_rows(self: Services, registered: list[dict[str, Any]] | None = None) -> list[dict[str, Any]]:
     """The b-roll library the index/planner see: the folder scan UNION the registry.
 
     ``brollDir`` stays the bulk source (a recursive scan) and the BR1 registry adds
     individual assets from anywhere on disk, so ONE list feeds ``broll.status`` /
     ``broll.index`` / ``broll.suggest`` and there is no second scanner. This is the
     ``list_assets`` seam the composition root hands to ``broll_ops.register``.
+
+    ``registered`` lets a caller pass a registry snapshot it has ALREADY read, so
+    :func:`broll_assets` can partition one snapshot into present/missing instead of
+    reading twice (two reads let an asset deleted between them land in both halves,
+    and one restored between them land in NEITHER — a silently dropped asset). It
+    defaults to reading the registry here, which is what the composition-root seam
+    does.
 
     Two rules, both load-bearing:
 
@@ -363,9 +370,10 @@ def broll_asset_rows(self: Services) -> list[dict[str, Any]]:
       the whole job. It is surfaced as ``broll.assets``' ``missing`` instead — loud,
       the same way ``library.reveal`` reports a missing source.
     """
+    known = self.library.list_broll() if registered is None else registered
     scanned = _broll_ops.scan_assets(str(self.settings.get().get(_broll_ops.BROLL_DIR_KEY) or ""))
     rows: dict[str, dict[str, Any]] = {_real_key(str(row["path"])): {**row, "registered": False} for row in scanned}
-    for asset in self.library.list_broll():
+    for asset in known:
         if asset["exists"]:
             rows[_real_key(str(asset["path"]))] = asset
     return list(rows.values())
@@ -379,11 +387,18 @@ def broll_assets(self: Services, params: dict[str, Any], ctx: RpcContext) -> dic
     ``missing`` lists REGISTERED assets whose file has moved or been deleted — they
     are reported rather than silently dropped, so the UI can offer a re-register or
     an unregister instead of leaving a phantom in the grid. No model, no provider,
-    no network: a scan plus one SQLite read.
+    no network: a scan plus ONE SQLite read.
+
+    The registry is read ONCE and the two halves are a partition of that single
+    snapshot, so every registered asset lands in exactly one of them. Reading twice
+    would let an asset deleted between the reads appear in BOTH, and one restored
+    between them appear in NEITHER — i.e. silently disappear from the payload, which
+    is precisely the failure the ``missing`` list exists to prevent.
     """
+    registered = self.library.list_broll()
     return {
-        "assets": broll_asset_rows(self),
-        "missing": [asset for asset in self.library.list_broll() if not asset["exists"]],
+        "assets": broll_asset_rows(self, registered),
+        "missing": [asset for asset in registered if not asset["exists"]],
     }
 
 

--- a/sidecar/media_studio/library.py
+++ b/sidecar/media_studio/library.py
@@ -20,6 +20,7 @@ the subprocess seam without importing ffmpeg/ffprobe.
 from __future__ import annotations
 
 import builtins
+import hashlib
 import json
 import os
 import shutil
@@ -120,6 +121,82 @@ class LibraryMigrationError(RuntimeError):
     ``user_version`` stamp and BEFORE the ``.bak`` rename, so the corrupt source
     stays authoritative (never a silently-stamped empty DB = total data loss).
     """
+
+
+# --------------------------------------------------------------------------- #
+# BR1 — the B-roll asset REGISTRY (``role='broll'`` rows in the SAME entity table)
+# --------------------------------------------------------------------------- #
+#: ``entity.role`` of a registered b-roll asset. Distinct from ``'source'`` so the
+#: two libraries cannot leak into each other: every b-roll query below is
+#: role-scoped exactly like the source-video ones, so a b-roll still can never
+#: surface in ``library.list`` and a source video can never be unregistered here.
+BROLL_ROLE = "broll"
+
+#: The two ``entity.kind`` values a b-roll asset may take (design BR1).
+BROLL_IMAGE_KIND = "brollImage"
+BROLL_CLIP_KIND = "brollClip"
+
+#: PROV entity kind -> the asset ``kind`` the planner/compositor speak. This
+#: translation is load-bearing, not cosmetic: ``features/broll_compose.py`` treats
+#: anything that is not the literal ``"video"`` as a still (``-loop 1``), so handing
+#: it a ``brollClip`` would composite a clip as one frozen frame. The lookup is
+#: strict on purpose — :meth:`Library.add_broll` is the ONLY writer of a
+#: ``role='broll'`` row and only ever writes these two constants, so a third value
+#: is a programming error that must be loud rather than silently read as a still.
+_BROLL_ASSET_KIND: dict[str, str] = {BROLL_IMAGE_KIND: "image", BROLL_CLIP_KIND: "video"}
+
+
+class BrollAssetError(RuntimeError):
+    """A b-roll asset cannot be registered: the file is missing, or is not b-roll."""
+
+
+def broll_asset_id(path: str) -> str:
+    """The stable asset id for ``path`` — ``sha256(path)[:16]``.
+
+    Deliberately the SAME derivation ``broll_ops.scan_assets`` uses for its
+    ``assetId``, so when the configured ``brollDir`` is already an absolute,
+    resolved path a file that is BOTH scanned and registered carries ONE id and
+    registering it does not churn its vector in the index. Where the two spellings
+    of one file differ (an 8.3 short component, a ``..`` segment, letter case) the
+    ids differ too — which is why the union lister dedups on the REAL path rather
+    than on this id, and a divergent spelling can never double-count an asset.
+    """
+    return hashlib.sha256(path.encode("utf-8")).hexdigest()[:16]
+
+
+def _broll_entity_kind(path: Path) -> str | None:
+    """``path``'s b-roll ``entity.kind``, or ``None`` when it is not b-roll at all.
+
+    The accepted extension sets are READ from ``features.broll_ops`` (lazily, so
+    importing this module stays stdlib-only and feature-free) rather than restated
+    here: a second copy would drift, and then a file the folder scan happily
+    indexes could be refused by ``add_broll`` — or, worse, the reverse.
+    """
+    from .features import broll_ops  # local import keeps this module import-light
+
+    suffix = path.suffix.lower()
+    if suffix in broll_ops.IMAGE_EXTS:
+        return BROLL_IMAGE_KIND
+    if suffix in broll_ops.VIDEO_EXTS:
+        return BROLL_CLIP_KIND
+    return None
+
+
+def _stat_or_zero(path: str) -> tuple[int, float, bool]:
+    """``(sizeBytes, mtime, exists)`` for ``path`` — zeros when the file is gone.
+
+    Those two stat fields are exactly what ``broll_index.fingerprint`` hashes, so a
+    registered row must carry them the way a scanned row does or every registered
+    asset would read as permanently stale and be re-embedded on every index run. A
+    vanished file reports ``exists=False`` rather than a fabricated size, and the
+    caller surfaces it LOUDLY instead of silently dropping it — the same discipline
+    as :meth:`Project.find_missing_sources`.
+    """
+    try:
+        stat = os.stat(path)
+    except OSError:
+        return 0, 0.0, False
+    return stat.st_size, stat.st_mtime, True
 
 
 class Library:
@@ -400,6 +477,122 @@ class Library:
                 return None
             row = conn.execute("SELECT * FROM entity WHERE role = ? AND id = ?", ("source", video_id)).fetchone()
         return self._row_to_video(row)
+
+    # ---- BR1 b-roll asset registry ----------------------------------------- #
+    def list_broll(self) -> builtins.list[dict[str, Any]]:
+        """Every registered b-roll asset, in registration order (BR1).
+
+        Rows are shaped like ``broll_ops.scan_assets``' rows — ``assetId``, ``path``,
+        ``kind``, ``durationSec``, ``sizeBytes``, ``mtime`` — so the index and the
+        planner consume a scanned and a registered asset without branching, PLUS the
+        registry-only fields: the PROV ``entityKind``, the ``title`` /
+        ``thumbnailPath`` the UI shows, ``contentHash``, ``registered=True``, and
+        ``exists``. A row whose file has since moved or been deleted is RETURNED
+        (marked absent), never hidden — the caller decides what to do about it.
+        """
+        with self._open() as conn:
+            rows = conn.execute("SELECT * FROM entity WHERE role = ? ORDER BY rowid", (BROLL_ROLE,)).fetchall()
+        return [self._row_to_broll_asset(r) for r in rows]
+
+    def add_broll(self, path: str, title: str | None = None) -> dict[str, Any]:
+        """Register ``path`` as a b-roll asset and return its asset row (BR1).
+
+        Reuses the SAME ``entity`` table as the source videos with ``role='broll'``
+        and ``kind`` in {``brollImage``, ``brollClip``} — a b-roll asset is a
+        first-class PROV entity, not a second store, so lineage/relink keep ONE
+        graph. Idempotent by RESOLVED path: re-registering an already-registered
+        file returns the existing row rather than creating a duplicate (mirroring
+        :meth:`add`). The bytes are never copied and the file is never moved; the
+        registry holds a path.
+
+        Raises :class:`BrollAssetError` for a file that does not exist, or whose
+        extension the b-roll folder scan would not pick up either.
+        """
+        src = Path(path)
+        if not src.exists():
+            raise BrollAssetError(f"b-roll asset not found: {path}")
+        kind = _broll_entity_kind(src)
+        if kind is None:
+            raise BrollAssetError(f"not a b-roll image or clip: {path}")
+        abspath = str(src.resolve())
+        with self._open() as conn:
+            existing = conn.execute(
+                "SELECT * FROM entity WHERE role = ? AND path = ?", (BROLL_ROLE, abspath)
+            ).fetchone()
+            if existing is not None:
+                return self._row_to_broll_asset(existing)  # idempotent re-register
+            asset_id = broll_asset_id(abspath)
+            conn.execute(
+                f"INSERT OR REPLACE INTO entity ({_ENTITY_COLUMNS}) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    asset_id,
+                    kind,
+                    abspath,
+                    BROLL_ROLE,
+                    title or src.stem,
+                    _now_iso(),
+                    self._broll_duration(abspath, kind),
+                    # content_hash: the column is SURFACED by the asset row but left
+                    # NULL here. Populating it means a whole-file BLAKE3 of a
+                    # possibly multi-GB asset inside a synchronous RPC; the stronger
+                    # staleness key is BR2's job (broll_index's docstring already
+                    # names it as the upgrade path from the size+mtime fingerprint).
+                    None,
+                    0,  # has_transcript: meaningless for a b-roll asset
+                    "",  # thumbnail_path: "" until a poster is extracted for it
+                ),
+            )
+            row = conn.execute("SELECT * FROM entity WHERE role = ? AND id = ?", (BROLL_ROLE, asset_id)).fetchone()
+        # Read the row BACK rather than assembling the return value by hand: what a
+        # caller gets from add_broll is then the SAME shape list_broll yields BY
+        # CONSTRUCTION, instead of via two literals someone has to keep in step.
+        return self._row_to_broll_asset(row)
+
+    def remove_broll(self, asset_id: str) -> bool:
+        """Unregister the b-roll asset with ``id == asset_id``. True if removed.
+
+        The USER's file on disk is NEVER deleted — the registry holds a path, not
+        bytes (the same rule :meth:`remove` follows for a source video). Role-scoped,
+        so a source-video id can never be removed through this door.
+        """
+        with self._open() as conn:
+            cur = conn.execute("DELETE FROM entity WHERE role = ? AND id = ?", (BROLL_ROLE, asset_id))
+            return cur.rowcount > 0
+
+    def _broll_duration(self, path: str, kind: str) -> float:
+        """The probed duration of a b-roll CLIP; ``0.0`` for a still.
+
+        A still has no duration, so probing one would be a pointless ffprobe spawn.
+        CONTRACT-NOTE: a probe failure degrades to ``0.0`` rather than blocking the
+        registration — the same rule :meth:`add` applies to a source video.
+        """
+        if kind != BROLL_CLIP_KIND:
+            return 0.0
+        try:
+            return float(self._probe(path))
+        except Exception:
+            return 0.0
+
+    @staticmethod
+    def _row_to_broll_asset(row: sqlite3.Row) -> dict[str, Any]:
+        """An ``entity`` row -> the planner/index-shaped b-roll asset dict (BR1)."""
+        size, mtime, exists = _stat_or_zero(row["path"])
+        return {
+            "assetId": row["id"],
+            "path": row["path"],
+            # The compose/planner vocabulary ("image"/"video"), NOT the entity kind.
+            "kind": _BROLL_ASSET_KIND[row["kind"]],
+            "entityKind": row["kind"],
+            "title": row["title"],
+            "addedAt": row["added_at"],
+            "durationSec": float(row["duration_sec"]),
+            "contentHash": row["content_hash"],
+            "thumbnailPath": row["thumbnail_path"],
+            "sizeBytes": size,
+            "mtime": mtime,
+            "exists": exists,
+            "registered": True,
+        }
 
     # ---- L2 lineage (PROV append on Job success) ---------------------------
     def record_lineage(

--- a/sidecar/media_studio/library.py
+++ b/sidecar/media_studio/library.py
@@ -160,6 +160,12 @@ def broll_asset_id(path: str) -> str:
     of one file differ (an 8.3 short component, a ``..`` segment, letter case) the
     ids differ too — which is why the union lister dedups on the REAL path rather
     than on this id, and a divergent spelling can never double-count an asset.
+
+    ``entity.id`` is a GLOBAL primary key shared with the source videos, so the two
+    id spaces must not overlap: this returns 16 hex chars where :func:`_new_id`
+    returns 12, which makes a b-roll id length-disjoint from every
+    ``_new_id``-derived source id and therefore incapable of replacing one through
+    the ``INSERT OR REPLACE`` in :meth:`Library.add_broll`.
     """
     return hashlib.sha256(path.encode("utf-8")).hexdigest()[:16]
 

--- a/sidecar/media_studio/library.py
+++ b/sidecar/media_studio/library.py
@@ -147,7 +147,7 @@ _BROLL_ASSET_KIND: dict[str, str] = {BROLL_IMAGE_KIND: "image", BROLL_CLIP_KIND:
 
 
 class BrollAssetError(RuntimeError):
-    """A b-roll asset cannot be registered: the file is missing, or is not b-roll."""
+    """A b-roll asset cannot be registered: the path is missing, is not a file, or is not b-roll."""
 
 
 def broll_asset_id(path: str) -> str:
@@ -177,6 +177,11 @@ def _broll_entity_kind(path: Path) -> str | None:
     importing this module stays stdlib-only and feature-free) rather than restated
     here: a second copy would drift, and then a file the folder scan happily
     indexes could be refused by ``add_broll`` — or, worse, the reverse.
+
+    Scoped to the EXTENSION gate, which is all this helper decides. ``scan_assets``
+    has a second gate — ``path.is_file()`` — and reproducing it is
+    :meth:`Library.add_broll`'s job (see its docstring); this function is not the
+    place, because a directory has a suffix like anything else.
     """
     from .features import broll_ops  # local import keeps this module import-light
 
@@ -511,12 +516,28 @@ class Library:
         :meth:`add`). The bytes are never copied and the file is never moved; the
         registry holds a path.
 
-        Raises :class:`BrollAssetError` for a file that does not exist, or whose
-        extension the b-roll folder scan would not pick up either.
+        CONTRACT-NOTE: on a re-register the supplied ``title`` is DISCARDED — the
+        early return below happens before any UPDATE, exactly as :meth:`add` does for
+        a source video. There is deliberately no rename door in BR1, so a caller that
+        wants a new title must ``remove_broll`` then ``add_broll``. Said explicitly
+        because the ``broll.addAsset`` param list makes ``title`` look mutable.
+
+        Raises :class:`BrollAssetError` when the path does not exist, is not a FILE,
+        or carries an extension the b-roll folder scan would not pick up either.
+        Those are the folder scan's own two gates — ``features.broll_ops.scan_assets``
+        skips a candidate unless ``path.is_file()`` AND its suffix is in
+        ``IMAGE_EXTS | VIDEO_EXTS`` — so the registry door admits exactly the same
+        class of path the bulk scan does. The ``is_file`` half is not decoration:
+        ``exists()`` alone is TRUE for a DIRECTORY, and a registered directory named
+        ``album.png`` survives the union lister's liveness filter (``os.stat`` of a
+        directory succeeds), reaches ``broll.index``' embed plan, and fails the whole
+        batched index job — measured, before this gate existed.
         """
         src = Path(path)
         if not src.exists():
             raise BrollAssetError(f"b-roll asset not found: {path}")
+        if not src.is_file():
+            raise BrollAssetError(f"not a file (a directory cannot be a b-roll asset): {path}")
         kind = _broll_entity_kind(src)
         if kind is None:
             raise BrollAssetError(f"not a b-roll image or clip: {path}")

--- a/sidecar/tests/test_broll_library.py
+++ b/sidecar/tests/test_broll_library.py
@@ -7,8 +7,18 @@ the registry (``role='broll'`` rows in the SAME ``entity`` table as the source
 videos), the three ``broll.assets`` / ``broll.addAsset`` / ``broll.removeAsset``
 handlers, and the UNION lister that feeds the already-wired engine.
 
-Four things here are correctness claims rather than shape assertions, and each has
+Six things here are correctness claims rather than shape assertions, and each has
 its own test because getting any of them wrong is silent:
+
+* **The registry door admits exactly what the folder scan admits** — BOTH of the
+  scanner's gates, not just the extension set. ``add_broll`` originally checked only
+  ``src.exists()``, which is TRUE for a directory, so ``mkdir album.png`` registered as
+  a b-roll IMAGE and reached ``broll.index``' embed plan, where the batched image tower
+  fails the WHOLE job on one unopenable path.
+* **The dedup survives an EMPTY registry.** A junction inside ``brollDir`` makes the
+  SCAN itself emit one file twice (measured: ``os.path.islink`` is False for a junction
+  and ``rglob`` descends into it), so the union may not short-circuit when nothing is
+  registered — only memoise the ``realpath`` per directory.
 
 * **The kind vocabulary is translated on the way out.** The DB stores the PROV
   kinds ``brollImage`` / ``brollClip``; ``broll_compose`` treats anything that is
@@ -35,6 +45,7 @@ images so no ffprobe subprocess is ever spawned.
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from typing import Any
 
@@ -45,6 +56,12 @@ from media_studio.handlers import Services, register_all
 from media_studio.handlers import library_ops as _library_ops
 from media_studio.library import Library
 from media_studio.protocol import RpcContext, RpcError
+
+#: sidecar/tests/<this file> -> sidecar/tests -> sidecar -> <repo root>. The
+#: key-injection allowlist is READ from here rather than transcribed (see
+#: :func:`test_the_registry_methods_are_absent_from_the_REAL_key_injection_allowlist`);
+#: ``test_director_op_kind_parity.py`` establishes this cross-language-read pattern.
+_KEY_BRIDGE_TS = Path(__file__).resolve().parents[2] / "app" / "main" / "keyBridge.ts"
 
 
 # --------------------------------------------------------------------------- #
@@ -169,17 +186,68 @@ def test_add_broll_unsupported_extension_raises(lib: Library, tmp_path: Path):
         lib.add_broll(str(notes))
 
 
-def test_add_broll_accepts_exactly_what_the_folder_scan_accepts(lib: Library, tmp_path: Path):
-    """The accepted extension set is READ from the scanner, never restated.
+def test_add_broll_accepts_the_same_extension_sets_as_the_folder_scan(lib: Library, tmp_path: Path):
+    """The accepted extension SET is READ from the scanner, never restated.
 
     A second copy could drift, and then a file the scan happily indexes would be
     refused by addAsset (or the reverse) — so assert against the scanner's own sets.
+
+    Scoped deliberately: this covers the extension sets ONLY, which is all it ever
+    measured. The scanner's OTHER gate — ``path.is_file()`` — is asserted by
+    :func:`test_add_broll_refuses_a_DIRECTORY_named_like_an_image` and
+    :func:`test_the_registry_door_and_the_folder_scan_refuse_THE_SAME_directory`.
+    (The earlier name, ``..._accepts_exactly_what_the_folder_scan_accepts``, was
+    REFUTED: it claimed full acceptance parity while the is_file half was missing.)
     """
     for ext in sorted(broll_ops.IMAGE_EXTS | broll_ops.VIDEO_EXTS):
         f = tmp_path / f"asset{ext}"
         f.write_bytes(b"x")
         registered = lib.add_broll(str(f))
         assert registered["kind"] == ("image" if ext in broll_ops.IMAGE_EXTS else "video")
+
+
+def test_add_broll_refuses_a_DIRECTORY_named_like_an_image(lib: Library, tmp_path: Path):
+    """The scanner's ``is_file()`` gate, reproduced at the registry door.
+
+    ``scan_assets`` skips anything that is not ``path.is_file()``
+    (``features/broll_ops.py``); ``add_broll`` used to gate only on ``src.exists()``,
+    which is TRUE for a directory. Measured before the fix, end to end against the
+    real composition root: ``broll.addAsset(<dir album.png>)`` -> ACCEPTED
+    ``kind='image' exists=True sizeBytes=0``; it then passed the union lister's
+    ``exists`` filter (``os.stat`` of a directory succeeds), and ``broll.status``
+    reported ``libraryCount=3 staleCount=3`` — and ``staleCount`` IS
+    ``len(refresh_plan()['embed'])``, verbatim the list ``broll.index`` hands to the
+    image tower, where ``open()`` on that path raises ``PermissionError``. One bad row
+    fails the WHOLE index job because the tower stacks the batch, so this is a
+    library-wide failure, not a per-asset one.
+    """
+    bogus = tmp_path / "album.png"
+    bogus.mkdir()
+    with pytest.raises(_library.BrollAssetError, match="not a file"):
+        lib.add_broll(str(bogus))
+    assert lib.list_broll() == []
+
+
+def test_the_registry_door_and_the_folder_scan_refuse_THE_SAME_directory(wired, tmp_path: Path):
+    """Acceptance parity asserted by RUNNING both gates over one tree, not by prose.
+
+    The control is in the same run: both gates ACCEPT ``real.png``, so a zero from
+    either of them is a refusal and not a broken probe.
+    """
+    handlers, services = wired
+    folder = tmp_path / "scanned"
+    folder.mkdir()
+    (folder / "real.png").write_bytes(b"x")
+    bogus = folder / "album.png"
+    bogus.mkdir()
+    # control: the scanner takes the real file and skips the directory
+    assert [Path(a["path"]).name for a in broll_ops.scan_assets(str(folder))] == ["real.png"]
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder)})
+    # control: the SAME door takes the real file
+    assert handlers["broll.addAsset"]({"path": str(folder / "real.png")}, _ctx())["asset"]["kind"] == "image"
+    with pytest.raises(RpcError, match="not a file"):
+        handlers["broll.addAsset"]({"path": str(bogus)}, _ctx())
+    assert [Path(r["path"]).name for r in _library_ops.broll_asset_rows(services)] == ["real.png"]
 
 
 # --------------------------------------------------------------------------- #
@@ -480,30 +548,53 @@ def test_a_registered_asset_lands_in_the_index_EMBED_PLAN(wired, tmp_path: Path)
     assert (after["stale"], after["staleCount"], after["libraryCount"]) == (True, 1, 2)
 
 
-def test_the_registry_methods_never_enter_the_key_injection_allowlist(wired):
-    """broll.* is LOCAL-only: no provider, so no key may ever be injected."""
+def test_the_registry_methods_are_absent_from_the_REAL_key_injection_allowlist(wired):
+    """broll.* is LOCAL-only: no provider, so no key may ever be injected.
+
+    This reads the ACTUAL allowlist out of ``app/main/keyBridge.ts`` — the file whose
+    ``INJECT_PREFIXES`` / ``INJECT_METHODS`` literals ``needsKeyInjection()`` consults
+    — instead of comparing against a second copy transcribed here. The previous
+    version of this test hardcoded both literals, so two of its three assertions were
+    constant-true over its own constants and adding ``broll.assets`` to the real
+    allowlist could never have turned it red: it was REFUTED as a gate that cannot
+    fail, and this is the replacement.
+
+    Detector control (asserted below before the real claim): the parse must find the
+    four known prefix families and the known-present ``subtitles.translate`` entry. A
+    regex that silently matched nothing would otherwise yield empty sets that every
+    method trivially passes.
+
+    Scope: this pins the DECLARED literals. It does not EXECUTE
+    ``needsKeyInjection()`` — that is ``app/main/keyBridge.test.ts``' job, and
+    measured on this branch that suite's "is false for non-provider methods" list
+    contains no ``broll.*`` case (UNVERIFIED whether a later lane adds one; the
+    settling experiment is a grep of ``keyBridge.test.ts`` for ``broll.``).
+    """
     handlers, _services = wired
-    prefixes = ("ai.", "director.", "shortmaker.", "index.")
-    exact = {
-        "subtitles.translate",
-        "providers.usage",
-        "providers.openrouterUsage",
-        "providers.revealKey",
-        "thumbnail.select",
-        "phase8.select",
-        "recipes.run",
-        "templates.apply",
-        "batch.start",
-        "batch.resume",
-    }
+    source = _KEY_BRIDGE_TS.read_text(encoding="utf-8")
+    prefix_match = re.search(r"const INJECT_PREFIXES[^=]*=\s*\[(.*?)\];", source, re.DOTALL)
+    methods_match = re.search(r"const INJECT_METHODS[^=]*=\s*new Set\(\[(.*?)\]\);", source, re.DOTALL)
+    assert prefix_match is not None, f"INJECT_PREFIXES not found in {_KEY_BRIDGE_TS} — update this gate, don't drop it"
+    assert methods_match is not None, f"INJECT_METHODS not found in {_KEY_BRIDGE_TS} — update this gate, don't drop it"
+    prefixes = tuple(re.findall(r"'([^']+)'", prefix_match.group(1)))
+    exact = set(re.findall(r"'([^']+)'", methods_match.group(1)))
+    # --- detector control: the parse really did read the live allowlist ---------
+    assert prefixes == ("ai.", "director.", "shortmaker.", "index.")
+    assert "subtitles.translate" in exact and "providers.revealKey" in exact
+    # --- the claim -------------------------------------------------------------
     for name in ("broll.assets", "broll.addAsset", "broll.removeAsset"):
         assert name in handlers
-        assert not name.startswith(prefixes)
-        assert name not in exact
+        assert not name.startswith(prefixes), f"{name} is prefix-matched by keyBridge.ts INJECT_PREFIXES"
+        assert name not in exact, f"{name} was added to keyBridge.ts INJECT_METHODS — broll.* takes no provider key"
 
 
-def test_the_real_path_dedup_key_collapses_short_names_and_dot_segments(tmp_path: Path):
-    """Control for the dedup key itself: it must see through both spellings."""
+def test_the_real_path_dedup_key_collapses_dot_segments(tmp_path: Path):
+    """Control for the dedup key itself: it must see through both spellings.
+
+    Scoped to the ``..`` dot-segment spelling, which is the only one this test
+    constructs. (The earlier name claimed 8.3 short names too; the module docstring
+    already admitted that case is NOT exercised here, so the name was REFUTED.)
+    """
     folder = tmp_path / "b"
     folder.mkdir()
     dog = folder / "dog.png"
@@ -512,3 +603,87 @@ def test_the_real_path_dedup_key_collapses_short_names_and_dot_segments(tmp_path
     assert weird != str(dog)
     assert _library_ops._real_key(weird) == _library_ops._real_key(str(dog.resolve()))
     assert _library_ops._real_key(weird) == os.path.normcase(os.path.realpath(str(dog)))
+
+
+def test_the_dedup_key_is_IDENTICAL_with_and_without_the_directory_cache(tmp_path: Path):
+    """The per-call directory memo must not change the key for ANY spelling.
+
+    ``_real_key`` resolves the DIRECTORY and normcases the basename onto it, memoising
+    the directory, because ``realpath`` is a per-path syscall and the union lister
+    calls it once per scanned asset. Equivalence is the whole safety argument for that
+    optimisation, so it is asserted rather than reasoned about.
+    """
+    folder = tmp_path / "b"
+    folder.mkdir()
+    dog = folder / "dog.png"
+    dog.write_bytes(b"x")
+    cache: dict[str, str] = {}
+    for spelling in (str(dog), str(folder / ".." / "b" / "dog.png"), str(dog).upper(), str(folder / "DOG.PNG")):
+        assert _library_ops._real_key(spelling, cache) == _library_ops._real_key(spelling)
+    # one entry per distinct directory spelling, and the uncached call is unaffected
+    assert len({_library_ops._real_key(s, cache) for s in (str(dog), str(dog).upper())}) == 1
+    # a trailing-separator spelling has no basename to join: it resolves whole
+    assert _library_ops._real_key(str(folder) + os.sep, cache) == _library_ops._real_key(str(folder) + os.sep)
+
+
+def test_the_union_lister_resolves_each_DIRECTORY_once_not_each_file(wired, tmp_path: Path, monkeypatch):
+    """PERF pin: N scanned assets in one folder cost ONE ``realpath``, not N.
+
+    Measured on this box before the memo, 2000 one-folder assets with an EMPTY
+    registry: ``scan_assets`` alone 94 ms vs ``broll_asset_rows`` 479 ms (x5.1), and
+    ``broll.status`` is a direct-return handler, so that delta is paid synchronously on
+    the RPC loop on every status/index/suggest call. Counting the syscall is a stabler
+    pin than a wall-clock threshold.
+    """
+    _handlers, services = wired
+    folder = tmp_path / "many"
+    folder.mkdir()
+    for i in range(12):
+        (folder / f"a{i}.png").write_bytes(b"x")
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder)})
+    outside = tmp_path / "elsewhere" / "city.jpg"
+    outside.parent.mkdir()
+    outside.write_bytes(b"y")
+    services.library.add_broll(str(outside))
+
+    real_realpath = os.path.realpath
+    calls: list[str] = []
+
+    def counting(path):
+        calls.append(str(path))
+        return real_realpath(path)
+
+    monkeypatch.setattr(_library_ops.os.path, "realpath", counting)
+    rows = _library_ops.broll_asset_rows(services)
+    assert len(rows) == 13  # 12 scanned + 1 registered — the memo changed no output
+    # 2 distinct directories (the scanned folder + the registered asset's folder).
+    assert len(calls) == 2, f"expected one realpath per DIRECTORY, got {len(calls)}: {calls}"
+
+
+def test_the_union_still_dedups_two_SCANNED_spellings_of_one_file(wired, tmp_path: Path, monkeypatch):
+    """Scanned-vs-scanned dedup must survive even with an EMPTY registry.
+
+    This is why the union CANNOT short-circuit to ``[{**row, 'registered': False} ...]``
+    when nothing is registered. Measured with ``mklink /J``: ``os.path.islink`` returns
+    **False** for a Windows junction and ``Path.rglob`` DOES descend into it, so a
+    junction inside ``brollDir`` makes ``scan_assets`` emit ``mirror\\dog.png`` AND
+    ``real\\dog.png`` — two spellings of ONE file, collapsing to one ``_real_key``.
+    Skipping the dedup on an empty registry would embed that file twice.
+
+    The two spellings are injected through the scanner seam rather than by creating a
+    junction, so this runs on every platform the gate runs on.
+    """
+    _handlers, services = wired
+    folder = tmp_path / "scanned"
+    folder.mkdir()
+    dog = folder / "dog.png"
+    dog.write_bytes(b"x")
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder)})
+    (row,) = broll_ops.scan_assets(str(folder))
+    twin = {**row, "path": str(folder / ".." / "scanned" / "dog.png")}
+    monkeypatch.setattr(_library_ops._broll_ops, "scan_assets", lambda _root: [row, twin])
+
+    assert services.library.list_broll() == []  # the registry really is empty
+    rows = _library_ops.broll_asset_rows(services)
+    assert len(rows) == 1, "one file spelled twice by the SCAN must still yield one row"
+    assert rows[0]["registered"] is False

--- a/sidecar/tests/test_broll_library.py
+++ b/sidecar/tests/test_broll_library.py
@@ -1,0 +1,443 @@
+"""BR1 — the B-roll ASSET REGISTRY (``add_broll`` / ``list_broll`` / ``remove_broll``).
+
+Before this unit there was no way to REGISTER a b-roll asset: ``broll.index`` /
+``broll.suggest`` / ``broll.apply`` shipped with a working engine whose entire view
+of the library was a recursive scan of the ``brollDir`` setting. This module covers
+the registry (``role='broll'`` rows in the SAME ``entity`` table as the source
+videos), the three ``broll.assets`` / ``broll.addAsset`` / ``broll.removeAsset``
+handlers, and the UNION lister that feeds the already-wired engine.
+
+Four things here are correctness claims rather than shape assertions, and each has
+its own test because getting any of them wrong is silent:
+
+* **The kind vocabulary is translated on the way out.** The DB stores the PROV
+  kinds ``brollImage`` / ``brollClip``; ``broll_compose`` treats anything that is
+  not the literal ``"video"`` as a still (``-loop 1``), so a row leaving the
+  registry as ``brollClip`` would be composited as a frozen frame.
+* **The registry row is index-compatible.** ``broll_index.fingerprint`` hashes
+  ``path|sizeBytes|mtime``, so a registered row must carry the same stat fields a
+  scanned row does — otherwise every registered asset reads as permanently stale.
+* **Dedup is on the REAL path, not the path string.** ``scan_assets`` reports the
+  configured folder with the relative parts joined on verbatim while ``add_broll``
+  stores resolved text, so the SAME file can reach the two halves of the union
+  under two different strings. The spelling exercised below is a ``..`` segment in
+  ``brollDir``; letter case, a symlink, a relative folder and an 8.3 short
+  component are the other sources. (Measured: ``tempfile.gettempdir()`` on this box
+  IS the 8.3 short form, but pytest's ``tmp_path`` is already resolved — so the
+  short-name case is real on the box and is NOT what these tests exercise.)
+* **A registered asset whose file vanished is excluded from the lister** (it would
+  be handed to the image tower) and surfaced as ``missing`` instead.
+
+Stdlib only: the duration prober is injected, and the wired tests register ``.png``
+images so no ffprobe subprocess is ever spawned.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+import pytest
+from media_studio import library as _library
+from media_studio.features import broll_index, broll_ops
+from media_studio.handlers import Services, register_all
+from media_studio.handlers import library_ops as _library_ops
+from media_studio.library import Library
+from media_studio.protocol import RpcContext, RpcError
+
+
+# --------------------------------------------------------------------------- #
+# fixtures / helpers
+# --------------------------------------------------------------------------- #
+@pytest.fixture
+def lib(tmp_path: Path) -> Library:
+    """A Library whose duration prober is a stub (never a real ffprobe)."""
+    return Library(tmp_path / "library.json", probe_duration=lambda _p: 4.25)
+
+
+@pytest.fixture
+def still(tmp_path: Path) -> Path:
+    p = tmp_path / "assets" / "a dog.PNG"  # upper-case ext + a space, on purpose
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x89PNG-not-really")
+    return p
+
+
+@pytest.fixture
+def clip(tmp_path: Path) -> Path:
+    p = tmp_path / "assets" / "city.mp4"
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_bytes(b"\x00\x00not-really-a-clip")
+    return p
+
+
+def _ctx() -> RpcContext:
+    return RpcContext(emit_notification=lambda _obj: None, jobs=None)
+
+
+@pytest.fixture
+def wired(tmp_path: Path):
+    """``(handlers, services)`` from the REAL composition root, tmp-dir backed."""
+    collected: dict[str, Any] = {}
+    services = Services(data_dir=tmp_path / "data")
+    register_all(services, register=lambda name, handler: collected.__setitem__(name, handler))
+    return collected, services
+
+
+# --------------------------------------------------------------------------- #
+# Library.add_broll
+# --------------------------------------------------------------------------- #
+def test_add_broll_returns_the_full_asset_row(lib: Library, still: Path):
+    asset = lib.add_broll(str(still))
+    assert set(asset) == {
+        "assetId",
+        "path",
+        "kind",
+        "entityKind",
+        "title",
+        "addedAt",
+        "durationSec",
+        "contentHash",
+        "thumbnailPath",
+        "sizeBytes",
+        "mtime",
+        "exists",
+        "registered",
+    }
+    assert asset["entityKind"] == _library.BROLL_IMAGE_KIND
+    assert asset["kind"] == "image"
+    assert asset["title"] == "a dog"  # stem default
+    assert asset["registered"] is True
+    assert asset["exists"] is True
+    assert asset["contentHash"] is None  # BR1 surfaces the column; BR2 populates it
+    assert asset["thumbnailPath"] == ""
+    assert Path(asset["path"]).name == "a dog.PNG"
+
+
+def test_add_broll_classifies_a_clip_and_probes_its_duration(lib: Library, clip: Path):
+    asset = lib.add_broll(str(clip))
+    assert asset["entityKind"] == _library.BROLL_CLIP_KIND
+    assert asset["kind"] == "video"  # the compose vocabulary, NOT the entity kind
+    assert asset["durationSec"] == 4.25  # the injected prober ran
+
+
+def test_add_broll_does_not_probe_a_still(tmp_path: Path, still: Path):
+    """An image has no duration; probing one would be a pointless ffprobe spawn."""
+    probed: list[str] = []
+
+    def probe(path: str) -> float:
+        probed.append(path)
+        return 9.0
+
+    asset = Library(tmp_path / "library.json", probe_duration=probe).add_broll(str(still))
+    assert probed == []
+    assert asset["durationSec"] == 0.0
+
+
+def test_add_broll_survives_a_failing_duration_probe(tmp_path: Path, clip: Path):
+    """A probe failure must not block registration (mirrors Library.add)."""
+
+    def boom(_path: str) -> float:
+        raise OSError("ffprobe missing")
+
+    asset = Library(tmp_path / "library.json", probe_duration=boom).add_broll(str(clip))
+    assert asset["durationSec"] == 0.0
+    assert asset["entityKind"] == _library.BROLL_CLIP_KIND
+
+
+def test_add_broll_custom_title(lib: Library, still: Path):
+    assert lib.add_broll(str(still), title="Hero shot")["title"] == "Hero shot"
+
+
+def test_add_broll_is_idempotent_by_resolved_path(lib: Library, still: Path):
+    first = lib.add_broll(str(still))
+    second = lib.add_broll(str(still), title="ignored on re-register")
+    assert second == first
+    assert len(lib.list_broll()) == 1
+
+
+def test_add_broll_missing_file_raises(lib: Library, tmp_path: Path):
+    with pytest.raises(_library.BrollAssetError, match="not found"):
+        lib.add_broll(str(tmp_path / "nope.png"))
+
+
+def test_add_broll_unsupported_extension_raises(lib: Library, tmp_path: Path):
+    notes = tmp_path / "notes.txt"
+    notes.write_text("not b-roll", encoding="utf-8")
+    with pytest.raises(_library.BrollAssetError, match="not a b-roll"):
+        lib.add_broll(str(notes))
+
+
+def test_add_broll_accepts_exactly_what_the_folder_scan_accepts(lib: Library, tmp_path: Path):
+    """The accepted extension set is READ from the scanner, never restated.
+
+    A second copy could drift, and then a file the scan happily indexes would be
+    refused by addAsset (or the reverse) — so assert against the scanner's own sets.
+    """
+    for ext in sorted(broll_ops.IMAGE_EXTS | broll_ops.VIDEO_EXTS):
+        f = tmp_path / f"asset{ext}"
+        f.write_bytes(b"x")
+        registered = lib.add_broll(str(f))
+        assert registered["kind"] == ("image" if ext in broll_ops.IMAGE_EXTS else "video")
+
+
+# --------------------------------------------------------------------------- #
+# role isolation — a b-roll asset is NOT a source video and vice versa
+# --------------------------------------------------------------------------- #
+def test_a_registered_broll_asset_never_appears_in_the_source_video_list(lib: Library, clip: Path):
+    lib.add_broll(str(clip))
+    assert lib.list() == []
+    assert lib.get(_library.broll_asset_id(str(clip.resolve()))) is None
+
+
+def test_a_source_video_never_appears_in_the_broll_list(lib: Library, clip: Path):
+    lib.add(str(clip))
+    assert lib.list_broll() == []
+
+
+def test_remove_broll_cannot_delete_a_source_video_row(lib: Library, clip: Path):
+    video = lib.add(str(clip))
+    assert lib.remove_broll(video["id"]) is False
+    assert len(lib.list()) == 1
+
+
+# --------------------------------------------------------------------------- #
+# Library.list_broll
+# --------------------------------------------------------------------------- #
+def test_list_broll_is_empty_on_a_fresh_library(lib: Library):
+    assert lib.list_broll() == []
+
+
+def test_list_broll_preserves_registration_order(lib: Library, still: Path, clip: Path):
+    lib.add_broll(str(clip))
+    lib.add_broll(str(still))
+    assert [Path(a["path"]).name for a in lib.list_broll()] == ["city.mp4", "a dog.PNG"]
+
+
+def test_list_broll_reports_a_vanished_file_without_fabricating_a_size(lib: Library, still: Path):
+    lib.add_broll(str(still))
+    still.unlink()
+    (gone,) = lib.list_broll()
+    assert gone["exists"] is False
+    assert gone["sizeBytes"] == 0
+    assert gone["mtime"] == 0.0
+
+
+def test_a_registered_row_fingerprints_IDENTICALLY_to_the_scanned_row(tmp_path: Path):
+    """The registry row is index-compatible: same file -> same staleness key.
+
+    ``broll_index.fingerprint`` hashes ``path|sizeBytes|mtime``. If a registered row
+    omitted (or mis-typed) the stat fields, ``broll.status`` would report every
+    registered asset stale forever and ``broll.index`` would re-embed it every run.
+
+    Scoped claim: the two fingerprints coincide when the scanned folder is already
+    an absolute RESOLVED path (so the two halves spell the file the same way). The
+    union's dedup does NOT rely on that — see the real-path dedup test below.
+    """
+    folder = (tmp_path / "broll").resolve()
+    folder.mkdir(parents=True)
+    (folder / "dog.png").write_bytes(b"pixels")
+
+    (scanned,) = broll_ops.scan_assets(str(folder))
+    registered = Library(tmp_path / "library.json").add_broll(str(folder / "dog.png"))
+    assert broll_index.fingerprint(registered) == broll_index.fingerprint(scanned)
+    assert registered["assetId"] == scanned["assetId"]
+
+
+# --------------------------------------------------------------------------- #
+# Library.remove_broll
+# --------------------------------------------------------------------------- #
+def test_remove_broll_unregisters_the_asset_and_keeps_the_file(lib: Library, still: Path):
+    asset = lib.add_broll(str(still))
+    assert lib.remove_broll(asset["assetId"]) is True
+    assert lib.list_broll() == []
+    assert still.exists(), "the USER's file must never be deleted by an unregister"
+
+
+def test_remove_broll_is_false_for_an_unknown_id(lib: Library):
+    assert lib.remove_broll("deadbeefdeadbeef") is False
+
+
+# --------------------------------------------------------------------------- #
+# the UNION lister (what broll.index / status / suggest actually see)
+# --------------------------------------------------------------------------- #
+def test_the_union_lister_is_the_folder_scan_when_nothing_is_registered(wired, tmp_path: Path):
+    _handlers, services = wired
+    folder = tmp_path / "scan-only"
+    folder.mkdir()
+    (folder / "dog.png").write_bytes(b"x")
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder)})
+    rows = _library_ops.broll_asset_rows(services)
+    assert [Path(r["path"]).name for r in rows] == ["dog.png"]
+    assert rows[0]["registered"] is False
+
+
+def test_the_union_lister_adds_a_registered_asset_from_OUTSIDE_the_folder(wired, tmp_path: Path):
+    _handlers, services = wired
+    folder = tmp_path / "scanned"
+    folder.mkdir()
+    (folder / "dog.png").write_bytes(b"x")
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder)})
+    elsewhere = tmp_path / "elsewhere" / "city.jpg"
+    elsewhere.parent.mkdir()
+    elsewhere.write_bytes(b"y")
+    services.library.add_broll(str(elsewhere))
+
+    rows = _library_ops.broll_asset_rows(services)
+    assert sorted(Path(r["path"]).name for r in rows) == ["city.jpg", "dog.png"]
+    assert {r["registered"] for r in rows} == {True, False}
+
+
+def test_the_union_dedups_on_the_REAL_path_not_the_path_string(wired, tmp_path: Path):
+    """One file, two spellings, ONE row — the registered one.
+
+    ``scan_assets`` reports each file as the configured folder with the relative
+    parts joined on, verbatim; ``add_broll`` stores ``Path.resolve()``'d text. So a
+    ``brollDir`` carrying a ``..`` segment (as used here) makes the SAME file arrive
+    at the two halves of the union under two different strings, and a string-keyed
+    dedup would count it twice and embed it twice.
+    """
+    _handlers, services = wired
+    folder = tmp_path / "scanned"
+    folder.mkdir()
+    dog = folder / "dog.png"
+    dog.write_bytes(b"x")
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder / ".." / "scanned")})
+    registered = services.library.add_broll(str(dog), title="Hero dog")
+    # Precondition of the test: the two halves really do spell it differently.
+    # (Without this assertion the test would still pass on a tree where the two
+    # spellings happen to coincide, and would then be measuring nothing.)
+    (scanned,) = broll_ops.scan_assets(str(folder / ".." / "scanned"))
+    assert scanned["path"] != registered["path"]
+
+    rows = _library_ops.broll_asset_rows(services)
+    assert len(rows) == 1
+    assert rows[0]["title"] == "Hero dog"  # the REGISTERED row won the collision
+    assert rows[0]["registered"] is True
+
+
+def test_the_union_excludes_a_registered_asset_whose_file_vanished(wired, tmp_path: Path):
+    """A vanished path must never reach broll.index (it would fail the job)."""
+    _handlers, services = wired
+    gone = tmp_path / "gone.png"
+    gone.write_bytes(b"x")
+    services.library.add_broll(str(gone))
+    assert len(_library_ops.broll_asset_rows(services)) == 1
+    gone.unlink()
+    assert _library_ops.broll_asset_rows(services) == []
+
+
+# --------------------------------------------------------------------------- #
+# the three handlers
+# --------------------------------------------------------------------------- #
+def test_broll_assets_returns_the_union_plus_a_loud_missing_list(wired, tmp_path: Path):
+    handlers, services = wired
+    here = tmp_path / "here.png"
+    here.write_bytes(b"x")
+    gone = tmp_path / "gone.png"
+    gone.write_bytes(b"y")
+    services.library.add_broll(str(here))
+    services.library.add_broll(str(gone))
+    gone.unlink()
+
+    out = handlers["broll.assets"]({}, _ctx())
+    assert [Path(a["path"]).name for a in out["assets"]] == ["here.png"]
+    assert [Path(a["path"]).name for a in out["missing"]] == ["gone.png"]
+    assert out["missing"][0]["exists"] is False
+
+
+def test_broll_add_asset_registers_and_returns_the_asset(wired, tmp_path: Path):
+    handlers, services = wired
+    png = tmp_path / "dog.png"
+    png.write_bytes(b"x")
+    out = handlers["broll.addAsset"]({"path": str(png), "title": "Dog"}, _ctx())
+    assert out["asset"]["title"] == "Dog"
+    assert [a["assetId"] for a in services.library.list_broll()] == [out["asset"]["assetId"]]
+
+
+def test_broll_add_asset_ignores_a_non_string_title(wired, tmp_path: Path):
+    handlers, _services = wired
+    png = tmp_path / "dog.png"
+    png.write_bytes(b"x")
+    out = handlers["broll.addAsset"]({"path": str(png), "title": 7}, _ctx())
+    assert out["asset"]["title"] == "dog"  # fell back to the stem
+
+
+def test_broll_add_asset_requires_a_path(wired):
+    handlers, _services = wired
+    with pytest.raises(RpcError, match="path"):
+        handlers["broll.addAsset"]({}, _ctx())
+
+
+def test_broll_add_asset_turns_a_refusal_into_invalid_params(wired, tmp_path: Path):
+    handlers, _services = wired
+    with pytest.raises(RpcError, match="not found"):
+        handlers["broll.addAsset"]({"path": str(tmp_path / "nope.png")}, _ctx())
+
+
+def test_broll_remove_asset_unregisters(wired, tmp_path: Path):
+    handlers, services = wired
+    png = tmp_path / "dog.png"
+    png.write_bytes(b"x")
+    asset = services.library.add_broll(str(png))
+    assert handlers["broll.removeAsset"]({"id": asset["assetId"]}, _ctx()) == {"ok": True}
+    assert services.library.list_broll() == []
+    assert handlers["broll.removeAsset"]({"id": asset["assetId"]}, _ctx()) == {"ok": False}
+
+
+def test_broll_remove_asset_requires_an_id(wired):
+    handlers, _services = wired
+    with pytest.raises(RpcError, match="id"):
+        handlers["broll.removeAsset"]({}, _ctx())
+
+
+# --------------------------------------------------------------------------- #
+# composition-root wiring: the registry reaches the ALREADY-WIRED engine
+# --------------------------------------------------------------------------- #
+def test_a_registered_asset_is_counted_by_the_wired_broll_status(wired, tmp_path: Path):
+    """The point of the whole unit: registration feeds the existing engine.
+
+    ``broll.status.libraryCount`` comes from the ``list_assets`` seam handed to
+    ``broll_ops.register``. If the registry were a parallel store, this stays 0.
+    """
+    handlers, services = wired
+    assert handlers["broll.status"]({}, _ctx())["libraryCount"] == 0
+    png = tmp_path / "outside-any-folder.png"
+    png.write_bytes(b"x")
+    services.library.add_broll(str(png))
+    assert handlers["broll.status"]({}, _ctx())["libraryCount"] == 1
+
+
+def test_the_registry_methods_never_enter_the_key_injection_allowlist(wired):
+    """broll.* is LOCAL-only: no provider, so no key may ever be injected."""
+    handlers, _services = wired
+    prefixes = ("ai.", "director.", "shortmaker.", "index.")
+    exact = {
+        "subtitles.translate",
+        "providers.usage",
+        "providers.openrouterUsage",
+        "providers.revealKey",
+        "thumbnail.select",
+        "phase8.select",
+        "recipes.run",
+        "templates.apply",
+        "batch.start",
+        "batch.resume",
+    }
+    for name in ("broll.assets", "broll.addAsset", "broll.removeAsset"):
+        assert name in handlers
+        assert not name.startswith(prefixes)
+        assert name not in exact
+
+
+def test_the_real_path_dedup_key_collapses_short_names_and_dot_segments(tmp_path: Path):
+    """Control for the dedup key itself: it must see through both spellings."""
+    folder = tmp_path / "b"
+    folder.mkdir()
+    dog = folder / "dog.png"
+    dog.write_bytes(b"x")
+    weird = str(folder / ".." / "b" / "dog.png")
+    assert weird != str(dog)
+    assert _library_ops._real_key(weird) == _library_ops._real_key(str(dog.resolve()))
+    assert _library_ops._real_key(weird) == os.path.normcase(os.path.realpath(str(dog)))

--- a/sidecar/tests/test_broll_library.py
+++ b/sidecar/tests/test_broll_library.py
@@ -620,8 +620,22 @@ def test_the_dedup_key_is_IDENTICAL_with_and_without_the_directory_cache(tmp_pat
     cache: dict[str, str] = {}
     for spelling in (str(dog), str(folder / ".." / "b" / "dog.png"), str(dog).upper(), str(folder / "DOG.PNG")):
         assert _library_ops._real_key(spelling, cache) == _library_ops._real_key(spelling)
-    # one entry per distinct directory spelling, and the uncached call is unaffected
-    assert len({_library_ops._real_key(s, cache) for s in (str(dog), str(dog).upper())}) == 1
+    # One entry per distinct directory spelling, and the uncached call is unaffected.
+    #
+    # CASE-FOLDING IS A FILESYSTEM PROPERTY, NOT A CONSTANT. `_real_key` normcases the
+    # basename, and `os.path.normcase` is identity on POSIX. So an ALL-CAPS respelling of
+    # the same path is the SAME file on Windows/NTFS and a genuinely DIFFERENT (absent)
+    # file on Linux — 1 key there, 2 keys here, and BOTH are correct.
+    #
+    # This assertion originally hardcoded `== 1`. It passed on the Windows box it was
+    # written on (7440 tests green) and FAILED the Linux CI gate with `assert 2 == 1`,
+    # which also cost the 100% coverage bar because the abort skipped the trailing-
+    # separator assertion below. Detecting the filesystem instead of the platform keeps
+    # this a real assertion on BOTH: it now pins the case-SENSITIVE behaviour too, rather
+    # than being relaxed to accommodate it.
+    case_insensitive_fs = os.path.normcase("A") != "A"
+    expected_keys = 1 if case_insensitive_fs else 2
+    assert len({_library_ops._real_key(s, cache) for s in (str(dog), str(dog).upper())}) == expected_keys
     # a trailing-separator spelling has no basename to join: it resolves whole
     assert _library_ops._real_key(str(folder) + os.sep, cache) == _library_ops._real_key(str(folder) + os.sep)
 

--- a/sidecar/tests/test_broll_library.py
+++ b/sidecar/tests/test_broll_library.py
@@ -443,6 +443,43 @@ def test_a_registered_asset_is_counted_by_the_wired_broll_status(wired, tmp_path
     assert handlers["broll.status"]({}, _ctx())["libraryCount"] == 1
 
 
+def test_a_registered_asset_lands_in_the_index_EMBED_PLAN(wired, tmp_path: Path):
+    """Stronger than a count: the registry participates in INCREMENTAL indexing.
+
+    Build a real index sidecar covering ONLY the scanned file, so ``broll.status``
+    honestly reports ``stale=False, staleCount=0``. Registering an asset from OUTSIDE
+    ``brollDir`` must then raise ``staleCount`` to 1 — and ``staleCount`` is
+    ``len(refresh_plan()['embed'])``, which is verbatim the list ``broll.index`` hands
+    to the image tower. A registry that were a parallel store would leave it at 0.
+
+    No weights are involved: the vector is a hand-written 2-D literal, so this runs in
+    the gate env. UNVERIFIED (out of scope here): whether the real SigLIP-2 tower then
+    produces a useful vector for that asset — the settling experiment is design BR8's
+    real-model tier.
+    """
+    handlers, services = wired
+    folder = tmp_path / "scanned"
+    folder.mkdir()
+    (folder / "dog.png").write_bytes(b"x")
+    services.settings.set({broll_ops.BROLL_DIR_KEY: str(folder)})
+
+    scanned = broll_ops.scan_assets(str(folder))
+    broll_ops.save_index_file(
+        services.data_dir / broll_ops.INDEX_FILENAME,
+        broll_index.build(scanned, [[0.0, 1.0]], model=broll_ops.DEFAULT_MODEL_ID, built_at="t"),
+    )
+    before = handlers["broll.status"]({}, _ctx())
+    assert (before["stale"], before["staleCount"], before["libraryCount"]) == (False, 0, 1)
+
+    city = tmp_path / "outside" / "city.jpg"
+    city.parent.mkdir()
+    city.write_bytes(b"y")
+    services.library.add_broll(str(city))
+
+    after = handlers["broll.status"]({}, _ctx())
+    assert (after["stale"], after["staleCount"], after["libraryCount"]) == (True, 1, 2)
+
+
 def test_the_registry_methods_never_enter_the_key_injection_allowlist(wired):
     """broll.* is LOCAL-only: no provider, so no key may ever be injected."""
     handlers, _services = wired

--- a/sidecar/tests/test_broll_library.py
+++ b/sidecar/tests/test_broll_library.py
@@ -347,6 +347,40 @@ def test_broll_assets_returns_the_union_plus_a_loud_missing_list(wired, tmp_path
     assert out["missing"][0]["exists"] is False
 
 
+def test_broll_assets_partitions_ONE_registry_snapshot(wired, tmp_path: Path):
+    """Every registered asset is in exactly one of ``assets`` / ``missing``.
+
+    The two halves must come from a SINGLE ``list_broll()`` read. With two reads an
+    asset deleted in between lands in BOTH, and one restored in between lands in
+    NEITHER — silently gone from the payload, which is the exact failure ``missing``
+    exists to prevent. Pinned by counting the reads: exactly one per call.
+    """
+    _handlers, services = wired
+    reads: list[int] = []
+    real_list = services.library.list_broll
+
+    def counted() -> list[dict[str, Any]]:
+        reads.append(1)
+        return real_list()
+
+    for name in ("a.png", "b.png", "c.png"):
+        f = tmp_path / name
+        f.write_bytes(b"x")
+        services.library.add_broll(str(f))
+    (tmp_path / "b.png").unlink()
+
+    services.library.list_broll = counted  # type: ignore[method-assign]
+    out = _library_ops.broll_assets(services, {}, _ctx())
+    assert sum(reads) == 1, "the registry must be read exactly once per broll.assets"
+
+    registered_ids = {a["assetId"] for a in real_list()}
+    present = {a["assetId"] for a in out["assets"] if a["registered"]}
+    missing = {a["assetId"] for a in out["missing"]}
+    assert present | missing == registered_ids  # nothing lost
+    assert present & missing == set()  # nothing double-reported
+    assert len(missing) == 1
+
+
 def test_broll_add_asset_registers_and_returns_the_asset(wired, tmp_path: Path):
     handlers, services = wired
     png = tmp_path / "dog.png"

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -38,8 +38,22 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         # v1.5 flagship #3 (auto-b-roll): local asset retrieval + compositing.
         # None of these may ever gain a key-injection prefix — they are
         # local-only and never call a provider (features/broll_ops.py).
+        #
+        # v1.5 DELIBERATE addition (design BR1): `broll.addAsset` / `broll.assets` /
+        # `broll.removeAsset` — the b-roll asset REGISTRY. Named explicitly here
+        # because adding an RPC method must be a conscious act: the four engine
+        # methods below shipped with NO way to register an asset, so the entire
+        # library was a scan of one `brollDir` setting and nothing in the app could
+        # put a specific file into it. These three are Library CRUD over
+        # `role='broll'` entity rows (handlers/library_ops.py) — local-only like the
+        # rest of the family, no provider, no model, no network. Verified this gate
+        # is not vacuous: registering them with the set unchanged failed
+        # test_rpc_surface_is_byte_identical first.
+        "broll.addAsset",
         "broll.apply",
+        "broll.assets",
         "broll.index",
+        "broll.removeAsset",
         "broll.status",
         "broll.suggest",
         "captions.cues",


### PR DESCRIPTION
## What landed, and what did NOT

Auto-B-roll is v1.5 flagship #3: ~58 KB of sidecar engine and four registered RPCs, and it is
entirely user-unreachable. **BR1 — the registration door — was missing**, so there was no way to
register an asset and the corpus was empty by construction. `add_broll` had zero hits anywhere.

This PR adds that door only: `add_broll` / `list_broll` / `remove_broll` in `library.py` reusing the
existing `entity` table (`kind ∈ {brollImage, brollClip}`, `role='broll'`), and the
`broll.assets` / `broll.addAsset` / `broll.removeAsset` handlers, per
`docs/plans/v1.5/flagship-auto-broll.md:296`.

**Auto-B-roll is still NOT complete and NOT user-reachable, and this PR does not claim otherwise.**
Verified with a control: `broll` (case-insensitive) matches **0 files under `app/`**, while the same
tool over the same tree finds `needsKeyInjection` 24× across 5 files. Registration is what landed;
the renderer surface, contentHash (BR2), b-roll poster extraction and BR6 reversibility all remain
missing and are each named.

The uncalibrated `DEFAULT_MIN_SIMILARITY = 0.22` was deliberately **not touched** — it is documented
in-module as a placeholder, not a tuned constant, and it is out of scope here.

## Verification

Three adversarial refuters, all three of which **refuted**; then remediation; then a fresh skeptic
who re-verified by mutation and execution rather than by reading the rebuttals. **12 objections,
all closed. 14 mutations applied, 14 killed, 0 survivors** — each with an anchor-presence and
uniqueness guard so an unapplied mutation reports as DETECTOR-FAIL rather than a false kill.

Gates run on the final tree: pytest **7440 passed**, 22364 statements / 5728 branches at **100%**,
`--cov-fail-under=100` reached; pre-commit all 6 hooks pass; basedpyright 0 errors; charter check
"OK — 6 gates consistent" (**no 7th gate added**); docs-check r1..r5 = 0.

### Notable closures

* **A vacuous key-injection test** was replaced with one that parses `INJECT_PREFIXES` /
  `INJECT_METHODS` out of the real `app/main/keyBridge.ts` and asserts its own detector control
  first. Both halves are now live — stronger than the remediation claimed.
* **`add_broll` refuses a directory named like an image**, with a distinct message per refusal
  class, probed with a control in the same run.
* **A proposed perf "fix" was correctly REBUTTED, and the skeptic re-ran the rebuttal
  independently**: `mklink /J` junctions report `islink=False`, so `rglob` descends and the
  suggested early return would have embedded one file twice. The accepted fix (a per-directory
  realpath memo) is pinned by a syscall-count test.

## MERGE HYGIENE — the squash subject must not come from the first commit

Commit `e47dc8b5`'s body still carries an unscoped sentence ("fingerprint over a registered row
EQUALS the fingerprint over the same file scanned"). A later commit records that as **REFUTED** and
supplies the scoped version, which is the record-don't-delete rule working correctly — but a squash
merge that inherits the first commit's wording would land the overclaim on `main` as the sole
record. This PR is titled from the corrected wording.

## Residuals (disclosed, non-blocking)

* **R1, the one genuinely new finding:** the `is_file` gate runs at the door only. Register a file,
  then replace it with a directory of the same name, and the registry half does not re-check
  (the *scanned* half self-heals, because `scan_assets` re-runs `is_file()` every scan). Consequence
  is a loud failed index job, recoverable by unregistering — no data loss, no silent wrong output.
  Reachability remote (1-20%). One-word fix plus one test; the correctly-scoped wording is given.
* **R2:** the union row is a superset in keys but not in value types — `durationSec` is `None` on a
  scanned row and `0.0` on a registered one. **The renderer lane must type it `number | null`.**
* **R3:** `library.lineage({id: <brollAssetId>})` returns the b-roll entity, because that one SELECT
  is unscoped. No mutation is reachable (`reveal` and `remove` are both role-scoped) and there is no
  UI path to obtain a b-roll id. All 14 entity statements were audited.
* **R4, scope:** `flagship-auto-broll.md` is outside the declared 5-file scope. Contention measured
  as zero against all five sibling worktrees on this box — including the high-contention
  `test_handlers_rpc_surface.py`.
* **R5:** `sast`/opengrep **NOT RUN** — absent on this box. Stand-in semgrep over `.quality/opengrep`
  (11 rules) → 0 findings. The diff introduces no subprocess/exec/eval/yaml/pickle/hashing
  construct, which is what that ruleset covers.
* **R8:** "watched the test fail first" is not verifiable post-hoc by anyone; it is corroborated
  functionally, since each new behavioural test is killed by a matching mutation.

CI is the arbiter. This merges only if `quality` is green.
