### PR TITLE
feat(wiring): reach tracks.audio.mux/replace/strip from the Dub panel (W62)

### DIFF
--- a/app/renderer/src/features/Dub.test.tsx
+++ b/app/renderer/src/features/Dub.test.tsx
@@ -12,10 +12,13 @@ import { createRoot, type Root } from 'react-dom/client';
 import Dub, {
   CONSENT_ATTESTATION_TEXT,
   ENGINES,
+  IMPORTED_AUDIO_TRACK_KIND,
   type AudioTrack,
   type TtsVoice,
   buildDubParams,
   buildSampleAddParams,
+  canEditAudioTrack,
+  canImportAudioTrack,
   dubMediaUrl,
   voicesForEngine,
 } from './Dub';
@@ -160,6 +163,44 @@ describe('CONSENT_ATTESTATION_TEXT', () => {
     expect(CONSENT_ATTESTATION_TEXT).toBe(
       "I own this voice or have the speaker's documented permission to clone it.",
     );
+  });
+});
+
+// W62 — the audio-track EDIT gate. `tracks.audio.replace` / `.strip` are offered
+// only for a dub, because their ORIGINAL branch re-muxes the whole container into
+// a derived file that is returned but never written back to the project
+// (`sidecar/media_studio/features/tracks_audio.py:533-554` / `:578-588`), so the
+// app would keep resolving the untouched source while the manifest row vanished.
+describe('canEditAudioTrack', () => {
+  it('permits a dub and refuses the source recording', () => {
+    expect(canEditAudioTrack({ kind: 'dub' })).toBe(true);
+    expect(canEditAudioTrack({ kind: 'original' })).toBe(false);
+  });
+});
+
+describe('canImportAudioTrack', () => {
+  it('requires all three fields tracks.audio.mux declares required', () => {
+    expect(canImportAudioTrack({ path: 'C:/vo.wav', lang: 'en', name: 'VO' })).toBe(true);
+    // Each of the three is independently blocking — `mux` _require_str's all of
+    // them (`sidecar/media_studio/features/tracks_audio.py:494-497`), so a blank
+    // one must never reach the wire as an INVALID_PARAMS round-trip.
+    expect(canImportAudioTrack({ path: '', lang: 'en', name: 'VO' })).toBe(false);
+    expect(canImportAudioTrack({ path: 'C:/vo.wav', lang: '', name: 'VO' })).toBe(false);
+    expect(canImportAudioTrack({ path: 'C:/vo.wav', lang: 'en', name: '' })).toBe(false);
+    // Whitespace-only is blank.
+    expect(canImportAudioTrack({ path: '  ', lang: ' en ', name: ' VO ' })).toBe(false);
+    expect(canImportAudioTrack({ path: 'C:/vo.wav', lang: '   ', name: 'VO' })).toBe(false);
+    expect(canImportAudioTrack({ path: 'C:/vo.wav', lang: 'en', name: '   ' })).toBe(false);
+  });
+});
+
+describe('IMPORTED_AUDIO_TRACK_KIND', () => {
+  it('is "dub" — an imported track is never registered as the original', () => {
+    // The AI-disclosure badge is withheld ONLY for kind "original"
+    // (AiDisclosure.isAiGeneratedAudioTrack), so letting a user pick the kind
+    // would let them suppress the label. Over-labelling an imported human
+    // recording is the disclosed, recoverable direction (AiDisclosure.tsx:45-58).
+    expect(IMPORTED_AUDIO_TRACK_KIND).toBe('dub');
   });
 });
 
@@ -945,5 +986,215 @@ describe('<Dub />', () => {
     expect(options).not.toContain('a1');
     // Exactly one tracks.audio.list on mount — the child reuses Dub's list.
     expect(calls.filter((c) => c.method === 'tracks.audio.list')).toHaveLength(1);
+  });
+
+  // ------------------------------------------------------------------------
+  // W62 — `tracks.audio.mux` / `.replace` / `.strip` were registered sidecar-side
+  // and wrapped in the typed client but had NO caller anywhere in the renderer,
+  // so the Audio-tracks list was read-only display. These tests pin the three
+  // user actions that make them reachable.
+  // ------------------------------------------------------------------------
+  const rowFor = (id: string): HTMLElement =>
+    container.querySelector(`li[data-audio-track="${id}"]`) as HTMLElement;
+  const rowBtn = (id: string, action: string): HTMLButtonElement =>
+    rowFor(id).querySelector(`[data-action="${action}"]`) as HTMLButtonElement;
+
+  it('offers Remove + Replace on a dub row and neither on the source recording', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    // AUDIO_TRACKS = [a1 kind:'original', a2 kind:'dub'].
+    expect(rowBtn('a2', 'strip-audio')).not.toBeNull();
+    expect(rowBtn('a2', 'replace-audio')).not.toBeNull();
+    expect(rowFor('a1').querySelector('[data-action="strip-audio"]')).toBeNull();
+    expect(rowFor('a1').querySelector('[data-action="replace-audio"]')).toBeNull();
+    // The original row says WHY instead of silently omitting the controls.
+    expect(rowFor('a1').textContent).toContain('Source audio');
+  });
+
+  it('removes a dub track via tracks.audio.strip and re-reads the list', async () => {
+    const { api, calls } = makeBridge({ 'tracks.audio.strip': { path: 'C:/v.mkv' } });
+    await mount(api);
+    await act(async () => rowBtn('a2', 'strip-audio').click());
+    await flush();
+    expect(calls.filter((c) => c.method === 'tracks.audio.strip')).toEqual([
+      { method: 'tracks.audio.strip', params: { videoId: 'v1', audioTrackId: 'a2' } },
+    ]);
+    // The list is re-read so the removed row disappears (mount + post-op refresh).
+    expect(calls.filter((c) => c.method === 'tracks.audio.list')).toHaveLength(2);
+    expect(container.querySelector('.audio-track-message')?.textContent).toContain('Removed');
+  });
+
+  it('surfaces a failed strip and does NOT re-read the list', async () => {
+    const { api, calls } = makeBridge();
+    (api.rpc as ReturnType<typeof vi.fn>).mockImplementation(
+      async (method: string, params?: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === 'tracks.audio.strip') throw new Error('ffmpeg exit 1');
+        if (method === 'tts.voices') return { voices: VOICES };
+        if (method === 'tracks.list') return { tracks: [] };
+        if (method === 'tracks.audio.list') return { audioTracks: AUDIO_TRACKS };
+        return {};
+      },
+    );
+    await mount(api);
+    await act(async () => rowBtn('a2', 'strip-audio').click());
+    await flush();
+    expect(container.querySelector('.audio-track-message')?.textContent).toContain('ffmpeg exit 1');
+    expect(calls.filter((c) => c.method === 'tracks.audio.list')).toHaveLength(1);
+  });
+
+  it('replaces a dub track audio via tracks.audio.replace and closes the editor', async () => {
+    const { api, calls } = makeBridge({
+      'tracks.audio.replace': { audioTrack: AUDIO_TRACKS[1] },
+    });
+    await mount(api);
+    // The editor is closed until the disclosure is opened.
+    expect(rowFor('a2').querySelector('[data-input="replace-audio-path"]')).toBeNull();
+    await act(async () => rowBtn('a2', 'replace-audio').click());
+    expect(rowFor('a2').querySelector('[data-input="replace-audio-path"]')).not.toBeNull();
+    // Save is gated on a non-blank path.
+    expect(rowBtn('a2', 'replace-audio-save').disabled).toBe(true);
+    pick('[data-input="replace-audio-path"]', '  C:/better-dub.wav  ');
+    expect(rowBtn('a2', 'replace-audio-save').disabled).toBe(false);
+    await act(async () => rowBtn('a2', 'replace-audio-save').click());
+    await flush();
+    expect(calls.filter((c) => c.method === 'tracks.audio.replace')).toEqual([
+      {
+        method: 'tracks.audio.replace',
+        params: { videoId: 'v1', audioTrackId: 'a2', path: 'C:/better-dub.wav' },
+      },
+    ]);
+    // Success closes the editor and clears the field.
+    expect(rowFor('a2').querySelector('[data-input="replace-audio-path"]')).toBeNull();
+  });
+
+  it('keeps the replace editor open with the typed path when the replace fails', async () => {
+    const { api, calls } = makeBridge();
+    (api.rpc as ReturnType<typeof vi.fn>).mockImplementation(
+      async (method: string, params?: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === 'tracks.audio.replace') throw new Error('audio file not found');
+        if (method === 'tts.voices') return { voices: VOICES };
+        if (method === 'tracks.list') return { tracks: [] };
+        if (method === 'tracks.audio.list') return { audioTracks: AUDIO_TRACKS };
+        return {};
+      },
+    );
+    await mount(api);
+    await act(async () => rowBtn('a2', 'replace-audio').click());
+    pick('[data-input="replace-audio-path"]', 'C:/missing.wav');
+    await act(async () => rowBtn('a2', 'replace-audio-save').click());
+    await flush();
+    expect(container.querySelector('.audio-track-message')?.textContent).toContain(
+      'audio file not found',
+    );
+    const input = rowFor('a2').querySelector(
+      '[data-input="replace-audio-path"]',
+    ) as HTMLInputElement;
+    expect(input).not.toBeNull();
+    expect(input.value).toBe('C:/missing.wav');
+  });
+
+  it('closes the replace editor when the disclosure is toggled off', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    await act(async () => rowBtn('a2', 'replace-audio').click());
+    expect(rowFor('a2').querySelector('[data-input="replace-audio-path"]')).not.toBeNull();
+    await act(async () => rowBtn('a2', 'replace-audio').click());
+    expect(rowFor('a2').querySelector('[data-input="replace-audio-path"]')).toBeNull();
+  });
+
+  it('imports an audio file as a dub track via tracks.audio.mux', async () => {
+    const { api, calls } = makeBridge({
+      'tracks.audio.mux': { audioTrack: AUDIO_TRACKS[1] },
+    });
+    await mount(api);
+    const importBtn = () =>
+      container.querySelector('[data-action="import-audio"]') as HTMLButtonElement;
+    // Gated until ALL THREE required params are present (mux _require_str's each).
+    expect(importBtn().disabled).toBe(true);
+    pick('[data-input="import-audio-path"]', '  C:/my-vo.wav  ');
+    expect(importBtn().disabled).toBe(true);
+    pick('[data-input="import-audio-lang"]', ' ro ');
+    expect(importBtn().disabled).toBe(true);
+    pick('[data-input="import-audio-name"]', ' My voiceover ');
+    expect(importBtn().disabled).toBe(false);
+
+    await act(async () => importBtn().click());
+    await flush();
+    expect(calls.filter((c) => c.method === 'tracks.audio.mux')).toEqual([
+      {
+        method: 'tracks.audio.mux',
+        params: {
+          videoId: 'v1',
+          path: 'C:/my-vo.wav',
+          lang: 'ro',
+          name: 'My voiceover',
+          // NEVER 'original': that would suppress the AI-generated badge.
+          kind: 'dub',
+        },
+      },
+    ]);
+    // A successful import clears the row and re-reads the list.
+    expect(
+      (container.querySelector('[data-input="import-audio-path"]') as HTMLInputElement).value,
+    ).toBe('');
+    expect(calls.filter((c) => c.method === 'tracks.audio.list')).toHaveLength(2);
+  });
+
+  it('keeps the import fields on failure and surfaces a non-Error rejection', async () => {
+    const { api, calls } = makeBridge();
+    (api.rpc as ReturnType<typeof vi.fn>).mockImplementation(
+      async (method: string, params?: Record<string, unknown>) => {
+        calls.push({ method, params });
+        if (method === 'tracks.audio.mux') throw 'plain mux error';
+        if (method === 'tts.voices') return { voices: VOICES };
+        if (method === 'tracks.list') return { tracks: [] };
+        if (method === 'tracks.audio.list') return { audioTracks: AUDIO_TRACKS };
+        return {};
+      },
+    );
+    await mount(api);
+    pick('[data-input="import-audio-path"]', 'C:/my-vo.wav');
+    pick('[data-input="import-audio-lang"]', 'ro');
+    pick('[data-input="import-audio-name"]', 'My voiceover');
+    await act(async () => {
+      (container.querySelector('[data-action="import-audio"]') as HTMLButtonElement).click();
+      await Promise.resolve();
+    });
+    await flush();
+    expect(container.querySelector('.audio-track-message')?.textContent).toContain(
+      'plain mux error',
+    );
+    expect(
+      (container.querySelector('[data-input="import-audio-path"]') as HTMLInputElement).value,
+    ).toBe('C:/my-vo.wav');
+  });
+
+  it('locks every audio-track control while a dub job is running', async () => {
+    const { api } = makeBridge();
+    await mount(api);
+    // Open the replace editor and fill it BEFORE the job starts, so the Save
+    // button's only remaining reason to be disabled is the job itself.
+    await act(async () => rowBtn('a2', 'replace-audio').click());
+    pick('[data-input="replace-audio-path"]', 'C:/other.wav');
+    expect(rowBtn('a2', 'replace-audio-save').disabled).toBe(false);
+
+    pick('[data-picker="track"]', 't1');
+    await act(async () => {
+      (container.querySelector('[data-action="start-dub"]') as HTMLButtonElement).click();
+    });
+    await flush();
+    expect(rowBtn('a2', 'strip-audio').disabled).toBe(true);
+    expect(rowBtn('a2', 'replace-audio').disabled).toBe(true);
+    // A concurrent replace would race the dub job's own track append, so Save is
+    // locked too even though its path is valid.
+    expect(rowBtn('a2', 'replace-audio-save').disabled).toBe(true);
+    expect(
+      (container.querySelector('[data-input="replace-audio-path"]') as HTMLInputElement).disabled,
+    ).toBe(true);
+    expect(
+      (container.querySelector('[data-action="import-audio"]') as HTMLButtonElement).disabled,
+    ).toBe(true);
   });
 });

--- a/app/renderer/src/features/Dub.tsx
+++ b/app/renderer/src/features/Dub.tsx
@@ -145,6 +145,51 @@ export function dubMediaUrl(path: string): string {
   return `mstream://media/${encodeURIComponent(`dub:${path}`)}`;
 }
 
+/**
+ * W62 — may this row's audio be edited (`tracks.audio.replace`) or dropped
+ * (`tracks.audio.strip`) from here?
+ *
+ * ONLY a dub. Both RPCs branch on `kind`, and the two branches have very
+ * different contracts:
+ *
+ *   * a DUB's audio is a standalone file, so both ops are pure MANIFEST edits —
+ *     no ffmpeg, nothing else on disk changes
+ *     (`sidecar/media_studio/features/tracks_audio.py:528-532` / `:572-577`);
+ *   * an ORIGINAL is a real container stream, so both ops re-mux the WHOLE
+ *     container into a NEW derived file — and that path is **returned but never
+ *     written back to the project** (`:533-554` / `:578-588` only mutate the
+ *     track row). The app would carry on resolving the untouched source while
+ *     the manifest row vanished, i.e. a control that looks like it edits the
+ *     video and does not.
+ *
+ * So the gate is a deliberate refusal to ship the second shape, not an
+ * oversight. Making original-track editing real needs the sidecar to re-point
+ * the project at the derivative — sidecar work, outside this lane.
+ */
+export function canEditAudioTrack(track: Pick<AudioTrack, 'kind'>): boolean {
+  return track.kind === 'dub';
+}
+
+/**
+ * The `kind` an IMPORTED audio track is registered under. Fixed, never a user
+ * choice: `isAiGeneratedAudioTrack` withholds the AI-generated badge for
+ * exactly one value, `"original"` (`AiDisclosure.tsx:83-85`), so a kind picker
+ * would hand the user a switch that turns the Article-50 label off. Marking an
+ * imported human recording is the disclosed, recoverable error direction —
+ * `AI_AUDIO_BADGE_TITLE` says so in the badge itself (`AiDisclosure.tsx:45-58`).
+ */
+export const IMPORTED_AUDIO_TRACK_KIND = 'dub';
+
+/**
+ * True when the import row carries everything `tracks.audio.mux` demands.
+ * `path`, `lang` and `name` are each `_require_str` on the sidecar
+ * (`sidecar/media_studio/features/tracks_audio.py:494-497`), so a blank one is
+ * gated here rather than sent to earn an INVALID_PARAMS round-trip.
+ */
+export function canImportAudioTrack(fields: { path: string; lang: string; name: string }): boolean {
+  return Boolean(fields.path.trim() && fields.lang.trim() && fields.name.trim());
+}
+
 export interface DubProps {
   videoId: string;
   /** Injectable bridge for tests; defaults to the preload-exposed api. */
@@ -174,12 +219,26 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
   const [message, setMessage] = useState<string>('');
   const [error, setError] = useState<string>('');
   const [result, setResult] = useState<DubDoneResult | null>(null);
+  // W62 audio-track ops (mux / replace / strip). One in-flight flag + one
+  // outcome line for all three: each op re-reads the list on success, so two
+  // overlapping ops would race the refresh.
+  const [audioBusy, setAudioBusy] = useState<boolean>(false);
+  const [audioMessage, setAudioMessage] = useState<string>('');
+  // The id of the track whose "Replace audio" disclosure is open ('' = none).
+  const [replaceFor, setReplaceFor] = useState<string>('');
+  const [replacePath, setReplacePath] = useState<string>('');
+  const [importPath, setImportPath] = useState<string>('');
+  const [importLang, setImportLang] = useState<string>('');
+  const [importName, setImportName] = useState<string>('');
 
   // `engine` is only ever set from the engine <select> whose options ARE ENGINES,
   // so the `?? ENGINES[0]` fallback is defensive.
   /* v8 ignore next */
   const engineOption = useMemo(() => ENGINES.find((e) => e.id === engine) ?? ENGINES[0], [engine]);
   const engineVoices = useMemo(() => voicesForEngine(voices, engine), [voices, engine]);
+  // Every W62 audio-track control is gated on the SAME flag: a dub job in flight
+  // is about to append a track, and a second audio op would race its refresh.
+  const audioLocked = busy || audioBusy;
 
   const refresh = useCallback(async (): Promise<void> => {
     setError('');
@@ -292,6 +351,94 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
       setJobId(null);
     }
   }, [bridge, busy, engine, engineOption.voiceClone, refresh, targetLang, trackId, videoId, voice]);
+
+  /**
+   * Run one audio-track mutation, report its outcome, and re-read the list so
+   * the panel shows the post-op truth. Returns whether it succeeded, so a caller
+   * clears its inputs only on success — a failed op must not eat the path the
+   * user typed. The list is deliberately NOT re-read on failure: nothing changed.
+   *
+   * The outcome rides a local flag and the single `return` sits AFTER the
+   * `finally`, mirroring `startDub` below. A `return` INSIDE a `try` that has a
+   * `finally` adds a completion path v8 counts as a branch and no test can reach
+   * (measured: `Dub.tsx:373` arm 0, the one branch short of the renderer's 100%
+   * gate). Restructuring removes it honestly; a `v8 ignore` would only have
+   * hidden it.
+   */
+  const runAudioOp = useCallback(
+    async (done: string, op: () => Promise<unknown>): Promise<boolean> => {
+      setAudioBusy(true);
+      setAudioMessage('');
+      let ok = false;
+      try {
+        await op();
+        setAudioMessage(done);
+        await refresh();
+        ok = true;
+      } catch (err) {
+        setAudioMessage(err instanceof Error ? err.message : String(err));
+      } finally {
+        setAudioBusy(false);
+      }
+      return ok;
+    },
+    [refresh],
+  );
+
+  const stripTrack = useCallback(
+    async (track: AudioTrack): Promise<void> => {
+      await runAudioOp(`Removed "${track.name}"`, () =>
+        bridge.rpc<{ path: string }>('tracks.audio.strip', {
+          videoId,
+          audioTrackId: track.id,
+        }),
+      );
+    },
+    [bridge, runAudioOp, videoId],
+  );
+
+  const replaceTrackAudio = useCallback(
+    async (track: AudioTrack): Promise<void> => {
+      const path = replacePath.trim();
+      // The Save button is disabled while the path is blank, so this is defensive.
+      /* v8 ignore next */
+      if (!path) return;
+      const ok = await runAudioOp(`Replaced the audio of "${track.name}"`, () =>
+        bridge.rpc<{ audioTrack: AudioTrack }>('tracks.audio.replace', {
+          videoId,
+          audioTrackId: track.id,
+          path,
+        }),
+      );
+      if (ok) {
+        setReplaceFor('');
+        setReplacePath('');
+      }
+    },
+    [bridge, replacePath, runAudioOp, videoId],
+  );
+
+  const importTrack = useCallback(async (): Promise<void> => {
+    const fields = { path: importPath, lang: importLang, name: importName };
+    // The Import button is disabled until all three are filled, so this is defensive.
+    /* v8 ignore next */
+    if (!canImportAudioTrack(fields)) return;
+    const name = fields.name.trim();
+    const ok = await runAudioOp(`Imported "${name}"`, () =>
+      bridge.rpc<{ audioTrack: AudioTrack }>('tracks.audio.mux', {
+        videoId,
+        path: fields.path.trim(),
+        lang: fields.lang.trim(),
+        name,
+        kind: IMPORTED_AUDIO_TRACK_KIND,
+      }),
+    );
+    if (ok) {
+      setImportPath('');
+      setImportLang('');
+      setImportName('');
+    }
+  }, [bridge, importLang, importName, importPath, runAudioOp, videoId]);
 
   const cancel = useCallback(async (): Promise<void> => {
     // The Cancel button renders only while `busy && jobId`, so this guard is
@@ -517,10 +664,126 @@ export function Dub({ videoId, api }: DubProps): React.ReactElement {
             <span className={`audio-track-kind audio-track-kind--${t.kind}`}>{t.kind}</span>
             {t.voice && <span className="audio-track-voice">{t.voice}</span>}
             {isAiGeneratedAudioTrack(t) && <AiAudioBadge />}
+            {/* W62 — the reachable end of `tracks.audio.replace` / `.strip`.
+                Offered for a dub only; see canEditAudioTrack for why the
+                original-recording branch is deliberately not surfaced. */}
+            {canEditAudioTrack(t) ? (
+              <span className="audio-track-actions">
+                <button
+                  type="button"
+                  className="secondary"
+                  data-action="replace-audio"
+                  onClick={() => setReplaceFor(replaceFor === t.id ? '' : t.id)}
+                  disabled={audioLocked}
+                >
+                  Replace audio…
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  data-action="strip-audio"
+                  onClick={() => void stripTrack(t)}
+                  disabled={audioLocked}
+                >
+                  Remove
+                </button>
+              </span>
+            ) : (
+              <span className="audio-track-locked">
+                Source audio — edit it in the video, not here
+              </span>
+            )}
+            {replaceFor === t.id && (
+              <span className="audio-track-replace">
+                <label>
+                  New audio file{' '}
+                  <input
+                    data-input="replace-audio-path"
+                    type="text"
+                    placeholder="C:\\path\\to\\better-dub.wav"
+                    value={replacePath}
+                    onChange={(e) => setReplacePath(e.target.value)}
+                    disabled={audioLocked}
+                  />
+                </label>
+                <button
+                  type="button"
+                  data-action="replace-audio-save"
+                  onClick={() => void replaceTrackAudio(t)}
+                  disabled={audioLocked || !replacePath.trim()}
+                >
+                  Save
+                </button>
+              </span>
+            )}
           </li>
         ))}
       </ul>
       {audioTracks.length === 0 && <p className="audio-track-empty">No audio tracks yet.</p>}
+
+      {/* W62 — the reachable end of `tracks.audio.mux`: register an audio file
+          that was produced elsewhere as a track on this video, so the ShortMaker
+          export picker (fed by the same `tracks.audio.list`) can mux it into a
+          short. `kind` is fixed — see IMPORTED_AUDIO_TRACK_KIND. */}
+      <div className="audio-track-import">
+        <h4>Import an audio track</h4>
+        <p className="audio-track-import-hint">
+          Register an existing audio file (an externally-produced dub or voiceover) as a track on
+          this video. It is marked as AI-generated audio like any non-source track — Reframe errs
+          toward marking.
+        </p>
+        <label>
+          File{' '}
+          <input
+            data-input="import-audio-path"
+            type="text"
+            placeholder="C:\\path\\to\\voiceover.wav"
+            value={importPath}
+            onChange={(e) => setImportPath(e.target.value)}
+            disabled={audioLocked}
+          />
+        </label>
+        <label>
+          Language{' '}
+          <input
+            data-input="import-audio-lang"
+            type="text"
+            placeholder="e.g. ro"
+            value={importLang}
+            onChange={(e) => setImportLang(e.target.value)}
+            disabled={audioLocked}
+          />
+        </label>
+        <label>
+          Name{' '}
+          <input
+            data-input="import-audio-name"
+            type="text"
+            placeholder="e.g. Romanian voiceover"
+            value={importName}
+            onChange={(e) => setImportName(e.target.value)}
+            disabled={audioLocked}
+          />
+        </label>
+        <button
+          type="button"
+          className="secondary"
+          data-action="import-audio"
+          onClick={() => void importTrack()}
+          disabled={
+            audioLocked ||
+            !canImportAudioTrack({ path: importPath, lang: importLang, name: importName })
+          }
+        >
+          Import
+        </button>
+      </div>
+
+      {audioMessage && (
+        <p className="audio-track-message" aria-live="polite">
+          {audioMessage}
+        </p>
+      )}
 
       {/* W20 — lip-sync sits AFTER the track list because it consumes a finished
           dub from it. `audioTracks` is handed down rather than re-fetched, so the

--- a/app/renderer/src/features/ProvidersKeys.test.tsx
+++ b/app/renderer/src/features/ProvidersKeys.test.tsx
@@ -970,6 +970,52 @@ describe('ProvidersKeys — WU-D3 reveal / re-validate / replace', () => {
     });
   });
 
+  // --- W64 / docs/plans/v1.5/SCOPE.md O-1: editKey is DEFERRED, not missing --
+  // O-1 records that no `providers.editKey` RPC exists on either side. This test
+  // is the pin for the DECISION not to add one: the index-targeted key edit it
+  // describes already ships here, over `providers.testKey` + `providers.upsert`.
+  // Routing that edit through a new `editKey` method turns this RED, which is the
+  // point — the deferral rationale in ProvidersKeys.tsx must be re-read first,
+  // because `editKey` would bypass keyBridge's `providers.upsert` interception
+  // and so never reach the DPAPI keystore.
+  it('W64/O-1: the index-targeted key edit rides testKey + upsert, never a providers.editKey', async () => {
+    const testKey = vi.fn(() => Promise.resolve({ ok: true, capabilities: ['text'] }));
+    const upsert = vi.fn(() =>
+      Promise.resolve({
+        providers: [{ id: 'groq', provider: 'Groq', apiKeys: ['…QRST'] }],
+      }),
+    );
+    const api = configuredApi({ testKey, upsert });
+    // Record which providers.* methods the panel actually reaches for. Property
+    // lookups happen at call time, so wrapping the object is enough.
+    const invoked: string[] = [];
+    const surface = (api as unknown as { providers: Record<string, (...a: never[]) => unknown> })
+      .providers;
+    for (const name of Object.keys(surface)) {
+      const original = surface[name];
+      surface[name] = (...args: never[]) => {
+        invoked.push(name);
+        return original(...args);
+      };
+    }
+    await mount({ rpcClient: api });
+    invoked.length = 0; // drop the mount reads (list / catalog / usage)
+
+    const toggle = container.querySelector<HTMLButtonElement>('.provider-key-row__replace-toggle')!;
+    await act(async () => toggle.click());
+    const input = container.querySelector<HTMLInputElement>('.provider-key-row__replace-input')!;
+    await act(async () => setInputValue(input, 'sk-edited-in-place'));
+    const save = container.querySelector<HTMLButtonElement>('.provider-key-row__replace-save')!;
+    await act(async () => save.click());
+    await flush();
+
+    // The WHOLE edit is these two calls, in this order — validate, then store.
+    expect(invoked).toEqual(['testKey', 'upsert']);
+    expect(invoked).not.toContain('editKey');
+    // And it is genuinely index-targeted: the new raw key lands at index 0.
+    expect(upsert).toHaveBeenCalledWith({ id: 'groq', apiKeys: ['sk-edited-in-place'] });
+  });
+
   // --- F38: the panel must not swallow a reveal/revalidate/replace rejection --
   // `revealKey` / `revalidateKey` / `replaceKey` had no try/catch at all, so the
   // role="alert" banner stayed empty while the sidecar's actionable refusal was

--- a/app/renderer/src/features/ProvidersKeys.tsx
+++ b/app/renderer/src/features/ProvidersKeys.tsx
@@ -478,6 +478,31 @@ export function ProvidersKeys({
   // it in place of the old one (preferred over silent in-place mutation). The
   // surviving redacted siblings round-trip back to their RAW form server-side; the
   // new raw key is written at its index.
+  //
+  // W64 / docs/plans/v1.5/SCOPE.md O-1 — `providers.editKey` is DEFERRED here, and
+  // this callback is the reason. O-1 reads "an index-targeted key edit has no RPC
+  // method behind it"; measured 2026-08-10, that is true of the METHOD NAME and
+  // false of the CAPABILITY. The edit ships, right here: validate the new value
+  // (`providers.testKey`), then write it at its index (`providers.upsert`), with
+  // the untouched siblings carried by their last-4 markers. `ProviderKeyRow`'s
+  // Replace disclosure is the user-facing affordance and
+  // `ProvidersKeys.test.tsx` pins both the mechanism and the index targeting.
+  //
+  // Adding the method would be a REGRESSION, not a completion, and it is a
+  // credential-loss shape rather than a cosmetic one:
+  //   * `app/main/keyBridge.ts:416-430` intercepts exactly two provider writes,
+  //     `providers.upsert` and `providers.remove`. `needsKeyInjection` (`:95-97`)
+  //     matches neither `providers.editKey` nor any prefix it would fall under, so
+  //     an `editKey` request is forwarded VERBATIM — its raw key reaches the
+  //     sidecar and is never written to the DPAPI keystore.
+  //   * the sidecar then redacts on persist
+  //     (`settings_store._strip_secrets_for_persist`), so the slot is left holding
+  //     a last-4 MARKER whose raw counterpart exists nowhere. `providers.revealKey`
+  //     answers INVALID_PARAMS on a marker slot by design, and every provider call
+  //     loses that key. The "edit" would silently destroy the credential.
+  // Closing that needs keyBridge + the generated contract — both outside this
+  // lane's scope. Since O-1's own note says a method absent from BOTH sides is
+  // parity-clean, nothing is drifting meanwhile: there is no half-landed surface.
   const replaceKey = useCallback(
     async (id: string, index: number, newKey: string): Promise<KeyCheckResult> => {
       const entry = providers.find((p) => p.id === id);

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -554,6 +554,26 @@ export const client = {
       rpc('tts.dub.start', { ...p }),
   },
 
+  /**
+   * `tracks.audio.*` — the container-level audio-track surface
+   * (`sidecar/media_studio/features/tracks_audio.py`).
+   *
+   * W62 — every method here has a REAL caller; none is a definition-only wrapper:
+   *   * `list` — `features/Dub.tsx` (the Audio-tracks list, also handed to
+   *     `LipSync`) and `features/ShortMaker.tsx` (the export audio picker).
+   *   * `mux` / `replace` / `strip` — the Audio-tracks section of
+   *     `features/Dub.tsx`: Import an audio track, and per-row Replace audio /
+   *     Remove. Until 2026-08-10 those three were wrapped and never called, so the
+   *     panel was read-only display.
+   *
+   * `replace` and `strip` are offered for a `kind: 'dub'` row ONLY. Both branch on
+   * `kind` sidecar-side, and the ORIGINAL branch re-muxes the whole container into
+   * a derived file that it returns but never writes back to the project
+   * (`tracks_audio.py:533-554` / `:578-588`) — so a UI control bound to it would
+   * drop the manifest row while the app kept resolving the untouched source. See
+   * `Dub.canEditAudioTrack`. These wrappers stay unrestricted: the gate belongs to
+   * the affordance, not the transport.
+   */
   tracksAudio: {
     list: (videoId: string): Promise<{ audioTracks: AudioTrack[] }> =>
       rpc('tracks.audio.list', { videoId }),

--- a/docs/wiring/WIRING-T2.md
+++ b/docs/wiring/WIRING-T2.md
@@ -67,6 +67,37 @@ Methods registered: `tracks.audio.list` / `tracks.audio.mux` /
 `tracks.audio.replace` / `tracks.audio.strip` / `tts.voices` /
 `tts.sample.add` / `tts.dub.start` (all frozen A2 names).
 
+> **W62 correction, 2026-08-10 — "registered" is not "wired", and this file used
+> to conflate them.** Registering a method and typing a client wrapper for it
+> makes it *callable*, not *reachable*. Measured on `db61ea6e`: of the four
+> `tracks.audio.*` methods, only `list` had a renderer caller
+> (`features/Dub.tsx`, `features/ShortMaker.tsx`); `mux`, `replace` and `strip`
+> existed sidecar-side and in the §8 client snippet below with **zero** call
+> sites, so no user could reach them — `mux` ran only in-process from the dub job
+> (`tracks_audio.mux_for_dub`). §8's list of "the T2 methods" is a client
+> inventory and was being read as a wiring receipt.
+>
+> All three are now reachable from the Audio-tracks section of
+> `features/Dub.tsx`: **Import an audio track** (`mux`), and per-row **Replace
+> audio** (`replace`) / **Remove** (`strip`).
+>
+> Two scope limits, stated here because they are deliberate, not omissions:
+>
+> 1. **`replace` / `strip` are offered for a `kind: 'dub'` row only.** For a dub
+>    both are pure manifest edits. For an ORIGINAL both re-mux the entire
+>    container into a new derived path which the handler **returns but never
+>    writes back to the project** (`tracks_audio.py:533-554`, `:578-588`), so the
+>    app would keep resolving the untouched source while the manifest row
+>    vanished. Making original-track editing real is sidecar work — re-point the
+>    project at the derivative — and is NOT done. Settling experiment: call
+>    `tracks.audio.strip` on an `original` row, then `library.get` that video and
+>    assert its `path` is the returned `-noaud-` derivative; today it is not.
+> 2. **An imported track's `kind` is fixed to `dub`, never user-selectable.**
+>    `isAiGeneratedAudioTrack` withholds the AI-generated badge for exactly one
+>    value, `original`, so a kind picker would be a switch that turns the
+>    Article-50 label off. Over-labelling an imported human recording is the
+>    already-disclosed direction (`AiDisclosure.AI_AUDIO_BADGE_TITLE`).
+
 ## 2. The translator seam (T3 `models/translation.py`)
 
 `tts.dub.start` with a `targetLang` needs the **models.translation seam**
@@ -183,6 +214,12 @@ const Dub = lazyPanel<{ videoId: string }>('../features/Dub', 'Dub');
 needed**.
 
 ## 8. `app/renderer/src/lib/rpc.ts` — optional typed client additions
+
+**This section is a client-wrapper inventory, NOT evidence that anything calls
+these methods** — see the W62 correction under §1 for what was actually reachable
+and what is now. The wrappers below shipped in
+`app/renderer/src/lib/rpc/client.ts`; three of the four `tracksAudio` entries had
+no caller until 2026-08-10.
 
 If the canonical client is being extended this round, the T2 methods are:
 

--- a/sidecar/media_studio/handlers/composition.py
+++ b/sidecar/media_studio/handlers/composition.py
@@ -243,6 +243,22 @@ def register_all(
     # renderer holds it in a ref only (never state/store/logs/telemetry/crash) and
     # re-masks on blur/timeout. Every other providers.* read stays last-4 redacted.
     reg("providers.revealKey", svc.providers_reveal_key)
+    # W64 / docs/plans/v1.5/SCOPE.md O-1 — there is DELIBERATELY no
+    # ``providers.editKey`` beside these two, and this is the one place that would
+    # register it. O-1 is right that the name is absent from both sides (so the
+    # surface is parity-clean, not drifted) and wrong that the CAPABILITY is
+    # missing: an index-targeted key edit already ships as validate-then-store,
+    # ``providers.testKey`` + ``providers.upsert``, driven by the Replace
+    # affordance in ``app/renderer/src/features/ProvidersKeys.tsx`` (see the long
+    # note on its ``replaceKey`` callback for the full rationale and the test that
+    # pins it).
+    #
+    # Registering ``providers.editKey`` here would ADD a credential-loss path, not
+    # a feature: ``app/main/keyBridge.ts`` intercepts only ``providers.upsert`` /
+    # ``providers.remove``, so an ``editKey`` request would carry its raw key past
+    # the DPAPI keystore into this process, where ``settings_store`` redacts on
+    # persist -- leaving a last-4 marker with no raw counterpart anywhere. Any
+    # future ``editKey`` must land together with a keyBridge interception.
     reg("providers.setConsent", svc.providers_set_consent)
     # WU-usage-ui: per-key live usage (cached, persisted, stale-flagged; no poll
     # burst). The rotation pool already accounts usage from optimistic decrement +


### PR DESCRIPTION
W62 — three RPC methods that were registered sidecar-side but reachable from no UI are now driven
from the Dub panel.

## What changed

`tracks.audio.mux` / `.replace` / `.strip` gain a reachable end:

* call sites `Dub.tsx:391` (strip), `:407` (replace), `:428` (mux)
* controls at `Dub.tsx:667` (edit/remove on an audio row) and `:724` (register an audio file)
* an edit gate (`canEditAudioTrack`) so a row is only offered edit/remove when the sidecar can
  actually honour it
* `ProvidersKeys.tsx` and `composition.py` follow-ups, and the `editKey` deferral recorded in
  `docs/wiring/WIRING-T2.md`

## Verification

`Dub.test.tsx` covers success **and** error paths for all three methods, plus the required-field
gate (`requires all three fields tracks.audio.mux declares required`) and the re-read after strip.

I verified reachability independently of the tests: the three wire strings resolve to real call
sites in production code, not only to test doubles.

## Known, not fixed here: the typed wrappers this PR adds are dead

The PR also adds `client.tracksAudio.{list,mux,replace,strip}` to `lib/rpc/client.ts`. **Nothing
but `rpc.test.ts` calls them.** `Dub.tsx` reaches the same methods through `bridge.rpc(...)`
because it takes an injectable `api` prop for tests (`Dub.tsx:195-200`), while the client wrappers
read a module-level bridge accessor that throws without `window.api` (`client.ts:99-103`). Dub
cannot use them without losing test injection.

This is not specific to this PR. Measured across the renderer:

| | |
|---|---|
| wrapper methods in `client.ts` | 140 |
| referenced in production | 65 |
| reachable **only** from tests | **75 (54%)** |
| fully dead groups | 8 (`audiomix`, `diarize`, `feedback`, `media`, `speed`, `timeline`, `tracksAudio`, `tts`) |

Production reaches those wire methods by other transports — `rpc('library.remove', …)` direct in
`Library.tsx`, a `{method, params}` descriptor in `repurposeTemplates.ts`, `rpc(BROLL_METHODS.status)`
via a constant map, `bridge.rpc(…)` in `Dub.tsx`. Detector control: 65 methods **do** match, and
there is zero destructuring of `client` in production, so the zeros are not a matcher artifact.

No user-visible bug — every one of those features works. The costs are dead production code at 54%
of a core module, each wrapper carrying a test that exists only to cover it (which inflates the
100% bar), and a blind spot in the W26 reachability gate, which is module-granular and therefore
cannot see an unused export inside a module that is itself imported everywhere.

Deleting just these four would leave the branch inconsistent with 71 other equally dead wrappers.
Consolidating onto one transport is a codebase-wide refactor and an owner decision, so it is filed
rather than done here.
