### PR TITLE
feat(renderer): mount the auto-b-roll flagship — the last unreachable v1.5 surface

### DIFF
--- a/app/e2e/preview.spec.ts
+++ b/app/e2e/preview.spec.ts
@@ -211,28 +211,29 @@ test('Advanced disclosure actually COLLAPSES the Deliver cluster (F17)', async (
   // ...so the cluster it owns must not paint. It does today: the author-origin
   // `display: flex` on `.tabbar--grouped .tabbar__advanced-panel` outranks the
   // UA `[hidden] { display: none }`, and no `[hidden]` selector anywhere under
-  // app/ restores it — so all 20 tabs paint instead of 15 and `aria-expanded`
+  // app/ restores it — so all 21 tabs paint instead of 16 and `aria-expanded`
   // lies about what is on screen.
   await expect(panel).toBeHidden();
   await expect(deliverTab).toBeHidden();
-  // The user-visible consequence: the default view paints the 15 primary tabs,
-  // not all 20. (`.tab` is exclusive to this strip.)
+  // The user-visible consequence: the default view paints the 16 primary tabs,
+  // not all 21. (`.tab` is exclusive to this strip.)
   //
   // These two numbers are DERIVED, not observed — they are `WORKSPACE_TABS.length`
   // and that minus the `advanced: true` group's `tabIds.length`
-  // (`Workspace.tsx`): 20 tabs total; Deliver holds 5 (convert, nle, recipes,
-  // assets, tracks), so 15 paint while it is collapsed. They were 13/8 until the
+  // (`Workspace.tsx`): 21 tabs total; Deliver holds 5 (convert, nle, recipes,
+  // assets, tracks), so 16 paint while it is collapsed. They were 13/8 until the
   // v1.5 wave added `transcriptEdit`, `timeline`, `speed` and `audiomix`; e2e is
   // opt-in and nightly, so it never gated those PRs and the stale pair merged
   // four times over. It went 17/12 -> 19/14 when W17/W18 mounted `reframeFix`
   // and `videoTimeline` into the visible "Frame & Cut" cluster, updated here in
   // the SAME commit as `Workspace.test.tsx`'s "pins the strip counts" test —
   // that PR-gating test is the only reason this nightly pair is not stale again.
-  // W19 took it 19/14 -> 20/15 by mounting `gaze` into that same visible cluster.
+  // W19 took it 19/14 -> 20/15 by mounting `gaze` into that same visible cluster,
+  // and W16-UI took it 20/15 -> 21/16 by mounting `broll` into it as well.
   // Re-derive from the source when the tab list changes — do NOT read a number
   // off a failing run and paste it back.
-  await expect(win.locator('.tab')).toHaveCount(20);
-  await expect(win.locator('.tab:visible')).toHaveCount(15);
+  await expect(win.locator('.tab')).toHaveCount(21);
+  await expect(win.locator('.tab:visible')).toHaveCount(16);
   // ...and the disclosure's own toggle is reachable WITHOUT horizontally
   // scrolling `.workspace .tabbar` (workspace.css `overflow-x: auto`). With the
   // cluster always painted the strip overflowed its 1064px track by 587px and

--- a/app/renderer/src/features/BrollPanel.test.tsx
+++ b/app/renderer/src/features/BrollPanel.test.tsx
@@ -1012,12 +1012,29 @@ describe('<BrollPanel />', () => {
   // only previous mention of a transcript was inside the EGRESS badge, which is a
   // different statement. Diarize.tsx:138, caption/CaptionInspector.tsx:47 and
   // TranscriptEditor.tsx:221 all say it up front; so does this now.
-  it('states BOTH prerequisites BEFORE the button that hits them', async () => {
+  it('states ALL THREE prerequisites BEFORE the button that hits them', async () => {
     await mount(makeFakeApi().api);
     const prereq = q('[data-section="prerequisites"]');
+    // NOTE on the first assertion: `toBe(BROLL_NEEDS_TRANSCRIPT)` proves the panel
+    // RENDERS the constant, but it cannot detect a content change — both sides move
+    // together. That is why the `toContain` pins below exist, and why the third one
+    // had to be added: this test passed unchanged while the copy omitted the
+    // prerequisite the sidecar enforces FIRST.
     expect(prereq?.textContent).toBe(BROLL_NEEDS_TRANSCRIPT);
     expect(prereq?.textContent).toContain('transcribe');
     expect(prereq?.textContent).toContain('index your library');
+    // THE MATCHER MODEL — enforced FIRST by `broll_ops.suggest` (`require_model` at
+    // broll_ops.py:403, ahead of the transcript raise at :408) and the most expensive
+    // to discover by clicking: SigLIP-2 is a 4.5 GB manifest asset
+    // (`vlm_backbone.py` BACKBONE_SIZE_MB = 4540). Pinned by CONTENT, not by
+    // reference, so the sentence cannot regress to the two-prerequisite version.
+    expect(prereq?.textContent).toContain('Assets tab');
+    expect(prereq?.textContent).toContain('4.5 GB');
+    // …and it must not send the user to the Index button for it. `broll.index`
+    // reaches RealBackboneBackend with NO models_present guard — the graceful-degrade
+    // path lives in `vlm_backbone.analyze`, which the b-roll path never calls — so
+    // "clicking Index loads the matcher" would be a false instruction, not a shortcut.
+    expect(prereq?.textContent).toContain('does NOT arrive by clicking');
     // BEFORE, not after: document order decides whether it is a warning or a
     // post-mortem. (`compareDocumentPosition` is the same check the one-way
     // disclosure uses against Apply.)

--- a/app/renderer/src/features/BrollPanel.test.tsx
+++ b/app/renderer/src/features/BrollPanel.test.tsx
@@ -45,20 +45,25 @@ import { createRoot, type Root } from 'react-dom/client';
 import BrollPanel, {
   APPLY_IS_ONE_WAY,
   BROLL_LAYOUTS,
+  BROLL_NEEDS_TRANSCRIPT,
   BROLL_REASON_NO_MATCH,
+  DEFAULT_BROLL_COOLDOWN_SEC,
   DEFAULT_BROLL_MAX_COVERAGE_PCT,
+  DEFAULT_BROLL_MIN_DURATION_SEC,
   DEFAULT_BROLL_THRESHOLD,
   NO_POSTER_LABEL,
   THRESHOLD_IS_UNCALIBRATED,
   assetDurationLabel,
   assetLabel,
+  emptyPlanExplanation,
   insertionWindowLabel,
+  isCoverageUsable,
   posterSrc,
   readBrollAssets,
   readBrollPlan,
   readBrollStatus,
 } from './BrollPanel';
-import type { BrollAsset } from '../lib/rpc';
+import { BROLL_METHODS, type BrollAsset } from '../lib/rpc';
 import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
 
 // --- fixtures --------------------------------------------------------------
@@ -248,8 +253,21 @@ describe('readBrollStatus', () => {
     expect(readBrollStatus('nope')).toBeNull();
   });
 
-  it('coerces absent fields to explicit zeros/falses, never invented numbers', () => {
-    expect(readBrollStatus({})).toEqual({
+  // REFUTED, and this is the red-proof. The first draft only rejected NON-objects,
+  // so `{}` — the canonical shapeless payload, and exactly what the lane's own
+  // real-mount seam test feeds every rpc — fell through and returned a full
+  // snapshot of zeros. Rendered, that reads "In library 0", a hard number the
+  // panel never measured, from a docstring promising the opposite.
+  it('returns null for an OBJECT carrying none of the snapshot fields ({} is not a snapshot)', () => {
+    expect(readBrollStatus({})).toBeNull();
+    expect(readBrollStatus({ somethingElse: 1 })).toBeNull();
+  });
+
+  // The coercion half was always right and is UNCHANGED: once a payload proves it
+  // is a snapshot by carrying at least one known field, its absent siblings become
+  // explicit zeros rather than `undefined` leaking into the DOM.
+  it('coerces the ABSENT siblings of a partial payload to explicit zeros/falses', () => {
+    expect(readBrollStatus({ indexed: false })).toEqual({
       indexed: false,
       assetCount: 0,
       libraryCount: 0,
@@ -259,6 +277,58 @@ describe('readBrollStatus', () => {
       staleCount: 0,
       willEgress: false,
     });
+    // …and the detector fires on EVERY one of the eight, not just the first.
+    expect(readBrollStatus({ willEgress: true })?.willEgress).toBe(true);
+    expect(readBrollStatus({ libraryCount: 3 })?.libraryCount).toBe(3);
+  });
+});
+
+describe('isCoverageUsable (the emptied-number-input trap)', () => {
+  // `Number('')` is 0, not NaN, and the sidecar's `_opt_float` passes 0 straight
+  // through — `float(0)` is valid, so the DEFAULT never kicks in — leaving
+  // `budget_sec = total_sec * 0 / 100 = 0`, which rejects every candidate.
+  it('rejects the value an emptied number input actually produces', () => {
+    expect(isCoverageUsable(Number(''))).toBe(false);
+    expect(isCoverageUsable(0)).toBe(false);
+  });
+
+  it('rejects a non-finite or out-of-range cap', () => {
+    expect(isCoverageUsable(Number.NaN)).toBe(false);
+    expect(isCoverageUsable(-5)).toBe(false);
+    expect(isCoverageUsable(101)).toBe(false);
+  });
+
+  it('accepts the inclusive 1..100 range the input advertises', () => {
+    expect(isCoverageUsable(1)).toBe(true);
+    expect(isCoverageUsable(DEFAULT_BROLL_MAX_COVERAGE_PCT)).toBe(true);
+    expect(isCoverageUsable(100)).toBe(true);
+  });
+});
+
+// REFUTED COPY. The old sentence — "nothing in your library scored at or above
+// {threshold} for any segment" — is a measurement the panel cannot make:
+// `broll_ops.py:425` emits the same reason for ANY empty plan, and `place` drops
+// candidates for min-duration, coverage budget, min-gap and per-asset cooldown,
+// none of which are the score. Executed against the real planner with identical
+// unit vectors (cosine 1.00 vs a 0.22 gate): default coverage -> 1 insertion,
+// `maxCoveragePct=1` -> 0, a 1.0s segment -> 0.
+describe('emptyPlanExplanation', () => {
+  it('never asserts the threshold as the cause, and names the causes that are not', () => {
+    const copy = emptyPlanExplanation(0.22, 40);
+    expect(copy).not.toContain('scored at or above');
+    expect(copy).toContain('SAME reason string');
+    expect(copy).toContain(`shorter than ${DEFAULT_BROLL_MIN_DURATION_SEC}s`);
+    expect(copy).toContain(`within ${DEFAULT_BROLL_COOLDOWN_SEC}s`);
+    expect(copy).toContain('too close to another insert');
+  });
+
+  it('quotes the dials the user actually set, including the coverage cap', () => {
+    const copy = emptyPlanExplanation(0.45, 25);
+    expect(copy).toContain('0.45');
+    expect(copy).toContain('coverage cap of 25%');
+    // The old copy pointed only at the threshold — which for a coverage-caused
+    // empty plan is the one control that provably cannot help.
+    expect(copy).toContain('RAISE the coverage cap');
   });
 });
 
@@ -321,8 +391,18 @@ describe('posterSrc (fact 2: a registered asset has no poster)', () => {
     expect(posterSrc(SCANNED)).toBeNull();
   });
 
-  it('a real poster path is used when one ever exists', () => {
-    expect(posterSrc({ ...REGISTERED, thumbnailPath: 'D:/th/dog.jpg' })).toBe('D:/th/dog.jpg');
+  // REFUTED PIN. This case used to assert the RAW path was the right answer,
+  // endorsing a value the renderer cannot load at all: the CSP is
+  // `img-src 'self' data: blob: mstream:` (app/main/security.ts:81, mirrored in
+  // app/renderer/index.html:17), so a filesystem path never resolves. The whole
+  // app routes posters through the traversal-guarded `thumb:` mstream resolver
+  // (components/useVideoThumbnail.ts:33, views/LibraryCard.tsx); this now does too.
+  it('a real poster is served as the thumb: mstream URL, never as a raw fs path', () => {
+    const url = posterSrc({ ...REGISTERED, thumbnailPath: 'D:/th/dog.jpg' });
+    expect(url).toBe(`mstream://media/${encodeURIComponent('thumb:D:/th/dog.jpg')}`);
+    // one path segment, and a scheme the CSP actually permits
+    expect(url?.startsWith('mstream://media/thumb%3A')).toBe(true);
+    expect(url).not.toContain('D:/th/dog.jpg');
   });
 });
 
@@ -450,6 +530,55 @@ describe('<BrollPanel />', () => {
     // `library.list` is the SOURCE-video lister; reading it here would show a
     // second, different library from the one broll.index actually embeds.
     expect(methods).not.toContain('library.list');
+  });
+
+  // THE SHIPPED WIRE STRINGS. A reviewer proved the gap executably: with the seven
+  // method names hand-written in this panel, renaming one to a method the sidecar
+  // does not register left `brollClient.conformance.test.ts` GREEN at 16/16 and
+  // `tsc --noEmit` at exit 0, because that suite only ever saw `client.broll.*` —
+  // a wrapper with no production caller. Both now read `BROLL_METHODS`; conformance
+  // pins that map against three readings of the sidecar source, and THIS case pins
+  // the other end of the chain: what the mounted panel actually emits.
+  it('puts ONLY the pinned BROLL_METHODS strings on the wire — never a hand-written literal', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api); // assets + status
+    pick('[data-input="add-path"]', 'D:/pictures/hero dog.png');
+    await click('add'); // addAsset
+    await act(async () => {
+      (
+        container.querySelector(
+          `[data-asset-id="${REGISTERED.assetId}"] [data-action="unregister"]`,
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush(); // removeAsset
+    await act(async () => {
+      btn('index').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b', result: { assetCount: 1, embedded: 1 } });
+      await Promise.resolve();
+    });
+    await flush(); // index
+    await suggestWith(fake, { insertions: [INSERTION_A], reason: 'matched' }); // suggest
+    await act(async () => {
+      btn('apply').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b', result: { path: 'C:/out/talk.broll.mp4', inserted: 1 } });
+      await Promise.resolve();
+    });
+    await flush(); // apply
+
+    const sent = [
+      ...new Set(fake.calls.map((c) => c.method).filter((m) => m.startsWith('broll.'))),
+    ].sort();
+    // EXACTLY the seven — equality, not containment, so an eighth invented string
+    // fails here just as loudly as a renamed one.
+    expect(sent).toEqual(Object.values(BROLL_METHODS).slice().sort());
   });
 
   it('renders the freshness snapshot including libraryCount and staleCount', async () => {
@@ -674,7 +803,12 @@ describe('<BrollPanel />', () => {
     await mount(makeFakeApi().api);
     const copy = q('[data-section="threshold-disclosure"]')?.textContent ?? '';
     expect(copy).toBe(THRESHOLD_IS_UNCALIBRATED);
-    expect(copy).toContain('0.22');
+    // REFUTED: this line used to read `toContain('0.22')` — a hardcoded literal
+    // checking a hardcoded literal, which stale copy satisfies. It now checks the
+    // copy against the CONSTANT, and `brollClient.conformance.test.ts` checks the
+    // copy against the sidecar's own value, so the §11.2 calibration cannot leave
+    // the panel telling the user a number it no longer seeds.
+    expect(copy).toContain(String(DEFAULT_BROLL_THRESHOLD));
     // The FULL relative path, not a bare basename: the disclosure sends a user to
     // the calibration experiment, and a bare filename is not a place they can go.
     expect(copy).toContain('docs/plans/v1.5/flagship-auto-broll.md');
@@ -704,6 +838,21 @@ describe('<BrollPanel />', () => {
     expect(q('[data-section="no-match"]')).not.toBeNull();
     expect(q('.error')).toBeNull();
     expect(container.querySelectorAll('[data-insertion]')).toHaveLength(0);
+  });
+
+  // The rendered half of the refuted-copy fix. `emptyPlanExplanation` is unit-tested
+  // above; this pins that the PANEL shows it, with the user's own dials in it, and
+  // still quotes the engine's reason verbatim rather than paraphrasing it.
+  it('the empty-plan copy blames no single cause and carries the coverage cap the user set', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="coverage"]', '25');
+    await suggestWith(fake, { insertions: [], reason: BROLL_REASON_NO_MATCH });
+    const copy = q('[data-section="no-match"]')?.textContent ?? '';
+    expect(copy).not.toContain('scored at or above');
+    expect(copy).toContain(emptyPlanExplanation(DEFAULT_BROLL_THRESHOLD, 25));
+    expect(copy).toContain('coverage cap of 25%');
+    expect(copy).toContain(BROLL_REASON_NO_MATCH);
   });
 
   it('a suggest answer with no jobId leaves an honest empty plan', async () => {
@@ -835,6 +984,46 @@ describe('<BrollPanel />', () => {
     expect(container.querySelectorAll('[data-insertion]')).toHaveLength(0);
   });
 
+  // THE PREREQUISITES. `broll_ops.suggest`'s job body runs `require_model` first
+  // (broll_ops.py:403) and then raises "<id> has no transcript yet; run
+  // transcribe.start first" (:408), so on a freshly imported video the advertised
+  // click path ends in an ERROR, discovered one failed click at a time. The panel's
+  // only previous mention of a transcript was inside the EGRESS badge, which is a
+  // different statement. Diarize.tsx:138, caption/CaptionInspector.tsx:47 and
+  // TranscriptEditor.tsx:221 all say it up front; so does this now.
+  it('states BOTH prerequisites BEFORE the button that hits them', async () => {
+    await mount(makeFakeApi().api);
+    const prereq = q('[data-section="prerequisites"]');
+    expect(prereq?.textContent).toBe(BROLL_NEEDS_TRANSCRIPT);
+    expect(prereq?.textContent).toContain('transcribe');
+    expect(prereq?.textContent).toContain('index your library');
+    // BEFORE, not after: document order decides whether it is a warning or a
+    // post-mortem. (`compareDocumentPosition` is the same check the one-way
+    // disclosure uses against Apply.)
+    expect(prereq?.compareDocumentPosition(btn('suggest'))).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+  });
+
+  // `min`/`max` on a number input constrain VALIDITY, not the value React reads:
+  // an emptied field reports '', `Number('')` is 0, and the sidecar's `_opt_float`
+  // passes 0 through, so `budget_sec` becomes 0 and `place` rejects every candidate
+  // — the feature dies silently while the panel blames the threshold.
+  it('refuses to send an unusable coverage cap rather than silently sending 0', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(btn('suggest').disabled).toBe(false);
+    expect(q('[data-section="coverage-invalid"]')).toBeNull();
+
+    pick('[data-input="coverage"]', '');
+    expect(btn('suggest').disabled).toBe(true);
+    expect(q('[data-section="coverage-invalid"]')?.textContent).toContain('between 1 and 100');
+    // and the wire stayed clean — no `maxCoveragePct: 0` was ever sent
+    expect(fake.calls.filter((c) => c.method === BROLL_METHODS.suggest)).toHaveLength(0);
+
+    pick('[data-input="coverage"]', '25');
+    expect(btn('suggest').disabled).toBe(false);
+    expect(q('[data-section="coverage-invalid"]')).toBeNull();
+  });
+
   it('names what is still missing so the copy cannot imply BR2 or posters shipped', async () => {
     await mount(makeFakeApi().api);
     const limits = q('[data-section="limits"]')?.textContent ?? '';
@@ -846,17 +1035,50 @@ describe('<BrollPanel />', () => {
     const withPoster: BrollAsset = { ...REGISTERED, thumbnailPath: 'D:/th/dog.jpg' };
     await mount(makeFakeApi({ assets: { assets: [withPoster], missing: [] } }).api);
     const row = q(`[data-asset-id="${REGISTERED.assetId}"]`);
-    expect(row?.querySelector('img')?.getAttribute('src')).toBe('D:/th/dog.jpg');
+    // The mstream URL, not the raw path — the CSP forbids the latter outright.
+    expect(row?.querySelector('img')?.getAttribute('src')).toBe(
+      `mstream://media/${encodeURIComponent('thumb:D:/th/dog.jpg')}`,
+    );
     expect(row?.querySelector('[data-poster="none"]')).toBeNull();
+  });
+
+  // …and the day a poster path does NOT resolve (main.ts:1465 serves `thumb:` ids
+  // ONLY from DATA_ROOT/thumbnails, and no b-roll poster writer exists yet to put
+  // them there), the tile must degrade to the readable placeholder rather than a
+  // permanently broken image icon. The `views/LibraryCard.tsx` pattern.
+  it('falls back to the placeholder when a poster fails to load', async () => {
+    const withPoster: BrollAsset = { ...REGISTERED, thumbnailPath: 'D:/th/dog.jpg' };
+    await mount(makeFakeApi({ assets: { assets: [withPoster], missing: [] } }).api);
+    const img = q(`[data-asset-id="${REGISTERED.assetId}"] img`) as HTMLImageElement;
+    expect(img).not.toBeNull();
+    await act(async () => {
+      img.dispatchEvent(new Event('error'));
+    });
+    expect(q(`[data-asset-id="${REGISTERED.assetId}"] img`)).toBeNull();
+    expect(
+      q(`[data-asset-id="${REGISTERED.assetId}"] [data-poster="none"]`)?.textContent,
+    ).toContain(NO_POSTER_LABEL);
   });
 
   // The un-indexed first-run state: every number the snapshot shows is ABSENT, and
   // the panel must say so rather than print zeros that look like measurements.
   it('reads a bare status payload as "not indexed yet", never as zeros', async () => {
-    await mount(makeFakeApi({ status: {} }).api);
+    await mount(makeFakeApi({ status: { indexed: false } }).api);
     expect(q('[data-field="indexed"]')?.textContent).toBe('not yet');
     expect(q('[data-field="stale"]')?.textContent).toBe('none');
     expect(q('[data-field="model"]')?.textContent).toBe('none');
+  });
+
+  // …but a payload carrying NOTHING is not a snapshot at all, and printing
+  // "In library 0" off it would be a measurement the panel never made. REFUTED
+  // behaviour, now pinned at the rendered layer as well as the parser.
+  it('renders NO status block at all for a `{}` payload — no invented zeros', async () => {
+    await mount(makeFakeApi({ status: {} }).api);
+    expect(q('[data-section="status"]')).toBeNull();
+    expect(q('[data-field="libraryCount"]')).toBeNull();
+    // control: the same mount DOES paint the rest of the panel, so the null above
+    // is the status guard firing and not a failed render.
+    expect(q('[data-section="threshold-disclosure"]')).not.toBeNull();
   });
 
   it('treats a job.done with NO result as the honest empty plan', async () => {

--- a/app/renderer/src/features/BrollPanel.test.tsx
+++ b/app/renderer/src/features/BrollPanel.test.tsx
@@ -655,7 +655,9 @@ describe('<BrollPanel />', () => {
     const copy = q('[data-section="threshold-disclosure"]')?.textContent ?? '';
     expect(copy).toBe(THRESHOLD_IS_UNCALIBRATED);
     expect(copy).toContain('0.22');
-    expect(copy).toContain('flagship-auto-broll.md');
+    // The FULL relative path, not a bare basename: the disclosure sends a user to
+    // the calibration experiment, and a bare filename is not a place they can go.
+    expect(copy).toContain('docs/plans/v1.5/flagship-auto-broll.md');
     // per-MODEL, the second warning in the sidecar docstring
     expect(copy).toContain('backbone');
   });

--- a/app/renderer/src/features/BrollPanel.test.tsx
+++ b/app/renderer/src/features/BrollPanel.test.tsx
@@ -855,6 +855,27 @@ describe('<BrollPanel />', () => {
     expect(copy).toContain(BROLL_REASON_NO_MATCH);
   });
 
+  // The explanation must quote the dials the RETURNED plan ran with, not whatever
+  // the controls happen to say now. Reading live state here would reintroduce the
+  // very defect the copy exists to avoid — stating a number that was not measured.
+  it('quotes the dials the plan RAN with, not the ones the user moved to afterwards', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="coverage"]', '25');
+    pick('[data-input="threshold"]', '0.35');
+    await suggestWith(fake, { insertions: [], reason: BROLL_REASON_NO_MATCH });
+    expect(q('[data-section="no-match"]')?.textContent).toContain('coverage cap of 25%');
+
+    // the user now drags both dials WITHOUT re-running
+    pick('[data-input="coverage"]', '60');
+    pick('[data-input="threshold"]', '0.80');
+    const copy = q('[data-section="no-match"]')?.textContent ?? '';
+    expect(copy).toContain('coverage cap of 25%');
+    expect(copy).toContain('0.35');
+    expect(copy).not.toContain('coverage cap of 60%');
+    expect(copy).not.toContain('0.80');
+  });
+
   it('a suggest answer with no jobId leaves an honest empty plan', async () => {
     const fake = makeFakeApi({ jobless: true });
     await mount(fake.api);

--- a/app/renderer/src/features/BrollPanel.test.tsx
+++ b/app/renderer/src/features/BrollPanel.test.tsx
@@ -546,14 +546,34 @@ describe('<BrollPanel />', () => {
     expect(btn('add').disabled).toBe(false);
   });
 
-  it('surfaces the registry-door refusal instead of swallowing it', async () => {
+  // The registry door refuses three real cases (missing path, a DIRECTORY with a
+  // media extension, a non-b-roll extension) and each is INVALID_PARAMS, i.e. loud.
+  // Two properties are pinned together because the second is what makes the first
+  // usable: the message is shown, AND the typed path survives so the user can
+  // correct it rather than retype it. `withBusy` swallows the rejection, so an
+  // earlier draft that cleared the field in a `.then()` chained onto it wiped the
+  // path on the refusal path too — this case is the red-proof for that fix.
+  it('surfaces the registry-door refusal AND keeps the typed path for correction', async () => {
     const fake = makeFakeApi({
       addError: new Error('not a file (a directory cannot be a b-roll asset): D:/album.png'),
     });
     await mount(fake.api);
     pick('[data-input="add-path"]', 'D:/album.png');
+    pick('[data-input="add-title"]', 'Album');
     await click('add');
     expect(q('.error')?.textContent).toContain('not a file');
+    expect((q('[data-input="add-path"]') as HTMLInputElement).value).toBe('D:/album.png');
+    expect((q('[data-input="add-title"]') as HTMLInputElement).value).toBe('Album');
+  });
+
+  it('clears the add fields ONLY after a successful registration', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="add-path"]', 'D:/pictures/hero dog.png');
+    pick('[data-input="add-title"]', 'Hero dog');
+    await click('add');
+    expect((q('[data-input="add-path"]') as HTMLInputElement).value).toBe('');
+    expect((q('[data-input="add-title"]') as HTMLInputElement).value).toBe('');
   });
 
   it('offers unregister on a REGISTERED row only — a scanned file is not ours to drop', async () => {

--- a/app/renderer/src/features/BrollPanel.test.tsx
+++ b/app/renderer/src/features/BrollPanel.test.tsx
@@ -1,0 +1,904 @@
+// BrollPanel.test.tsx — tests for the "Auto B-roll" panel (W16-UI).
+//
+// MEASURED GAP, detector controlled BOTH ways before a line was written.
+// The sidecar ships ~58 KB of b-roll engine across four modules
+// (`sidecar/media_studio/features/broll_ops.py`, `broll_plan.py`, `broll_index.py`,
+// `broll_compose.py`) and SEVEN registered RPCs, frozen into the authoritative
+// method list (`sidecar/tests/test_handlers_rpc_surface.py:52-58`). Probe, run at
+// 2e1f5fbf:
+//   target : rg -i broll app/   -> 0 files
+//   control: rg -i broll sidecar/ -> 15 files (so the matcher fires)
+// i.e. the whole flagship was unreachable by any user. This panel is the surface.
+//
+// THE SEVEN RPCs AND THEIR TRANSPORT (read off the landed code, not the design doc):
+//   broll.assets()                        -> {assets, missing}   direct
+//   broll.addAsset({path, title?})        -> {asset}             direct
+//   broll.removeAsset({id})               -> {ok}                direct
+//   broll.status()                        -> {indexed, assetCount, libraryCount,
+//                                             model, dim, stale, staleCount,
+//                                             willEgress}         direct
+//   broll.index({force?})                 -> {jobId} -> {assetCount, embedded, ...}
+//   broll.suggest({videoId, threshold?, maxCoveragePct?, layout?})
+//                                         -> {jobId} -> {insertions, reason, ...}
+//   broll.apply({videoId, insertions})    -> {jobId} -> {path, inserted}
+//
+// FIVE LANDED-CODE FACTS THAT EACH GET THEIR OWN CASE HERE, because working from
+// the design doc instead would have got each one wrong:
+//   1. `durationSec` is `number | null` (a SCANNED row reports None; a REGISTERED
+//      row reports 0.0) — `library.py:615` / `broll_ops.py:131`.
+//   2. A registered asset has NO poster: `add_broll` writes `""` and the only
+//      writer, `Library.set_thumbnail`, is `role='source'`-scoped
+//      (`library.py:477-490,569`). A grid that assumes an image renders holes.
+//   3. `missing` is a FEATURE, not an error (`handlers/library_ops.py:400-406`).
+//   4. TWO sources, ONE list: `broll_asset_rows` merges the `brollDir` scan with
+//      the BR1 registry (`handlers/library_ops.py:373-449`), so the panel must
+//      read that one seam and never build a second lister.
+//   5. A non-canonical `brollDir` spelling diverges `assetId`
+//      (`handlers/library_ops.py:416-427`), so no UI state may be keyed on it
+//      across a library change — the review list is keyed by POSITION.
+
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+
+import BrollPanel, {
+  APPLY_IS_ONE_WAY,
+  BROLL_LAYOUTS,
+  BROLL_REASON_NO_MATCH,
+  DEFAULT_BROLL_MAX_COVERAGE_PCT,
+  DEFAULT_BROLL_THRESHOLD,
+  NO_POSTER_LABEL,
+  THRESHOLD_IS_UNCALIBRATED,
+  assetDurationLabel,
+  assetLabel,
+  insertionWindowLabel,
+  posterSrc,
+  readBrollAssets,
+  readBrollPlan,
+  readBrollStatus,
+} from './BrollPanel';
+import type { BrollAsset } from '../lib/rpc';
+import type { DoneEvent, MediaStudioApi, ProgressEvent } from './_api';
+
+// --- fixtures --------------------------------------------------------------
+
+/** A row as the `brollDir` SCAN emits it (`broll_ops.scan_assets`). */
+const SCANNED: BrollAsset = {
+  assetId: 'aaaa1111bbbb2222',
+  path: 'C:/broll/city.mp4',
+  kind: 'video',
+  sizeBytes: 1024,
+  mtime: 1000,
+  durationSec: null,
+  registered: false,
+};
+
+/** A row as the BR1 REGISTRY emits it (`Library._row_to_broll_asset`). */
+const REGISTERED: BrollAsset = {
+  assetId: 'cccc3333dddd4444',
+  path: 'D:/pictures/hero dog.png',
+  kind: 'image',
+  entityKind: 'brollImage',
+  title: 'Hero dog',
+  addedAt: '2026-08-10T00:00:00Z',
+  durationSec: 0,
+  contentHash: null,
+  thumbnailPath: '',
+  sizeBytes: 2048,
+  mtime: 2000,
+  exists: true,
+  registered: true,
+};
+
+/** A registered row whose file has since vanished (the `missing` half). */
+const VANISHED: BrollAsset = {
+  ...REGISTERED,
+  assetId: 'eeee5555ffff6666',
+  path: 'D:/pictures/gone.png',
+  title: 'Gone',
+  sizeBytes: 0,
+  mtime: 0,
+  exists: false,
+};
+
+const STATUS = {
+  indexed: true,
+  assetCount: 2,
+  libraryCount: 3,
+  model: 'google/siglip2-so400m-patch16-384',
+  dim: 1152,
+  stale: true,
+  staleCount: 1,
+  willEgress: false,
+};
+
+const INSERTION_A = {
+  segmentIndex: 0,
+  start: 4,
+  end: 8,
+  duration: 4,
+  sourceStart: 0,
+  assetId: REGISTERED.assetId,
+  path: REGISTERED.path,
+  kind: 'image',
+  score: 0.61,
+  reason: '"the dog ran off" (0.61)',
+  layout: 'cutaway',
+};
+const INSERTION_B = {
+  ...INSERTION_A,
+  segmentIndex: 4,
+  start: 30,
+  end: 33,
+  duration: 3,
+  assetId: SCANNED.assetId,
+  path: SCANNED.path,
+  kind: 'video',
+  score: 0.34,
+  reason: '"downtown at night" (0.34)',
+};
+
+// --- fake bridge -----------------------------------------------------------
+
+interface FakeApi {
+  api: MediaStudioApi;
+  calls: Array<{ method: string; params?: Record<string, unknown> }>;
+  fireProgress: (ev: ProgressEvent) => void;
+  fireDone: (ev: DoneEvent) => void;
+}
+
+interface Overrides {
+  assets?: unknown;
+  assetsError?: Error;
+  status?: unknown;
+  addError?: Error;
+  indexError?: Error;
+  suggestError?: Error;
+  jobless?: boolean;
+  cancelError?: Error;
+}
+
+function makeFakeApi(overrides: Overrides = {}): FakeApi {
+  const calls: FakeApi['calls'] = [];
+  let progressCbs: Array<(ev: ProgressEvent) => void> = [];
+  let doneCbs: Array<(ev: DoneEvent) => void> = [];
+  const handle = overrides.jobless ? {} : { jobId: 'job-b' };
+  const api: MediaStudioApi = {
+    rpc: vi.fn(async <T,>(method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params });
+      if (method === 'broll.assets') {
+        if (overrides.assetsError) throw overrides.assetsError;
+        return (overrides.assets ?? { assets: [SCANNED, REGISTERED], missing: [VANISHED] }) as T;
+      }
+      if (method === 'broll.status') return (overrides.status ?? STATUS) as T;
+      if (method === 'broll.addAsset') {
+        if (overrides.addError) throw overrides.addError;
+        return { asset: REGISTERED } as T;
+      }
+      if (method === 'broll.removeAsset') return { ok: true } as T;
+      if (method === 'broll.index') {
+        if (overrides.indexError) throw overrides.indexError;
+        return handle as T;
+      }
+      if (method === 'broll.suggest') {
+        if (overrides.suggestError) throw overrides.suggestError;
+        return handle as T;
+      }
+      if (method === 'broll.apply') return handle as T;
+      if (method === 'job.cancel') {
+        if (overrides.cancelError) throw overrides.cancelError;
+        return { ok: true } as T;
+      }
+      return {} as T;
+    }) as MediaStudioApi['rpc'],
+    onProgress: (cb) => {
+      progressCbs.push(cb);
+      return () => {
+        progressCbs = progressCbs.filter((c) => c !== cb);
+      };
+    },
+    onJobDone: (cb) => {
+      doneCbs.push(cb);
+      return () => {
+        doneCbs = doneCbs.filter((c) => c !== cb);
+      };
+    },
+  };
+  return {
+    api,
+    calls,
+    fireProgress: (ev) => progressCbs.slice().forEach((cb) => cb(ev)),
+    fireDone: (ev) => doneCbs.slice().forEach((cb) => cb(ev)),
+  };
+}
+
+// --- pure helpers ----------------------------------------------------------
+
+describe('readBrollAssets (the ONE list — fact 4)', () => {
+  it('partitions {assets, missing} and preserves every landed field', () => {
+    expect(readBrollAssets({ assets: [SCANNED, REGISTERED], missing: [VANISHED] })).toEqual({
+      assets: [SCANNED, REGISTERED],
+      missing: [VANISHED],
+    });
+  });
+
+  it('degrades a shapeless payload to two EMPTY lists rather than throwing', () => {
+    expect(readBrollAssets(null)).toEqual({ assets: [], missing: [] });
+    expect(readBrollAssets({ assets: 'nope', missing: 7 })).toEqual({ assets: [], missing: [] });
+  });
+
+  it('drops a row with no usable assetId/path — a phantom must never reach the grid', () => {
+    expect(
+      readBrollAssets({
+        assets: [SCANNED, { assetId: '', path: 'C:/x.png' }, { path: 'C:/y.png' }, 42],
+        missing: [],
+      }).assets,
+    ).toEqual([SCANNED]);
+  });
+});
+
+describe('readBrollStatus', () => {
+  it('reads the freshness snapshot the sidecar actually returns', () => {
+    expect(readBrollStatus(STATUS)).toEqual(STATUS);
+  });
+
+  it('returns null for a shapeless payload (renders nothing, never junk)', () => {
+    expect(readBrollStatus(null)).toBeNull();
+    expect(readBrollStatus('nope')).toBeNull();
+  });
+
+  it('coerces absent fields to explicit zeros/falses, never invented numbers', () => {
+    expect(readBrollStatus({})).toEqual({
+      indexed: false,
+      assetCount: 0,
+      libraryCount: 0,
+      model: '',
+      dim: 0,
+      stale: false,
+      staleCount: 0,
+      willEgress: false,
+    });
+  });
+});
+
+describe('readBrollPlan', () => {
+  it('reads the insertions plus the sidecar reason string verbatim', () => {
+    expect(readBrollPlan({ insertions: [INSERTION_A], reason: 'matched' })).toEqual({
+      insertions: [INSERTION_A],
+      reason: 'matched',
+    });
+  });
+
+  it('an absent/shapeless payload is the HONEST empty plan, not an error', () => {
+    expect(readBrollPlan(null)).toEqual({ insertions: [], reason: BROLL_REASON_NO_MATCH });
+    expect(readBrollPlan({ insertions: 'nope' })).toEqual({
+      insertions: [],
+      reason: BROLL_REASON_NO_MATCH,
+    });
+  });
+
+  it('drops an insertion row that carries no usable path/assetId', () => {
+    expect(
+      readBrollPlan({ insertions: [INSERTION_A, { assetId: 'x' }, 3], reason: 'matched' })
+        .insertions,
+    ).toEqual([INSERTION_A]);
+  });
+});
+
+// FACT 1 — `durationSec` is `number | null`. Typing it `number` is wrong at
+// runtime, and `0.0` is what a registered STILL reports, so neither may render as
+// a duration the file does not have.
+describe('assetDurationLabel (fact 1: durationSec is number | null)', () => {
+  it('a still has no timeline at all', () => {
+    expect(assetDurationLabel(REGISTERED)).toBe('still');
+  });
+
+  it('formats a real clip duration', () => {
+    expect(assetDurationLabel({ ...SCANNED, durationSec: 12.5 })).toBe('12.5s');
+  });
+
+  it('a SCANNED clip reports null — shown as unknown, never as 0s', () => {
+    expect(assetDurationLabel(SCANNED)).toBe('—');
+  });
+
+  it('a probe-failed clip reports 0.0 — also unknown, never "0.0s"', () => {
+    expect(assetDurationLabel({ ...SCANNED, durationSec: 0 })).toBe('—');
+  });
+
+  it('a non-finite duration is unknown too (NaN never reaches toFixed)', () => {
+    expect(assetDurationLabel({ ...SCANNED, durationSec: Number.NaN })).toBe('—');
+  });
+});
+
+// FACT 2 — registered assets have NO poster.
+describe('posterSrc (fact 2: a registered asset has no poster)', () => {
+  it('the empty string add_broll writes is NOT an image source', () => {
+    expect(posterSrc(REGISTERED)).toBeNull();
+  });
+
+  it('an absent thumbnailPath (a scanned row) is not an image source either', () => {
+    expect(posterSrc(SCANNED)).toBeNull();
+  });
+
+  it('a real poster path is used when one ever exists', () => {
+    expect(posterSrc({ ...REGISTERED, thumbnailPath: 'D:/th/dog.jpg' })).toBe('D:/th/dog.jpg');
+  });
+});
+
+describe('assetLabel', () => {
+  it('prefers the registry title', () => {
+    expect(assetLabel(REGISTERED)).toBe('Hero dog');
+  });
+
+  it('falls back to the basename of a Windows path', () => {
+    expect(assetLabel({ ...REGISTERED, title: '   ' })).toBe('hero dog.png');
+  });
+
+  it('falls back to the basename of a POSIX path', () => {
+    expect(assetLabel(SCANNED)).toBe('city.mp4');
+  });
+
+  it('falls back to the assetId when there is no basename at all', () => {
+    expect(assetLabel({ ...SCANNED, path: '' })).toBe(SCANNED.assetId);
+  });
+});
+
+describe('insertionWindowLabel', () => {
+  it('states the window the composite will occupy', () => {
+    expect(insertionWindowLabel(INSERTION_A)).toBe('4.0s - 8.0s (4.0s)');
+  });
+});
+
+// --- component -------------------------------------------------------------
+
+describe('<BrollPanel />', () => {
+  let container: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    container = document.createElement('div');
+    document.body.appendChild(container);
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await act(async () => {
+      root.unmount();
+    });
+    container.remove();
+  });
+
+  const flush = async (): Promise<void> => {
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  };
+
+  async function mount(api: MediaStudioApi, videoId = 'v1'): Promise<void> {
+    await act(async () => {
+      root.render(<BrollPanel videoId={videoId} api={api} />);
+    });
+    await flush();
+  }
+
+  async function rerender(api: MediaStudioApi, videoId: string): Promise<void> {
+    await act(async () => {
+      root.render(<BrollPanel videoId={videoId} api={api} />);
+    });
+    await flush();
+  }
+
+  const q = (selector: string): HTMLElement | null => container.querySelector(selector);
+  const btn = (action: string): HTMLButtonElement =>
+    container.querySelector(`[data-action="${action}"]`) as HTMLButtonElement;
+
+  function pick(selector: string, value: string): void {
+    const el = container.querySelector(selector) as HTMLInputElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+  }
+
+  function choose(selector: string, value: string): void {
+    const el = container.querySelector(selector) as HTMLSelectElement;
+    const setter = Object.getOwnPropertyDescriptor(HTMLSelectElement.prototype, 'value')!.set!;
+    act(() => {
+      setter.call(el, value);
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  }
+
+  async function click(action: string): Promise<void> {
+    await act(async () => {
+      btn(action).click();
+      await Promise.resolve();
+    });
+    await flush();
+  }
+
+  function toggle(selector: string): void {
+    const el = container.querySelector(selector) as HTMLInputElement;
+    act(() => {
+      el.click();
+    });
+  }
+
+  /** Drive a suggest to completion with the given job.done payload. */
+  async function suggestWith(fake: FakeApi, result: unknown): Promise<void> {
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b', result });
+      await Promise.resolve();
+    });
+    await flush();
+  }
+
+  it('reads the ONE list on mount and adds no second lister (fact 4)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    const methods = fake.calls.map((c) => c.method);
+    expect(methods).toContain('broll.assets');
+    expect(methods).toContain('broll.status');
+    // `library.list` is the SOURCE-video lister; reading it here would show a
+    // second, different library from the one broll.index actually embeds.
+    expect(methods).not.toContain('library.list');
+  });
+
+  it('renders the freshness snapshot including libraryCount and staleCount', async () => {
+    await mount(makeFakeApi().api);
+    const status = q('[data-section="status"]');
+    expect(status?.textContent).toContain('3');
+    expect(status?.textContent).toContain('siglip2');
+    expect(q('[data-field="stale"]')?.textContent).toContain('1');
+  });
+
+  it('badges the run as fully local off the wire, not off a hardcoded promise', async () => {
+    await mount(makeFakeApi().api);
+    expect(q('[data-section="local-only"]')).not.toBeNull();
+    expect(q('[data-section="egress-warning"]')).toBeNull();
+  });
+
+  it('flips that badge to a WARNING if the sidecar ever reports egress', async () => {
+    await mount(makeFakeApi({ status: { ...STATUS, willEgress: true } }).api);
+    expect(q('[data-section="egress-warning"]')).not.toBeNull();
+    expect(q('[data-section="local-only"]')).toBeNull();
+  });
+
+  it('renders a placeholder tile — never a broken img — for a poster-less asset (fact 2)', async () => {
+    await mount(makeFakeApi().api);
+    const row = q(`[data-asset-id="${REGISTERED.assetId}"]`);
+    expect(row).not.toBeNull();
+    expect(row?.querySelector('img')).toBeNull();
+    expect(row?.querySelector('[data-poster="none"]')?.textContent).toContain(NO_POSTER_LABEL);
+  });
+
+  it('shows an unknown duration for a scanned clip rather than inventing 0s (fact 1)', async () => {
+    await mount(makeFakeApi().api);
+    expect(
+      q(`[data-asset-id="${SCANNED.assetId}"] [data-field="duration"]`)?.textContent,
+    ).toContain('—');
+  });
+
+  it('surfaces the missing list LOUDLY in its own section (fact 3)', async () => {
+    await mount(makeFakeApi().api);
+    const missing = q('[data-section="missing"]');
+    expect(missing).not.toBeNull();
+    expect(missing?.textContent).toContain('gone.png');
+    // and a vanished row is NOT in the indexable grid
+    expect(q(`[data-asset-id="${VANISHED.assetId}"]`)).toBeNull();
+  });
+
+  it('unregisters a missing asset and re-reads the one list', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      (
+        container.querySelector(
+          `[data-missing-id="${VANISHED.assetId}"] [data-action="unregister-missing"]`,
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'broll.removeAsset')?.params).toEqual({
+      id: VANISHED.assetId,
+    });
+    expect(fake.calls.filter((c) => c.method === 'broll.assets')).toHaveLength(2);
+  });
+
+  it('registers a new asset by path with an optional title, then refreshes', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="add-path"]', ' D:/pictures/hero dog.png ');
+    pick('[data-input="add-title"]', ' Hero dog ');
+    await click('add');
+    expect(fake.calls.find((c) => c.method === 'broll.addAsset')?.params).toEqual({
+      path: 'D:/pictures/hero dog.png',
+      title: 'Hero dog',
+    });
+    expect(fake.calls.filter((c) => c.method === 'broll.assets')).toHaveLength(2);
+  });
+
+  it('OMITS title entirely when the field is blank (no empty-string title)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="add-path"]', 'D:/pictures/hero dog.png');
+    await click('add');
+    expect(fake.calls.find((c) => c.method === 'broll.addAsset')?.params).toEqual({
+      path: 'D:/pictures/hero dog.png',
+    });
+  });
+
+  it('keeps the register control shut until a non-blank path exists', async () => {
+    await mount(makeFakeApi().api);
+    expect(btn('add').disabled).toBe(true);
+    pick('[data-input="add-path"]', '   ');
+    expect(btn('add').disabled).toBe(true);
+    pick('[data-input="add-path"]', 'D:/x.png');
+    expect(btn('add').disabled).toBe(false);
+  });
+
+  it('surfaces the registry-door refusal instead of swallowing it', async () => {
+    const fake = makeFakeApi({
+      addError: new Error('not a file (a directory cannot be a b-roll asset): D:/album.png'),
+    });
+    await mount(fake.api);
+    pick('[data-input="add-path"]', 'D:/album.png');
+    await click('add');
+    expect(q('.error')?.textContent).toContain('not a file');
+  });
+
+  it('offers unregister on a REGISTERED row only — a scanned file is not ours to drop', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    expect(
+      container.querySelector(`[data-asset-id="${SCANNED.assetId}"] [data-action="unregister"]`),
+    ).toBeNull();
+    await act(async () => {
+      (
+        container.querySelector(
+          `[data-asset-id="${REGISTERED.assetId}"] [data-action="unregister"]`,
+        ) as HTMLButtonElement
+      ).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'broll.removeAsset')?.params).toEqual({
+      id: REGISTERED.assetId,
+    });
+  });
+
+  it('surfaces a failed first read rather than showing an empty library', async () => {
+    await mount(makeFakeApi({ assetsError: new Error('library.json is corrupt') }).api);
+    expect(q('.error')?.textContent).toContain('library.json is corrupt');
+  });
+
+  it('indexes the library, threading the force flag, then re-reads status', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    toggle('[data-input="force"]');
+    await act(async () => {
+      btn('index').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b', result: { assetCount: 2, embedded: 2 } });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'broll.index')?.params).toEqual({ force: true });
+    expect(fake.calls.filter((c) => c.method === 'broll.status')).toHaveLength(2);
+  });
+
+  it('still refreshes when the index answer carries no jobId', async () => {
+    const fake = makeFakeApi({ jobless: true });
+    await mount(fake.api);
+    await click('index');
+    expect(fake.calls.filter((c) => c.method === 'broll.status')).toHaveLength(2);
+  });
+
+  it('surfaces an index failure', async () => {
+    const fake = makeFakeApi({ indexError: new Error('no local image backbone is wired') });
+    await mount(fake.api);
+    await click('index');
+    expect(q('.error')?.textContent).toContain('no local image backbone');
+  });
+
+  // THE THRESHOLD DECISION (option a). `broll_plan.DEFAULT_MIN_SIMILARITY = 0.22`
+  // is documented in-module as an UNCALIBRATED placeholder. The panel therefore
+  // SENDS an explicit threshold on every call, so what the slider says is what the
+  // planner uses — the sidecar default is never the silent authority.
+  it('sends an EXPLICIT threshold, coverage and layout — never relies on the guess', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'broll.suggest')?.params).toEqual({
+      videoId: 'v1',
+      threshold: DEFAULT_BROLL_THRESHOLD,
+      maxCoveragePct: DEFAULT_BROLL_MAX_COVERAGE_PCT,
+      layout: BROLL_LAYOUTS[0],
+    });
+  });
+
+  it('the slider moves the threshold that is actually sent', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    pick('[data-input="threshold"]', '0.45');
+    pick('[data-input="coverage"]', '25');
+    choose('[data-input="layout"]', 'pip');
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'broll.suggest')?.params).toEqual({
+      videoId: 'v1',
+      threshold: 0.45,
+      maxCoveragePct: 25,
+      layout: 'pip',
+    });
+    expect(q('.broll-threshold-value')?.textContent).toContain('0.45');
+  });
+
+  it('presents the threshold as adjustable and UNCALIBRATED, naming the experiment', async () => {
+    await mount(makeFakeApi().api);
+    const copy = q('[data-section="threshold-disclosure"]')?.textContent ?? '';
+    expect(copy).toBe(THRESHOLD_IS_UNCALIBRATED);
+    expect(copy).toContain('0.22');
+    expect(copy).toContain('flagship-auto-broll.md');
+    // per-MODEL, the second warning in the sidecar docstring
+    expect(copy).toContain('backbone');
+  });
+
+  it('renders every suggestion with its score, its reason and its window', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await suggestWith(fake, { insertions: [INSERTION_A, INSERTION_B], reason: 'matched' });
+    const rows = container.querySelectorAll('[data-insertion]');
+    expect(rows).toHaveLength(2);
+    expect(rows[0].querySelector('[data-field="score"]')?.textContent).toContain('0.61');
+    expect(rows[0].querySelector('[data-field="reason"]')?.textContent).toContain(
+      'the dog ran off',
+    );
+    expect(rows[0].querySelector('[data-field="window"]')?.textContent).toBe(
+      insertionWindowLabel(INSERTION_A),
+    );
+  });
+
+  it('treats "no confident match" as a RESULT, not an error', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await suggestWith(fake, { insertions: [], reason: BROLL_REASON_NO_MATCH });
+    expect(q('[data-section="no-match"]')).not.toBeNull();
+    expect(q('.error')).toBeNull();
+    expect(container.querySelectorAll('[data-insertion]')).toHaveLength(0);
+  });
+
+  it('a suggest answer with no jobId leaves an honest empty plan', async () => {
+    const fake = makeFakeApi({ jobless: true });
+    await mount(fake.api);
+    await click('suggest');
+    expect(q('[data-section="no-match"]')).not.toBeNull();
+    expect(q('.error')).toBeNull();
+  });
+
+  it('surfaces a suggest failure (e.g. no transcript yet)', async () => {
+    const fake = makeFakeApi({
+      suggestError: new Error('v1 has no transcript yet; run transcribe.start first'),
+    });
+    await mount(fake.api);
+    await click('suggest');
+    expect(q('.error')?.textContent).toContain('no transcript yet');
+  });
+
+  it('applies ONLY the accepted insertions (review-first, keyed by position — fact 5)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await suggestWith(fake, { insertions: [INSERTION_A, INSERTION_B], reason: 'matched' });
+    toggle('[data-insertion="1"] [data-input="accept"]');
+    await act(async () => {
+      btn('apply').click();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'broll.apply')?.params).toEqual({
+      videoId: 'v1',
+      insertions: [INSERTION_A],
+    });
+  });
+
+  it('cannot apply an empty plan (the sidecar rejects it; the button never sends it)', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await suggestWith(fake, { insertions: [INSERTION_A], reason: 'matched' });
+    expect(btn('apply').disabled).toBe(false);
+    toggle('[data-insertion="0"] [data-input="accept"]');
+    expect(btn('apply').disabled).toBe(true);
+  });
+
+  it('reports the flat file apply produced, and says it is one-way BEFORE the click', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    // The disclosure is present as soon as an apply is possible, not after.
+    await suggestWith(fake, { insertions: [INSERTION_A], reason: 'matched' });
+    const notice = q('[data-section="one-way"]');
+    expect(notice?.textContent).toBe(APPLY_IS_ONE_WAY);
+    expect(notice?.compareDocumentPosition(btn('apply'))).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+
+    await act(async () => {
+      btn('apply').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b', result: { path: 'C:/out/talk.broll.mp4', inserted: 1 } });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(q('[data-section="result"]')?.textContent).toContain('talk.broll.mp4');
+  });
+
+  it('streams progress for its own job and ignores another', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireProgress({ jobId: 'job-b', pct: 42, message: 'matching 12 segments' });
+      await Promise.resolve();
+    });
+    expect(q('.progress-pct')?.textContent).toContain('42');
+    expect(q('.progress-message')?.textContent).toContain('matching 12 segments');
+    await act(async () => {
+      fake.fireProgress({ jobId: 'someone-else', pct: 99, message: 'other' });
+      await Promise.resolve();
+    });
+    expect(q('.progress-pct')?.textContent).not.toContain('99');
+  });
+
+  it('cancels the running job, and a failed cancel is not a panel error', async () => {
+    const fake = makeFakeApi({ cancelError: new Error('already finished') });
+    await mount(fake.api);
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    await act(async () => {
+      btn('cancel').click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(fake.calls.find((c) => c.method === 'job.cancel')?.params).toEqual({ jobId: 'job-b' });
+    expect(q('.error')).toBeNull();
+  });
+
+  // A PLAN BELONGS TO ONE VIDEO. `broll.apply` sends the CURRENT videoId with
+  // whatever insertions are on screen, so a plan left over from the previous video
+  // would composite video A's windows and assets onto video B.
+  it('clears a stale plan when a different video is opened in place', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await suggestWith(fake, { insertions: [INSERTION_A], reason: 'matched' });
+    expect(container.querySelectorAll('[data-insertion]')).toHaveLength(1);
+    await rerender(fake.api, 'v2');
+    expect(container.querySelectorAll('[data-insertion]')).toHaveLength(0);
+    expect(q('[data-section="review"]')).toBeNull();
+  });
+
+  it('discards a DEFERRED suggest whose video was switched away mid-flight', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    // the user moves on while the job is still running…
+    await rerender(fake.api, 'v2');
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b', result: { insertions: [INSERTION_A], reason: 'matched' } });
+      await Promise.resolve();
+    });
+    await flush();
+    // …so video v1's plan must NOT appear under video v2.
+    expect(container.querySelectorAll('[data-insertion]')).toHaveLength(0);
+  });
+
+  it('names what is still missing so the copy cannot imply BR2 or posters shipped', async () => {
+    await mount(makeFakeApi().api);
+    const limits = q('[data-section="limits"]')?.textContent ?? '';
+    expect(limits).toContain('size and modified time');
+    expect(limits).toContain(NO_POSTER_LABEL.toLowerCase());
+  });
+
+  it('renders a real poster when one ever exists, instead of the placeholder', async () => {
+    const withPoster: BrollAsset = { ...REGISTERED, thumbnailPath: 'D:/th/dog.jpg' };
+    await mount(makeFakeApi({ assets: { assets: [withPoster], missing: [] } }).api);
+    const row = q(`[data-asset-id="${REGISTERED.assetId}"]`);
+    expect(row?.querySelector('img')?.getAttribute('src')).toBe('D:/th/dog.jpg');
+    expect(row?.querySelector('[data-poster="none"]')).toBeNull();
+  });
+
+  // The un-indexed first-run state: every number the snapshot shows is ABSENT, and
+  // the panel must say so rather than print zeros that look like measurements.
+  it('reads a bare status payload as "not indexed yet", never as zeros', async () => {
+    await mount(makeFakeApi({ status: {} }).api);
+    expect(q('[data-field="indexed"]')?.textContent).toBe('not yet');
+    expect(q('[data-field="stale"]')?.textContent).toBe('none');
+    expect(q('[data-field="model"]')?.textContent).toBe('none');
+  });
+
+  it('treats a job.done with NO result as the honest empty plan', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    await act(async () => {
+      fake.fireDone({ jobId: 'job-b' });
+      await Promise.resolve();
+    });
+    await flush();
+    expect(q('[data-section="no-match"]')).not.toBeNull();
+    expect(q('.error')).toBeNull();
+  });
+
+  it('a successful cancel reports back without becoming an error', async () => {
+    const fake = makeFakeApi();
+    await mount(fake.api);
+    await act(async () => {
+      btn('suggest').click();
+    });
+    await flush();
+    await act(async () => {
+      btn('cancel').click();
+      await Promise.resolve();
+    });
+    expect(q('.progress-message')?.textContent).toContain('Cancelling');
+    expect(q('.error')).toBeNull();
+  });
+
+  it('surfaces a NON-Error rejection as text rather than "[object Object]"', async () => {
+    const api = {
+      rpc: vi.fn(async (method: string) => {
+        if (method === 'broll.assets') throw 'sidecar pipe closed';
+        return {};
+      }),
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    } as unknown as MediaStudioApi;
+    await mount(api);
+    expect(q('.error')?.textContent).toContain('sidecar pipe closed');
+  });
+
+  // The `api` prop exists only for these tests; the SHIPPED path reads the
+  // preload-injected bridge through getApi(), so that default has to be exercised
+  // or the packaged panel would be running an untested line.
+  it('falls back to the preload bridge when no api prop is injected', async () => {
+    const rpc = vi.fn(async () => ({}));
+    (globalThis as { api?: unknown }).api = {
+      rpc,
+      onProgress: () => () => {},
+      onJobDone: () => () => {},
+    };
+    try {
+      await act(async () => {
+        root.render(<BrollPanel videoId="v1" />);
+      });
+      await flush();
+      expect(rpc).toHaveBeenCalledWith('broll.assets');
+    } finally {
+      delete (globalThis as { api?: unknown }).api;
+    }
+  });
+});

--- a/app/renderer/src/features/BrollPanel.tsx
+++ b/app/renderer/src/features/BrollPanel.tsx
@@ -1,0 +1,815 @@
+// BrollPanel.tsx — "Auto B-roll" (W16-UI: the renderer surface for v1.5 flagship #3).
+//
+// WHY THIS PANEL EXISTS (measured, detector controlled BOTH ways).
+// The sidecar ships the whole flagship: `features/broll_ops.py`, `broll_plan.py`,
+// `broll_index.py`, `broll_compose.py` (~58 KB) and SEVEN registered RPCs, frozen
+// into the authoritative method list (`sidecar/tests/test_handlers_rpc_surface.py`).
+// Probe run at `2e1f5fbf`:
+//   target : `rg -i broll app/`     -> 0 files
+//   control: `rg -i broll sidecar/` -> 15 files  (so the matcher fires)
+// A zero with a live control is a real absence: not one line of the flagship was
+// reachable by any user. BR1 (#393) added the registration door — `broll.assets` /
+// `broll.addAsset` / `broll.removeAsset` — so the library can now be FILLED from
+// the app, which is what makes a panel worth mounting. This lane is renderer-only;
+// it changes nothing under `sidecar/`.
+//
+// TRANSPORT (`_api.ts` CONTRACT-NOTE). `status` / `assets` / `addAsset` /
+// `removeAsset` are DIRECT-return. `index` / `suggest` / `apply` are deferred JOBS:
+// the rpc promise carries `{jobId}` only and the payload arrives on the later
+// `job.done`, so those three go through `waitForJobDone` — same shape as
+// `Stabilize.tsx` / `Gaze.tsx`.
+//
+// ─── THE THRESHOLD IS A GUESS, AND MOUNTING A UI MAKES IT USER-VISIBLE ───────
+// `broll_plan.py:77` `DEFAULT_MIN_SIMILARITY = 0.22` is documented at
+// `broll_plan.py:50-55` as an UNCALIBRATED placeholder carried from the design
+// doc, with the settling experiment named at
+// `docs/plans/v1.5/flagship-auto-broll.md` §11.2 (20-30 (segment, relevant-asset,
+// decoy) triples per tier, pick the precision/recall knee). It is inert today
+// because nothing reaches it. The moment this panel exposes matching, that guess
+// decides which clips a user is offered: too high offers nothing and reads as
+// "broken", too low offers junk and reads as "stupid".
+//
+// DECISION: option (a) — EXPOSE A THRESHOLD SLIDER, presented as adjustable rather
+// than authoritative. Two reasons it is (a) and not (b) "calibrate it":
+//   * (b) needs a labelled probe set AND a real SigLIP-2 tower, and would change
+//     `broll_plan.py` — outside this lane's file scope, which is renderer-only;
+//   * the sidecar module itself prescribes (a) in so many words: "Until then treat
+//     the default as 'requires a threshold slider', not as a tuned constant."
+// So the panel SENDS an explicit `threshold` on every call. That matters beyond
+// cosmetics: if the field were omitted the sidecar default would silently be the
+// authority, and the number on screen would not be the number that ran. The
+// disclosure below states the value, that it is uncalibrated, that it is
+// PER-BACKBONE (the docstring's second warning), and the experiment that settles
+// it. Shipping 0.22 silently, as though tuned, is the thing this avoids.
+//
+// ─── WHAT IS STILL MISSING — THE COPY MUST NOT IMPLY OTHERWISE ──────────────
+//   * BR2 content-hash staleness is ABSENT. `add_broll` leaves `content_hash`
+//     NULL on purpose (a whole-file BLAKE3 inside a synchronous RPC), so
+//     freshness is size+mtime only — an edit that preserves both is invisible.
+//   * B-roll POSTER extraction does not exist. `thumbnailPath` is
+//     unconditionally `""`; the only writer, `Library.set_thumbnail`, is
+//     `role='source'`-scoped, and `set_thumbnail(<brollAssetId>, …)` was measured
+//     to return `None` and change nothing. So the grid is designed for the ABSENT
+//     case and renders a labelled placeholder, never an <img> that would 404.
+//   * BR6 REVERSIBILITY is design-only. `broll.apply` renders a flat
+//     `{stem}.broll.mp4` (`broll_ops.py:450`) — there is no inverse op and no
+//     overlay track, so a user who dislikes the result has no undo beyond
+//     re-exporting. That is disclosed ABOVE the Apply button, not after it.
+import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import './panels.css';
+import './broll.css';
+import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+import type { BrollAsset, BrollAssetsResult, BrollInsertion, BrollStatus } from '../lib/rpc';
+
+/**
+ * Mirror of `broll_plan.DEFAULT_MIN_SIMILARITY` — the slider's starting point, NOT
+ * a tuned value. Pinned against the real `.py` by `brollClient.conformance.test.ts`
+ * so a calibration landing in the sidecar cannot leave this seed behind.
+ */
+export const DEFAULT_BROLL_THRESHOLD = 0.22;
+
+/** Mirror of `broll_plan.DEFAULT_MAX_COVERAGE_PCT` (also conformance-pinned). */
+export const DEFAULT_BROLL_MAX_COVERAGE_PCT = 40;
+
+/** Mirror of `broll_plan.LAYOUTS`; `[0]` is `DEFAULT_LAYOUT`. */
+export const BROLL_LAYOUTS = ['cutaway', 'pip'] as const;
+
+/** Mirror of `broll_ops.NO_CONFIDENT_MATCH` — the honest empty-plan reason. */
+export const BROLL_REASON_NO_MATCH = 'no confident match';
+
+/** Mirror of `broll_ops.MATCHED`. */
+export const BROLL_REASON_MATCHED = 'matched';
+
+/** Shown in place of a poster. Registered assets have none (see the header). */
+export const NO_POSTER_LABEL = 'No preview';
+
+/**
+ * The threshold disclosure. Names the number, that it is UNCALIBRATED, that it is
+ * per-backbone, and the experiment that would settle it — so the slider reads as
+ * adjustable rather than authoritative.
+ */
+export const THRESHOLD_IS_UNCALIBRATED =
+  'Match threshold: a suggestion is only offered when the cosine similarity between ' +
+  'the spoken segment and the asset reaches this value. The starting value of 0.22 is ' +
+  'an UNCALIBRATED placeholder, not a tuned number — no labelled probe set has been ' +
+  'measured yet, and the right value is specific to the matching backbone, so a ' +
+  'different backbone needs its own. Treat it as a dial, not an answer: raise it if ' +
+  'you are offered junk, lower it if you are offered nothing. The calibration that ' +
+  'would replace it is described in docs/plans/v1.5/flagship-auto-broll.md section 11.2.';
+
+/**
+ * The BR6 disclosure, rendered directly ABOVE the Apply control. A user must know
+ * an apply cannot be undone BEFORE clicking, not from a support thread afterwards.
+ */
+export const APPLY_IS_ONE_WAY =
+  'Apply is a ONE-WAY render: it writes a new flat video file into the broll folder ' +
+  'under your exports, with the b-roll burned in. Your source video is never ' +
+  'modified, but there is no undo and no separate b-roll track to switch off — ' +
+  'reversible apply is designed and not built yet. If you dislike the result, delete ' +
+  'that file and apply a different selection.';
+
+/** What the engine cannot yet do. Stated so the panel never implies otherwise. */
+export const BROLL_KNOWN_LIMITS =
+  'Two engine limits worth knowing: staleness is tracked by file size and modified ' +
+  'time only (a re-edit that preserves both will not trigger a re-index, so use ' +
+  'Re-embed everything after one), and there is no preview extraction for b-roll ' +
+  'files yet — every tile below shows a no preview placeholder rather than a frame.';
+
+/** The badge the design doc asks for, driven by the WIRE and not by a promise. */
+export const BROLL_LOCAL_ONLY =
+  'Fully local: matching runs on this machine, and no frame, transcript or filename ' +
+  'is uploaded.';
+
+/** Rendered instead of the badge if the sidecar ever reports egress on this path. */
+export const BROLL_EGRESS_WARNING =
+  'This build reports that b-roll matching would send data off this machine. That is ' +
+  'not the designed behaviour for auto-b-roll — stop and check the build before using it.';
+
+// --- pure helpers (exported for tests) -------------------------------------
+
+/** The message text of any thrown value (shared by every catch below). */
+function errText(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return typeof value === 'object' && value !== null ? (value as Record<string, unknown>) : {};
+}
+
+function num(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+function str(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * True when `row` carries the two fields every consumer dereferences. A row that
+ * fails this is DROPPED rather than rendered as a phantom the user cannot act on
+ * (`removeAsset` needs the id, `apply` needs the path).
+ */
+function isAssetRow(row: unknown): row is BrollAsset {
+  const rec = asRecord(row);
+  return str(rec.assetId).length > 0 && str(rec.path).length > 0;
+}
+
+/**
+ * Read `broll.assets` -> `{assets, missing}`.
+ *
+ * The two halves are a PARTITION of one sidecar snapshot (`broll_assets` reads the
+ * registry exactly once), so this keeps them together rather than re-deriving
+ * `missing` from `assets` — a second derivation is how an asset ends up in both
+ * halves or in neither.
+ */
+export function readBrollAssets(result: unknown): BrollAssetsResult {
+  const rec = asRecord(result);
+  const pickList = (value: unknown): BrollAsset[] =>
+    Array.isArray(value) ? value.filter(isAssetRow) : [];
+  return { assets: pickList(rec.assets), missing: pickList(rec.missing) };
+}
+
+/**
+ * Read `broll.status`. `null` for a shapeless payload so the panel renders nothing
+ * instead of a snapshot of invented zeros presented as measurements.
+ */
+export function readBrollStatus(result: unknown): BrollStatus | null {
+  if (typeof result !== 'object' || result === null) return null;
+  const rec = result as Record<string, unknown>;
+  return {
+    indexed: rec.indexed === true,
+    assetCount: num(rec.assetCount),
+    libraryCount: num(rec.libraryCount),
+    model: str(rec.model),
+    dim: num(rec.dim),
+    stale: rec.stale === true,
+    staleCount: num(rec.staleCount),
+    willEgress: rec.willEgress === true,
+  };
+}
+
+/**
+ * Read a `broll.suggest` job.done payload. An unusable payload becomes the HONEST
+ * empty plan (`no confident match`) rather than an error: "nothing cleared the
+ * threshold" is a legitimate result and the whole point of the gate.
+ */
+export function readBrollPlan(result: unknown): { insertions: BrollInsertion[]; reason: string } {
+  const rec = asRecord(result);
+  const rows = Array.isArray(rec.insertions) ? rec.insertions.filter(isAssetRow) : [];
+  const insertions = rows as unknown as BrollInsertion[];
+  return {
+    insertions,
+    reason: insertions.length > 0 ? str(rec.reason) : BROLL_REASON_NO_MATCH,
+  };
+}
+
+/**
+ * A human label for an asset: the registry title, else the file's basename, else
+ * the id. Never blank — a nameless tile is not actionable.
+ */
+export function assetLabel(asset: BrollAsset): string {
+  const title = str(asset.title).trim();
+  if (title.length > 0) return title;
+  const parts = asset.path.split(/[\\/]/);
+  const base = parts[parts.length - 1];
+  return base.length > 0 ? base : asset.assetId;
+}
+
+/**
+ * The duration cell. FACT: `durationSec` is `number | null` — a SCANNED row always
+ * reports `null` and a registered still (or a failed ffprobe) reports `0.0`, so
+ * neither may be printed as a duration. A still is labelled as such; anything
+ * without a positive finite length is explicitly UNKNOWN.
+ */
+export function assetDurationLabel(asset: BrollAsset): string {
+  if (asset.kind === 'image') return 'still';
+  const value = asset.durationSec;
+  if (typeof value !== 'number') return '—';
+  if (!Number.isFinite(value)) return '—';
+  return value > 0 ? `${value.toFixed(1)}s` : '—';
+}
+
+/**
+ * The poster source, or `null` when there is none. FACT: `add_broll` writes `""`
+ * and no b-roll poster extractor exists, so `null` is the NORMAL answer and the
+ * grid must render a placeholder rather than an <img> with an empty `src`.
+ */
+export function posterSrc(asset: BrollAsset): string | null {
+  const path = str(asset.thumbnailPath);
+  return path.length > 0 ? path : null;
+}
+
+/** The timeline window a suggestion would occupy, in the source's own seconds. */
+export function insertionWindowLabel(insertion: BrollInsertion): string {
+  return `${insertion.start.toFixed(1)}s - ${insertion.end.toFixed(1)}s (${insertion.duration.toFixed(1)}s)`;
+}
+
+// --- component -------------------------------------------------------------
+
+export interface BrollPanelProps {
+  videoId: string;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+
+export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+
+  // library state (global to the app, not to this video)
+  const [assets, setAssets] = useState<BrollAsset[]>([]);
+  const [missing, setMissing] = useState<BrollAsset[]>([]);
+  const [status, setStatus] = useState<BrollStatus | null>(null);
+  const [addPath, setAddPath] = useState<string>('');
+  const [addTitle, setAddTitle] = useState<string>('');
+  const [force, setForce] = useState<boolean>(false);
+  // matching controls
+  const [threshold, setThreshold] = useState<number>(DEFAULT_BROLL_THRESHOLD);
+  const [coverage, setCoverage] = useState<number>(DEFAULT_BROLL_MAX_COVERAGE_PCT);
+  const [layout, setLayout] = useState<string>(BROLL_LAYOUTS[0]);
+  // the reviewed plan — PER VIDEO (see the reset effect below)
+  const [insertions, setInsertions] = useState<BrollInsertion[]>([]);
+  const [accepted, setAccepted] = useState<boolean[]>([]);
+  const [reason, setReason] = useState<string>('');
+  const [planned, setPlanned] = useState<boolean>(false);
+  const [appliedPath, setAppliedPath] = useState<string>('');
+  // job lane
+  const [busy, setBusy] = useState<string>('');
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [pct, setPct] = useState<number>(0);
+  const [message, setMessage] = useState<string>('');
+  const [error, setError] = useState<string>('');
+
+  const loadLibrary = useCallback(async (): Promise<void> => {
+    const [assetsRes, statusRes] = await Promise.all([
+      bridge.rpc<unknown>('broll.assets'),
+      bridge.rpc<unknown>('broll.status'),
+    ]);
+    const parsed = readBrollAssets(assetsRes);
+    setAssets(parsed.assets);
+    setMissing(parsed.missing);
+    setStatus(readBrollStatus(statusRes));
+  }, [bridge]);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        await loadLibrary();
+      } catch (err) {
+        // A corrupt `library.json` really does fail this read (the registry half
+        // runs `Library._open` -> `_migrate`). Showing the error beats showing an
+        // empty grid, which would look like "you have no b-roll".
+        setError(errText(err));
+      }
+    })();
+  }, [loadLibrary]);
+
+  // ─── A PLAN BELONGS TO EXACTLY ONE VIDEO ───────────────────────────────────
+  // `broll.apply` sends the CURRENT `videoId` together with whatever insertions
+  // are on screen and composites them verbatim, so a plan left over from the
+  // previous video would burn video A's windows and assets into video B. This
+  // panel is mounted UNKEYED (`views/Workspace.tsx` renderPanel), and App.tsx's
+  // launch-restore effect swaps the open video IN PLACE without an unmount, so the
+  // stale-plan state is reachable rather than hypothetical.
+  //
+  // useLAYOUTEffect, not useEffect: a passive effect runs after the browser can
+  // paint, so React could commit — and show — the new video with the old plan and
+  // an enabled Apply button for one frame. Clearing before paint closes it
+  // outright. The LIBRARY state is deliberately NOT reset: the b-roll library and
+  // its index are per MACHINE, not per video, and re-reading them on every video
+  // switch would cost a scan plus a SQLite read for no new information.
+  const videoIdRef = useRef<string>(videoId);
+  useLayoutEffect(() => {
+    videoIdRef.current = videoId;
+    setInsertions([]);
+    setAccepted([]);
+    setReason('');
+    setPlanned(false);
+    setAppliedPath('');
+    setError('');
+  }, [videoId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const off = bridge.onProgress((ev) => {
+      if (ev.jobId !== jobId) return;
+      setPct(ev.pct);
+      setMessage(ev.message);
+    });
+    return off;
+  }, [bridge, jobId]);
+
+  /** Start a deferred job and resolve its terminal `job.done` payload. */
+  const runJob = useCallback(
+    async (method: string, params: Record<string, unknown>): Promise<unknown> => {
+      const res = await bridge.rpc<unknown>(method, params);
+      const id = extractJobId(res);
+      setJobId(id ?? null);
+      // waitForJobDone REJECTS on an `{error}` job.done payload, so a failed job is
+      // never laundered into a silent success.
+      return id ? await waitForJobDone<unknown>(bridge, id, (r) => r ?? null) : null;
+    },
+    [bridge],
+  );
+
+  /**
+   * Run a VIDEO-SCOPED deferred job and apply its outcome only if the panel is
+   * still showing the video that asked for it.
+   *
+   * ONE gate for BOTH the success and the failure write, on purpose: video A's
+   * plan must not appear under video B, and neither must video A's error message.
+   * The write is deferred into `settle` so a single `if` covers both paths — an
+   * id COMPARISON rather than a latch, so switching away and back re-admits it.
+   */
+  const runVideoJob = useCallback(
+    async (
+      method: string,
+      params: Record<string, unknown>,
+      onResult: (result: unknown) => void,
+    ): Promise<void> => {
+      const startedFor = videoId;
+      let settle: () => void;
+      try {
+        const result = await runJob(method, { videoId, ...params });
+        settle = () => onResult(result);
+      } catch (err) {
+        const text = errText(err);
+        settle = () => setError(text);
+      }
+      if (videoIdRef.current === startedFor) settle();
+    },
+    [runJob, videoId],
+  );
+
+  /** Shared prologue/epilogue so every action has one busy + progress contract. */
+  const act = useCallback(async (label: string, body: () => Promise<void>): Promise<void> => {
+    setBusy(label);
+    setError('');
+    setPct(0);
+    setMessage('Starting…');
+    try {
+      await body();
+    } catch (err) {
+      setError(errText(err));
+    } finally {
+      setBusy('');
+      setJobId(null);
+    }
+  }, []);
+
+  const refresh = useCallback(
+    (label: string, mutate: () => Promise<unknown>): Promise<void> =>
+      act(label, async () => {
+        await mutate();
+        await loadLibrary();
+      }),
+    [act, loadLibrary],
+  );
+
+  const addAsset = useCallback(
+    (): Promise<void> =>
+      refresh('add', () => {
+        const title = addTitle.trim();
+        return bridge.rpc('broll.addAsset', {
+          path: addPath.trim(),
+          // A blank field means "no title", which is the ABSENT param — not an
+          // empty-string title. `add_broll` falls back to the file stem itself.
+          ...(title.length > 0 ? { title } : {}),
+        });
+      }).then(() => {
+        setAddPath('');
+        setAddTitle('');
+      }),
+    [addPath, addTitle, bridge, refresh],
+  );
+
+  const removeAsset = useCallback(
+    (id: string): Promise<void> => refresh('remove', () => bridge.rpc('broll.removeAsset', { id })),
+    [bridge, refresh],
+  );
+
+  const runIndex = useCallback(
+    (): Promise<void> => refresh('index', () => runJob('broll.index', { force })),
+    [force, refresh, runJob],
+  );
+
+  const suggest = useCallback(
+    (): Promise<void> =>
+      act('suggest', () =>
+        runVideoJob(
+          'broll.suggest',
+          // Sent EXPLICITLY, always: an omitted threshold would make the sidecar's
+          // uncalibrated 0.22 the silent authority and the slider a decoration.
+          { threshold, maxCoveragePct: coverage, layout },
+          (result) => {
+            const plan = readBrollPlan(result);
+            setInsertions(plan.insertions);
+            setAccepted(plan.insertions.map(() => true));
+            setReason(plan.reason);
+            setPlanned(true);
+            setAppliedPath('');
+          },
+        ),
+      ),
+    [act, coverage, layout, runVideoJob, threshold],
+  );
+
+  const approved = insertions.filter((_row, index) => accepted[index]);
+
+  const apply = useCallback(
+    (): Promise<void> =>
+      act('apply', () =>
+        runVideoJob('broll.apply', { insertions: approved }, (result) => {
+          setAppliedPath(str(pickField<string>(result, 'path')));
+        }),
+      ),
+    [act, approved, runVideoJob],
+  );
+
+  const cancel = useCallback(async (): Promise<void> => {
+    // Defensive: Cancel renders only while `busy && jobId`.
+    /* v8 ignore next */
+    if (!jobId) return;
+    try {
+      await bridge.rpc('job.cancel', { jobId });
+    } catch {
+      // Best-effort — a failed cancel must not become a panel error.
+    }
+    setMessage('Cancelling…');
+  }, [bridge, jobId]);
+
+  const toggleAccept = useCallback((index: number): void => {
+    setAccepted((prev) => prev.map((on, at) => (at === index ? !on : on)));
+  }, []);
+
+  const working = busy !== '';
+
+  return (
+    <section className="feature-panel broll-panel" aria-label="Auto B-roll">
+      <h2>Auto B-roll</h2>
+      <p className="assets-intro">
+        Match what you are SAYING to clips and stills you already own, then cut them in. Nothing is
+        inserted unless a segment clears the match threshold, and nothing is rendered until you
+        review the list — a confidently wrong cutaway is worse than no cutaway.
+      </p>
+
+      {status?.willEgress === true ? (
+        <p className="broll-egress" data-section="egress-warning" role="alert">
+          {BROLL_EGRESS_WARNING}
+        </p>
+      ) : (
+        <p className="broll-local" data-section="local-only" role="status">
+          {BROLL_LOCAL_ONLY}
+        </p>
+      )}
+
+      <p className="broll-limits" data-section="limits">
+        {BROLL_KNOWN_LIMITS}
+      </p>
+
+      <h3>Library</h3>
+      {status && (
+        <dl className="broll-status" data-section="status">
+          <div>
+            <dt>In library</dt>
+            <dd data-field="libraryCount">{status.libraryCount}</dd>
+          </div>
+          <div>
+            <dt>Indexed</dt>
+            <dd data-field="indexed">{status.indexed ? status.assetCount : 'not yet'}</dd>
+          </div>
+          <div>
+            <dt>Needs embedding</dt>
+            <dd data-field="stale">{status.stale ? status.staleCount : 'none'}</dd>
+          </div>
+          <div>
+            <dt>Matcher</dt>
+            <dd data-field="model">
+              <code>{status.model || 'none'}</code>
+              {status.dim > 0 ? ` · ${status.dim}d` : ''}
+            </dd>
+          </div>
+        </dl>
+      )}
+
+      <div className="field broll-add">
+        <label>
+          Add a b-roll file{' '}
+          <input
+            data-input="add-path"
+            type="text"
+            placeholder="D:/pictures/hero dog.png"
+            value={addPath}
+            onChange={(e) => setAddPath(e.target.value)}
+            disabled={working}
+          />
+        </label>
+        <label>
+          Name it (optional){' '}
+          <input
+            data-input="add-title"
+            type="text"
+            placeholder="Hero dog"
+            value={addTitle}
+            onChange={(e) => setAddTitle(e.target.value)}
+            disabled={working}
+          />
+        </label>
+        <button
+          type="button"
+          data-action="add"
+          onClick={() => void addAsset()}
+          disabled={working || addPath.trim().length === 0}
+        >
+          Register
+        </button>
+        <span className="broll-add-hint">
+          The file is referenced where it lives — nothing is copied or moved, and unregistering
+          never deletes it. A folder set as your bulk b-roll directory is scanned as well; both
+          sources are merged into the one list below.
+        </span>
+      </div>
+
+      {assets.length > 0 && (
+        <ul className="broll-grid" data-section="grid">
+          {assets.map((asset) => {
+            const poster = posterSrc(asset);
+            return (
+              <li key={asset.assetId} data-asset-id={asset.assetId} className="broll-tile">
+                {poster ? (
+                  <img className="broll-poster" src={poster} alt="" />
+                ) : (
+                  <span className="broll-poster broll-poster--none" data-poster="none">
+                    {NO_POSTER_LABEL}
+                  </span>
+                )}
+                <span className="broll-tile-name">{assetLabel(asset)}</span>
+                <span className="broll-tile-meta">
+                  <span data-field="kind">{asset.kind}</span>
+                  {' · '}
+                  <span data-field="duration">{assetDurationLabel(asset)}</span>
+                  {' · '}
+                  <span data-field="origin">{asset.registered ? 'registered' : 'folder scan'}</span>
+                </span>
+                <code className="broll-tile-path">{asset.path}</code>
+                {asset.registered && (
+                  <button
+                    type="button"
+                    className="secondary"
+                    data-action="unregister"
+                    onClick={() => void removeAsset(asset.assetId)}
+                    disabled={working}
+                  >
+                    Unregister
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      {/* A registered asset whose file has vanished is REPORTED, never silently
+          dropped: it is excluded from indexing (a dead path would fail the whole
+          batch), so without this section it would simply disappear. */}
+      {missing.length > 0 && (
+        <div className="broll-missing" data-section="missing" role="status">
+          <h3>Missing files</h3>
+          <p>
+            These are still registered, but the file is no longer where it was. They are left out of
+            matching until you put the file back or unregister them.
+          </p>
+          <ul>
+            {missing.map((asset) => (
+              <li key={asset.assetId} data-missing-id={asset.assetId}>
+                <span className="broll-missing-name">{assetLabel(asset)}</span>
+                <code>{asset.path}</code>
+                <button
+                  type="button"
+                  className="secondary"
+                  data-action="unregister-missing"
+                  onClick={() => void removeAsset(asset.assetId)}
+                  disabled={working}
+                >
+                  Unregister
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <div className="actions broll-index-actions">
+        <button
+          type="button"
+          data-action="index"
+          onClick={() => void runIndex()}
+          disabled={working}
+        >
+          {busy === 'index' ? 'Indexing…' : 'Index library'}
+        </button>
+        <label className="broll-force">
+          <input
+            data-input="force"
+            type="checkbox"
+            checked={force}
+            onChange={(e) => setForce(e.target.checked)}
+            disabled={working}
+          />{' '}
+          Re-embed everything (needed after a matcher change)
+        </label>
+      </div>
+
+      <h3>Matching</h3>
+      <p className="broll-threshold-copy" data-section="threshold-disclosure">
+        {THRESHOLD_IS_UNCALIBRATED}
+      </p>
+      <div className="field broll-match">
+        <label>
+          Match threshold{' '}
+          <input
+            data-input="threshold"
+            type="range"
+            min={0.05}
+            max={0.9}
+            step={0.01}
+            value={threshold}
+            onChange={(e) => setThreshold(Number(e.target.value))}
+            disabled={working}
+          />{' '}
+          <span className="broll-threshold-value">{threshold.toFixed(2)}</span>
+        </label>
+        <label>
+          Most of the video b-roll may cover (%){' '}
+          <input
+            data-input="coverage"
+            type="number"
+            min={1}
+            max={100}
+            value={coverage}
+            onChange={(e) => setCoverage(Number(e.target.value))}
+            disabled={working}
+          />
+        </label>
+        <label>
+          Style{' '}
+          <select
+            data-input="layout"
+            value={layout}
+            onChange={(e) => setLayout(e.target.value)}
+            disabled={working}
+          >
+            {BROLL_LAYOUTS.map((option) => (
+              <option key={option} value={option}>
+                {option === 'cutaway' ? 'Full-frame cutaway' : 'Inset (picture in picture)'}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      <div className="actions">
+        <button
+          type="button"
+          data-action="suggest"
+          onClick={() => void suggest()}
+          disabled={working}
+        >
+          {busy === 'suggest' ? 'Matching…' : 'Suggest b-roll'}
+        </button>
+        {working && jobId && (
+          <button
+            type="button"
+            data-action="cancel"
+            className="secondary"
+            onClick={() => void cancel()}
+          >
+            Cancel
+          </button>
+        )}
+      </div>
+
+      {working && (
+        <div className="progress" aria-live="polite">
+          <progress max={100} value={pct} />
+          <span className="progress-pct">{Math.round(pct)}%</span>
+          {message && <span className="progress-message"> · {message}</span>}
+        </div>
+      )}
+
+      {error && (
+        <p className="error" role="alert">
+          {error}
+        </p>
+      )}
+
+      {/* "Nothing cleared the threshold" is a RESULT, not a failure. Saying so
+          plainly — with the dial to change it right above — is the honest answer;
+          inserting something anyway is the competitor behaviour being avoided. */}
+      {planned && insertions.length === 0 && (
+        <p className="broll-no-match" data-section="no-match" role="status">
+          No confident match: nothing in your library scored at or above {threshold.toFixed(2)} for
+          any segment, so nothing is offered. Lower the threshold, or add assets that match what you
+          talk about, and try again. Reason from the engine: {reason}
+        </p>
+      )}
+
+      {insertions.length > 0 && (
+        <div className="broll-review" data-section="review">
+          <h3>
+            Review ({approved.length} of {insertions.length} selected)
+          </h3>
+          <ul>
+            {insertions.map((insertion, index) => (
+              <li
+                key={`${insertion.segmentIndex}-${insertion.start}-${insertion.assetId}`}
+                data-insertion={index}
+                className="broll-review-row"
+              >
+                <label>
+                  <input
+                    data-input="accept"
+                    type="checkbox"
+                    checked={accepted[index] === true}
+                    onChange={() => toggleAccept(index)}
+                    disabled={working}
+                  />{' '}
+                  <span data-field="window">{insertionWindowLabel(insertion)}</span>
+                </label>
+                <span className="broll-review-score" data-field="score">
+                  {insertion.score.toFixed(2)}
+                </span>
+                <span className="broll-review-reason" data-field="reason">
+                  {insertion.reason}
+                </span>
+                <code data-field="path">{insertion.path}</code>
+              </li>
+            ))}
+          </ul>
+
+          <p className="broll-one-way" data-section="one-way" role="status">
+            {APPLY_IS_ONE_WAY}
+          </p>
+          <div className="actions">
+            <button
+              type="button"
+              data-action="apply"
+              onClick={() => void apply()}
+              disabled={working || approved.length === 0}
+            >
+              {busy === 'apply' ? 'Rendering…' : `Apply ${approved.length} cutaway(s)`}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {appliedPath && (
+        <div className="output-done" data-section="result">
+          <span className="output-done-label">B-roll rendered</span>
+          <code>{appliedPath}</code>
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default BrollPanel;

--- a/app/renderer/src/features/BrollPanel.tsx
+++ b/app/renderer/src/features/BrollPanel.tsx
@@ -440,7 +440,20 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
   const [insertions, setInsertions] = useState<BrollInsertion[]>([]);
   const [accepted, setAccepted] = useState<boolean[]>([]);
   const [reason, setReason] = useState<string>('');
-  const [planned, setPlanned] = useState<boolean>(false);
+  /**
+   * The dials the RETURNED plan was actually computed with — `null` until one
+   * comes back, which is also the "a plan has been run" flag (it replaced a plain
+   * `planned` boolean, so the two can never disagree).
+   *
+   * SNAPSHOT, NOT LIVE STATE, and that distinction is the whole point of the
+   * empty-plan copy: reading `threshold`/`coverage` straight out of the controls
+   * would make the explanation quote whatever the user has since dragged the
+   * slider to, which is a different number from the one that ran — the same class
+   * of "state something you did not measure" defect the copy exists to avoid.
+   */
+  const [plannedWith, setPlannedWith] = useState<{ threshold: number; coverage: number } | null>(
+    null,
+  );
   const [appliedPath, setAppliedPath] = useState<string>('');
   // job lane
   const [busy, setBusy] = useState<string>('');
@@ -493,7 +506,7 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
     setInsertions([]);
     setAccepted([]);
     setReason('');
-    setPlanned(false);
+    setPlannedWith(null);
     setAppliedPath('');
     setError('');
   }, [videoId]);
@@ -628,7 +641,9 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
             setInsertions(plan.insertions);
             setAccepted(plan.insertions.map(() => true));
             setReason(plan.reason);
-            setPlanned(true);
+            // The values SENT above, captured for the explanation — not re-read
+            // from the controls at render time.
+            setPlannedWith({ threshold, coverage });
             setAppliedPath('');
           },
         ),
@@ -937,9 +952,10 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
           something anyway is the competitor behaviour being avoided. What it is
           NOT is a measurement: see `emptyPlanExplanation` for the executed proof
           that the engine's single reason string covers five different causes. */}
-      {planned && insertions.length === 0 && (
+      {plannedWith !== null && insertions.length === 0 && (
         <p className="broll-no-match" data-section="no-match" role="status">
-          {emptyPlanExplanation(threshold, coverage)} Reason from the engine: {reason}
+          {emptyPlanExplanation(plannedWith.threshold, plannedWith.coverage)} Reason from the
+          engine: {reason}
         </p>
       )}
 

--- a/app/renderer/src/features/BrollPanel.tsx
+++ b/app/renderer/src/features/BrollPanel.tsx
@@ -49,8 +49,27 @@
 //   * B-roll POSTER extraction does not exist. `thumbnailPath` is
 //     unconditionally `""`; the only writer, `Library.set_thumbnail`, is
 //     `role='source'`-scoped, and `set_thumbnail(<brollAssetId>, …)` was measured
-//     to return `None` and change nothing. So the grid is designed for the ABSENT
-//     case and renders a labelled placeholder, never an <img> that would 404.
+//     to return `None` and change nothing. So the ABSENT case is the normal one,
+//     and the grid renders a labelled placeholder for it.
+//     REFUTED — an earlier draft of this line claimed the grid renders "never an
+//     <img> that would 404". BOTH halves were wrong. There IS a present-case
+//     <img> branch (whenever `posterSrc` is non-null), and it would not 404: it
+//     would never resolve at all, because the renderer CSP is
+//     `img-src 'self' data: blob: mstream:` (`app/main/security.ts:81`, mirrored
+//     in `app/renderer/index.html:17`) and a raw filesystem path is not a loadable
+//     source under it. The branch is latent today only because `add_broll` writes
+//     `""` — so the bug would have shipped, green, on the day a poster writer
+//     landed. It is now correct in advance: `posterSrc` returns the `thumb:`
+//     mstream URL through `components/Player.thumbMediaUrl` (the same
+//     traversal-guarded resolver `components/useVideoThumbnail.ts:33` uses for
+//     source posters), and the <img> carries an `onError` fallback to the
+//     placeholder, the `views/LibraryCard.tsx` pattern.
+//     STILL UNVERIFIED, inline where it belongs: nothing here proves a b-roll
+//     poster will LOAD, because no writer exists to produce one. `main.ts:1465`
+//     resolves a `thumb:` id ONLY inside `DATA_ROOT/thumbnails`, so a future
+//     writer that puts b-roll posters anywhere else stays unrenderable. The
+//     settling experiment is the poster writer itself: register an asset, have it
+//     emit `<DATA_ROOT>/thumbnails/<assetId>.jpg`, and assert the tile paints.
 //   * BR6 REVERSIBILITY is design-only. `broll.apply` renders a flat
 //     `{stem}.broll.mp4` (`broll_ops.py:450`) — there is no inverse op and no
 //     overlay track, so a user who dislikes the result has no undo beyond
@@ -59,6 +78,8 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useSta
 import './panels.css';
 import './broll.css';
 import { extractJobId, getApi, pickField, waitForJobDone, type MediaStudioApi } from './_api';
+import { thumbMediaUrl } from '../components/Player';
+import { BROLL_METHODS } from '../lib/rpc';
 import type { BrollAsset, BrollAssetsResult, BrollInsertion, BrollStatus } from '../lib/rpc';
 
 /**
@@ -70,6 +91,21 @@ export const DEFAULT_BROLL_THRESHOLD = 0.22;
 
 /** Mirror of `broll_plan.DEFAULT_MAX_COVERAGE_PCT` (also conformance-pinned). */
 export const DEFAULT_BROLL_MAX_COVERAGE_PCT = 40;
+
+/**
+ * Mirror of `broll_plan.DEFAULT_MIN_DURATION_SEC` — a candidate window shorter
+ * than this is DROPPED by `place` (`broll_plan.py:339`), not stretched. Named in
+ * the empty-plan copy because it is one of the causes of an empty plan that has
+ * nothing to do with the match threshold. Conformance-pinned.
+ */
+export const DEFAULT_BROLL_MIN_DURATION_SEC = 1.5;
+
+/**
+ * Mirror of `broll_plan.DEFAULT_COOLDOWN_SEC` — the same asset may not reappear
+ * within this many seconds (`broll_plan.py:299`). Also an empty-plan cause.
+ * Conformance-pinned.
+ */
+export const DEFAULT_BROLL_COOLDOWN_SEC = 30;
 
 /** Mirror of `broll_plan.LAYOUTS`; `[0]` is `DEFAULT_LAYOUT`. */
 export const BROLL_LAYOUTS = ['cutaway', 'pip'] as const;
@@ -87,15 +123,44 @@ export const NO_POSTER_LABEL = 'No preview';
  * The threshold disclosure. Names the number, that it is UNCALIBRATED, that it is
  * per-backbone, and the experiment that would settle it — so the slider reads as
  * adjustable rather than authoritative.
+ *
+ * THE NUMBER IS INTERPOLATED, NOT TYPED. REFUTED first draft: it carried the
+ * literal `'0.22'` and its only test was `toContain('0.22')` — a second literal,
+ * which stale copy satisfies. The seed pin in `brollClient.conformance.test.ts`
+ * would then have caught the §11.2 calibration, a dev would have bumped
+ * {@link DEFAULT_BROLL_THRESHOLD} alone, and the panel would have shipped seeding
+ * (say) 0.31 while telling the user in plain English that the starting value is
+ * 0.22 AND that it has never been measured — a tuned value presented as untuned,
+ * with the wrong number. Interpolating closes it, and the conformance test now
+ * asserts this COPY contains the sidecar's own value.
  */
 export const THRESHOLD_IS_UNCALIBRATED =
   'Match threshold: a suggestion is only offered when the cosine similarity between ' +
-  'the spoken segment and the asset reaches this value. The starting value of 0.22 is ' +
+  `the spoken segment and the asset reaches this value. The starting value of ${String(DEFAULT_BROLL_THRESHOLD)} is ` +
   'an UNCALIBRATED placeholder, not a tuned number — no labelled probe set has been ' +
   'measured yet, and the right value is specific to the matching backbone, so a ' +
   'different backbone needs its own. Treat it as a dial, not an answer: raise it if ' +
   'you are offered junk, lower it if you are offered nothing. The calibration that ' +
   'would replace it is described in docs/plans/v1.5/flagship-auto-broll.md section 11.2.';
+
+/**
+ * The two PREREQUISITES, stated up front rather than discovered by clicking.
+ *
+ * `broll_ops.suggest`'s job body enforces them in this order: `require_model`
+ * against the index (`broll_ops.py:403`), then
+ * `raise _invalid(f"{video_id} has no transcript yet; run transcribe.start
+ * first")` (`:408`). So a user on a freshly imported video reaches an ERROR, not
+ * a suggestion, and discovers the two serially. The repo's own convention is to
+ * say so first — `Diarize.tsx:138` ("Needs a transcript first"),
+ * `caption/CaptionInspector.tsx:47`, `TranscriptEditor.tsx:221` all do. This
+ * panel previously mentioned a transcript exactly once, inside
+ * {@link BROLL_LOCAL_ONLY}, which is an EGRESS statement and not a prerequisite.
+ */
+export const BROLL_NEEDS_TRANSCRIPT =
+  'Before this can match anything: index your library above (a matcher must be ' +
+  'loaded), and transcribe THIS video first — matching compares what you say ' +
+  'against your clips, so with no transcript there is nothing to compare and ' +
+  'Suggest fails with "has no transcript yet".';
 
 /**
  * The BR6 disclosure, rendered directly ABOVE the Apply control. A user must know
@@ -169,13 +234,37 @@ export function readBrollAssets(result: unknown): BrollAssetsResult {
   return { assets: pickList(rec.assets), missing: pickList(rec.missing) };
 }
 
+/** The eight fields `broll.status` returns. A payload with NONE of them is not a snapshot. */
+const BROLL_STATUS_FIELDS = [
+  'indexed',
+  'assetCount',
+  'libraryCount',
+  'model',
+  'dim',
+  'stale',
+  'staleCount',
+  'willEgress',
+] as const;
+
 /**
  * Read `broll.status`. `null` for a shapeless payload so the panel renders nothing
  * instead of a snapshot of invented zeros presented as measurements.
+ *
+ * REFUTED first draft: the guard was `typeof result !== 'object'`, which lets `{}`
+ * — the canonical shapeless payload — straight through and returns exactly the
+ * snapshot of invented zeros the sentence above says it prevents. That rendered as
+ * the user-visible "In library 0 · Indexed not yet · Needs embedding none ·
+ * Matcher none", i.e. a hard `0` the panel never measured. Not hypothetical: the
+ * lane's own real-mount reachability test answers every rpc with `{}`, so the test
+ * offered as proof of reachability was itself painting a fabricated measurement.
+ * The guard now requires at least ONE recognised field, which is what makes the
+ * docstring true. A payload that DOES carry a field still has its absent siblings
+ * coerced to explicit zeros — that half was always correct and is unchanged.
  */
 export function readBrollStatus(result: unknown): BrollStatus | null {
   if (typeof result !== 'object' || result === null) return null;
   const rec = result as Record<string, unknown>;
+  if (!BROLL_STATUS_FIELDS.some((field) => field in rec)) return null;
   return {
     indexed: rec.indexed === true,
     assetCount: num(rec.assetCount),
@@ -230,13 +319,74 @@ export function assetDurationLabel(asset: BrollAsset): string {
 }
 
 /**
- * The poster source, or `null` when there is none. FACT: `add_broll` writes `""`
- * and no b-roll poster extractor exists, so `null` is the NORMAL answer and the
- * grid must render a placeholder rather than an <img> with an empty `src`.
+ * The poster `<img src>`, or `null` when there is none. FACT: `add_broll` writes
+ * `""` and no b-roll poster extractor exists, so `null` is the NORMAL answer and
+ * the grid must render a placeholder rather than an <img> with an empty `src`.
+ *
+ * The non-null answer is the `thumb:` MSTREAM URL, never the raw filesystem path.
+ * REFUTED first draft: it returned `asset.thumbnailPath` verbatim and a test
+ * pinned that as correct (`toBe('D:/th/dog.jpg')`) — endorsing a value the
+ * renderer cannot load at all, since the CSP is
+ * `img-src 'self' data: blob: mstream:`. Every other poster surface in the app
+ * wraps (`components/useVideoThumbnail.ts:33`, `views/LibraryCard.tsx`); this one
+ * did not, so the first poster writer to land would have turned every tile into a
+ * permanently broken image with a green suite.
  */
 export function posterSrc(asset: BrollAsset): string | null {
   const path = str(asset.thumbnailPath);
-  return path.length > 0 ? path : null;
+  return path.length > 0 ? thumbMediaUrl(path) : null;
+}
+
+/**
+ * Whether the typed coverage cap is a value the planner can act on.
+ *
+ * `<input type="number" min={1} max={100}>` constrains VALIDITY, not the value
+ * React reads: an emptied field reports `''` (the DOM also sanitises non-numeric
+ * text to `''`), so `Number('')` lands `0` in state and would be sent verbatim as
+ * `maxCoveragePct: 0`. The sidecar's `_opt_float` passes `0` through — `float(0)`
+ * is valid, so the default never kicks in — and `place` then computes
+ * `budget_sec = total_sec * 0 / 100 = 0`, which makes
+ * `used_sec + duration > budget_sec` reject EVERY candidate unconditionally
+ * (`broll_plan.py:333,362`). The feature would be silently and permanently dead
+ * until the user retyped a number, while the panel blamed the match threshold.
+ * So the panel REFUSES to send it — the same shape as the Register button, which
+ * stays shut until a non-blank path exists — rather than silently clamping a
+ * number the user did not choose.
+ */
+export function isCoverageUsable(pct: number): boolean {
+  return Number.isFinite(pct) && pct >= 1 && pct <= 100;
+}
+
+/**
+ * What an empty plan actually tells you — and, just as importantly, what it does
+ * NOT.
+ *
+ * REFUTED first draft: "No confident match: nothing in your library scored at or
+ * above {threshold} for any segment, so nothing is offered. Lower the threshold…".
+ * That is a specific measurement the panel cannot make. `broll_ops.py:425` emits
+ * `NO_CONFIDENT_MATCH` whenever `insertions` is empty for ANY reason, and
+ * `plan()` runs `suggest` (the threshold gate) THEN `diversify` THEN `place`,
+ * and `place` drops candidates for four reasons unrelated to score:
+ * `duration < min_duration_sec` (`:339`), `used_sec + duration > budget_sec`
+ * (`:333,362`), `min_gap_sec`, and the per-asset `cooldown_sec` (`:299`).
+ * Executed against the real planner with IDENTICAL unit vectors (cosine 1.00,
+ * 4.5x the gate): default coverage -> 1 insertion; `maxCoveragePct=1` -> 0; a
+ * 1.0 s segment -> 0. In both zero cases the old copy told the user, as fact,
+ * that nothing scored >= the threshold and pointed them at the one control that
+ * provably could not help — and for the coverage case the fix is to RAISE the
+ * cap, which it never mentioned.
+ */
+export function emptyPlanExplanation(threshold: number, coveragePct: number): string {
+  return (
+    'Nothing was offered for this video. The engine returns the SAME reason string for every ' +
+    'empty plan, so it does not say which rule stopped it and this panel will not guess. Any of ' +
+    `these produces one: no segment's best asset reached the match threshold ` +
+    `(${threshold.toFixed(2)}); or a match was found and then dropped because its window came ` +
+    `out shorter than ${DEFAULT_BROLL_MIN_DURATION_SEC}s, because it reused an asset within ` +
+    `${DEFAULT_BROLL_COOLDOWN_SEC}s, because it sat too close to another insert, or because it ` +
+    `did not fit your coverage cap of ${coveragePct}% of the video. Worth trying: lower the ` +
+    'threshold, RAISE the coverage cap, or add assets that match what you talk about.'
+  );
 }
 
 /** The timeline window a suggestion would occupy, in the source's own seconds. */
@@ -245,6 +395,26 @@ export function insertionWindowLabel(insertion: BrollInsertion): string {
 }
 
 // --- component -------------------------------------------------------------
+
+/**
+ * One grid tile's poster: the `thumb:` <img> when the asset has one, the labelled
+ * placeholder otherwise — and the placeholder again if the <img> fails to load.
+ * The `onError` swap is the `views/LibraryCard.tsx` pattern; without it a poster
+ * path that does not resolve (see the header's UNVERIFIED note on the thumbnails
+ * root) leaves a permanently broken image icon with no readable fallback.
+ */
+function BrollPoster({ asset }: { asset: BrollAsset }): React.ReactElement {
+  const poster = posterSrc(asset);
+  const [failed, setFailed] = useState<boolean>(false);
+  if (poster === null || failed) {
+    return (
+      <span className="broll-poster broll-poster--none" data-poster="none">
+        {NO_POSTER_LABEL}
+      </span>
+    );
+  }
+  return <img className="broll-poster" src={poster} alt="" onError={() => setFailed(true)} />;
+}
 
 export interface BrollPanelProps {
   videoId: string;
@@ -281,8 +451,8 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
 
   const loadLibrary = useCallback(async (): Promise<void> => {
     const [assetsRes, statusRes] = await Promise.all([
-      bridge.rpc<unknown>('broll.assets'),
-      bridge.rpc<unknown>('broll.status'),
+      bridge.rpc<unknown>(BROLL_METHODS.assets),
+      bridge.rpc<unknown>(BROLL_METHODS.status),
     ]);
     const parsed = readBrollAssets(assetsRes);
     setAssets(parsed.assets);
@@ -415,7 +585,7 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
     (): Promise<void> =>
       withBusy('add', async () => {
         const title = addTitle.trim();
-        await bridge.rpc('broll.addAsset', {
+        await bridge.rpc(BROLL_METHODS.addAsset, {
           path: addPath.trim(),
           // A blank field means "no title", which is the ABSENT param — not an
           // empty-string title. `add_broll` falls back to the file stem itself.
@@ -435,12 +605,13 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
   );
 
   const removeAsset = useCallback(
-    (id: string): Promise<void> => refresh('remove', () => bridge.rpc('broll.removeAsset', { id })),
+    (id: string): Promise<void> =>
+      refresh('remove', () => bridge.rpc(BROLL_METHODS.removeAsset, { id })),
     [bridge, refresh],
   );
 
   const runIndex = useCallback(
-    (): Promise<void> => refresh('index', () => runJob('broll.index', { force })),
+    (): Promise<void> => refresh('index', () => runJob(BROLL_METHODS.index, { force })),
     [force, refresh, runJob],
   );
 
@@ -448,7 +619,7 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
     (): Promise<void> =>
       withBusy('suggest', () =>
         runVideoJob(
-          'broll.suggest',
+          BROLL_METHODS.suggest,
           // Sent EXPLICITLY, always: an omitted threshold would make the sidecar's
           // uncalibrated 0.22 the silent authority and the slider a decoration.
           { threshold, maxCoveragePct: coverage, layout },
@@ -470,7 +641,7 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
   const apply = useCallback(
     (): Promise<void> =>
       withBusy('apply', () =>
-        runVideoJob('broll.apply', { insertions: approved }, (result) => {
+        runVideoJob(BROLL_METHODS.apply, { insertions: approved }, (result) => {
           setAppliedPath(str(pickField<string>(result, 'path')));
         }),
       ),
@@ -584,16 +755,9 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
       {assets.length > 0 && (
         <ul className="broll-grid" data-section="grid">
           {assets.map((asset) => {
-            const poster = posterSrc(asset);
             return (
               <li key={asset.assetId} data-asset-id={asset.assetId} className="broll-tile">
-                {poster ? (
-                  <img className="broll-poster" src={poster} alt="" />
-                ) : (
-                  <span className="broll-poster broll-poster--none" data-poster="none">
-                    {NO_POSTER_LABEL}
-                  </span>
-                )}
+                <BrollPoster asset={asset} />
                 <span className="broll-tile-name">{assetLabel(asset)}</span>
                 <span className="broll-tile-meta">
                   <span data-field="kind">{asset.kind}</span>
@@ -672,6 +836,13 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
       </div>
 
       <h3>Matching</h3>
+      {/* The two prerequisites, BEFORE the button that hits them (the repo
+          convention: Diarize.tsx:138, caption/CaptionInspector.tsx:47,
+          TranscriptEditor.tsx:221). The sidecar enforces them serially, so a user
+          told nothing discovers them one failed click at a time. */}
+      <p className="broll-prereq" data-section="prerequisites" role="status">
+        {BROLL_NEEDS_TRANSCRIPT}
+      </p>
       <p className="broll-threshold-copy" data-section="threshold-disclosure">
         {THRESHOLD_IS_UNCALIBRATED}
       </p>
@@ -702,6 +873,13 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
             disabled={working}
           />
         </label>
+        {!isCoverageUsable(coverage) && (
+          <span className="broll-coverage-invalid" data-section="coverage-invalid" role="alert">
+            Coverage must be between 1 and 100. An empty or zero cap leaves the planner no room at
+            all, so every match would be dropped and the result would look like "nothing matched" —
+            Suggest stays shut until this is a usable number.
+          </span>
+        )}
         <label>
           Style{' '}
           <select
@@ -724,7 +902,7 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
           type="button"
           data-action="suggest"
           onClick={() => void suggest()}
-          disabled={working}
+          disabled={working || !isCoverageUsable(coverage)}
         >
           {busy === 'suggest' ? 'Matching…' : 'Suggest b-roll'}
         </button>
@@ -754,14 +932,14 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
         </p>
       )}
 
-      {/* "Nothing cleared the threshold" is a RESULT, not a failure. Saying so
-          plainly — with the dial to change it right above — is the honest answer;
-          inserting something anyway is the competitor behaviour being avoided. */}
+      {/* An empty plan is a RESULT, not a failure — saying so plainly, with the
+          dials to change it right above, is the honest answer, and inserting
+          something anyway is the competitor behaviour being avoided. What it is
+          NOT is a measurement: see `emptyPlanExplanation` for the executed proof
+          that the engine's single reason string covers five different causes. */}
       {planned && insertions.length === 0 && (
         <p className="broll-no-match" data-section="no-match" role="status">
-          No confident match: nothing in your library scored at or above {threshold.toFixed(2)} for
-          any segment, so nothing is offered. Lower the threshold, or add assets that match what you
-          talk about, and try again. Reason from the engine: {reason}
+          {emptyPlanExplanation(threshold, coverage)} Reason from the engine: {reason}
         </p>
       )}
 

--- a/app/renderer/src/features/BrollPanel.tsx
+++ b/app/renderer/src/features/BrollPanel.tsx
@@ -380,8 +380,14 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
     [runJob, videoId],
   );
 
-  /** Shared prologue/epilogue so every action has one busy + progress contract. */
-  const act = useCallback(async (label: string, body: () => Promise<void>): Promise<void> => {
+  /**
+   * Shared prologue/epilogue so every action has ONE busy + progress + error
+   * contract. It SWALLOWS the rejection (surfacing it as `error` instead), which is
+   * why a caller must never chain post-success work onto the returned promise — see
+   * `addAsset`. Deliberately NOT called `act`: React's test `act()` is all over this
+   * panel's suite and a same-named callback inside the component reads as that.
+   */
+  const withBusy = useCallback(async (label: string, body: () => Promise<void>): Promise<void> => {
     setBusy(label);
     setError('');
     setPct(0);
@@ -398,28 +404,34 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
 
   const refresh = useCallback(
     (label: string, mutate: () => Promise<unknown>): Promise<void> =>
-      act(label, async () => {
+      withBusy(label, async () => {
         await mutate();
         await loadLibrary();
       }),
-    [act, loadLibrary],
+    [loadLibrary, withBusy],
   );
 
   const addAsset = useCallback(
     (): Promise<void> =>
-      refresh('add', () => {
+      withBusy('add', async () => {
         const title = addTitle.trim();
-        return bridge.rpc('broll.addAsset', {
+        await bridge.rpc('broll.addAsset', {
           path: addPath.trim(),
           // A blank field means "no title", which is the ABSENT param — not an
           // empty-string title. `add_broll` falls back to the file stem itself.
           ...(title.length > 0 ? { title } : {}),
         });
-      }).then(() => {
+        // Cleared INSIDE the body and only after the rpc resolves. `withBusy`
+        // swallows the rejection, so a `.then()` chained onto it would also run on
+        // the REFUSAL path — and the registry door refuses three real cases (missing
+        // path, a directory with a media extension, a non-b-roll extension). Wiping
+        // the field there would make the user retype a path they need to CORRECT,
+        // right next to the error telling them what was wrong with it.
         setAddPath('');
         setAddTitle('');
+        await loadLibrary();
       }),
-    [addPath, addTitle, bridge, refresh],
+    [addPath, addTitle, bridge, loadLibrary, withBusy],
   );
 
   const removeAsset = useCallback(
@@ -434,7 +446,7 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
 
   const suggest = useCallback(
     (): Promise<void> =>
-      act('suggest', () =>
+      withBusy('suggest', () =>
         runVideoJob(
           'broll.suggest',
           // Sent EXPLICITLY, always: an omitted threshold would make the sidecar's
@@ -450,19 +462,19 @@ export function BrollPanel({ videoId, api }: BrollPanelProps): React.ReactElemen
           },
         ),
       ),
-    [act, coverage, layout, runVideoJob, threshold],
+    [coverage, layout, runVideoJob, threshold, withBusy],
   );
 
   const approved = insertions.filter((_row, index) => accepted[index]);
 
   const apply = useCallback(
     (): Promise<void> =>
-      act('apply', () =>
+      withBusy('apply', () =>
         runVideoJob('broll.apply', { insertions: approved }, (result) => {
           setAppliedPath(str(pickField<string>(result, 'path')));
         }),
       ),
-    [act, approved, runVideoJob],
+    [approved, runVideoJob, withBusy],
   );
 
   const cancel = useCallback(async (): Promise<void> => {

--- a/app/renderer/src/features/BrollPanel.tsx
+++ b/app/renderer/src/features/BrollPanel.tsx
@@ -144,23 +144,49 @@ export const THRESHOLD_IS_UNCALIBRATED =
   'would replace it is described in docs/plans/v1.5/flagship-auto-broll.md section 11.2.';
 
 /**
- * The two PREREQUISITES, stated up front rather than discovered by clicking.
+ * The THREE PREREQUISITES, stated up front rather than discovered by clicking.
  *
- * `broll_ops.suggest`'s job body enforces them in this order: `require_model`
- * against the index (`broll_ops.py:403`), then
+ * `broll_ops.suggest`'s job body enforces them in THIS order: `require_model`
+ * against the index (`broll_ops.py:403`) FIRST, then
  * `raise _invalid(f"{video_id} has no transcript yet; run transcribe.start
  * first")` (`:408`). So a user on a freshly imported video reaches an ERROR, not
- * a suggestion, and discovers the two serially. The repo's own convention is to
- * say so first — `Diarize.tsx:138` ("Needs a transcript first"),
- * `caption/CaptionInspector.tsx:47`, `TranscriptEditor.tsx:221` all do. This
- * panel previously mentioned a transcript exactly once, inside
- * {@link BROLL_LOCAL_ONLY}, which is an EGRESS statement and not a prerequisite.
+ * a suggestion, and discovers them serially.
+ *
+ * REFUTED IN REVIEW, and recorded rather than quietly edited: this docstring said
+ * "the two PREREQUISITES" and the shipped copy named only two. There are three, and
+ * the omitted one is the one enforced FIRST — the matcher itself. It is
+ * `google/siglip2-so400m-patch16-384`, a registered manifest asset installed from the
+ * Assets tab (`vlm_backbone.py:482-491`, `installer="hf"`), and its declared size is
+ * `BACKBONE_SIZE_MB = 4540` — a **4.5 GB** download.
+ *
+ * The previous wording was worse than merely incomplete: "index your library above (a
+ * matcher must be loaded)" implies that clicking Index is what loads it. For a user
+ * without the weights it is not. `broll.index` reaches
+ * `broll_ops._default_backbone_factory` -> `vlm._default_backbone_factory` ->
+ * `RealBackboneBackend(settings)` with NO `models_present` guard — the graceful-degrade
+ * path lives in `vlm_backbone.analyze`, which the b-roll path never calls. So the copy
+ * pointed at a button instead of at the Assets tab that actually fixes it.
+ *
+ * The repo's own convention states BOTH halves in one breath and this panel had copied
+ * only the first: `Diarize.tsx:138` ("Needs a transcript first;") plus `:139` ("the
+ * SpeechBrain models install on demand from the Assets tab"). `Gaze.tsx:102`, the
+ * sibling panel from this same wave, carries the full form. Detector controlled: a
+ * probe for `Assets tab|install|download` returned 0 hits here while firing on both of
+ * those files, so the omission was real and not a matcher artifact.
+ *
+ * UNVERIFIED, inline: nobody has run a first index on a machine with NO cached
+ * SigLIP-2, so it is unknown whether that path raises cleanly or silently begins a
+ * 4.5 GB fetch. The disclosure does not depend on which — either way the user must be
+ * told before clicking. SETTLING EXPERIMENT: clear the siglip2-so400m cache, click
+ * "Index library", observe.
  */
 export const BROLL_NEEDS_TRANSCRIPT =
-  'Before this can match anything: index your library above (a matcher must be ' +
-  'loaded), and transcribe THIS video first — matching compares what you say ' +
-  'against your clips, so with no transcript there is nothing to compare and ' +
-  'Suggest fails with "has no transcript yet".';
+  'Before this can match anything, three things must be in place. First, the matcher ' +
+  'model (SigLIP-2, about 4.5 GB) must be installed — it does NOT arrive by clicking ' +
+  'Index; install it from the Assets tab. Then index your library above. Then ' +
+  'transcribe THIS video — matching compares what you say against your clips, so with ' +
+  'no transcript there is nothing to compare and Suggest fails with "has no transcript ' +
+  'yet".';
 
 /**
  * The BR6 disclosure, rendered directly ABOVE the Apply control. A user must know

--- a/app/renderer/src/features/broll.css
+++ b/app/renderer/src/features/broll.css
@@ -1,0 +1,310 @@
+/* broll.css — the Auto B-roll panel (W16-UI).
+   Deepens the shared panel voice in panels.css rather than restating it: quiet
+   tracked-caps labels, mono for every path and number, status colours only where
+   something IS a status. Kept in its own file because the panel introduces two
+   shapes panels.css has no vocabulary for — an asset TILE GRID whose primary cell
+   is deliberately EMPTY (there is no b-roll poster extractor, so the placeholder
+   is the normal state, not a fallback), and a REVIEW row that has to put a score,
+   a quoted reason and a timecode window on one line without any of the three
+   winning. Class names are asserted by BrollPanel.test.tsx; restyle only. */
+
+.broll-panel .broll-limits,
+.broll-panel .broll-threshold-copy,
+.broll-panel .broll-add-hint {
+  margin: 0 0 var(--space-4);
+  max-width: 72ch;
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-body-leading);
+}
+
+/* The privacy badge is the ONE piece of good news worth a colour, and it is
+   driven off the wire (`willEgress`) rather than a hardcoded promise. */
+.broll-panel .broll-local {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--status-success);
+  border-radius: var(--radius-sm);
+  background: var(--status-success-soft);
+  color: var(--status-success);
+  font-size: var(--type-caption-size);
+}
+
+/* …and its inverse. If the sidecar ever reports egress on this path something is
+   wrong with the build, so it takes the error rail, not the warn rail. */
+.broll-panel .broll-egress {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--status-error);
+  border-radius: var(--radius-sm);
+  background: var(--status-error-soft);
+  color: var(--status-error-text);
+  font-size: var(--type-caption-size);
+}
+
+/* ---- freshness snapshot ------------------------------------------------------ */
+
+.broll-panel .broll-status {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-3);
+  margin: 0 0 var(--space-5);
+}
+
+.broll-panel .broll-status dt {
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.broll-panel .broll-status dd {
+  margin: var(--space-1) 0 0;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+/* ---- the add-by-path row ----------------------------------------------------- */
+
+.broll-panel .broll-add {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: var(--space-3);
+}
+
+.broll-panel .broll-add > label {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.broll-panel .broll-add input[type="text"] {
+  min-width: 26ch;
+}
+
+.broll-panel .broll-add-hint {
+  flex-basis: 100%;
+  margin: 0;
+}
+
+/* ---- the asset grid ---------------------------------------------------------- */
+
+.broll-panel .broll-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+  gap: var(--space-3);
+  margin: 0 0 var(--space-5);
+  padding: 0;
+  list-style: none;
+}
+
+.broll-panel .broll-tile {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border: 1px solid var(--edge);
+  border-radius: var(--radius-md);
+  background: var(--surface-raised);
+}
+
+.broll-panel .broll-tile:hover {
+  background: var(--surface-hover);
+}
+
+.broll-panel .broll-poster {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  aspect-ratio: 16 / 9;
+  border-radius: var(--radius-sm);
+  background: var(--surface-deep);
+  object-fit: cover;
+}
+
+/* The EMPTY state of that cell is the normal one: no b-roll poster extractor
+   exists, so this is a labelled well rather than a broken-image slot. */
+.broll-panel .broll-poster--none {
+  font-size: var(--type-caption-size);
+  font-weight: var(--type-caption-weight);
+  letter-spacing: var(--type-caption-tracking);
+  text-transform: uppercase;
+  color: var(--text-faint);
+}
+
+.broll-panel .broll-tile-name {
+  font-size: var(--type-card-title-size);
+  font-weight: var(--weight-semibold);
+  color: var(--text-primary);
+  overflow-wrap: anywhere;
+}
+
+.broll-panel .broll-tile-meta {
+  font-size: var(--type-caption-size);
+  color: var(--text-muted);
+}
+
+.broll-panel .broll-tile-path {
+  overflow-wrap: anywhere;
+}
+
+.broll-panel .broll-tile button {
+  align-self: flex-start;
+}
+
+/* ---- missing files ----------------------------------------------------------- */
+
+/* Reported, never silently dropped — a vanished registration is excluded from
+   indexing, so this section is the only place it can still be seen. WARN, not
+   error: nothing failed, the user just moved a file. */
+.broll-panel .broll-missing {
+  margin: 0 0 var(--space-5);
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--status-warn);
+  border-radius: var(--radius-sm);
+  background: var(--status-warn-soft);
+}
+
+.broll-panel .broll-missing h3 {
+  margin-top: 0;
+  color: var(--status-warn);
+}
+
+.broll-panel .broll-missing p {
+  margin: 0 0 var(--space-3);
+  max-width: 72ch;
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+}
+
+.broll-panel .broll-missing ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.broll-panel .broll-missing li {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+}
+
+.broll-panel .broll-missing-name {
+  font-weight: var(--weight-medium);
+  color: var(--text-primary);
+}
+
+/* ---- matching controls ------------------------------------------------------- */
+
+.broll-panel .broll-index-actions {
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.broll-panel .broll-force,
+.broll-panel .broll-match > label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--text-secondary);
+  font-size: var(--type-control-size);
+}
+
+.broll-panel .broll-match {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+}
+
+.broll-panel .broll-threshold-value {
+  min-width: 4ch;
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+.broll-panel .broll-match input[type="number"] {
+  width: 8ch;
+}
+
+/* ---- the review list -------------------------------------------------------- */
+
+/* "Nothing cleared the threshold" is a RESULT. It reads as a neutral status with
+   the dial immediately above it, never as an error. */
+.broll-panel .broll-no-match {
+  margin: var(--space-4) 0;
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--edge-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  max-width: 72ch;
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+}
+
+.broll-panel .broll-review ul {
+  margin: 0 0 var(--space-4);
+  padding: 0;
+  list-style: none;
+}
+
+.broll-panel .broll-review-row {
+  display: grid;
+  grid-template-columns: minmax(180px, auto) 6ch minmax(160px, 1fr);
+  align-items: baseline;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--edge);
+}
+
+.broll-panel .broll-review-row:hover {
+  background: var(--surface-hover);
+}
+
+.broll-panel .broll-review-row > label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  color: var(--text-primary);
+}
+
+/* The score is the one number a reviewer scans down the column, so it is mono and
+   right-aligned; it is NOT colour-coded, because the threshold that decides
+   good-enough is itself uncalibrated and a green dot would overstate it. */
+.broll-panel .broll-review-score {
+  font-family: var(--font-mono);
+  text-align: right;
+  color: var(--text-primary);
+}
+
+.broll-panel .broll-review-reason {
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+}
+
+.broll-panel .broll-review-row code {
+  grid-column: 1 / -1;
+}
+
+/* The no-undo disclosure sits between the list and the Apply button, so it cannot
+   be scrolled past on the way to clicking. */
+.broll-panel .broll-one-way {
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border-left: 3px solid var(--status-warn);
+  border-radius: var(--radius-sm);
+  background: var(--status-warn-soft);
+  max-width: 72ch;
+  color: var(--status-warn);
+  font-size: var(--type-caption-size);
+}

--- a/app/renderer/src/features/broll.css
+++ b/app/renderer/src/features/broll.css
@@ -18,6 +18,21 @@
   line-height: var(--type-body-leading);
 }
 
+/* The two PREREQUISITES (an indexed library, a transcript for this video). Not an
+   error and not a warning — it is the instruction that comes first, so it takes
+   the neutral info rail and sits above the threshold copy. */
+.broll-panel .broll-prereq {
+  margin: 0 0 var(--space-4);
+  padding: var(--space-2) var(--space-3);
+  border-left: 3px solid var(--edge-strong);
+  border-radius: var(--radius-sm);
+  background: var(--surface-raised);
+  max-width: 72ch;
+  color: var(--text-secondary);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-body-leading);
+}
+
 /* The privacy badge is the ONE piece of good news worth a colour, and it is
    driven off the wire (`willEgress`) rather than a hardcoded promise. */
 .broll-panel .broll-local {
@@ -234,6 +249,18 @@
 
 .broll-panel .broll-match input[type="number"] {
   width: 8ch;
+}
+
+/* An emptied number input reads back as 0, which the planner turns into a zero
+   coverage budget that silently rejects every candidate. The panel refuses to
+   send it, so this line has to say WHY the Suggest button went quiet — a disabled
+   control with no explanation is just a dead button. */
+.broll-panel .broll-coverage-invalid {
+  flex-basis: 100%;
+  max-width: 72ch;
+  color: var(--status-error-text);
+  font-size: var(--type-caption-size);
+  line-height: var(--type-body-leading);
 }
 
 /* ---- the review list -------------------------------------------------------- */

--- a/app/renderer/src/features/brollClient.conformance.test.ts
+++ b/app/renderer/src/features/brollClient.conformance.test.ts
@@ -2,8 +2,7 @@
 //
 // TWO things drift silently and this file makes both fail the build.
 //
-// 1. THE METHOD SET. `client.broll.*` is the renderer's only typed door to the
-//    flagship. A wrapper naming a method the sidecar does not register is a
+// 1. THE METHOD SET. A wrapper naming a method the sidecar does not register is a
 //    guaranteed runtime "method not found", and a REGISTERED method with no wrapper
 //    is exactly the defect this lane exists to fix (the whole family had zero
 //    callers under `app/`). So the method strings the wrappers actually PUT ON THE
@@ -15,6 +14,33 @@
 //    The engine tuple and the composition root each cover only PART of the family
 //    (four engine methods vs the three BR1 registry methods), so their UNION is the
 //    real registration and the frozen list is the independent check on it.
+//
+//    REFUTED, AND FIXED — this file's first draft said "`client.broll.*` is the
+//    renderer's only typed door to the flagship". That was FALSE. `features/
+//    BrollPanel.tsx` is the door, and it reached the bridge with its own
+//    hand-written copies of the same seven strings; `client.broll` appeared in
+//    ZERO files under `app/` outside this one. A reviewer proved the gap
+//    executably: renaming the PANEL's `'broll.removeAsset'` to `'broll.remove'`
+//    left this suite 16/16 GREEN and `tsc --noEmit` at exit 0, i.e. the
+//    sidecar-anchored check was guarding a surface no user path executes. The fix
+//    is `lib/rpc/client.ts`'s exported `BROLL_METHODS` map: BOTH the wrappers and
+//    the panel now read every method string from it, and the test below pins THAT
+//    MAP against the sidecar, so the strings that actually go on the wire are the
+//    pinned ones. `BrollPanel.test.tsx` closes the other half — it drives the
+//    mounted panel and asserts the `broll.*` set it emits IS `BROLL_METHODS`.
+//
+//    RESIDUAL, disclosed rather than papered over: the seven `client.broll.*`
+//    wrappers still have no PRODUCTION caller. That is this repo's existing
+//    convention rather than a lane invention — measured on this branch,
+//    `client.stabilize`, `client.gaze`, `client.audiomix` and `client.speed`
+//    likewise appear only in `lib/rpc/*.test.ts`, while their panels call
+//    `bridge.rpc` through the injectable `api` prop (`features/_api.ts`, which
+//    exists precisely so a panel can be mounted against a fake bridge). Routing
+//    the panel through the module-singleton `client` would break that injection
+//    seam for one panel out of many. The settling experiment for whether the
+//    wrappers should exist at all is a repo-wide decision on the `_api.ts` seam,
+//    not a b-roll question; until then the value they add is the typed param
+//    shapes pinned below.
 //
 // 2. THE MIRRORED CONSTANTS. The panel seeds its threshold slider from
 //    `broll_plan.DEFAULT_MIN_SIMILARITY`, its coverage field from
@@ -28,18 +54,34 @@
 //
 // Reads the REAL `.py` sources (never a copy), the same idiom as
 // `AudioMix.conformance.test.ts`. Runs in the default node environment.
+//
+// CROSS-LANE COUPLING, stated because "renderer-only, zero changes under
+// `sidecar/`" is true of the DIFF and still understates this: two of the four
+// paths read below — `handlers/composition.py` and `tests/test_handlers_rpc_
+// surface.py` — are sidecar files, so an edit there can redden the RENDERER
+// suite. Reading `features/*.py` from a renderer conformance test is well
+// precedented here (AudioMix, batchSurface, languages, reframeDegraded,
+// captionTemplates all do it); reading the composition root and the frozen-surface
+// test is NOT — this is the only one of the ten `*conformance*` files that does.
+// The exposure is bounded: the two scanners key on `reg("broll.` and on per-line
+// `"broll.x",` entries, so only an edit to the broll REGISTRATIONS can move them,
+// which is exactly the drift this file exists to catch. Accepted deliberately —
+// the three-way cross-check is what makes a single hand-written list impossible.
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
-import { client } from '../lib/rpc/client';
+import { BROLL_METHODS, client } from '../lib/rpc/client';
 import {
   BROLL_LAYOUTS,
   BROLL_REASON_MATCHED,
   BROLL_REASON_NO_MATCH,
+  DEFAULT_BROLL_COOLDOWN_SEC,
   DEFAULT_BROLL_MAX_COVERAGE_PCT,
+  DEFAULT_BROLL_MIN_DURATION_SEC,
   DEFAULT_BROLL_THRESHOLD,
+  THRESHOLD_IS_UNCALIBRATED,
 } from './BrollPanel';
 
 // app/renderer/src/features -> repo root is four levels up.
@@ -177,6 +219,43 @@ describe('client.broll covers exactly the registered broll.* surface', () => {
     expect(wired).toHaveLength(3);
     expect([...new Set([...engine, ...wired])].sort()).toEqual(sent);
   });
+
+  // THE FIX FOR THE SURVIVING MUTANT (see the header). Pinning the WRAPPERS was
+  // never enough, because the shipped door is `BrollPanel.tsx`. Both now read
+  // every method string from `BROLL_METHODS`, so pinning the MAP pins the wire.
+  // The panel-side half of the chain — that the mounted panel emits exactly this
+  // set — is asserted in `BrollPanel.test.tsx`.
+  it('BROLL_METHODS (the ONE source both the wrappers and the panel read) IS the sidecar surface', () => {
+    const engine = pyStringTuple(BROLL_OPS, 'METHODS');
+    const wired = registeredMethods('broll');
+    const registered = [...new Set([...engine, ...wired])].sort();
+    expect(Object.values(BROLL_METHODS).sort()).toEqual(registered);
+    // and the same set, read a third way (the frozen surface).
+    expect(Object.values(BROLL_METHODS).sort()).toEqual([...frozenMethods('broll')].sort());
+  });
+
+  it('every wrapper puts its OWN mapped string on the wire (no key/value crossover)', async () => {
+    // A map whose values are all correct can still be wired to the wrong wrapper —
+    // `status: () => rpc(BROLL_METHODS.assets)` type-checks and passes the SET
+    // comparison above. Pin the pairing, not just the membership.
+    const rpc = installApi();
+    await client.broll.status();
+    await client.broll.assets();
+    await client.broll.addAsset('D:/broll/dog.png');
+    await client.broll.removeAsset('cccc3333dddd4444');
+    await client.broll.index();
+    await client.broll.suggest('v1');
+    await client.broll.apply('v1', []);
+    expect(rpc.mock.calls.map((call) => String(call[0]))).toEqual([
+      BROLL_METHODS.status,
+      BROLL_METHODS.assets,
+      BROLL_METHODS.addAsset,
+      BROLL_METHODS.removeAsset,
+      BROLL_METHODS.index,
+      BROLL_METHODS.suggest,
+      BROLL_METHODS.apply,
+    ]);
+  });
 });
 
 describe('client.broll wire shapes', () => {
@@ -263,8 +342,28 @@ describe('renderer mirrors of the sidecar planner constants', () => {
     expect(DEFAULT_BROLL_THRESHOLD).toBe(pyNumber(BROLL_PLAN, 'DEFAULT_MIN_SIMILARITY'));
   });
 
+  // THE DISCLOSURE, not just the seed. REFUTED first draft: the seed was pinned
+  // here while `THRESHOLD_IS_UNCALIBRATED` carried a HARD-CODED '0.22' and its only
+  // test was `toContain('0.22')` — another literal, satisfied by stale copy. So the
+  // §11.2 calibration would have reddened the seed pin, a dev would bump the one
+  // constant, and the panel would then seed 0.31 while TELLING the user the
+  // starting value is 0.22. The copy is now interpolated from the constant and
+  // pinned against the sidecar here, so the number on screen cannot outlive it.
+  it('the threshold DISCLOSURE quotes the sidecar number, not a frozen literal', () => {
+    expect(THRESHOLD_IS_UNCALIBRATED).toContain(
+      String(pyNumber(BROLL_PLAN, 'DEFAULT_MIN_SIMILARITY')),
+    );
+  });
+
   it('the coverage field seed IS broll_plan.DEFAULT_MAX_COVERAGE_PCT', () => {
     expect(DEFAULT_BROLL_MAX_COVERAGE_PCT).toBe(pyNumber(BROLL_PLAN, 'DEFAULT_MAX_COVERAGE_PCT'));
+  });
+
+  // The empty-plan copy NAMES these two as causes an empty result can have, so
+  // they are mirrors like the rest and drift the same way.
+  it('the placement limits quoted in the empty-plan copy ARE the planner defaults', () => {
+    expect(DEFAULT_BROLL_MIN_DURATION_SEC).toBe(pyNumber(BROLL_PLAN, 'DEFAULT_MIN_DURATION_SEC'));
+    expect(DEFAULT_BROLL_COOLDOWN_SEC).toBe(pyNumber(BROLL_PLAN, 'DEFAULT_COOLDOWN_SEC'));
   });
 
   it('offers exactly the layouts the planner accepts, default first', () => {

--- a/app/renderer/src/features/brollClient.conformance.test.ts
+++ b/app/renderer/src/features/brollClient.conformance.test.ts
@@ -1,0 +1,264 @@
+// Conformance test for the auto-b-roll wire surface + the MIRRORED engine constants.
+//
+// TWO things drift silently and this file makes both fail the build.
+//
+// 1. THE METHOD SET. `client.broll.*` is the renderer's only typed door to the
+//    flagship. A wrapper naming a method the sidecar does not register is a
+//    guaranteed runtime "method not found", and a REGISTERED method with no wrapper
+//    is exactly the defect this lane exists to fix (the whole family had zero
+//    callers under `app/`). So the method strings the wrappers actually PUT ON THE
+//    WIRE are collected from a spy and compared against THREE independent readings
+//    of the sidecar source, not against a hand-written list:
+//      * the frozen surface  `sidecar/tests/test_handlers_rpc_surface.py`
+//      * the engine's own    `broll_ops.METHODS` tuple
+//      * the composition root `handlers/composition.py` `reg("broll.…")` calls
+//    The engine tuple and the composition root each cover only PART of the family
+//    (four engine methods vs the three BR1 registry methods), so their UNION is the
+//    real registration and the frozen list is the independent check on it.
+//
+// 2. THE MIRRORED CONSTANTS. The panel seeds its threshold slider from
+//    `broll_plan.DEFAULT_MIN_SIMILARITY`, its coverage field from
+//    `DEFAULT_MAX_COVERAGE_PCT`, its style picker from `LAYOUTS`, and its
+//    empty-plan copy from `broll_ops.NO_CONFIDENT_MATCH`. Every one of those is a
+//    value the SIDECAR owns. The threshold in particular is documented in-module as
+//    an UNCALIBRATED placeholder, so a later calibration WILL change it — and if
+//    this mirror is not pinned, the slider would keep seeding the old guess while
+//    the sidecar used the measured value, and the panel would be lying about which
+//    number is in force.
+//
+// Reads the REAL `.py` sources (never a copy), the same idiom as
+// `AudioMix.conformance.test.ts`. Runs in the default node environment.
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { client } from '../lib/rpc/client';
+import {
+  BROLL_LAYOUTS,
+  BROLL_REASON_MATCHED,
+  BROLL_REASON_NO_MATCH,
+  DEFAULT_BROLL_MAX_COVERAGE_PCT,
+  DEFAULT_BROLL_THRESHOLD,
+} from './BrollPanel';
+
+// app/renderer/src/features -> repo root is four levels up.
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(HERE, '..', '..', '..', '..');
+const SIDECAR = resolve(REPO_ROOT, 'sidecar');
+const BROLL_PLAN = resolve(SIDECAR, 'media_studio', 'features', 'broll_plan.py');
+const BROLL_OPS = resolve(SIDECAR, 'media_studio', 'features', 'broll_ops.py');
+const COMPOSITION = resolve(SIDECAR, 'media_studio', 'handlers', 'composition.py');
+const FROZEN_SURFACE = resolve(SIDECAR, 'tests', 'test_handlers_rpc_surface.py');
+
+function source(path: string): string {
+  return readFileSync(path, 'utf8');
+}
+
+/** Parse a top-level `NAME = <number>` module constant. */
+function pyNumber(path: string, name: string): number {
+  const m = source(path).match(new RegExp(`^${name} = (-?\\d+(?:\\.\\d+)?)$`, 'm'));
+  if (!m) throw new Error(`could not find ${name} in ${path}`);
+  return Number(m[1]);
+}
+
+/** Parse a top-level `NAME = "<text>"` module constant. */
+function pyString(path: string, name: string): string {
+  const m = source(path).match(new RegExp(`^${name} = "([^"]*)"$`, 'm'));
+  if (!m) throw new Error(`could not find ${name} in ${path}`);
+  return m[1];
+}
+
+/** Parse a top-level `NAME: <ann> = ("a", "b")` / `NAME = ("a", "b")` tuple. */
+function pyStringTuple(path: string, name: string): string[] {
+  const m = source(path).match(new RegExp(`^${name}(?::[^=]+)? = \\(([^)]*)\\)`, 'm'));
+  if (!m) throw new Error(`could not find ${name} in ${path}`);
+  return [...m[1].matchAll(/"([^"]+)"/g)].map((hit) => hit[1]);
+}
+
+/** Every `"<prefix>.<name>",` entry of the frozen-surface set literal. */
+function frozenMethods(prefix: string): string[] {
+  const pattern = new RegExp(`^\\s*"(${prefix}\\.[A-Za-z.]+)",\\s*$`, 'gm');
+  return [...source(FROZEN_SURFACE).matchAll(pattern)].map((hit) => hit[1]);
+}
+
+/** Every `reg("<prefix>.<name>"` call in the composition root. */
+function registeredMethods(prefix: string): string[] {
+  const pattern = new RegExp(`reg\\("(${prefix}\\.[A-Za-z.]+)"`, 'g');
+  return [...source(COMPOSITION).matchAll(pattern)].map((hit) => hit[1]);
+}
+
+/** Install a fake preload bridge so `rpc()` resolves through a spy. */
+function installApi(): ReturnType<typeof vi.fn> {
+  const rpc = vi.fn().mockResolvedValue({ jobId: 'job-b' });
+  (globalThis as { window?: { api?: unknown } }).window = {
+    api: { rpc, onProgress: vi.fn(() => () => {}) },
+  };
+  return rpc;
+}
+
+afterEach(() => {
+  delete (globalThis as { window?: unknown }).window;
+  vi.restoreAllMocks();
+});
+
+// rules/common/single-signal-verification.md §3: prove each parser can FIND a
+// known-present item, and FAIL on an absent one, before any assertion is built on
+// its output. A silently-empty parse would make every check below vacuously pass —
+// `expect([]).toEqual([])` is green and measures nothing.
+describe('sidecar parse helpers (detector control)', () => {
+  it('finds a known-present number, string and tuple', () => {
+    expect(pyNumber(BROLL_PLAN, 'DEFAULT_TOP_K')).toBe(5);
+    expect(pyString(BROLL_OPS, 'MATCHED')).toBe('matched');
+    expect(pyStringTuple(BROLL_PLAN, 'LAYOUTS')).toContain('cutaway');
+  });
+
+  it('throws (never silently returns a default) when the symbol is absent', () => {
+    expect(() => pyNumber(BROLL_PLAN, 'NOT_A_REAL_CONSTANT')).toThrow(/could not find/);
+    expect(() => pyString(BROLL_OPS, 'NOT_A_REAL_CONSTANT')).toThrow(/could not find/);
+    expect(() => pyStringTuple(BROLL_PLAN, 'NOT_A_REAL_TUPLE')).toThrow(/could not find/);
+  });
+
+  it('the method scanners find a known-present NON-broll method, and no bogus one', () => {
+    // `captions.cues` sits in the same frozen set literal; `library.list` is
+    // registered through the same `reg(...)` call shape. If either scanner returned
+    // an empty list the broll assertions below would pass for the wrong reason.
+    expect(frozenMethods('captions')).toContain('captions.cues');
+    expect(registeredMethods('library')).toContain('library.list');
+    expect(frozenMethods('definitelynotarealnamespace')).toEqual([]);
+  });
+});
+
+describe('client.broll covers exactly the registered broll.* surface', () => {
+  /** The method strings the seven wrappers actually put on the wire. */
+  async function wireMethods(): Promise<string[]> {
+    const rpc = installApi();
+    await client.broll.status();
+    await client.broll.assets();
+    await client.broll.addAsset('D:/broll/dog.png');
+    await client.broll.removeAsset('cccc3333dddd4444');
+    await client.broll.index();
+    await client.broll.suggest('v1');
+    await client.broll.apply('v1', []);
+    return rpc.mock.calls.map((call) => String(call[0]));
+  }
+
+  it('matches the FROZEN rpc surface exactly — no phantom, no orphan', async () => {
+    const sent = [...new Set(await wireMethods())].sort();
+    const frozen = [...frozenMethods('broll')].sort();
+    expect(frozen).toHaveLength(7);
+    expect(sent).toEqual(frozen);
+  });
+
+  it('matches the composition root + engine tuple (a second, independent reading)', async () => {
+    const sent = [...new Set(await wireMethods())].sort();
+    // The engine module owns four methods; BR1's three registry methods are wired
+    // as closures in the composition root. Neither list is the whole family.
+    const engine = pyStringTuple(BROLL_OPS, 'METHODS');
+    const wired = registeredMethods('broll');
+    expect(engine).toHaveLength(4);
+    expect(wired).toHaveLength(3);
+    expect([...new Set([...engine, ...wired])].sort()).toEqual(sent);
+  });
+});
+
+describe('client.broll wire shapes', () => {
+  it('status / assets take no params', async () => {
+    const rpc = installApi();
+    await client.broll.status();
+    await client.broll.assets();
+    expect(rpc).toHaveBeenNthCalledWith(1, 'broll.status', undefined);
+    expect(rpc).toHaveBeenNthCalledWith(2, 'broll.assets', undefined);
+  });
+
+  it('addAsset OMITS title entirely when none is given (never an empty-string title)', async () => {
+    const rpc = installApi();
+    await client.broll.addAsset('D:/broll/dog.png');
+    expect(rpc).toHaveBeenCalledWith('broll.addAsset', { path: 'D:/broll/dog.png' });
+  });
+
+  it('addAsset forwards a title when one is given', async () => {
+    const rpc = installApi();
+    await client.broll.addAsset('D:/broll/dog.png', 'Hero dog');
+    expect(rpc).toHaveBeenCalledWith('broll.addAsset', {
+      path: 'D:/broll/dog.png',
+      title: 'Hero dog',
+    });
+  });
+
+  it('removeAsset sends the id under the key the handler reads', async () => {
+    const rpc = installApi();
+    await client.broll.removeAsset('cccc3333dddd4444');
+    expect(rpc).toHaveBeenCalledWith('broll.removeAsset', { id: 'cccc3333dddd4444' });
+  });
+
+  it('index defaults force to false and forwards an explicit true', async () => {
+    const rpc = installApi();
+    await client.broll.index();
+    await client.broll.index(true);
+    expect(rpc).toHaveBeenNthCalledWith(1, 'broll.index', { force: false });
+    expect(rpc).toHaveBeenNthCalledWith(2, 'broll.index', { force: true });
+  });
+
+  it('suggest forwards videoId alone, and the full tunable set when given', async () => {
+    const rpc = installApi();
+    await client.broll.suggest('v1');
+    await client.broll.suggest('v1', { threshold: 0.45, maxCoveragePct: 25, layout: 'pip' });
+    expect(rpc).toHaveBeenNthCalledWith(1, 'broll.suggest', { videoId: 'v1' });
+    expect(rpc).toHaveBeenNthCalledWith(2, 'broll.suggest', {
+      videoId: 'v1',
+      threshold: 0.45,
+      maxCoveragePct: 25,
+      layout: 'pip',
+    });
+  });
+
+  it('apply sends the REVIEWED list verbatim under `insertions`', async () => {
+    const rpc = installApi();
+    const insertion = {
+      segmentIndex: 0,
+      start: 4,
+      end: 8,
+      duration: 4,
+      sourceStart: 0,
+      assetId: 'cccc3333dddd4444',
+      path: 'D:/broll/dog.png',
+      kind: 'image',
+      score: 0.61,
+      reason: '"the dog ran off" (0.61)',
+      layout: 'cutaway',
+    };
+    await client.broll.apply('v1', [insertion]);
+    // `insertions`, NOT the design doc's first-draft `suggestions`
+    // (docs/plans/v1.5/flagship-auto-broll.md §5) — the landed handler reads
+    // `params.get("insertions")` and raises INVALID_PARAMS on an empty list.
+    expect(rpc).toHaveBeenCalledWith('broll.apply', { videoId: 'v1', insertions: [insertion] });
+  });
+});
+
+describe('renderer mirrors of the sidecar planner constants', () => {
+  // THE THRESHOLD PIN. The panel ships option (a) — a slider seeded from this
+  // value and sent EXPLICITLY on every suggest. That is only honest while the seed
+  // equals what the sidecar would have used, so a calibration landing in
+  // `broll_plan.py` (the §11.2 experiment) must fail here and force the mirror,
+  // rather than leaving the slider seeding a superseded guess.
+  it('the slider seed IS broll_plan.DEFAULT_MIN_SIMILARITY', () => {
+    expect(DEFAULT_BROLL_THRESHOLD).toBe(pyNumber(BROLL_PLAN, 'DEFAULT_MIN_SIMILARITY'));
+  });
+
+  it('the coverage field seed IS broll_plan.DEFAULT_MAX_COVERAGE_PCT', () => {
+    expect(DEFAULT_BROLL_MAX_COVERAGE_PCT).toBe(pyNumber(BROLL_PLAN, 'DEFAULT_MAX_COVERAGE_PCT'));
+  });
+
+  it('offers exactly the layouts the planner accepts, default first', () => {
+    // `broll_plan.suggest` raises ValueError on anything outside LAYOUTS, so a
+    // renderer-only option would be a guaranteed job failure.
+    expect([...BROLL_LAYOUTS]).toEqual(pyStringTuple(BROLL_PLAN, 'LAYOUTS'));
+    expect(BROLL_LAYOUTS[0]).toBe(pyString(BROLL_PLAN, 'DEFAULT_LAYOUT'));
+  });
+
+  it('quotes the engine reason strings verbatim, not a paraphrase', () => {
+    expect(BROLL_REASON_NO_MATCH).toBe(pyString(BROLL_OPS, 'NO_CONFIDENT_MATCH'));
+    expect(BROLL_REASON_MATCHED).toBe(pyString(BROLL_OPS, 'MATCHED'));
+  });
+});

--- a/app/renderer/src/features/brollClient.conformance.test.ts
+++ b/app/renderer/src/features/brollClient.conformance.test.ts
@@ -51,6 +51,23 @@ const BROLL_OPS = resolve(SIDECAR, 'media_studio', 'features', 'broll_ops.py');
 const COMPOSITION = resolve(SIDECAR, 'media_studio', 'handlers', 'composition.py');
 const FROZEN_SURFACE = resolve(SIDECAR, 'tests', 'test_handlers_rpc_surface.py');
 
+/**
+ * The `.py` source, read verbatim.
+ *
+ * LINE ENDINGS ARE NOT A HAZARD HERE, and that is MEASURED, not assumed — the
+ * usual worry is that the `pyNumber` / `pyString` patterns below anchor with `$`
+ * straight after the value, which would fail on a CRLF checkout. It does not:
+ * ECMAScript counts `\r` itself as a LineTerminator, so in multiline mode `$`
+ * matches before `\r\n` exactly as it does before `\n`.
+ *
+ * PROBED BOTH WAYS rather than reasoned about: the four parsed `.py` files were
+ * rewritten to CRLF and this suite stayed 16/16 green. A first draft of this
+ * helper added a `.replace(/\r\n/g, '\n')` on the stated premise that the parse
+ * "would fail to match" on CRLF — that premise was REFUTED by the probe above, so
+ * the line was removed rather than kept with a false rationale attached to it.
+ * (For the record the tree is LF anyway: `.gitattributes` carries
+ * `* text=auto eol=lf` and all four files measure 0 CRLF, on this box and on CI.)
+ */
 function source(path: string): string {
   return readFileSync(path, 'utf8');
 }
@@ -102,10 +119,10 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-// rules/common/single-signal-verification.md §3: prove each parser can FIND a
-// known-present item, and FAIL on an absent one, before any assertion is built on
-// its output. A silently-empty parse would make every check below vacuously pass —
-// `expect([]).toEqual([])` is green and measures nothing.
+// DETECTOR CONTROL, the single-signal-verification discipline: prove each parser
+// can FIND a known-present item, and FAIL on an absent one, before any assertion
+// is built on its output. A silently-empty parse would make every check below
+// vacuously pass — `expect([]).toEqual([])` is green and measures nothing.
 describe('sidecar parse helpers (detector control)', () => {
   it('finds a known-present number, string and tuple', () => {
     expect(pyNumber(BROLL_PLAN, 'DEFAULT_TOP_K')).toBe(5);

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -137,6 +137,100 @@ export function onProxyState(cb: (event: ProxyStateEvent) => void): () => void {
   return api.onProxyState(cb);
 }
 
+// ---- v1.5 flagship #3 (auto-b-roll) wire types ---------------------------
+//
+// Declared HERE rather than in ./schemas because `broll.*` is NOT a CONTRACTS.md
+// §3 schema: `grep -i broll CONTRACTS.md` -> 0 hits, so there is no frozen §3 row
+// for these shapes and adding one is the contract owner's call, not this lane's.
+// ./index re-exports this module, so `import type { BrollAsset } from '../lib/rpc'`
+// resolves for callers either way.
+//
+// Every field name below was read off the LANDED sidecar, not off
+// `docs/plans/v1.5/flagship-auto-broll.md` §5 — that section's first draft said
+// `id`/`thumbPath`/`{removed}` and was corrected in-place by BR1. Two runtime
+// facts the doc still does not make obvious, and both bite a renderer:
+//   * `durationSec` is `number | null`. `broll_ops.scan_assets` writes `None` for
+//     every SCANNED row and `Library.add_broll` writes `0.0` for a still or a
+//     failed probe, so neither a `number` type nor a "0 means zero seconds"
+//     reading is safe.
+//   * `thumbnailPath` exists but is UNCONDITIONALLY `""`. `add_broll` writes the
+//     empty string and the only poster writer, `Library.set_thumbnail`, is
+//     `role='source'`-scoped — measured, `set_thumbnail(<brollAssetId>, …)`
+//     returns `None` and changes nothing. There is no b-roll poster extractor.
+
+/** How a b-roll window is composited (`broll_plan.LAYOUTS`). */
+export type BrollLayout = 'cutaway' | 'pip';
+
+/**
+ * One row of the b-roll library. The SAME shape whether it came from the
+ * `brollDir` recursive scan or from the BR1 registry — `broll_asset_rows` merges
+ * both into ONE list so the panel and the engine can never see two libraries.
+ * The registry-only fields are optional because a scanned row does not carry them.
+ */
+export interface BrollAsset {
+  assetId: string;
+  path: string;
+  /** The planner/compositor vocabulary: `'image'` or `'video'` — NOT `entityKind`. */
+  kind: string;
+  /** `null` on a scanned row; `0` for a still or a failed probe. Never assume seconds. */
+  durationSec: number | null;
+  sizeBytes: number;
+  mtime: number;
+  /** False for a `brollDir` scan hit, true for a BR1 registry row. */
+  registered: boolean;
+  /** PROV entity kind (`brollImage` / `brollClip`) — registry rows only. */
+  entityKind?: string;
+  title?: string;
+  addedAt?: string;
+  /** BR2 is NOT implemented: the column is surfaced but left NULL. */
+  contentHash?: string | null;
+  /** Always `''` today — see the note above. */
+  thumbnailPath?: string;
+  exists?: boolean;
+}
+
+/**
+ * `broll.assets` -> the library PLUS the registered rows whose file has vanished.
+ * `missing` is a FEATURE: a vanished path must not reach `broll.index` (it would
+ * hand a dead path to the image tower and fail the whole batch), so it is reported
+ * loudly instead of silently dropped.
+ */
+export interface BrollAssetsResult {
+  assets: BrollAsset[];
+  missing: BrollAsset[];
+}
+
+/** `broll.status` -> the index freshness snapshot (a pure read; no model load). */
+export interface BrollStatus {
+  indexed: boolean;
+  /** Rows in the persisted index sidecar. */
+  assetCount: number;
+  /** Rows in the LIVE library (scan + registry). */
+  libraryCount: number;
+  model: string;
+  dim: number;
+  stale: boolean;
+  /** How many assets an index run would have to embed to become current. */
+  staleCount: number;
+  /** False by construction — auto-b-roll is local retrieval, nothing egresses. */
+  willEgress: boolean;
+}
+
+/** One timed, constraint-satisfying b-roll window (`broll_plan.BrollInsertion`). */
+export interface BrollInsertion {
+  segmentIndex: number;
+  start: number;
+  end: number;
+  duration: number;
+  sourceStart: number;
+  assetId: string;
+  path: string;
+  kind: string;
+  score: number;
+  reason: string;
+  layout: string;
+}
+
 // ---- Method-typed convenience surface (the canonical client) -------------
 //
 // Thin, named wrappers around `rpc(...)` for the §2 method registry. New code
@@ -977,6 +1071,62 @@ export const client = {
         notice?: { type: string; message: string };
       }
     > => rpc('stabilize.run', typeof target === 'string' ? { videoId: target } : { ...target }),
+  },
+
+  /**
+   * `broll.*` (v1.5 flagship #3) — auto-b-roll: LOCAL asset retrieval over the
+   * user's own library, then a composite render. Seven registered methods
+   * (`sidecar/tests/test_handlers_rpc_surface.py`), and before this lane the
+   * string `broll` appeared in ZERO files under `app/` while matching 15 under
+   * `sidecar/` — the detector was controlled both ways, so the whole flagship was
+   * genuinely user-unreachable.
+   *
+   * `status` / `assets` / `addAsset` / `removeAsset` are DIRECT-return.
+   * `index` / `suggest` / `apply` are deferred JOBS: they resolve `{jobId}` only
+   * and the typed payload arrives on the later `job.done`.
+   *
+   * PRIVACY: none of the seven may ever join the key-injection allowlist — they
+   * take no provider, load no cloud model and open no socket, which is exactly why
+   * `willEgress` is `false` by construction rather than by promise.
+   *
+   * THRESHOLD: `suggest`'s `threshold` is OPTIONAL on the wire, but the sidecar
+   * default (`broll_plan.DEFAULT_MIN_SIMILARITY = 0.22`) is documented in-module
+   * as an UNCALIBRATED placeholder — see `docs/plans/v1.5/flagship-auto-broll.md`
+   * §11.2 for the experiment that would settle it. A caller that omits it inherits
+   * a guess; `features/BrollPanel.tsx` therefore always sends an explicit value.
+   */
+  broll: {
+    /** `broll.status()` -> the index freshness snapshot. */
+    status: (): Promise<BrollStatus> => rpc('broll.status'),
+    /** `broll.assets()` -> the ONE merged library + the vanished registry rows. */
+    assets: (): Promise<BrollAssetsResult> => rpc('broll.assets'),
+    /**
+     * `broll.addAsset({path, title?})` -> `{asset}`. Registers a file BY PATH (no
+     * copy, no move). `title` applies on FIRST registration only — re-posting the
+     * same path returns the existing row and drops the new title without a signal,
+     * so a rename is `removeAsset` + `addAsset`.
+     */
+    addAsset: (path: string, title?: string): Promise<{ asset: BrollAsset }> =>
+      rpc('broll.addAsset', title === undefined ? { path } : { path, title }),
+    /** `broll.removeAsset({id})` -> `{ok}`. UNREGISTERS; the user's file is never deleted. */
+    removeAsset: (id: string): Promise<{ ok: boolean }> => rpc('broll.removeAsset', { id }),
+    /** `broll.index({force})` -> `{jobId}`. Embeds only the stale subset unless forced. */
+    index: (force = false): Promise<JobHandle> => rpc('broll.index', { force }),
+    /** `broll.suggest({videoId, ...})` -> `{jobId}` -> `{insertions, reason}`. */
+    suggest: (
+      videoId: string,
+      opts?: { threshold?: number; maxCoveragePct?: number; layout?: BrollLayout },
+    ): Promise<JobHandle> => rpc('broll.suggest', { videoId, ...(opts ?? {}) }),
+    /**
+     * `broll.apply({videoId, insertions})` -> `{jobId}` -> `{path, inserted}`.
+     *
+     * REVIEW-FIRST: it composites exactly the list handed to it and never re-plans.
+     * ONE-WAY: the output is a flat `{stem}.broll.mp4`. BR6's reversible overlay
+     * track + inverse op are DESIGN-ONLY on this branch, so there is no undo —
+     * a caller must say so before the user clicks.
+     */
+    apply: (videoId: string, insertions: readonly BrollInsertion[]): Promise<JobHandle> =>
+      rpc('broll.apply', { videoId, insertions }),
   },
 } as const;
 

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -231,6 +231,34 @@ export interface BrollInsertion {
   layout: string;
 }
 
+/**
+ * The seven `broll.*` method strings, in ONE place — the auto-b-roll wire
+ * vocabulary shared by the typed wrappers in {@link client} and by the SHIPPED
+ * caller, `features/BrollPanel.tsx`.
+ *
+ * WHY A MAP AND NOT LITERALS AT THE CALL SITES. The first draft of the W16-UI
+ * lane wrote the strings twice: once in the wrappers below, once by hand in the
+ * panel. A reviewer proved the gap executably — renaming the PANEL's
+ * `'broll.removeAsset'` to `'broll.remove'` (a method the sidecar does not
+ * register) left `features/brollClient.conformance.test.ts` fully GREEN at 16/16
+ * and `tsc --noEmit` at exit 0, because the sidecar-anchored check only ever saw
+ * the wrappers, which no user path executes. Only `BrollPanel.test.tsx` reddened.
+ *
+ * With one map, a call site cannot invent a string — `BROLL_METHODS.remove` is a
+ * type error — and `brollClient.conformance.test.ts` pins these seven VALUES
+ * against three independent readings of the sidecar source, so a rename there
+ * reddens the build for the strings that actually go on the wire.
+ */
+export const BROLL_METHODS = {
+  status: 'broll.status',
+  assets: 'broll.assets',
+  addAsset: 'broll.addAsset',
+  removeAsset: 'broll.removeAsset',
+  index: 'broll.index',
+  suggest: 'broll.suggest',
+  apply: 'broll.apply',
+} as const;
+
 // ---- Method-typed convenience surface (the canonical client) -------------
 //
 // Thin, named wrappers around `rpc(...)` for the §2 method registry. New code
@@ -1081,6 +1109,18 @@ export const client = {
    * `sidecar/` — the detector was controlled both ways, so the whole flagship was
    * genuinely user-unreachable.
    *
+   * NO PRODUCTION CALLER YET, and that is disclosed rather than implied away.
+   * `features/BrollPanel.tsx` is the shipped door and it reaches the sidecar
+   * through the injectable `api` bridge (`features/_api.ts`), the same as
+   * Stabilize / Gaze / AudioMix / Speed — measured on this branch,
+   * `client.stabilize`, `client.gaze`, `client.audiomix` and `client.speed` also
+   * appear only in `lib/rpc/*.test.ts`. What these wrappers DO carry is the typed
+   * param shapes, and — since the panel and the wrappers now share
+   * {@link BROLL_METHODS} — the sidecar pin on the strings the panel puts on the
+   * wire. An earlier draft of the conformance test called this "the renderer's
+   * only typed door"; that was REFUTED by a surviving mutant and is corrected
+   * there.
+   *
    * `status` / `assets` / `addAsset` / `removeAsset` are DIRECT-return.
    * `index` / `suggest` / `apply` are deferred JOBS: they resolve `{jobId}` only
    * and the typed payload arrives on the later `job.done`.
@@ -1097,9 +1137,9 @@ export const client = {
    */
   broll: {
     /** `broll.status()` -> the index freshness snapshot. */
-    status: (): Promise<BrollStatus> => rpc('broll.status'),
+    status: (): Promise<BrollStatus> => rpc(BROLL_METHODS.status),
     /** `broll.assets()` -> the ONE merged library + the vanished registry rows. */
-    assets: (): Promise<BrollAssetsResult> => rpc('broll.assets'),
+    assets: (): Promise<BrollAssetsResult> => rpc(BROLL_METHODS.assets),
     /**
      * `broll.addAsset({path, title?})` -> `{asset}`. Registers a file BY PATH (no
      * copy, no move). `title` applies on FIRST registration only — re-posting the
@@ -1107,16 +1147,16 @@ export const client = {
      * so a rename is `removeAsset` + `addAsset`.
      */
     addAsset: (path: string, title?: string): Promise<{ asset: BrollAsset }> =>
-      rpc('broll.addAsset', title === undefined ? { path } : { path, title }),
+      rpc(BROLL_METHODS.addAsset, title === undefined ? { path } : { path, title }),
     /** `broll.removeAsset({id})` -> `{ok}`. UNREGISTERS; the user's file is never deleted. */
-    removeAsset: (id: string): Promise<{ ok: boolean }> => rpc('broll.removeAsset', { id }),
+    removeAsset: (id: string): Promise<{ ok: boolean }> => rpc(BROLL_METHODS.removeAsset, { id }),
     /** `broll.index({force})` -> `{jobId}`. Embeds only the stale subset unless forced. */
-    index: (force = false): Promise<JobHandle> => rpc('broll.index', { force }),
+    index: (force = false): Promise<JobHandle> => rpc(BROLL_METHODS.index, { force }),
     /** `broll.suggest({videoId, ...})` -> `{jobId}` -> `{insertions, reason}`. */
     suggest: (
       videoId: string,
       opts?: { threshold?: number; maxCoveragePct?: number; layout?: BrollLayout },
-    ): Promise<JobHandle> => rpc('broll.suggest', { videoId, ...(opts ?? {}) }),
+    ): Promise<JobHandle> => rpc(BROLL_METHODS.suggest, { videoId, ...(opts ?? {}) }),
     /**
      * `broll.apply({videoId, insertions})` -> `{jobId}` -> `{path, inserted}`.
      *
@@ -1126,7 +1166,7 @@ export const client = {
      * a caller must say so before the user clicks.
      */
     apply: (videoId: string, insertions: readonly BrollInsertion[]): Promise<JobHandle> =>
-      rpc('broll.apply', { videoId, insertions }),
+      rpc(BROLL_METHODS.apply, { videoId, insertions }),
   },
 } as const;
 

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -278,9 +278,18 @@ describe('Workspace ↔ BrollPanel seam (W16-UI)', () => {
     expect(container.querySelector('[data-section="status"]')).toBeNull();
     // The prerequisites are the first thing a user on a fresh video needs, so they
     // must survive the real lazy mount, not just the unit harness.
-    expect(container.querySelector('[data-section="prerequisites"]')?.textContent).toContain(
-      'transcribe THIS video first',
-    );
+    //
+    // THIS ASSERTION WAS CHANGED, and the reason matters: it used to pin the phrase
+    // 'transcribe THIS video first'. That wording was itself the defect. The sidecar
+    // enforces `require_model` (broll_ops.py:403) BEFORE the transcript raise (:408),
+    // so transcribing is the THIRD prerequisite, not the first — and the omitted one
+    // is a 4.5 GB SigLIP-2 download that no copy mentioned. Pinning "first" therefore
+    // locked in a false ordering. The replacement is STRICTER, not looser: it keeps
+    // the transcript pin and adds the matcher pin, so the seam now proves both halves
+    // survive the real lazy mount.
+    const prereq = container.querySelector('[data-section="prerequisites"]')?.textContent;
+    expect(prereq).toContain('transcribe THIS video');
+    expect(prereq).toContain('Assets tab');
   });
 });
 

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -236,6 +236,43 @@ describe('Workspace ↔ Dub/LipSync seam (W20)', () => {
   });
 });
 
+// W16-UI. Same reason the Gaze block above exists, and the reachability claim here
+// is the whole point of the lane: `Workspace.test.tsx` mocks
+// `../features/BrollPanel` to a marker div, so it proves the TabBar + the
+// `renderPanel()` switch and nothing about whether
+// `lazy(() => import('../features/BrollPanel'))` resolves. Only a REAL mount can
+// show that a user clicking "Auto B-roll" actually reaches the seven `broll.*`
+// RPCs — the claim this lane is making — so it is asserted here, executably,
+// rather than narrowed away or rested on `tsc --noEmit`.
+describe('Workspace ↔ BrollPanel seam (W16-UI)', () => {
+  it('mounts the REAL b-roll panel on its tab, with its honesty surfaces present', async () => {
+    await import('../features/BrollPanel'); // warm the lazy chunk (same idiom as above)
+    rpcMock.mockResolvedValue({ project });
+
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} initialTab="broll" />);
+    });
+    await flush();
+
+    // The real panel, not the Suspense fallback and not a marker div: its own
+    // section class plus the two disclosures only the real component renders.
+    expect(container.querySelector('.broll-panel')).not.toBeNull();
+    expect(container.querySelector('[data-section="threshold-disclosure"]')?.textContent).toContain(
+      'UNCALIBRATED',
+    );
+    expect(container.querySelector('[data-section="limits"]')).not.toBeNull();
+    // The threshold really is a control the user can move, not a fixed constant.
+    expect(container.querySelector('[data-input="threshold"]')).not.toBeNull();
+    // Fail-closed on this scaffold: the fake bridge answers `broll.assets` with
+    // `{}`, so the library reads EMPTY and the register control stays shut until a
+    // path is typed. That IS the shipped first-run behaviour.
+    expect(container.querySelector('[data-section="grid"]')).toBeNull();
+    expect((container.querySelector('[data-action="add"]') as HTMLButtonElement).disabled).toBe(
+      true,
+    );
+  });
+});
+
 describe('Workspace ↔ Speed seam', () => {
   it('mounts the REAL Speed panel on the speed tab, threaded with the video duration', async () => {
     // The point of this test: before v1.5 the re-time engine had no control in

--- a/app/renderer/src/views/Workspace.seam.test.tsx
+++ b/app/renderer/src/views/Workspace.seam.test.tsx
@@ -270,6 +270,17 @@ describe('Workspace ↔ BrollPanel seam (W16-UI)', () => {
     expect((container.querySelector('[data-action="add"]') as HTMLButtonElement).disabled).toBe(
       true,
     );
+    // …and the same `{}` must NOT paint a freshness snapshot. A reviewer caught
+    // this scaffold doing exactly that: `readBrollStatus` only rejected NON-objects,
+    // so `{}` returned a full row of zeros and THIS test — the one offered as proof
+    // of reachability — rendered "In library 0" as though it were a measurement.
+    // Fixed in the panel; pinned here so the scaffold can never fabricate again.
+    expect(container.querySelector('[data-section="status"]')).toBeNull();
+    // The prerequisites are the first thing a user on a fresh video needs, so they
+    // must survive the real lazy mount, not just the unit harness.
+    expect(container.querySelector('[data-section="prerequisites"]')?.textContent).toContain(
+      'transcribe THIS video first',
+    );
   });
 });
 

--- a/app/renderer/src/views/Workspace.test.tsx
+++ b/app/renderer/src/views/Workspace.test.tsx
@@ -98,6 +98,11 @@ vi.mock('../features/ReframeCorrect', () => stubPanel('ReframeCorrect'));
 // ("Workspace ↔ Gaze seam"), which drains macrotasks and renders the REAL panel;
 // that case goes red if `case 'gaze'` is removed from `renderPanel` (measured).
 vi.mock('../features/Gaze', () => stubPanel('Gaze'));
+// W16-UI: auto-b-roll. Same STUB caveat as `Gaze` above — this file proves the
+// TabBar + `renderPanel()` switch and the props handed down, NOT that
+// `lazy(() => import('../features/BrollPanel'))` resolves. The real lazy mount is
+// asserted in `Workspace.seam.test.tsx` ("Workspace ↔ BrollPanel seam").
+vi.mock('../features/BrollPanel', () => stubPanel('BrollPanel'));
 
 import {
   Workspace,
@@ -195,9 +200,15 @@ describe('Workspace', () => {
   // for "polish the footage" ops in the Frame & Cut cluster. WIDENED by exactly
   // one entry, never weakened.
   //
-  // The assertion remains exact and order-sensitive, six elements longer than
+  // SCOPE CHANGE #6 (W16-UI auto-b-roll): the list gains 'Auto B-roll', placed
+  // immediately after 'Video timeline' because it is the same KIND of operation —
+  // it puts additional footage INTO the timeline for chosen windows. Before it, the
+  // seven `broll.*` RPCs (~58 KB of engine) had zero callers anywhere under `app/`.
+  // WIDENED by exactly one entry, never weakened.
+  //
+  // The assertion remains exact and order-sensitive, seven elements longer than
   // the pre-v1.5 list and with two labels corrected. Nothing was weakened.
-  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes; expose-engines: +Stabilize; speed: +Speed; audiomix-ui: +Audio mix; W17/W18: +Fix framing/Video timeline; W19: +Eye contact)', () => {
+  it('exposes the contract tabs in order (P2: +Subtitle timeline/Dub/Assets; captions-export: +NLE export; system-advanced: +Diarize/Recipes; expose-engines: +Stabilize; speed: +Speed; audiomix-ui: +Audio mix; W17/W18: +Fix framing/Video timeline; W19: +Eye contact; W16-UI: +Auto B-roll)', () => {
     expect(WORKSPACE_TABS.map((t) => t.label)).toEqual([
       'Transcribe',
       'Search',
@@ -211,6 +222,10 @@ describe('Workspace', () => {
       'Fix framing',
       'Subtitle timeline',
       'Video timeline',
+      // W16-UI: auto-b-roll. Before it, `broll.assets/addAsset/removeAsset/status/
+      // index/suggest/apply` had no caller anywhere in the renderer, so the whole
+      // flagship — engine, registry door and all — was user-unreachable.
+      'Auto B-roll',
       'Stabilize',
       // W19: eye-contact correction. Before it, gaze.probe/gaze.run had no caller
       // anywhere in the renderer, so the whole feature was user-unreachable.
@@ -302,6 +317,52 @@ describe('Workspace', () => {
         .querySelector('[role="tab"][data-tab-id="tracks"]')
         ?.closest('.tabbar__advanced-panel'),
     ).not.toBeNull();
+  });
+
+  // W16-UI. Auto-b-roll must be in a VISIBLE cluster, and for a reason specific to
+  // it rather than by analogy: the panel is where the UNCALIBRATED match threshold
+  // and the NO-UNDO apply disclosure live. Parking it behind the Advanced
+  // disclosure would hide the two honesty surfaces the feature ships with, which is
+  // the opposite of the point. It is also the only door to the seven `broll.*`
+  // methods, so a hidden tab is a hidden flagship.
+  it('puts Auto B-roll in the VISIBLE "Frame & Cut" cluster, not behind Advanced', async () => {
+    const frame = WORKSPACE_TAB_GROUPS.find((g) => g.id === 'frame');
+    expect(frame?.tabIds).toContain('broll');
+    expect(frame?.advanced).not.toBe(true);
+    // exactly-once membership across the strip
+    expect(WORKSPACE_TAB_GROUPS.filter((g) => g.tabIds.includes('broll'))).toHaveLength(1);
+
+    // A SECOND, mechanically different signal: the array above states intent, this
+    // reads the rendered DOM. jsdom computes no visibility, so DOM POSITION
+    // (outside the container the disclosure hides) is the strongest check here; the
+    // pixel check is `.tab:visible` in the nightly `app/e2e/preview.spec.ts`.
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} />);
+    });
+    await flush();
+    const tab = container.querySelector('[role="tab"][data-tab-id="broll"]');
+    expect(tab).not.toBeNull();
+    expect(tab?.closest('.tabbar__advanced-panel')).toBeNull();
+    // Control for that assertion: a tab that IS behind the disclosure must be found
+    // INSIDE it, or the `.closest()` selector could be silently wrong and the check
+    // above would pass for every tab in the strip.
+    expect(
+      container
+        .querySelector('[role="tab"][data-tab-id="tracks"]')
+        ?.closest('.tabbar__advanced-panel'),
+    ).not.toBeNull();
+  });
+
+  it('mounts the b-roll panel on its tab, threaded with the videoId it needs', async () => {
+    await act(async () => {
+      root.render(<Workspace video={video} onBack={() => {}} initialTab="broll" />);
+    });
+    await flush();
+    const panel = container.querySelector('[data-panel="BrollPanel"]');
+    expect(panel).not.toBeNull();
+    // `broll.suggest` and `broll.apply` are both videoId-scoped; without it the
+    // panel could list and index a library but never match or render anything.
+    expect(panel?.getAttribute('data-videoid')).toBe('v1');
   });
 
   it('puts Speed in the Frame & Cut group and selects it from a deep-link', async () => {
@@ -810,15 +871,30 @@ describe('Workspace tab clusters (WU-3a2)', () => {
   // in the SAME commit — that file is owned by another live lane this wave, so the
   // edit there is confined to the two count literals and the sentences that state
   // them, nothing else.
+  //
+  // W16-UI UPDATE: 20 -> 21 and 15 -> 16. The new `broll` tab joins the VISIBLE
+  // "Frame & Cut" cluster (see its own test below for why it must not sit behind
+  // the Advanced disclosure), so BOTH counts move by one and the hidden count is
+  // unchanged at 5. Numbers RE-DERIVED from the source in this commit, not read off
+  // a failing run: WORKSPACE_TABS has 21 entries, and the four groups hold
+  // 6 (speech) + 8 (frame) + 2 (audio) + 5 (deliver, `advanced`) = 21, so 16 paint
+  // while Deliver is collapsed. `app/e2e/preview.spec.ts` was updated in the SAME
+  // commit; that is the whole point of this test existing.
   it('pins the strip counts that the nightly e2e spec hardcodes', () => {
-    expect(WORKSPACE_TABS).toHaveLength(20);
+    expect(WORKSPACE_TABS).toHaveLength(21);
     const hiddenWhenCollapsed = WORKSPACE_TAB_GROUPS.filter((g) => g.advanced).reduce(
       (n, g) => n + g.tabIds.length,
       0,
     );
     expect(hiddenWhenCollapsed).toBe(5);
     // What actually paints while the Advanced cluster is collapsed.
-    expect(WORKSPACE_TABS.length - hiddenWhenCollapsed).toBe(15);
+    expect(WORKSPACE_TABS.length - hiddenWhenCollapsed).toBe(16);
+    // Every tab belongs to EXACTLY ONE group, so the two numbers above are a
+    // partition of the strip rather than two independent counts that could drift
+    // apart (an id in no group would not paint at all).
+    const grouped = WORKSPACE_TAB_GROUPS.flatMap((g) => g.tabIds);
+    expect(grouped).toHaveLength(WORKSPACE_TABS.length);
+    expect([...new Set(grouped)].sort()).toEqual(WORKSPACE_TABS.map((t) => t.id).sort());
   });
 
   it('collapses the Deliver cluster behind Advanced by default and toggles it open/closed', async () => {

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -70,6 +70,13 @@ const ReframeCorrect = lazy(() => import('../features/ReframeCorrect'));
 // ZERO times, case-insensitively, anywhere under `app/renderer` — so the entire
 // feature, ethics gate included, was unreachable by any user. This mounts it.
 const Gaze = lazy(() => import('../features/Gaze'));
+// W16-UI: auto-b-roll — the last v1.5 flagship with no user surface. The sidecar
+// ships ~58 KB of engine (features/broll_ops.py, broll_plan.py, broll_index.py,
+// broll_compose.py) behind SEVEN registered RPCs, and `broll` matched ZERO files
+// under `app/` while matching 15 under `sidecar/` (detector controlled both ways).
+// BR1 (#393) added the registration door, so the library can now be filled from the
+// app; this mounts the surface that fills and uses it.
+const BrollPanel = lazy(() => import('../features/BrollPanel'));
 
 /**
  * v1.5 timeline-naming — two LABELS name their real subject. Ids are untouched
@@ -112,6 +119,12 @@ export const WORKSPACE_TABS: TabDef[] = [
   { id: 'timeline', label: 'Subtitle timeline' },
   // W18: the real video timeline (see the reconciliation note above).
   { id: 'videoTimeline', label: 'Video timeline' },
+  // W16-UI: auto-b-roll sits next to the video timeline because it is the same KIND
+  // of operation — it puts additional footage INTO the timeline for chosen windows.
+  // It is NOT filed under "Advanced": the panel carries the feature's two honesty
+  // surfaces (an UNCALIBRATED match threshold, and an apply with no undo), and
+  // hiding those behind a disclosure toggle would defeat the point of shipping them.
+  { id: 'broll', label: 'Auto B-roll' },
   { id: 'stabilize', label: 'Stabilize' },
   // W19: eye-contact correction sits next to Stabilize because it is the same KIND
   // of operation — a whole-clip, token-free, fully local image correction that
@@ -155,7 +168,21 @@ export const WORKSPACE_TAB_GROUPS: TabGroup[] = [
     // W19: 'gaze' joins the same VISIBLE cluster, taking the painted strip to 15
     // for the same reason — plus one specific to it: the panel IS the likeness
     // consent gate, so it must be findable, not filed under Advanced.
-    tabIds: ['shortmaker', 'reframeFix', 'timeline', 'videoTimeline', 'stabilize', 'gaze', 'speed'],
+    //
+    // W16-UI: 'broll' joins it too, taking the painted strip to 16. Same shape of
+    // argument, different surfaces: the b-roll panel is where the uncalibrated match
+    // threshold is presented as a dial and where "apply cannot be undone" is stated
+    // before the click. Both belong in front of the user, not behind a toggle.
+    tabIds: [
+      'shortmaker',
+      'reframeFix',
+      'timeline',
+      'videoTimeline',
+      'broll',
+      'stabilize',
+      'gaze',
+      'speed',
+    ],
   },
   { id: 'audio', label: 'Audio', tabIds: ['dub', 'audiomix'] },
   {
@@ -383,6 +410,12 @@ export function Workspace({
             sourceDurationSec={video.durationSec}
           />
         );
+      case 'broll':
+        // No extra props: every `broll.*` method takes either nothing or
+        // `{videoId, …}` — the library half is per MACHINE (a `brollDir` scan plus
+        // the BR1 registry), so passing this video's path or duration would imply
+        // per-video inputs the RPCs do not accept.
+        return <BrollPanel videoId={video.id} />;
       case 'stabilize':
         return <Stabilize videoId={video.id} />;
       case 'gaze':


### PR DESCRIPTION
## The last unreachable v1.5 flagship

Auto-B-roll was ~58 KB of sidecar engine and **seven** registered RPCs with **zero** files under
`app/` mentioning it (detector controlled: the same probe matched many files under `sidecar/`).
BR1 — the registration door — landed in #393, so the corpus could finally be filled. This is the
renderer surface: register by path → one merged library → freshness snapshot → index → suggest →
review → apply. **Renderer-only; nothing under `sidecar/` changed.**

## The five landed-code facts each have their own case

Written against the code that actually shipped in #393, not the design doc:

* **`durationSec` is `number | null`** — renders `still` / `—`, never `0.0s`.
* **Registered assets have no poster** — a labelled placeholder, never an empty `<img>`.
* **`missing` is a result, not an error** — its own loud section, excluded from the grid.
* **One list** — the panel reads only `broll.assets`; a test asserts it never calls `library.list`.
* **Ids diverge on a `brollDir` respelling** — the review list is keyed by POSITION, and a plan is
  cleared on a video change *before paint* with a `videoIdRef` gate on the deferred write.

## The two things the brief said would be blocking overclaims — both genuinely avoided

* **The threshold is not presented as tuned.** Option (a), a slider, and it is load-bearing rather
  than cosmetic: `threshold` is sent **explicitly on every suggest**, so the uncalibrated sidecar
  default is never the silent authority. The copy interpolates the constant rather than typing a
  literal, says "an UNCALIBRATED placeholder, not a tuned number", carries the per-backbone
  warning, and cites §11.2. The empty-plan copy names **all five** causes and states that the
  engine's single reason string does not discriminate — it reads a `plannedWith` **snapshot**, so
  dragging the slider after a result cannot rewrite what ran.
* **Apply is not presented as reversible.** `APPLY_IS_ONE_WAY` matches `broll_ops.py:450` and is
  rendered **above** the Apply button.

## The blocking defect the fresh skeptic found — and it is the panel's own class

The panel said "the two PREREQUISITES". **There are three, and the omitted one is enforced FIRST:**
`broll_index.require_model()` at `broll_ops.py:403`, ahead of the transcript raise at `:408`. That
matcher is SigLIP-2 — `BACKBONE_SIZE_MB = 4540`, a **4.5 GB download**.

Worse than incomplete: the shipped sentence *"index your library above (a matcher must be loaded)"*
implies clicking **Index** loads it. It does not — `broll.index` reaches `RealBackboneBackend` with
**no `models_present` guard** (the graceful-degrade path lives in `vlm_backbone.analyze`, which the
b-roll path never calls). The copy pointed at a button instead of at the Assets tab that fixes it.

The panel had cited `Diarize.tsx:138` as its precedent for stating prerequisites up front — and
copied only line 138, leaving `:139` ("the models install on demand from the Assets tab") behind.
`Gaze.tsx:102`, the sibling from this same wave, carries the full form. Detector controlled: the
`Assets tab|install|download` probe returned **0 hits** here while firing on both siblings; it now
returns 8.

### Why no test caught it, and what now does
`BrollPanel.test.tsx:1018` asserts `textContent).toBe(BROLL_NEEDS_TRANSCRIPT)` — which proves the
panel *renders* the constant but **cannot detect a content change**, because both sides move
together. Rewriting the entire string left all 74 tests green. The third fact is now pinned by
CONTENT (`'Assets tab'`, `'4.5 GB'`, `'does NOT arrive by clicking'`), proven by both-states:

| state | result |
|---|---|
| fixed copy | 1 passed |
| reverted to the two-prerequisite version | **1 FAILED** (anchor verified to hit) |
| restored | 74 passed |

**One existing assertion was changed, deliberately, and it is a strengthening.**
`Workspace.seam.test.tsx` pinned `'transcribe THIS video first'` — wording that *was itself the
defect*, since transcribing is the third prerequisite and "first" locked in a false ordering. It
now pins `'transcribe THIS video'` **and** `'Assets tab'`, so the seam asserts strictly more.

## Verification

TDD RED watched first (`Failed to resolve import "./BrollPanel"`; Workspace reddened 4 focused
failures before wiring). Then implement → **3 refuters, all three REFUTED** (13 objections) →
remediation → fresh skeptic.

The lane fixed two defects in its own code with red-proofs: `addAsset` cleared the typed path on a
**refusal** (the busy wrapper swallows rejections, so a chained `.then()` ran on the error path),
and it **refuted its own CRLF-normalisation comment** by probe (ECMAScript treats `\r` as a
LineTerminator) rather than keeping the line with a false rationale.

`docs-check` was observed in **both states** — it went RED (r5=1) the moment the files became
tracked, on a real bare-citation violation, and green after. The earlier scoped run had passed for
the wrong reason, because that hook is `pass_filenames: false` and only scans tracked files.

Gates on the committed tree: `tsc --noEmit` 0 · `tsc -p tsconfig.e2e.json` 0 · full renderer
coverage **100%** (24559 statements / 8106 branches / 1435 functions) · `pre-commit run --all-files`
all 6 hooks pass · biome verified against the **stored LF blobs** with a both-states control ·
oxlint with a detector control.

Tab counts re-derived from source and updated in **both** pinned places: **20 → 21** total,
**15 → 16** painted. The count test now also asserts the groups are a **partition** of the strip.

## Residuals (disclosed, non-blocking)

* **UNVERIFIED:** nobody has run a first index on a machine with **no cached SigLIP-2**, so it is
  unknown whether that path raises cleanly or silently starts a 4.5 GB fetch. The disclosure does
  not depend on which. Settling experiment: clear the cache, click "Index library", observe.
* The two e2e count literals (`.tab` = 21, `.tab:visible` = 16) execute **only** in the nightly
  Playwright run — UNVERIFIED by execution here. The PR-gating pin in `Workspace.test.tsx` is what
  keeps the pair from going stale, and it is green with the same numbers derived independently.
* Nothing under `sidecar/` was touched — those files belong to the W22 lane. NOT-CHECKED by choice.

CI is the arbiter. This merges only if `quality` is green.
