### PR TITLE
docs(reframe): the reframe.* surface is six names now — and the new pair is not user-reachable

### DIFF
--- a/app/renderer/src/features/ReframeCorrect.tsx
+++ b/app/renderer/src/features/ReframeCorrect.tsx
@@ -15,11 +15,21 @@
 // CORRECTION 2026-08-10. The first version of this file said the corrections
 // cannot be applied because "the sidecar registers no reframe.render method …
 // reframe.render (or an override-persist method) has to be built sidecar-side
-// first". That named the WRONG BLOCKER and it is retracted here. The literal
-// half is still true — the registered reframe surface really is exactly four
-// methods (`sidecar/tests/test_handlers_rpc_surface.py:118-121`):
-//   reframe.applyOverrides · reframe.eval · reframe.shotPlan · reframe.shotPlanFor
-// — but the re-render path was never supposed to live in that namespace. It is
+// first". That named the WRONG BLOCKER and it is retracted here.
+//
+// SECOND CORRECTION, same day, AFTER W22 LANDED. The paragraph above used to add
+// that "the literal half is still true — the registered reframe surface really is
+// exactly four methods". That is now FALSE and is retracted in turn: W22 shipped
+// `reframe.analyze` and `reframe.render`, so the frozen surface
+// (`sidecar/tests/test_handlers_rpc_surface.py`) carries SIX names:
+//   reframe.analyze · reframe.applyOverrides · reframe.eval · reframe.render ·
+//   reframe.shotPlan · reframe.shotPlanFor
+// The old line-range citation (`:118-121`) moved with that change, which is why
+// this comment cites the file rather than a range — a pinned range is the part
+// most likely to rot silently.
+//
+// What has NOT changed is this file's actual point, and it still stands: the
+// re-render path THIS panel uses was never supposed to live in that namespace. It is
 // BUILT, and it lives in the export pipeline:
 //   * `MultiSpeakerReframeEngine.rerender_with_overrides` replays corrections
 //     onto the persisted plan without re-running the ML analysis;

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -1011,11 +1011,27 @@ export const client = {
    * rendered clip's persisted decision sidecar, and `applyOverrides` resolves a
    * user's per-shot edits and returns the `affected` shot indices.
    *
-   * SCOPE OF THIS NAMESPACE (measured 2026-08-09 against
-   * `sidecar/tests/test_handlers_rpc_surface.py:118-121`): the whole registered
-   * `reframe.*` surface is exactly FOUR names — `reframe.applyOverrides`,
-   * `reframe.eval`, `reframe.shotPlan`, `reframe.shotPlanFor`. Three are wrapped
-   * below; `reframe.eval` has no wrapper here. There is no `reframe.render`.
+   * SCOPE OF THIS NAMESPACE — re-measured 2026-08-10 against
+   * `sidecar/tests/test_handlers_rpc_surface.py` (the file, deliberately not a line
+   * range; the old citation said `:118-121` and that range MOVED, which is exactly how
+   * a pinned range rots without anyone noticing). The registered `reframe.*` surface is
+   * **SIX** names:
+   *   `reframe.analyze` · `reframe.applyOverrides` · `reframe.eval` ·
+   *   `reframe.render` · `reframe.shotPlan` · `reframe.shotPlanFor`
+   *
+   * SUPERSEDED 2026-08-10, recorded rather than deleted. This block previously read
+   * "exactly FOUR names … There is no `reframe.render`." That was true when written and
+   * is now FALSE: W22 shipped `reframe.analyze` (the trace producer) and
+   * `reframe.render` (affected-only re-render over a cached `ShotAnalysis`).
+   *
+   * IMPORTANT — the new pair is BACKEND-ONLY and has no wrapper here on purpose. W22
+   * was a sidecar lane; the renderer surface for it (WU-U1..U4) is a separate,
+   * unstarted wave. So `reframe.analyze` / `reframe.render` are registered and NOT
+   * user-reachable, which is the same shape as five defects this programme already
+   * fixed — stated here so the next reader does not infer from their presence in the
+   * frozen list that a UI can already reach them.
+   *
+   * Of the six, three are wrapped below; `reframe.eval` still has no wrapper.
    *
    * RETRACTION 2026-08-10. This comment used to infer from that list that
    * `affected` "cannot be handed to anything that re-encodes" and that a UI must


### PR DESCRIPTION
## Two comments that assert a wire surface which changed under them

Both were flagged by W22's fresh skeptic as a cross-lane hand-off it correctly declined
to fix itself (that lane was sidecar-only). Comment-level, so **no false statement ever
reached the UI** — but both sit in the files a reader consults to learn what the
`reframe.*` surface is.

| file | said | measured at `2a55879b` |
|---|---|---|
| `features/ReframeCorrect.tsx` | "the registered reframe surface really is exactly four methods" | **six** |
| `lib/rpc/client.ts` | "exactly FOUR names … There is no `reframe.render`" | **six**, and `reframe.render` exists |

W22 shipped `reframe.analyze` and `reframe.render`. Both statements were true when
written on 2026-08-09 and became false the moment that lane landed.

## The part that matters more than the count

A reader who sees the two new names in the frozen list could reasonably conclude a UI can
reach them. **It cannot.** W22 was sidecar-only and the renderer surface for it
(WU-U1..U4) is a separate, unstarted wave — so both are *registered and not
user-reachable*. That is the exact shape of five defects this programme has already
fixed, so the comment now states it outright rather than leaving the inference open.

## Two process points worth more than the diff

**Pinned line ranges rot silently.** Both files cited
`test_handlers_rpc_surface.py:118-121`. Adding two methods MOVED that range, so the
citation kept looking authoritative while pointing at the wrong lines. Both now cite the
file.

**Only one of the two was reported.** The skeptic flagged `ReframeCorrect.tsx`; I found
`client.ts` by sweeping. My first probe missed **both**, because the phrase wraps a line
(`exactly four\n// methods`) and I grepped for the whole phrase on one line. The
detector was controlled before I concluded anything — the file is 253 lines and greppable,
and a looser pattern found both immediately. That is the third unanchored-probe mistake I
have made today, and it is recorded in the commit rather than quietly fixed.

## Verification

Detector controlled **both directions**: the `exactly four|four names|four methods` probe
over `app/` returns 3 hits before and 3 after — same COUNT, different CONTENT. Two live
claims became two quotations inside their own retractions; the third
(`brollClient.conformance.test.ts:214`, about the b-roll engine owning four methods) is
unrelated and true. **Counting alone would have read as "no change".**

Both corrections are written as SUPERSEDED/RETRACTED stacked on the existing text, not as
edits — each surrounding block is itself a retraction of an earlier wrong claim, and
silently rewriting a retraction destroys the record of what was believed and why.

`npx tsc --noEmit` → 0 · `npx vitest run` → **246 files / 4799 tests passed** ·
`biome@2.5.0` → no fixes applied. Comment-only in both files; no executable line changed.

CI is the arbiter. This merges only if `quality` is green.
