### PR TITLE
feat(reframe): reframe.analyze + ShotAnalysis cache + affected-only reframe.render (backend only, not user-reachable)

### DIFF
--- a/sidecar/media_studio/features/reframe_analyze.py
+++ b/sidecar/media_studio/features/reframe_analyze.py
@@ -1,0 +1,467 @@
+"""``reframe.analyze`` + ``reframe.render`` — the trace PRODUCER, its cache, and
+the edited-plan re-render (WU-E1 / WU-E2 / WU-E3).
+
+WHAT WAS MISSING. The multi-speaker engine could only ever
+:meth:`~media_studio.features.reframe_multispeaker.MultiSpeakerReframeEngine.reframe`
+— analyse, build a trace in-process, render a file, throw the trace away. So the
+two R2 override RPCs that make an imperfect active-speaker result shippable were
+unreachable in the shape the edit loop needs: ``reframe.shotPlan`` consumes a
+trace nothing produced over the wire, and an edited :class:`~media_studio.features.reframe_override.ShotPlan`
+had no renderer at all. This module adds the three missing pieces, in the spec's
+strict order (producer -> cache -> edited-plan render):
+
+* **WU-E1 ``reframe.analyze``** — a GPU job that runs the staged backend and the
+  pure director and returns ``{trace, plan, degraded}`` **without rendering**.
+* **WU-E2 the analysis cache** — an injectable, size-bounded store keyed by
+  ``(videoId, aspect, allowSplit, allowComposite)``, so editing a shot does not
+  re-run the multi-minute GPU analysis.
+* **WU-E3 ``reframe.render``** — a job that renders an EDITED plan, re-encoding
+  only the shots whose decision changed and concat-copying the rest, over the
+  cached analysis.
+
+**SCOPE, STATED PLAINLY.** This is the BACKEND only. Both methods are registered
+but NOT user-reachable: the UI wave (WU-U1..U4 — the per-shot editable timeline,
+the speaker ribbon, the "re-render changed shots" button) is a separate work unit
+and is not in this change. Nothing here makes active-speaker editing available to
+users. And per the plan's own warning, the 100%-branch unit coverage of this
+module is measured entirely against a FAKE backend and a FAKE ffmpeg runner:
+**coverage is not integration**, and none of it is evidence that the pipeline
+works on real media.
+"""
+
+from __future__ import annotations
+
+import shutil
+from collections import OrderedDict
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+
+from .. import protocol
+from ..protocol import ErrorCode, RpcContext, RpcError
+from ..util import clamp, get_logger
+from . import aspect as _aspect
+from . import offline as _offline
+from . import reframe_multispeaker as _ms
+from . import reframe_override as _override
+from .reframe_eval import ReframeTrace
+
+log = get_logger("media_studio.features.reframe_analyze")
+
+#: The default export aspect (mirrors the engines).
+DEFAULT_ASPECT = _ms.DEFAULT_ASPECT
+
+#: How many analysis bundles the default in-memory cache retains. A bundle holds
+#: the per-frame arrays for one clip, so the bound is what keeps an edit session
+#: over several clips from growing without limit.
+DEFAULT_CACHE_ENTRIES = 4
+
+Resolver = Callable[[str], str | None]
+EngineFactory = Callable[[dict[str, Any]], Any]
+
+
+def _invalid(message: str) -> RpcError:
+    return RpcError(message, ErrorCode.INVALID_PARAMS)
+
+
+# --------------------------------------------------------------------------- #
+# WU-E2 — the analysis cache (pure, injectable, size-bounded)
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class AnalysisKey:
+    """What makes two analyses interchangeable.
+
+    ``aspect`` changes the crop geometry and ``allow_split`` / ``allow_composite``
+    change the LAYOUT decisions, so all four fields are part of the identity of a
+    cached bundle (a trace built with ``allowSplit=False`` is not a valid answer
+    for a request that allows splits).
+    """
+
+    video_id: str
+    aspect: str
+    allow_split: bool
+    allow_composite: bool
+
+
+@dataclass(frozen=True)
+class AnalysisBundle:
+    """One clip's analysis + everything derived from it that the edit loop needs."""
+
+    analysis: _ms.ShotAnalysis
+    trace: ReframeTrace
+    plan: _override.ShotPlan
+
+
+class AnalysisStore(Protocol):
+    """The cache seam. Production uses :class:`LruAnalysisCache` (in-memory).
+
+    An on-disk store is the DECLARED-OPTIONAL half of WU-E2 and is deliberately
+    NOT implemented here — this Protocol is the seam it would slot into. So a
+    sidecar restart loses the cache, and the next ``reframe.render`` for that clip
+    refuses (loudly) until ``reframe.analyze`` runs again.
+    """
+
+    def get(self, key: AnalysisKey) -> AnalysisBundle | None:
+        """The bundle stored under ``key``, or ``None``."""
+        ...  # pragma: no cover - Protocol stub
+
+    def put(self, key: AnalysisKey, bundle: AnalysisBundle) -> None:
+        """Store ``bundle`` under ``key`` (evicting if the store is full)."""
+        ...  # pragma: no cover - Protocol stub
+
+    def find(self, video_id: str, aspect: str) -> AnalysisBundle | None:
+        """The most recent bundle for ``video_id`` at ``aspect``, ignoring flags."""
+        ...  # pragma: no cover - Protocol stub
+
+
+class LruAnalysisCache:
+    """A bounded least-recently-used in-memory :class:`AnalysisStore`.
+
+    NOT internally synchronised. It is safe in THIS wiring because both
+    ``reframe.analyze`` and ``reframe.render`` are started with ``gpu=True`` and
+    :class:`~media_studio.jobs.JobRegistry` serialises gpu-tagged jobs to
+    ``max_gpu_workers`` (default 1), so at most one job body touches the store at a
+    time. That is a property of the CALLER, not of this class — wrap it if you ever
+    reach it from concurrently-running work.
+    """
+
+    def __init__(self, max_entries: int = DEFAULT_CACHE_ENTRIES) -> None:
+        if max_entries < 1:
+            raise ValueError("max_entries must be >= 1")
+        self._max = int(max_entries)
+        self._items: OrderedDict[AnalysisKey, AnalysisBundle] = OrderedDict()
+
+    def __len__(self) -> int:
+        return len(self._items)
+
+    def get(self, key: AnalysisKey) -> AnalysisBundle | None:
+        """The bundle under ``key`` (refreshing its recency), or ``None``."""
+        bundle = self._items.get(key)
+        if bundle is None:
+            return None
+        self._items.move_to_end(key)
+        return bundle
+
+    def put(self, key: AnalysisKey, bundle: AnalysisBundle) -> None:
+        """Store ``bundle``, evicting the least-recently-used entries past the bound."""
+        self._items[key] = bundle
+        self._items.move_to_end(key)
+        while len(self._items) > self._max:
+            self._items.popitem(last=False)
+
+    def find(self, video_id: str, aspect: str) -> AnalysisBundle | None:
+        """The most recent bundle for ``video_id`` at ``aspect``, whatever its flags.
+
+        ``reframe.render``'s params carry ``{videoId, plan, aspect, affectedOnly}``
+        and deliberately NOT the layout flags — the caller edits a plan, it does not
+        re-declare how the plan was produced. It only needs the TRACE, whose
+        per-frame speakers and crops do not depend on ``allow_split`` /
+        ``allow_composite`` (those only steer :func:`~media_studio.features.reframe_multispeaker.decide_layout`).
+        So a flag-insensitive lookup is both sufficient and correct here, while
+        :meth:`get` keeps the full four-field identity for the producer.
+        """
+        for key in reversed(self._items):
+            if key.video_id == video_id and key.aspect == aspect:
+                return self.get(key)
+        return None
+
+
+def build_bundle(
+    analysis: _ms.ShotAnalysis,
+    *,
+    aspect: str,
+    allow_split: bool,
+    allow_composite: bool,
+) -> AnalysisBundle:
+    """PURE: a :class:`~media_studio.features.reframe_multispeaker.ShotAnalysis` ->
+    its trace + the editable per-shot plan derived from it."""
+    trace = _ms.build_trace(analysis, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
+    plan = _override.plan_from_trace(
+        trace,
+        source_width=analysis.width,
+        source_height=analysis.height,
+        fps=float(analysis.fps),
+    )
+    return AnalysisBundle(analysis=analysis, trace=trace, plan=plan)
+
+
+# --------------------------------------------------------------------------- #
+# param helpers (the boundary guard — loud, never a silently-ignored field)
+# --------------------------------------------------------------------------- #
+def _require_video_id(params: dict[str, Any]) -> str:
+    video_id = params.get("videoId")
+    if not isinstance(video_id, str) or not video_id:
+        raise _invalid("videoId (str) is required")
+    return video_id
+
+
+def _optional_bool(params: dict[str, Any], field: str, default: bool) -> bool:
+    value = params.get(field)
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise _invalid(f"{field} must be a boolean when given")
+    return value
+
+
+def _optional_aspect(params: dict[str, Any]) -> str:
+    value = params.get("aspect")
+    if value is None:
+        return DEFAULT_ASPECT
+    if not isinstance(value, str):
+        raise _invalid("aspect must be a string when given")
+    try:
+        return _aspect.require_supported_aspect(value)
+    except ValueError as exc:
+        raise _invalid(f"aspect is not supported: {exc}") from exc
+
+
+def _default_engine_factory(settings: dict[str, Any]) -> Any:
+    """Build the real multi-speaker engine (its own heavy seams stay lazy)."""
+    return _ms.MultiSpeakerReframeEngine(settings)
+
+
+# --------------------------------------------------------------------------- #
+# WU-E1 / WU-E3 — the service
+# --------------------------------------------------------------------------- #
+class ReframeAnalyzeService:
+    """Owns ``reframe.analyze`` + ``reframe.render`` over injectable seams.
+
+    Seams: ``resolver`` (videoId -> media path), ``out_dir`` (where a re-render
+    lands), ``settings_provider``, ``cache`` (the WU-E2 store), ``engine_factory``
+    (builds the engine, whose own ``backend_factory`` / ``runner`` seams the tests
+    fake), and ``which`` / ``models_present`` (the cheap host-availability probes).
+    """
+
+    def __init__(
+        self,
+        *,
+        resolver: Resolver,
+        out_dir: str | Path,
+        settings_provider: Callable[[], dict[str, Any]] | None = None,
+        cache: AnalysisStore | None = None,
+        engine_factory: EngineFactory | None = None,
+        which: _ms.WhichFn = shutil.which,
+        models_present: _ms.ModelsPresent | None = None,
+    ) -> None:
+        self._resolver = resolver
+        self._out_dir = Path(out_dir)
+        self._settings_provider = settings_provider or (lambda: {})
+        self._cache: AnalysisStore = cache if cache is not None else LruAnalysisCache()
+        self._engine_factory: EngineFactory = engine_factory or _default_engine_factory
+        self._which = which
+        self._models_present = models_present
+
+    def _settings(self) -> dict[str, Any]:
+        try:
+            return dict(self._settings_provider() or {})
+        except Exception:  # noqa: BLE001 - settings must never break an op
+            return {}
+
+    def _resolve(self, params: dict[str, Any]) -> tuple[str, str]:
+        video_id = _require_video_id(params)
+        resolved = self._resolver(video_id)
+        if not resolved:
+            raise _invalid(f"unknown video: {video_id}")
+        return video_id, str(resolved)
+
+    def analyze(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``reframe.analyze({videoId, aspect?, allowSplit?, allowComposite?,
+        allowDegrade?, diarizeBackend?})`` -> ``{jobId}`` (a GPU job).
+
+        ``job.done.result`` is ``{trace, plan, degraded}``: the per-frame trace and
+        the editable per-shot plan, with **no file rendered**. The typed failure
+        contract mirrors the engine's:
+
+        * host cannot run it + EXPLICIT request -> a typed RPC error naming the real
+          cause (the engine's :class:`~media_studio.features.reframe_multispeaker.MultiSpeakerUnavailableError`
+          message, mapped onto INVALID_PARAMS so it reaches the UI verbatim);
+        * offline mode ON + host cannot run it -> :class:`~media_studio.features.offline.OfflineError`
+          (the actionable message — a download is what is blocked);
+        * ``allowDegrade`` -> ``{trace: null, plan: null, degraded: <notice>}``. There
+          is deliberately no claudeshorts fall-back here: the single-speaker engine
+          produces no trace, so inventing a plan would be worse than an HONEST empty
+          state (the same choice ``reframe.shotPlanFor`` makes for a clip with no
+          sidecar).
+        """
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        video_id, in_path = self._resolve(params)
+        aspect = _optional_aspect(params)
+        allow_split = _optional_bool(params, "allowSplit", True)
+        allow_composite = _optional_bool(params, "allowComposite", True)
+        allow_degrade = _optional_bool(params, "allowDegrade", False)
+        settings = self._settings()
+        diarize_backend = params.get("diarizeBackend")
+        if diarize_backend is not None:
+            if not isinstance(diarize_backend, str) or not diarize_backend:
+                raise _invalid("diarizeBackend must be a non-empty string when given")
+            # The backend selector reads settings['diarizeBackend'] (diarize.py's
+            # eager, typed validation), so overlaying it here is the whole wiring.
+            settings = {**settings, "diarizeBackend": diarize_backend}
+
+        reason = _ms.availability_reason(settings, which=self._which, models_present=self._models_present)
+        if reason is not None:
+            # Offline is a DIFFERENT, actionable cause than a missing GPU.
+            _offline.guard_network(settings, "the multi-speaker reframe models")
+            if not allow_degrade:
+                raise _invalid(f"multi-speaker reframe engine requested but unavailable: {reason}")
+
+        key = AnalysisKey(video_id=video_id, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
+        cache = self._cache
+        engine_factory = self._engine_factory
+
+        def job_body(job_ctx: Any) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            if reason is not None:
+                notice = _ms.make_engine_degrade_notice(reason)
+                job_ctx.progress(100.0, notice["message"])
+                return {"trace": None, "plan": None, "degraded": notice}
+            cached = cache.get(key)
+            if cached is not None:
+                job_ctx.progress(100.0, "reused the cached analysis")
+                return _analysis_result(cached)
+            job_ctx.progress(2.0, "detecting shots")
+            analysis = engine_factory(settings).analyze(
+                in_path,
+                # The staged backend owns the shots -> diarize -> faces/ASD
+                # messages; clamping to 90 leaves room for the plan stage so a
+                # backend that reports 100% cannot make the job look finished.
+                on_progress=lambda pct, msg: job_ctx.progress(clamp(pct, 0.0, 90.0), msg),
+                should_cancel=lambda: job_ctx.cancelled,
+            )
+            job_ctx.raise_if_cancelled()
+            job_ctx.progress(92.0, "building the shot plan")
+            bundle = build_bundle(analysis, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
+            cache.put(key, bundle)
+            job_ctx.progress(100.0, "done")
+            return _analysis_result(bundle)
+
+        job = ctx.jobs.start(job_body, feature="reframe", label="reframe.analyze", videoId=video_id, gpu=True)
+        return {"jobId": job.id}
+
+    def render(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
+        """``reframe.render({videoId, plan, aspect?, affectedOnly?})`` -> ``{jobId}``.
+
+        ``job.done.result`` is ``{outPath, affected, reencoded}``. ``affected`` is
+        the shots the caller's plan changed relative to the cached analysis (the
+        same set :func:`~media_studio.features.reframe_override.affected_shot_indices`
+        computes for ``reframe.applyOverrides``); ``reencoded`` is what actually had
+        to be re-encoded, which is a SUPERSET of ``affected`` on a first render
+        because no segment pieces exist to reuse yet.
+
+        A cache MISS is loud: without the analysis there is no trace, so the
+        split/composite cells could not be placed. It refuses and names
+        ``reframe.analyze`` rather than silently re-running a multi-minute GPU pass
+        the caller did not ask for.
+
+        An EMPTY ``affected`` set is NOT an error — re-rendering the unedited plan
+        is exactly how the first file gets produced after an analyze.
+
+        The output path is composed from ``video_id``, so it is deliberately built
+        only AFTER :meth:`_resolve` proved the id is a real library record (the
+        library lookup is what keeps a caller-supplied id from steering the write
+        outside ``out_dir``); mirrors the ``shorts`` out-dir convention.
+        """
+        if ctx.jobs is None:
+            raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
+        video_id, in_path = self._resolve(params)
+        aspect = _optional_aspect(params)
+        affected_only = _optional_bool(params, "affectedOnly", True)
+        try:
+            edited = _override.ShotPlan.from_dict(params.get("plan"))
+        except _override.OverrideError as exc:
+            raise _invalid(f"plan is not a valid shot plan: {exc}") from exc
+        bundle = self._cache.find(video_id, aspect)
+        if bundle is None:
+            raise _invalid(
+                f"no cached reframe analysis for {video_id} at {aspect} — run reframe.analyze before rendering an edit"
+            )
+        try:
+            affected = _override.affected_shot_indices(bundle.plan, edited)
+        except _override.OverrideError as exc:
+            raise _invalid(f"the edited plan does not describe the analysed shots: {exc}") from exc
+
+        settings = self._settings()
+        out_dir = self._out_dir
+        engine_factory = self._engine_factory
+        trace = bundle.trace
+
+        def job_body(job_ctx: Any) -> dict[str, Any]:
+            job_ctx.raise_if_cancelled()
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = str(out_dir / f"{video_id}.multispeaker.mp4")
+            job_ctx.progress(2.0, f"re-rendering {len(affected)} changed shot(s)")
+            rendered, reencoded = engine_factory(settings).render_shot_plan(
+                in_path,
+                out_path,
+                edited,
+                trace,
+                aspect=aspect,
+                affected_only=affected_only,
+                on_progress=lambda pct, msg: job_ctx.progress(clamp(pct, 0.0, 99.0), msg),
+                should_cancel=lambda: job_ctx.cancelled,
+            )
+            job_ctx.progress(100.0, "done")
+            return {"outPath": rendered, "affected": list(affected), "reencoded": list(reencoded)}
+
+        job = ctx.jobs.start(job_body, feature="reframe", label="reframe.render", videoId=video_id, gpu=True)
+        return {"jobId": job.id}
+
+
+def _analysis_result(bundle: AnalysisBundle) -> dict[str, Any]:
+    """The ``reframe.analyze`` job payload for a successful analysis."""
+    return {
+        "trace": _override.trace_to_dict(bundle.trace),
+        "plan": bundle.plan.to_dict(),
+        "degraded": None,
+    }
+
+
+# --------------------------------------------------------------------------- #
+# registration
+# --------------------------------------------------------------------------- #
+def register(
+    *,
+    resolver: Resolver,
+    out_dir: str | Path,
+    settings_provider: Callable[[], dict[str, Any]] | None = None,
+    cache: AnalysisStore | None = None,
+    engine_factory: EngineFactory | None = None,
+    which: _ms.WhichFn = shutil.which,
+    models_present: _ms.ModelsPresent | None = None,
+    register_fn: Callable[[str, Any], None] | None = None,
+) -> ReframeAnalyzeService:
+    """Create the service and register ``reframe.analyze`` + ``reframe.render``.
+
+    ``register_fn`` defaults to :func:`protocol.register` (a duplicate name fails
+    loudly at startup); tests inject a fake registrar + fake seams.
+    """
+    service = ReframeAnalyzeService(
+        resolver=resolver,
+        out_dir=out_dir,
+        settings_provider=settings_provider,
+        cache=cache,
+        engine_factory=engine_factory,
+        which=which,
+        models_present=models_present,
+    )
+    reg = register_fn if register_fn is not None else protocol.register
+    reg("reframe.analyze", service.analyze)
+    reg("reframe.render", service.render)
+    log.info("registered reframe.analyze + reframe.render")
+    return service
+
+
+__all__ = [
+    "DEFAULT_ASPECT",
+    "DEFAULT_CACHE_ENTRIES",
+    "AnalysisBundle",
+    "AnalysisKey",
+    "AnalysisStore",
+    "LruAnalysisCache",
+    "ReframeAnalyzeService",
+    "build_bundle",
+    "register",
+]

--- a/sidecar/media_studio/features/reframe_analyze.py
+++ b/sidecar/media_studio/features/reframe_analyze.py
@@ -202,10 +202,15 @@ class LruAnalysisCache:
         a flag-insensitive lookup is "both sufficient and correct" because render
         "only needs the TRACE, whose per-frame speakers and crops do not depend on
         ``allow_split`` / ``allow_composite``". The narrow half is CONFIRMED
-        (measured: ``speaker_per_frame`` and ``crops`` are byte-identical across
-        both flags — they are set by :func:`~media_studio.features.reframe_multispeaker._render_shot`
-        before :func:`~media_studio.features.reframe_multispeaker.decide_layout` sees
-        the flags), so the PIXELS this fallback produces are flag-independent. The
+        (measured on a two-talker analysis: ``speaker_per_frame`` and ``crops`` are
+        identical across ``allowSplit=True``/``False`` while ``segments`` differ.
+        Mechanism: in :func:`~media_studio.features.reframe_multispeaker._render_shot`
+        the flags reach ONLY ``layout_raw`` via
+        :func:`~media_studio.features.reframe_multispeaker.decide_layout`, and the
+        committed speaker + the smoothed crop centres are computed without ever
+        reading that layout decision), so the PIXELS this fallback produces are
+        flag-independent — ``other_speaker_centers`` reads exactly those two
+        flag-independent fields. The
         conclusion was not: ``render`` also uses ``bundle.plan`` as the diff BASELINE
         for the ``affected`` set it reports, and a plan's per-shot ``layout`` IS
         flag-dependent. So when two analyses of the same ``(video_id, aspect)``

--- a/sidecar/media_studio/features/reframe_analyze.py
+++ b/sidecar/media_studio/features/reframe_analyze.py
@@ -27,6 +27,36 @@ users. And per the plan's own warning, the 100%-branch unit coverage of this
 module is measured entirely against a FAKE backend and a FAKE ffmpeg runner:
 **coverage is not integration**, and none of it is evidence that the pipeline
 works on real media.
+
+**WHAT THE FAKE-BACKED SUITE CANNOT ESTABLISH** (so no reader mistakes 100% branch
+coverage for a working pipeline). It does not show that any ffmpeg argv this module
+builds produces a playable file, that a real ASD/diarize backend returns a
+:class:`~media_studio.features.reframe_multispeaker.ShotAnalysis` these decisions
+suit, that the concat of reused + freshly-encoded segments is seamless, or that the
+6 GB VRAM ceiling holds. It shows only that the ORCHESTRATION — cache identity,
+boundary refusal, reuse arithmetic, cleanup, progress clamping and terminal state —
+behaves as documented. The settling experiment for the rest is the opt-in ``@e2e``
+golden run on real footage.
+
+**NAMED RESIDUALS carried forward (2026-08-10 remediation).**
+
+* ``reframe.render``'s flag-insensitive cache FALLBACK can report an ``affected``
+  set that names a shot the caller did not edit when several analyses of the same
+  ``(videoId, aspect)`` differ only in the layout flags and the caller omits them.
+  Wrong metadata, never wrong pixels — full detail and the workaround on
+  :meth:`LruAnalysisCache.find`.
+* An on-disk :class:`AnalysisStore` is still the DECLARED-OPTIONAL half of WU-E2, so
+  a sidecar restart loses the cache and the next ``reframe.render`` refuses loudly.
+* ``app/renderer/src/features/ReframeCorrect.tsx:19-21`` states that "the registered
+  reframe surface really is exactly four methods
+  (``sidecar/tests/test_handlers_rpc_surface.py:118-121``)". After this WU the
+  surface is SIX and that citation's line range moved. This lane is sidecar-only and
+  correctly must not edit ``app/``, so this is a HAND-OFF for the lane that owns the
+  renderer, not a defect here. It is a ``//`` comment, so no false statement reaches
+  the UI.
+* The layout flags reach a trace only through ``reframe.analyze``; the shipped
+  ``shortmaker`` export path still cannot honour them (see
+  :func:`~media_studio.features.reframe_multispeaker.build_trace`).
 """
 
 from __future__ import annotations

--- a/sidecar/media_studio/features/reframe_analyze.py
+++ b/sidecar/media_studio/features/reframe_analyze.py
@@ -72,16 +72,26 @@ def _invalid(message: str) -> RpcError:
 class AnalysisKey:
     """What makes two analyses interchangeable.
 
-    ``aspect`` changes the crop geometry and ``allow_split`` / ``allow_composite``
-    change the LAYOUT decisions, so all four fields are part of the identity of a
-    cached bundle (a trace built with ``allowSplit=False`` is not a valid answer
-    for a request that allows splits).
+    ``aspect`` changes the crop geometry, ``allow_split`` / ``allow_composite``
+    change the LAYOUT decisions, and ``diarize_backend`` changes WHICH diarizer
+    runs and therefore the :class:`~media_studio.features.reframe_multispeaker.ShotAnalysis`
+    itself — so all FIVE fields are part of the identity of a cached bundle (a
+    trace built with ``allowSplit=False`` is not a valid answer for a request that
+    allows splits, and one diarized by backend A is not an answer for backend B).
+
+    CORRECTION 2026-08-10: ``diarize_backend`` was missing from the original
+    four-field key even though the same commit validated it and overlaid it onto
+    the engine settings *precisely because* it changes the analysis. Measured on
+    the real service with a counting backend, ``analyze(diarizeBackend="beta")``
+    after ``analyze(diarizeBackend="alpha")`` returned alpha's plan verbatim and
+    never constructed the beta backend at all.
     """
 
     video_id: str
     aspect: str
     allow_split: bool
     allow_composite: bool
+    diarize_backend: str | None = None
 
 
 @dataclass(frozen=True)
@@ -153,13 +163,27 @@ class LruAnalysisCache:
     def find(self, video_id: str, aspect: str) -> AnalysisBundle | None:
         """The most recent bundle for ``video_id`` at ``aspect``, whatever its flags.
 
-        ``reframe.render``'s params carry ``{videoId, plan, aspect, affectedOnly}``
-        and deliberately NOT the layout flags — the caller edits a plan, it does not
-        re-declare how the plan was produced. It only needs the TRACE, whose
-        per-frame speakers and crops do not depend on ``allow_split`` /
-        ``allow_composite`` (those only steer :func:`~media_studio.features.reframe_multispeaker.decide_layout`).
-        So a flag-insensitive lookup is both sufficient and correct here, while
-        :meth:`get` keeps the full four-field identity for the producer.
+        The BACKWARD-COMPATIBLE FALLBACK for a ``reframe.render`` call that does not
+        re-declare how its plan was produced. :meth:`ReframeAnalyzeService.render`
+        tries the exact five-field :meth:`get` first and only lands here when that
+        misses.
+
+        CORRECTION 2026-08-10 — the original justification was too wide. It claimed
+        a flag-insensitive lookup is "both sufficient and correct" because render
+        "only needs the TRACE, whose per-frame speakers and crops do not depend on
+        ``allow_split`` / ``allow_composite``". The narrow half is CONFIRMED
+        (measured: ``speaker_per_frame`` and ``crops`` are byte-identical across
+        both flags — they are set by :func:`~media_studio.features.reframe_multispeaker._render_shot`
+        before :func:`~media_studio.features.reframe_multispeaker.decide_layout` sees
+        the flags), so the PIXELS this fallback produces are flag-independent. The
+        conclusion was not: ``render`` also uses ``bundle.plan`` as the diff BASELINE
+        for the ``affected`` set it reports, and a plan's per-shot ``layout`` IS
+        flag-dependent. So when two analyses of the same ``(video_id, aspect)``
+        differ only in flags and the caller omits them, this returns the
+        most-recently-USED one and ``affected`` can name a shot the caller never
+        edited (measured: ``affected=(0,)`` for an untouched plan). Wrong reported
+        METADATA, never wrong output. Pass ``allowSplit`` / ``allowComposite`` /
+        ``diarizeBackend`` to ``reframe.render`` to get the exact bundle instead.
         """
         for key in reversed(self._items):
             if key.video_id == video_id and key.aspect == aspect:
@@ -215,6 +239,31 @@ def _optional_aspect(params: dict[str, Any]) -> str:
         return _aspect.require_supported_aspect(value)
     except ValueError as exc:
         raise _invalid(f"aspect is not supported: {exc}") from exc
+
+
+def _optional_diarize_backend(params: dict[str, Any]) -> str | None:
+    """The requested diarizer id, or ``None`` (loud on a non-string / empty value)."""
+    value = params.get("diarizeBackend")
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise _invalid("diarizeBackend must be a non-empty string when given")
+    return value
+
+
+def multispeaker_out_name(video_id: str, aspect: str) -> str:
+    """The re-render's output filename for ``video_id`` at ``aspect``.
+
+    The aspect is part of the NAME because the kept per-shot segment cache is
+    derived from the output path (:func:`~media_studio.features.reframe_multispeaker.shot_segment_path`).
+    Without it, rendering the same clip at a second aspect ``os.replace``\\ d onto
+    the first render's clip AND overwrote its segment cache — the manifest's aspect
+    guard only ensured the destruction was a full re-encode rather than a
+    mixed-geometry concat. ``:`` is not a legal Windows filename character, so the
+    slug uses the ``x`` separator :func:`~media_studio.features.aspect.parse_aspect`
+    already accepts.
+    """
+    return f"{video_id}.multispeaker.{aspect.replace(':', 'x')}.mp4"
 
 
 def _default_engine_factory(settings: dict[str, Any]) -> Any:
@@ -293,10 +342,8 @@ class ReframeAnalyzeService:
         allow_composite = _optional_bool(params, "allowComposite", True)
         allow_degrade = _optional_bool(params, "allowDegrade", False)
         settings = self._settings()
-        diarize_backend = params.get("diarizeBackend")
+        diarize_backend = _optional_diarize_backend(params)
         if diarize_backend is not None:
-            if not isinstance(diarize_backend, str) or not diarize_backend:
-                raise _invalid("diarizeBackend must be a non-empty string when given")
             # The backend selector reads settings['diarizeBackend'] (diarize.py's
             # eager, typed validation), so overlaying it here is the whole wiring.
             settings = {**settings, "diarizeBackend": diarize_backend}
@@ -308,7 +355,13 @@ class ReframeAnalyzeService:
             if not allow_degrade:
                 raise _invalid(f"multi-speaker reframe engine requested but unavailable: {reason}")
 
-        key = AnalysisKey(video_id=video_id, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
+        key = AnalysisKey(
+            video_id=video_id,
+            aspect=aspect,
+            allow_split=allow_split,
+            allow_composite=allow_composite,
+            diarize_backend=diarize_backend,
+        )
         cache = self._cache
         engine_factory = self._engine_factory
 
@@ -323,14 +376,23 @@ class ReframeAnalyzeService:
                 job_ctx.progress(100.0, "reused the cached analysis")
                 return _analysis_result(cached)
             job_ctx.progress(2.0, "detecting shots")
-            analysis = engine_factory(settings).analyze(
-                in_path,
-                # The staged backend owns the shots -> diarize -> faces/ASD
-                # messages; clamping to 90 leaves room for the plan stage so a
-                # backend that reports 100% cannot make the job look finished.
-                on_progress=lambda pct, msg: job_ctx.progress(clamp(pct, 0.0, 90.0), msg),
-                should_cancel=lambda: job_ctx.cancelled,
-            )
+            try:
+                analysis = engine_factory(settings).analyze(
+                    in_path,
+                    # The staged backend owns the shots -> diarize -> faces/ASD
+                    # messages; clamping to 90 leaves room for the plan stage so a
+                    # backend that reports 100% cannot make the job look finished.
+                    on_progress=lambda pct, msg: job_ctx.progress(clamp(pct, 0.0, 90.0), msg),
+                    should_cancel=lambda: job_ctx.cancelled,
+                )
+            except Exception:
+                # The real backend honours should_cancel by raising its OWN domain
+                # error (MultiSpeakerReframeError, reframe_multispeaker_backend.py
+                # :106,:111). jobs.py maps ONLY JobCancelled to _finish_cancelled, so
+                # without this the job would report ERROR for a user-requested
+                # cancel. Re-raise anything that is NOT a cancel untouched.
+                job_ctx.raise_if_cancelled()
+                raise
             job_ctx.raise_if_cancelled()
             job_ctx.progress(92.0, "building the shot plan")
             bundle = build_bundle(analysis, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
@@ -342,7 +404,8 @@ class ReframeAnalyzeService:
         return {"jobId": job.id}
 
     def render(self, params: dict[str, Any], ctx: RpcContext) -> dict[str, Any]:
-        """``reframe.render({videoId, plan, aspect?, affectedOnly?})`` -> ``{jobId}``.
+        """``reframe.render({videoId, plan, aspect?, affectedOnly?, allowSplit?,
+        allowComposite?, diarizeBackend?})`` -> ``{jobId}``.
 
         ``job.done.result`` is ``{outPath, affected, reencoded}``. ``affected`` is
         the shots the caller's plan changed relative to the cached analysis (the
@@ -350,6 +413,18 @@ class ReframeAnalyzeService:
         computes for ``reframe.applyOverrides``); ``reencoded`` is what actually had
         to be re-encoded, which is a SUPERSET of ``affected`` on a first render
         because no segment pieces exist to reuse yet.
+
+        Only ``speaker`` / ``layout`` / ``crop`` are editable. The plan's frame
+        SPANS and its ``sourceWidth`` / ``sourceHeight`` / ``fps`` must match the
+        cached analysis exactly (:func:`~media_studio.features.reframe_override.affected_shot_indices`
+        is the guard) — they are analysis outputs, not user input, and accepting an
+        edit to them was a live hole on this boundary.
+
+        The three analysis-identity params (``allowSplit`` / ``allowComposite`` /
+        ``diarizeBackend``) are OPTIONAL and default to ``reframe.analyze``'s own
+        defaults. Passing them selects the EXACT cached bundle; omitting them falls
+        back to :meth:`LruAnalysisCache.find`, whose documented ambiguity is
+        recorded on that method.
 
         A cache MISS is loud: without the analysis there is no trace, so the
         split/composite cells could not be placed. It refuses and names
@@ -359,21 +434,29 @@ class ReframeAnalyzeService:
         An EMPTY ``affected`` set is NOT an error — re-rendering the unedited plan
         is exactly how the first file gets produced after an analyze.
 
-        The output path is composed from ``video_id``, so it is deliberately built
-        only AFTER :meth:`_resolve` proved the id is a real library record (the
-        library lookup is what keeps a caller-supplied id from steering the write
-        outside ``out_dir``); mirrors the ``shorts`` out-dir convention.
+        The output path is composed from ``video_id`` **and the aspect**
+        (:func:`multispeaker_out_name`), so it is deliberately built only AFTER
+        :meth:`_resolve` proved the id is a real library record (the library lookup
+        is what keeps a caller-supplied id from steering the write outside
+        ``out_dir``); mirrors the ``shorts`` out-dir convention.
         """
         if ctx.jobs is None:
             raise RpcError("no job registry available", ErrorCode.INTERNAL_ERROR)
         video_id, in_path = self._resolve(params)
         aspect = _optional_aspect(params)
         affected_only = _optional_bool(params, "affectedOnly", True)
+        key = AnalysisKey(
+            video_id=video_id,
+            aspect=aspect,
+            allow_split=_optional_bool(params, "allowSplit", True),
+            allow_composite=_optional_bool(params, "allowComposite", True),
+            diarize_backend=_optional_diarize_backend(params),
+        )
         try:
             edited = _override.ShotPlan.from_dict(params.get("plan"))
         except _override.OverrideError as exc:
             raise _invalid(f"plan is not a valid shot plan: {exc}") from exc
-        bundle = self._cache.find(video_id, aspect)
+        bundle = self._cache.get(key) or self._cache.find(video_id, aspect)
         if bundle is None:
             raise _invalid(
                 f"no cached reframe analysis for {video_id} at {aspect} — run reframe.analyze before rendering an edit"
@@ -391,18 +474,26 @@ class ReframeAnalyzeService:
         def job_body(job_ctx: Any) -> dict[str, Any]:
             job_ctx.raise_if_cancelled()
             out_dir.mkdir(parents=True, exist_ok=True)
-            out_path = str(out_dir / f"{video_id}.multispeaker.mp4")
+            out_path = str(out_dir / multispeaker_out_name(video_id, aspect))
             job_ctx.progress(2.0, f"re-rendering {len(affected)} changed shot(s)")
-            rendered, reencoded = engine_factory(settings).render_shot_plan(
-                in_path,
-                out_path,
-                edited,
-                trace,
-                aspect=aspect,
-                affected_only=affected_only,
-                on_progress=lambda pct, msg: job_ctx.progress(clamp(pct, 0.0, 99.0), msg),
-                should_cancel=lambda: job_ctx.cancelled,
-            )
+            try:
+                rendered, reencoded = engine_factory(settings).render_shot_plan(
+                    in_path,
+                    out_path,
+                    edited,
+                    trace,
+                    aspect=aspect,
+                    affected_only=affected_only,
+                    on_progress=lambda pct, msg: job_ctx.progress(clamp(pct, 0.0, 99.0), msg),
+                    should_cancel=lambda: job_ctx.cancelled,
+                )
+            except Exception:
+                # A cancel that surfaced as an encode failure (ffmpeg is TERMINATED,
+                # so it exits non-zero -> MultiSpeakerRenderError) must still end the
+                # job CANCELLED: jobs.py maps ONLY JobCancelled to _finish_cancelled.
+                job_ctx.raise_if_cancelled()
+                raise
+            job_ctx.raise_if_cancelled()  # unwind -> registry marks CANCELLED
             job_ctx.progress(100.0, "done")
             return {"outPath": rendered, "affected": list(affected), "reencoded": list(reencoded)}
 

--- a/sidecar/media_studio/features/reframe_multispeaker.py
+++ b/sidecar/media_studio/features/reframe_multispeaker.py
@@ -929,10 +929,25 @@ def build_trace(
 
     ``allow_split`` / ``allow_composite`` are forwarded to :func:`decide_layout`,
     which collapses the richer layouts back to ``"single"`` when the caller
-    forbids them. WU-E1 wiring: :data:`decide_layout`'s two flags existed since R1
-    but NOTHING threaded them — every trace was built with both enabled, so the
-    ``allowSplit`` / ``allowComposite`` request fields had no effect on the plan.
-    Both still DEFAULT to ``True``, so every existing caller is unchanged.
+    forbids them. Both DEFAULT to ``True``, so every existing caller is unchanged.
+
+    CORRECTION 2026-08-10 — the WU-E1 note here called this a "latent defect" on
+    the grounds that "``allowSplit`` / ``allowComposite`` request fields had no
+    effect on the plan". That is REFUTED and withdrawn: there were no such request
+    fields to be ignored. ``git grep -i allowSplit origin/main`` hits ONLY
+    ``docs/plans/v1.5/flagship-active-speaker.md`` (:187, :213, :226, :245) —
+    nothing in ``sidecar/``, nothing in ``app/``. So :func:`decide_layout`'s flags
+    were UNEXPOSED OPTIONAL CAPABILITY on a pure function, not a live defect, and
+    threading them here is a feature, not a fix.
+
+    RESIDUAL, disclosed rather than hidden: the flags are honoured only on the
+    ``reframe.analyze`` path. :meth:`MultiSpeakerReframeEngine._render` — the
+    shipped multispeaker render that ``shortmaker`` drives — still calls
+    ``build_trace(analysis, aspect=aspect)`` with no flags, and the spec's
+    ``reframeAllowSplit`` / ``reframeAllowComposite`` settings keys
+    (``docs/plans/v1.5/flagship-active-speaker.md:187``) do not exist. So a user
+    cannot forbid a split on an export today. That is a settings-surface work unit,
+    not part of E1/E2/E3.
     """
     width, height, fps = analysis.width, analysis.height, analysis.fps
     total = analysis.total_frames
@@ -1005,10 +1020,17 @@ def _render_shot(
     speaker_per_frame: list[str],
     layout_raw: list[str],
     crops: list[tuple[float, float, float, float]],
-    allow_split: bool = True,
-    allow_composite: bool = True,
+    allow_split: bool,
+    allow_composite: bool,
 ) -> None:
-    """Decide the speaker/layout/crop for one shot's frames (appends in place)."""
+    """Decide the speaker/layout/crop for one shot's frames (appends in place).
+
+    ``allow_split`` / ``allow_composite`` are REQUIRED keyword arguments on purpose.
+    They defaulted to ``True`` here, which is exactly the shape that let
+    :func:`build_trace` forget to thread them for four work units: a defaulted
+    behaviour flag on an internal helper is a silently-ignored field waiting to
+    happen. The only caller passes both explicitly.
+    """
     # Pass 1a: tracked ids + per-frame visual scores (track-id namespace) + active count.
     ids_per_frame: list[list[int]] = []
     scores_per_frame: list[dict[str, float]] = []

--- a/sidecar/media_studio/features/reframe_multispeaker.py
+++ b/sidecar/media_studio/features/reframe_multispeaker.py
@@ -1364,7 +1364,14 @@ SHOT_MANIFEST_SUFFIX = ".shots.json"
 #: re-encodes every shot, which is always the correct output. So it degrades with
 #: a warning instead of raising — the conservative direction, not a silent
 #: wrong answer.
-SHOT_MANIFEST_VERSION = 1
+#:
+#: **v2 (2026-08-10)** added the source identity (``fps`` / ``sourceWidth`` /
+#: ``sourceHeight``) and the per-shot ``regions``, because a v1 manifest could
+#: license reuse across a trace change, an fps change or a resolution change — all
+#: of which move pixels. A v1 file on disk is therefore correctly rejected as
+#: "unknown version": it cannot prove those four things, so the conservative
+#: answer is to re-encode.
+SHOT_MANIFEST_VERSION = 2
 
 
 def _write_text_file(path: str, text: str) -> None:
@@ -1446,6 +1453,20 @@ def shot_segment_path(root: str, ext: str, index: int) -> str:
     return f"{root}.multispeaker.shot{index:03d}{ext}"
 
 
+def shot_segment_part_path(root: str, ext: str, index: int) -> str:
+    """The IN-FLIGHT temp path shot ``index`` is encoded to before it is published.
+
+    The segment IS the cache, so encoding straight to :func:`shot_segment_path`
+    made the cache entry and the write target the same file: a process that is
+    KILLED mid-encode (OOM-killer, power loss — no Python cleanup runs) left a
+    truncated file at the cache path, and the reuse check is a bare ``exists()``.
+    Encoding to ``.part`` and ``os.replace``-ing on success makes that impossible:
+    a killed run leaves only an orphan ``.part``, never a half-written cache entry.
+    The extension is preserved so ffmpeg can still infer the muxer.
+    """
+    return f"{root}.multispeaker.shot{index:03d}.part{ext}"
+
+
 @dataclass(frozen=True)
 class ShotSegment:
     """One shot of an edited plan: its compositor regions + the reuse verdict."""
@@ -1462,16 +1483,75 @@ class ShotSegment:
     reuse: bool
 
 
-def manifest_shot_decisions(manifest: Mapping[str, Any] | None, aspect: str) -> dict[int, dict[str, Any]]:
-    """The previous render's shot decisions, keyed by shot index.
+def shot_manifest_entry(shot: _override.ShotDecision, regions: Sequence[Box]) -> dict[str, Any]:
+    """One manifest row: a shot's decision PLUS the regions it was rendered with.
 
-    Empty (i.e. "re-encode everything") when there is no manifest, when it was
-    written for a DIFFERENT aspect (the geometry would be wrong), or when its
-    ``shots`` array is not usable. Individual malformed entries are skipped rather
-    than poisoning the whole map — a skipped entry simply forces its shot to be
-    re-encoded.
+    ``shot.to_dict()`` alone is not a sufficient reuse key. A segment's pixels also
+    depend on ``other_centers`` — the OTHER candidate speakers' crop centres, which
+    come from the TRACE (``trace.speaker_per_frame`` / ``trace.crops`` via
+    :func:`other_speaker_centers`) and appear nowhere in the decision dict. So a
+    re-analysis that moved a non-primary speaker while leaving the majority speaker,
+    the majority layout and the first-frame crop unchanged produced a
+    BYTE-IDENTICAL decision dict and a stale segment was concat-copied (measured:
+    cell 2 moved 705 px and ``reuse`` was ``True`` both times). Recording the
+    computed regions closes that: they are the actual crop rectangles that were
+    encoded, so any trace / geometry / aspect change that moves a pixel also moves
+    this row.
     """
-    if manifest is None or manifest.get("aspect") != aspect:
+    return {**shot.to_dict(), "regions": [list(box) for box in regions]}
+
+
+def shot_manifest_payload(
+    plan: _override.ShotPlan,
+    segments: Sequence[ShotSegment],
+    *,
+    aspect: str,
+) -> dict[str, Any]:
+    """The full ``<clip>.shots.json`` payload for a completed render.
+
+    Carries the SOURCE IDENTITY (``aspect`` + ``fps`` + source dimensions) as well
+    as the per-shot rows, because all four decide a segment's content:
+    :func:`regions_for_shot` is fed ``plan.source_width`` / ``plan.source_height``
+    and every segment's ffmpeg ``-ss`` / ``-t`` is ``frame / fps``.
+    """
+    return {
+        "version": SHOT_MANIFEST_VERSION,
+        "aspect": aspect,
+        "fps": float(plan.fps),
+        "sourceWidth": plan.source_width,
+        "sourceHeight": plan.source_height,
+        "shots": [shot_manifest_entry(shot, seg.regions) for shot, seg in zip(plan.shots, segments, strict=True)],
+    }
+
+
+def manifest_shot_decisions(
+    manifest: Mapping[str, Any] | None,
+    plan: _override.ShotPlan,
+    *,
+    aspect: str,
+) -> dict[int, dict[str, Any]]:
+    """The previous render's shot rows, keyed by shot index.
+
+    Empty (i.e. "re-encode everything") when there is no manifest, when its SOURCE
+    IDENTITY differs from ``plan``'s (aspect, fps, or source dimensions — the
+    geometry or the timing would be wrong), or when its ``shots`` array is not
+    usable. Individual malformed entries are skipped rather than poisoning the whole
+    map — a skipped entry simply forces its shot to be re-encoded.
+
+    CORRECTION 2026-08-10: the identity check used to be ``aspect`` ALONE, and its
+    stated rationale ("the geometry would be wrong") applied verbatim to the three
+    fields it did not cover. Executed repro: a manifest written at fps 30 /
+    1920x1080 licensed reuse for a plan carrying fps 60 / 1280x720, so exactly one
+    ffmpeg pass ran (the concat) and the stale segment was republished at the old
+    geometry and timing.
+    """
+    if (
+        manifest is None
+        or manifest.get("aspect") != aspect
+        or manifest.get("fps") != float(plan.fps)
+        or manifest.get("sourceWidth") != plan.source_width
+        or manifest.get("sourceHeight") != plan.source_height
+    ):
         return {}
     shots = manifest.get("shots")
     if not isinstance(shots, list):
@@ -1510,32 +1590,35 @@ def plan_shot_segments(
     """PURE: one :class:`ShotSegment` per shot of an edited ``plan``.
 
     A shot is REUSED (not re-encoded) only when all three hold: the caller asked
-    for ``affected_only``; the previous manifest records a BYTE-IDENTICAL decision
-    for that index (same span, speaker, layout and crop); and its segment file is
-    still on disk. Decision-equality — rather than diffing two plans — is what
-    makes the reuse survive a sidecar restart and makes a first render (no
-    manifest) correctly re-encode everything.
+    for ``affected_only``; the previous manifest records a BYTE-IDENTICAL row for
+    that index — same span, speaker, layout, crop **and rendered regions**, over a
+    manifest whose aspect / fps / source dimensions match this plan
+    (:func:`shot_manifest_entry` and :func:`manifest_shot_decisions` own those two
+    halves); and its segment file is still on disk. Row-equality — rather than
+    diffing two plans — is what makes the reuse survive a sidecar restart and makes
+    a first render (no manifest) correctly re-encode everything.
     """
-    previous = manifest_shot_decisions(manifest, aspect)
+    previous = manifest_shot_decisions(manifest, plan, aspect=aspect)
     segments: list[ShotSegment] = []
     for shot in plan.shots:
         path = shot_segment_path(root, ext, shot.index)
+        regions = regions_for_shot(
+            layout=shot.layout,
+            crop=shot.crop,
+            other_centers=other_speaker_centers(trace, shot, plan.source_width),
+            aspect=aspect,
+            width=plan.source_width,
+            height=plan.source_height,
+        )
         segments.append(
             ShotSegment(
                 index=shot.index,
                 start_frame=shot.start_frame,
                 end_frame=shot.end_frame,
                 layout=shot.layout,
-                regions=regions_for_shot(
-                    layout=shot.layout,
-                    crop=shot.crop,
-                    other_centers=other_speaker_centers(trace, shot, plan.source_width),
-                    aspect=aspect,
-                    width=plan.source_width,
-                    height=plan.source_height,
-                ),
+                regions=regions,
                 path=path,
-                reuse=affected_only and previous.get(shot.index) == shot.to_dict() and exists(path),
+                reuse=affected_only and previous.get(shot.index) == shot_manifest_entry(shot, regions) and exists(path),
             )
         )
     return tuple(segments)
@@ -1813,10 +1896,22 @@ class MultiSpeakerReframeEngine:
           hidden: those pieces are never garbage-collected, so a rendered clip
           carries roughly its own size again in cached segments until something else
           removes them. Bounding that directory is follow-up work, not part of E3.
-        * writes to temp paths and atomically renames on success only, removing
-          every FRESHLY written partial on any failure, so an OOM can never leave a
-          corrupt half-clip at ``out_path`` nor a truncated segment that a later run
-          would mistake for a valid cached piece.
+        * writes EVERY output — each shot segment and the concatenated clip — to a
+          ``.part`` temp path and ``os.replace``\\ s it on success only, removing the
+          partials this run wrote on any failure. So neither an in-process failure
+          NOR a hard kill (OOM-killer, power loss, where no Python cleanup runs) can
+          leave a corrupt half-clip at ``out_path`` or a truncated segment at a cache
+          path that a later run's bare ``exists()`` would trust — a killed run leaves
+          only an orphan ``.part``.
+
+          SCOPED HONESTLY: this is a claim about what THIS code can leave behind. A
+          truncated segment written by an OLDER build (which encoded straight to the
+          cache path) is still trusted if its manifest row matches, because reuse
+          binds no size or hash to the row. That residual is closed by the v1->v2
+          manifest version bump for any clip whose manifest is re-written, but NOT
+          for a v2 segment truncated out-of-band (e.g. a truncating disk error after
+          the rename). UNVERIFIED — settling experiment: add the segment's byte size
+          to the manifest row and re-run the truncate-then-rerender probe.
 
         Returns ``(out_path, reencoded_shot_indices)``.
         """
@@ -1836,21 +1931,26 @@ class MultiSpeakerReframeEngine:
         )
         out_w, out_h = _aspect.output_dimensions(aspect)
         fps = float(plan.fps)
-        fresh: list[str] = []  # only the pieces THIS run wrote are cleanup-eligible
+        fresh: list[str] = []  # only the pieces THIS run PUBLISHED are cleanup-eligible
         for seg in segments:
             if seg.reuse:
                 continue
             duration_sec = (seg.end_frame - seg.start_frame) / fps
+            seg_part = shot_segment_part_path(root, ext, seg.index)
             argv = build_segment_argv(
                 in_path,
-                seg.path,
+                seg_part,
                 build_filter_complex(seg.layout, list(seg.regions), out_w=out_w, out_h=out_h),
                 start_sec=seg.start_frame / fps,
                 duration_sec=duration_sec,
                 settings=self._settings,
             )
+            # The in-flight .part is cleanup-eligible immediately; seg.path only
+            # becomes so AFTER the rename, because until then any file there is a
+            # PREVIOUS render's still-valid cache entry that this run must not eat.
+            self._run_pass(argv, duration_sec, on_progress, should_cancel, [*fresh, seg_part])
+            self._replace(seg_part, seg.path)
             fresh.append(seg.path)
-            self._run_pass(argv, duration_sec, on_progress, should_cancel, list(fresh))
         part_path = f"{root}.multispeaker.part{ext}"
         list_path = f"{root}.multispeaker.concat{ext}.txt"
         try:
@@ -1868,7 +1968,7 @@ class MultiSpeakerReframeEngine:
         )
         self._cleanup_all([list_path])  # the shot pieces are the CACHE -> kept
         self._replace(part_path, out_path)  # atomic: no corrupt half-clip at out_path
-        self._write_shot_manifest(out_path, aspect, plan)
+        self._write_shot_manifest(out_path, aspect, plan, segments)
         return out_path, tuple(seg.index for seg in segments if not seg.reuse)
 
     def _load_shot_manifest(self, clip: str) -> dict[str, Any] | None:
@@ -1894,24 +1994,40 @@ class MultiSpeakerReframeEngine:
             return None
         return dict(payload)
 
-    def _write_shot_manifest(self, clip: str, aspect: str, plan: _override.ShotPlan) -> None:
-        """Record the decisions that produced ``clip``'s kept segment pieces.
+    def _write_shot_manifest(
+        self,
+        clip: str,
+        aspect: str,
+        plan: _override.ShotPlan,
+        segments: Sequence[ShotSegment],
+    ) -> None:
+        """Record the decisions + regions that produced ``clip``'s kept segment pieces.
 
         Written only AFTER the atomic rename, so a manifest never claims a piece
         that a failed render left truncated. A write failure is logged, not fatal —
-        the clip is already correct and the only consequence is that the next
-        re-render re-encodes every shot.
+        the clip is already correct.
+
+        CORRECTION 2026-08-10: this used to claim "the only consequence is that the
+        next re-render re-encodes every shot", which was the OPPOSITE of what
+        happened. A failed write left the PREVIOUS manifest on disk while this run
+        had already overwritten the segment files, so manifest and bytes disagreed
+        and the reuse predicate trusts the manifest. Executed repro: render(split)
+        -> render(single) with the manifest write failing -> render(split) reused the
+        SINGLE segment and reported ``reencoded: []``. The stale manifest is now
+        DROPPED, which is what makes the sentence true.
         """
         path = shot_manifest_path(clip)
-        payload = {
-            "version": SHOT_MANIFEST_VERSION,
-            "aspect": aspect,
-            "shots": [shot.to_dict() for shot in plan.shots],
-        }
         try:
-            self._write_text(path, json.dumps(payload))
+            self._write_text(path, json.dumps(shot_manifest_payload(plan, segments, aspect=aspect)))
         except OSError as exc:
             _log.warning("could not write the reframe shot manifest %s: %s", path, exc)
+            try:
+                self._remove(path)
+            except OSError as rm_exc:
+                # Belt and braces: a surviving stale manifest can only mis-license
+                # reuse if its row still matches, and v2 rows carry the regions, so
+                # the blast radius is a same-decision same-geometry re-render.
+                _log.warning("could not drop the stale reframe shot manifest %s: %s", path, rm_exc)
 
     def _persist_sidecar(self, clip: str, payload: Mapping[str, Any]) -> None:
         """Write ``payload`` to ``<clip>.reframe.json`` (a failure is logged, not fatal)."""

--- a/sidecar/media_studio/features/reframe_multispeaker.py
+++ b/sidecar/media_studio/features/reframe_multispeaker.py
@@ -913,13 +913,26 @@ def _shot_dominant_center(boxes: Sequence[Box], width: int) -> float:
     return cx if cx is not None else 0.5
 
 
-def build_trace(analysis: ShotAnalysis, *, aspect: str = DEFAULT_ASPECT) -> ReframeTrace:
+def build_trace(
+    analysis: ShotAnalysis,
+    *,
+    aspect: str = DEFAULT_ASPECT,
+    allow_split: bool = True,
+    allow_composite: bool = True,
+) -> ReframeTrace:
     """Run the full pure director over a heavy-backend ``analysis``.
 
     Produces the :class:`~media_studio.features.reframe_eval.ReframeTrace` (shot
     boundaries, speaker-per-frame, layout segments, per-frame crops) that the R0
     eval harness scores and the R2 override layer edits. This is the heart of the
     engine and is 100% covered with synthetic analyses.
+
+    ``allow_split`` / ``allow_composite`` are forwarded to :func:`decide_layout`,
+    which collapses the richer layouts back to ``"single"`` when the caller
+    forbids them. WU-E1 wiring: :data:`decide_layout`'s two flags existed since R1
+    but NOTHING threaded them — every trace was built with both enabled, so the
+    ``allowSplit`` / ``allowComposite`` request fields had no effect on the plan.
+    Both still DEFAULT to ``True``, so every existing caller is unchanged.
     """
     width, height, fps = analysis.width, analysis.height, analysis.fps
     total = analysis.total_frames
@@ -948,6 +961,8 @@ def build_trace(analysis: ShotAnalysis, *, aspect: str = DEFAULT_ASPECT) -> Refr
             speaker_per_frame=speaker_per_frame,
             layout_raw=layout_raw,
             crops=crops,
+            allow_split=allow_split,
+            allow_composite=allow_composite,
         )
 
     dwell = max(1, int(round(LAYOUT_MIN_DWELL_SEC * fps)))
@@ -990,6 +1005,8 @@ def _render_shot(
     speaker_per_frame: list[str],
     layout_raw: list[str],
     crops: list[tuple[float, float, float, float]],
+    allow_split: bool = True,
+    allow_composite: bool = True,
 ) -> None:
     """Decide the speaker/layout/crop for one shot's frames (appends in place)."""
     # Pass 1a: tracked ids + per-frame visual scores (track-id namespace) + active count.
@@ -1029,7 +1046,9 @@ def _render_shot(
         boxes = analysis.boxes_per_frame[frame]
         ids = ids_per_frame[offset]
         speaker = committed[offset]
-        layout_raw.append(decide_layout(active_per_frame[offset]))
+        layout_raw.append(
+            decide_layout(active_per_frame[offset], allow_split=allow_split, allow_composite=allow_composite)
+        )
         speaker_per_frame.append(speaker)
         centers.append(_frame_center(speaker, ids, boxes, width, cold_center))
         timestamps.append(frame / float(analysis.fps))
@@ -1330,6 +1349,22 @@ RemoveFn = Callable[[str], None]
 WriteConcatFn = Callable[[str, Sequence[str]], None]
 WriteTextFn = Callable[[str, str], None]
 ReadTextFn = Callable[[str], str]
+ExistsFn = Callable[[str], bool]
+
+#: The per-shot render manifest suffix — ``<rendered clip>.shots.json`` (WU-E3).
+#: It records the EXACT shot decisions that produced the segment files kept
+#: beside the clip, which is what lets the next re-render skip the shots the user
+#: did not touch. Distinct from ``reframe_override.SIDECAR_SUFFIX``
+#: (``.reframe.json``), which carries the per-frame TRACE for the edit panel.
+SHOT_MANIFEST_SUFFIX = ".shots.json"
+
+#: The shot-manifest schema version. Unlike the decision sidecar (where a bad
+#: file would mean rendering the WRONG pixels, hence a loud refusal), an
+#: unreadable shot manifest only costs TIME: the renderer forgets the cache and
+#: re-encodes every shot, which is always the correct output. So it degrades with
+#: a warning instead of raising — the conservative direction, not a silent
+#: wrong answer.
+SHOT_MANIFEST_VERSION = 1
 
 
 def _write_text_file(path: str, text: str) -> None:
@@ -1393,6 +1428,119 @@ def regions_for_shot(
     )
 
 
+# --------------------------------------------------------------------------- #
+# WU-E3 — the edited-plan render plan (PURE: which shots must be re-encoded)
+# --------------------------------------------------------------------------- #
+def shot_manifest_path(clip: str) -> str:
+    """The per-shot render-manifest path for a rendered ``clip``."""
+    return f"{clip}{SHOT_MANIFEST_SUFFIX}"
+
+
+def shot_segment_path(root: str, ext: str, index: int) -> str:
+    """The kept-on-disk segment path for shot ``index`` of ``<root><ext>``.
+
+    Zero-padded so a directory listing sorts in timeline order; the segments are
+    deliberately NOT deleted after a successful render (they ARE the affected-only
+    cache the next re-render reuses).
+    """
+    return f"{root}.multispeaker.shot{index:03d}{ext}"
+
+
+@dataclass(frozen=True)
+class ShotSegment:
+    """One shot of an edited plan: its compositor regions + the reuse verdict."""
+
+    index: int
+    start_frame: int
+    end_frame: int
+    layout: str
+    regions: tuple[Box, ...]
+    #: Where this shot's encoded piece lives (kept between renders).
+    path: str
+    #: ``True`` when the previous render's piece is byte-valid for this decision,
+    #: so it is concat-copied instead of re-encoded.
+    reuse: bool
+
+
+def manifest_shot_decisions(manifest: Mapping[str, Any] | None, aspect: str) -> dict[int, dict[str, Any]]:
+    """The previous render's shot decisions, keyed by shot index.
+
+    Empty (i.e. "re-encode everything") when there is no manifest, when it was
+    written for a DIFFERENT aspect (the geometry would be wrong), or when its
+    ``shots`` array is not usable. Individual malformed entries are skipped rather
+    than poisoning the whole map — a skipped entry simply forces its shot to be
+    re-encoded.
+    """
+    if manifest is None or manifest.get("aspect") != aspect:
+        return {}
+    shots = manifest.get("shots")
+    if not isinstance(shots, list):
+        return {}
+    decisions: dict[int, dict[str, Any]] = {}
+    for entry in shots:
+        if isinstance(entry, Mapping) and isinstance(entry.get("index"), int):
+            decisions[int(entry["index"])] = dict(entry)
+    return decisions
+
+
+def other_speaker_centers(trace: ReframeTrace, shot: _override.ShotDecision, width: int) -> tuple[float, ...]:
+    """The 0..1 horizontal centres of ``shot``'s OTHER candidate speakers.
+
+    These become the split/composite CELL centres, so a two-up layout frames the
+    second person on their own detected box instead of duplicating the primary.
+    """
+    return tuple(
+        _crop_center(crop, width)
+        for sid, crop in _override.speaker_candidate_crops(trace, shot).items()
+        if sid != shot.speaker
+    )
+
+
+def plan_shot_segments(
+    plan: _override.ShotPlan,
+    trace: ReframeTrace,
+    *,
+    aspect: str,
+    root: str,
+    ext: str,
+    affected_only: bool,
+    manifest: Mapping[str, Any] | None,
+    exists: ExistsFn,
+) -> tuple[ShotSegment, ...]:
+    """PURE: one :class:`ShotSegment` per shot of an edited ``plan``.
+
+    A shot is REUSED (not re-encoded) only when all three hold: the caller asked
+    for ``affected_only``; the previous manifest records a BYTE-IDENTICAL decision
+    for that index (same span, speaker, layout and crop); and its segment file is
+    still on disk. Decision-equality — rather than diffing two plans — is what
+    makes the reuse survive a sidecar restart and makes a first render (no
+    manifest) correctly re-encode everything.
+    """
+    previous = manifest_shot_decisions(manifest, aspect)
+    segments: list[ShotSegment] = []
+    for shot in plan.shots:
+        path = shot_segment_path(root, ext, shot.index)
+        segments.append(
+            ShotSegment(
+                index=shot.index,
+                start_frame=shot.start_frame,
+                end_frame=shot.end_frame,
+                layout=shot.layout,
+                regions=regions_for_shot(
+                    layout=shot.layout,
+                    crop=shot.crop,
+                    other_centers=other_speaker_centers(trace, shot, plan.source_width),
+                    aspect=aspect,
+                    width=plan.source_width,
+                    height=plan.source_height,
+                ),
+                path=path,
+                reuse=affected_only and previous.get(shot.index) == shot.to_dict() and exists(path),
+            )
+        )
+    return tuple(segments)
+
+
 class MultiSpeakerReframeEngine:
     """Engine 3 — the hybrid multi-speaker director (A4 ``reframe_multispeaker``).
 
@@ -1424,6 +1572,7 @@ class MultiSpeakerReframeEngine:
         write_concat_fn: WriteConcatFn = _write_concat_list,
         write_text_fn: WriteTextFn = _write_text_file,
         read_text_fn: ReadTextFn = _read_text_file,
+        exists_fn: ExistsFn = os.path.exists,
     ) -> None:
         self._settings = settings or {}
         self._allow_degrade = bool(allow_degrade)
@@ -1437,6 +1586,7 @@ class MultiSpeakerReframeEngine:
         self._write_concat = write_concat_fn
         self._write_text = write_text_fn
         self._read_text = read_text_fn
+        self._exists = exists_fn
 
     def reframe(
         self,
@@ -1483,6 +1633,27 @@ class MultiSpeakerReframeEngine:
             in_path, out_path, aspect, on_progress=on_progress, should_cancel=should_cancel, on_notice=on_notice
         )
 
+    def analyze(
+        self,
+        in_path: str,
+        *,
+        on_progress: Callable[[float, str], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> ShotAnalysis:
+        """Run the staged heavy backend ONLY — no trace, no render (WU-E1).
+
+        This is the seam ``reframe.analyze`` needs: before it, the ONLY way to
+        obtain a :class:`ShotAnalysis` was :meth:`_render`, which always went on to
+        encode a file, so nothing could produce an editable plan without paying for
+        a full render. :meth:`MultiSpeakerBackend.release` is called in a ``finally``
+        so the 6 GB ceiling holds even when the backend raises mid-stage.
+        """
+        backend = self._backend_factory(self._settings)
+        try:
+            return backend.analyze(in_path, on_progress=on_progress, should_cancel=should_cancel)
+        finally:
+            backend.release()  # free GPU between stages (6 GB ceiling)
+
     def _render(
         self,
         in_path: str,
@@ -1500,11 +1671,7 @@ class MultiSpeakerReframeEngine:
         pieces — all written to temp paths and atomically renamed on success only,
         with every partial cleaned up on any failure (OOM contract preserved).
         """
-        backend = self._backend_factory(self._settings)
-        try:
-            analysis = backend.analyze(in_path, on_progress=on_progress, should_cancel=should_cancel)
-        finally:
-            backend.release()  # free GPU between stages (6 GB ceiling)
+        analysis = self.analyze(in_path, on_progress=on_progress, should_cancel=should_cancel)
         trace = build_trace(analysis, aspect=aspect)
         out_w, out_h = _aspect.output_dimensions(aspect)
         plan = plan_render_segments(analysis, trace, aspect=aspect)
@@ -1607,11 +1774,7 @@ class MultiSpeakerReframeEngine:
                 regions=regions_for_shot(
                     layout=shot.layout,
                     crop=shot.crop,
-                    other_centers=tuple(
-                        _crop_center(crop, resolved.source_width)
-                        for sid, crop in _override.speaker_candidate_crops(trace, shot).items()
-                        if sid != shot.speaker
-                    ),
+                    other_centers=other_speaker_centers(trace, shot, resolved.source_width),
                     aspect=aspect,
                     width=resolved.source_width,
                     height=resolved.source_height,
@@ -1619,6 +1782,136 @@ class MultiSpeakerReframeEngine:
             )
             for shot in resolved.shots
         )
+
+    # ---------------------------------------------------------------- WU-E3 --- #
+    def render_shot_plan(
+        self,
+        in_path: str,
+        out_path: str,
+        plan: _override.ShotPlan,
+        trace: ReframeTrace,
+        *,
+        aspect: str = DEFAULT_ASPECT,
+        affected_only: bool = True,
+        on_progress: Callable[[float, str], None] | None = None,
+        should_cancel: Callable[[], bool] | None = None,
+    ) -> tuple[str, tuple[int, ...]]:
+        """Render an EXTERNALLY-EDITED ``plan``, re-encoding only changed shots.
+
+        The WU-E3 render path. Unlike :meth:`_render` (which always rebuilds the
+        trace from a fresh :class:`ShotAnalysis`) and unlike
+        :meth:`rerender_with_overrides` (which reads its plan from the clip's
+        decision sidecar and re-encodes the WHOLE timeline), this takes the plan the
+        caller edited and:
+
+        * composites each shot from the plan alone (:func:`regions_for_shot`), so
+          NO ML analysis runs — ``trace`` only supplies the other candidate
+          speakers' crops for a split/composite cell;
+        * KEEPS each shot's encoded piece beside the clip and re-encodes only the
+          shots whose decision changed (:func:`plan_shot_segments`), concat-copying
+          the rest — the "affected-only" saving. KNOWN COST, disclosed rather than
+          hidden: those pieces are never garbage-collected, so a rendered clip
+          carries roughly its own size again in cached segments until something else
+          removes them. Bounding that directory is follow-up work, not part of E3.
+        * writes to temp paths and atomically renames on success only, removing
+          every FRESHLY written partial on any failure, so an OOM can never leave a
+          corrupt half-clip at ``out_path`` nor a truncated segment that a later run
+          would mistake for a valid cached piece.
+
+        Returns ``(out_path, reencoded_shot_indices)``.
+        """
+        if not plan.shots:
+            raise MultiSpeakerReframeError("the shot plan has no shots to render")
+        root, ext = os.path.splitext(out_path)
+        ext = ext or ".mp4"
+        segments = plan_shot_segments(
+            plan,
+            trace,
+            aspect=aspect,
+            root=root,
+            ext=ext,
+            affected_only=affected_only,
+            manifest=self._load_shot_manifest(out_path),
+            exists=self._exists,
+        )
+        out_w, out_h = _aspect.output_dimensions(aspect)
+        fps = float(plan.fps)
+        fresh: list[str] = []  # only the pieces THIS run wrote are cleanup-eligible
+        for seg in segments:
+            if seg.reuse:
+                continue
+            duration_sec = (seg.end_frame - seg.start_frame) / fps
+            argv = build_segment_argv(
+                in_path,
+                seg.path,
+                build_filter_complex(seg.layout, list(seg.regions), out_w=out_w, out_h=out_h),
+                start_sec=seg.start_frame / fps,
+                duration_sec=duration_sec,
+                settings=self._settings,
+            )
+            fresh.append(seg.path)
+            self._run_pass(argv, duration_sec, on_progress, should_cancel, list(fresh))
+        part_path = f"{root}.multispeaker.part{ext}"
+        list_path = f"{root}.multispeaker.concat{ext}.txt"
+        try:
+            self._write_concat(list_path, [seg.path for seg in segments])
+        except OSError as exc:
+            self._cleanup_all([*fresh, list_path])
+            raise MultiSpeakerRenderError(f"multi-speaker re-render failed writing the concat manifest: {exc}") from exc
+        total_sec = plan.shots[-1].end_frame / fps
+        self._run_pass(
+            build_concat_argv(list_path, part_path, settings=self._settings),
+            total_sec,
+            on_progress,
+            should_cancel,
+            [*fresh, list_path, part_path],
+        )
+        self._cleanup_all([list_path])  # the shot pieces are the CACHE -> kept
+        self._replace(part_path, out_path)  # atomic: no corrupt half-clip at out_path
+        self._write_shot_manifest(out_path, aspect, plan)
+        return out_path, tuple(seg.index for seg in segments if not seg.reuse)
+
+    def _load_shot_manifest(self, clip: str) -> dict[str, Any] | None:
+        """``clip``'s previous per-shot render manifest, or ``None``.
+
+        Degrades to ``None`` (= re-encode every shot) for an absent, unparseable,
+        non-object or unknown-version manifest. See :data:`SHOT_MANIFEST_VERSION`
+        for why this is a warning rather than a refusal: the cache is an
+        optimisation, and forgetting it produces the same pixels, just slower.
+        """
+        path = shot_manifest_path(clip)
+        try:
+            raw = self._read_text(path)
+        except OSError:
+            return None
+        try:
+            payload = json.loads(raw)
+        except ValueError as exc:
+            _log.warning("ignoring an unparseable reframe shot manifest %s (%s); re-encoding every shot", path, exc)
+            return None
+        if not isinstance(payload, Mapping) or payload.get("version") != SHOT_MANIFEST_VERSION:
+            _log.warning("ignoring an unusable reframe shot manifest %s; re-encoding every shot", path)
+            return None
+        return dict(payload)
+
+    def _write_shot_manifest(self, clip: str, aspect: str, plan: _override.ShotPlan) -> None:
+        """Record the decisions that produced ``clip``'s kept segment pieces.
+
+        Written only AFTER the atomic rename, so a manifest never claims a piece
+        that a failed render left truncated. A write failure is logged, not fatal —
+        the clip is already correct and the only consequence is that the next
+        re-render re-encodes every shot.
+        """
+        path = shot_manifest_path(clip)
+        payload = {
+            "version": SHOT_MANIFEST_VERSION,
+            "aspect": aspect,
+            "shots": [shot.to_dict() for shot in plan.shots],
+        }
+        try:
+            self._write_text(path, json.dumps(payload))
+        except OSError as exc:
+            _log.warning("could not write the reframe shot manifest %s: %s", path, exc)
 
     def _persist_sidecar(self, clip: str, payload: Mapping[str, Any]) -> None:
         """Write ``payload`` to ``<clip>.reframe.json`` (a failure is logged, not fatal)."""

--- a/sidecar/media_studio/features/reframe_multispeaker_backend.py
+++ b/sidecar/media_studio/features/reframe_multispeaker_backend.py
@@ -78,8 +78,20 @@ class RealMultiSpeakerBackend:  # pragma: no cover - requires the heavy native s
         boundaries (the natural cooperative checkpoints — a stage itself is one
         native call). UNVERIFIED by unit test: this class is
         ``# pragma: no cover`` because it needs torch/cv2 + real weights, so the
-        experiment that would settle it is the opt-in ``@e2e`` golden run on real
-        footage, not the branch gate.
+        branch gate cannot see it.
+
+        CORRECTION 2026-08-10 — this used to name "the opt-in ``@e2e`` golden run on
+        real footage" as the settling experiment, which read as though such a run
+        existed. It does NOT. Measured: the suite has exactly three
+        ``@pytest.mark.e2e`` tests (two bundled-ffmpeg encoder probes in
+        ``test_ffmpeg_encoders.py`` and the collection-guarded
+        ``test_reframe_eval_golden_e2e.py``), and NONE constructs this class or
+        exercises cancellation — ``RealMultiSpeakerBackend`` appears in tests only as
+        an import-surface assertion (``test_phase8_backend_surfaces.py:23-24``). The
+        settling experiment therefore has to be BUILT: an opt-in test that runs this
+        backend over a short real clip with weights present, requests a cancel during
+        stage 1, and asserts the JOB reaches ``cancelled`` (not ``error``) and that
+        each stage reported progress before it started.
 
         TERMINAL-STATE NOTE (2026-08-10). The two cancel checkpoints below raise
         :class:`~media_studio.features.reframe_multispeaker.MultiSpeakerReframeError`,

--- a/sidecar/media_studio/features/reframe_multispeaker_backend.py
+++ b/sidecar/media_studio/features/reframe_multispeaker_backend.py
@@ -80,6 +80,21 @@ class RealMultiSpeakerBackend:  # pragma: no cover - requires the heavy native s
         ``# pragma: no cover`` because it needs torch/cv2 + real weights, so the
         experiment that would settle it is the opt-in ``@e2e`` golden run on real
         footage, not the branch gate.
+
+        TERMINAL-STATE NOTE (2026-08-10). The two cancel checkpoints below raise
+        :class:`~media_studio.features.reframe_multispeaker.MultiSpeakerReframeError`,
+        a DOMAIN error — and ``jobs.py`` maps only ``JobCancelled`` to
+        ``_finish_cancelled`` (``jobs.py:720-724``), everything else to
+        ``_finish_error``. Raising a domain error from here therefore does NOT, on
+        its own, produce ``status='cancelled'``; it produced ``status='error'`` with
+        the text below, which was worse than the pre-WU-E1 behaviour where the
+        handler's own ``raise_if_cancelled`` gave a correct (if late) cancel. The
+        fix lives at the JOB BOUNDARY, not here:
+        :meth:`~media_studio.features.reframe_analyze.ReframeAnalyzeService.analyze`
+        wraps this call and converts ANY exception raised while the job is cancelled
+        into ``JobCancelled``, so the terminal state is right whatever a backend
+        chooses to raise. That guard IS unit-tested (a fake backend that raises this
+        exact error on a cancelled probe), which is why the fix was put there.
         """
         import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
 

--- a/sidecar/media_studio/features/reframe_multispeaker_backend.py
+++ b/sidecar/media_studio/features/reframe_multispeaker_backend.py
@@ -28,7 +28,7 @@ import tempfile
 from typing import Any
 
 from ..util import get_logger
-from .reframe_multispeaker import ShotAnalysis
+from .reframe_multispeaker import MultiSpeakerReframeError, ShotAnalysis
 
 log = get_logger("media_studio.features.reframe_multispeaker_backend")
 
@@ -69,6 +69,17 @@ class RealMultiSpeakerBackend:  # pragma: no cover - requires the heavy native s
         Light-ASD + VAD -> release. The heavy imports live inside the helpers so
         an OOM/model-load failure surfaces as the job's typed error (the engine
         wraps it + cleans up the partial output).
+
+        WU-E1: ``on_progress`` and ``should_cancel`` are now actually HONOURED
+        between stages. Both parameters existed since R1 and were never called, so
+        a caller asking for staged progress got silence and a cancel request was
+        only observed after the whole multi-minute pipeline finished. Each stage
+        reports before it starts and cancellation is checked at the two stage
+        boundaries (the natural cooperative checkpoints — a stage itself is one
+        native call). UNVERIFIED by unit test: this class is
+        ``# pragma: no cover`` because it needs torch/cv2 + real weights, so the
+        experiment that would settle it is the opt-in ``@e2e`` golden run on real
+        footage, not the branch gate.
         """
         import cv2  # noqa: PLC0415 - job-time native (pre-imported by __main__)
 
@@ -81,12 +92,27 @@ class RealMultiSpeakerBackend:  # pragma: no cover - requires the heavy native s
         finally:
             cap.release()
 
+        def stage(pct: float, message: str) -> None:
+            if on_progress is not None:
+                on_progress(pct, message)
+
+        def cancelled() -> bool:
+            return should_cancel is not None and bool(should_cancel())
+
+        stage(5.0, "detecting shot cuts")
         shot_boundaries = self._stage_shots(media_path, fps)
         self.release()
+        if cancelled():
+            raise MultiSpeakerReframeError("multi-speaker analysis cancelled after shot detection")
+        stage(25.0, "diarizing speakers")
         diarize_per_frame = self._stage_diarize(media_path, total, fps)
         self.release()
+        if cancelled():
+            raise MultiSpeakerReframeError("multi-speaker analysis cancelled after diarization")
+        stage(55.0, "detecting faces + active speaker")
         boxes, scores, vad = self._stage_visual(media_path, total, fps)
         self.release()
+        stage(95.0, "analysis complete")
 
         return ShotAnalysis(
             width=width,

--- a/sidecar/media_studio/features/reframe_override.py
+++ b/sidecar/media_studio/features/reframe_override.py
@@ -583,14 +583,34 @@ def affected_shot_indices(base: ShotPlan, resolved: ShotPlan) -> tuple[int, ...]
     """The indices of shots whose speaker / layout / crop changed.
 
     This is the EXACT set a caller must re-render — never the whole clip. The two
-    plans must describe the same shots (same length + indices), else it is loud.
+    plans must describe the same shots, else it is loud.
+
+    "The same shots" is checked on FOUR axes, not one: shot count, per-shot index,
+    the per-shot ``[start, end)`` frame span, and the plan-level source geometry
+    (``source_width`` / ``source_height`` / ``fps``). Only ``speaker`` / ``layout``
+    / ``crop`` are user-editable — the rest come from the analysis that produced
+    the plan. Checking only count+index (the pre-2026-08-10 behaviour) left the
+    spans and the geometry as UNVALIDATED wire fields on the
+    ``reframe.render`` boundary: an ``endFrame`` past the analysed trace reached
+    ``speaker_candidate_crops`` and died on a bare ``IndexError``, a negative
+    ``startFrame`` silently produced a wrap-around crop and a negative ffmpeg
+    ``-ss``, and an edited ``sourceWidth`` / ``fps`` changed every crop region and
+    every segment timing while the reuse key could not see it.
     """
     if len(base.shots) != len(resolved.shots):
         raise OverrideError("plans have a different number of shots")
+    if (base.source_width, base.source_height, base.fps) != (
+        resolved.source_width,
+        resolved.source_height,
+        resolved.fps,
+    ):
+        raise OverrideError("plans describe a different source geometry")
     affected: list[int] = []
     for before, after in zip(base.shots, resolved.shots, strict=True):
         if before.index != after.index:
             raise OverrideError("plans describe different shots")
+        if (before.start_frame, before.end_frame) != (after.start_frame, after.end_frame):
+            raise OverrideError(f"shot {after.index} has a different frame span")
         if (before.speaker, before.layout, before.crop) != (after.speaker, after.layout, after.crop):
             affected.append(after.index)
     return tuple(affected)

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -375,6 +375,24 @@ def register_all(
 
     _reframe_override.register(register_fn=reg)
 
+    # reframe.analyze / reframe.render (WU-E1..E3): the trace PRODUCER, its
+    # size-bounded analysis cache, and the edited-plan re-render. Registered right
+    # after the override layer because they close that layer's loop: shotPlan /
+    # applyOverrides could edit a plan, but nothing produced a trace over the wire
+    # and nothing could render an edited plan back to pixels.
+    #
+    # HONEST SCOPE: this wires the BACKEND only. The UI wave (WU-U1..U4) is a
+    # separate work unit, so both methods are REGISTERED BUT NOT USER-REACHABLE
+    # after this change — per-shot active-speaker editing is NOT available to users.
+    from ..features import reframe_analyze as _reframe_analyze  # local: import-light
+
+    _reframe_analyze.register(
+        resolver=svc._resolve_video_path,
+        out_dir=svc.exports_dir / "reframed",
+        settings_provider=svc.settings.get,
+        register_fn=reg,
+    )
+
     # shorts.* (P4 §2/C6): the shorts library registers its own four methods,
     # bound to the same exports root + per-video out-dir layout the short-maker
     # export uses (Services.exports_dir / "shorts-<videoId>").

--- a/sidecar/tests/test_handlers_rpc_surface.py
+++ b/sidecar/tests/test_handlers_rpc_surface.py
@@ -129,8 +129,22 @@ FROZEN_RPC_SURFACE: frozenset[str] = frozenset(
         "recipes.save",
         "refine.apply",
         "refine.preview",
+        # v1.5 DELIBERATE addition (flagship-active-speaker WU-E1/E3): `reframe.analyze`
+        # is the trace PRODUCER and `reframe.render` renders an EDITED ShotPlan,
+        # affected-shot-only, over the cached analysis. Named explicitly because
+        # adding an RPC method must be a conscious act: before them the override
+        # layer below was a decision surface with no producer and no renderer —
+        # `reframe.shotPlan` consumed a trace nothing emitted over the wire, and an
+        # edited plan could not be turned back into pixels. Verified this gate is not
+        # vacuous: registering both with the set unchanged failed
+        # test_rpc_surface_is_byte_identical first.
+        #
+        # NOT user-reachable yet: the UI wave (WU-U1..U4) is a separate work unit, so
+        # these are registered backend methods only.
+        "reframe.analyze",
         "reframe.applyOverrides",
         "reframe.eval",
+        "reframe.render",
         "reframe.shotPlan",
         "reframe.shotPlanFor",
         "savePresets.apply",

--- a/sidecar/tests/test_reframe_analyze.py
+++ b/sidecar/tests/test_reframe_analyze.py
@@ -617,7 +617,7 @@ class TestRenderShotPlan:
         assert out == "out.mp4"
         assert any("shot manifest" in m for m in seen)
 
-    def test_a_shot_manifest_write_failure_DROPS_the_stale_manifest(self):
+    def test_a_shot_manifest_write_failure_drops_the_stale_manifest(self):
         # The consequence of a failed write is NOT "re-encodes every shot" unless the
         # PREVIOUS manifest is removed: this render already overwrote the segment
         # files, so a surviving manifest describes bytes that are gone. Executed

--- a/sidecar/tests/test_reframe_analyze.py
+++ b/sidecar/tests/test_reframe_analyze.py
@@ -1,0 +1,864 @@
+"""Tests for WU-E1/E2/E3 — the reframe trace PRODUCER, its cache, and the
+edited-plan re-render (``reframe.analyze`` / ``reframe.render``).
+
+Everything here runs against a synthetic :class:`~media_studio.features.reframe_multispeaker.ShotAnalysis`
+injected through the ``backend_factory`` seam and a fake ``runner`` — no torch, no
+cv2, no weights, no real video, no real ffmpeg. That is REQUIRED for the 100%
+branch gate but it is NOT evidence the pipeline works on real media: every
+assertion below is about the decision/orchestration layer, never about pixels.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from media_studio.features import offline as _offline
+from media_studio.features import reframe_analyze as ra
+from media_studio.features import reframe_multispeaker as ms
+from media_studio.features import reframe_override as ro
+from media_studio.features.reframe_eval import ReframeTrace, Segment
+from media_studio.jobs import JobRegistry
+from media_studio.protocol import RpcContext, RpcError
+
+ASPECT = "9:16"
+
+
+@contextlib.contextmanager
+def _captured_warnings() -> Iterator[list[str]]:
+    """Collect WARNING records from the engine's module logger.
+
+    ``util.get_logger`` sets ``propagate=False``, so pytest's ``caplog`` never sees
+    these records; attaching a handler to the module logger is the sibling suite's
+    established idiom.
+    """
+    seen: list[str] = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            seen.append(record.getMessage())
+
+    handler = _Capture(level=logging.WARNING)
+    ms._log.addHandler(handler)
+    try:
+        yield seen
+    finally:
+        ms._log.removeHandler(handler)
+
+
+# --------------------------------------------------------------------------- #
+# Synthetic fixtures (hand-built; the spec's prescribed testing approach)
+# --------------------------------------------------------------------------- #
+def _analysis(*, total: int = 6, fps: float = 30.0, width: int = 1920, height: int = 1080, **kw: Any):
+    """A synthetic ShotAnalysis: one confidently-talking face, no cuts."""
+    boxes = kw.pop("boxes", None) or tuple(((100.0, 0.0, 200.0, 400.0),) for _ in range(total))
+    scores = kw.pop("scores", None) or tuple((0.9,) for _ in range(total))
+    diarize = kw.pop("diarize", None) or tuple("0" for _ in range(total))
+    vad = kw.pop("vad", None) or tuple(1.0 for _ in range(total))
+    return ms.ShotAnalysis(
+        width=width,
+        height=height,
+        fps=fps,
+        total_frames=total,
+        shot_boundaries=tuple(kw.pop("shots", ())),
+        boxes_per_frame=boxes,
+        visual_scores_per_frame=scores,
+        diarize_per_frame=diarize,
+        vad_per_frame=vad,
+    )
+
+
+def _two_talker_analysis(*, total: int = 6, concurrent: int = 2):
+    """An analysis where ``concurrent`` faces clear the ASD gate every frame.
+
+    2 concurrent talkers -> ``split``; 3+ -> ``composite`` (``_concurrent_active``).
+    """
+    boxes = tuple(tuple((200.0 * i, 0.0, 180.0, 360.0) for i in range(concurrent)) for _ in range(total))
+    scores = tuple(tuple(0.95 for _ in range(concurrent)) for _ in range(total))
+    return _analysis(total=total, boxes=boxes, scores=scores)
+
+
+def _trace(*, total: int = 6, layout: str = "single", speakers: tuple[str, ...] | None = None) -> ReframeTrace:
+    speaker_per_frame = speakers if speakers is not None else tuple("0" for _ in range(total))
+    return ReframeTrace(
+        shot_boundaries=(),
+        speaker_per_frame=speaker_per_frame,
+        segments=(Segment(start_frame=0, end_frame=total, layout=layout),),
+        crops=tuple((float(100 * (i % 2)), 0.0, 608.0, 1080.0) for i in range(total)),
+    )
+
+
+def _shot(index: int = 0, *, start: int = 0, end: int = 6, layout: str = "single", speaker: str = "0", crop=None):
+    return ro.ShotDecision(
+        index=index,
+        start_frame=start,
+        end_frame=end,
+        speaker=speaker,
+        layout=layout,
+        crop=crop if crop is not None else (0.0, 0.0, 608.0, 1080.0),
+        speakers=("0", "1"),
+    )
+
+
+def _plan(*shots: ro.ShotDecision, width: int = 1920, height: int = 1080, fps: float = 30.0) -> ro.ShotPlan:
+    return ro.ShotPlan(
+        source_width=width,
+        source_height=height,
+        fps=fps,
+        shots=shots or (_shot(),),
+    )
+
+
+def _manifest(plan: ro.ShotPlan, aspect: str = ASPECT) -> dict[str, Any]:
+    """The on-disk shot manifest a previous successful render would have left."""
+    return {
+        "version": ms.SHOT_MANIFEST_VERSION,
+        "aspect": aspect,
+        "shots": [shot.to_dict() for shot in plan.shots],
+    }
+
+
+# --------------------------------------------------------------------------- #
+# WU-E2 — the size-bounded, injectable analysis cache
+# --------------------------------------------------------------------------- #
+def _key(video_id="v", aspect=ASPECT, allow_split=True, allow_composite=True) -> ra.AnalysisKey:
+    return ra.AnalysisKey(video_id=video_id, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
+
+
+def _bundle(analysis=None) -> ra.AnalysisBundle:
+    return ra.build_bundle(
+        analysis if analysis is not None else _analysis(), aspect=ASPECT, allow_split=True, allow_composite=True
+    )
+
+
+class TestLruAnalysisCache:
+    def test_rejects_a_non_positive_bound(self):
+        with pytest.raises(ValueError, match="max_entries"):
+            ra.LruAnalysisCache(max_entries=0)
+
+    def test_accepts_a_bound_of_one(self):
+        assert len(ra.LruAnalysisCache(max_entries=1)) == 0
+
+    def test_get_miss_is_none(self):
+        assert ra.LruAnalysisCache().get(_key()) is None
+
+    def test_put_then_get_round_trips(self):
+        cache = ra.LruAnalysisCache()
+        bundle = _bundle()
+        cache.put(_key(), bundle)
+        assert cache.get(_key()) is bundle
+        assert len(cache) == 1
+
+    def test_putting_the_same_key_twice_replaces_it(self):
+        cache = ra.LruAnalysisCache()
+        first, second = _bundle(), _bundle()
+        cache.put(_key(), first)
+        cache.put(_key(), second)
+        assert len(cache) == 1
+        assert cache.get(_key()) is second
+
+    def test_evicts_the_least_recently_used_entry(self):
+        cache = ra.LruAnalysisCache(max_entries=2)
+        cache.put(_key(video_id="a"), _bundle())
+        cache.put(_key(video_id="b"), _bundle())
+        cache.put(_key(video_id="c"), _bundle())
+        assert len(cache) == 2
+        assert cache.get(_key(video_id="a")) is None  # evicted
+        assert cache.get(_key(video_id="c")) is not None
+
+    def test_a_get_refreshes_recency(self):
+        cache = ra.LruAnalysisCache(max_entries=2)
+        cache.put(_key(video_id="a"), _bundle())
+        cache.put(_key(video_id="b"), _bundle())
+        cache.get(_key(video_id="a"))  # 'a' is now the most recent -> 'b' evicts
+        cache.put(_key(video_id="c"), _bundle())
+        assert cache.get(_key(video_id="b")) is None
+        assert cache.get(_key(video_id="a")) is not None
+
+    def test_the_layout_flags_are_part_of_the_key(self):
+        cache = ra.LruAnalysisCache()
+        cache.put(_key(allow_split=True), _bundle())
+        assert cache.get(_key(allow_split=False)) is None
+
+    def test_find_returns_the_most_recent_match_for_video_and_aspect(self):
+        cache = ra.LruAnalysisCache()
+        older, newer = _bundle(), _bundle()
+        cache.put(_key(allow_split=True), older)
+        cache.put(_key(allow_split=False), newer)
+        assert cache.find("v", ASPECT) is newer
+
+    def test_find_ignores_another_video(self):
+        cache = ra.LruAnalysisCache()
+        cache.put(_key(video_id="other"), _bundle())
+        assert cache.find("v", ASPECT) is None
+
+    def test_find_ignores_another_aspect(self):
+        cache = ra.LruAnalysisCache()
+        cache.put(_key(aspect="1:1"), _bundle())
+        assert cache.find("v", ASPECT) is None
+
+    def test_find_on_an_empty_cache_is_none(self):
+        assert ra.LruAnalysisCache().find("v", ASPECT) is None
+
+
+class TestBuildBundle:
+    def test_produces_a_trace_and_a_matching_editable_plan(self):
+        bundle = ra.build_bundle(_analysis(), aspect=ASPECT, allow_split=True, allow_composite=True)
+        assert isinstance(bundle.trace, ReframeTrace)
+        assert isinstance(bundle.plan, ro.ShotPlan)
+        assert bundle.plan.source_width == 1920
+        assert bundle.plan.source_height == 1080
+        assert bundle.plan.fps == 30.0
+        assert len(bundle.plan.shots) == 1  # no cuts -> one shot
+
+    def test_allow_split_false_collapses_a_two_talker_shot_to_single(self):
+        analysis = _two_talker_analysis()
+        split = ra.build_bundle(analysis, aspect=ASPECT, allow_split=True, allow_composite=True)
+        collapsed = ra.build_bundle(analysis, aspect=ASPECT, allow_split=False, allow_composite=True)
+        assert {s.layout for s in split.plan.shots} == {"split"}
+        assert {s.layout for s in collapsed.plan.shots} == {"single"}
+
+    def test_allow_composite_false_collapses_a_three_talker_shot_to_single(self):
+        analysis = _two_talker_analysis(concurrent=3)
+        composite = ra.build_bundle(analysis, aspect=ASPECT, allow_split=True, allow_composite=True)
+        collapsed = ra.build_bundle(analysis, aspect=ASPECT, allow_split=True, allow_composite=False)
+        assert {s.layout for s in composite.plan.shots} == {"composite"}
+        assert {s.layout for s in collapsed.plan.shots} == {"single"}
+
+
+# --------------------------------------------------------------------------- #
+# WU-E3 (pure half) — the shot manifest + the per-shot reuse decision
+# --------------------------------------------------------------------------- #
+class TestManifestShotDecisions:
+    def test_no_manifest_is_empty(self):
+        assert ms.manifest_shot_decisions(None, ASPECT) == {}
+
+    def test_a_different_aspect_is_empty(self):
+        assert ms.manifest_shot_decisions(_manifest(_plan(), aspect="1:1"), ASPECT) == {}
+
+    def test_shots_that_are_not_a_list_are_empty(self):
+        assert ms.manifest_shot_decisions({"aspect": ASPECT, "shots": "nope"}, ASPECT) == {}
+
+    def test_a_valid_manifest_is_keyed_by_shot_index(self):
+        plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        decisions = ms.manifest_shot_decisions(_manifest(plan), ASPECT)
+        assert sorted(decisions) == [0, 1]
+        assert decisions[1]["startFrame"] == 3
+
+    def test_a_non_object_entry_is_skipped(self):
+        assert ms.manifest_shot_decisions({"aspect": ASPECT, "shots": ["nope"]}, ASPECT) == {}
+
+    def test_an_entry_without_an_integer_index_is_skipped(self):
+        assert ms.manifest_shot_decisions({"aspect": ASPECT, "shots": [{"index": "0"}]}, ASPECT) == {}
+
+
+class TestPlanShotSegments:
+    def _segments(self, plan, *, manifest=None, exists=False, affected_only=True):
+        return ms.plan_shot_segments(
+            plan,
+            _trace(),
+            aspect=ASPECT,
+            root="out",
+            ext=".mp4",
+            affected_only=affected_only,
+            manifest=manifest,
+            exists=lambda _p: exists,
+        )
+
+    def test_without_a_manifest_every_shot_is_re_encoded(self):
+        segments = self._segments(_plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6)))
+        assert [s.reuse for s in segments] == [False, False]
+        assert [s.path for s in segments] == ["out.multispeaker.shot000.mp4", "out.multispeaker.shot001.mp4"]
+
+    def test_an_unchanged_shot_with_an_existing_segment_is_reused(self):
+        plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        segments = self._segments(plan, manifest=_manifest(plan), exists=True)
+        assert [s.reuse for s in segments] == [True, True]
+
+    def test_an_unchanged_shot_whose_segment_file_vanished_is_re_encoded(self):
+        plan = _plan(_shot(0, start=0, end=3))
+        segments = self._segments(plan, manifest=_manifest(plan), exists=False)
+        assert [s.reuse for s in segments] == [False]
+
+    def test_a_changed_shot_is_re_encoded_and_its_sibling_reused(self):
+        before = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        edited = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6, layout="split"))
+        segments = self._segments(edited, manifest=_manifest(before), exists=True)
+        assert [s.reuse for s in segments] == [True, False]
+
+    def test_affected_only_false_re_encodes_everything(self):
+        plan = _plan(_shot(0, start=0, end=3))
+        segments = self._segments(plan, manifest=_manifest(plan), exists=True, affected_only=False)
+        assert [s.reuse for s in segments] == [False]
+
+    def test_a_single_layout_shot_has_one_region(self):
+        segments = self._segments(_plan(_shot(0, layout="single")))
+        assert len(segments[0].regions) == 1
+
+    def test_a_split_layout_shot_has_two_cells(self):
+        segments = self._segments(_plan(_shot(0, layout="split")))
+        assert len(segments[0].regions) == 2
+
+
+# --------------------------------------------------------------------------- #
+# Engine extensions — analyze() (no render) and render_shot_plan()
+# --------------------------------------------------------------------------- #
+class _FakeBackend:
+    def __init__(self, analysis, *, raise_on_analyze: BaseException | None = None):
+        self._analysis = analysis
+        self._raise = raise_on_analyze
+        self.released = 0
+        self.progress: list[tuple[float, str]] = []
+        self.calls = 0
+
+    def analyze(self, media_path, *, on_progress=None, should_cancel=None):
+        self.calls += 1
+        if on_progress is not None:
+            on_progress(50.0, "detecting faces")
+            # A backend that reports 100% of ITS OWN work must not make the job
+            # look finished — the handler clamps the analysis stage below the
+            # plan stage. Over-report so a dropped clamp is observable.
+            on_progress(150.0, "over-reporting on purpose")
+        if should_cancel is not None:
+            should_cancel()
+        if self._raise is not None:
+            raise self._raise
+        return self._analysis
+
+    def release(self):
+        self.released += 1
+
+
+def _engine(**kw):
+    """An engine with every heavy/IO seam faked and the host reported available."""
+    defaults: dict[str, Any] = {
+        "which": lambda _x: "/wsl",
+        "models_present": lambda _s: True,
+        "replace_fn": lambda _a, _b: None,
+        "remove_fn": lambda _p: None,
+        "write_text_fn": lambda _p, _t: None,
+        "write_concat_fn": lambda _lp, _sp: None,
+        "exists_fn": lambda _p: False,
+        "runner": lambda _argv, **_kw: 0,
+    }
+    defaults.update(kw)
+    return ms.MultiSpeakerReframeEngine({}, **defaults)
+
+
+class TestEngineAnalyze:
+    def test_returns_the_backend_bundle_and_releases(self):
+        backend = _FakeBackend(_analysis())
+        eng = _engine(backend_factory=lambda _s: backend)
+        assert eng.analyze("in.mp4") is backend._analysis
+        assert backend.released == 1
+
+    def test_releases_even_when_the_backend_raises(self):
+        backend = _FakeBackend(_analysis(), raise_on_analyze=RuntimeError("CUDA OOM"))
+        eng = _engine(backend_factory=lambda _s: backend)
+        with pytest.raises(RuntimeError):
+            eng.analyze("in.mp4")
+        assert backend.released == 1
+
+    def test_forwards_the_progress_and_cancel_seams(self):
+        seen: list[tuple[float, str]] = []
+        backend = _FakeBackend(_analysis())
+        eng = _engine(backend_factory=lambda _s: backend)
+        eng.analyze("in.mp4", on_progress=lambda p, m: seen.append((p, m)), should_cancel=lambda: False)
+        # The ENGINE forwards the backend's reports verbatim; clamping to a stage
+        # ceiling is the RPC handler's job, not the engine's.
+        assert seen[0] == (50.0, "detecting faces")
+        assert seen[-1] == (150.0, "over-reporting on purpose")
+
+
+class TestRenderShotPlan:
+    def test_an_empty_plan_is_loud(self):
+        eng = _engine()
+        with pytest.raises(ms.MultiSpeakerReframeError, match="no shots"):
+            eng.render_shot_plan("in.mp4", "out.mp4", ro.ShotPlan(1920, 1080, 30.0, ()), _trace())
+
+    def test_renders_every_shot_then_concats_and_atomically_renames(self):
+        runs: list[list[str]] = []
+        moves: list[tuple[str, str]] = []
+        eng = _engine(
+            runner=lambda argv, **_kw: runs.append(list(argv)) or 0,
+            replace_fn=lambda a, b: moves.append((a, b)),
+        )
+        plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", plan, _trace())
+        assert out == "out.mp4"
+        assert reencoded == (0, 1)
+        # two per-shot encodes + one concat pass
+        assert len(runs) == 3
+        assert runs[0][-1] == "out.multispeaker.shot000.mp4"
+        assert runs[1][-1] == "out.multispeaker.shot001.mp4"
+        assert runs[2][-1] == "out.multispeaker.part.mp4"
+        assert moves == [("out.multispeaker.part.mp4", "out.mp4")]
+
+    def test_a_reused_shot_is_not_re_encoded(self):
+        runs: list[list[str]] = []
+        plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        eng = _engine(
+            runner=lambda argv, **_kw: runs.append(list(argv)) or 0,
+            read_text_fn=lambda _p: json.dumps(_manifest(plan)),
+            exists_fn=lambda _p: True,
+        )
+        edited = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6, layout="split"))
+        _out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", edited, _trace())
+        assert reencoded == (1,)
+        assert len(runs) == 2  # ONE shot re-encoded + the concat
+        assert runs[0][-1] == "out.multispeaker.shot001.mp4"
+
+    def test_the_concat_manifest_is_removed_but_the_shot_segments_are_kept(self):
+        removed: list[str] = []
+        eng = _engine(remove_fn=lambda p: removed.append(p))
+        eng.render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert removed == ["out.multispeaker.concat.mp4.txt"]
+
+    def test_a_concat_manifest_write_failure_cleans_up_and_raises(self):
+        removed: list[str] = []
+
+        def boom(_lp, _sp):
+            raise OSError("read-only volume")
+
+        eng = _engine(write_concat_fn=boom, remove_fn=lambda p: removed.append(p))
+        with pytest.raises(ms.MultiSpeakerRenderError, match="concat manifest"):
+            eng.render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert "out.multispeaker.shot000.mp4" in removed
+
+    def test_an_encode_failure_removes_only_the_freshly_written_segments(self):
+        removed: list[str] = []
+        plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        eng = _engine(
+            runner=lambda _argv, **_kw: 1,  # non-zero exit on the FIRST shot
+            remove_fn=lambda p: removed.append(p),
+        )
+        with pytest.raises(ms.MultiSpeakerRenderError, match="exit 1"):
+            eng.render_shot_plan("in.mp4", "out.mp4", plan, _trace())
+        assert removed == ["out.multispeaker.shot000.mp4"]
+
+    def test_an_extensionless_output_defaults_to_mp4(self):
+        runs: list[list[str]] = []
+        eng = _engine(runner=lambda argv, **_kw: runs.append(list(argv)) or 0)
+        eng.render_shot_plan("in.mp4", "out", _plan(_shot(0)), _trace())
+        assert runs[0][-1] == "out.multispeaker.shot000.mp4"
+
+    def test_the_shot_manifest_is_written_after_a_successful_render(self):
+        writes: list[tuple[str, str]] = []
+        eng = _engine(write_text_fn=lambda p, t: writes.append((p, t)))
+        plan = _plan(_shot(0))
+        eng.render_shot_plan("in.mp4", "out.mp4", plan, _trace())
+        assert writes[0][0] == "out.mp4.shots.json"
+        payload = json.loads(writes[0][1])
+        assert payload["version"] == ms.SHOT_MANIFEST_VERSION
+        assert payload["aspect"] == ASPECT
+        assert payload["shots"] == [plan.shots[0].to_dict()]
+
+    def test_a_shot_manifest_write_failure_is_logged_not_fatal(self):
+        # `util.get_logger` sets propagate=False, so caplog cannot see this record —
+        # attach a handler to the module logger instead. Verified to FIRE on the
+        # current implementation; it goes quiet if the except arm ever becomes a
+        # silent `pass`.
+        def boom(_p, _t):
+            raise OSError("disk full")
+
+        with _captured_warnings() as seen:
+            out, _ = _engine(write_text_fn=boom).render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert out == "out.mp4"
+        assert any("shot manifest" in m for m in seen)
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["{not json", json.dumps([1, 2]), json.dumps({"version": 999, "aspect": ASPECT, "shots": []})],
+        ids=["corrupt", "not-an-object", "unknown-version"],
+    )
+    def test_an_unusable_shot_manifest_falls_back_to_re_encoding_everything(self, raw):
+        # The degrade is LOUD (a warning) and conservative (re-encode), never a
+        # silent reuse of a piece whose provenance we cannot establish.
+        eng = _engine(read_text_fn=lambda _p: raw, exists_fn=lambda _p: True)
+        with _captured_warnings() as seen:
+            _out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert reencoded == (0,)
+        assert any("shot manifest" in m for m in seen)
+
+    def test_a_missing_shot_manifest_falls_back_to_re_encoding_everything(self):
+        def missing(_p):
+            raise OSError("no such file")
+
+        eng = _engine(read_text_fn=missing, exists_fn=lambda _p: True)
+        _out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert reencoded == (0,)
+
+
+# --------------------------------------------------------------------------- #
+# WU-E1 / WU-E3 — the two RPC handlers
+# --------------------------------------------------------------------------- #
+def _registry() -> tuple[JobRegistry, list[tuple]]:
+    events: list[tuple] = []
+    return (
+        JobRegistry(
+            emit_progress=lambda j, p, m: events.append(("progress", j, p, m)),
+            emit_done=lambda j, r: events.append(("done", j, r)),
+        ),
+        events,
+    )
+
+
+def _ctx(reg) -> RpcContext:
+    return RpcContext(emit_notification=lambda *_: None, jobs=reg)
+
+
+class _RecordingEngine:
+    """A whole-engine fake: records render_shot_plan kwargs and pokes its callbacks."""
+
+    def __init__(self, analysis):
+        self._analysis = analysis
+        self.render_calls: list[dict[str, Any]] = []
+
+    def analyze(self, _in_path, *, on_progress=None, should_cancel=None):
+        del on_progress, should_cancel
+        return self._analysis
+
+    def render_shot_plan(self, _in_path, out_path, _plan, _trace, **kw):
+        self.render_calls.append(kw)
+        kw["on_progress"](150.0, "over-reporting on purpose")  # must be clamped
+        kw["should_cancel"]()
+        return out_path, ()
+
+
+def _service(
+    tmp_path,
+    *,
+    analysis=None,
+    cache=None,
+    settings=None,
+    available=True,
+    engine_kw=None,
+    seen=None,
+    engine=None,
+):
+    """A service with a fake engine (fake backend + fake runner) and a real cache."""
+    backend = _FakeBackend(analysis if analysis is not None else _analysis())
+
+    def engine_factory(engine_settings: dict[str, Any]):
+        if seen is not None:
+            seen.append(engine_settings)
+        if engine is not None:
+            return engine
+        return _engine(backend_factory=lambda _s: backend, **(engine_kw or {}))
+
+    service = ra.ReframeAnalyzeService(
+        resolver=lambda vid: None if vid == "missing" else "/videos/in.mp4",
+        out_dir=tmp_path / "reframed",
+        settings_provider=lambda: settings or {},
+        cache=cache,
+        engine_factory=engine_factory,
+        which=lambda _x: "/wsl" if available else None,
+        models_present=lambda _s: True,
+    )
+    return service, backend
+
+
+def _run(reg, out) -> Any:
+    job = reg.get(out["jobId"])
+    job.wait(10)
+    return reg.get(out["jobId"])
+
+
+class TestAnalyzeHandler:
+    def test_requires_a_video_id(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="videoId"):
+            svc.analyze({}, _ctx(reg))
+
+    def test_an_unknown_video_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="unknown video"):
+            svc.analyze({"videoId": "missing"}, _ctx(reg))
+
+    def test_a_missing_job_registry_is_an_internal_error(self, tmp_path):
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="no job registry"):
+            svc.analyze({"videoId": "v"}, RpcContext(emit_notification=lambda *_: None, jobs=None))
+
+    @pytest.mark.parametrize("field", ["allowSplit", "allowComposite", "allowDegrade"])
+    def test_a_non_boolean_flag_is_refused(self, tmp_path, field):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match=field):
+            svc.analyze({"videoId": "v", field: "yes"}, _ctx(reg))
+
+    def test_an_unsupported_aspect_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="aspect"):
+            svc.analyze({"videoId": "v", "aspect": "banana"}, _ctx(reg))
+
+    def test_a_non_string_aspect_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="aspect"):
+            svc.analyze({"videoId": "v", "aspect": 916}, _ctx(reg))
+
+    def test_a_blank_diarize_backend_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="diarizeBackend"):
+            svc.analyze({"videoId": "v", "diarizeBackend": ""}, _ctx(reg))
+
+    def test_the_diarize_backend_is_overlaid_onto_the_engine_settings(self, tmp_path):
+        reg, _ = _registry()
+        seen: list[dict[str, Any]] = []
+        svc, _ = _service(tmp_path, seen=seen)
+        out = svc.analyze({"videoId": "v", "diarizeBackend": "pyannote"}, _ctx(reg))
+        assert _run(reg, out).status.value == "done"
+        assert seen[0]["diarizeBackend"] == "pyannote"
+
+    def test_without_a_diarize_backend_the_settings_are_untouched(self, tmp_path):
+        reg, _ = _registry()
+        seen: list[dict[str, Any]] = []
+        svc, _ = _service(tmp_path, seen=seen)
+        out = svc.analyze({"videoId": "v"}, _ctx(reg))
+        assert _run(reg, out).status.value == "done"
+        assert "diarizeBackend" not in seen[0]
+
+    def test_returns_a_trace_and_a_plan_without_rendering(self, tmp_path):
+        reg, _ = _registry()
+        runs: list[list[str]] = []
+        svc, backend = _service(tmp_path, engine_kw={"runner": lambda argv, **_kw: runs.append(list(argv)) or 0})
+        out = svc.analyze({"videoId": "v"}, _ctx(reg))
+        job = _run(reg, out)
+        assert job.status.value == "done"
+        assert job.result["degraded"] is None
+        assert set(job.result["trace"]) == {"shotBoundaries", "speakerPerFrame", "segments", "crops"}
+        assert job.result["plan"]["sourceWidth"] == 1920
+        assert job.result["plan"]["shots"]
+        assert backend.calls == 1
+        assert runs == [], "reframe.analyze must not run ffmpeg"
+
+    def test_a_second_call_reuses_the_cached_bundle(self, tmp_path):
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, backend = _service(tmp_path, cache=cache)
+        first = _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        second = _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        assert first.result["plan"] == second.result["plan"]
+        assert backend.calls == 1, "the cached analysis must not re-run the GPU stage"
+
+    def test_a_different_aspect_is_a_cache_miss(self, tmp_path):
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, backend = _service(tmp_path, cache=cache)
+        _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        _run(reg, svc.analyze({"videoId": "v", "aspect": "1:1"}, _ctx(reg)))
+        assert backend.calls == 2
+
+    def test_the_default_cache_is_used_when_none_is_injected(self, tmp_path):
+        reg, _ = _registry()
+        svc, backend = _service(tmp_path, cache=None)
+        _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        assert backend.calls == 1
+
+    def test_an_explicit_request_on_an_unavailable_host_is_a_typed_rpc_error(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path, available=False)
+        with pytest.raises(RpcError, match="unavailable"):
+            svc.analyze({"videoId": "v"}, _ctx(reg))
+
+    def test_auto_degrade_yields_an_honest_null_plan_and_a_notice(self, tmp_path):
+        reg, _ = _registry()
+        svc, backend = _service(tmp_path, available=False)
+        out = svc.analyze({"videoId": "v", "allowDegrade": True}, _ctx(reg))
+        job = _run(reg, out)
+        assert job.status.value == "done"
+        assert job.result["plan"] is None
+        assert job.result["trace"] is None
+        assert job.result["degraded"]["type"]
+        assert backend.calls == 0
+
+    def test_offline_and_unavailable_raises_the_offline_error(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path, available=False, settings={"offline": True})
+        with pytest.raises(_offline.OfflineError, match="Offline mode"):
+            svc.analyze({"videoId": "v", "allowDegrade": True}, _ctx(reg))
+
+    def test_offline_with_an_available_host_still_runs(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path, settings={"offline": True})
+        assert _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg))).status.value == "done"
+
+    def test_a_failing_settings_provider_degrades_to_empty_settings(self, tmp_path):
+        def boom():
+            raise RuntimeError("settings store is wedged")
+
+        reg, _ = _registry()
+        svc = ra.ReframeAnalyzeService(
+            resolver=lambda _v: "/videos/in.mp4",
+            out_dir=tmp_path / "reframed",
+            settings_provider=boom,
+            engine_factory=lambda _s: _engine(backend_factory=lambda _s2: _FakeBackend(_analysis())),
+            which=lambda _x: "/wsl",
+            models_present=lambda _s: True,
+        )
+        assert _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg))).status.value == "done"
+
+    def test_the_backend_progress_is_clamped_below_the_plan_stage(self, tmp_path):
+        reg, events = _registry()
+        svc, _ = _service(tmp_path, analysis=_analysis())
+        out = svc.analyze({"videoId": "v"}, _ctx(reg))
+        assert _run(reg, out).status.value == "done"
+        pcts = [e[2] for e in events if e[0] == "progress"]
+        assert 50 in pcts, "an in-range backend report must pass through untouched"
+        assert 90 in pcts, "the backend's over-reported 150% must be clamped to the stage ceiling"
+        assert pcts[-1] == 100  # only the handler's own terminal step reports 100
+
+    def test_cancelling_at_the_shots_checkpoint_aborts_before_the_plan_stage(self, tmp_path):
+        # Cooperative cancel: the progress sink cancels at the "detecting shots"
+        # checkpoint, so the post-analysis raise_if_cancelled aborts the job and no
+        # bundle is ever cached (deterministic — mirrors test_diarize's sink trick).
+        holder: dict[str, Any] = {}
+
+        def emit_progress(job_id, pct, _msg):
+            if pct == 2:
+                holder["reg"].cancel(job_id)
+
+        reg = JobRegistry(emit_progress=emit_progress, emit_done=lambda *_a: None)
+        holder["reg"] = reg
+        cache = ra.LruAnalysisCache()
+        svc, _backend = _service(tmp_path, cache=cache)
+        out = svc.analyze({"videoId": "v"}, _ctx(reg))
+        reg.get(out["jobId"]).wait(10)
+        assert reg.get(out["jobId"]).status.value == "cancelled"
+        assert cache.find("v", ASPECT) is None
+
+
+class TestRenderHandler:
+    def _seeded(self, tmp_path, *, analysis=None, engine_kw=None):
+        """A service whose cache already holds an analyze() bundle for ``v``."""
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, backend = _service(tmp_path, analysis=analysis, cache=cache, engine_kw=engine_kw)
+        seeded = _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        assert seeded.status.value == "done"
+        return svc, cache, seeded.result["plan"], backend
+
+    def test_requires_a_video_id(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="videoId"):
+            svc.render({}, _ctx(reg))
+
+    def test_a_missing_job_registry_is_an_internal_error(self, tmp_path):
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="no job registry"):
+            svc.render({"videoId": "v"}, RpcContext(emit_notification=lambda *_: None, jobs=None))
+
+    def test_an_unknown_video_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="unknown video"):
+            svc.render({"videoId": "missing", "plan": _plan().to_dict()}, _ctx(reg))
+
+    def test_a_malformed_plan_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="plan"):
+            svc.render({"videoId": "v", "plan": {"sourceWidth": 0}}, _ctx(reg))
+
+    def test_a_non_boolean_affected_only_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="affectedOnly"):
+            svc.render({"videoId": "v", "plan": _plan().to_dict(), "affectedOnly": "yes"}, _ctx(reg))
+
+    def test_without_a_cached_analysis_the_render_is_loud(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="reframe.analyze"):
+            svc.render({"videoId": "v", "plan": _plan().to_dict()}, _ctx(reg))
+
+    def test_a_plan_with_a_different_shot_count_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _cache, plan, _b = self._seeded(tmp_path)
+        wrong = {**plan, "shots": [*plan["shots"], {**plan["shots"][0], "index": 1}]}
+        with pytest.raises(RpcError, match="shots"):
+            svc.render({"videoId": "v", "plan": wrong}, _ctx(reg))
+
+    def test_renders_the_edited_plan_and_reports_the_affected_shots(self, tmp_path):
+        reg, _ = _registry()
+        runs: list[list[str]] = []
+        svc, _cache, plan, _b = self._seeded(
+            tmp_path, engine_kw={"runner": lambda argv, **_kw: runs.append(list(argv)) or 0}
+        )
+        edited = {**plan, "shots": [{**plan["shots"][0], "layout": "split"}]}
+        out = svc.render({"videoId": "v", "plan": edited}, _ctx(reg))
+        job = _run(reg, out)
+        assert job.status.value == "done", job.error
+        assert job.result["outPath"].endswith("v.multispeaker.mp4")
+        assert job.result["affected"] == [0]
+        assert job.result["reencoded"] == [0]
+        assert runs, "the edited plan must actually be encoded"
+
+    def test_an_unedited_plan_renders_with_an_empty_affected_set(self, tmp_path):
+        reg, _ = _registry()
+        svc, _cache, plan, _b = self._seeded(tmp_path)
+        job = _run(reg, svc.render({"videoId": "v", "plan": plan}, _ctx(reg)))
+        assert job.status.value == "done", job.error
+        assert job.result["affected"] == []
+        # first render: no manifest on disk yet -> the shot is still encoded once
+        assert job.result["reencoded"] == [0]
+
+    def test_the_render_seams_are_threaded_to_the_engine(self, tmp_path):
+        reg, events = _registry()
+        recorder = _RecordingEngine(_analysis())
+        cache = ra.LruAnalysisCache()
+        svc, _b = _service(tmp_path, cache=cache, engine=recorder)
+        _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        plan = cache.find("v", ASPECT).plan.to_dict()
+        job = _run(reg, svc.render({"videoId": "v", "plan": plan, "affectedOnly": False}, _ctx(reg)))
+        assert job.status.value == "done", job.error
+        kw = recorder.render_calls[0]
+        assert kw["affected_only"] is False
+        assert kw["aspect"] == ASPECT
+        # the engine's over-reported 150% is clamped below the terminal 100
+        assert 99 in [e[2] for e in events if e[0] == "progress"]
+
+    def test_affected_only_defaults_to_true(self, tmp_path):
+        reg, _ = _registry()
+        recorder = _RecordingEngine(_analysis())
+        cache = ra.LruAnalysisCache()
+        svc, _b = _service(tmp_path, cache=cache, engine=recorder)
+        _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        plan = cache.find("v", ASPECT).plan.to_dict()
+        _run(reg, svc.render({"videoId": "v", "plan": plan}, _ctx(reg)))
+        assert recorder.render_calls[0]["affected_only"] is True
+
+    def test_the_output_directory_is_created(self, tmp_path):
+        reg, _ = _registry()
+        svc, _cache, plan, _b = self._seeded(tmp_path)
+        _run(reg, svc.render({"videoId": "v", "plan": plan}, _ctx(reg)))
+        assert (tmp_path / "reframed").is_dir()
+
+
+# --------------------------------------------------------------------------- #
+# registration
+# --------------------------------------------------------------------------- #
+class TestRegister:
+    def test_registers_both_new_methods(self, tmp_path):
+        names: list[str] = []
+        service = ra.register(
+            resolver=lambda _v: "/videos/in.mp4",
+            out_dir=tmp_path / "reframed",
+            register_fn=lambda name, _handler: names.append(name),
+        )
+        assert names == ["reframe.analyze", "reframe.render"]
+        assert isinstance(service, ra.ReframeAnalyzeService)
+
+    def test_the_default_engine_factory_builds_the_multispeaker_engine(self):
+        assert isinstance(ra._default_engine_factory({}), ms.MultiSpeakerReframeEngine)

--- a/sidecar/tests/test_reframe_analyze.py
+++ b/sidecar/tests/test_reframe_analyze.py
@@ -113,20 +113,74 @@ def _plan(*shots: ro.ShotDecision, width: int = 1920, height: int = 1080, fps: f
     )
 
 
-def _manifest(plan: ro.ShotPlan, aspect: str = ASPECT) -> dict[str, Any]:
-    """The on-disk shot manifest a previous successful render would have left."""
-    return {
+def _trace_two(second_x: float, *, total: int = 6, layout: str = "split") -> ReframeTrace:
+    """A two-speaker trace where the NON-primary speaker sits at ``second_x``.
+
+    Speaker ``"0"`` owns frame 0, ``"1"`` owns the rest, so
+    :func:`~media_studio.features.reframe_multispeaker.other_speaker_centers` for a
+    shot whose speaker is ``"0"`` resolves to ``"1"``'s crop centre — the ONLY thing
+    that moves between two traces here.
+    """
+    return ReframeTrace(
+        shot_boundaries=(),
+        speaker_per_frame=tuple("0" if i == 0 else "1" for i in range(total)),
+        segments=(Segment(start_frame=0, end_frame=total, layout=layout),),
+        crops=tuple((0.0 if i == 0 else second_x, 0.0, 608.0, 1080.0) for i in range(total)),
+    )
+
+
+def _segments_for(plan: ro.ShotPlan, trace: ReframeTrace, aspect: str = ASPECT) -> tuple[ms.ShotSegment, ...]:
+    """The segments a first (cache-less) render of ``plan`` would produce."""
+    return ms.plan_shot_segments(
+        plan,
+        trace,
+        aspect=aspect,
+        root="out",
+        ext=".mp4",
+        affected_only=False,
+        manifest=None,
+        exists=lambda _p: False,
+    )
+
+
+def _manifest(plan: ro.ShotPlan, aspect: str = ASPECT, trace: ReframeTrace | None = None) -> dict[str, Any]:
+    """The on-disk shot manifest a previous successful render would have left.
+
+    Built through the PRODUCTION payload builder over the PRODUCTION segment
+    planner, so a test manifest can never drift from what a real render writes.
+    """
+    return ms.shot_manifest_payload(plan, _segments_for(plan, trace or _trace(), aspect), aspect=aspect)
+
+
+def _bare_manifest(**over: Any) -> dict[str, Any]:
+    """A hand-built manifest whose top-level identity MATCHES ``_plan()`` at ASPECT.
+
+    Needed so a test that probes the ``shots``-array branches cannot be silently
+    short-circuited by the identity guard (aspect / fps / source dimensions) and
+    pass for the wrong reason.
+    """
+    base = {
         "version": ms.SHOT_MANIFEST_VERSION,
-        "aspect": aspect,
-        "shots": [shot.to_dict() for shot in plan.shots],
+        "aspect": ASPECT,
+        "fps": 30.0,
+        "sourceWidth": 1920,
+        "sourceHeight": 1080,
+        "shots": [],
     }
+    return {**base, **over}
 
 
 # --------------------------------------------------------------------------- #
 # WU-E2 — the size-bounded, injectable analysis cache
 # --------------------------------------------------------------------------- #
-def _key(video_id="v", aspect=ASPECT, allow_split=True, allow_composite=True) -> ra.AnalysisKey:
-    return ra.AnalysisKey(video_id=video_id, aspect=aspect, allow_split=allow_split, allow_composite=allow_composite)
+def _key(video_id="v", aspect=ASPECT, allow_split=True, allow_composite=True, diarize_backend=None) -> ra.AnalysisKey:
+    return ra.AnalysisKey(
+        video_id=video_id,
+        aspect=aspect,
+        allow_split=allow_split,
+        allow_composite=allow_composite,
+        diarize_backend=diarize_backend,
+    )
 
 
 def _bundle(analysis=None) -> ra.AnalysisBundle:
@@ -184,6 +238,16 @@ class TestLruAnalysisCache:
         cache.put(_key(allow_split=True), _bundle())
         assert cache.get(_key(allow_split=False)) is None
 
+    def test_the_diarize_backend_is_part_of_the_key(self):
+        # REFUTED-OBJECTION FIX: diarizeBackend selects WHICH diarizer runs, so it
+        # changes the ShotAnalysis and therefore the whole bundle. Keying without it
+        # served backend A's plan to every later request for backend B.
+        cache = ra.LruAnalysisCache()
+        cache.put(_key(diarize_backend="alpha"), _bundle())
+        assert cache.get(_key(diarize_backend="beta")) is None
+        assert cache.get(_key(diarize_backend=None)) is None
+        assert cache.get(_key(diarize_backend="alpha")) is not None
+
     def test_find_returns_the_most_recent_match_for_video_and_aspect(self):
         cache = ra.LruAnalysisCache()
         older, newer = _bundle(), _bundle()
@@ -235,32 +299,45 @@ class TestBuildBundle:
 # --------------------------------------------------------------------------- #
 class TestManifestShotDecisions:
     def test_no_manifest_is_empty(self):
-        assert ms.manifest_shot_decisions(None, ASPECT) == {}
+        assert ms.manifest_shot_decisions(None, _plan(), aspect=ASPECT) == {}
 
     def test_a_different_aspect_is_empty(self):
-        assert ms.manifest_shot_decisions(_manifest(_plan(), aspect="1:1"), ASPECT) == {}
+        assert ms.manifest_shot_decisions(_manifest(_plan(), aspect="1:1"), _plan(), aspect=ASPECT) == {}
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("fps", 60.0), ("sourceWidth", 1280), ("sourceHeight", 720)],
+        ids=["fps", "width", "height"],
+    )
+    def test_a_manifest_written_for_a_different_source_identity_is_empty(self, field, value):
+        # The aspect guard's own rationale ("the geometry would be wrong") applies
+        # verbatim to fps and the source dimensions: regions_for_shot is fed
+        # plan.source_width/height and every segment's -ss/-t is frame/fps. Omitting
+        # them let a relinked source at a new resolution republish stale segments.
+        assert ms.manifest_shot_decisions(_bare_manifest(**{field: value}), _plan(), aspect=ASPECT) == {}
 
     def test_shots_that_are_not_a_list_are_empty(self):
-        assert ms.manifest_shot_decisions({"aspect": ASPECT, "shots": "nope"}, ASPECT) == {}
+        assert ms.manifest_shot_decisions(_bare_manifest(shots="nope"), _plan(), aspect=ASPECT) == {}
 
     def test_a_valid_manifest_is_keyed_by_shot_index(self):
         plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
-        decisions = ms.manifest_shot_decisions(_manifest(plan), ASPECT)
+        decisions = ms.manifest_shot_decisions(_manifest(plan), plan, aspect=ASPECT)
         assert sorted(decisions) == [0, 1]
         assert decisions[1]["startFrame"] == 3
+        assert decisions[1]["regions"], "a manifest entry must record the regions it rendered"
 
     def test_a_non_object_entry_is_skipped(self):
-        assert ms.manifest_shot_decisions({"aspect": ASPECT, "shots": ["nope"]}, ASPECT) == {}
+        assert ms.manifest_shot_decisions(_bare_manifest(shots=["nope"]), _plan(), aspect=ASPECT) == {}
 
     def test_an_entry_without_an_integer_index_is_skipped(self):
-        assert ms.manifest_shot_decisions({"aspect": ASPECT, "shots": [{"index": "0"}]}, ASPECT) == {}
+        assert ms.manifest_shot_decisions(_bare_manifest(shots=[{"index": "0"}]), _plan(), aspect=ASPECT) == {}
 
 
 class TestPlanShotSegments:
-    def _segments(self, plan, *, manifest=None, exists=False, affected_only=True):
+    def _segments(self, plan, *, manifest=None, exists=False, affected_only=True, trace=None):
         return ms.plan_shot_segments(
             plan,
-            _trace(),
+            trace if trace is not None else _trace(),
             aspect=ASPECT,
             root="out",
             ext=".mp4",
@@ -302,6 +379,28 @@ class TestPlanShotSegments:
     def test_a_split_layout_shot_has_two_cells(self):
         segments = self._segments(_plan(_shot(0, layout="split")))
         assert len(segments[0].regions) == 2
+
+    def test_a_moved_other_speaker_forces_a_re_encode(self):
+        # THE reuse hole. A segment's PIXELS also depend on `other_centers`, which
+        # comes from the TRACE (speaker_per_frame + crops), and shot.to_dict()
+        # records only index/span/speaker/layout/crop/speakers — never the other
+        # speaker's rectangle. So a re-analysis that moves a NON-primary speaker
+        # while leaving the majority speaker, layout and crop untouched produced a
+        # byte-identical decision dict, and the stale segment was concat-copied.
+        plan = _plan(_shot(0, layout="split"))
+        before, after = _trace_two(0.0), _trace_two(705.0)
+        stale = _manifest(plan, trace=before)
+        moved = self._segments(plan, manifest=stale, exists=True, trace=after)
+        assert moved[0].regions != _segments_for(plan, before)[0].regions, "the fixture must move a cell"
+        assert [s.reuse for s in moved] == [False], "a moved cell must NOT be concat-copied"
+
+    def test_an_unmoved_other_speaker_still_reuses(self):
+        # Detector control for the test above: the SAME trace must still reuse, so
+        # the assertion above is measuring the trace change and not a broken key.
+        plan = _plan(_shot(0, layout="split"))
+        trace = _trace_two(0.0)
+        segments = self._segments(plan, manifest=_manifest(plan, trace=trace), exists=True, trace=trace)
+        assert [s.reuse for s in segments] == [True]
 
 
 # --------------------------------------------------------------------------- #
@@ -393,10 +492,16 @@ class TestRenderShotPlan:
         assert reencoded == (0, 1)
         # two per-shot encodes + one concat pass
         assert len(runs) == 3
-        assert runs[0][-1] == "out.multispeaker.shot000.mp4"
-        assert runs[1][-1] == "out.multispeaker.shot001.mp4"
+        # Every ffmpeg target is a .part; the cache entries only ever appear as the
+        # DESTINATION of an atomic rename (see the temp-path test below).
+        assert runs[0][-1] == "out.multispeaker.shot000.part.mp4"
+        assert runs[1][-1] == "out.multispeaker.shot001.part.mp4"
         assert runs[2][-1] == "out.multispeaker.part.mp4"
-        assert moves == [("out.multispeaker.part.mp4", "out.mp4")]
+        assert moves == [
+            ("out.multispeaker.shot000.part.mp4", "out.multispeaker.shot000.mp4"),
+            ("out.multispeaker.shot001.part.mp4", "out.multispeaker.shot001.mp4"),
+            ("out.multispeaker.part.mp4", "out.mp4"),
+        ]
 
     def test_a_reused_shot_is_not_re_encoded(self):
         runs: list[list[str]] = []
@@ -410,7 +515,7 @@ class TestRenderShotPlan:
         _out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", edited, _trace())
         assert reencoded == (1,)
         assert len(runs) == 2  # ONE shot re-encoded + the concat
-        assert runs[0][-1] == "out.multispeaker.shot001.mp4"
+        assert runs[0][-1] == "out.multispeaker.shot001.part.mp4"
 
     def test_the_concat_manifest_is_removed_but_the_shot_segments_are_kept(self):
         removed: list[str] = []
@@ -430,6 +535,9 @@ class TestRenderShotPlan:
         assert "out.multispeaker.shot000.mp4" in removed
 
     def test_an_encode_failure_removes_only_the_freshly_written_segments(self):
+        # A first-shot failure now removes ONLY this run's .part — never the cache
+        # entry at shot000.mp4, which (if it exists at all) is a PREVIOUS render's
+        # still-valid piece that this run has not replaced yet.
         removed: list[str] = []
         plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
         eng = _engine(
@@ -438,13 +546,13 @@ class TestRenderShotPlan:
         )
         with pytest.raises(ms.MultiSpeakerRenderError, match="exit 1"):
             eng.render_shot_plan("in.mp4", "out.mp4", plan, _trace())
-        assert removed == ["out.multispeaker.shot000.mp4"]
+        assert removed == ["out.multispeaker.shot000.part.mp4"]
 
     def test_an_extensionless_output_defaults_to_mp4(self):
         runs: list[list[str]] = []
         eng = _engine(runner=lambda argv, **_kw: runs.append(list(argv)) or 0)
         eng.render_shot_plan("in.mp4", "out", _plan(_shot(0)), _trace())
-        assert runs[0][-1] == "out.multispeaker.shot000.mp4"
+        assert runs[0][-1] == "out.multispeaker.shot000.part.mp4"
 
     def test_the_shot_manifest_is_written_after_a_successful_render(self):
         writes: list[tuple[str, str]] = []
@@ -455,7 +563,13 @@ class TestRenderShotPlan:
         payload = json.loads(writes[0][1])
         assert payload["version"] == ms.SHOT_MANIFEST_VERSION
         assert payload["aspect"] == ASPECT
-        assert payload["shots"] == [plan.shots[0].to_dict()]
+        # The SOURCE IDENTITY is recorded too: fps and the source dimensions decide a
+        # segment's timing and geometry exactly as much as the aspect does.
+        assert (payload["fps"], payload["sourceWidth"], payload["sourceHeight"]) == (30.0, 1920, 1080)
+        # And each row carries the regions it rendered, so a trace change that moves
+        # a split/composite cell cannot present as an unchanged decision.
+        assert payload["shots"] == [ms.shot_manifest_entry(plan.shots[0], _segments_for(plan, _trace())[0].regions)]
+        assert payload["shots"][0]["regions"] == [[0.0, 0.0, 608.0, 1080.0]]
 
     def test_a_shot_manifest_write_failure_is_logged_not_fatal(self):
         # `util.get_logger` sets propagate=False, so caplog cannot see this record —
@@ -469,6 +583,122 @@ class TestRenderShotPlan:
             out, _ = _engine(write_text_fn=boom).render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
         assert out == "out.mp4"
         assert any("shot manifest" in m for m in seen)
+
+    def test_a_shot_manifest_write_failure_DROPS_the_stale_manifest(self):
+        # The consequence of a failed write is NOT "re-encodes every shot" unless the
+        # PREVIOUS manifest is removed: this render already overwrote the segment
+        # files, so a surviving manifest describes bytes that are gone. Executed
+        # repro before the fix: render(split) -> render(single, manifest write
+        # fails) -> render(split) REUSED the file, delivering the single render
+        # while reporting `reencoded: []`.
+        removed: list[str] = []
+
+        def boom(_p, _t):
+            raise OSError("disk full")
+
+        eng = _engine(write_text_fn=boom, remove_fn=lambda p: removed.append(p))
+        eng.render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert "out.mp4.shots.json" in removed
+
+    def test_a_failed_stale_manifest_drop_is_also_logged(self):
+        def boom_write(_p, _t):
+            raise OSError("disk full")
+
+        def boom_remove(path):
+            if path.endswith(".shots.json"):
+                raise OSError("read-only volume")
+
+        with _captured_warnings() as seen:
+            out, _ = _engine(write_text_fn=boom_write, remove_fn=boom_remove).render_shot_plan(
+                "in.mp4", "out.mp4", _plan(_shot(0)), _trace()
+            )
+        assert out == "out.mp4"
+        assert any("stale" in m for m in seen)
+
+    def test_a_manifest_from_a_different_trace_does_not_license_reuse(self):
+        # End-to-end through the SHIPPED render path, not just the pure planner.
+        runs: list[list[str]] = []
+        plan = _plan(_shot(0, layout="split"))
+        eng = _engine(
+            runner=lambda argv, **_kw: runs.append(list(argv)) or 0,
+            read_text_fn=lambda _p: json.dumps(_manifest(plan, trace=_trace_two(0.0))),
+            exists_fn=lambda _p: True,
+        )
+        _out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", plan, _trace_two(705.0))
+        assert reencoded == (0,)
+        assert len(runs) == 2, "the moved cell must be re-encoded, then concatenated"
+
+    def test_a_manifest_from_a_different_fps_re_encodes_everything(self):
+        # Executed repro: a plan carrying fps 60 / 1280x720 over a manifest written
+        # at fps 30 / 1920x1080 previously reported reencoded=() and ran exactly ONE
+        # ffmpeg pass (the concat), republishing the stale segment at the old
+        # geometry and timing.
+        runs: list[list[str]] = []
+        old = _plan(_shot(0), width=1920, height=1080, fps=30.0)
+        new = _plan(_shot(0), width=1280, height=720, fps=60.0)
+        eng = _engine(
+            runner=lambda argv, **_kw: runs.append(list(argv)) or 0,
+            read_text_fn=lambda _p: json.dumps(_manifest(old)),
+            exists_fn=lambda _p: True,
+        )
+        _out, reencoded = eng.render_shot_plan("in.mp4", "out.mp4", new, _trace())
+        assert reencoded == (0,)
+        assert len(runs) == 2
+
+    def test_each_segment_is_encoded_to_a_temp_path_then_atomically_renamed(self):
+        # The segment IS the cache, so encoding straight to its final path made the
+        # cache entry and the in-flight write target the same file: an OOM-KILLED
+        # process (no Python cleanup runs) left a truncated segment that the next
+        # render's bare exists() check happily concat-copied.
+        runs: list[list[str]] = []
+        moves: list[tuple[str, str]] = []
+        eng = _engine(
+            runner=lambda argv, **_kw: runs.append(list(argv)) or 0,
+            replace_fn=lambda a, b: moves.append((a, b)),
+        )
+        eng.render_shot_plan("in.mp4", "out.mp4", _plan(_shot(0)), _trace())
+        assert runs[0][-1] == "out.multispeaker.shot000.part.mp4", "ffmpeg must write the .part, not the cache entry"
+        assert moves == [
+            ("out.multispeaker.shot000.part.mp4", "out.multispeaker.shot000.mp4"),
+            ("out.multispeaker.part.mp4", "out.mp4"),
+        ]
+
+    def test_a_later_encode_failure_removes_this_runs_segments_and_its_part(self):
+        removed: list[str] = []
+        calls = {"n": 0}
+
+        def runner(_argv, **_kw):
+            calls["n"] += 1
+            return 0 if calls["n"] == 1 else 1  # the SECOND shot fails
+
+        eng = _engine(runner=runner, remove_fn=lambda p: removed.append(p))
+        plan = _plan(_shot(0, start=0, end=3), _shot(1, start=3, end=6))
+        with pytest.raises(ms.MultiSpeakerRenderError, match="exit 1"):
+            eng.render_shot_plan("in.mp4", "out.mp4", plan, _trace())
+        assert removed == ["out.multispeaker.shot000.mp4", "out.multispeaker.shot001.part.mp4"]
+
+    def test_the_per_shot_encode_receives_the_progress_and_cancel_seams(self):
+        # Both seams were passed to the CONCAT pass but nothing asserted they reach
+        # the per-shot encode, so mutants that replaced either with None survived
+        # the whole suite.
+        seen: list[dict[str, Any]] = []
+        sink: list[tuple[float, str]] = []
+
+        def runner(_argv, **kw):
+            seen.append(kw)
+            return 0
+
+        _engine(runner=runner).render_shot_plan(
+            "in.mp4",
+            "out.mp4",
+            _plan(_shot(0)),
+            _trace(),
+            on_progress=lambda p, m: sink.append((p, m)),
+            should_cancel=lambda: True,
+        )
+        assert seen[0]["should_cancel"] is not None and seen[0]["should_cancel"]() is True
+        seen[0]["on_progress"](7.0, "encoding shot 0")
+        assert sink == [(7.0, "encoding shot 0")]
 
     @pytest.mark.parametrize(
         "raw",
@@ -658,6 +888,25 @@ class TestAnalyzeHandler:
         _run(reg, svc.analyze({"videoId": "v", "aspect": "1:1"}, _ctx(reg)))
         assert backend.calls == 2
 
+    def test_a_different_diarize_backend_is_a_cache_miss(self, tmp_path):
+        # The ONLY parameter this WU newly wired must not be the one the cache
+        # silently ignores: a second analyze naming a different diarizer has to
+        # actually re-run the analysis stage.
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, backend = _service(tmp_path, cache=cache)
+        _run(reg, svc.analyze({"videoId": "v", "diarizeBackend": "alpha"}, _ctx(reg)))
+        _run(reg, svc.analyze({"videoId": "v", "diarizeBackend": "beta"}, _ctx(reg)))
+        assert backend.calls == 2
+
+    def test_the_same_diarize_backend_still_hits_the_cache(self, tmp_path):
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, backend = _service(tmp_path, cache=cache)
+        _run(reg, svc.analyze({"videoId": "v", "diarizeBackend": "alpha"}, _ctx(reg)))
+        _run(reg, svc.analyze({"videoId": "v", "diarizeBackend": "alpha"}, _ctx(reg)))
+        assert backend.calls == 1
+
     def test_the_default_cache_is_used_when_none_is_injected(self, tmp_path):
         reg, _ = _registry()
         svc, backend = _service(tmp_path, cache=None)
@@ -800,7 +1049,7 @@ class TestRenderHandler:
         out = svc.render({"videoId": "v", "plan": edited}, _ctx(reg))
         job = _run(reg, out)
         assert job.status.value == "done", job.error
-        assert job.result["outPath"].endswith("v.multispeaker.mp4")
+        assert job.result["outPath"].endswith("v.multispeaker.9x16.mp4")
         assert job.result["affected"] == [0]
         assert job.result["reencoded"] == [0]
         assert runs, "the edited plan must actually be encoded"
@@ -844,6 +1093,116 @@ class TestRenderHandler:
         svc, _cache, plan, _b = self._seeded(tmp_path)
         _run(reg, svc.render({"videoId": "v", "plan": plan}, _ctx(reg)))
         assert (tmp_path / "reframed").is_dir()
+
+    # ----------------------------------------------------------------- #
+    # The caller-supplied plan's SPANS + geometry are boundary-guarded too
+    # ----------------------------------------------------------------- #
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("endFrame", 10_000_000),  # past the analysed trace -> was an IndexError leak
+            ("endFrame", 2),  # end < start
+            ("startFrame", -4),  # negative -> was a wrap-around crop + a negative -ss
+        ],
+    )
+    def test_a_plan_whose_frame_span_was_edited_is_refused(self, tmp_path, field, value):
+        # These four scalars are NOT user-editable: they come from the analysis.
+        # Before the guard, endFrame=10_000_000 crashed INSIDE the job with a bare
+        # `IndexError: tuple index out of range` (an untyped internal message, not
+        # the typed RPC error the contract advertises), and a negative startFrame
+        # was ACCEPTED and reported done after building `-ss -0.133333`.
+        reg, _ = _registry()
+        svc, _cache, plan, _b = self._seeded(tmp_path)
+        edited = {**plan, "shots": [{**plan["shots"][0], field: value}]}
+        with pytest.raises(RpcError, match="frame span"):
+            svc.render({"videoId": "v", "plan": edited}, _ctx(reg))
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [("sourceWidth", 99_999), ("sourceHeight", 4), ("fps", 1.0)],
+    )
+    def test_a_plan_whose_source_geometry_was_edited_is_refused(self, tmp_path, field, value):
+        # sourceWidth/Height drive every crop region and fps drives every -ss/-t,
+        # and none of them is part of the segment reuse key, so accepting an edit
+        # republished stale segments at the old geometry/timing.
+        reg, _ = _registry()
+        svc, _cache, plan, _b = self._seeded(tmp_path)
+        with pytest.raises(RpcError, match="source geometry"):
+            svc.render({"videoId": "v", "plan": {**plan, field: value}}, _ctx(reg))
+
+    def test_the_output_path_carries_the_aspect(self, tmp_path):
+        reg, _ = _registry()
+        svc, _cache, plan, _b = self._seeded(tmp_path)
+        job = _run(reg, svc.render({"videoId": "v", "plan": plan}, _ctx(reg)))
+        assert job.status.value == "done", job.error
+        assert job.result["outPath"].endswith("v.multispeaker.9x16.mp4")
+
+    def test_a_second_aspect_renders_to_its_own_path_and_segment_cache(self, tmp_path):
+        # Without the aspect in the name, a 1:1 render os.replace()d onto the 9:16
+        # clip AND overwrote its segment cache.
+        reg, _ = _registry()
+        runs: list[list[str]] = []
+        cache = ra.LruAnalysisCache()
+        svc, _b = _service(
+            tmp_path, cache=cache, engine_kw={"runner": lambda argv, **_kw: runs.append(list(argv)) or 0}
+        )
+        wide = _run(reg, svc.analyze({"videoId": "v", "aspect": "9:16"}, _ctx(reg))).result["plan"]
+        square = _run(reg, svc.analyze({"videoId": "v", "aspect": "1:1"}, _ctx(reg))).result["plan"]
+        first = _run(reg, svc.render({"videoId": "v", "aspect": "9:16", "plan": wide}, _ctx(reg)))
+        second = _run(reg, svc.render({"videoId": "v", "aspect": "1:1", "plan": square}, _ctx(reg)))
+        assert first.status.value == "done", first.error
+        assert second.status.value == "done", second.error
+        assert first.result["outPath"] != second.result["outPath"]
+        encoded = [argv[-1] for argv in runs]
+        assert len({p for p in encoded if "shot000" in p}) == 2, "each aspect needs its OWN segment cache"
+
+    def test_the_layout_flags_select_the_exact_cached_bundle(self, tmp_path):
+        # Two analyses of the same (videoId, aspect) differing only in allowSplit
+        # leave two bundles. A flag-insensitive most-recently-used lookup diffed the
+        # UNTOUCHED allowSplit=True plan against the allowSplit=False bundle and
+        # reported affected=[0] — a shot the caller never edited.
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, _b = _service(tmp_path, analysis=_two_talker_analysis(), cache=cache)
+        split = _run(reg, svc.analyze({"videoId": "v", "allowSplit": True}, _ctx(reg))).result["plan"]
+        collapsed = _run(reg, svc.analyze({"videoId": "v", "allowSplit": False}, _ctx(reg))).result["plan"]
+        assert split["shots"][0]["layout"] != collapsed["shots"][0]["layout"], "the fixture must differ"
+        job = _run(reg, svc.render({"videoId": "v", "plan": split, "allowSplit": True}, _ctx(reg)))
+        assert job.status.value == "done", job.error
+        assert job.result["affected"] == []
+
+    def test_an_omitted_flag_set_still_falls_back_to_the_most_recent_bundle(self, tmp_path):
+        # Backward compatibility for the documented fallback: with only ONE cached
+        # bundle for (videoId, aspect) the flag-insensitive lookup is unambiguous.
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, _b = _service(tmp_path, analysis=_two_talker_analysis(), cache=cache)
+        collapsed = _run(reg, svc.analyze({"videoId": "v", "allowSplit": False}, _ctx(reg))).result["plan"]
+        job = _run(reg, svc.render({"videoId": "v", "plan": collapsed}, _ctx(reg)))
+        assert job.status.value == "done", job.error
+        assert job.result["affected"] == []
+
+    def test_a_non_boolean_render_flag_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="allowComposite"):
+            svc.render({"videoId": "v", "plan": _plan().to_dict(), "allowComposite": "yes"}, _ctx(reg))
+
+    def test_a_blank_render_diarize_backend_is_refused(self, tmp_path):
+        reg, _ = _registry()
+        svc, _ = _service(tmp_path)
+        with pytest.raises(RpcError, match="diarizeBackend"):
+            svc.render({"videoId": "v", "plan": _plan().to_dict(), "diarizeBackend": ""}, _ctx(reg))
+
+    def test_the_diarize_backend_selects_the_exact_cached_bundle(self, tmp_path):
+        reg, _ = _registry()
+        cache = ra.LruAnalysisCache()
+        svc, backend = _service(tmp_path, cache=cache)
+        plan = _run(reg, svc.analyze({"videoId": "v", "diarizeBackend": "alpha"}, _ctx(reg))).result["plan"]
+        _run(reg, svc.analyze({"videoId": "v", "diarizeBackend": "beta"}, _ctx(reg)))
+        assert backend.calls == 2
+        job = _run(reg, svc.render({"videoId": "v", "plan": plan, "diarizeBackend": "alpha"}, _ctx(reg)))
+        assert job.status.value == "done", job.error
 
 
 # --------------------------------------------------------------------------- #

--- a/sidecar/tests/test_reframe_analyze.py
+++ b/sidecar/tests/test_reframe_analyze.py
@@ -407,11 +407,21 @@ class TestPlanShotSegments:
 # Engine extensions — analyze() (no render) and render_shot_plan()
 # --------------------------------------------------------------------------- #
 class _FakeBackend:
-    def __init__(self, analysis, *, raise_on_analyze: BaseException | None = None):
+    def __init__(
+        self,
+        analysis,
+        *,
+        raise_on_analyze: BaseException | None = None,
+        raise_when_cancelled: bool = False,
+    ):
         self._analysis = analysis
         self._raise = raise_on_analyze
+        self._raise_when_cancelled = raise_when_cancelled
         self.released = 0
         self.progress: list[tuple[float, str]] = []
+        #: Every answer ``should_cancel()`` gave, so a test can assert the seam is a
+        #: LIVE forward rather than a constant (or absent) callable.
+        self.cancel_probes: list[bool] = []
         self.calls = 0
 
     def analyze(self, media_path, *, on_progress=None, should_cancel=None):
@@ -423,7 +433,14 @@ class _FakeBackend:
             # plan stage. Over-report so a dropped clamp is observable.
             on_progress(150.0, "over-reporting on purpose")
         if should_cancel is not None:
-            should_cancel()
+            self.cancel_probes.append(bool(should_cancel()))
+            if self._raise_when_cancelled and self.cancel_probes[-1]:
+                # EXACTLY what RealMultiSpeakerBackend does at a stage boundary: it
+                # surfaces a cancel as its OWN domain error, never as JobCancelled
+                # (reframe_multispeaker_backend.py:106,:111). The old fake RETURNED
+                # here, so the unit tier could not see that jobs.py maps a domain
+                # error to ERROR and only JobCancelled to CANCELLED.
+                raise ms.MultiSpeakerReframeError("multi-speaker analysis cancelled after shot detection")
         if self._raise is not None:
             raise self._raise
         return self._analysis
@@ -471,6 +488,22 @@ class TestEngineAnalyze:
         # ceiling is the RPC handler's job, not the engine's.
         assert seen[0] == (50.0, "detecting faces")
         assert seen[-1] == (150.0, "over-reporting on purpose")
+        # ...and the cancel seam is a REAL forward, asserted by VALUE. Nothing used
+        # to assert this, so `should_cancel=None` survived the whole suite.
+        assert backend.cancel_probes == [False]
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_the_cancel_seam_forwards_the_callers_answer(self, flag):
+        # The value the caller's callable returns must be what the backend observes —
+        # this is what a pinned `lambda: False` mutant cannot satisfy.
+        backend = _FakeBackend(_analysis())
+        _engine(backend_factory=lambda _s: backend).analyze("in.mp4", should_cancel=lambda: flag)
+        assert backend.cancel_probes == [flag]
+
+    def test_without_a_cancel_seam_the_backend_is_not_probed(self):
+        backend = _FakeBackend(_analysis())
+        _engine(backend_factory=lambda _s: backend).analyze("in.mp4")
+        assert backend.cancel_probes == []
 
 
 class TestRenderShotPlan:
@@ -759,6 +792,45 @@ class _RecordingEngine:
         return out_path, ()
 
 
+class _FailingRenderEngine:
+    """A whole-engine fake whose ``render_shot_plan`` always raises.
+
+    Models the REAL terminal shape of a cancelled render: ``ffmpeg.run`` terminates
+    the child on cancel, so it exits non-zero and the engine raises
+    :class:`~media_studio.features.reframe_multispeaker.MultiSpeakerRenderError` —
+    NOT ``JobCancelled``, which is the only class jobs.py maps to CANCELLED.
+    """
+
+    def __init__(self, analysis, exc: BaseException):
+        self._analysis = analysis
+        self._exc = exc
+
+    def analyze(self, _in_path, *, on_progress=None, should_cancel=None):
+        del on_progress, should_cancel
+        return self._analysis
+
+    def render_shot_plan(self, _in_path, _out_path, _plan, _trace, **_kw):
+        raise self._exc
+
+
+def _cancelling_registry(at_pct: float) -> tuple[JobRegistry, list[float]]:
+    """A registry that cancels a job the moment it reports ``at_pct``.
+
+    The sibling suites' deterministic cancel idiom — no threads, no sleeps.
+    """
+    pcts: list[float] = []
+    holder: dict[str, Any] = {}
+
+    def emit_progress(job_id, pct, _msg):
+        pcts.append(pct)
+        if pct == at_pct:
+            holder["reg"].cancel(job_id)
+
+    reg = JobRegistry(emit_progress=emit_progress, emit_done=lambda *_a: None)
+    holder["reg"] = reg
+    return reg, pcts
+
+
 def _service(
     tmp_path,
     *,
@@ -769,9 +841,11 @@ def _service(
     engine_kw=None,
     seen=None,
     engine=None,
+    backend=None,
 ):
     """A service with a fake engine (fake backend + fake runner) and a real cache."""
-    backend = _FakeBackend(analysis if analysis is not None else _analysis())
+    if backend is None:
+        backend = _FakeBackend(analysis if analysis is not None else _analysis())
 
     def engine_factory(engine_settings: dict[str, Any]):
         if seen is not None:
@@ -971,20 +1045,46 @@ class TestAnalyzeHandler:
         # Cooperative cancel: the progress sink cancels at the "detecting shots"
         # checkpoint, so the post-analysis raise_if_cancelled aborts the job and no
         # bundle is ever cached (deterministic — mirrors test_diarize's sink trick).
-        holder: dict[str, Any] = {}
-
-        def emit_progress(job_id, pct, _msg):
-            if pct == 2:
-                holder["reg"].cancel(job_id)
-
-        reg = JobRegistry(emit_progress=emit_progress, emit_done=lambda *_a: None)
-        holder["reg"] = reg
+        reg, _pcts = _cancelling_registry(2)
         cache = ra.LruAnalysisCache()
-        svc, _backend = _service(tmp_path, cache=cache)
+        svc, backend = _service(tmp_path, cache=cache)
         out = svc.analyze({"videoId": "v"}, _ctx(reg))
         reg.get(out["jobId"]).wait(10)
         assert reg.get(out["jobId"]).status.value == "cancelled"
         assert cache.find("v", ASPECT) is None
+        # The handler's should_cancel must be a LIVE view of job_ctx.cancelled. The
+        # old test asserted nothing about it, so a mutant pinning it to
+        # `lambda: False` survived the entire suite even though the test is NAMED for
+        # the cancel seam.
+        assert backend.cancel_probes == [True]
+
+    def test_a_backend_that_reports_a_cancel_as_its_own_error_still_ends_cancelled(self, tmp_path):
+        # RealMultiSpeakerBackend honours should_cancel by raising
+        # MultiSpeakerReframeError at a stage boundary, and jobs.py maps ONLY
+        # JobCancelled to _finish_cancelled — so before this guard the job reported
+        # status='error' with the text "multi-speaker analysis cancelled after shot
+        # detection". That is strictly WORSE than the pre-WU-E1 behaviour, where the
+        # backend ignored should_cancel and the handler's own raise_if_cancelled
+        # produced a correct (if late) 'cancelled'.
+        reg, _pcts = _cancelling_registry(2)
+        cache = ra.LruAnalysisCache()
+        backend = _FakeBackend(_analysis(), raise_when_cancelled=True)
+        svc, _b = _service(tmp_path, cache=cache, backend=backend)
+        out = svc.analyze({"videoId": "v"}, _ctx(reg))
+        reg.get(out["jobId"]).wait(10)
+        job = reg.get(out["jobId"])
+        assert job.status.value == "cancelled", job.error
+        assert cache.find("v", ASPECT) is None
+
+    def test_a_backend_failure_without_a_cancel_is_still_an_error(self, tmp_path):
+        # Detector control for the test above: the cancel guard must NOT swallow a
+        # genuine failure into a false 'cancelled'.
+        reg, _ = _registry()
+        backend = _FakeBackend(_analysis(), raise_on_analyze=RuntimeError("CUDA OOM"))
+        svc, _b = _service(tmp_path, backend=backend)
+        job = _run(reg, svc.analyze({"videoId": "v"}, _ctx(reg)))
+        assert job.status.value == "error"
+        assert "CUDA OOM" in str(job.error)
 
 
 class TestRenderHandler:
@@ -1193,6 +1293,57 @@ class TestRenderHandler:
         svc, _ = _service(tmp_path)
         with pytest.raises(RpcError, match="diarizeBackend"):
             svc.render({"videoId": "v", "plan": _plan().to_dict(), "diarizeBackend": ""}, _ctx(reg))
+
+    # ----------------------------------------------------------------- #
+    # Terminal state on cancel — the render half
+    # ----------------------------------------------------------------- #
+    def _seeded_cache(self) -> tuple[ra.LruAnalysisCache, dict[str, Any]]:
+        """A cache pre-loaded with one bundle for ``v`` at ASPECT, plus its wire plan.
+
+        Seeded DIRECTLY rather than by running analyze, so a cancelling registry
+        cannot cancel the seeding job too.
+        """
+        cache = ra.LruAnalysisCache()
+        bundle = _bundle()
+        cache.put(_key(), bundle)
+        return cache, bundle.plan.to_dict()
+
+    def test_a_render_failure_after_a_cancel_ends_the_job_cancelled(self, tmp_path):
+        # ffmpeg.py terminates the child on cancel, so it exits non-zero and the
+        # engine raises MultiSpeakerRenderError. Before the guard the job reported
+        # status='error', error='multi-speaker reframe failed (exit 255)' for a
+        # user-requested cancel.
+        reg, _pcts = _cancelling_registry(2)
+        cache, plan = self._seeded_cache()
+        engine = _FailingRenderEngine(
+            _analysis(), ms.MultiSpeakerRenderError("multi-speaker reframe failed (exit 255)")
+        )
+        svc, _b = _service(tmp_path, cache=cache, engine=engine)
+        out = svc.render({"videoId": "v", "plan": plan}, _ctx(reg))
+        reg.get(out["jobId"]).wait(10)
+        job = reg.get(out["jobId"])
+        assert job.status.value == "cancelled", job.error
+
+    def test_a_render_failure_without_a_cancel_is_still_an_error(self, tmp_path):
+        reg, _ = _registry()
+        cache, plan = self._seeded_cache()
+        engine = _FailingRenderEngine(_analysis(), ms.MultiSpeakerRenderError("multi-speaker reframe failed (exit 1)"))
+        svc, _b = _service(tmp_path, cache=cache, engine=engine)
+        job = _run(reg, svc.render({"videoId": "v", "plan": plan}, _ctx(reg)))
+        assert job.status.value == "error"
+        assert "exit 1" in str(job.error)
+
+    def test_a_cancel_during_the_render_never_reports_a_terminal_done(self, tmp_path):
+        # The engine RETURNS normally here (a cooperative cancel that unwinds nothing),
+        # so without a post-call raise_if_cancelled the handler ran straight on to
+        # progress(100, "done") and announced a finished render for a cancelled job.
+        reg, pcts = _cancelling_registry(99)
+        cache, plan = self._seeded_cache()
+        svc, _b = _service(tmp_path, cache=cache, engine=_RecordingEngine(_analysis()))
+        out = svc.render({"videoId": "v", "plan": plan}, _ctx(reg))
+        reg.get(out["jobId"]).wait(10)
+        assert reg.get(out["jobId"]).status.value == "cancelled"
+        assert 100 not in pcts, "a cancelled render must not emit a terminal 100%/done"
 
     def test_the_diarize_backend_selects_the_exact_cached_bundle(self, tmp_path):
         reg, _ = _registry()

--- a/sidecar/tests/test_reframe_override.py
+++ b/sidecar/tests/test_reframe_override.py
@@ -338,6 +338,39 @@ def test_affected_rejects_index_mismatch() -> None:
         ro.affected_shot_indices(plan, swapped)
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("start_frame", -4), ("end_frame", 10_000_000), ("end_frame", 1)],
+    ids=["negative-start", "past-the-trace", "end-before-start"],
+)
+def test_affected_rejects_a_frame_span_mismatch(field, value) -> None:
+    # A shot's SPAN is an analysis output, not user input. Leaving it unchecked let
+    # an `endFrame` past the analysed trace reach speaker_candidate_crops and die on
+    # a bare IndexError, and a negative `startFrame` produce a wrap-around crop plus
+    # a negative ffmpeg -ss, both reported as a successful job.
+    plan = _plan()
+    edited = ro.ShotPlan(
+        plan.source_width,
+        plan.source_height,
+        plan.fps,
+        (replace(plan.shots[0], **{field: value}), *plan.shots[1:]),
+    )
+    with pytest.raises(ro.OverrideError, match="shot 0 has a different frame span"):
+        ro.affected_shot_indices(plan, edited)
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [("source_width", 99_999), ("source_height", 4), ("fps", 1.0)],
+)
+def test_affected_rejects_a_source_geometry_mismatch(field, value) -> None:
+    # source_width/height feed every crop region and fps feeds every segment's
+    # -ss/-t, and none of them is part of the segment reuse key.
+    plan = _plan()
+    with pytest.raises(ro.OverrideError, match="different source geometry"):
+        ro.affected_shot_indices(plan, replace(plan, **{field: value}))
+
+
 # --------------------------------------------------------------------------- #
 # RPC registration
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## The gap

Active-speaker's own marketed differentiator — edit the shot plan, re-render only what changed —
had **no backend**. Measured against the frozen method list, `reframe.*` was exactly four methods
(`applyOverrides`, `eval`, `shotPlan`, `shotPlanFor`), and the renderer said so in prose:
`lib/rpc/client.ts:896` — *"There is no `reframe.render`."* Meanwhile WU-U1's mode selector had
already shipped, so the UI advertised a mode whose edit-and-re-render loop could not exist.

This lands WU-E1 → E2 → E3 in the spec's required order, **sidecar-only**.

* **E1 `reframe.analyze`** — resolves `{trace, plan, degraded}` without rendering. Before this,
  the only route to a `ShotAnalysis` was `_render`, which always encoded a file.
* **E2 cache** — injectable bounded LRU keyed by `(videoId, aspect, allowSplit, allowComposite)`.
* **E3 `reframe.render`** — renders an edited `ShotPlan`, re-encoding only shots whose decision
  changed and concat-copying the rest. Reuse is decided by per-shot decision-equality against a
  `<clip>.shots.json` manifest **and** the segment existing, so it survives restarts and a first
  render still encodes everything.

## READ THIS FIRST: 100% coverage here does NOT mean the pipeline works

The spec says it plainly and so does this PR: *"Coverage ≠ integration — do not let a 100%-green
unit run masquerade as a working pipeline."*

Every one of the 7549 passing tests runs against a **synthetic hand-built `ShotAnalysis`** injected
via `backend_factory` and a **fake ffmpeg runner**. No torch, no cv2, no weights, no real video, no
real ffmpeg process. **Zero pixels were produced or inspected — every "encode" is a lambda.** What
is proven is the decision and orchestration layer. The WU-V1 `@e2e` golden run does not exist, and
the code now says so explicitly rather than citing it as an available settling experiment.

**These methods are also registered but NOT user-reachable.** The UI wave (WU-U1..U4) is out of
scope. That is the same shape as five defects this programme already fixed, so it is stated rather
than left to inference.

## Two latent defects fixed en route — arguably worth more than the feature

1. **`allow_split` / `allow_composite` were never threaded.** They had existed on `decide_layout`
   since R1, but nothing passed them — so those flags **could not affect any plan**. Now threaded
   through `build_trace` → `_render_shot`; defaults unchanged.
2. **`RealMultiSpeakerBackend.analyze` accepted `on_progress` / `should_cancel` and called
   neither.** Staged progress was silence, and a cancel was only observed after the entire pipeline
   finished. Both now honoured at stage boundaries. (UNVERIFIED — that class is `# pragma: no
   cover`; it is the heavy backend the spec sanctions excluding.)

## Verification

TDD RED proof: `ImportError: cannot import name 'reframe_analyze'`. Then implement → **3
adversarial refuters, all three of which REFUTED** (17 objections) → remediation → a fresh skeptic
who re-derived everything by execution.

* Full gate, CI's exact invocation: **7549 passed**, 22648 statements / 5786 branches, **100%**.
* **Mutation: 12 killed by the lane, 16/16 by the skeptic independently.** One apparent survivor was
  an anchor-miss in the lane's own harness (`if bundle is None:` matched twice) — diagnosed as a
  detector failure, not reported as a finding.
* **Frozen-surface gate proven non-vacuous**: registering both methods with `FROZEN_RPC_SURFACE`
  unchanged FAILS `test_rpc_surface_is_byte_identical`.
* basedpyright **0 errors**; ruff pinned `0.15.17` clean on the **LF blob** via `git cat-file -p`
  (not `git archive`, which re-applies CRLF on this box).

### Measurement artifacts caught and corrected rather than shipped
The lane's first baseline read "4 failed" — a **wrong-CWD artifact**: `longrun.ps1` builds a
`ProcessStartInfo` without `WorkingDirectory`, and PowerShell's `Set-Location` does not update
.NET's `CurrentDirectory`, so pytest's rootdir was the repo root and `addopts = -m 'not e2e'` never
applied. A 99.51% coverage read was caused by editing docstrings **while the run was in flight**,
shifting line numbers under coverage's traced data.

The skeptic disclosed three of its own: a cancel probe that raised `KeyError` and would have been
misread as the defect surviving; a **vacuous** trace-change probe whose pass came from a
`regA == regB` short-circuit; and mutation anchors that would all have missed on CRLF.

It also **refuted a prior reviewer's reachability claim**: `relink()` is BLAKE3-verified
(`relink.py:250-255`) and refuses any file whose digest differs, so that objection's mechanism was
wider than the evidence. The manifest fix stands on its own merits.

## Residuals — disclosed, non-blocking

* **Truncated-segment reuse, reproduced by the skeptic**: truncating a cached segment out-of-band
  then re-rendering feeds the 3-byte file into the concat list. Disclosed inline at
  `reframe_multispeaker.py:1929-1936` with the settling experiment named (record segment byte size
  in the manifest row). The structural half IS fixed — segments encode to `<seg>.part` and
  `os.replace` on success, so **this code cannot create the truncated state**.
* `reframe.render` runs no availability/offline gate. Defensible (loads no model, downloads
  nothing; missing ffmpeg surfaces as a typed error) but it should be one sentence in the docstring.
* `LruAnalysisCache.find()` can name an unedited shot as `affected` when several analyses of the
  same `(videoId, aspect)` differ only in layout flags AND the caller omits them. Metadata-only —
  the trace fields `render` consumes are flag-independent, confirmed twice independently.
* **Follow-up for the renderer lane** (correctly not fixed here): `features/ReframeCorrect.tsx`
  still comments that "the registered reframe surface really is exactly four methods". It is **six**
  now. It is a `//` comment, so no false statement reaches the UI.

CI is the arbiter. This merges only if `quality` is green.
