### PR TITLE
feat(renderer): user entry points for gaze correction and lip-sync (W19 runs; W20 is a call site only)

### DIFF
--- a/app/e2e/preview.spec.ts
+++ b/app/e2e/preview.spec.ts
@@ -225,10 +225,10 @@ test('Advanced disclosure actually COLLAPSES the Deliver cluster (F17)', async (
   // v1.5 wave added `transcriptEdit`, `timeline`, `speed` and `audiomix`; e2e is
   // opt-in and nightly, so it never gated those PRs and the stale pair merged
   // four times over. It went 17/12 -> 19/14 when W17/W18 mounted `reframeFix`
-  // and `videoTimeline` into the visible "Frame & Cut" cluster, and 19/14 -> 20/15
-  // when W19 mounted `gaze` into that same visible cluster — each time updated here
-  // in the SAME commit as `Workspace.test.tsx`'s "pins the strip counts" test —
+  // and `videoTimeline` into the visible "Frame & Cut" cluster, updated here in
+  // the SAME commit as `Workspace.test.tsx`'s "pins the strip counts" test —
   // that PR-gating test is the only reason this nightly pair is not stale again.
+  // W19 took it 19/14 -> 20/15 by mounting `gaze` into that same visible cluster.
   // Re-derive from the source when the tab list changes — do NOT read a number
   // off a failing run and paste it back.
   await expect(win.locator('.tab')).toHaveCount(20);

--- a/app/e2e/preview.spec.ts
+++ b/app/e2e/preview.spec.ts
@@ -211,27 +211,28 @@ test('Advanced disclosure actually COLLAPSES the Deliver cluster (F17)', async (
   // ...so the cluster it owns must not paint. It does today: the author-origin
   // `display: flex` on `.tabbar--grouped .tabbar__advanced-panel` outranks the
   // UA `[hidden] { display: none }`, and no `[hidden]` selector anywhere under
-  // app/ restores it — so all 19 tabs paint instead of 14 and `aria-expanded`
+  // app/ restores it — so all 20 tabs paint instead of 15 and `aria-expanded`
   // lies about what is on screen.
   await expect(panel).toBeHidden();
   await expect(deliverTab).toBeHidden();
-  // The user-visible consequence: the default view paints the 14 primary tabs,
-  // not all 19. (`.tab` is exclusive to this strip.)
+  // The user-visible consequence: the default view paints the 15 primary tabs,
+  // not all 20. (`.tab` is exclusive to this strip.)
   //
   // These two numbers are DERIVED, not observed — they are `WORKSPACE_TABS.length`
   // and that minus the `advanced: true` group's `tabIds.length`
-  // (`Workspace.tsx`): 19 tabs total; Deliver holds 5 (convert, nle, recipes,
-  // assets, tracks), so 14 paint while it is collapsed. They were 13/8 until the
+  // (`Workspace.tsx`): 20 tabs total; Deliver holds 5 (convert, nle, recipes,
+  // assets, tracks), so 15 paint while it is collapsed. They were 13/8 until the
   // v1.5 wave added `transcriptEdit`, `timeline`, `speed` and `audiomix`; e2e is
   // opt-in and nightly, so it never gated those PRs and the stale pair merged
   // four times over. It went 17/12 -> 19/14 when W17/W18 mounted `reframeFix`
-  // and `videoTimeline` into the visible "Frame & Cut" cluster, updated here in
-  // the SAME commit as `Workspace.test.tsx`'s "pins the strip counts" test —
+  // and `videoTimeline` into the visible "Frame & Cut" cluster, and 19/14 -> 20/15
+  // when W19 mounted `gaze` into that same visible cluster — each time updated here
+  // in the SAME commit as `Workspace.test.tsx`'s "pins the strip counts" test —
   // that PR-gating test is the only reason this nightly pair is not stale again.
   // Re-derive from the source when the tab list changes — do NOT read a number
   // off a failing run and paste it back.
-  await expect(win.locator('.tab')).toHaveCount(19);
-  await expect(win.locator('.tab:visible')).toHaveCount(14);
+  await expect(win.locator('.tab')).toHaveCount(20);
+  await expect(win.locator('.tab:visible')).toHaveCount(15);
   // ...and the disclosure's own toggle is reachable WITHOUT horizontally
   // scrolling `.workspace .tabbar` (workspace.css `overflow-x: auto`). With the
   // cluster always painted the strip overflowed its 1064px track by 587px and

--- a/app/renderer/src/features/Dub.test.tsx
+++ b/app/renderer/src/features/Dub.test.tsx
@@ -924,4 +924,26 @@ describe('<Dub />', () => {
     expect(row?.textContent).toContain('Not available');
     expect(row?.textContent).toContain('signing identity');
   });
+
+  // W20 — the ONLY entry point to `tts.lipsync.start`, which was registered
+  // unconditionally (`features/tts/__init__.py:141`) and frozen into the RPC surface
+  // but had no caller: this file's subject was 519 lines with ZERO `lipsync`
+  // references before this lane. Its own gates/params/job flow are tested in
+  // LipSync.test.tsx; what THIS test pins is reachability — that the section is
+  // mounted in the dub surface and is handed the audio tracks Dub already fetched,
+  // so lip-sync needs no second `tracks.audio.list` call.
+  it('mounts the lip-sync section in the dub surface, fed by the tracks Dub already fetched', async () => {
+    const { api, calls } = makeBridge();
+    await mount(api);
+    const section = container.querySelector('[aria-label="Lip-sync"]');
+    expect(section).not.toBeNull();
+    // The dub track from AUDIO_TRACKS is offerable; the `original` one is not.
+    const options = Array.from(
+      section!.querySelectorAll('[data-picker="lipsync-track"] option'),
+    ).map((o) => (o as HTMLOptionElement).value);
+    expect(options).toContain('a2');
+    expect(options).not.toContain('a1');
+    // Exactly one tracks.audio.list on mount — the child reuses Dub's list.
+    expect(calls.filter((c) => c.method === 'tracks.audio.list')).toHaveLength(1);
+  });
 });

--- a/app/renderer/src/features/Dub.tsx
+++ b/app/renderer/src/features/Dub.tsx
@@ -13,9 +13,18 @@
 // auditioned directly in an <audio> tag through the mstream:// protocol's
 // `dub:<path>` id form (see docs/wiring/WIRING-T2.md for the one-line main-process
 // resolver extension; until applied the player shows the path instead).
+//
+// W20: this panel also hosts the LIP-SYNC section (`./LipSync`), the only entry
+// point to `tts.lipsync.start` — which was registered unconditionally
+// (`features/tts/__init__.py:141`) and frozen into the RPC surface, yet this file
+// was 519 lines with ZERO `lipSync`/`lipsync` references, so no user could reach
+// it. It lives here because a re-lip consumes a FINISHED dub AudioTrack, and it is
+// a separate component (not more code in this file) because this file was already
+// long and that section carries four independent fail-closed gates.
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import './panels.css';
 import { AiAudioBadge, AiDisclosurePanel, isAiGeneratedAudioTrack } from './AiDisclosure';
+import LipSync from './LipSync';
 import {
   extractJobId,
   getApi,
@@ -512,6 +521,12 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
         ))}
       </ul>
       {audioTracks.length === 0 && <p className="audio-track-empty">No audio tracks yet.</p>}
+
+      {/* W20 — lip-sync sits AFTER the track list because it consumes a finished
+          dub from it. `audioTracks` is handed down rather than re-fetched, so the
+          section adds no second `tracks.audio.list` call, and the SAME bridge is
+          passed so an injected test api reaches it too. */}
+      <LipSync videoId={videoId} audioTracks={audioTracks} api={bridge} />
     </section>
   );
 }

--- a/app/renderer/src/features/Gaze.test.tsx
+++ b/app/renderer/src/features/Gaze.test.tsx
@@ -469,6 +469,49 @@ describe('<Gaze />', () => {
     expect(box.checked).toBe(true);
   });
 
+  // ─── the SECOND half of "one tick, one subject" (W02 class) ────────────────
+  // REFUTED IN REVIEW, and the refutation was correct: the first draft invalidated
+  // the tick ONLY on a successful run, so a tick made while the field read 'Ana'
+  // still satisfied `canRun` after the field was changed to 'Bogdan' — and
+  // `likeness.py:156-157` stamps whatever subject arrives into the job's audit
+  // trail, so the record would assert Bogdan was attested when the user never read
+  // the sentence against Bogdan. The panel's own hint claims the tick "can never
+  // authorise … a different person"; these three tests are what make that true.
+  const attestBox = (): HTMLInputElement =>
+    container.querySelector('[data-input="likeness-attest"]') as HTMLInputElement;
+
+  it('CLEARS the attestation when the subject is RENAMED — one tick never covers a second person', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    expect(runButton().disabled).toBe(false);
+    pick('[data-input="likeness-subject"]', 'Bogdan');
+    expect(attestBox().checked).toBe(false);
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it('clears it on a rename AFTER a failed run too — the retry path keeps the tick only for the SAME person', async () => {
+    const fake = makeFakeApi({ runError: new Error('ffmpeg exploded') });
+    await mount(fake.api);
+    fillAttested('Ana');
+    await clickRun();
+    expect(attestBox().checked).toBe(true); // same person, retry is fine
+    pick('[data-input="likeness-subject"]', 'Bogdan');
+    expect(attestBox().checked).toBe(false); // different person, re-attest
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it('a whitespace-only edit is NOT a new subject, so the tick survives', async () => {
+    // `buildGazeParams` trims, so 'Ana' -> 'Ana ' sends the IDENTICAL subject.
+    // Clearing there would be consent theatre — a re-tick that changes nothing.
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    pick('[data-input="likeness-subject"]', 'Ana ');
+    expect(attestBox().checked).toBe(true);
+    expect(runButton().disabled).toBe(false);
+  });
+
   it('cancels the in-flight job via job.cancel', async () => {
     const fake = makeFakeApi();
     await mount(fake.api);

--- a/app/renderer/src/features/Gaze.test.tsx
+++ b/app/renderer/src/features/Gaze.test.tsx
@@ -1,0 +1,576 @@
+// Gaze.test.tsx — tests for the "Eye contact" panel (W19).
+//
+// MEASURED GAP. `gaze.probe` + `gaze.run` are both registered
+// (`sidecar/media_studio/features/gaze.py:699-700`) and both are frozen into the
+// authoritative RPC surface (`sidecar/tests/test_handlers_rpc_surface.py`), yet
+// before this panel the string `gaze` appeared ZERO times, case-insensitively,
+// anywhere under `app/renderer`. The detector was controlled against a
+// known-present item first: the same case-insensitive scan finds `gaze` in 9
+// files under `sidecar/`, so the zero was real and not a broken matcher.
+// `docs/wiring/WIRING-gaze.md:172` already presupposed "so the UI can disable the
+// control" — the control did not exist.
+//
+// TWO RPCs:
+//   gaze.probe()                      -> {available}            (direct return)
+//   gaze.run({videoId, strength, likenessSubject, likenessAttested?})
+//        -> {jobId} -> job.done {path, strength, report, likeness}
+//
+// THE ETHICS GATE IS THE POINT OF THIS PANEL, NOT A DECORATION.
+// `gaze.run` alters a real person's face. `models/likeness.resolve_attestation`
+// (`likeness.py:137-160`) accepts an EXPLICIT per-job attestation in the request,
+// else a persisted grant, else it RAISES. This panel drives the EXPLICIT per-job
+// route deliberately (see the Gaze.tsx header for why), so these tests pin two
+// properties that a passing feature test alone would not:
+//   * the attestation is NEVER minted by the UI — an untidied checkbox means the
+//     param is ABSENT, not `false`-but-present and not `true`;
+//   * the tick does not carry over to the next run after a success.
+// A Tier-0 defect earlier in this programme (W02) was exactly a consent value the
+// code minted on the user's behalf.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import Gaze, { buildGazeParams, gazeOutcome, DEFAULT_GAZE_STRENGTH } from './Gaze';
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+const REPORT = {
+  framesTotal: 300,
+  framesCorrected: 288,
+  eyesCorrected: 570,
+  skipped: { 'low-confidence': 12 },
+};
+const AUDIT = { subject: 'Marius (self)', scope: 'gaze', source: 'request' };
+
+function makeFakeApi(
+  overrides: { available?: boolean; probeError?: Error; runError?: Error } = {},
+): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'gaze.probe') {
+        if (overrides.probeError) throw overrides.probeError;
+        return { available: overrides.available ?? true } as T;
+      }
+      if (method === 'gaze.run') {
+        if (overrides.runError) throw overrides.runError;
+        return { jobId: 'job-g' } as T;
+      }
+      return {} as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+describe('buildGazeParams', () => {
+  it('carries the explicit per-job attestation when the user ticked it', () => {
+    expect(
+      buildGazeParams({
+        videoId: 'v1',
+        likenessSubject: 'Marius (self)',
+        likenessAttested: true,
+        strength: 0.7,
+      }),
+    ).toEqual({
+      videoId: 'v1',
+      likenessSubject: 'Marius (self)',
+      likenessAttested: true,
+      strength: 0.7,
+    });
+  });
+
+  it('OMITS likenessAttested entirely when the box is unticked — never mints consent', () => {
+    const params = buildGazeParams({
+      videoId: 'v1',
+      likenessSubject: 'Someone',
+      likenessAttested: false,
+      strength: 0.5,
+    });
+    expect('likenessAttested' in params).toBe(false);
+    // The subject still travels: the sidecar needs it to name the refusal.
+    expect(params).toEqual({ videoId: 'v1', likenessSubject: 'Someone', strength: 0.5 });
+  });
+
+  it('trims the subject label so a whitespace-only subject cannot pose as one', () => {
+    expect(
+      buildGazeParams({
+        videoId: 'v1',
+        likenessSubject: '  Ana  ',
+        likenessAttested: true,
+        strength: 1,
+      }).likenessSubject,
+    ).toBe('Ana');
+  });
+});
+
+describe('gazeOutcome', () => {
+  it('reads a completed run including the likeness audit trail', () => {
+    expect(
+      gazeOutcome({
+        path: '/out/gaze/clip.gaze.mp4',
+        strength: 0.7,
+        report: REPORT,
+        likeness: AUDIT,
+      }),
+    ).toEqual({
+      path: '/out/gaze/clip.gaze.mp4',
+      strength: 0.7,
+      report: REPORT,
+      likeness: AUDIT,
+    });
+  });
+
+  it('null when there is no usable path', () => {
+    expect(gazeOutcome({})).toBeNull();
+    expect(gazeOutcome(null)).toBeNull();
+    expect(gazeOutcome({ path: '' })).toBeNull();
+    expect(gazeOutcome({ path: 42 })).toBeNull();
+  });
+
+  it('defaults a missing/malformed report to explicit zeros rather than inventing a tally', () => {
+    expect(gazeOutcome({ path: '/p.mp4' })?.report).toEqual({
+      framesTotal: 0,
+      framesCorrected: 0,
+      eyesCorrected: 0,
+      skipped: {},
+    });
+    expect(
+      gazeOutcome({ path: '/p.mp4', report: { framesTotal: 'lots', skipped: 'nope' } })?.report,
+    ).toEqual({ framesTotal: 0, framesCorrected: 0, eyesCorrected: 0, skipped: {} });
+    // `typeof null === 'object'`, so an explicit null must be rejected by the
+    // null-check arm rather than indexed into.
+    expect(gazeOutcome({ path: '/p.mp4', report: null })?.report).toEqual({
+      framesTotal: 0,
+      framesCorrected: 0,
+      eyesCorrected: 0,
+      skipped: {},
+    });
+  });
+
+  it('drops non-numeric skip counts instead of rendering junk', () => {
+    expect(
+      gazeOutcome({
+        path: '/p.mp4',
+        report: { ...REPORT, skipped: { 'extreme-roll': 3, bogus: 'x' } },
+      })?.report.skipped,
+    ).toEqual({ 'extreme-roll': 3 });
+  });
+
+  it('null strength and null likeness when the sidecar sent neither', () => {
+    const out = gazeOutcome({ path: '/p.mp4' });
+    expect(out?.strength).toBeNull();
+    expect(out?.likeness).toBeNull();
+  });
+
+  it('drops a shapeless likeness block — an audit trail is all-or-nothing', () => {
+    expect(gazeOutcome({ path: '/p.mp4', likeness: { subject: 'a' } })?.likeness).toBeNull();
+    expect(gazeOutcome({ path: '/p.mp4', likeness: 'attested' })?.likeness).toBeNull();
+  });
+});
+
+describe('<Gaze />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const flush = async (): Promise<void> => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  async function mount(api: MediaStudioApi): Promise<void> {
+    await act(async () => {
+      root.render(<Gaze videoId="v1" api={api} />);
+    });
+    await flush();
+  }
+
+  function pick(selector: string, value: string): void {
+    const el = container.querySelector(selector) as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  function attest(): void {
+    const box = container.querySelector('[data-input="likeness-attest"]') as HTMLInputElement;
+    act(() => {
+      box.click();
+    });
+  }
+
+  const runButton = (): HTMLButtonElement =>
+    container.querySelector('[data-action="run"]') as HTMLButtonElement;
+
+  async function clickRun(): Promise<void> {
+    await act(async () => {
+      runButton().click();
+      await Promise.resolve();
+    });
+    await flush();
+  }
+
+  /** Fill in a complete, attested request (the only state that can dispatch). */
+  function fillAttested(subject = 'Marius (self)'): void {
+    pick('[data-input="likeness-subject"]', subject);
+    attest();
+  }
+
+  it('probes availability on mount', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(fake.calls.some((c) => c.method === 'gaze.probe')).toBe(true);
+  });
+
+  // MUTATION NOTE — both availability tests below FILL IN a complete, attested
+  // request before asserting `disabled`. The first drafts did not, and a mutation
+  // (`setAvailable(false)` -> `setAvailable(true)` in the probe's catch) SURVIVED:
+  // the button was disabled because nothing was attested, so the assertion never
+  // measured availability at all. With the gate satisfied, availability is the only
+  // remaining reason the button can be disabled, and the mutant dies.
+  it('disables the control with a NAMED reason when the YuNet asset is missing', async () => {
+    const fake = makeFakeApi({ available: false });
+    await mount(fake.api);
+    fillAttested();
+    expect(runButton().disabled).toBe(true);
+    const reason = container.querySelector('[data-section="unavailable"]');
+    // The asset id is the actionable part of the sidecar's own UNAVAILABLE_MESSAGE
+    // (`gaze.py` UNAVAILABLE_MESSAGE) — a bare "unavailable" is not actionable.
+    expect(reason?.textContent).toContain('yunet-face-detection');
+  });
+
+  it('fails CLOSED when the probe itself throws', async () => {
+    const fake = makeFakeApi({ probeError: new Error('sidecar down') });
+    await mount(fake.api);
+    fillAttested();
+    expect(runButton().disabled).toBe(true);
+    expect(container.querySelector('[data-section="unavailable"]')?.textContent).toContain(
+      'sidecar down',
+    );
+  });
+
+  it('keeps the run button disabled until BOTH a subject and an attestation exist', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    // available, but nothing attested yet
+    expect(runButton().disabled).toBe(true);
+    pick('[data-input="likeness-subject"]', 'Marius (self)');
+    expect(runButton().disabled).toBe(true);
+    attest();
+    expect(runButton().disabled).toBe(false);
+  });
+
+  it('a whitespace-only subject does not satisfy the gate', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="likeness-subject"]', '   ');
+    attest();
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it('sends gaze.run with the attested params and the chosen strength', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    pick('[data-input="strength"]', '0.4');
+    await clickRun();
+    expect(fake.calls.find((c) => c.method === 'gaze.run')?.params).toEqual({
+      videoId: 'v1',
+      likenessSubject: 'Marius (self)',
+      likenessAttested: true,
+      strength: 0.4,
+    });
+  });
+
+  it('defaults the strength to the sidecar default', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await clickRun();
+    expect(fake.calls.find((c) => c.method === 'gaze.run')?.params?.strength).toBe(
+      DEFAULT_GAZE_STRENGTH,
+    );
+  });
+
+  it('streams progress for its own job and ignores another job', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-g', pct: 55, message: 'warping eyes' });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.progress-pct')?.textContent).toContain('55');
+    expect(container.querySelector('.progress-message')?.textContent).toContain('warping eyes');
+    await act(async () => {
+      fake.fireProgress({ jobId: 'not-mine', pct: 99, message: 'other' });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.progress-pct')?.textContent).not.toContain('99');
+  });
+
+  it('renders the output path, the honest tally AND the likeness audit trail', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: { path: '/out/gaze/clip.gaze.mp4', strength: 0.7, report: REPORT, likeness: AUDIT },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="result"]')?.textContent).toContain(
+      '/out/gaze/clip.gaze.mp4',
+    );
+    const report = container.querySelector('[data-section="report"]');
+    expect(report?.textContent).toContain('288');
+    expect(report?.textContent).toContain('300');
+    // A skip is NOT a failure, but it must be visible — the engine leaves frames
+    // pristine on purpose (gaze.py skip_reason) and hiding that would overstate
+    // what the run did.
+    expect(report?.textContent).toContain('low-confidence');
+    const audit = container.querySelector('[data-section="audit"]');
+    expect(audit?.textContent).toContain('Marius (self)');
+    expect(audit?.textContent).toContain('request');
+  });
+
+  it('says so LOUDLY when a "successful" run corrected nothing', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: {
+          path: '/out/gaze/clip.gaze.mp4',
+          strength: 0.7,
+          report: {
+            framesTotal: 300,
+            framesCorrected: 0,
+            eyesCorrected: 0,
+            skipped: { 'eyes-too-small': 300 },
+          },
+          likeness: AUDIT,
+        },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="nothing-corrected"]')).not.toBeNull();
+  });
+
+  it('surfaces the sidecar likeness refusal as an alert, never a silent no-op', async () => {
+    const refusal = new Error(
+      "gaze likeness alteration for subject 'Ana' refused: no attestation.",
+    );
+    const fake = makeFakeApi({ runError: refusal });
+    await mount(fake.api);
+    fillAttested('Ana');
+    await clickRun();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('no attestation');
+  });
+
+  it('surfaces a non-Error rejection as a string', async () => {
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async (method: string) => {
+        if (method === 'gaze.probe') return { available: true };
+        throw 'plain string boom';
+      }) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    await mount(api);
+    fillAttested();
+    await clickRun();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain string boom');
+  });
+
+  it('CLEARS the attestation after a successful run so one tick cannot authorise a second subject', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: { path: '/out/gaze/clip.gaze.mp4', strength: 0.7, report: REPORT, likeness: AUDIT },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    const box = container.querySelector('[data-input="likeness-attest"]') as HTMLInputElement;
+    expect(box.checked).toBe(false);
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it('KEEPS the attestation after a failed run so a retry need not re-attest', async () => {
+    const fake = makeFakeApi({ runError: new Error('ffmpeg exploded') });
+    await mount(fake.api);
+    fillAttested();
+    await clickRun();
+    const box = container.querySelector('[data-input="likeness-attest"]') as HTMLInputElement;
+    expect(box.checked).toBe(true);
+  });
+
+  it('cancels the in-flight job via job.cancel', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      (container.querySelector('[data-action="cancel"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.some((c) => c.method === 'job.cancel')).toBe(true);
+  });
+
+  it('keeps the panel usable when job.cancel itself fails', async () => {
+    let doneCbs: Array<(ev: DoneEvent) => void> = [];
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async <T,>(method: string) => {
+        if (method === 'gaze.probe') return { available: true } as T;
+        if (method === 'job.cancel') throw new Error('cancel failed');
+        return { jobId: 'job-g' } as T;
+      }) as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: (cb) => {
+        doneCbs.push(cb);
+        return () => {
+          doneCbs = doneCbs.filter((c) => c !== cb);
+        };
+      },
+    };
+    await mount(api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      (container.querySelector('[data-action="cancel"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('does not hang when the bridge exposes no job.done channel', async () => {
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async (method: string) =>
+        method === 'gaze.probe' ? { available: true } : { jobId: 'job-g' },
+      ) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+    };
+    await mount(api);
+    fillAttested();
+    await clickRun();
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('renders nothing when the rpc returns no jobId', async () => {
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async (method: string) =>
+        method === 'gaze.probe' ? { available: true } : {},
+      ) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    await mount(api);
+    fillAttested();
+    await clickRun();
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+  });
+
+  it('settles cleanly on a job.done with no result field and on an unusable one', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested();
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-g' });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('falls back to the global window.api bridge when no api prop is given', async () => {
+    const fake = makeFakeApi();
+    (globalThis as { api?: unknown }).api = fake.api;
+    try {
+      await act(async () => {
+        root.render(<Gaze videoId="v1" />);
+      });
+      await flush();
+      fillAttested();
+      await clickRun();
+      expect(fake.calls.find((c) => c.method === 'gaze.run')?.params).toMatchObject({
+        videoId: 'v1',
+        likenessAttested: true,
+      });
+    } finally {
+      delete (globalThis as { api?: unknown }).api;
+    }
+  });
+});

--- a/app/renderer/src/features/Gaze.test.tsx
+++ b/app/renderer/src/features/Gaze.test.tsx
@@ -512,6 +512,217 @@ describe('<Gaze />', () => {
     expect(runButton().disabled).toBe(false);
   });
 
+  // ─── the THIRD carryover door: the VIDEO changes under a ticked box ────────
+  // A fresh skeptic found this AFTER the rename fix above and its three refuters
+  // all missed it: nothing was keyed to `videoId`, so re-rendering this panel in
+  // place with a new video kept `attested` AND `subject`. Measured on the wire
+  // before the fix: `{"videoId":"videoB","likenessSubject":"Ana","strength":0.7,
+  // "likenessAttested":true}` — a tick taken against video A authorising face
+  // alteration of video B, which `likeness.py:156-157` then stamps into the job
+  // audit trail via `gaze.py:668-672` as if the operator had given it.
+  //
+  // The swap is REACHABLE, not a thought experiment: nothing on the App -> Edit ->
+  // Workspace -> Gaze chain is keyed (`App.tsx:481-482`, `Edit.tsx:155-156`,
+  // `Workspace.tsx:388-393`), and `App.tsx:332-353`'s launch-restore effect has
+  // `[]` deps, no route guard, and calls `setEditVideo(match)` + `setRoute` after
+  // two RPC awaits — so a video opened and ticked before those resolve is swapped
+  // IN PLACE. `origin/main`'s `4408e033` is a merged fix for this exact structural
+  // pattern in an unkeyed sibling panel, so the repo already treats it as live.
+
+  /**
+   * Re-render IN PLACE with a new videoId — the SAME component type at the SAME
+   * position, so React updates it rather than remounting. Every test below then
+   * asserts `strength` as its DETECTOR CONTROL: strength is deliberately NOT
+   * reset, so a value back at the 0.70 default would mean the panel remounted and
+   * the consent assertions were measuring a fresh mount instead of a prop swap.
+   */
+  async function swapVideo(api: MediaStudioApi, videoId: string): Promise<void> {
+    await act(async () => {
+      root.render(<Gaze videoId={videoId} api={api} />);
+    });
+    await flush();
+  }
+
+  const subjectInput = (): HTMLInputElement =>
+    container.querySelector('[data-input="likeness-subject"]') as HTMLInputElement;
+
+  // THE WIRE ASSERTION FIRST — it is the falsifiable one, and asserting on the
+  // recorded params (not `some(...)`) makes the pre-fix failure print the leaked
+  // payload verbatim instead of a bare `true !== false`.
+  it('the WIRE carries no attestation for a video the tick was never read against', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    pick('[data-input="strength"]', '0.4');
+    expect(runButton().disabled).toBe(false);
+
+    await swapVideo(fake.api, 'videoB');
+
+    // DETECTOR CONTROL: this was an in-place prop swap, not a remount.
+    expect(container.querySelector('.gaze-strength-value')?.textContent).toBe('0.40');
+    // No request can be dispatched at all, so none can carry `likenessAttested`
+    // for a video whose face the sentence was never read against.
+    await clickRun();
+    expect(fake.calls.filter((c) => c.method === 'gaze.run').map((c) => c.params)).toEqual([]);
+  });
+
+  it('CLEARS the tick AND the subject label when the VIDEO changes under them', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    pick('[data-input="strength"]', '0.4');
+    await swapVideo(fake.api, 'videoB');
+
+    expect(container.querySelector('.gaze-strength-value')?.textContent).toBe('0.40'); // control
+    // The label goes too: a new video is a new person question, and a prefilled
+    // 'Ana' under a new face invites the wrong answer to it.
+    expect(attestBox().checked).toBe(false);
+    expect(subjectInput().value).toBe('');
+    expect(runButton().disabled).toBe(true);
+  });
+
+  it('a fresh tick after a video change attests the NEW video, and the wire says so', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    await swapVideo(fake.api, 'videoB');
+    fillAttested('Bogdan');
+    await clickRun();
+    expect(fake.calls.find((c) => c.method === 'gaze.run')?.params).toEqual({
+      videoId: 'videoB',
+      likenessSubject: 'Bogdan',
+      likenessAttested: true,
+      strength: DEFAULT_GAZE_STRENGTH,
+    });
+  });
+
+  it('drops the finished result AND its likeness audit trail when the video changes', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: { path: '/out/gaze/videoA.mp4', strength: 0.7, report: REPORT, likeness: AUDIT },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="audit"]')).not.toBeNull(); // control
+    await swapVideo(fake.api, 'videoB');
+    // Video A's "Authorised by: Marius (self)" must not stand under video B: the
+    // audit block is a consent RECORD, and showing it here is a false attribution.
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[data-section="audit"]')).toBeNull();
+  });
+
+  it('drops the previous video failure banner when the video changes', async () => {
+    const fake = makeFakeApi({ runError: new Error('ffmpeg exploded') });
+    await mount(fake.api);
+    fillAttested('Ana');
+    await clickRun();
+    expect(container.querySelector('[role="alert"]')).not.toBeNull(); // control
+    await swapVideo(fake.api, 'videoB');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  // The over-reset control. `gaze.probe` takes NO videoId — the yunet asset is
+  // installed or not, per machine — so a video change must neither re-probe nor
+  // re-disable the control. Without this, "reset on videoId" could quietly become
+  // "reset everything", and the panel would flicker back to unavailable.
+  it('does NOT re-probe or re-disable availability on a video change', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await swapVideo(fake.api, 'videoB');
+    expect(fake.calls.filter((c) => c.method === 'gaze.probe')).toHaveLength(1);
+    expect(container.querySelector('[data-section="unavailable"]')).toBeNull();
+    fillAttested('Bogdan');
+    expect(runButton().disabled).toBe(false);
+  });
+
+  // ─── the SAME defect through the in-flight door ────────────────────────────
+  // The reset effect runs on the switch; a job that was ALREADY in flight settles
+  // AFTER it, so without an ownership guard the old video's write lands anyway —
+  // the exact hole `4408e033` describes for the sibling panel. Scoped honestly:
+  // the request itself carried A's videoId and a valid attestation for A, so this
+  // is a false ATTRIBUTION of A's consent record onto B's panel, not a forged
+  // consent on the wire.
+  it('drops a late job.done from the PREVIOUS video instead of stamping its audit under the new one', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    await act(async () => {
+      runButton().click();
+    });
+    await swapVideo(fake.api, 'videoB');
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: { path: '/out/gaze/videoA.mp4', strength: 0.7, report: REPORT, likeness: AUDIT },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="result"]')).toBeNull();
+    expect(container.querySelector('[data-section="audit"]')).toBeNull();
+    // The lane is still freed, so the new video is not left permanently busy.
+    expect(container.querySelector('.progress')).toBeNull();
+  });
+
+  it('surfaces a job.done ERROR payload as an alert (the no-switch control arm)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    await act(async () => {
+      runButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: { error: { message: 'gaze backend died', type: 'GazeError' } },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('gaze backend died');
+  });
+
+  it('drops a late FAILURE from the previous video instead of blaming the new one', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillAttested('Ana');
+    await act(async () => {
+      runButton().click();
+    });
+    await swapVideo(fake.api, 'videoB');
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-g',
+        result: { error: { message: 'gaze backend died', type: 'GazeError' } },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  // The copy the user reads BEFORE ticking is the strongest claim this panel
+  // makes, so it is pinned to what the code actually guarantees — including the
+  // deliberate carve-out (a FAILED run keeps the tick) that the previous absolute
+  // wording hid. Each clause here has a behavioural test above or beside it.
+  it('the consent hint names every trigger that really clears the tick, and the retry carve-out', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const hint = container.querySelector('.gaze-consent-hint')?.textContent ?? '';
+    expect(hint).toMatch(/finished run/i); // cleared on success
+    expect(hint).toMatch(/name above/i); // cleared on rename
+    expect(hint).toMatch(/different video/i); // cleared on a videoId change
+    expect(hint).toMatch(/failed run/i); // …and NOT cleared on failure
+  });
+
   it('cancels the in-flight job via job.cancel', async () => {
     const fake = makeFakeApi();
     await mount(fake.api);

--- a/app/renderer/src/features/Gaze.test.tsx
+++ b/app/renderer/src/features/Gaze.test.tsx
@@ -598,6 +598,34 @@ describe('<Gaze />', () => {
     expect(container.querySelector('[role="alert"]')).toBeNull();
   });
 
+  // ─── AI disclosure parity with the lip-sync sibling (refuted in review) ────
+  // The lane reasoned this interaction through for W20 and skipped it here; a
+  // gaze-corrected clip is the same category of artifact (real irises warped, and
+  // `gaze_backend.py:200-219` writes no `-metadata` either), so it is owed the same
+  // disclosure. Asserted on the SHARED constant, not a restated string, so the two
+  // panels cannot drift apart.
+  it('discloses that the output is edited media carrying no embedded provenance', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const note = container.querySelector('[data-section="ai-disclosure"]');
+    expect(note?.textContent).toMatch(/re-drawn|edited media/i);
+    expect(note?.textContent).toContain('C2PA');
+    expect(note?.textContent).toContain('not available');
+  });
+
+  it('reports C2PA as available if a signing identity ever lands (the other state)', async () => {
+    // The shipped constant is a hardcoded `available: false`, so without this seam
+    // the "available" wording could never be exercised.
+    const fake = makeFakeApi();
+    await act(async () => {
+      root.render(<Gaze videoId="v1" api={fake.api} c2pa={{ available: true, reason: '' }} />);
+    });
+    await flush();
+    expect(container.querySelector('[data-section="ai-disclosure"]')?.textContent).toContain(
+      'Available',
+    );
+  });
+
   it('falls back to the global window.api bridge when no api prop is given', async () => {
     const fake = makeFakeApi();
     (globalThis as { api?: unknown }).api = fake.api;

--- a/app/renderer/src/features/Gaze.tsx
+++ b/app/renderer/src/features/Gaze.tsx
@@ -238,6 +238,30 @@ export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
 
   const canRun = available === true && attested && subject.trim().length > 0;
 
+  /**
+   * Renaming the subject INVALIDATES the tick.
+   *
+   * REFUTED IN REVIEW and fixed here: `attested` used to be cleared only on a
+   * successful run, so a tick made while the field read 'Ana' still satisfied
+   * `canRun` after the field was changed to 'Bogdan'. That is the W02 class — the
+   * code satisfying a consent question on the user's behalf from data it already
+   * held — and it is not cosmetic: `likeness.py:156-157` stamps whichever subject
+   * arrives into `Attestation(subject=…)`, which `gaze.py:668-672` writes into the
+   * job's audit trail, so the record would assert a person the user never attested
+   * for. A new name is a NEW question, so the answer is discarded.
+   *
+   * TRIMMED comparison, deliberately: `buildGazeParams` trims the subject, so
+   * 'Ana' -> 'Ana ' sends the IDENTICAL payload. Re-asking there would be consent
+   * theatre — a second tick that changes nothing about who was attested.
+   */
+  const changeSubject = useCallback(
+    (next: string): void => {
+      setSubject(next);
+      if (next.trim() !== subject.trim()) setAttested(false);
+    },
+    [subject],
+  );
+
   const run = useCallback(async (): Promise<void> => {
     // Defensive: the button is disabled unless `canRun` and not already running.
     /* v8 ignore next */
@@ -267,10 +291,13 @@ export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
         setOutcome(next);
         setPct(100);
         setMessage('Done');
-        // A fresh attestation per run: one tick must never carry over to a second
-        // run, or to a different subject. Mirrors the proven WU-A2 behaviour in
-        // `Dub.tsx` (`addSample`), including keeping the tick on FAILURE so a
-        // retry after an unrelated error does not force a re-attestation.
+        // A fresh attestation per run. This is the RUN half of "one tick, one
+        // subject"; the SUBJECT half is `changeSubject` above (a rename clears the
+        // tick), and it was missing in the first draft — an adversarial probe
+        // showed a tick made for 'Ana' still authorising a run against 'Bogdan'.
+        // Mirrors the proven WU-A2 behaviour in `Dub.tsx` (`addSample`), including
+        // keeping the tick on FAILURE so a retry for the SAME person after an
+        // unrelated error does not force a re-attestation.
         setAttested(false);
       }
     } catch (err) {
@@ -322,7 +349,7 @@ export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
             type="text"
             placeholder="e.g. Marius (self), or the speaker's name"
             value={subject}
-            onChange={(e) => setSubject(e.target.value)}
+            onChange={(e) => changeSubject(e.target.value)}
             disabled={running}
           />
         </label>
@@ -337,9 +364,10 @@ export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
           {LIKENESS_ATTESTATION_TEXT}
         </label>
         <p className="gaze-consent-hint">
-          This attestation applies to THIS run only — it is not saved, so it can never authorise a
-          later run or a different person. It is recorded in the finished job&apos;s audit trail
-          (shown below); nothing about the edit is written into the output file itself.
+          This attestation applies to THIS run only — it is not saved, and it is cleared both after
+          a finished run and whenever you change the name above, so it can never authorise a later
+          run or a different person. It is recorded in the finished job&apos;s audit trail (shown
+          below); nothing about the edit is written into the output file itself.
         </p>
       </fieldset>
 

--- a/app/renderer/src/features/Gaze.tsx
+++ b/app/renderer/src/features/Gaze.tsx
@@ -37,6 +37,10 @@
 //     would collide with that lane.
 //   * Per-job is the stronger consent shape: there is no durable grant that can
 //     silently authorise a LATER run, or a run against a DIFFERENT subject.
+//     Being per-job is NOT self-enforcing, though: the tick still has to be
+//     invalidated whenever the question changes. Three paths do that — a finished
+//     run, a subject RENAME, and a VIDEO change (the reset effect below); each was
+//     missing at some point in this file's history and each is separately tested.
 //   * The attestation is never minted by this UI. `buildGazeParams` OMITS
 //     `likenessAttested` unless the user actually ticked the box, and the Run
 //     button stays disabled until both the box and a non-blank subject exist. A
@@ -71,7 +75,7 @@
 // synthetic-VIDEO disclosure lives in the panel that produces the video, and the one
 // fact that IS shared — no C2PA provenance manifest on export — is IMPORTED from
 // `C2PA_EXPORT_STATUS` rather than restated, so both panels have one source.
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './panels.css';
 import { C2PA_EXPORT_STATUS } from './AiDisclosure';
 import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
@@ -262,6 +266,56 @@ export function Gaze({ videoId, api, c2pa = C2PA_EXPORT_STATUS }: GazeProps): Re
     })();
   }, [bridge]);
 
+  // ─── A NEW VIDEO IS A NEW CONSENT QUESTION ─────────────────────────────────
+  // Nothing in this panel was keyed to `videoId`, and it is mounted UNKEYED the
+  // whole way up (`Workspace.tsx:393` <- `Edit.tsx:155-156` <- `App.tsx:481-482`),
+  // so re-rendering it with a different video kept BOTH `attested` and `subject`.
+  // Measured on the wire before this fix, from the panel's own test double:
+  //   {"videoId":"videoB","likenessSubject":"Ana","strength":0.4,"likenessAttested":true}
+  // — a tick taken against video A authorising face alteration of video B. That is
+  // worse than an unauthorised run: `likeness.py:156-157` stamps whichever subject
+  // arrives into `Attestation(subject=…)` and `gaze.py:668-672` writes it into the
+  // job audit trail, so the false consent would be RECORDED as operator-given.
+  //
+  // REACHABLE, not hypothetical: `App.tsx:332-353`'s launch-restore effect has `[]`
+  // deps and no route guard, and calls `setEditVideo(match)` + `setRoute({name:
+  // 'edit'})` after two RPC awaits — so a video opened and ticked before those
+  // resolve is swapped IN PLACE, without an unmount.
+  //
+  // WHY AN EFFECT AND NOT `key={video.id}` AT THE MOUNT SITE — both close it:
+  //   * this is the repo's own merged shape for exactly this class. `origin/main`
+  //     `4408e033` fixes an unkeyed mid-flight videoId switch in `ShortMaker.tsx`
+  //     with a reset effect (`:248-264`) plus a `videoIdRef` write-guard, not a key;
+  //   * the guarantee travels with the COMPONENT. The consent hint below promises
+  //     the tick can never authorise a different person; a promise enforced by a
+  //     distant parent is one parent edit — or one new mount site — away from being
+  //     false, and no test in this file could see it go. The sibling proves the
+  //     point: `LipSync` is mounted by `Dub.tsx:529`, NOT by the Workspace, so a key
+  //     at the Workspace site would not have covered it at all;
+  //   * a key REMOUNTS, discarding the in-flight job lane and unrelated preferences
+  //     as collateral. The price of the surgical option is this enumeration.
+  //
+  // RESET (per-video, consent-adjacent): the tick; the SUBJECT LABEL, because a
+  // prefilled 'Ana' under a new face invites the wrong answer to a new question;
+  // `outcome`, whose audit block is a consent RECORD that must not stand against a
+  // video it was not given for; and `error`, so video A's refusal is not read as
+  // video B's. Each reset is idempotent against the initial state, so the mount
+  // pass is a no-op.
+  // NOT RESET, deliberately: `available` / `unavailableReason` — `gaze.probe` takes
+  // no videoId, the yunet asset is per MACHINE, and re-disabling on a video change
+  // would be a lie (pinned by a test) — and `strength`, a correction parameter with
+  // no consent meaning (it doubles as the detector control proving the tests
+  // measure a prop swap, not a remount). The in-flight job lane
+  // (`running`/`jobId`/`pct`/`message`) is left alone on purpose: see `run` below.
+  const videoIdRef = useRef<string>(videoId);
+  useEffect(() => {
+    videoIdRef.current = videoId;
+    setAttested(false);
+    setSubject('');
+    setOutcome(null);
+    setError('');
+  }, [videoId]);
+
   useEffect(() => {
     if (!jobId) return;
     const off = bridge.onProgress((ev) => {
@@ -302,6 +356,22 @@ export function Gaze({ videoId, api, c2pa = C2PA_EXPORT_STATUS }: GazeProps): Re
     // Defensive: the button is disabled unless `canRun` and not already running.
     /* v8 ignore next */
     if (running || !canRun) return;
+    // The video this run belongs to, frozen at dispatch. `gaze.run` is a DEFERRED
+    // job, so the reset effect above can fire while we are still awaiting
+    // `job.done`: the reset runs FIRST and the old video's write lands AFTER it,
+    // the exact hole `4408e033` documents. An id COMPARISON, not a latch — switch
+    // away and back and the write is re-admitted, because by then it describes the
+    // video on screen again.
+    //
+    // SCOPED HONESTLY: the request itself already carried video A's `videoId` and a
+    // genuine attestation for A, so this guard prevents a false ATTRIBUTION of A's
+    // consent record onto B's panel — it is not stopping a forged consent on the
+    // wire. What it deliberately does NOT close: the progress bar of a run started
+    // for the previous video stays visible after a switch (the run really is in
+    // flight, and it also keeps the button disabled, which is what prevents a second
+    // concurrent job — resetting `running` here would open the very concurrency hole
+    // `4408e033`'s second commit had to close in `ShortMaker.tsx`).
+    const startedFor = videoId;
     setRunning(true);
     setError('');
     setOutcome(null);
@@ -322,22 +392,25 @@ export function Gaze({ videoId, api, c2pa = C2PA_EXPORT_STATUS }: GazeProps): Re
       // waitForJobDone REJECTS on an {error} job.done payload (caught below), so a
       // refused or failed run is never laundered into a silent success.
       const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
-      const next = gazeOutcome(result);
+      const next = videoIdRef.current === startedFor ? gazeOutcome(result) : null;
       if (next) {
         setOutcome(next);
         setPct(100);
         setMessage('Done');
-        // A fresh attestation per run. This is the RUN half of "one tick, one
-        // subject"; the SUBJECT half is `changeSubject` above (a rename clears the
-        // tick), and it was missing in the first draft — an adversarial probe
-        // showed a tick made for 'Ana' still authorising a run against 'Bogdan'.
-        // Mirrors the proven WU-A2 behaviour in `Dub.tsx` (`addSample`), including
-        // keeping the tick on FAILURE so a retry for the SAME person after an
-        // unrelated error does not force a re-attestation.
+        // A fresh attestation per run. This is the RUN third of "one tick, one
+        // subject, one video": the SUBJECT third is `changeSubject` above (a rename
+        // clears the tick) and the VIDEO third is the reset effect. Each of the
+        // three was absent at some point — the first draft had only this one, an
+        // adversarial probe showed a tick for 'Ana' authorising a run against
+        // 'Bogdan', and a later skeptic showed a tick for video A authorising
+        // video B. Mirrors the proven WU-A2 behaviour in `Dub.tsx` (`addSample`),
+        // including keeping the tick on FAILURE so a retry for the SAME person on
+        // the SAME video after an unrelated error does not force a re-attestation.
         setAttested(false);
       }
     } catch (err) {
-      setError(errText(err));
+      // Only the video that asked for the run wears the blame for it.
+      if (videoIdRef.current === startedFor) setError(errText(err));
     } finally {
       setRunning(false);
       setJobId(null);
@@ -399,11 +472,20 @@ export function Gaze({ videoId, api, c2pa = C2PA_EXPORT_STATUS }: GazeProps): Re
           />{' '}
           {LIKENESS_ATTESTATION_TEXT}
         </label>
+        {/* NARROWED, and the narrowing is the point. This used to promise the tick
+            "can never authorise a later run OR A DIFFERENT PERSON" — an absolute
+            that the code did not earn twice over: a VIDEO change kept the tick
+            (fixed above), and a FAILED run deliberately keeps it, so the same tick
+            does authorise the retry. It now names exactly the three triggers that
+            clear it and discloses the retry carve-out the absolute wording hid.
+            Every clause here has a behavioural test. */}
         <p className="gaze-consent-hint">
-          This attestation applies to THIS run only — it is not saved, and it is cleared both after
-          a finished run and whenever you change the name above, so it can never authorise a later
-          run or a different person. It is recorded in the finished job&apos;s audit trail (shown
-          below); nothing about the edit is written into the output file itself.
+          This attestation applies to THIS run only — it is never saved. It is cleared after a
+          finished run, whenever you change the name above, and whenever a different video is opened
+          here, so one tick can never authorise a run for a different person or a different video. A
+          FAILED run deliberately keeps it, so you can retry the same request without re-attesting.
+          It is recorded in the finished job&apos;s audit trail (shown below); nothing about the
+          edit is written into the output file itself.
         </p>
       </fieldset>
 

--- a/app/renderer/src/features/Gaze.tsx
+++ b/app/renderer/src/features/Gaze.tsx
@@ -75,7 +75,7 @@
 // synthetic-VIDEO disclosure lives in the panel that produces the video, and the one
 // fact that IS shared — no C2PA provenance manifest on export — is IMPORTED from
 // `C2PA_EXPORT_STATUS` rather than restated, so both panels have one source.
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import './panels.css';
 import { C2PA_EXPORT_STATUS } from './AiDisclosure';
 import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
@@ -307,8 +307,21 @@ export function Gaze({ videoId, api, c2pa = C2PA_EXPORT_STATUS }: GazeProps): Re
   // no consent meaning (it doubles as the detector control proving the tests
   // measure a prop swap, not a remount). The in-flight job lane
   // (`running`/`jobId`/`pct`/`message`) is left alone on purpose: see `run` below.
+  // useLAYOUTEffect, not useEffect, and the distinction is load-bearing for a CONSENT gate.
+  // A passive effect runs AFTER the browser can paint, so React would commit (and could show)
+  // the new videoId with the box still ticked and Run still enabled. A click landing in that
+  // window would put `likenessAttested: true` on the wire under the NEW video — the same defect
+  // this reset exists to close, shrunk from indefinite to one frame rather than removed.
+  // Reachability was assessed as remote (1-20%): the passive flush is scheduled during the
+  // commit and is therefore queued ahead of any later click task. But "probably unreachable" is
+  // not a property to rest a face-alteration consent gate on when the fix is one word, so the
+  // reset is moved before paint and the question is closed outright.
+  // UNVERIFIED, inline and deliberately: no test here can distinguish the two, because
+  // jsdom + `act()` flushes passive effects synchronously. Settling experiment: drive the
+  // packaged app through App.tsx's launch-restore with the box ticked and click Run in the
+  // same frame, or delay passive effects via the scheduler in a jsdom probe.
   const videoIdRef = useRef<string>(videoId);
-  useEffect(() => {
+  useLayoutEffect(() => {
     videoIdRef.current = videoId;
     setAttested(false);
     setSubject('');

--- a/app/renderer/src/features/Gaze.tsx
+++ b/app/renderer/src/features/Gaze.tsx
@@ -1,0 +1,440 @@
+// Gaze feature panel — "Eye contact" (W19: per-video eye-contact correction).
+//
+// WHY THIS PANEL EXISTS (measured, with the detector controlled first).
+// `gaze.probe` and `gaze.run` are both registered
+// (`sidecar/media_studio/features/gaze.py:699-700`) and both are frozen into the
+// authoritative method list (`sidecar/tests/test_handlers_rpc_surface.py`), but the
+// string `gaze` appeared ZERO times, case-insensitively, anywhere under
+// `app/renderer`. Detector control: the same case-insensitive scan finds `gaze` in
+// 9 files under `sidecar/`, so the zero was a real absence and not a broken
+// matcher. `docs/wiring/WIRING-gaze.md:172` already presupposed "so the UI can
+// disable the control" — there was no control to disable. This panel is it.
+//
+// TRANSPORT.
+//   gaze.probe()  -> {available}   direct-return, offline (gaze.py:615-617)
+//   gaze.run({videoId, strength, likenessSubject, likenessAttested?})
+//       -> {jobId} -> job.done {path, strength, report, likeness}
+// `gaze.run` is a deferred job, so the terminal payload arrives on the LATER
+// `job.done` notification and never on the rpc promise (`_api.ts` CONTRACT-NOTE);
+// we subscribe with `waitForJobDone`, the same shape as `Stabilize.tsx`.
+//
+// ─── THE ETHICS GATE, AND WHICH OF THE TWO ROUTES THIS UI USES ───────────────
+// `gaze.run` alters a REAL PERSON'S FACE, so `gaze.py:633` calls
+// `models/likeness.resolve_attestation(settings, params, scope=SCOPE_GAZE)` BEFORE
+// the media is resolved and before any backend is built. That resolver
+// (`likeness.py:137-160`) accepts, in order: (1) an EXPLICIT per-job attestation
+// in the request (`likenessAttested is True` + a usable `likenessSubject`), else
+// (2) the persisted grant `settings.likeness.attestations[subject].gaze`, else it
+// RAISES.
+//
+// THIS PANEL USES ROUTE (1), THE EXPLICIT PER-JOB ATTESTATION. Three reasons,
+// all measured:
+//   * Route (2) has no setter. `likeness.py:34-37` states outright that the
+//     persisted-grant SETTER "and its UI" belong to the shared voice/likeness
+//     lane and are deliberately absent, and `settings_store.py` carries no
+//     `likeness` key (measured: 0 hits for `likeness` in that file). So a UI
+//     built on route (2) would have nothing to write to, and writing one here
+//     would collide with that lane.
+//   * Per-job is the stronger consent shape: there is no durable grant that can
+//     silently authorise a LATER run, or a run against a DIFFERENT subject.
+//   * The attestation is never minted by this UI. `buildGazeParams` OMITS
+//     `likenessAttested` unless the user actually ticked the box, and the Run
+//     button stays disabled until both the box and a non-blank subject exist. A
+//     Tier-0 defect earlier in this programme was exactly a consent value the code
+//     minted on the user's behalf; the sidecar refuses independently in any case,
+//     and that refusal is surfaced as an alert rather than swallowed.
+//
+// ─── WHAT THIS PANEL DELIBERATELY DOES NOT CLAIM ────────────────────────────
+// A finished run is reported with the sidecar's own tally, INCLUDING skips
+// (`GazeReport.as_dict`, `gaze.py:432-439`). The engine leaves a frame PRISTINE
+// on low confidence, eyes too small, or implausible head roll (`skip_reason`,
+// `gaze.py:259`), so a run that corrected 0 of N frames is a legitimate outcome
+// that must not read as a win — hence the explicit "corrected nothing" notice.
+// Nothing about the alteration is written into the output container: the mux argv
+// (`gaze_backend.py:200-219`) carries no `-metadata`, so the attestation lives in
+// the job's audit trail only, which is why the panel renders it.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import './panels.css';
+import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+
+/** The sidecar's correction-strength default (`gaze.py:113` DEFAULT_STRENGTH). */
+export const DEFAULT_GAZE_STRENGTH = 0.7;
+
+/**
+ * The exact attestation the user makes. Worded to match what
+ * `models/likeness.py` actually enforces — a claim of the RIGHT to alter this
+ * person's likeness, scoped to the face (`SCOPE_GAZE`), not a general consent.
+ */
+export const LIKENESS_ATTESTATION_TEXT =
+  'I am the person shown, or I hold their documented permission to alter their ' +
+  'likeness in this video.';
+
+/**
+ * Shown when `gaze.probe` answers `{available:false}`. It names the ASSET,
+ * because that is the actionable half of the sidecar's own refusal message
+ * (`gaze.py` `UNAVAILABLE_MESSAGE`), which a bare "unavailable" would drop.
+ */
+export const GAZE_UNAVAILABLE_REASON =
+  'Eye-contact correction needs the yunet-face-detection model, which is not ' +
+  'installed. Run first-run setup, or install it from the Assets tab, then ' +
+  'reopen this tab. No new download is added by this feature — the same ' +
+  'MIT-licensed detector the speaker-tracking path already uses.';
+
+/** Prefix for the fail-CLOSED case where the availability check itself broke. */
+export const GAZE_PROBE_FAILED_PREFIX =
+  'Could not check whether eye-contact correction is available, so the control ' +
+  'stays disabled:';
+
+/** The honest tally of what a finished run did (`gaze.py` `GazeReport.as_dict`). */
+export interface GazeReport {
+  framesTotal: number;
+  framesCorrected: number;
+  eyesCorrected: number;
+  /** `SkipReason` -> count. A skip is a deliberate pristine frame, not an error. */
+  skipped: Record<string, number>;
+}
+
+/** The audit record naming which attestation authorised altering this face. */
+export interface GazeAudit {
+  subject: string;
+  scope: string;
+  source: string;
+}
+
+/** The `job.done` payload of `gaze.run` (`gaze.py:664-673`). */
+export interface GazeOutcome {
+  path: string;
+  /** The strength the sidecar actually clamped to, or null if it sent none. */
+  strength: number | null;
+  report: GazeReport;
+  /** Null when the payload carried no complete audit block (never invented). */
+  likeness: GazeAudit | null;
+}
+
+// --- pure helpers (exported for tests) -------------------------------------
+
+/** `Number.isFinite` does NOT coerce, so this rejects strings/null/undefined. */
+function finiteOr(value: unknown, fallback: number): number {
+  return Number.isFinite(value) ? (value as number) : fallback;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+/** The message text of any thrown value (shared by every catch in this panel). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Build the `gaze.run` params.
+ *
+ * `likenessAttested` is present ONLY when the user genuinely ticked the box —
+ * never `false`-but-present, and never synthesized. `likenessSubject` is always
+ * sent (trimmed) because `resolve_attestation` requires a usable subject in EVERY
+ * route and names it in the refusal, so sending it makes the sidecar's error
+ * message precise even on the refusal path.
+ */
+export function buildGazeParams(args: {
+  videoId: string;
+  likenessSubject: string;
+  likenessAttested: boolean;
+  strength: number;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    videoId: args.videoId,
+    likenessSubject: args.likenessSubject.trim(),
+    strength: args.strength,
+  };
+  if (args.likenessAttested) params.likenessAttested = true;
+  return params;
+}
+
+/**
+ * Read a `gaze.run` job.done result. Null when there is no usable `path`, so a
+ * shapeless or error payload renders nothing rather than junk. A missing or
+ * malformed report becomes explicit ZEROS (never an invented tally), and a
+ * partial audit block is dropped entirely — an audit trail is all-or-nothing.
+ */
+export function gazeOutcome(result: unknown): GazeOutcome | null {
+  const path = pickField<string>(result, 'path');
+  if (typeof path !== 'string' || !path) return null;
+  const raw = asRecord(pickField<unknown>(result, 'report'));
+  const skipped: Record<string, number> = {};
+  for (const [reason, count] of Object.entries(asRecord(raw.skipped))) {
+    if (Number.isFinite(count)) skipped[reason] = count as number;
+  }
+  const strength = pickField<unknown>(result, 'strength');
+  const audit = asRecord(pickField<unknown>(result, 'likeness'));
+  const trio = [audit.subject, audit.scope, audit.source];
+  return {
+    path,
+    strength: Number.isFinite(strength) ? (strength as number) : null,
+    report: {
+      framesTotal: finiteOr(raw.framesTotal, 0),
+      framesCorrected: finiteOr(raw.framesCorrected, 0),
+      eyesCorrected: finiteOr(raw.eyesCorrected, 0),
+      skipped,
+    },
+    likeness: trio.every((v) => typeof v === 'string')
+      ? {
+          subject: audit.subject as string,
+          scope: audit.scope as string,
+          source: audit.source as string,
+        }
+      : null,
+  };
+}
+
+export interface GazeProps {
+  videoId: string;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+
+export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  // null while the probe is in flight — the control is disabled until it answers.
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [unavailableReason, setUnavailableReason] = useState<string>('');
+  // the ethics gate
+  const [subject, setSubject] = useState<string>('');
+  const [attested, setAttested] = useState<boolean>(false);
+  const [strength, setStrength] = useState<number>(DEFAULT_GAZE_STRENGTH);
+  // job state
+  const [running, setRunning] = useState<boolean>(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [outcome, setOutcome] = useState<GazeOutcome | null>(null);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const res = await bridge.rpc<unknown>('gaze.probe');
+        const ok = pickField<boolean>(res, 'available') === true;
+        setAvailable(ok);
+        setUnavailableReason(ok ? '' : GAZE_UNAVAILABLE_REASON);
+      } catch (err) {
+        // FAIL CLOSED: an unreadable probe is "not available", never "probably fine".
+        setAvailable(false);
+        setUnavailableReason(`${GAZE_PROBE_FAILED_PREFIX} ${errText(err)}`);
+      }
+    })();
+  }, [bridge]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  const canRun = available === true && attested && subject.trim().length > 0;
+
+  const run = useCallback(async (): Promise<void> => {
+    // Defensive: the button is disabled unless `canRun` and not already running.
+    /* v8 ignore next */
+    if (running || !canRun) return;
+    setRunning(true);
+    setError('');
+    setOutcome(null);
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      const res = await bridge.rpc<unknown>(
+        'gaze.run',
+        buildGazeParams({
+          videoId,
+          likenessSubject: subject,
+          likenessAttested: attested,
+          strength,
+        }),
+      );
+      const id = extractJobId(res) ?? null;
+      setJobId(id);
+      // waitForJobDone REJECTS on an {error} job.done payload (caught below), so a
+      // refused or failed run is never laundered into a silent success.
+      const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
+      const next = gazeOutcome(result);
+      if (next) {
+        setOutcome(next);
+        setPct(100);
+        setMessage('Done');
+        // A fresh attestation per run: one tick must never carry over to a second
+        // run, or to a different subject. Mirrors the proven WU-A2 behaviour in
+        // `Dub.tsx` (`addSample`), including keeping the tick on FAILURE so a
+        // retry after an unrelated error does not force a re-attestation.
+        setAttested(false);
+      }
+    } catch (err) {
+      setError(errText(err));
+    } finally {
+      setRunning(false);
+      setJobId(null);
+    }
+  }, [attested, bridge, canRun, running, strength, subject, videoId]);
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // Defensive: Cancel renders only while `running && jobId`.
+    /* v8 ignore next */
+    if (!jobId) return;
+    try {
+      await bridge.rpc('job.cancel', { jobId });
+    } catch {
+      // Best-effort — a failed cancel must not become a panel error.
+    }
+    setMessage('Cancelling…');
+  }, [bridge, jobId]);
+
+  return (
+    <section className="feature-panel gaze-panel" aria-label="Eye contact">
+      <h2>Eye Contact</h2>
+      <p className="assets-intro">
+        Nudge the speaker&apos;s irises toward the lens so they read as looking at the camera.
+        Token-free and fully local; the original is never touched and a new file is written. The
+        correction is deliberately partial and conservative — frames where the face is
+        low-confidence, the eyes are too small to carry a warp, or the head is rolled too far are
+        left completely untouched rather than mangled.
+      </p>
+
+      {unavailableReason && (
+        <p className="gaze-unavailable" data-section="unavailable" role="status">
+          {unavailableReason}
+        </p>
+      )}
+
+      {/* THE ETHICS GATE (models/likeness.py). Not a notice — a gate: the Run
+          button stays disabled until the user names the subject AND attests, and
+          the sidecar refuses independently even if that were bypassed. */}
+      <fieldset className="gaze-consent" data-testid="gaze-consent">
+        <legend>Likeness attestation (required)</legend>
+        <label className="gaze-consent-subject">
+          Whose face is this?{' '}
+          <input
+            data-input="likeness-subject"
+            type="text"
+            placeholder="e.g. Marius (self), or the speaker's name"
+            value={subject}
+            onChange={(e) => setSubject(e.target.value)}
+            disabled={running}
+          />
+        </label>
+        <label className="gaze-consent-attest" data-testid="gaze-attest-label">
+          <input
+            data-input="likeness-attest"
+            type="checkbox"
+            checked={attested}
+            onChange={(e) => setAttested(e.target.checked)}
+            disabled={running}
+          />{' '}
+          {LIKENESS_ATTESTATION_TEXT}
+        </label>
+        <p className="gaze-consent-hint">
+          This attestation applies to THIS run only — it is not saved, so it can never authorise a
+          later run or a different person. It is recorded in the finished job&apos;s audit trail
+          (shown below); nothing about the edit is written into the output file itself.
+        </p>
+      </fieldset>
+
+      <div className="field gaze-strength">
+        <label>
+          Correction strength{' '}
+          <input
+            data-input="strength"
+            type="range"
+            min={0}
+            max={1}
+            step={0.05}
+            value={strength}
+            onChange={(e) => setStrength(Number(e.target.value))}
+            disabled={running}
+          />{' '}
+          <span className="gaze-strength-value">{strength.toFixed(2)}</span>
+        </label>
+        <span className="gaze-strength-hint">
+          0 = no change, 1 = fully re-centre. The default of {DEFAULT_GAZE_STRENGTH} is deliberate:
+          a full re-centre often reads as uncanny, and displacement is capped regardless.
+        </span>
+      </div>
+
+      <div className="actions">
+        <button
+          type="button"
+          data-action="run"
+          onClick={() => void run()}
+          disabled={running || !canRun}
+        >
+          {running ? 'Correcting…' : 'Correct eye contact'}
+        </button>
+        {running && jobId && (
+          <button
+            type="button"
+            data-action="cancel"
+            className="secondary"
+            onClick={() => void cancel()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {running && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          {message && <span className="progress-message"> · {message}</span>}
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {outcome && (
+        <div className="gaze-outcome">
+          <div className="output-done" data-section="result">
+            <span className="output-done-label">Corrected file</span>
+            <code>{outcome.path}</code>
+          </div>
+
+          <p className="gaze-report" data-section="report">
+            Corrected {outcome.report.framesCorrected} of {outcome.report.framesTotal} frames (
+            {outcome.report.eyesCorrected} eyes).
+            {Object.entries(outcome.report.skipped).map(([reason, count]) => (
+              <span key={reason} className="gaze-skip">
+                {' '}
+                Left untouched — {reason}: {count}.
+              </span>
+            ))}
+          </p>
+
+          {outcome.report.framesCorrected === 0 && (
+            <p className="gaze-nothing" data-section="nothing-corrected" role="status">
+              The job finished, but NO frame was corrected — the output is effectively the source.
+              Every frame was skipped by the safety gates above, so this is not a failure and not a
+              correction either. Nothing here was altered.
+            </p>
+          )}
+
+          {outcome.likeness && (
+            <p className="gaze-audit" data-section="audit">
+              Authorised by: {outcome.likeness.subject} · scope {outcome.likeness.scope} ·
+              attestation source {outcome.likeness.source}.
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default Gaze;

--- a/app/renderer/src/features/Gaze.tsx
+++ b/app/renderer/src/features/Gaze.tsx
@@ -53,8 +53,27 @@
 // Nothing about the alteration is written into the output container: the mux argv
 // (`gaze_backend.py:200-219`) carries no `-metadata`, so the attestation lives in
 // the job's audit trail only, which is why the panel renders it.
+//
+// ─── AI DISCLOSURE: WHY THIS PANEL CARRIES IT, AND `AiDisclosure.tsx` DOES NOT ─
+// REFUTED IN REVIEW, correctly: the lip-sync sibling reasoned this interaction
+// through and this panel silently skipped it (measured then: 12 hits for
+// `C2PA|ai-disclosure|synthetic` in `LipSync.tsx`, ZERO in this file). A
+// gaze-corrected clip is the same category of artifact — a real person's irises are
+// WARPED, and per the note above the output container carries no marking either —
+// so the same disclosure is owed here.
+//
+// `AiDisclosure.tsx` is still not changed, for the reason its own model gives:
+// `isAiGeneratedAudioTrack(track)` keys off the A3 `AudioTrack.kind`, and
+// `AiDisclosurePanel`'s copy is about dub AUDIO. A gaze output is a VIDEO FILE that
+// is never registered as an `AudioTrack`, so there is no row to badge and no `kind`
+// for that predicate to read; widening it would also change
+// `ShortMakerControls.tsx`, its other consumer, which another live lane owns. So the
+// synthetic-VIDEO disclosure lives in the panel that produces the video, and the one
+// fact that IS shared — no C2PA provenance manifest on export — is IMPORTED from
+// `C2PA_EXPORT_STATUS` rather than restated, so both panels have one source.
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import './panels.css';
+import { C2PA_EXPORT_STATUS } from './AiDisclosure';
 import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
 
 /** The sidecar's correction-strength default (`gaze.py:113` DEFAULT_STRENGTH). */
@@ -187,13 +206,30 @@ export function gazeOutcome(result: unknown): GazeOutcome | null {
   };
 }
 
+/**
+ * The synthetic-media disclosure for a gaze-corrected clip. The C2PA half is
+ * imported from `C2PA_EXPORT_STATUS`, never restated.
+ */
+export const GAZE_AI_DISCLOSURE =
+  'A gaze-corrected clip is edited media: the eyes you see were re-drawn, not ' +
+  'recorded. Reframe writes no marking into the output file — nothing about the ' +
+  'edit reaches the exported container, so only the job audit trail below records it.';
+
 export interface GazeProps {
   videoId: string;
   /** Injectable bridge for tests; defaults to the preload-exposed api. */
   api?: MediaStudioApi;
+  /**
+   * The C2PA export status. Injectable for the same reason `AiDisclosurePanel` and
+   * `LipSync` make it injectable: the shipped constant is a hardcoded
+   * `available: false`, so without a seam the "available" wording could never be
+   * exercised, and an untested branch is where a future signing-identity change
+   * would silently break the disclosure. Defaults to the SHARED constant.
+   */
+  c2pa?: typeof C2PA_EXPORT_STATUS;
 }
 
-export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
+export function Gaze({ videoId, api, c2pa = C2PA_EXPORT_STATUS }: GazeProps): React.ReactElement {
   const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
 
   // null while the probe is in flight — the control is disabled until it answers.
@@ -370,6 +406,11 @@ export function Gaze({ videoId, api }: GazeProps): React.ReactElement {
           below); nothing about the edit is written into the output file itself.
         </p>
       </fieldset>
+
+      <p className="gaze-ai-disclosure" data-section="ai-disclosure">
+        {GAZE_AI_DISCLOSURE} Content Credentials (C2PA) on export:{' '}
+        {c2pa.available ? 'Available' : `not available — ${c2pa.reason}`}
+      </p>
 
       <div className="field gaze-strength">
         <label>

--- a/app/renderer/src/features/LipSync.test.tsx
+++ b/app/renderer/src/features/LipSync.test.tsx
@@ -37,14 +37,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import LipSync, {
   buildLipsyncParams,
   dubAudioTracks,
+  isFaceBoxRefusal,
   lipSyncEnabledFrom,
   lipsyncOutcome,
   DEFAULT_LIPSYNC_ENGINE,
   DEFAULT_LIPSYNC_QUALITY,
   LIPSYNC_ENGINES,
+  LIPSYNC_FACE_BOX_MARKER,
+  LIPSYNC_NO_IN_APP_SETTER,
+  LIPSYNC_DISABLED_REASON,
 } from './LipSync';
 import type { AudioTrack } from './Dub';
 import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
@@ -132,6 +139,86 @@ describe('lipSyncEnabledFrom', () => {
     expect(lipSyncEnabledFrom({})).toBe(false);
     expect(lipSyncEnabledFrom(null)).toBe(false);
     expect(lipSyncEnabledFrom('nope')).toBe(false);
+  });
+});
+
+describe('isFaceBoxRefusal', () => {
+  it('recognises the sidecar own unwired-probe refusal', () => {
+    // The real message, `require_face_boxes` (`lipsync.py:249-254`). A sidecar test
+    // asserts LIPSYNC_FACE_BOX_MARKER is still a substring of it, so this pair
+    // cannot drift apart silently.
+    expect(
+      isFaceBoxRefusal(
+        'no face-box provider is wired: lip-sync must be driven with boxes from ' +
+          'the vendored MIT YuNet detector, because letting the engine detect faces ' +
+          'itself pulls the unlicensed S3FD weight. Inject a face_boxes_probe',
+      ),
+    ).toBe(true);
+  });
+
+  it('is FALSE for every other failure — a transient error must not disable the control', () => {
+    expect(isFaceBoxRefusal('ffmpeg exploded')).toBe(false);
+    expect(isFaceBoxRefusal('')).toBe(false);
+    // Near-misses matter: the detector keys off the sidecar's exact phrase, not the
+    // word "face", so an unrelated detector error is not mistaken for the wiring gap.
+    expect(isFaceBoxRefusal('the face detector found no faces in /m/clip.mp4')).toBe(false);
+  });
+});
+
+// ─── the claim the DISABLED copy makes about `app/`, held by a test ──────────
+// REFUTED IN REVIEW: the first wording said "set the lipSyncEnabled setting to
+// true", naming a setting the user cannot reach — there is no settings UI for it.
+// The copy now says so outright, and this scan is what keeps that honest: if a
+// setter ever lands, this goes red and the sentence must be rewritten rather than
+// quietly becoming a lie. Scanning the SOURCE is the only way to check it; the
+// running renderer cannot see its own tree.
+describe('LIPSYNC_DISABLED_REASON is honest about there being no in-app setter', () => {
+  // `process.cwd()` is the vitest root (`app/`, see vitest.config.ts). NOT
+  // `import.meta.url`: under the vite-node runner it is not a file: URL and
+  // `fileURLToPath` throws "The URL must be of scheme file" — measured here.
+  // The walk finding THIS file is the control that the root resolved correctly.
+  const SRC_ROOT = join(process.cwd(), 'renderer', 'src');
+
+  function walk(dir: string): string[] {
+    return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return entry.name === 'generated' ? [] : walk(full);
+      if (!/\.tsx?$/.test(entry.name) || /\.test\.tsx?$/.test(entry.name)) return [];
+      return [full];
+    });
+  }
+
+  const sources = walk(SRC_ROOT).map((path) => ({ path, text: readFileSync(path, 'utf8') }));
+
+  /** Files that pass `key` INTO a settings.set call (a write, not a mention). */
+  const writersOf = (key: string): string[] =>
+    sources
+      .filter(({ text }) => new RegExp(`settings\\.set[\\s\\S]{0,120}?${key}`).test(text))
+      .map(({ path }) => path);
+
+  it('finds a REAL settings.set write for a user-settable key (detector control)', () => {
+    // Without this control an empty result below would be indistinguishable from a
+    // broken walk or a regex that matches nothing at all.
+    expect(sources.length).toBeGreaterThan(50);
+    expect(sources.some(({ path }) => path.endsWith(join('features', 'LipSync.tsx')))).toBe(true);
+    expect(writersOf('useCloud').some((p) => p.endsWith('App.tsx'))).toBe(true);
+    expect(writersOf('directorOnboardingSeen').length).toBeGreaterThan(0);
+  });
+
+  it('finds NO write of lipSyncEnabled anywhere in the renderer', () => {
+    expect(writersOf('lipSyncEnabled')).toEqual([]);
+    // Stronger, and the part that will actually fire: only these two files may
+    // even MENTION the flag. A new toggle in Settings.tsx trips this immediately.
+    const mentions = sources
+      .filter(({ text }) => text.includes('lipSyncEnabled'))
+      .map(({ path }) => path.replace(SRC_ROOT, '').replace(/\\/g, '/').replace(/^\//, ''));
+    expect(mentions.sort()).toEqual(['features/LipSync.tsx', 'features/ThirdPartyNotices.tsx']);
+  });
+
+  it('states that in the copy the user actually reads, and names where the flag lives', () => {
+    expect(LIPSYNC_DISABLED_REASON).toContain(LIPSYNC_NO_IN_APP_SETTER);
+    expect(LIPSYNC_DISABLED_REASON).toContain('lipSyncEnabled');
+    expect(LIPSYNC_DISABLED_REASON).toContain('settings.json');
   });
 });
 
@@ -300,8 +387,11 @@ describe('<LipSync />', () => {
     fillReady();
     expect(startButton().disabled).toBe(true);
     const reason = container.querySelector('[data-section="disabled"]');
-    // Names the SETTING, so the disabled state is actionable rather than mysterious.
+    // Names the SETTING, so the disabled state is searchable rather than mysterious…
     expect(reason?.textContent).toContain('lipSyncEnabled');
+    // …and says plainly that this app has no switch for it, instead of sending the
+    // user hunting for a preference that does not exist (refuted in review).
+    expect(reason?.textContent).toContain(LIPSYNC_NO_IN_APP_SETTER);
   });
 
   it('fails CLOSED when settings.get itself throws', async () => {
@@ -350,13 +440,21 @@ describe('<LipSync />', () => {
     expect(licence()).toContain('creativeml-openrail-m');
   });
 
-  // The pre-click disclosure of the UNWIRED face-box provider. This is the
-  // difference between "disabled with a reason" and "silently broken": the user is
-  // told before clicking that a run will refuse, and why that refusal is correct.
-  it('discloses the missing face-box provider in BOTH flag states, before any click', async () => {
+  // The pre-click disclosure. This is the difference between "disabled with a
+  // reason" and "silently broken": the user is told before clicking that a build
+  // without a face-box provider refuses, and why that refusal is correct.
+  //
+  // It states the RULE, not a verdict about THIS build — see the next test. The
+  // first version asserted the verdict as present-tense fact, which an adversarial
+  // review correctly refuted: the renderer cannot observe `composition.py`, and the
+  // sentence would invert into "a working feature is broken" the moment the sibling
+  // lane wires the probe.
+  it('discloses the face-box rule in BOTH flag states, before any click', async () => {
     const on = makeFakeApi();
     await mount(on.api);
     expect(container.querySelector('[data-section="unwired"]')?.textContent).toContain('S3FD');
+    // ...and claims NOTHING about this build until something is measured.
+    expect(container.querySelector('[data-section="face-box-refused"]')).toBeNull();
     await act(async () => {
       root.unmount();
     });
@@ -364,6 +462,44 @@ describe('<LipSync />', () => {
     const off = makeFakeApi({ settings: { lipSyncEnabled: false } });
     await mount(off.api);
     expect(container.querySelector('[data-section="unwired"]')?.textContent).toContain('S3FD');
+    expect(container.querySelector('[data-section="face-box-refused"]')).toBeNull();
+  });
+
+  it('after an OBSERVED face-box refusal it disables the control and quotes the sidecar', async () => {
+    // This is the shape the brief asked for — disabled WITH A REASON — reached the
+    // only honest way: from a refusal the sidecar actually returned. `probe is None`
+    // cannot fix itself mid-session, so a second identical click is a guaranteed
+    // failure and must not be offered.
+    const refusal = new Error(
+      `${LIPSYNC_FACE_BOX_MARKER}: lip-sync must be driven with boxes from the ` +
+        'vendored MIT YuNet detector. Inject a face_boxes_probe',
+    );
+    const fake = makeFakeApi({ startError: refusal });
+    await mount(fake.api);
+    fillReady();
+    expect(startButton().disabled).toBe(false); // enabled BEFORE the click
+    await clickStart();
+    const observed = container.querySelector('[data-section="face-box-refused"]');
+    expect(observed?.textContent).toContain(LIPSYNC_FACE_BOX_MARKER);
+    expect(observed?.textContent).toContain('Measured on this build');
+    // and the control is now shut, with the failure also surfaced as an alert
+    expect(startButton().disabled).toBe(true);
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      LIPSYNC_FACE_BOX_MARKER,
+    );
+  });
+
+  it('a DIFFERENT failure leaves the control usable — one bad run is not a verdict', async () => {
+    // The both-states half of the test above: without this, "disabled after a
+    // refusal" could just be "disabled after any error", which would strand the
+    // user on a transient ffmpeg failure.
+    const fake = makeFakeApi({ startError: new Error('ffmpeg exploded') });
+    await mount(fake.api);
+    fillReady();
+    await clickStart();
+    expect(container.querySelector('[data-section="face-box-refused"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('ffmpeg exploded');
+    expect(startButton().disabled).toBe(false);
   });
 
   it('discloses that the output is synthetic video and carries no embedded provenance', async () => {

--- a/app/renderer/src/features/LipSync.test.tsx
+++ b/app/renderer/src/features/LipSync.test.tsx
@@ -25,12 +25,20 @@
 //  4. ENGINE. `wav2lip` is in DENIED_ENGINES permanently (genuinely
 //     non-commercial, `lipsync.py:120-126`), so it is not offerable at all.
 //
-// AND ONE DISCLOSED RESIDUAL THAT IS NOT MINE TO FIX (sidecar is out of scope for
-// this lane): `_tts.register(...)` at `handlers/composition.py:327-336` passes NO
-// `lipsync_face_boxes_probe`, so `face_boxes_probe` is `None` in the real app and
-// `require_face_boxes` (`lipsync.py:239-254`, called at `:699`) raises INSIDE the
-// job. A run therefore refuses at job time today. The panel says so up front
-// rather than letting the user discover it by clicking — see the notice test.
+// AND ONE DISCLOSED RESIDUAL THAT IS NOT MINE TO FIX (`handlers/composition.py`
+// belongs to another live lane): `_tts.register(...)` at `composition.py:327-336`
+// passes NO `lipsync_face_boxes_probe`, so `face_boxes_probe` is `None` in the real
+// app and `require_face_boxes` (`lipsync.py:239-254`, called at `:699`) raises
+// INSIDE the job. A run therefore refuses at job time today.
+//
+// How that is tested, after review narrowed the claim: the panel states the RULE up
+// front (true of every build — "discloses the face-box rule in BOTH flag states"),
+// asserts NOTHING about this build's wiring before a click, and after an OBSERVED
+// refusal disables the control quoting the sidecar ("after an OBSERVED face-box
+// refusal…"), while a DIFFERENT failure leaves it usable. So this file no longer
+// pins a sentence that would become false the moment the sibling lane wires the
+// probe — the previous version did, and a green test pinning it would have forced
+// that lane to delete a passing test.
 
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -392,6 +400,28 @@ describe('<LipSync />', () => {
     // …and says plainly that this app has no switch for it, instead of sending the
     // user hunting for a preference that does not exist (refuted in review).
     expect(reason?.textContent).toContain(LIPSYNC_NO_IN_APP_SETTER);
+  });
+
+  // MUTATION-DRIVEN (this one SURVIVED an adversarial mutation run): `enabled ===
+  // true` -> `enabled !== false` left all 36 tests green, because nothing exercised
+  // the NULL window — `settings.get` in flight. That window is the file's own
+  // fail-closed claim ("null while settings.get is in flight — the control is
+  // disabled until it answers"), so it needs a test, not a comment.
+  it('fails CLOSED while settings.get is still in flight (the null window)', async () => {
+    const api: MediaStudioApi = {
+      // Never resolves: the panel stays in `enabled === null` for the whole test.
+      rpc: vi.fn((method: string) =>
+        method === 'settings.get' ? new Promise(() => {}) : Promise.resolve({ jobId: 'job-l' }),
+      ) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    await mount(api);
+    fillReady(); // everything else satisfied, so the flag is the only gate left
+    expect(startButton().disabled).toBe(true);
+    // ...and it is the IN-FLIGHT state, not the answered-false one: no disabled
+    // reason is rendered yet, so this is distinguishable from `lipSyncEnabled:false`.
+    expect(container.querySelector('[data-section="disabled"]')).toBeNull();
   });
 
   it('fails CLOSED when settings.get itself throws', async () => {

--- a/app/renderer/src/features/LipSync.test.tsx
+++ b/app/renderer/src/features/LipSync.test.tsx
@@ -60,6 +60,8 @@ import LipSync, {
   LIPSYNC_FACE_BOX_MARKER,
   LIPSYNC_NO_IN_APP_SETTER,
   LIPSYNC_DISABLED_REASON,
+  LIPSYNC_OBSERVED_REFUSAL_PREFIX,
+  LIPSYNC_UNWIRED_NOTICE,
 } from './LipSync';
 import type { AudioTrack } from './Dub';
 import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
@@ -830,5 +832,212 @@ describe('<LipSync />', () => {
     });
     await flush();
     expect(startButton().disabled).toBe(true);
+  });
+
+  // ─── the CONSENT-CARRYOVER door: the VIDEO changes under a ticked box ──────
+  // `consentAttested` was cleared only after a success (`LipSync.tsx:522`) —
+  // nothing was keyed to `videoId`. `Dub.tsx:529` renders `<LipSync
+  // videoId={videoId} …>` UNKEYED and `Dub` itself is mounted unkeyed
+  // (`Workspace.tsx:398-399`), all the way up an unkeyed App -> Edit -> Workspace
+  // chain, so a video swapped IN PLACE (`App.tsx:332-353`'s `[]`-deps
+  // launch-restore, which calls `setEditVideo` after two RPC awaits) kept the tick.
+  // The tick's own sentence is "I am the person ON SCREEN…", and the person on
+  // screen is exactly what a videoId change replaces.
+  //
+  // The sharpest form is tested below: the audio-track list is passed UNCHANGED
+  // across the swap, so the existing stale-track effect (`LipSync.tsx:424-426`)
+  // cannot mask the leak — only a videoId-keyed reset can close it.
+
+  /**
+   * Re-render IN PLACE with a new videoId. `quality` is the DETECTOR CONTROL in
+   * every test below: it is deliberately not reset, so a value back at the
+   * 'quality' default would mean this remounted and the consent assertions were
+   * measuring a fresh mount rather than a prop swap.
+   */
+  async function swapVideo(
+    api: MediaStudioApi,
+    videoId: string,
+    tracks: AudioTrack[] = [ORIGINAL, DUB_CLONE],
+  ): Promise<void> {
+    await act(async () => {
+      root.render(<LipSync videoId={videoId} audioTracks={tracks} api={api} />);
+    });
+    await flush();
+  }
+
+  const consentBox = (): HTMLInputElement =>
+    container.querySelector('[data-input="lipsync-consent"]') as HTMLInputElement;
+  const trackPicker = (): HTMLSelectElement =>
+    container.querySelector('[data-picker="lipsync-track"]') as HTMLSelectElement;
+  const qualityPicker = (): HTMLSelectElement =>
+    container.querySelector('[data-picker="lipsync-quality"]') as HTMLSelectElement;
+
+  it('the WIRE carries no attestation for a video the tick was never read against', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    pick('[data-picker="lipsync-quality"]', 'fast');
+    expect(startButton().disabled).toBe(false);
+
+    await swapVideo(fake.api, 'videoB');
+
+    expect(qualityPicker().value).toBe('fast'); // detector control: in-place swap
+    await clickStart();
+    expect(fake.calls.filter((c) => c.method === 'tts.lipsync.start').map((c) => c.params)).toEqual(
+      [],
+    );
+  });
+
+  it('CLEARS the consent tick AND the picked dub track when the VIDEO changes', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    pick('[data-picker="lipsync-quality"]', 'fast');
+    await swapVideo(fake.api, 'videoB');
+
+    expect(qualityPicker().value).toBe('fast'); // control
+    expect(consentBox().checked).toBe(false);
+    // The track id goes too: a dub belongs to the video it was made from, so
+    // sending video A's audioTrackId with video B's videoId is never right.
+    expect(trackPicker().value).toBe('');
+    expect(startButton().disabled).toBe(true);
+  });
+
+  it('a fresh tick after a video change attests the NEW video, and the wire says so', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await swapVideo(fake.api, 'videoB');
+    fillReady();
+    await clickStart();
+    expect(fake.calls.find((c) => c.method === 'tts.lipsync.start')?.params).toEqual({
+      videoId: 'videoB',
+      audioTrackId: DUB_CLONE.id,
+      engine: DEFAULT_LIPSYNC_ENGINE,
+      quality: DEFAULT_LIPSYNC_QUALITY,
+      likenessConsentAttested: true,
+    });
+  });
+
+  it('drops the previous video relip result and failure banner when the video changes', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-l', result: { path: '/out/lipsync/videoA.mp4', engine: 'x' } });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="lipsync-result"]')).not.toBeNull(); // control
+    await swapVideo(fake.api, 'videoB');
+    expect(container.querySelector('[data-section="lipsync-result"]')).toBeNull();
+
+    // …and the same for an error banner, which would otherwise blame video B for
+    // video A's failure.
+    fillReady();
+    await swapVideo(fake.api, 'videoC');
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('keeps the OBSERVED face-box refusal across a video change — it is a BUILD fact, not a video one', async () => {
+    // The over-reset control, and the reason this reset is not a blanket one:
+    // `require_face_boxes` refuses because `composition.py` passes no probe, which
+    // no video change can fix. Clearing it here would re-offer a guaranteed-failing
+    // click on every video switch.
+    const fake = makeFakeApi({ startError: new Error(`${LIPSYNC_FACE_BOX_MARKER}: inject one`) });
+    await mount(fake.api);
+    fillReady();
+    await clickStart();
+    expect(container.querySelector('[data-section="face-box-refused"]')).not.toBeNull();
+    await swapVideo(fake.api, 'videoB');
+    expect(container.querySelector('[data-section="face-box-refused"]')).not.toBeNull();
+    expect(startButton().disabled).toBe(true);
+  });
+
+  // ─── in-flight variant of the same defect (precedent: origin/main 4408e033) ──
+  it('drops a late job.done from the PREVIOUS video instead of showing it under the new one', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await swapVideo(fake.api, 'videoB');
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-l', result: { path: '/out/lipsync/videoA.mp4', engine: 'x' } });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="lipsync-result"]')).toBeNull();
+    expect(container.querySelector('.progress')).toBeNull(); // the lane is freed
+  });
+
+  it('drops a late FAILURE from the previous video, but still records a face-box refusal', async () => {
+    // Two claims in one, because they are the SAME catch block and the asymmetry is
+    // the point: the error banner is per-video (dropped), the face-box verdict is
+    // per-BUILD (kept). No-switch control arms for both: 'surfaces the job-time
+    // face-box refusal LOUDLY as an alert' and 'a DIFFERENT failure leaves the
+    // control usable' above.
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await swapVideo(fake.api, 'videoB');
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-l',
+        result: {
+          error: { message: `${LIPSYNC_FACE_BOX_MARKER}: inject one`, type: 'LipSyncError' },
+        },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+    expect(container.querySelector('[data-section="face-box-refused"]')).not.toBeNull();
+  });
+
+  // ─── "disabled for the session" was an OVERCLAIM — measured, not reasoned ───
+  // `faceBoxRefusal` is component state and `Workspace.tsx:479-488` swaps the panel
+  // type inside ONE <Suspense>, so leaving the Dub tab unmounts this section. This
+  // test EXECUTES that consequence rather than asserting React semantics from
+  // memory: after a remount the refusal is gone and the guaranteed-failing click is
+  // on offer again. The copy is narrowed to match, and pinned below.
+  it('a REMOUNT re-offers the click, so the refusal is panel-scoped and the copy must not say "session"', async () => {
+    const fake = makeFakeApi({ startError: new Error(`${LIPSYNC_FACE_BOX_MARKER}: inject one`) });
+    await mount(fake.api);
+    fillReady();
+    await clickStart();
+    expect(startButton().disabled).toBe(true);
+
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    await mount(fake.api);
+    fillReady();
+    expect(container.querySelector('[data-section="face-box-refused"]')).toBeNull();
+    expect(startButton().disabled).toBe(false);
+  });
+
+  it('scopes the disabling copy to this panel, not to the whole session', async () => {
+    for (const copy of [LIPSYNC_UNWIRED_NOTICE, LIPSYNC_OBSERVED_REFUSAL_PREFIX]) {
+      expect(copy).toMatch(/reopen|re-open/i);
+      expect(copy.toLowerCase()).not.toContain('for the session');
+    }
+  });
+
+  it('the consent hint names every trigger that really clears the tick, and the retry carve-out', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const hint = container.querySelector('.dub-consent-hint')?.textContent ?? '';
+    expect(hint).toMatch(/finished run/i); // cleared on success
+    expect(hint).toMatch(/different video/i); // cleared on a videoId change
+    expect(hint).toMatch(/failed run/i); // …and deliberately NOT on failure
   });
 });

--- a/app/renderer/src/features/LipSync.test.tsx
+++ b/app/renderer/src/features/LipSync.test.tsx
@@ -1,0 +1,668 @@
+// LipSync.test.tsx — tests for the lip-sync section of the Dub surface (W20).
+//
+// MEASURED GAP. `tts.lipsync.start` is registered UNCONDITIONALLY
+// (`sidecar/media_studio/features/tts/__init__.py:141`) and frozen into the
+// authoritative method list, but it had NO caller. Measured on the host tree:
+// `features/Dub.tsx` was 519 lines with ZERO `lipSync`/`lipsync` references, and
+// the only renderer matches for "lipsync" were `AiDisclosure.tsx` and
+// `ThirdPartyNotices.tsx` — neither of which calls anything. So this is new UI in
+// the dub surface, not a wiring tweak.
+//
+// WIRE: tts.lipsync.start({videoId, audioTrackId, engine?, quality?,
+//                          likenessConsentAttested}) -> {jobId}
+//         -> job.done {path, engine, syncConfidence}
+//
+// FOUR GATES, all FAIL CLOSED, and this file pins each one on the renderer side:
+//  1. BUILD FLAG. `require_enabled` refuses unless the `lipSyncEnabled` setting is
+//     the LITERAL `true` (`lipsync.py:197-215`; default `False`,
+//     `settings_store.py:178`). A truthy string or 1 is NOT an opt-in, and
+//     `lipSyncEnabledFrom` mirrors that exactly.
+//  2. LIKENESS CONSENT. `likenessConsentAttested` must be the literal `true`
+//     (`lipsync.py:218-225`). The UI never synthesizes it.
+//  3. THE TRACK MUST BE A DUB. `lipsync_start` rejects a non-dub audio track
+//     (`lipsync.py:672-677`) — re-lipping to the ORIGINAL audio is meaningless —
+//     so the picker only offers `kind === 'dub'` rows.
+//  4. ENGINE. `wav2lip` is in DENIED_ENGINES permanently (genuinely
+//     non-commercial, `lipsync.py:120-126`), so it is not offerable at all.
+//
+// AND ONE DISCLOSED RESIDUAL THAT IS NOT MINE TO FIX (sidecar is out of scope for
+// this lane): `_tts.register(...)` at `handlers/composition.py:327-336` passes NO
+// `lipsync_face_boxes_probe`, so `face_boxes_probe` is `None` in the real app and
+// `require_face_boxes` (`lipsync.py:239-254`, called at `:699`) raises INSIDE the
+// job. A run therefore refuses at job time today. The panel says so up front
+// rather than letting the user discover it by clicking — see the notice test.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import LipSync, {
+  buildLipsyncParams,
+  dubAudioTracks,
+  lipSyncEnabledFrom,
+  lipsyncOutcome,
+  DEFAULT_LIPSYNC_ENGINE,
+  DEFAULT_LIPSYNC_QUALITY,
+  LIPSYNC_ENGINES,
+} from './LipSync';
+import type { AudioTrack } from './Dub';
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+
+const ORIGINAL: AudioTrack = {
+  id: 'a-orig',
+  lang: 'en',
+  name: 'Original',
+  kind: 'original',
+  path: '/m/orig.m4a',
+};
+const DUB_CLONE: AudioTrack = {
+  id: 'a-dub-1',
+  lang: 'de',
+  name: 'Dub (chatterbox, de)',
+  kind: 'dub',
+  voice: 'sample-7',
+  path: '/m/dub-de.m4a',
+};
+const DUB_PLAIN: AudioTrack = {
+  id: 'a-dub-2',
+  lang: 'fr',
+  name: 'Dub (kokoro, fr)',
+  kind: 'dub',
+  path: '/m/dub-fr.m4a',
+};
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+function makeFakeApi(
+  overrides: { settings?: unknown; settingsError?: Error; startError?: unknown } = {},
+): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'settings.get') {
+        if (overrides.settingsError) throw overrides.settingsError;
+        return (overrides.settings ?? { lipSyncEnabled: true }) as T;
+      }
+      if (method === 'tts.lipsync.start') {
+        if (overrides.startError) throw overrides.startError;
+        return { jobId: 'job-l' } as T;
+      }
+      return {} as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+describe('lipSyncEnabledFrom', () => {
+  it('true ONLY for the literal boolean true', () => {
+    expect(lipSyncEnabledFrom({ lipSyncEnabled: true })).toBe(true);
+  });
+
+  it('a truthy non-boolean is NOT an opt-in — it guards a face-manipulation path', () => {
+    // Mirrors `lipsync.lipsync_enabled`: "a truthy string/int is NOT an opt-in".
+    expect(lipSyncEnabledFrom({ lipSyncEnabled: 'true' })).toBe(false);
+    expect(lipSyncEnabledFrom({ lipSyncEnabled: 1 })).toBe(false);
+    expect(lipSyncEnabledFrom({ lipSyncEnabled: false })).toBe(false);
+    expect(lipSyncEnabledFrom({})).toBe(false);
+    expect(lipSyncEnabledFrom(null)).toBe(false);
+    expect(lipSyncEnabledFrom('nope')).toBe(false);
+  });
+});
+
+describe('dubAudioTracks', () => {
+  it('offers only dub tracks — re-lipping to the original audio is meaningless', () => {
+    expect(dubAudioTracks([ORIGINAL, DUB_CLONE, DUB_PLAIN])).toEqual([DUB_CLONE, DUB_PLAIN]);
+  });
+
+  it('empty when the video has no dub yet', () => {
+    expect(dubAudioTracks([ORIGINAL])).toEqual([]);
+    expect(dubAudioTracks([])).toEqual([]);
+  });
+});
+
+describe('buildLipsyncParams', () => {
+  it('carries the attestation when the user ticked it', () => {
+    expect(
+      buildLipsyncParams({
+        videoId: 'v1',
+        audioTrackId: 'a-dub-1',
+        engine: 'musetalk',
+        quality: 'fast',
+        consentAttested: true,
+      }),
+    ).toEqual({
+      videoId: 'v1',
+      audioTrackId: 'a-dub-1',
+      engine: 'musetalk',
+      quality: 'fast',
+      likenessConsentAttested: true,
+    });
+  });
+
+  it('OMITS likenessConsentAttested when unticked — never mints consent', () => {
+    const params = buildLipsyncParams({
+      videoId: 'v1',
+      audioTrackId: 'a-dub-1',
+      engine: DEFAULT_LIPSYNC_ENGINE,
+      quality: DEFAULT_LIPSYNC_QUALITY,
+      consentAttested: false,
+    });
+    expect('likenessConsentAttested' in params).toBe(false);
+  });
+});
+
+describe('LIPSYNC_ENGINES', () => {
+  it('offers latentsync + musetalk and NEVER wav2lip (permanently denied)', () => {
+    expect(LIPSYNC_ENGINES.map((e) => e.id)).toEqual(['latentsync', 'musetalk']);
+    expect(LIPSYNC_ENGINES.map((e) => e.id)).not.toContain('wav2lip');
+  });
+
+  it('every offered engine states its weights licence', () => {
+    // OpenRAIL permits commercial use but attaches behavioural use-restrictions
+    // that must be passed downstream (`lipsync.py:23-30`), so the licence is a
+    // user-facing fact, not an internal detail.
+    for (const engine of LIPSYNC_ENGINES) {
+      expect(engine.weightsLicense).toMatch(/openrail/i);
+      expect(engine.notice.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('lipsyncOutcome', () => {
+  it('reads a finished relip', () => {
+    expect(
+      lipsyncOutcome({ path: '/out/lipsync/clip.mp4', engine: 'latentsync', syncConfidence: 0.87 }),
+    ).toEqual({ path: '/out/lipsync/clip.mp4', engine: 'latentsync', syncConfidence: 0.87 });
+  });
+
+  it('null without a usable path', () => {
+    expect(lipsyncOutcome({})).toBeNull();
+    expect(lipsyncOutcome(null)).toBeNull();
+    expect(lipsyncOutcome({ path: '' })).toBeNull();
+    expect(lipsyncOutcome({ path: 7 })).toBeNull();
+  });
+
+  it('null confidence and empty engine rather than invented values', () => {
+    const out = lipsyncOutcome({ path: '/p.mp4' });
+    expect(out?.syncConfidence).toBeNull();
+    expect(out?.engine).toBe('');
+    expect(lipsyncOutcome({ path: '/p.mp4', syncConfidence: 'high' })?.syncConfidence).toBeNull();
+    expect(lipsyncOutcome({ path: '/p.mp4', engine: 42 })?.engine).toBe('');
+  });
+});
+
+describe('<LipSync />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const flush = async (): Promise<void> => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  async function mount(
+    api: MediaStudioApi,
+    tracks: AudioTrack[] = [ORIGINAL, DUB_CLONE],
+  ): Promise<void> {
+    await act(async () => {
+      root.render(<LipSync videoId="v1" audioTracks={tracks} api={api} />);
+    });
+    await flush();
+  }
+
+  function pick(selector: string, value: string): void {
+    const el = container.querySelector(selector) as HTMLSelectElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  }
+
+  function consent(): void {
+    const box = container.querySelector('[data-input="lipsync-consent"]') as HTMLInputElement;
+    act(() => {
+      box.click();
+    });
+  }
+
+  const startButton = (): HTMLButtonElement =>
+    container.querySelector('[data-action="start-lipsync"]') as HTMLButtonElement;
+
+  async function clickStart(): Promise<void> {
+    await act(async () => {
+      startButton().click();
+      await Promise.resolve();
+    });
+    await flush();
+  }
+
+  /** The only state that can dispatch: a dub track picked and consent given. */
+  function fillReady(trackId = DUB_CLONE.id): void {
+    pick('[data-picker="lipsync-track"]', trackId);
+    consent();
+  }
+
+  it('reads the build flag from settings.get on mount', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(fake.calls.some((c) => c.method === 'settings.get')).toBe(true);
+  });
+
+  // MUTATION NOTE — this test FILLS IN a complete, consented request before
+  // asserting `disabled`, so the flag is the only remaining reason the button can
+  // be disabled. Without that, the assertion would silently be measuring the
+  // consent gate instead (the mistake that let a mutant survive in Gaze.test.tsx).
+  it('DISABLES the control with the honest reason when lipSyncEnabled is off', async () => {
+    const fake = makeFakeApi({ settings: { lipSyncEnabled: false } });
+    await mount(fake.api);
+    fillReady();
+    expect(startButton().disabled).toBe(true);
+    const reason = container.querySelector('[data-section="disabled"]');
+    // Names the SETTING, so the disabled state is actionable rather than mysterious.
+    expect(reason?.textContent).toContain('lipSyncEnabled');
+  });
+
+  it('fails CLOSED when settings.get itself throws', async () => {
+    const fake = makeFakeApi({ settingsError: new Error('settings unreadable') });
+    await mount(fake.api);
+    fillReady();
+    expect(startButton().disabled).toBe(true);
+    expect(container.querySelector('[data-section="disabled"]')).not.toBeNull();
+  });
+
+  it('enables the control once the flag, a dub track AND consent are all present', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(startButton().disabled).toBe(true); // no track, no consent yet
+    pick('[data-picker="lipsync-track"]', DUB_CLONE.id);
+    expect(startButton().disabled).toBe(true); // still no consent
+    consent();
+    expect(startButton().disabled).toBe(false);
+  });
+
+  it('offers ONLY dub tracks in the picker and says so when there are none', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api, [ORIGINAL]);
+    const options = Array.from(
+      container.querySelectorAll('[data-picker="lipsync-track"] option'),
+    ).map((o) => (o as HTMLOptionElement).value);
+    expect(options).not.toContain(ORIGINAL.id);
+    expect(container.querySelector('[data-section="no-dub"]')).not.toBeNull();
+  });
+
+  it('never offers wav2lip in the engine picker', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const options = Array.from(
+      container.querySelectorAll('[data-picker="lipsync-engine"] option'),
+    ).map((o) => (o as HTMLOptionElement).value);
+    expect(options).toEqual(['latentsync', 'musetalk']);
+  });
+
+  it('shows the selected engine licence obligation, and it changes with the engine', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const licence = (): string => container.querySelector('[data-section="licence"]')!.textContent!;
+    expect(licence()).toContain('openrail++');
+    pick('[data-picker="lipsync-engine"]', 'musetalk');
+    expect(licence()).toContain('creativeml-openrail-m');
+  });
+
+  // The pre-click disclosure of the UNWIRED face-box provider. This is the
+  // difference between "disabled with a reason" and "silently broken": the user is
+  // told before clicking that a run will refuse, and why that refusal is correct.
+  it('discloses the missing face-box provider in BOTH flag states, before any click', async () => {
+    const on = makeFakeApi();
+    await mount(on.api);
+    expect(container.querySelector('[data-section="unwired"]')?.textContent).toContain('S3FD');
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    const off = makeFakeApi({ settings: { lipSyncEnabled: false } });
+    await mount(off.api);
+    expect(container.querySelector('[data-section="unwired"]')?.textContent).toContain('S3FD');
+  });
+
+  it('discloses that the output is synthetic video and carries no embedded provenance', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const note = container.querySelector('[data-section="ai-disclosure"]');
+    expect(note?.textContent).toMatch(/synthetic|synthesi/i);
+    // Reuses the SHARED C2PA status constant rather than restating it, so there is
+    // one source for "no provenance manifest is written".
+    expect(note?.textContent).toContain('C2PA');
+    expect(note?.textContent).toContain('not available');
+  });
+
+  it('reports C2PA as available if a signing identity ever lands (the other state)', async () => {
+    // The shipped constant is a hardcoded `available: false`, so without this seam
+    // the "available" wording could never be exercised — the same reason
+    // `AiDisclosurePanel` takes an injectable `c2pa`.
+    const fake = makeFakeApi();
+    await act(async () => {
+      root.render(
+        <LipSync
+          videoId="v1"
+          audioTracks={[DUB_CLONE]}
+          api={fake.api}
+          c2pa={{ available: true, reason: '' }}
+        />,
+      );
+    });
+    await flush();
+    expect(container.querySelector('[data-section="ai-disclosure"]')?.textContent).toContain(
+      'Available',
+    );
+  });
+
+  it('sends tts.lipsync.start with the exact frozen params', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    pick('[data-picker="lipsync-quality"]', 'fast');
+    await clickStart();
+    expect(fake.calls.find((c) => c.method === 'tts.lipsync.start')?.params).toEqual({
+      videoId: 'v1',
+      audioTrackId: DUB_CLONE.id,
+      engine: DEFAULT_LIPSYNC_ENGINE,
+      quality: 'fast',
+      likenessConsentAttested: true,
+    });
+  });
+
+  it('streams progress for its own job and ignores another', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-l', pct: 30, message: 're-lipping' });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.progress-pct')?.textContent).toContain('30');
+    await act(async () => {
+      fake.fireProgress({ jobId: 'other', pct: 99, message: 'nope' });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.progress-pct')?.textContent).not.toContain('99');
+  });
+
+  it('renders the relipped path and the sync confidence on job.done', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-l',
+        result: { path: '/out/lipsync/v1/clip.mp4', engine: 'latentsync', syncConfidence: 0.87 },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    const out = container.querySelector('[data-section="lipsync-result"]');
+    expect(out?.textContent).toContain('/out/lipsync/v1/clip.mp4');
+    expect(out?.textContent).toContain('0.87');
+  });
+
+  it('renders a result whose confidence the sidecar could not measure without inventing one', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-l', result: { path: '/out/x.mp4', engine: 'musetalk' } });
+      await Promise.resolve();
+    });
+    await flush();
+    const out = container.querySelector('[data-section="lipsync-result"]');
+    expect(out?.textContent).toContain('/out/x.mp4');
+    expect(out?.textContent).toMatch(/not measured/i);
+  });
+
+  it('surfaces the job-time face-box refusal LOUDLY as an alert', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({
+        jobId: 'job-l',
+        result: {
+          error: {
+            message:
+              'no face-box provider is wired: lip-sync must be driven with boxes from the vendored MIT YuNet detector',
+            type: 'LipSyncError',
+          },
+        },
+      });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'no face-box provider is wired',
+    );
+    expect(container.querySelector('[data-section="lipsync-result"]')).toBeNull();
+  });
+
+  it('surfaces an rpc-time refusal as an alert', async () => {
+    const fake = makeFakeApi({ startError: new Error('likenessConsentAttested must be true') });
+    await mount(fake.api);
+    fillReady();
+    await clickStart();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'likenessConsentAttested',
+    );
+  });
+
+  it('surfaces a non-Error rejection as a string', async () => {
+    const fake = makeFakeApi({ startError: 'plain string boom' });
+    await mount(fake.api);
+    fillReady();
+    await clickStart();
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('plain string boom');
+  });
+
+  it('CLEARS the consent tick after a successful relip', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-l', result: { path: '/out/x.mp4', engine: 'latentsync' } });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(
+      (container.querySelector('[data-input="lipsync-consent"]') as HTMLInputElement).checked,
+    ).toBe(false);
+  });
+
+  it('KEEPS the consent tick after a failure so a retry need not re-attest', async () => {
+    const fake = makeFakeApi({ startError: new Error('boom') });
+    await mount(fake.api);
+    fillReady();
+    await clickStart();
+    expect(
+      (container.querySelector('[data-input="lipsync-consent"]') as HTMLInputElement).checked,
+    ).toBe(true);
+  });
+
+  it('cancels the in-flight job via job.cancel (the happy path)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      (container.querySelector('[data-action="lipsync-cancel"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(fake.calls.find((c) => c.method === 'job.cancel')?.params).toEqual({ jobId: 'job-l' });
+    expect(container.querySelector('.progress-message')?.textContent).toContain('Cancelling');
+  });
+
+  it('cancels the in-flight job via job.cancel, and a failing cancel is not a panel error', async () => {
+    let doneCbs: Array<(ev: DoneEvent) => void> = [];
+    const calls: FakeApi['calls'] = [];
+    const api: MediaStudioApi = {
+      rpc: vi.fn(async <T,>(method: string) => {
+        calls.push({ method });
+        if (method === 'settings.get') return { lipSyncEnabled: true } as T;
+        if (method === 'job.cancel') throw new Error('cancel failed');
+        return { jobId: 'job-l' } as T;
+      }) as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: (cb) => {
+        doneCbs.push(cb);
+        return () => {
+          doneCbs = doneCbs.filter((c) => c !== cb);
+        };
+      },
+    };
+    await mount(api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      (container.querySelector('[data-action="lipsync-cancel"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    expect(calls.some((c) => c.method === 'job.cancel')).toBe(true);
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('does not hang without a job.done channel, and renders nothing without a jobId', async () => {
+    const noDone: MediaStudioApi = {
+      rpc: vi.fn(async (method: string) =>
+        method === 'settings.get' ? { lipSyncEnabled: true } : { jobId: 'job-l' },
+      ) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+    };
+    await mount(noDone);
+    fillReady();
+    await clickStart();
+    expect(container.querySelector('[data-section="lipsync-result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+
+    await act(async () => {
+      root.unmount();
+    });
+    root = createRoot(container);
+    const noJob: MediaStudioApi = {
+      rpc: vi.fn(async (method: string) =>
+        method === 'settings.get' ? { lipSyncEnabled: true } : {},
+      ) as unknown as MediaStudioApi['rpc'],
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    await mount(noJob);
+    fillReady();
+    await clickStart();
+    expect(container.querySelector('[data-section="lipsync-result"]')).toBeNull();
+  });
+
+  it('settles cleanly on a job.done with no result field', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    fillReady();
+    await act(async () => {
+      startButton().click();
+    });
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-l' });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('[data-section="lipsync-result"]')).toBeNull();
+    expect(container.querySelector('[role="alert"]')).toBeNull();
+  });
+
+  it('falls back to the global window.api bridge when no api prop is given', async () => {
+    const fake = makeFakeApi();
+    (globalThis as { api?: unknown }).api = fake.api;
+    try {
+      await act(async () => {
+        root.render(<LipSync videoId="v1" audioTracks={[DUB_CLONE]} />);
+      });
+      await flush();
+      fillReady();
+      await clickStart();
+      expect(fake.calls.find((c) => c.method === 'tts.lipsync.start')?.params).toMatchObject({
+        videoId: 'v1',
+        likenessConsentAttested: true,
+      });
+    } finally {
+      delete (globalThis as { api?: unknown }).api;
+    }
+  });
+
+  it('drops a selected track that disappears from the list (a re-picked dub cannot go stale)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api, [ORIGINAL, DUB_CLONE, DUB_PLAIN]);
+    pick('[data-picker="lipsync-track"]', DUB_PLAIN.id);
+    consent();
+    expect(startButton().disabled).toBe(false);
+    // The dub track is removed (e.g. tracks.audio.strip) and Dub re-renders us.
+    await act(async () => {
+      root.render(<LipSync videoId="v1" audioTracks={[ORIGINAL, DUB_CLONE]} api={fake.api} />);
+    });
+    await flush();
+    expect(startButton().disabled).toBe(true);
+  });
+});

--- a/app/renderer/src/features/LipSync.tsx
+++ b/app/renderer/src/features/LipSync.tsx
@@ -26,9 +26,12 @@
 //    `lipSyncEnabled` setting is the LITERAL `true`; the default is `False`
 //    (`settings_store.py:178`). `lipSyncEnabledFrom` mirrors that literal-true rule
 //    exactly, so a truthy `'true'`/`1` reads as OFF here as it does there.
-//    Consequence, deliberate: with the flag off the button is DISABLED and names
-//    the setting. It is not hidden — "disabled, here is how to enable it" is the
-//    same honesty the sidecar chose by registering the method unconditionally.
+//    Consequence, deliberate: with the flag off the button is DISABLED and the
+//    reason names the flag. It is not hidden — "disabled, and here is exactly what
+//    is off" is the same honesty the sidecar chose by registering the method
+//    unconditionally. What that reason must NOT do is imply an in-app switch: there
+//    is none (see the scope section below), and the first wording did, which is why
+//    `LIPSYNC_DISABLED_REASON` now says so outright.
 // 2. LIKENESS CONSENT (`lipsync.py:218-225`). `likenessConsentAttested` must be
 //    the literal `true`. `buildLipsyncParams` OMITS the key unless the user
 //    actually ticked the box — it is never synthesized, and the tick is cleared
@@ -41,23 +44,59 @@
 //    behavioural use-restrictions that must be passed downstream
 //    (`lipsync.py:23-30`), which is why each engine's licence is shown.
 //
-// ─── THE DISCLOSED RESIDUAL: WHY A RUN REFUSES TODAY ────────────────────────
-// `_tts.register(...)` (`handlers/composition.py:327-336`) passes NO
-// `lipsync_face_boxes_probe`, so `face_boxes_probe` is `None` in the real app and
-// `require_face_boxes` (`lipsync.py:239-254`, called at `:699`) RAISES inside the
-// job. A relip therefore refuses at job time today, naming S3FD.
+// ─── SCOPE OF THE CLAIM: THIS IS A CALL SITE, NOT A WORKING FEATURE ─────────
+// An earlier version of this header, and the lane report around it, said "both
+// RPCs now have real user entry points". For gaze that is true end to end; for
+// lip-sync it was WIDER THAN THE EVIDENCE and was refuted in review. What landed
+// here is the first CALLER of `tts.lipsync.start`. It is not an executable path in
+// any stock build, for two independent reasons, both measured:
 //
-// The panel states that BEFORE the user clicks (`data-section="unwired"`) instead
-// of letting them discover it by clicking. It deliberately does NOT hard-disable
-// the button on a client-side "wiring is incomplete" constant, for two reasons:
-//   * the renderer cannot OBSERVE whether the probe is wired — no RPC reports it —
-//     so such a constant would be an unverifiable claim baked into the UI; and
-//   * it would go stale in the WORST direction: the moment the sibling lane wires
-//     the probe, a hardcoded `false` would make the feature unreachable again,
-//     recreating the exact defect class this lane exists to fix.
-// So the UI reflects only what it can actually measure (`lipSyncEnabled`), states
-// the residual as text, and lets the sidecar's own typed refusal surface LOUDLY as
-// an alert. Fixing the sidecar wiring is out of this lane's scope.
+//   1. THE CONTROL IS DISABLED IN EVERY STOCK BUILD. `canStart` requires
+//      `enabled === true`, `lipSyncEnabled` defaults to `False`
+//      (`settings_store.py:178`), and NOTHING in `app/` ever writes it — a
+//      case-sensitive scan of `app/` for `lipSyncEnabled` finds only the generated
+//      type (`lib/rpc/generated/schemas.generated.ts:54`), this file, its test, and
+//      `ThirdPartyNotices.tsx` copy. Detector controlled: the same scan style finds
+//      real `settings.set` writes for user-settable keys (`App.tsx:308` `useCloud`,
+//      `Edit.tsx:117`, `DirectorPanel.tsx:267`), so the zero is a real absence.
+//      `LIPSYNC_NO_IN_APP_SETTER` is pinned by a test that re-runs that scan, so
+//      the copy cannot rot if a setter is ever added. This is by DESIGN, not an
+//      oversight: `docs/plans/v1.5/flagship-lip-sync-dub.md:151,177` files
+//      `lipSyncEnabled` as "(personal-only)" and says the commercial build's
+//      handler hard-refuses with the flag OFF.
+//   2. EVEN WITH THE FLAG FORCED ON, THE JOB REFUSES. `_tts.register(...)`
+//      (`handlers/composition.py:327-336`) passes no `lipsync_face_boxes_probe`, so
+//      `face_boxes_probe` is `None` and `require_face_boxes`
+//      (`lipsync.py:239-254`, called at `:699`) RAISES inside the job. Wiring that
+//      is the sibling sidecar lane's work — `handlers/composition.py` belongs to
+//      another live lane this wave and is deliberately untouched here.
+//
+// So: correctly scoped, W20 adds the call site, the four fail-closed gates and the
+// disclosure; it does NOT make lip-sync runnable. Do not read "reachable" as
+// "works".
+//
+// ─── HOW THE PANEL HANDLES THAT WITHOUT LYING IN EITHER DIRECTION ───────────
+// The pre-click notice (`data-section="unwired"`) states the RULE, which is true of
+// every build: a run needs YuNet face boxes from the sidecar and REFUSES without
+// them. It deliberately does not assert, as present-tense fact, that THIS build
+// has no provider — the renderer cannot observe that (no RPC reports it), and the
+// previous wording did assert it, which would have started telling every user a
+// working feature was broken the moment the sibling lane wired the probe. That is
+// the same "stale in the WORST direction" failure the lane used to justify not
+// hardcoding `false` on the button, so it is now avoided on both surfaces.
+//
+// What the renderer CAN measure is a refusal it has actually received. Once the
+// sidecar has answered with `require_face_boxes`'s own message
+// (`LIPSYNC_FACE_BOX_MARKER`), the control is disabled for the session and the
+// verbatim reason is shown: a build with no probe refuses EVERY run, so inviting a
+// second identical click would be the "button that is present but always errors"
+// shape. It is self-healing — when the probe is wired, that refusal never arrives
+// and nothing is disabled. UNVERIFIED: whether the transport preserves the
+// sidecar's message text byte-for-byte end to end in the packaged app (the unit
+// tests inject the message through the same `waitForJobDone` rejection path the
+// real bridge uses); settled by forcing `lipSyncEnabled` true in the per-user
+// settings.json of a packaged build, clicking Re-lip once, and reading whether
+// `[data-section="face-box-refused"]` appears.
 //
 // ─── AI DISCLOSURE: WHY `AiDisclosure.tsx` IS NOT CHANGED ───────────────────
 // Checked, not ignored. That module's model is AUDIO-TRACK-scoped:
@@ -131,21 +170,60 @@ export const LIPSYNC_CONSENT_TEXT =
   'I am the person on screen, or I hold their documented permission to alter ' +
   'their face in this video.';
 
-/** Shown when the build flag is off. Names the SETTING so it is actionable. */
+/**
+ * Shown when the build flag is off.
+ *
+ * REFUTED IN REVIEW, and the objection was right: the previous wording said "set
+ * the lipSyncEnabled setting to true to enable it", which named a setting the user
+ * has NO way to change — there is no settings UI for it anywhere in `app/` (see the
+ * header's measured scan, pinned by a test). The one actionable sentence in the
+ * panel was a dead end. It now says what is actually true: this is a personal-tier
+ * BUILD flag living in the sidecar's own per-user config file, not an in-app
+ * preference. The `lipSyncEnabled` key name stays, because it is what a user would
+ * have to search for and what the sidecar's own refusal names.
+ */
 export const LIPSYNC_DISABLED_REASON =
-  'Lip-sync is OFF in this build. It ships disabled: set the lipSyncEnabled ' +
-  'setting to true to enable it, and note that the engine weights are a separate ' +
-  'opt-in download with their own licence acceptance.';
+  'Lip-sync is OFF in this build, and there is no switch for it in this app: ' +
+  'lipSyncEnabled is a personal-tier build flag stored in the sidecar per-user ' +
+  'settings.json config file, not an app preference — a commercial build refuses ' +
+  'lip-sync outright. Turning it on there also means accepting a separate opt-in ' +
+  'download of the engine weights under their own licence.';
+
+/** The claim `LIPSYNC_DISABLED_REASON` makes about `app/`, pinned by a test. */
+export const LIPSYNC_NO_IN_APP_SETTER = 'there is no switch for it in this app';
 
 /**
- * The pre-click disclosure of the missing face-box provider. Rendered in BOTH flag
- * states, because it is a property of the BUILD, not of the setting.
+ * The pre-click disclosure, rendered in BOTH flag states.
+ *
+ * REFUTED IN REVIEW: this used to assert as present-tense fact that "no face-box
+ * provider is wired" in this build — a property of `handlers/composition.py` that
+ * the renderer cannot observe, and one that would invert into telling every user a
+ * working feature was broken the moment the sibling lane wires the probe. It now
+ * states the RULE, which holds for every build, and leaves the per-build verdict to
+ * `LIPSYNC_OBSERVED_REFUSAL_PREFIX`, which is only ever shown from a refusal the
+ * sidecar actually returned. It keeps naming S3FD, because WHY the refusal is
+ * correct is the part a user cannot infer.
  */
 export const LIPSYNC_UNWIRED_NOTICE =
-  'Known limitation in this build: no face-box provider is wired, so a run will ' +
-  'refuse instead of producing a video. That refusal is deliberate — letting the ' +
-  'engine detect faces itself would pull the S3FD weight, which ships under no ' +
-  'licence at all — but it means lip-sync cannot complete here yet.';
+  'Lip-sync runs only when the sidecar supplies face boxes from the vendored ' +
+  'MIT-licensed YuNet detector: letting the engine find faces itself would pull the ' +
+  'S3FD weight, which ships under no licence at all. A build with no face-box ' +
+  'provider wired therefore REFUSES the run instead of producing a video — that ' +
+  'refusal is deliberate, and if it happens the reason is shown here verbatim and ' +
+  'this control is disabled for the session.';
+
+/**
+ * The sidecar's own marker for the unwired-probe refusal (`require_face_boxes`,
+ * `lipsync.py:249-254`). A sidecar test asserts this exact substring is still in
+ * that message, so a reworded refusal cannot silently stop being detected.
+ */
+export const LIPSYNC_FACE_BOX_MARKER = 'no face-box provider is wired';
+
+/** Prefix for a refusal this session actually OBSERVED — never a prediction. */
+export const LIPSYNC_OBSERVED_REFUSAL_PREFIX =
+  'Measured on this build, not predicted: the sidecar refused the last run because ' +
+  'it has no face-box provider, and it will refuse every identical run, so the ' +
+  'control above is disabled until Reframe runs with one wired. Sidecar reason:';
 
 /** The synthetic-VIDEO disclosure. The C2PA half is imported, never restated. */
 export const LIPSYNC_AI_DISCLOSURE =
@@ -166,6 +244,19 @@ export interface LipSyncOutcome {
 
 function errText(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Did the sidecar just refuse because no face-box provider is wired?
+ *
+ * OBSERVED, never assumed. This is the one thing the renderer CAN establish about
+ * the sidecar's wiring, and only after a run has come back: the refusal is
+ * deterministic (`probe is None` cannot fix itself mid-session), so one is enough
+ * to stop offering the same click. A message that does not carry the marker is a
+ * different failure — transient, ffmpeg, cancel — and must NOT disable anything.
+ */
+export function isFaceBoxRefusal(message: string): boolean {
+  return message.includes(LIPSYNC_FACE_BOX_MARKER);
 }
 
 /**
@@ -277,6 +368,9 @@ export function LipSync({
   const [message, setMessage] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [outcome, setOutcome] = useState<LipSyncOutcome | null>(null);
+  // Empty until the sidecar has actually refused for the unwired probe. The
+  // renderer must not pre-judge a build it cannot inspect (see the header).
+  const [faceBoxRefusal, setFaceBoxRefusal] = useState<string>('');
 
   const dubs = useMemo(() => dubAudioTracks(audioTracks), [audioTracks]);
   // `engine` is only ever set from the <select> whose options ARE LIPSYNC_ENGINES,
@@ -316,7 +410,7 @@ export function LipSync({
     return off;
   }, [bridge, jobId]);
 
-  const canStart = enabled === true && trackId !== '' && consentAttested;
+  const canStart = enabled === true && trackId !== '' && consentAttested && faceBoxRefusal === '';
 
   const start = useCallback(async (): Promise<void> => {
     // Defensive: the button is disabled unless `canStart` and not already busy.
@@ -348,7 +442,11 @@ export function LipSync({
         setConsentAttested(false);
       }
     } catch (err) {
-      setError(errText(err));
+      const message = errText(err);
+      setError(message);
+      // Turn an observed, deterministic refusal into a disabled control carrying
+      // the sidecar's own words, rather than inviting an identical second click.
+      if (isFaceBoxRefusal(message)) setFaceBoxRefusal(message);
     } finally {
       setBusy(false);
       setJobId(null);
@@ -382,10 +480,17 @@ export function LipSync({
         </p>
       )}
 
-      {/* Stated in BOTH flag states: it is a property of the build, not the flag. */}
+      {/* The RULE, stated in BOTH flag states: it governs every build. */}
       <p className="lipsync-unwired" data-section="unwired" role="status">
         {LIPSYNC_UNWIRED_NOTICE}
       </p>
+
+      {/* ...and the per-build verdict, ONLY once the sidecar has actually said it. */}
+      {faceBoxRefusal !== '' && (
+        <p className="lipsync-refused" data-section="face-box-refused" role="status">
+          {LIPSYNC_OBSERVED_REFUSAL_PREFIX} {faceBoxRefusal}
+        </p>
+      )}
 
       <div className="dub-pickers">
         <label>

--- a/app/renderer/src/features/LipSync.tsx
+++ b/app/renderer/src/features/LipSync.tsx
@@ -173,6 +173,19 @@ function errText(err: unknown): string {
  * (`lipsync.lipsync_enabled`, `lipsync.py:197-205`). A truthy string or `1` is NOT
  * an opt-in: this flag guards a face-manipulation path, so a sloppy value reads as
  * OFF on both sides of the wire rather than only one.
+ *
+ * A TYPED accessor exists and is deliberately NOT used:
+ * `lib/rpc/generated/client.generated.ts` declares
+ * `settings.get(): Promise<Settings>` with `Settings.lipSyncEnabled: boolean`
+ * (`generated/schemas.generated.ts:54`). Two reasons to read `unknown` instead:
+ *   * that type is a COMPILE-TIME claim about a value that comes off DISK, and the
+ *     sidecar itself does not trust it — `lipsync_enabled` treats a truthy
+ *     non-`true` as OFF precisely because a settings store can hold a malformed
+ *     value. Consuming it as a declared `boolean` would make the renderer LESS
+ *     defensive than the backend guarding the same path, which is the wrong
+ *     direction for a safety gate;
+ *   * `clientGenerated` calls the non-injectable module-level `rpc()`, so it cannot
+ *     take the `api?` test bridge every panel in `features/` is built around.
  */
 export function lipSyncEnabledFrom(settings: unknown): boolean {
   return pickField<unknown>(settings, 'lipSyncEnabled') === true;

--- a/app/renderer/src/features/LipSync.tsx
+++ b/app/renderer/src/features/LipSync.tsx
@@ -87,11 +87,22 @@
 //
 // What the renderer CAN measure is a refusal it has actually received. Once the
 // sidecar has answered with `require_face_boxes`'s own message
-// (`LIPSYNC_FACE_BOX_MARKER`), the control is disabled for the session and the
-// verbatim reason is shown: a build with no probe refuses EVERY run, so inviting a
-// second identical click would be the "button that is present but always errors"
-// shape. It is self-healing — when the probe is wired, that refusal never arrives
-// and nothing is disabled. UNVERIFIED: whether the transport preserves the
+// (`LIPSYNC_FACE_BOX_MARKER`), the control is disabled FOR AS LONG AS THIS PANEL
+// STAYS MOUNTED and the verbatim reason is shown: a build with no probe refuses
+// EVERY run, so inviting a second identical click would be the "button that is
+// present but always errors" shape. It is self-healing — when the probe is wired,
+// that refusal never arrives and nothing is disabled.
+//
+// "…FOR THE SESSION" WAS AN OVERCLAIM, now corrected in the copy as well as here.
+// `faceBoxRefusal` is component state, and `Workspace.tsx:479-488` swaps the panel
+// type inside ONE `<Suspense>`, so leaving the Dub tab UNMOUNTS this section and
+// returning to it offers the guaranteed-failing click again. Measured, not reasoned
+// from React semantics: a test unmounts and remounts and asserts the refusal is
+// gone and the button enabled. A module-scoped latch WOULD make "session" true and
+// was rejected — it needs a test-only reset export in production code to stay
+// isolatable, and the honest cost of the panel-scoped version is one extra click
+// that shows the sidecar's own words again, not a wrong result.
+// UNVERIFIED: whether the transport preserves the
 // sidecar's message text byte-for-byte end to end in the packaged app (the unit
 // tests inject the message through the same `waitForJobDone` rejection path the
 // real bridge uses); settled by forcing `lipSyncEnabled` true in the per-user
@@ -112,7 +123,7 @@
 // Measured, and the reason the copy can claim it: `lipsync.py` contains zero
 // `metadata` occurrences, so its remux writes no marking into the output container
 // either — the same in-app-only limitation the audio badge already discloses.
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import './panels.css';
 import { C2PA_EXPORT_STATUS } from './AiDisclosure';
 import type { AudioTrack } from './Dub';
@@ -210,7 +221,7 @@ export const LIPSYNC_UNWIRED_NOTICE =
   'S3FD weight, which ships under no licence at all. A build with no face-box ' +
   'provider wired therefore REFUSES the run instead of producing a video — that ' +
   'refusal is deliberate, and if it happens the reason is shown here verbatim and ' +
-  'this control is disabled for the session.';
+  'this control is disabled until you reopen this panel.';
 
 /**
  * The sidecar's own marker for the unwired-probe refusal (`require_face_boxes`,
@@ -219,11 +230,22 @@ export const LIPSYNC_UNWIRED_NOTICE =
  */
 export const LIPSYNC_FACE_BOX_MARKER = 'no face-box provider is wired';
 
-/** Prefix for a refusal this session actually OBSERVED — never a prediction. */
+/**
+ * Prefix for a refusal actually OBSERVED — never a prediction.
+ *
+ * SCOPE CORRECTED: this used to say the control is "disabled until Reframe runs
+ * with one wired", which overstated how long the verdict is remembered. It lives in
+ * component state, so it is forgotten when this panel unmounts (measured: a
+ * remount test re-enables the button). The sentence now says exactly that, and adds
+ * the one fact a user needs to not read the re-offer as the feature having been
+ * fixed.
+ */
 export const LIPSYNC_OBSERVED_REFUSAL_PREFIX =
   'Measured on this build, not predicted: the sidecar refused the last run because ' +
   'it has no face-box provider, and it will refuse every identical run, so the ' +
-  'control above is disabled until Reframe runs with one wired. Sidecar reason:';
+  'control above is disabled until you reopen this panel. Reopening offers the click ' +
+  'again — this verdict is not remembered beyond the panel — and only a build with a ' +
+  'provider wired makes it succeed. Sidecar reason:';
 
 /** The synthetic-VIDEO disclosure. The C2PA half is imported, never restated. */
 export const LIPSYNC_AI_DISCLOSURE =
@@ -403,6 +425,56 @@ export function LipSync({
     if (trackId && !dubs.some((t) => t.id === trackId)) setTrackId('');
   }, [dubs, trackId]);
 
+  // ─── A NEW VIDEO IS A NEW CONSENT QUESTION ─────────────────────────────────
+  // `consentAttested` was cleared ONLY after a success, and nothing was keyed to
+  // `videoId`. `Dub.tsx:529` renders `<LipSync videoId={videoId} …>` unkeyed, `Dub`
+  // is mounted unkeyed (`Workspace.tsx:398-399`), and the App -> Edit -> Workspace
+  // chain above it is unkeyed too — so a video swapped IN PLACE
+  // (`App.tsx:332-353`'s `[]`-deps launch-restore, which calls `setEditVideo` after
+  // two RPC awaits) kept the tick. Measured on the wire before this fix:
+  //   {"videoId":"videoB","audioTrackId":"a-dub-1","engine":"latentsync",
+  //    "quality":"fast","likenessConsentAttested":true}
+  // The tick's own sentence is "I am the person ON SCREEN…", and the person on
+  // screen is precisely what a videoId change replaces.
+  //
+  // The comment in the consent fieldset below used to argue this section needed no
+  // invalidation because it "has no such field — the subject is whoever is on screen
+  // in `videoId`". That reasoning was right about the field and wrong about the
+  // conclusion: it treated `videoId` as fixed for the component's lifetime, which it
+  // is not. Recorded rather than deleted, because the same premise could be
+  // re-derived by the next reader.
+  //
+  // Shape (an effect, not `key=` at the mount site) and its trade-offs: see the
+  // matching block in `Gaze.tsx`. It applies with extra force here — this section's
+  // mount site is `Dub.tsx`, so a key at the Workspace panel site would not have
+  // reached it at all.
+  //
+  // RESET: the tick, and the picked dub TRACK — a dub belongs to the video it was
+  // generated from, so pairing video A's `audioTrackId` with video B's `videoId` is
+  // never right, and the stale-track effect above cannot catch it when the parent
+  // hands over the same list. Plus `outcome` and `error`, so video A's result and
+  // failure do not read as video B's.
+  // NOT RESET, deliberately, and both pinned by tests: `enabled` (the build flag is
+  // per machine, not per video) and `faceBoxRefusal` (a BUILD fact —
+  // `composition.py` passes no probe, which no video change can fix, so clearing it
+  // would re-offer a guaranteed-failing click on every switch). `engine`/`quality`
+  // are preferences with no consent meaning; `quality` doubles as the tests'
+  // detector control that a swap is a prop update and not a remount.
+  //
+  // The SIBLING consent gate in this same panel was audited and is NOT affected:
+  // `Dub.tsx`'s voice-clone tick attests to the person in the chosen SAMPLE FILE,
+  // and `buildSampleAddParams` (`Dub.tsx:65-77`) sends no `videoId` at all — the
+  // tick and its subject (`samplePath`) travel together, so a video change cannot
+  // put them out of step. Checked, not assumed to be fine.
+  const videoIdRef = useRef<string>(videoId);
+  useEffect(() => {
+    videoIdRef.current = videoId;
+    setConsentAttested(false);
+    setTrackId('');
+    setOutcome(null);
+    setError('');
+  }, [videoId]);
+
   useEffect(() => {
     if (!jobId) return;
     const off = bridge.onProgress((ev) => {
@@ -419,6 +491,16 @@ export function LipSync({
     // Defensive: the button is disabled unless `canStart` and not already busy.
     /* v8 ignore next */
     if (busy || !canStart) return;
+    // The video this relip belongs to, frozen at dispatch. `tts.lipsync.start` is a
+    // DEFERRED job, so the reset effect above can fire while we are still awaiting
+    // `job.done` — the reset runs FIRST and the old video's write lands AFTER it
+    // (the hole `origin/main` `4408e033` documents for the sibling panel). An id
+    // comparison, not a latch. Scoped honestly: the request carried video A's own
+    // videoId and a genuine attestation for A, so this prevents a false ATTRIBUTION
+    // onto B's panel, not a forged consent on the wire. The in-flight progress bar
+    // is deliberately NOT reset — see the `Gaze.tsx` note; keeping `busy` true is
+    // also what stops a second concurrent job.
+    const startedFor = videoId;
     setBusy(true);
     setError('');
     setOutcome(null);
@@ -435,20 +517,25 @@ export function LipSync({
       // the job-time face-box refusal reaches the user: as a loud alert carrying the
       // sidecar's own typed message, never as a silent no-op or an empty success.
       const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
-      const next = lipsyncOutcome(result);
+      const next = videoIdRef.current === startedFor ? lipsyncOutcome(result) : null;
       if (next) {
         setOutcome(next);
         setPct(100);
         setMessage('Done');
         // A fresh attestation per relip; kept on FAILURE so an unrelated retry does
-        // not force a re-attestation (same shape as `Dub.tsx` addSample).
+        // not force a re-attestation (same shape as `Dub.tsx` addSample), and
+        // cleared by the reset effect above when the VIDEO changes.
         setConsentAttested(false);
       }
     } catch (err) {
       const message = errText(err);
-      setError(message);
-      // Turn an observed, deterministic refusal into a disabled control carrying
-      // the sidecar's own words, rather than inviting an identical second click.
+      // Only the video that asked for the relip wears the blame for it…
+      if (videoIdRef.current === startedFor) setError(message);
+      // …but the face-box verdict is deliberately NOT scoped to that video. Turn an
+      // observed, deterministic refusal into a disabled control carrying the
+      // sidecar's own words, rather than inviting an identical second click. It is a
+      // property of how the sidecar was BUILT (`composition.py` passes no probe), so
+      // it holds for whichever video is on screen when the refusal arrives.
       if (isFaceBoxRefusal(message)) setFaceBoxRefusal(message);
     } finally {
       setBusy(false);
@@ -483,7 +570,17 @@ export function LipSync({
         </p>
       )}
 
-      {/* The RULE, stated in BOTH flag states: it governs every build. */}
+      {/* The RULE, stated in BOTH flag states: it governs every build.
+          RAISED IN REVIEW as an undisclosed cost — with the flag off (every stock
+          build) this puts two paragraphs of S3FD/YuNet licensing internals in front
+          of a user who cannot turn the feature on. KEPT UNCONDITIONAL, as a decision
+          rather than an accident, for two reasons: gating it on `enabled === true`
+          would require deleting a green assertion ("discloses the face-box rule in
+          BOTH flag states"), and the rule is the answer to the question the disabled
+          paragraph provokes — why a personal-tier build refuses at all. What the
+          notice must not do is state a per-BUILD verdict the renderer cannot observe;
+          that is `LIPSYNC_OBSERVED_REFUSAL_PREFIX`'s job and it fires only from a
+          refusal actually received. */}
       <p className="lipsync-unwired" data-section="unwired" role="status">
         {LIPSYNC_UNWIRED_NOTICE}
       </p>
@@ -578,14 +675,21 @@ export function LipSync({
         {/* No subject-rename invalidation here, unlike `Gaze.tsx`: that panel has a
             free-text subject LABEL the user can change under a ticked box, which is
             how a tick for 'Ana' could authorise a run against 'Bogdan'. This section
-            has no such field — the subject is whoever is on screen in `videoId`, the
-            component is bound to that one video, and changing the dub TRACK does not
-            change the person whose face is altered. The tick is still cleared after
-            every success, so it never covers a second run. */}
+            has no such field — the subject is whoever is on screen in `videoId`, and
+            changing the dub TRACK does not change the person whose face is altered.
+            REFUTED IN REVIEW: this used to add "the component is bound to that one
+            video", and conclude that no invalidation was needed. The component is
+            NOT bound to one video — `videoId` is a PROP that its unkeyed parents
+            swap in place — so the tick did carry across a video change. The reset
+            effect above is the fix; the wrong premise is recorded here rather than
+            deleted, because it is exactly what a later reader would re-derive. */}
         <p className="dub-consent-hint">
-          This attestation applies to THIS run only — it is not saved, so it can never authorise a
-          later run. A dub voiced by a stored voice CLONE needs that sample&apos;s own consent
-          record as well; the sidecar checks it independently and refuses without it.
+          This attestation applies to THIS run only — it is never saved. It is cleared after a
+          finished run and whenever a different video is opened here, so one tick can never
+          authorise a run against a different person. A FAILED run deliberately keeps it, so you can
+          retry the same request without re-attesting. A dub voiced by a stored voice CLONE needs
+          that sample&apos;s own consent record as well; the sidecar checks it independently and
+          refuses without it.
         </p>
       </fieldset>
 

--- a/app/renderer/src/features/LipSync.tsx
+++ b/app/renderer/src/features/LipSync.tsx
@@ -1,0 +1,514 @@
+// Lip-sync section of the Dub surface — re-lip the on-screen mouth to a finished
+// dub (W20).
+//
+// MEASURED GAP. `tts.lipsync.start` is registered UNCONDITIONALLY
+// (`sidecar/media_studio/features/tts/__init__.py:141`) and is frozen into the
+// authoritative method list, but it had NO caller anywhere. Measured on the host
+// tree: `Dub.tsx` was 519 lines with ZERO `lipSync`/`lipsync` references, and the
+// only renderer matches for "lipsync" were `AiDisclosure.tsx` and
+// `ThirdPartyNotices.tsx`, neither of which calls anything. It is registered
+// unconditionally and refuses at CALL time on the flag (`tts/__init__.py:23-28`),
+// so it was never flag-gated out of existence — it simply had no entry point.
+//
+// This is a SEPARATE component mounted inside the Dub panel rather than more code
+// in `Dub.tsx`: that file was already 519 lines and this section carries four
+// gates, three pickers and its own job lifecycle. It consumes the audio-track list
+// Dub has already fetched (`tracks.audio.list`), so it adds no duplicate RPC, and
+// it renders inside `.dub-panel` so the existing `.dub-consent` / `.dub-pickers`
+// styling applies without touching a stylesheet (another lane owns those).
+//
+// WIRE: tts.lipsync.start({videoId, audioTrackId, engine?, quality?,
+//                          likenessConsentAttested}) -> {jobId}
+//         -> job.done {path, engine, syncConfidence}
+//
+// ─── THE FOUR GATES, ALL FAIL CLOSED ────────────────────────────────────────
+// 1. BUILD FLAG (`lipsync.py:197-215`). `require_enabled` refuses unless the
+//    `lipSyncEnabled` setting is the LITERAL `true`; the default is `False`
+//    (`settings_store.py:178`). `lipSyncEnabledFrom` mirrors that literal-true rule
+//    exactly, so a truthy `'true'`/`1` reads as OFF here as it does there.
+//    Consequence, deliberate: with the flag off the button is DISABLED and names
+//    the setting. It is not hidden — "disabled, here is how to enable it" is the
+//    same honesty the sidecar chose by registering the method unconditionally.
+// 2. LIKENESS CONSENT (`lipsync.py:218-225`). `likenessConsentAttested` must be
+//    the literal `true`. `buildLipsyncParams` OMITS the key unless the user
+//    actually ticked the box — it is never synthesized, and the tick is cleared
+//    after a success so it cannot carry into a second run.
+// 3. THE TRACK MUST BE A DUB (`lipsync.py:672-677`). Re-lipping the mouth to the
+//    ORIGINAL audio is meaningless, so the picker offers `kind === 'dub'` only.
+// 4. ENGINE. `wav2lip` is permanently in `DENIED_ENGINES` because it genuinely
+//    forbids commercial use (`lipsync.py:120-126`), so it is not offerable at all.
+//    The two offered engines are OpenRAIL — commercial use IS permitted, but with
+//    behavioural use-restrictions that must be passed downstream
+//    (`lipsync.py:23-30`), which is why each engine's licence is shown.
+//
+// ─── THE DISCLOSED RESIDUAL: WHY A RUN REFUSES TODAY ────────────────────────
+// `_tts.register(...)` (`handlers/composition.py:327-336`) passes NO
+// `lipsync_face_boxes_probe`, so `face_boxes_probe` is `None` in the real app and
+// `require_face_boxes` (`lipsync.py:239-254`, called at `:699`) RAISES inside the
+// job. A relip therefore refuses at job time today, naming S3FD.
+//
+// The panel states that BEFORE the user clicks (`data-section="unwired"`) instead
+// of letting them discover it by clicking. It deliberately does NOT hard-disable
+// the button on a client-side "wiring is incomplete" constant, for two reasons:
+//   * the renderer cannot OBSERVE whether the probe is wired — no RPC reports it —
+//     so such a constant would be an unverifiable claim baked into the UI; and
+//   * it would go stale in the WORST direction: the moment the sibling lane wires
+//     the probe, a hardcoded `false` would make the feature unreachable again,
+//     recreating the exact defect class this lane exists to fix.
+// So the UI reflects only what it can actually measure (`lipSyncEnabled`), states
+// the residual as text, and lets the sidecar's own typed refusal surface LOUDLY as
+// an alert. Fixing the sidecar wiring is out of this lane's scope.
+//
+// ─── AI DISCLOSURE: WHY `AiDisclosure.tsx` IS NOT CHANGED ───────────────────
+// Checked, not ignored. That module's model is AUDIO-TRACK-scoped:
+// `isAiGeneratedAudioTrack(track)` keys off the A3 `AudioTrack.kind`, and
+// `AiDisclosurePanel`'s copy says "Audio produced here is synthesized, and every
+// dub track is marked…". A lip-synced output is a VIDEO FILE — it is never
+// registered as an `AudioTrack`, so it has no `kind` for that predicate to read and
+// no row in the track list to badge. Widening that panel's copy to cover video
+// would also change `ShortMakerControls.tsx`, its other consumer, which is outside
+// this lane. So the synthetic-VIDEO disclosure lives here, and the one fact that IS
+// shared — that no C2PA provenance manifest is written on export — is IMPORTED from
+// `C2PA_EXPORT_STATUS` rather than restated, so there is a single source for it.
+// Measured, and the reason the copy can claim it: `lipsync.py` contains zero
+// `metadata` occurrences, so its remux writes no marking into the output container
+// either — the same in-app-only limitation the audio badge already discloses.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import './panels.css';
+import { C2PA_EXPORT_STATUS } from './AiDisclosure';
+import type { AudioTrack } from './Dub';
+import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+
+/** One offerable re-lip engine and the licence facts the user must be told. */
+export interface LipSyncEngineOption {
+  id: string;
+  label: string;
+  /** The HUB tag on the WEIGHTS (`lipsync.py` ENGINES), not the code licence. */
+  weightsLicense: string;
+  notice: string;
+}
+
+/**
+ * The OpenRAIL obligation in user-facing words, mirroring `_OPENRAIL_NOTICE`
+ * (`lipsync.py:128-134`). Commercial use is permitted; the restrictions are
+ * behavioural and must be passed on.
+ */
+const OPENRAIL_OBLIGATION =
+  'Commercial use IS permitted, but the licence attaches behavioural ' +
+  'use-restrictions you must not breach and must pass on to anyone you give the ' +
+  'output or the model to. Re-lipping a real person without their consent is not ' +
+  'a use Reframe supports.';
+
+/**
+ * The engines this UI offers — exactly the keys of `lipsync.ENGINES`.
+ * `wav2lip` is ABSENT on purpose: it is in `DENIED_ENGINES` (`lipsync.py:120-126`)
+ * because its README forbids commercial use outright, and the sidecar raises a loud
+ * refusal for it. Not offering it means a typo cannot reach it either.
+ */
+export const LIPSYNC_ENGINES: readonly LipSyncEngineOption[] = [
+  {
+    id: 'latentsync',
+    label: 'LatentSync (ByteDance) — highest quality',
+    weightsLicense: 'openrail++',
+    notice: OPENRAIL_OBLIGATION,
+  },
+  {
+    id: 'musetalk',
+    label: 'MuseTalk (Tencent) — real-time capable',
+    weightsLicense: 'creativeml-openrail-m',
+    notice: OPENRAIL_OBLIGATION,
+  },
+];
+
+/** `lipsync.DEFAULT_ENGINE` (`lipsync.py:160`). */
+export const DEFAULT_LIPSYNC_ENGINE = 'latentsync';
+/** `lipsync.QUALITIES` / `DEFAULT_QUALITY` (`lipsync.py:165-166`). */
+export const LIPSYNC_QUALITIES: readonly string[] = ['fast', 'quality'];
+export const DEFAULT_LIPSYNC_QUALITY = 'quality';
+
+/** The exact attestation the user makes (higher bar than the dub's, by design). */
+export const LIPSYNC_CONSENT_TEXT =
+  'I am the person on screen, or I hold their documented permission to alter ' +
+  'their face in this video.';
+
+/** Shown when the build flag is off. Names the SETTING so it is actionable. */
+export const LIPSYNC_DISABLED_REASON =
+  'Lip-sync is OFF in this build. It ships disabled: set the lipSyncEnabled ' +
+  'setting to true to enable it, and note that the engine weights are a separate ' +
+  'opt-in download with their own licence acceptance.';
+
+/**
+ * The pre-click disclosure of the missing face-box provider. Rendered in BOTH flag
+ * states, because it is a property of the BUILD, not of the setting.
+ */
+export const LIPSYNC_UNWIRED_NOTICE =
+  'Known limitation in this build: no face-box provider is wired, so a run will ' +
+  'refuse instead of producing a video. That refusal is deliberate — letting the ' +
+  'engine detect faces itself would pull the S3FD weight, which ships under no ' +
+  'licence at all — but it means lip-sync cannot complete here yet.';
+
+/** The synthetic-VIDEO disclosure. The C2PA half is imported, never restated. */
+export const LIPSYNC_AI_DISCLOSURE =
+  'A re-lipped video is synthetic media: the mouth you see was generated, not ' +
+  'recorded. Reframe writes no marking into the output file — nothing about the ' +
+  'edit reaches the exported container.';
+
+/** The `job.done` payload of `tts.lipsync.start` (`lipsync.py:575`). */
+export interface LipSyncOutcome {
+  path: string;
+  /** The engine the sidecar reports it actually used; '' when it sent none. */
+  engine: string;
+  /** Null when the sidecar could not measure it — never a fabricated number. */
+  syncConfidence: number | null;
+}
+
+// --- pure helpers (exported for tests) -------------------------------------
+
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * The build flag, read with the sidecar's own literal-`true` rule
+ * (`lipsync.lipsync_enabled`, `lipsync.py:197-205`). A truthy string or `1` is NOT
+ * an opt-in: this flag guards a face-manipulation path, so a sloppy value reads as
+ * OFF on both sides of the wire rather than only one.
+ */
+export function lipSyncEnabledFrom(settings: unknown): boolean {
+  return pickField<unknown>(settings, 'lipSyncEnabled') === true;
+}
+
+/**
+ * The audio tracks that can be re-lipped: dubs only. `lipsync_start` rejects any
+ * other kind (`lipsync.py:672-677`) because re-lipping the mouth to the ORIGINAL
+ * recorded audio is meaningless, so offering one would be offering a guaranteed
+ * error.
+ */
+export function dubAudioTracks(tracks: readonly AudioTrack[]): AudioTrack[] {
+  return tracks.filter((t) => t.kind === 'dub');
+}
+
+/**
+ * Build the `tts.lipsync.start` params. `likenessConsentAttested` is present ONLY
+ * when the user genuinely ticked the box — never `false`-but-present, never
+ * synthesized.
+ */
+export function buildLipsyncParams(args: {
+  videoId: string;
+  audioTrackId: string;
+  engine: string;
+  quality: string;
+  consentAttested: boolean;
+}): Record<string, unknown> {
+  const params: Record<string, unknown> = {
+    videoId: args.videoId,
+    audioTrackId: args.audioTrackId,
+    engine: args.engine,
+    quality: args.quality,
+  };
+  if (args.consentAttested) params.likenessConsentAttested = true;
+  return params;
+}
+
+/**
+ * Read a `tts.lipsync.start` job.done result. Null without a usable `path`, so a
+ * shapeless payload renders nothing. A missing/malformed `syncConfidence` stays
+ * NULL and is displayed as "not measured" rather than as a number the sidecar
+ * never produced.
+ */
+export function lipsyncOutcome(result: unknown): LipSyncOutcome | null {
+  const path = pickField<string>(result, 'path');
+  if (typeof path !== 'string' || !path) return null;
+  const engine = pickField<unknown>(result, 'engine');
+  const confidence = pickField<unknown>(result, 'syncConfidence');
+  return {
+    path,
+    engine: typeof engine === 'string' ? engine : '',
+    syncConfidence: Number.isFinite(confidence) ? (confidence as number) : null,
+  };
+}
+
+export interface LipSyncProps {
+  videoId: string;
+  /** The A3 audio-track list Dub has already fetched (no duplicate RPC here). */
+  audioTracks: readonly AudioTrack[];
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+  /**
+   * The C2PA export status. Injectable for the same reason `AiDisclosurePanel`
+   * makes it injectable — the shipped constant is a hardcoded `available: false`,
+   * so without a seam the "available" wording could never be exercised, and an
+   * untested branch is where a future signing-identity change would silently break
+   * the disclosure. Defaults to the SHARED constant so production has one source.
+   */
+  c2pa?: typeof C2PA_EXPORT_STATUS;
+}
+
+export function LipSync({
+  videoId,
+  audioTracks,
+  api,
+  c2pa = C2PA_EXPORT_STATUS,
+}: LipSyncProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  // null while settings.get is in flight — the control is disabled until it answers.
+  const [enabled, setEnabled] = useState<boolean | null>(null);
+  const [trackId, setTrackId] = useState<string>('');
+  const [engine, setEngine] = useState<string>(DEFAULT_LIPSYNC_ENGINE);
+  const [quality, setQuality] = useState<string>(DEFAULT_LIPSYNC_QUALITY);
+  const [consentAttested, setConsentAttested] = useState<boolean>(false);
+  const [busy, setBusy] = useState<boolean>(false);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+  const [outcome, setOutcome] = useState<LipSyncOutcome | null>(null);
+
+  const dubs = useMemo(() => dubAudioTracks(audioTracks), [audioTracks]);
+  // `engine` is only ever set from the <select> whose options ARE LIPSYNC_ENGINES,
+  // so the fallback is defensive and unreachable from the UI.
+  const engineOption = useMemo(
+    /* v8 ignore next */
+    () => LIPSYNC_ENGINES.find((e) => e.id === engine) ?? LIPSYNC_ENGINES[0],
+    [engine],
+  );
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const settings = await bridge.rpc<unknown>('settings.get');
+        setEnabled(lipSyncEnabledFrom(settings));
+      } catch {
+        // FAIL CLOSED, exactly as `LipSyncService._settings` does for an unreadable
+        // store: lip-sync stays disabled rather than assuming it is on.
+        setEnabled(false);
+      }
+    })();
+  }, [bridge]);
+
+  // A dub track that vanishes from the list (e.g. tracks.audio.strip) must not stay
+  // selected, or the panel would dispatch a stale id the sidecar cannot resolve.
+  useEffect(() => {
+    if (trackId && !dubs.some((t) => t.id === trackId)) setTrackId('');
+  }, [dubs, trackId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  const canStart = enabled === true && trackId !== '' && consentAttested;
+
+  const start = useCallback(async (): Promise<void> => {
+    // Defensive: the button is disabled unless `canStart` and not already busy.
+    /* v8 ignore next */
+    if (busy || !canStart) return;
+    setBusy(true);
+    setError('');
+    setOutcome(null);
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      const res = await bridge.rpc<unknown>(
+        'tts.lipsync.start',
+        buildLipsyncParams({ videoId, audioTrackId: trackId, engine, quality, consentAttested }),
+      );
+      const id = extractJobId(res) ?? null;
+      setJobId(id);
+      // waitForJobDone REJECTS on an {error} job.done payload, which is exactly how
+      // the job-time face-box refusal reaches the user: as a loud alert carrying the
+      // sidecar's own typed message, never as a silent no-op or an empty success.
+      const result = id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
+      const next = lipsyncOutcome(result);
+      if (next) {
+        setOutcome(next);
+        setPct(100);
+        setMessage('Done');
+        // A fresh attestation per relip; kept on FAILURE so an unrelated retry does
+        // not force a re-attestation (same shape as `Dub.tsx` addSample).
+        setConsentAttested(false);
+      }
+    } catch (err) {
+      setError(errText(err));
+    } finally {
+      setBusy(false);
+      setJobId(null);
+    }
+  }, [bridge, busy, canStart, consentAttested, engine, quality, trackId, videoId]);
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // Defensive: Cancel renders only while `busy && jobId`.
+    /* v8 ignore next */
+    if (!jobId) return;
+    try {
+      await bridge.rpc('job.cancel', { jobId });
+    } catch {
+      // Best-effort — a failed cancel must not become a panel error.
+    }
+    setMessage('Cancelling…');
+  }, [bridge, jobId]);
+
+  return (
+    <section className="lipsync-section" aria-label="Lip-sync">
+      <h3>Lip-sync (re-lip the mouth to a dub)</h3>
+      <p className="dub-intro">
+        Re-generate the speaker&apos;s mouth so it matches a finished dub track instead of the
+        original language. This alters a real person&apos;s face, so it is gated separately from the
+        dub itself.
+      </p>
+
+      {enabled === false && (
+        <p className="lipsync-disabled" data-section="disabled" role="status">
+          {LIPSYNC_DISABLED_REASON}
+        </p>
+      )}
+
+      {/* Stated in BOTH flag states: it is a property of the build, not the flag. */}
+      <p className="lipsync-unwired" data-section="unwired" role="status">
+        {LIPSYNC_UNWIRED_NOTICE}
+      </p>
+
+      <div className="dub-pickers">
+        <label>
+          Dub track to match{' '}
+          <select
+            data-picker="lipsync-track"
+            value={trackId}
+            onChange={(e) => setTrackId(e.target.value)}
+            disabled={busy || dubs.length === 0}
+          >
+            <option value="">— pick a dub track —</option>
+            {dubs.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name} ({t.lang})
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Engine{' '}
+          <select
+            data-picker="lipsync-engine"
+            value={engine}
+            onChange={(e) => setEngine(e.target.value)}
+            disabled={busy}
+          >
+            {LIPSYNC_ENGINES.map((e) => (
+              <option key={e.id} value={e.id}>
+                {e.label}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label>
+          Quality{' '}
+          <select
+            data-picker="lipsync-quality"
+            value={quality}
+            onChange={(e) => setQuality(e.target.value)}
+            disabled={busy}
+          >
+            {LIPSYNC_QUALITIES.map((q) => (
+              <option key={q} value={q}>
+                {q}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {dubs.length === 0 && (
+        <p className="lipsync-no-dub" data-section="no-dub" role="status">
+          This video has no dub track yet. Lip-sync re-lips the mouth to a GENERATED dub, so make
+          one above first — the original recorded audio already matches the mouth.
+        </p>
+      )}
+
+      <p className="lipsync-licence" data-section="licence">
+        {engineOption.label} — weights licensed <code>{engineOption.weightsLicense}</code>.{' '}
+        {engineOption.notice}
+      </p>
+
+      <p className="lipsync-ai-disclosure" data-section="ai-disclosure">
+        {LIPSYNC_AI_DISCLOSURE} Content Credentials (C2PA) on export:{' '}
+        {c2pa.available ? 'Available' : `not available — ${c2pa.reason}`}
+      </p>
+
+      <fieldset className="dub-consent" data-testid="lipsync-consent-gate">
+        <legend>Face-alteration consent (required)</legend>
+        <label className="dub-consent-attest">
+          <input
+            data-input="lipsync-consent"
+            type="checkbox"
+            checked={consentAttested}
+            onChange={(e) => setConsentAttested(e.target.checked)}
+            disabled={busy}
+          />{' '}
+          {LIPSYNC_CONSENT_TEXT}
+        </label>
+        <p className="dub-consent-hint">
+          This attestation applies to THIS run only — it is not saved, so it can never authorise a
+          later run. A dub voiced by a stored voice CLONE needs that sample&apos;s own consent
+          record as well; the sidecar checks it independently and refuses without it.
+        </p>
+      </fieldset>
+
+      <div className="actions">
+        <button
+          type="button"
+          data-action="start-lipsync"
+          onClick={() => void start()}
+          disabled={busy || !canStart}
+        >
+          {busy ? 'Re-lipping…' : 'Re-lip to this dub'}
+        </button>
+        {busy && jobId && (
+          <button
+            type="button"
+            data-action="lipsync-cancel"
+            className="secondary"
+            onClick={() => void cancel()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {busy && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          {message && <span className="progress-message"> · {message}</span>}
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {outcome && (
+        <div className="output-done" data-section="lipsync-result">
+          <span className="output-done-label">Re-lipped file</span>
+          <code>{outcome.path}</code>
+          <span className="lipsync-confidence">
+            {' '}
+            engine {outcome.engine} · sync confidence{' '}
+            {outcome.syncConfidence === null ? 'not measured' : outcome.syncConfidence.toFixed(2)}
+          </span>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default LipSync;

--- a/app/renderer/src/features/LipSync.tsx
+++ b/app/renderer/src/features/LipSync.tsx
@@ -123,7 +123,7 @@
 // Measured, and the reason the copy can claim it: `lipsync.py` contains zero
 // `metadata` occurrences, so its remux writes no marking into the output container
 // either — the same in-app-only limitation the audio badge already discloses.
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import './panels.css';
 import { C2PA_EXPORT_STATUS } from './AiDisclosure';
 import type { AudioTrack } from './Dub';
@@ -466,8 +466,14 @@ export function LipSync({
   // and `buildSampleAddParams` (`Dub.tsx:65-77`) sends no `videoId` at all — the
   // tick and its subject (`samplePath`) travel together, so a video change cannot
   // put them out of step. Checked, not assumed to be fine.
+  // useLAYOUTEffect for the same reason as the Gaze reset (see the note there): a passive
+  // effect lets React paint the new videoId with the consent box still ticked, leaving a
+  // one-frame window in which a click sends `likenessConsentAttested: true` under the NEW
+  // video. Remote, but this is a face-alteration consent gate and the fix is one word.
+  // UNVERIFIED inline: indistinguishable under jsdom + `act()`, which flushes passive effects
+  // synchronously; settling experiment is in the Gaze note.
   const videoIdRef = useRef<string>(videoId);
-  useEffect(() => {
+  useLayoutEffect(() => {
     videoIdRef.current = videoId;
     setConsentAttested(false);
     setTrackId('');

--- a/app/renderer/src/features/LipSync.tsx
+++ b/app/renderer/src/features/LipSync.tsx
@@ -357,6 +357,9 @@ export function LipSync({
   const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
 
   // null while settings.get is in flight — the control is disabled until it answers.
+  // `canStart` therefore tests `enabled === true`, never `!== false`. That mutation
+  // SURVIVED an adversarial run (all 36 tests stayed green because nothing exercised
+  // the null window); "fails CLOSED while settings.get is still in flight" now kills it.
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [trackId, setTrackId] = useState<string>('');
   const [engine, setEngine] = useState<string>(DEFAULT_LIPSYNC_ENGINE);
@@ -572,6 +575,13 @@ export function LipSync({
           />{' '}
           {LIPSYNC_CONSENT_TEXT}
         </label>
+        {/* No subject-rename invalidation here, unlike `Gaze.tsx`: that panel has a
+            free-text subject LABEL the user can change under a ticked box, which is
+            how a tick for 'Ana' could authorise a run against 'Bogdan'. This section
+            has no such field — the subject is whoever is on screen in `videoId`, the
+            component is bound to that one video, and changing the dub TRACK does not
+            change the person whose face is altered. The tick is still cleared after
+            every success, so it never covers a second run. */}
         <p className="dub-consent-hint">
           This attestation applies to THIS run only — it is not saved, so it can never authorise a
           later run. A dub voiced by a stored voice CLONE needs that sample&apos;s own consent

--- a/app/renderer/src/features/ThirdPartyNotices.tsx
+++ b/app/renderer/src/features/ThirdPartyNotices.tsx
@@ -320,11 +320,21 @@ export const OPT_IN_MODEL_NOTICES: readonly OptInModelNotice[] = [
     useRestricted: true,
     attribution: '© Tencent Music Entertainment Lyra Lab (TMElyralab/MuseTalk)',
     source: 'https://huggingface.co/TMElyralab/MuseTalk',
+    // REFUTED IN REVIEW (W20): this sentence used to read "Reframe drives this
+    // engine with its own MIT YuNet face boxes", asserting a wiring that does not
+    // exist yet — `handlers/composition.py:327-336` passes no
+    // `lipsync_face_boxes_probe`, so nothing drives the engine at all today. The
+    // COMPLIANCE claim survives (in fact more strongly: the run refuses outright),
+    // but the mechanism claim was wider than the evidence, and it contradicted the
+    // lip-sync panel's own copy. Reworded to state the RULE, which is true in both
+    // wiring states: `require_face_boxes` (`lipsync.py:239-254`) either gets boxes
+    // from the vendored MIT YuNet detector or REFUSES — it never falls back.
     note:
       'Commercial use IS permitted under CreativeML OpenRAIL-M, subject to the same ' +
-      'Attachment A prohibited-use list and the same pass-through obligation. Reframe drives ' +
-      'this engine with its own MIT YuNet face boxes so the unlicensed S3FD detector bundled ' +
-      'with the upstream pipeline is never fetched or used.',
+      'Attachment A prohibited-use list and the same pass-through obligation. Reframe never lets ' +
+      'this engine find faces itself: it requires face boxes from its own MIT YuNet detector and ' +
+      'refuses the run outright when no provider is wired, so the unlicensed S3FD detector ' +
+      'bundled with the upstream pipeline is never fetched or used.',
   },
 ];
 

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -177,6 +177,65 @@ describe('Workspace ↔ Subtitles seam', () => {
   });
 });
 
+// ─── W19 / W20: the seam tests the lane's reachability claim actually needs ──
+// REFUTED IN REVIEW, twice and correctly: the lane offered
+// `Workspace.test.tsx`'s "renders the gaze panel for its tab" as "the actual
+// reachability test", but that file does `vi.mock('../features/Gaze', () =>
+// stubPanel('Gaze'))` — it mounts a STUB. It proves the TabBar + `renderPanel()`
+// switch and the props handed down; it cannot prove that
+// `lazy(() => import('../features/Gaze'))` resolves or that the real panel mounts.
+// That was resting on `tsc --noEmit`. These two cases close it in the file whose
+// whole purpose is real lazy panel mounts, so the claim is now executable rather
+// than narrowed away.
+describe('Workspace ↔ Gaze seam (W19)', () => {
+  it('mounts the REAL Gaze panel on the eye-contact tab', async () => {
+    await import('../features/Gaze'); // warm the lazy chunk (same idiom as above)
+    rpcMock.mockResolvedValue({ project });
+
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} initialTab="gaze" />);
+    });
+    await flush();
+
+    // The real panel, not the Suspense fallback and not a marker div: its own
+    // section class plus the ethics gate that only the real component renders.
+    expect(container.querySelector('.gaze-panel')).not.toBeNull();
+    expect(container.querySelector('[data-testid="gaze-consent"]')).not.toBeNull();
+    expect(container.querySelector('[data-input="likeness-attest"]')).not.toBeNull();
+    // Fail-closed on this scaffold: the fake bridge answers `gaze.probe` with `{}`,
+    // so the panel treats the model as unavailable and the Run button stays shut.
+    // That IS the shipped behaviour for a machine without the YuNet asset.
+    expect((container.querySelector('[data-action="run"]') as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+});
+
+describe('Workspace ↔ Dub/LipSync seam (W20)', () => {
+  it('mounts the REAL lip-sync section inside the Dub tab, disabled by default', async () => {
+    await import('../features/Dub'); // Dub hosts the LipSync section
+    rpcMock.mockResolvedValue({ project });
+
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} initialTab="dub" />);
+    });
+    await flush();
+
+    // The reachability half that IS true for W20: the control exists on a surface a
+    // user can open. It is DISABLED here — the fake bridge answers `settings.get`
+    // with `{}`, so `lipSyncEnabled` is not the literal true, exactly as every stock
+    // build behaves. See the LipSync header: this is a call site, not a runnable
+    // feature, and this test pins that distinction rather than papering over it.
+    expect(container.querySelector('.lipsync-section')).not.toBeNull();
+    const start = container.querySelector('[data-action="start-lipsync"]') as HTMLButtonElement;
+    expect(start).not.toBeNull();
+    expect(start.disabled).toBe(true);
+    expect(container.querySelector('[data-section="disabled"]')?.textContent).toContain(
+      'lipSyncEnabled',
+    );
+  });
+});
+
 describe('Workspace ↔ Speed seam', () => {
   it('mounts the REAL Speed panel on the speed tab, threaded with the video duration', async () => {
     // The point of this test: before v1.5 the re-time engine had no control in

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -264,13 +264,35 @@ describe('Workspace', () => {
   // correction is a normal editing op, not an advanced/deliver one, so it must be
   // in a VISIBLE cluster: burying an ethics-gated control makes the gate harder to
   // find, which is the opposite of the point.
-  it('puts Eye contact in the VISIBLE "Frame & Cut" cluster, not behind Advanced', () => {
+  it('puts Eye contact in the VISIBLE "Frame & Cut" cluster, not behind Advanced', async () => {
     const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
     expect(frame?.tabIds).toContain('gaze');
     expect(frame?.advanced).not.toBe(true);
     // and in no other cluster (exactly-once membership across the strip)
     const owners = WORKSPACE_TAB_GROUPS.filter((g) => g.tabIds.includes('gaze'));
     expect(owners).toHaveLength(1);
+
+    // A SECOND, mechanically different signal: the config array above is a claim
+    // about intent; this reads the rendered DOM. The `gaze` tab must sit OUTSIDE
+    // `.tabbar__advanced-panel` (the container the disclosure hides), which is what
+    // "painted by default" actually means. jsdom does not compute visibility, so DOM
+    // POSITION is the strongest check available at this level — the true pixel check
+    // is `.tab:visible` in the nightly `app/e2e/preview.spec.ts`.
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} />);
+    });
+    await flush();
+    const gazeTab = container.querySelector('[role="tab"][data-tab-id="gaze"]');
+    expect(gazeTab).not.toBeNull();
+    expect(gazeTab?.closest('.tabbar__advanced-panel')).toBeNull();
+    // Control for that assertion: a tab that IS behind the disclosure must be found
+    // inside it, otherwise the `.closest()` selector could be silently wrong and the
+    // check above would pass for every tab.
+    expect(
+      container
+        .querySelector('[role="tab"][data-tab-id="tracks"]')
+        ?.closest('.tabbar__advanced-panel'),
+    ).not.toBeNull();
   });
 
   it('puts Speed in the Frame & Cut group and selects it from a deep-link', async () => {

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -88,6 +88,15 @@ vi.mock('../features/ReframeCorrect', () => stubPanel('ReframeCorrect'));
 // W19: eye-contact correction. `gaze.probe` + `gaze.run` were registered and
 // frozen into the RPC surface but had NO renderer caller at all (0 hits for
 // `gaze`, case-insensitive, under app/renderer); this tab is the entry point.
+//
+// SCOPE OF THAT CLAIM, narrowed after review: this is a STUB, like every other
+// panel here. The `it.each` case below therefore proves the TabBar + `renderPanel()`
+// switch and the props handed down — NOT that
+// `lazy(() => import('../features/Gaze'))` resolves or that the real panel mounts.
+// The lane originally offered it as "the actual reachability test", which was wider
+// than the evidence. The real lazy mount is asserted in `Workspace.seam.test.tsx`
+// ("Workspace ↔ Gaze seam"), which drains macrotasks and renders the REAL panel;
+// that case goes red if `case 'gaze'` is removed from `renderPanel` (measured).
 vi.mock('../features/Gaze', () => stubPanel('Gaze'));
 
 import {

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -85,6 +85,10 @@ vi.mock('../features/SemanticSearch', () => stubPanel('SemanticSearch'));
 // W17 / W18: the two surfaces this lane mounts.
 vi.mock('../features/VideoTimeline', () => stubPanel('VideoTimeline'));
 vi.mock('../features/ReframeCorrect', () => stubPanel('ReframeCorrect'));
+// W19: eye-contact correction. `gaze.probe` + `gaze.run` were registered and
+// frozen into the RPC surface but had NO renderer caller at all (0 hits for
+// `gaze`, case-insensitive, under app/renderer); this tab is the entry point.
+vi.mock('../features/Gaze', () => stubPanel('Gaze'));
 
 import {
   Workspace,
@@ -175,9 +179,16 @@ describe('Workspace', () => {
   // was reachable by any user. WIDENED by exactly two entries, never weakened —
   // every previously pinned label keeps its position relative to the others.
   //
-  // The assertion remains exact and order-sensitive, five elements longer than
+  // SCOPE CHANGE #5 (W19 gaze-entrypoint): the list gains 'Eye contact'. It sits
+  // immediately after 'Stabilize' because it is the same KIND of operation — a
+  // whole-clip, token-free, local image correction that writes a new file and
+  // never touches the source — and because `stabilize` is the de-facto neighbour
+  // for "polish the footage" ops in the Frame & Cut cluster. WIDENED by exactly
+  // one entry, never weakened.
+  //
+  // The assertion remains exact and order-sensitive, six elements longer than
   // the pre-v1.5 list and with two labels corrected. Nothing was weakened.
-  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes; expose-engines: +Stabilize; speed: +Speed; audiomix-ui: +Audio mix; W17/W18: +Fix framing/Video timeline)', () => {
+  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes; expose-engines: +Stabilize; speed: +Speed; audiomix-ui: +Audio mix; W17/W18: +Fix framing/Video timeline; W19: +Eye contact)', () => {
     expect(WORKSPACE_TABS.map((t) => t.label)).toEqual([
       'Transcribe',
       'Search',
@@ -192,6 +203,9 @@ describe('Workspace', () => {
       'Subtitle timeline',
       'Video timeline',
       'Stabilize',
+      // W19: eye-contact correction. Before it, gaze.probe/gaze.run had no caller
+      // anywhere in the renderer, so the whole feature was user-unreachable.
+      'Eye contact',
       // v1.5: the Speed panel joins "Frame & Cut". Before it, the re-time engine
       // had NO control in any panel — only an LLM-planned Director op reached it.
       'Speed',
@@ -241,6 +255,22 @@ describe('Workspace', () => {
     const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
     expect(frame?.tabIds).toContain('stabilize');
     expect(frame?.advanced).not.toBe(true);
+  });
+
+  // W19. A tab id present in WORKSPACE_TABS but absent from every GROUP would not
+  // paint at all (TabBar renders from the groups when `groups` is passed), and the
+  // "every id stays in the tablist" test below would catch that — but not the
+  // weaker failure of parking it behind the Advanced disclosure. Eye-contact
+  // correction is a normal editing op, not an advanced/deliver one, so it must be
+  // in a VISIBLE cluster: burying an ethics-gated control makes the gate harder to
+  // find, which is the opposite of the point.
+  it('puts Eye contact in the VISIBLE "Frame & Cut" cluster, not behind Advanced', () => {
+    const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
+    expect(frame?.tabIds).toContain('gaze');
+    expect(frame?.advanced).not.toBe(true);
+    // and in no other cluster (exactly-once membership across the strip)
+    const owners = WORKSPACE_TAB_GROUPS.filter((g) => g.tabIds.includes('gaze'));
+    expect(owners).toHaveLength(1);
   });
 
   it('puts Speed in the Frame & Cut group and selects it from a deep-link', async () => {
@@ -399,6 +429,7 @@ describe('Workspace', () => {
     ['timeline', 'Timeline'],
     ['videoTimeline', 'VideoTimeline'],
     ['stabilize', 'Stabilize'],
+    ['gaze', 'Gaze'],
     ['dub', 'Dub'],
     ['nle', 'NleExport'],
     ['recipes', 'Recipes'],
@@ -741,15 +772,22 @@ describe('Workspace tab clusters (WU-3a2)', () => {
   // auto`) — and it is the price of the panels being reachable at all. The
   // matching literals in `app/e2e/preview.spec.ts:229-230` were updated in the
   // same commit; that is the whole point of this test existing.
+  //
+  // W19 UPDATE: 19 -> 20 and 14 -> 15. The new `gaze` tab goes in the VISIBLE
+  // "Frame & Cut" cluster for the reason given by its own test above, so both
+  // counts move. The matching literals in `app/e2e/preview.spec.ts` were updated
+  // in the SAME commit — that file is owned by another live lane this wave, so the
+  // edit there is confined to the two count literals and the sentences that state
+  // them, nothing else.
   it('pins the strip counts that the nightly e2e spec hardcodes', () => {
-    expect(WORKSPACE_TABS).toHaveLength(19);
+    expect(WORKSPACE_TABS).toHaveLength(20);
     const hiddenWhenCollapsed = WORKSPACE_TAB_GROUPS.filter((g) => g.advanced).reduce(
       (n, g) => n + g.tabIds.length,
       0,
     );
     expect(hiddenWhenCollapsed).toBe(5);
     // What actually paints while the Advanced cluster is collapsed.
-    expect(WORKSPACE_TABS.length - hiddenWhenCollapsed).toBe(14);
+    expect(WORKSPACE_TABS.length - hiddenWhenCollapsed).toBe(15);
   });
 
   it('collapses the Deliver cluster behind Advanced by default and toggles it open/closed', async () => {

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -65,6 +65,11 @@ const VideoTimeline = lazy(() => import('../features/VideoTimeline'));
 // W17: manual per-shot reframe correction (panels/ReframeOverridePanel), wrapped
 // by the container that finds a clip and loads its persisted decision plan.
 const ReframeCorrect = lazy(() => import('../features/ReframeCorrect'));
+// W19: eye-contact correction. `gaze.probe` + `gaze.run` were registered
+// (`features/gaze.py:699-700`) and frozen into the RPC surface, but `gaze` appeared
+// ZERO times, case-insensitively, anywhere under `app/renderer` — so the entire
+// feature, ethics gate included, was unreachable by any user. This mounts it.
+const Gaze = lazy(() => import('../features/Gaze'));
 
 /**
  * v1.5 timeline-naming — two LABELS name their real subject. Ids are untouched
@@ -108,6 +113,12 @@ export const WORKSPACE_TABS: TabDef[] = [
   // W18: the real video timeline (see the reconciliation note above).
   { id: 'videoTimeline', label: 'Video timeline' },
   { id: 'stabilize', label: 'Stabilize' },
+  // W19: eye-contact correction sits next to Stabilize because it is the same KIND
+  // of operation — a whole-clip, token-free, fully local image correction that
+  // writes a NEW file and never rewrites the source. It is NOT filed under
+  // "Advanced": it carries a likeness-attestation ethics gate, and burying that
+  // gate behind a disclosure would make the consent surface harder to find.
+  { id: 'gaze', label: 'Eye contact' },
   // v1.5: constant-factor speed / slow motion. The re-time ENGINE was already
   // wired for the Director, but nothing in the renderer could reach it, so a
   // user had to prompt the planner and hope. This is the direct control.
@@ -140,7 +151,11 @@ export const WORKSPACE_TAB_GROUPS: TabGroup[] = [
     // `overflow-x: auto`), a real cost accepted deliberately: burying a
     // correction surface behind the Advanced disclosure would leave a wrong
     // auto-crop effectively uncorrectable, which is the defect being fixed.
-    tabIds: ['shortmaker', 'reframeFix', 'timeline', 'videoTimeline', 'stabilize', 'speed'],
+    //
+    // W19: 'gaze' joins the same VISIBLE cluster, taking the painted strip to 15
+    // for the same reason — plus one specific to it: the panel IS the likeness
+    // consent gate, so it must be findable, not filed under Advanced.
+    tabIds: ['shortmaker', 'reframeFix', 'timeline', 'videoTimeline', 'stabilize', 'gaze', 'speed'],
   },
   { id: 'audio', label: 'Audio', tabIds: ['dub', 'audiomix'] },
   {
@@ -370,6 +385,12 @@ export function Workspace({
         );
       case 'stabilize':
         return <Stabilize videoId={video.id} />;
+      case 'gaze':
+        // No extra props: `gaze.run` accepts only {videoId|path, strength,
+        // likeness*} (`gaze.py:619-637`), and the panel owns the strength control
+        // plus the likeness attestation itself. Passing a duration/path here would
+        // imply per-run inputs the RPC does not take.
+        return <Gaze videoId={video.id} />;
       case 'speed':
         // durationSec drives the before/after prediction only; the sidecar
         // probes the real length itself, so a stale/zero value cannot mis-render.

--- a/sidecar/tests/test_tts_lipsync.py
+++ b/sidecar/tests/test_tts_lipsync.py
@@ -947,6 +947,21 @@ class TestLicenceDriftGuard:
         # sidecar module exists to correct.
         assert "Commercial use IS permitted" in source
 
+    def test_the_panel_face_box_marker_matches_the_sidecar_refusal(self):
+        """The renderer DISABLES its control on this marker; both sides must agree.
+
+        `features/LipSync.tsx` reflects an OBSERVED refusal — once the sidecar has
+        said "no face-box provider is wired" it stops offering the click. That is
+        the only honest way for the renderer to know this build's wiring, and it
+        keys off the sidecar's own message text, so a reword on either side would
+        silently stop the detection. Pin both directions.
+        """
+        with pytest.raises(ls.LipSyncError) as excinfo:
+            ls.require_face_boxes(None, "clip.mp4")
+        marker = "no face-box provider is wired"
+        assert marker in str(excinfo.value)
+        assert f"LIPSYNC_FACE_BOX_MARKER = '{marker}'" in _PANEL_TSX.read_text(encoding="utf-8")
+
     def test_the_prose_normaliser_can_find_a_known_present_clause(self):
         # DETECTOR CONTROL for the test above. `_tsx_prose` exists because a
         # user-facing sentence in a .tsx file is written as several string literals

--- a/sidecar/tests/test_tts_lipsync.py
+++ b/sidecar/tests/test_tts_lipsync.py
@@ -25,6 +25,7 @@ the real SyncNet/LSE-C measurement is the separate opt-in ``@e2e`` gate.
 from __future__ import annotations
 
 import json
+import re
 import sys
 import threading
 from pathlib import Path
@@ -845,17 +846,39 @@ class TestSettingParity:
 # --------------------------------------------------------------------------- #
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _NOTICES_TSX = _REPO_ROOT / "app" / "renderer" / "src" / "features" / "ThirdPartyNotices.tsx"
+_PANEL_TSX = _REPO_ROOT / "app" / "renderer" / "src" / "features" / "LipSync.tsx"
 _LICENSES_DOC = _REPO_ROOT / "docs/THIRD-PARTY-LICENSES.md"  # ssot-allow: this IS the path, joined for the gate's r5
 
 
+def _tsx_prose(path: Path) -> str:
+    """A .tsx file's user-facing sentences, with concat seams closed up.
+
+    A long sentence in a .tsx file is written as several quoted literals joined
+    with ``+`` across lines, so a raw substring search for the sentence reports a
+    FALSE ABSENCE. This rejoins ``' + '`` seams and collapses whitespace so a
+    clause can be searched as the user reads it. Controlled by
+    ``test_the_prose_normaliser_can_find_a_known_present_clause``.
+    """
+    return " ".join(re.sub(r"'\s*\+\s*'", "", path.read_text(encoding="utf-8")).split())
+
+
 class TestLicenceDriftGuard:
-    """The same licence fact lives in three files. Assert it agrees in all three.
+    """The same licence fact lives in FOUR files. Assert it agrees in all four.
 
     A licence claim is precisely the kind of duplicated fact that must not drift:
-    the engine registry decides what runs, the notices component is what the user
-    is shown, and the licences doc is where the pass-through obligation is
-    recorded. A silent disagreement between them is a misrepresentation, so this
-    reads the other two files rather than trusting a comment to keep them in step.
+    the engine registry decides what runs, the notices component is the reference
+    list the user can browse, the licences doc is where the pass-through
+    obligation is recorded, and ``features/LipSync.tsx`` shows it AT THE POINT OF
+    USE (the panel where the user clicks "Re-lip to this dub"). A silent
+    disagreement between them is a misrepresentation, so this reads the other
+    three files rather than trusting a comment to keep them in step.
+
+    W19/W20 UPDATE — this guard was written for THREE files and an adversarial
+    review caught the gap: the new panel introduced a fourth copy of the same
+    facts (weights licence, engine label, the OpenRAIL pass-on obligation) that
+    the guard did not read, so its own premise had gone stale. The panel copy is
+    the one a user actually reads before consenting, which makes it the worst
+    place for a drifted licence, not the most forgivable.
     """
 
     def test_the_renderer_notice_quotes_the_same_weights_licences(self):
@@ -890,6 +913,50 @@ class TestLicenceDriftGuard:
 
     def test_the_setting_name_is_the_same_string_in_the_ui_and_the_gate(self):
         assert f"gatedBy: '{ls.SETTING_ENABLED}'" in _NOTICES_TSX.read_text(encoding="utf-8")
+
+    def test_the_lipsync_PANEL_quotes_the_same_engines_labels_and_licences(self):
+        # The panel is the FOURTH copy and the one shown at the point of consent.
+        # Field-shaped assertions (`id: '...'`, not a bare substring) so a mention
+        # in a comment cannot satisfy the gate — the use-vs-mention discipline.
+        source = _PANEL_TSX.read_text(encoding="utf-8")
+        for spec in ls.ENGINES.values():
+            assert f"id: '{spec.id}'" in source, f"{spec.id}: the lip-sync panel does not offer this engine"
+            assert f"label: '{spec.label}'" in source, f"{spec.id}: the panel's label has drifted from ENGINES"
+            assert f"weightsLicense: '{spec.weights_license}'" in source, (
+                f"{spec.id}: the panel does not carry weights licence {spec.weights_license!r}"
+            )
+
+    def test_the_lipsync_PANEL_never_offers_a_denied_engine(self):
+        # `wav2lip` is genuinely non-commercial and permanently denied. It IS named
+        # in the panel's comments (explaining the absence), so the assertion is on
+        # the offered FIELD, never on the document.
+        source = _PANEL_TSX.read_text(encoding="utf-8")
+        for denied in ls.DENIED_ENGINES:
+            assert f"id: '{denied}'" not in source, f"{denied} is DENIED but the panel offers it"
+
+    def test_the_panel_carries_the_openrail_pass_on_obligation_verbatim(self):
+        # The obligation is the half of an OpenRAIL licence an attribution block
+        # does NOT discharge: it binds the USER and must be passed downstream. The
+        # panel rewords the sentence around it for a user reading it mid-task, so
+        # only the load-bearing clause is pinned verbatim in both files.
+        clause = "must pass on to anyone you give the output or the model to"
+        assert clause in ls._OPENRAIL_NOTICE
+        source = _tsx_prose(_PANEL_TSX)
+        assert clause in source
+        # ...and it must not be softened into the "non-commercial" misreading the
+        # sidecar module exists to correct.
+        assert "Commercial use IS permitted" in source
+
+    def test_the_prose_normaliser_can_find_a_known_present_clause(self):
+        # DETECTOR CONTROL for the test above. `_tsx_prose` exists because a
+        # user-facing sentence in a .tsx file is written as several string literals
+        # joined with `+` across lines, so a raw substring search reports a FALSE
+        # ABSENCE — measured: the first draft of that assertion failed against a
+        # panel that carries the clause. Prove the reassembly works on a literal
+        # that IS split, and that the raw source does NOT contain it.
+        clause = "must pass on to anyone you give the output or the model to"
+        assert clause not in _PANEL_TSX.read_text(encoding="utf-8")
+        assert clause in _tsx_prose(_PANEL_TSX)
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Two registered RPCs that no user could reach

Measured against the frozen method list (`sidecar/tests/test_handlers_rpc_surface.py`):
`gaze.probe` / `gaze.run` and `tts.lipsync.start` were all registered and frozen, while `gaze`
matched **zero** files under `app/renderer` (detector control: 9 files under `sidecar/`, so the
zero was real). `WIRING-gaze.md:172` already presupposed *"so the UI can disable the control"* —
there was no control.

This adds `features/Gaze.tsx` ("Eye Contact", mounted as a tab in the visible Frame & Cut cluster)
and `features/LipSync.tsx` (mounted inside the Dub panel).

## READ THIS BEFORE BELIEVING THE TITLE: the two halves are NOT equally real

| | gaze (W19) | lip-sync (W20) |
|---|---|---|
| entry point exists | yes | yes |
| **runs in a stock build** | **yes** | **NO** |

`_gaze.register(...)` is wired in production (`handlers/composition.py:459-464`, YuNet resolved via
`resolve_yunet_model_path`), so W19 genuinely runs.

**`tts.lipsync.start` cannot run in any stock build, for two independent measured reasons:**
1. `canStart` requires `enabled === true`; `lipSyncEnabled` defaults to `False`
   (`settings_store.py:178`) and **nothing in `app/` ever writes it** — by design, the flagship doc
   files it as "(personal-only)".
2. Even with the flag forced on, `_tts.register(...)` (`handlers/composition.py:328-337`) passes
   **none** of `lipsync_face_boxes_probe`, `lipsync_backend_factory`, `lipsync_confidence_probe`, so
   `require_face_boxes(None, …)` raises unconditionally.

So W20 lands **the call site, four fail-closed gates and the disclosure — not a working feature.**
An earlier version of the lane's own header said "both RPCs now have real user entry points"; that
was wider than the evidence, was refuted in review, and is corrected in-file. Do not read
"reachable" as "works".

## A BLOCKING ethics defect was found after the lane and all three refuters passed it

The fresh skeptic caught what the diff-focused refuters did not: **the likeness attestation was not
keyed to `videoId`.** The lane had closed the subject-RENAME door but nothing invalidated the tick
when the VIDEO changed. Measured, the leaked payload was:

```
{"videoId":"videoB","likenessSubject":"Ana","strength":0.4,"likenessAttested":true}
```

A tick taken against video A authorising alteration of video B — which `likeness.py:156-157` then
stamps into the job audit trail as though the operator had given it. And the shipped copy asserted
an absolute that was false: *"it can never authorise a later run or a different person."*

### The fix, and why the shape matters
A `useEffect` keyed to `videoId` in each panel, **not** `key={video.id}` at the mount site. The
decisive reason: **`LipSync` is mounted by `Dub.tsx:529`, not the Workspace**, so a key at the
Workspace panel site would not have covered it at all. It also matches the repo's own merged shape
for this class (`4408e033`, the ShortMaker mid-flight-switch fix).

A reset alone is insufficient — both RPCs are deferred, so the reset runs first and the old video's
write lands after it. `const startedFor = videoId` plus a `videoIdRef` gates the settle-time writes.
Scoped honestly: this stops a false **attribution** of A's consent record onto B's panel, not a
forged consent on the wire.

Then a further **one-frame window** was closed on top: the reset was a *passive* effect, so React
could paint the new videoId with the box still ticked. Rated remote (1-20%) and non-blocking by the
skeptic — closed anyway with `useLayoutEffect`, because "probably unreachable" is not a property to
rest a face-alteration gate on when the fix is one word. Tagged UNVERIFIED inline: jsdom + `act()`
flushes passive effects synchronously, so no test here can distinguish the two.

### Verification
**44 mutants killed** — 26 from the fix author, **18 authored independently by the skeptic**, which
also mutated its own detector controls to prove they can fail. Both-states reproduced against the
pre-fix blob: `15 RED` before, `98 passed` after. Test diffs are pure additions (`grep '^-'` returns
zero lines), so "no assertion weakened" is mechanically true.

Earlier in the lane a mutation **survived** and exposed that an availability test was actually
measuring the consent gate; that was fixed and the correction applied preventatively to the sibling.

## Copy corrections — three absolutes narrowed, none widened
The false "can never authorise… a different person" is gone. Its replacement names the three real
triggers **and discloses a carve-out the old text hid**: a FAILED run deliberately keeps the tick so
you can retry without re-attesting. Also corrected: "disabled for the session" (it is panel-scoped —
leaving the tab remounts and re-offers the click; pinned by an executed unmount/remount test).

## Residuals — disclosed, non-blocking
* **No CSS for 22 new class names.** New work, not inherited: `panels.css` is untouched by this
  branch and no `.gaze-`/`.lipsync-` selector exists in any renderer stylesheet. Partial mitigation
  measured: both panels sit inside `feature-panel`, so shell button/input/focus-ring rules apply;
  what is missing is every panel-specific rule.
* **Gaze output quality is unmeasured by anyone** — no runtime, no video, no YuNet asset exercised.
  This is a live question precisely *because* gaze actually runs.
* `sidecar/tests/test_tts_lipsync.py` (+87/-5, docstrings only among the deletions) is test-only and
  re-run independently at 109 passed. Cross-lane overlap with the live W22 branch was checked and
  measured **zero** — W22 touches `composition.py` and `reframe_*`, not this file.
* `sast`/opengrep NOT RUN — absent on this box. Stand-in semgrep over the repo's own 9 rules → 0
  findings, detector-controlled against synthetic positives.

## Gates
`tsc --noEmit` 0 · `vitest run --coverage` **244 files / 4672 tests / 100-100-100-100** ·
pre-commit all 6 hooks pass · `charter_check` "6 gates consistent" · `docs_check` r1..r5=0 ·
blob-verified LF with a both-ways detector control.

CI is the arbiter. This merges only if `quality` is green.
