### PR TITLE
fix(library): gate search/sort on content and scope the drop hint (W53, W54)

### DIFF
--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -1154,6 +1154,67 @@ describe('Library search + sort (v1.5 §4)', () => {
   });
 });
 
+// W53 + W54 — two claims the Library made that its own code does not back.
+describe('Library first-run honesty + control gating (W53/W54)', () => {
+  // W53. The ONLY drag-and-drop handlers in the entire renderer are the three on
+  // this view's ROOT div (views/Library.tsx:519-523); a repo-wide scan for
+  // `onDrop=`/`onDragOver=` under app/renderer/src returns exactly those two
+  // attribute lines and nothing else. So "drop video files anywhere here" stops
+  // being true the instant the user leaves the Library — the drop scope has to be
+  // named, not implied. Same shape as Edit.test.tsx's "does not promise editing
+  // verbs the app cannot deliver".
+  it('names the Library as the drop target instead of claiming files drop anywhere', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [] });
+    await renderLibrary();
+    const hint = container.querySelector('.library__empty-hint')?.textContent ?? '';
+    // Guard the guard: a missing element or empty copy would satisfy the absence
+    // check below for the wrong reason.
+    expect(hint.length).toBeGreaterThan(20);
+    expect(hint.toLowerCase()).not.toContain('anywhere');
+    // ...and it must still say WHERE a dropped file lands.
+    expect(hint.toLowerCase()).toContain('library');
+  });
+
+  // W54. Search and Sort were mounted unconditionally as a SIBLING of the
+  // `videos.length === 0` arm, so a first-run user got a live, enabled search box
+  // and sort select over zero rows. LibraryToolbar already gates its batch bar on
+  // `selectedCount > 0`; the filters now use the same gate on the video count.
+  it('does not offer search or sort over an empty library', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [] });
+    await renderLibrary();
+    // We really are in the first-run arm (not, say, the error arm).
+    expect(container.querySelector('.library__empty')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__search')).toBeNull();
+    expect(container.querySelector('.library-toolbar__sort-select')).toBeNull();
+  });
+
+  // Detector control for the two `toBeNull()` assertions above: prove these
+  // selectors DO find the controls when they are present, so their absence in the
+  // empty case is a real absence and not a typo'd selector.
+  it('offers search and sort as soon as the library has content', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo()] });
+    await renderLibrary();
+    expect(container.querySelector('.library-toolbar__search')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__sort-select')).not.toBeNull();
+  });
+
+  // The gate is the RAW library count, never the filtered/visible count. Gating on
+  // `visible.length` would delete the only control that can undo the filter the
+  // moment a query matched nothing, trapping the user in "No matches".
+  it('keeps search reachable when a query matches nothing', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [makeVideo({ id: 'a', title: 'Keynote' })] });
+    await renderLibrary();
+    const search = container.querySelector('.library-toolbar__search') as HTMLInputElement;
+    await act(async () => {
+      typeInto(search, 'zzz');
+    });
+    await flush();
+    expect(container.querySelector('.library__empty--filtered')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__search')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__sort-select')).not.toBeNull();
+  });
+});
+
 describe('Library multi-select + batch actions (v1.5 §4)', () => {
   it('selects cards and batch-removes them', async () => {
     rpcMock.mockResolvedValueOnce({

--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -1156,23 +1156,36 @@ describe('Library search + sort (v1.5 §4)', () => {
 
 // W53 + W54 — two claims the Library made that its own code does not back.
 describe('Library first-run honesty + control gating (W53/W54)', () => {
-  // W53. The ONLY drag-and-drop handlers in the entire renderer are the three on
-  // this view's ROOT div (views/Library.tsx:519-523); a repo-wide scan for
-  // `onDrop=`/`onDragOver=` under app/renderer/src returns exactly those two
-  // attribute lines and nothing else. So "drop video files anywhere here" stops
-  // being true the instant the user leaves the Library — the drop scope has to be
-  // named, not implied. Same shape as Edit.test.tsx's "does not promise editing
-  // verbs the app cannot deliver".
+  // The EXACT first-run hint. Pinned byte-for-byte on purpose — see below.
+  const EMPTY_HINT = 'Click “Add videos”, or drop video files onto the Library.';
+
+  // W53. The only React drag-and-drop HANDLERS in the renderer are the three on
+  // this view's ROOT div (views/Library.tsx:521-523), so the Library is the only
+  // surface that handles a dropped VIDEO; "drop video files anywhere here" stops
+  // being true the instant the user leaves it. Independently corroborated by the
+  // audit that raised W53: docs/plans/v1.5/uiux-qol-audit-2026-08.md:299 ("M6.
+  // Drag-and-drop works only on Library"). Same shape as Edit.test.tsx's "does not
+  // promise editing verbs the app cannot deliver".
   it('names the Library as the drop target instead of claiming files drop anywhere', async () => {
     rpcMock.mockResolvedValueOnce({ videos: [] });
     await renderLibrary();
-    const hint = container.querySelector('.library__empty-hint')?.textContent ?? '';
-    // Guard the guard: a missing element or empty copy would satisfy the absence
-    // check below for the wrong reason.
-    expect(hint.length).toBeGreaterThan(20);
+    const hint = container.querySelector('.library__empty-hint')?.textContent?.trim() ?? '';
+    // EXACT pin. The first version of this test asserted only `length > 20` +
+    // `not.toContain('anywhere')` + `toContain('library')`, and adversarial review
+    // REFUTED that as a keyword filter rather than a property check: it stayed
+    // green for at least six defect-preserving rewrites, including
+    // "...onto the Library, Edit or Export view." (names two surfaces with no drop
+    // handler), "...somewhere in the library", and deleting the drop clause
+    // outright. Exact equality kills every one of them.
+    expect(hint).toBe(EMPTY_HINT);
+    // The properties the exact string exists to satisfy, asserted separately so a
+    // future reword must keep them AND so the failure names which one broke.
     expect(hint.toLowerCase()).not.toContain('anywhere');
-    // ...and it must still say WHERE a dropped file lands.
     expect(hint.toLowerCase()).toContain('library');
+    // ...and it must not point at a view that cannot take a drop.
+    expect(hint.toLowerCase()).not.toMatch(
+      /\bedit\b|\bcaption\b|\bexport\b|\bshorts\b|\bworkspace\b|\bdeliver\b|\banywhere\b|\bany screen\b/,
+    );
   });
 
   // W54. Search and Sort were mounted unconditionally as a SIBLING of the
@@ -1214,17 +1227,58 @@ describe('Library first-run honesty + control gating (W53/W54)', () => {
     expect(container.querySelector('.library-toolbar__sort-select')).not.toBeNull();
   });
 
-  // A SECOND consequence of keying the gate on `videos.length`, pinned here so it
-  // is an intended behaviour rather than an incidental one: while the first
-  // `library.list` is still in flight the list is empty, so the toolbar is absent
-  // over the skeleton rows too. That is the point — there is nothing to search or
-  // sort yet either. The controls appear with the content.
-  it('shows no toolbar while the first listing is still in flight', async () => {
-    rpcMock.mockReturnValueOnce(new Promise(() => {})); // library.list never settles
+  // The W54 gate must NOT swallow the in-flight arm. `videos` is `[]` while the
+  // first `library.list` is outstanding, so gating on the raw count alone unmounted
+  // the whole strip over the skeleton rows and then mounted it when the data landed
+  // — pushing the entire list down by the toolbar's box at first paint. That
+  // contradicts the skeleton's own reason for existing ("the ghost rows
+  // (aria-hidden) hold the layout so it doesn't jump", Library.tsx below), and it is
+  // not a one-off: App.tsx's renderRoute() switch returns <Library> only on the
+  // library route, so the view unmounts on every tab switch and remounts with
+  // `videos` reset to [] — the shift would recur on every return to the Library.
+  //
+  // An earlier revision of this suite PINNED that unmount as intended ("shows no
+  // toolbar while the first listing is still in flight"); adversarial review refuted
+  // it as a first-paint layout-shift regression and this test deliberately replaces
+  // it. `loading` now holds the strip mounted.
+  it('keeps the toolbar mounted across the first listing so the list cannot shift', async () => {
+    let settle: (r: { videos: Video[] }) => void = () => {};
+    rpcMock.mockReturnValueOnce(
+      new Promise<{ videos: Video[] }>((resolve) => {
+        settle = resolve;
+      }),
+    );
     await act(async () => {
       root.render(<Library onOpen={() => {}} />);
     });
+    // In flight: skeleton rows AND an already-mounted strip holding its own box.
     expect(container.querySelector('.library__loading')).not.toBeNull();
+    const during = container.querySelector('.library-toolbar');
+    expect(during).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__search')).not.toBeNull();
+
+    await act(async () => {
+      settle({ videos: [makeVideo()] });
+    });
+    await flush();
+
+    // The listing landed...
+    expect(container.querySelector('.library__loading')).toBeNull();
+    expect(container.querySelector('.library__item-title')).not.toBeNull();
+    // ...and it is the SAME host node. Node identity is the property that matters:
+    // a strip that unmounted and remounted is what displaces the list, and a
+    // presence-only assertion cannot tell the two apart.
+    expect(container.querySelector('.library-toolbar')).toBe(during);
+  });
+
+  // ...but once the listing resolves EMPTY there is genuinely nothing to filter, so
+  // the strip goes (W54). This is the arm where hiding is correct, and it is the
+  // only one: `loading` is false and the count is really 0.
+  it('drops the toolbar once the listing resolves to an empty library', async () => {
+    rpcMock.mockResolvedValueOnce({ videos: [] });
+    await renderLibrary();
+    expect(container.querySelector('.library__loading')).toBeNull();
+    expect(container.querySelector('.library__empty')).not.toBeNull();
     expect(container.querySelector('.library-toolbar')).toBeNull();
   });
 });

--- a/app/renderer/src/views/Library.test.tsx
+++ b/app/renderer/src/views/Library.test.tsx
@@ -1213,6 +1213,20 @@ describe('Library first-run honesty + control gating (W53/W54)', () => {
     expect(container.querySelector('.library-toolbar__search')).not.toBeNull();
     expect(container.querySelector('.library-toolbar__sort-select')).not.toBeNull();
   });
+
+  // A SECOND consequence of keying the gate on `videos.length`, pinned here so it
+  // is an intended behaviour rather than an incidental one: while the first
+  // `library.list` is still in flight the list is empty, so the toolbar is absent
+  // over the skeleton rows too. That is the point — there is nothing to search or
+  // sort yet either. The controls appear with the content.
+  it('shows no toolbar while the first listing is still in flight', async () => {
+    rpcMock.mockReturnValueOnce(new Promise(() => {})); // library.list never settles
+    await act(async () => {
+      root.render(<Library onOpen={() => {}} />);
+    });
+    expect(container.querySelector('.library__loading')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar')).toBeNull();
+  });
 });
 
 describe('Library multi-select + batch actions (v1.5 §4)', () => {

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -556,13 +556,23 @@ export function Library({
           filtered count would remove the search box the moment a query matched
           nothing and trap the user in the "No matches" arm with no way to clear it
           (pinned by Library.test.tsx "keeps search reachable when a query matches
-          nothing"). */}
+          nothing").
+
+          `loading` rides along because the count alone is ambiguous: it is also 0
+          while the first `library.list` is in flight, and hiding the strip there
+          made it mount when the data landed, pushing the whole list down by the
+          strip's box — the opposite of what the skeleton below exists to do. This
+          view remounts on every tab switch (App.tsx renderRoute()), so that was a
+          shift on every return, not just a first-run one. Pinned by
+          Library.test.tsx "keeps the toolbar mounted across the first listing so
+          the list cannot shift". */}
       <LibraryToolbar
         query={query}
         onQueryChange={setQuery}
         sort={sortMode}
         onSortChange={setSortMode}
         videoCount={videos.length}
+        loading={loading}
         selectedCount={selected.size}
         onRemoveSelected={() => void removeSelected()}
         onClearSelection={clearSelection}
@@ -643,13 +653,39 @@ export function Library({
             </div>
             <p className="library__empty-title">No videos yet</p>
             {/* W53 — this used to read "drop video files anywhere here". "anywhere"
-                is wider than the app: the ONLY drag-and-drop handlers in the whole
-                renderer are the three on this view's root div (:519-523 above), so
-                a user who reads "anywhere" and then drops onto Edit, Caption or
-                Export gets nothing — the browser navigates away or ignores it. The
-                copy now names the surface that actually accepts the drop. Pinned by
-                Library.test.tsx. If an app-level drop target ever lands, widen this
-                sentence in the SAME commit that ships it. */}
+                is wider than the app: this view's root div carries the only React
+                drag-and-drop HANDLERS in the renderer (:521-523 above), so it is
+                the only surface that HANDLES a dropped video, and the copy now
+                names it.
+
+                Two earlier versions of this comment were refuted and are corrected
+                here rather than deleted, so the next reader inherits the scope and
+                not the overclaim:
+                  * "the ONLY drop target in the whole renderer" was wider than the
+                    grep behind it. `onDrop=`/`onDragOver=` cannot see a NATIVE drop
+                    target, and there is one: features/Subtitles.tsx:348 renders
+                    <input type="file" accept=".srt,.vtt,.ass,.ssa"> (:48), which
+                    Chromium treats as a drop target. It cannot take a video (that
+                    `accept` filters it out), so the operative conclusion holds — but
+                    "only React DnD handlers" is the claim the evidence supports.
+                  * "the browser navigates away or ignores it" asserted a runtime
+                    behaviour nobody ran. What IS grounded: no view outside the
+                    Library registers a drop handler, so nothing in the app reacts;
+                    and main.ts:1111-1117 preventDefault()s any navigation failing
+                    isAllowedNavigation, which for a packaged `file:` app pins the
+                    target to the app's own bundle pathname and so denies any
+                    sibling `file:` document (security.ts:32-35) — a dropped
+                    clip.mp4 included. UNVERIFIED: whether a drop onto a
+                    handler-less view even reaches `will-navigate` in Electron, and
+                    what the user actually sees; no drop was executed outside the
+                    Library. Settling experiment: an e2e that drags a file onto
+                    Edit/Caption/Export and asserts no `library.add` RPC, no route
+                    change, and no window navigation.
+                Independent corroboration of the drop scope, from the audit that
+                raised W53: docs/plans/v1.5/uiux-qol-audit-2026-08.md:299 ("M6.
+                Drag-and-drop works only on Library"). Pinned by Library.test.tsx.
+                If an app-level drop target ever lands, widen this sentence in the
+                SAME commit that ships it. */}
             <p className="library__empty-hint">
               Click “Add videos”, or drop video files onto the Library.
             </p>

--- a/app/renderer/src/views/Library.tsx
+++ b/app/renderer/src/views/Library.tsx
@@ -549,11 +549,20 @@ export function Library({
           separate from the visible card count). */}
       <CapabilitiesChip onAction={onReadinessAction} />
 
+      {/* W54: `videos.length` — the RAW count — gates the search + sort controls,
+          which used to mount unconditionally as a sibling of the
+          `videos.length === 0` arm below and so offered a live, enabled search box
+          over a first-run library of zero rows. NOT `visible.length`: gating on the
+          filtered count would remove the search box the moment a query matched
+          nothing and trap the user in the "No matches" arm with no way to clear it
+          (pinned by Library.test.tsx "keeps search reachable when a query matches
+          nothing"). */}
       <LibraryToolbar
         query={query}
         onQueryChange={setQuery}
         sort={sortMode}
         onSortChange={setSortMode}
+        videoCount={videos.length}
         selectedCount={selected.size}
         onRemoveSelected={() => void removeSelected()}
         onClearSelection={clearSelection}
@@ -633,8 +642,16 @@ export function Library({
               <span className="library__empty-timecode">--:--</span>
             </div>
             <p className="library__empty-title">No videos yet</p>
+            {/* W53 — this used to read "drop video files anywhere here". "anywhere"
+                is wider than the app: the ONLY drag-and-drop handlers in the whole
+                renderer are the three on this view's root div (:519-523 above), so
+                a user who reads "anywhere" and then drops onto Edit, Caption or
+                Export gets nothing — the browser navigates away or ignores it. The
+                copy now names the surface that actually accepts the drop. Pinned by
+                Library.test.tsx. If an app-level drop target ever lands, widen this
+                sentence in the SAME commit that ships it. */}
             <p className="library__empty-hint">
-              Click “Add videos” or drop video files anywhere here.
+              Click “Add videos”, or drop video files onto the Library.
             </p>
           </div>
         )

--- a/app/renderer/src/views/LibraryToolbar.test.tsx
+++ b/app/renderer/src/views/LibraryToolbar.test.tsx
@@ -26,6 +26,7 @@ interface Over {
   sort?: LibrarySort;
   onSortChange?: (s: LibrarySort) => void;
   videoCount?: number;
+  loading?: boolean;
   selectedCount?: number;
   onRemoveSelected?: () => void;
   onClearSelection?: () => void;
@@ -44,6 +45,9 @@ function renderToolbar(over: Over = {}): void {
         // one is about the controls' behaviour, which presupposes content). The
         // empty-library cases pass 0 explicitly.
         videoCount={over.videoCount ?? 2}
+        // Settled-listing default: `loading` false, so the video count alone
+        // decides. The in-flight cases pass true explicitly.
+        loading={over.loading ?? false}
         selectedCount={over.selectedCount ?? 0}
         onRemoveSelected={over.onRemoveSelected ?? (() => {})}
         onClearSelection={over.onClearSelection ?? (() => {})}
@@ -135,7 +139,46 @@ describe('LibraryToolbar', () => {
     expect(container.querySelector('.library-toolbar')).toBeNull();
   });
 
-  it('still shows the batch bar when a selection exists with the filters hidden', () => {
+  // `loading` is the SECOND half of the filter gate. A count of 0 with the listing
+  // still outstanding is "unknown", not "empty": unmounting there and remounting on
+  // arrival displaces the whole list at first paint (Library.test.tsx "keeps the
+  // toolbar mounted across the first listing so the list cannot shift"). The
+  // controls stay ENABLED rather than `disabled`, deliberately — library-shell.css
+  // sets an author background+colour on both and defines no `:disabled` rule for
+  // them (its only one is .capabilities-chip__toggle:disabled, :44-47), so a
+  // disabled search box would look identical to a live one, which is the
+  // looks-live-but-is-dead defect the audit's §4.3 complains about. Typing during
+  // the in-flight window is also not dead: `query` is retained and applies to the
+  // list the moment it lands.
+  it('keeps search + sort mounted over zero rows while the listing is in flight', () => {
+    renderToolbar({ videoCount: 0, loading: true });
+    expect(container.querySelector('.library-toolbar')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__filters')).not.toBeNull();
+    const search = container.querySelector('.library-toolbar__search') as HTMLInputElement;
+    const sort = container.querySelector('.library-toolbar__sort-select') as HTMLSelectElement;
+    expect(search.disabled).toBe(false);
+    expect(sort.disabled).toBe(false);
+  });
+
+  // DEFENSIVE ARM, not a live guarantee. Adversarial review REFUTED the earlier
+  // framing of this case ("still shows the batch bar when a selection exists with
+  // the filters hidden") as a user-facing behaviour: `videos.length === 0 &&
+  // selected.size > 0` is UNREACHABLE from the sole caller. Every writer of
+  // `videos` keeps the selection in step — batch remove empties the selection
+  // BEFORE its first RPC (Library.tsx:419-420), single remove prunes the id via
+  // `unselect` (:391, defined :360-367), and the only wholesale replacement,
+  // `refresh` (:221-232), is a `useCallback(…, [])` fired once from
+  // `useEffect(…, [refresh])` (:234-236), so no re-list can strand a stale
+  // selection over an emptied library. Kept because the guard is cheap and a
+  // caller that DID reach it should still get its batch bar; asserted here so the
+  // `showBatch` disjunct in that guard is exercised at all.
+  //
+  // Residual, disclosed rather than fixed: in this state the pill sits hard-LEFT.
+  // `.library-toolbar__filters` (flex: 1, library-shell.css:95-101) is the only
+  // thing pushing `.library-toolbar__batch` (inline-flex, no margin-left: auto,
+  // :147-156) to the right. Unreachable in the app, and the one-line fix lives in
+  // a stylesheet shared with concurrently-live lanes, so it is named, not taken.
+  it('still renders the batch bar with the filters hidden (defensive, unreachable arm)', () => {
     renderToolbar({ videoCount: 0, selectedCount: 2 });
     expect(container.querySelector('.library-toolbar')).not.toBeNull();
     expect(container.querySelector('.library-toolbar__batch-count')?.textContent).toBe(

--- a/app/renderer/src/views/LibraryToolbar.test.tsx
+++ b/app/renderer/src/views/LibraryToolbar.test.tsx
@@ -25,6 +25,7 @@ interface Over {
   onQueryChange?: (q: string) => void;
   sort?: LibrarySort;
   onSortChange?: (s: LibrarySort) => void;
+  videoCount?: number;
   selectedCount?: number;
   onRemoveSelected?: () => void;
   onClearSelection?: () => void;
@@ -38,6 +39,11 @@ function renderToolbar(over: Over = {}): void {
         onQueryChange={over.onQueryChange ?? (() => {})}
         sort={over.sort ?? 'recent'}
         onSortChange={over.onSortChange ?? (() => {})}
+        // W54: the filters only exist over a NON-empty library, so a populated
+        // library is the default state for every pre-existing case below (each
+        // one is about the controls' behaviour, which presupposes content). The
+        // empty-library cases pass 0 explicitly.
+        videoCount={over.videoCount ?? 2}
         selectedCount={over.selectedCount ?? 0}
         onRemoveSelected={over.onRemoveSelected ?? (() => {})}
         onClearSelection={over.onClearSelection ?? (() => {})}
@@ -109,5 +115,32 @@ describe('LibraryToolbar', () => {
       );
     });
     expect(onClearSelection).toHaveBeenCalledTimes(1);
+  });
+
+  // W54 — search + sort were the one part of this toolbar that rendered
+  // unconditionally: on an empty library the user got an enabled search box and
+  // sort select over zero rows. They now ride the SAME gate the batch bar above
+  // already used, just keyed on the video count instead of the selection count.
+  it('hides search + sort when there is nothing to filter', () => {
+    renderToolbar({ videoCount: 0 });
+    expect(container.querySelector('.library-toolbar__search')).toBeNull();
+    expect(container.querySelector('.library-toolbar__sort-select')).toBeNull();
+    expect(container.querySelector('.library-toolbar__filters')).toBeNull();
+  });
+
+  it('renders no toolbar strip at all when there is neither content nor a selection', () => {
+    renderToolbar({ videoCount: 0, selectedCount: 0 });
+    // Keeping the wrapper would leave an empty padded strip above the first-run
+    // poster (.library-toolbar carries its own padding in library-shell.css).
+    expect(container.querySelector('.library-toolbar')).toBeNull();
+  });
+
+  it('still shows the batch bar when a selection exists with the filters hidden', () => {
+    renderToolbar({ videoCount: 0, selectedCount: 2 });
+    expect(container.querySelector('.library-toolbar')).not.toBeNull();
+    expect(container.querySelector('.library-toolbar__batch-count')?.textContent).toBe(
+      '2 selected',
+    );
+    expect(container.querySelector('.library-toolbar__filters')).toBeNull();
   });
 });

--- a/app/renderer/src/views/LibraryToolbar.tsx
+++ b/app/renderer/src/views/LibraryToolbar.tsx
@@ -15,7 +15,7 @@ export interface LibraryToolbarProps {
   onSortChange: (sort: LibrarySort) => void;
   /**
    * Number of videos in the library BEFORE `query`/`sort` are applied (0 hides
-   * the search + sort controls).
+   * the search + sort controls unless `loading`).
    *
    * W54: this is deliberately the RAW count, not the filtered/visible one. Gating
    * on the visible count would remove the search box the moment a query matched
@@ -23,6 +23,11 @@ export interface LibraryToolbarProps {
    * the user in the "No matches" state.
    */
   videoCount: number;
+  /**
+   * True while the owning listing RPC is outstanding. A count of 0 then means
+   * "unknown", not "empty", so the controls stay mounted: see the gate below.
+   */
+  loading: boolean;
   /** Number of currently-selected cards (0 hides the batch bar). */
   selectedCount: number;
   onRemoveSelected: () => void;
@@ -35,6 +40,7 @@ export function LibraryToolbar({
   sort,
   onSortChange,
   videoCount,
+  loading,
   selectedCount,
   onRemoveSelected,
   onClearSelection,
@@ -43,11 +49,23 @@ export function LibraryToolbar({
   // offered a live, enabled search box and sort select over zero rows — a promise
   // of scale affordances with nothing to apply them to. They now ride the SAME
   // gate the batch bar below already used, keyed on the video count.
-  const showFilters = videoCount > 0;
+  //
+  // `|| loading` is load-bearing, not defensive. The first version of this gate was
+  // `videoCount > 0` alone, which ALSO unmounted the strip while the owning
+  // `library.list` was in flight (the count is 0 then) and remounted it on arrival
+  // — displacing the entire list by this strip's box at first paint, and again on
+  // every remount of the view. Adversarial review refuted that as a regression; a
+  // count of 0 with the listing outstanding is "unknown", not "empty".
+  const showFilters = videoCount > 0 || loading;
   const showBatch = selectedCount > 0;
   // Nothing to show -> no strip. `.library-toolbar` carries its own padding
   // (components/library-shell.css), so keeping an empty wrapper would leave a
   // blank band between the capabilities chip and the first-run poster.
+  //
+  // `showBatch` here is a DEFENSIVE disjunct, not a reachable app state: a
+  // selection cannot outlive its videos in the sole caller (Library.tsx:391,
+  // :419-420, :221-236 — see LibraryToolbar.test.tsx for the trace). It is kept so
+  // a future caller that does reach it still gets its batch bar.
   if (!showFilters && !showBatch) return null;
 
   return (

--- a/app/renderer/src/views/LibraryToolbar.tsx
+++ b/app/renderer/src/views/LibraryToolbar.tsx
@@ -13,6 +13,16 @@ export interface LibraryToolbarProps {
   onQueryChange: (query: string) => void;
   sort: LibrarySort;
   onSortChange: (sort: LibrarySort) => void;
+  /**
+   * Number of videos in the library BEFORE `query`/`sort` are applied (0 hides
+   * the search + sort controls).
+   *
+   * W54: this is deliberately the RAW count, not the filtered/visible one. Gating
+   * on the visible count would remove the search box the moment a query matched
+   * nothing — i.e. delete the only control that can undo the filter — and strand
+   * the user in the "No matches" state.
+   */
+  videoCount: number;
   /** Number of currently-selected cards (0 hides the batch bar). */
   selectedCount: number;
   onRemoveSelected: () => void;
@@ -24,39 +34,53 @@ export function LibraryToolbar({
   onQueryChange,
   sort,
   onSortChange,
+  videoCount,
   selectedCount,
   onRemoveSelected,
   onClearSelection,
-}: LibraryToolbarProps): React.ReactElement {
+}: LibraryToolbarProps): React.ReactElement | null {
+  // W54: search + sort used to mount unconditionally, so a first-run library
+  // offered a live, enabled search box and sort select over zero rows — a promise
+  // of scale affordances with nothing to apply them to. They now ride the SAME
+  // gate the batch bar below already used, keyed on the video count.
+  const showFilters = videoCount > 0;
+  const showBatch = selectedCount > 0;
+  // Nothing to show -> no strip. `.library-toolbar` carries its own padding
+  // (components/library-shell.css), so keeping an empty wrapper would leave a
+  // blank band between the capabilities chip and the first-run poster.
+  if (!showFilters && !showBatch) return null;
+
   return (
     <div className="library-toolbar">
-      <div className="library-toolbar__filters">
-        <input
-          type="search"
-          className="library-toolbar__search"
-          placeholder="Search videos"
-          aria-label="Search videos"
-          value={query}
-          onChange={(event) => onQueryChange(event.target.value)}
-        />
-        <label className="library-toolbar__sort">
-          <span className="library-toolbar__sort-label">Sort</span>
-          <select
-            className="library-toolbar__sort-select"
-            aria-label="Sort videos"
-            value={sort}
-            onChange={(event) => onSortChange(event.target.value as LibrarySort)}
-          >
-            {LIBRARY_SORT_MODES.map((mode) => (
-              <option key={mode} value={mode}>
-                {LIBRARY_SORT_LABELS[mode]}
-              </option>
-            ))}
-          </select>
-        </label>
-      </div>
+      {showFilters ? (
+        <div className="library-toolbar__filters">
+          <input
+            type="search"
+            className="library-toolbar__search"
+            placeholder="Search videos"
+            aria-label="Search videos"
+            value={query}
+            onChange={(event) => onQueryChange(event.target.value)}
+          />
+          <label className="library-toolbar__sort">
+            <span className="library-toolbar__sort-label">Sort</span>
+            <select
+              className="library-toolbar__sort-select"
+              aria-label="Sort videos"
+              value={sort}
+              onChange={(event) => onSortChange(event.target.value as LibrarySort)}
+            >
+              {LIBRARY_SORT_MODES.map((mode) => (
+                <option key={mode} value={mode}>
+                  {LIBRARY_SORT_LABELS[mode]}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+      ) : null}
 
-      {selectedCount > 0 ? (
+      {showBatch ? (
         <div className="library-toolbar__batch" role="group" aria-label="Batch actions">
           <span className="library-toolbar__batch-count" aria-live="polite">
             {selectedCount} selected


### PR DESCRIPTION
Two Library affordance defects from the v1.5 UI/UX audit (W53, W54), plus four claim corrections.

## What changed

**W54 — search + sort were offered over an empty library.** They mounted unconditionally as a
sibling of the `videos.length === 0` arm, so a first-run library presented a live, enabled search
box and sort select with nothing to search. They now ride the same count gate the batch bar
already used.

Two details that are load-bearing rather than defensive:

* The gate keys on the **raw** `videos.length`, not the filtered `visible.length`. Gating on the
  visible count would remove the search box the moment a query matched nothing — deleting the only
  control that can undo the filter and stranding the user in the "No matches" arm.
* `|| loading` is required. The first version gated on `videoCount > 0` alone, which also unmounted
  the strip while the first `library.list` was in flight (the count is 0 then) and remounted it on
  arrival, displacing the list by the strip's box at first paint. Since this view remounts on every
  tab switch (`App.tsx renderRoute()`), that was a shift on every return, not just on first run.
  Adversarial review refuted the first version as a regression; a count of 0 with the listing
  outstanding means "unknown", not "empty".

**W53 — the empty-state hint overstated the drop surface.** It read "drop video files anywhere
here"; "anywhere" is wider than the app. It now names the Library.

## Claim corrections carried in the diff

The comments record two **refuted** earlier versions rather than deleting them:

* "the ONLY drop target in the whole renderer" was wider than the grep behind it —
  `features/Subtitles.tsx:348` renders an `<input type="file">` that Chromium treats as a drop
  target. It cannot accept a video (its `accept` filters it out), so the operative conclusion
  holds, but "only React DnD handlers" is what the evidence supports.
* "the browser navigates away or ignores it" asserted a runtime behaviour nobody ran. Left inline
  as UNVERIFIED with its settling experiment named (an e2e that drops onto Edit/Caption/Export and
  asserts no `library.add`, no route change, no navigation).

## Verification

* Both behaviours pinned by tests: `Library.test.tsx` ("keeps search reachable when a query matches
  nothing", "keeps the toolbar mounted across the first listing so the list cannot shift") and
  `LibraryToolbar.test.tsx`.
* `LibraryToolbar` now returns `null` when neither the filters nor the batch bar apply, because
  `.library-toolbar` carries its own padding and an empty wrapper would leave a blank band.
* The `showBatch` disjunct in that early return is documented as defensive and unreachable in the
  sole caller, with the trace cited.

Coverage and the rest of gate 3 are enforced by `quality` on this PR.
