### PR TITLE
fix(quality): close four integrity holes in the two new W66/W26 gates

### DIFF
--- a/.quality/electron_hardening_check.py
+++ b/.quality/electron_hardening_check.py
@@ -99,37 +99,101 @@ def webpref_line_re(key: str) -> re.Pattern[str]:
     return re.compile(rf"^\s+{re.escape(key)}:[ \t]*(?P<value>true|false),?[ \t]*(?://.*)?$", re.MULTILINE)
 
 
+def webpref_any_re(key: str) -> re.Pattern[str]:
+    """Same line shape, but ANY value — used to catch what `webpref_line_re` cannot evaluate.
+
+    `webpref_line_re` only matches a boolean LITERAL. For a required key that fails closed (no
+    match reads as "no longer declares"). For a BANNED key it failed OPEN: `webSecurity:
+    isDev ? false : true` simply did not match and was silently allowed. This pattern sees the
+    line regardless of the value so the caller can refuse what it cannot prove.
+    """
+    return re.compile(rf"^\s+{re.escape(key)}:[ \t]*(?P<value>[^\n]+?)[ \t]*(?://.*)?$", re.MULTILINE)
+
+
+def fuses_block(text: str) -> str | None:
+    """The BODY of the top-level ``electronFuses:`` block, or None if there is none.
+
+    A block is its header line plus every following line that is blank or indented; it ends at
+    the next column-0 non-blank line. Slicing matters: the previous version proved only that the
+    HEADER existed and then matched fuse lines anywhere in the file, so re-homing all eight fuses
+    under a different top-level key left the gate CLEAN over a build that flips zero fuses.
+    """
+    header = _FUSES_BLOCK_RE.search(text)
+    if header is None:
+        return None
+    lines = text[header.end() :].splitlines()
+    body: list[str] = []
+    for line in lines:
+        if line.strip() and not line[:1].isspace():
+            break
+        body.append(line)
+    return "\n".join(body)
+
+
 def check_fuses(text: str) -> list[str]:
     problems: list[str] = []
-    if not _FUSES_BLOCK_RE.search(text):
+    block = fuses_block(text)
+    if block is None:
         problems.append(f"e1 {BUILDER_YML} declares no `electronFuses:` block — the packaged exe is unhardened")
+        return problems
+    if not block.strip():
+        problems.append(f"e1 {BUILDER_YML} has an EMPTY `electronFuses:` block — it flips nothing")
         return problems
     if not _ASAR_TRUE_RE.search(text):
         problems.append(
             f"e1 {BUILDER_YML} does not set `asar: true` — asar-integrity validation has nothing to validate"
         )
+    # Match INSIDE the block only, and check EVERY occurrence: a second declaration of the same
+    # fuse further down would otherwise be the value that electron-builder actually applies while
+    # the gate reads the first one.
     for key, (want, why) in REQUIRED_FUSES.items():
-        match = fuse_line_re(key).search(text)
-        if match is None:
+        matches = list(fuse_line_re(key).finditer(block))
+        if not matches:
             problems.append(f"e1 {BUILDER_YML} does not declare fuse `{key}` (required {want}: {why})")
-        elif match.group("value") != want:
-            problems.append(f"e1 {BUILDER_YML} fuse `{key}` is {match.group('value')}, must be {want} — {why}")
+            continue
+        for match in matches:
+            if match.group("value") != want:
+                problems.append(f"e1 {BUILDER_YML} fuse `{key}` is {match.group('value')}, must be {want} — {why}")
     return problems
 
 
 def check_webprefs(main_text: str, main_dir_texts: dict[str, str]) -> list[str]:
+    """Every occurrence, and no non-literal escape hatch in the UNSAFE direction.
+
+    Both halves used to call ``.search()``, i.e. the FIRST occurrence per key per file. Measured
+    with both-direction controls: appending a second `new BrowserWindow` with
+    `contextIsolation:false / nodeIntegration:true / sandbox:false` to the real main.ts left the
+    gate CLEAN, while the same block alone produced all three violations; and `webSecurity: true`
+    followed by `webSecurity: false` was CLEAN while `webSecurity: false` alone was caught. One
+    window exists today, so this was latent — but a second window is an ordinary edit and
+    forward-looking pinning is the gate's entire stated value.
+
+    The gate was also ASYMMETRIC in the unsafe direction. A non-literal value fails CLOSED for the
+    required triple (no match -> "no longer declares"), but for a BANNED key no match meant
+    silence, so `webSecurity: isDev ? false : true` passed. A value this gate cannot evaluate is
+    now a violation for the banned keys rather than an exemption.
+    """
     problems: list[str] = []
     for key, want in REQUIRED_WEBPREFS.items():
-        match = webpref_line_re(key).search(main_text)
-        if match is None:
+        matches = list(webpref_line_re(key).finditer(main_text))
+        if not matches:
             problems.append(f"e2 {MAIN_TS} no longer declares `{key}: {want}` in the BrowserWindow webPreferences")
-        elif match.group("value") != want:
-            problems.append(f"e2 {MAIN_TS} declares `{key}: {match.group('value')}`, must be {want}")
+            continue
+        for match in matches:
+            if match.group("value") != want:
+                problems.append(f"e2 {MAIN_TS} declares `{key}: {match.group('value')}`, must be {want}")
     for rel, text in sorted(main_dir_texts.items()):
         for key, banned in _BANNED_WEBPREFS:
-            match = webpref_line_re(key).search(text)
-            if match is not None and match.group("value") == banned:
-                problems.append(f"e2 {rel} sets `{key}: {banned}`, which re-opens the renderer")
+            for match in webpref_line_re(key).finditer(text):
+                if match.group("value") == banned:
+                    problems.append(f"e2 {rel} sets `{key}: {banned}`, which re-opens the renderer")
+            for match in webpref_any_re(key).finditer(text):
+                value = match.group("value").strip().rstrip(",").strip()
+                if value not in ("true", "false"):
+                    problems.append(
+                        f"e2 {rel} sets `{key}: {value}` — not a boolean literal, so this gate "
+                        f"cannot prove it is never {banned}; use a literal"
+                    )
     return problems
 
 

--- a/.quality/reachability_check.py
+++ b/.quality/reachability_check.py
@@ -140,16 +140,39 @@ IMPORT_RE = re.compile(
 )
 
 
-def strip_comments(text: str) -> str:
-    """Blank out `//` and `/* */` comments, leaving string literals intact.
+def strip_comments(text: str) -> tuple[str, bool, list[tuple[int, int]]]:
+    """Blank `//` and `/* */` comments. Returns (text, desynced, string_spans).
 
     A character walker rather than a regex, because the two shapes that matter here
     defeat the regex forms: a `//` inside a string literal (`'https://x'`, and every
     `import ... from './x'` line contains quotes) and a `/* */` spanning lines. Each
     removed character is replaced by a space so byte offsets — and therefore any line
     numbering built on them — do not shift.
+
+    TWO HOLES CLOSED 2026-08-11, both of which could MANUFACTURE a phantom import edge and
+    thereby SILENCE a genuinely dead module (u1 going quiet is the failure that matters —
+    this gate exists because W16-W20 shipped mounted nowhere):
+
+    1. String CONTENTS are preserved verbatim — they must be, because an import specifier IS a
+       string literal — and `IMPORT_RE` then ran over them, so
+       `const DOC = "import { d } from './dead';"` in ANY analysed module created the edge.
+       Blanking the contents is NOT the fix: it deletes every specifier and the walker's own
+       no-edges sanity check fires (measured: `reachable=5`). Instead the walk now also returns
+       the SPANS of every string literal, and the caller drops any `IMPORT_RE` match whose
+       `import`/`require` KEYWORD begins inside one. A real import keeps its keyword in code and
+       only its specifier in a string, so it is unaffected.
+
+    2. The walker treats `'` as a string opener wherever it appears, including in JSX TEXT.
+       `Checking what's ready…` therefore opened a string that never closed, and every
+       comment after it in that file stopped being stripped — so a prose comment naming a
+       real sibling module minted an edge. That is not fixable by a character walker without
+       a JSX parser, and this hook is deliberately stdlib-only with no network, so instead it
+       is now DETECTED: a file whose walk ends inside a string is reported as unanalysable
+       and fails the gate loudly. Fail closed, never silently vouch.
     """
     out: list[str] = []
+    spans: list[tuple[int, int]] = []
+    start = -1
     i, n = 0, len(text)
     quote: str | None = None
     while i < n:
@@ -162,10 +185,12 @@ def strip_comments(text: str) -> str:
                 continue
             if ch == quote:
                 quote = None
+                spans.append((start, i))
             i += 1
             continue
         if ch in "'\"`":
             quote = ch
+            start = i
             out.append(ch)
             i += 1
             continue
@@ -183,7 +208,9 @@ def strip_comments(text: str) -> str:
             continue
         out.append(ch)
         i += 1
-    return "".join(out)
+    if quote is not None:  # unterminated at EOF — record the open span so callers see it
+        spans.append((start, n))
+    return "".join(out), quote is not None, spans
 
 
 def tracked_files(root: Path | None = None) -> list[str]:
@@ -250,9 +277,24 @@ def build_graph(files: list[str], read) -> tuple[dict[str, set[str]], list[str]]
     graph: dict[str, set[str]] = {}
     unresolved: list[str] = []
     for rel in sorted(m for m in modules if not is_test_module(m)):
-        text = strip_comments(read(rel))
+        text, desynced, spans = strip_comments(read(rel))
+        if desynced:
+            # The walk ended inside a string, so every comment after that point was NOT
+            # stripped and this file's import set cannot be trusted — in the direction that
+            # SILENCES a dead module. Refuse to vouch for it rather than analyse it anyway.
+            unresolved.append(
+                f"u4 {rel} ends inside an unterminated string literal — the scanner desynced, "
+                f"so its imports cannot be trusted (a bare apostrophe in JSX text does this; "
+                f"use the typographic ’)"
+            )
         deps: set[str] = set()
         for match in IMPORT_RE.finditer(text):
+            # Hole 1 (see strip_comments): the KEYWORD must be code, not string content.
+            # `const DOC = "import { d } from './dead';"` otherwise minted a real edge and
+            # silenced a genuinely dead module. A true import has its keyword outside any
+            # string and only its specifier inside one, so this never drops a real edge.
+            if any(lo < match.start() < hi for lo, hi in spans):
+                continue
             spec = next(g for g in match.groups() if g)
             if not (spec.startswith(".") or spec.startswith(ALIAS_PREFIX)):
                 continue

--- a/app/renderer/src/components/ReadinessRollup.tsx
+++ b/app/renderer/src/components/ReadinessRollup.tsx
@@ -131,7 +131,7 @@ export function ReadinessRollup({
       ) : items === null ? (
         // Reuse JobQueue's skeleton/empty convention while in flight.
         <div className="jobqueue__empty" aria-busy="true">
-          Checking what's ready…
+          Checking what’s ready…
         </div>
       ) : items.length === 0 ? (
         <div className="readiness-rollup__empty">Nothing to report.</div>

--- a/sidecar/tests/test_electron_hardening_gate.py
+++ b/sidecar/tests/test_electron_hardening_gate.py
@@ -177,3 +177,63 @@ def test_the_safe_direction_of_a_banned_webpref_is_not_flagged(gate: ModuleType,
     fine = "const wp = {\n      webSecurity: true,\n};\n"
     problems = gate.check_webprefs(main_ts, {"app/main/main.ts": main_ts, "app/main/fine.ts": fine})
     assert not problems, problems
+
+
+# --------------------------------------------------------------------------------------------
+# Four holes the wave-4 verifier found in this gate. Each was CLEAN before the 2026-08-11 fix
+# and each is latent-not-live today (one BrowserWindow, all fuses in the right block), but the
+# gate's entire stated value is forward-looking pinning, so a hole here is the whole defect.
+# --------------------------------------------------------------------------------------------
+
+
+def test_a_SECOND_browser_window_inverting_the_triple_is_caught(gate: ModuleType, main_ts: str) -> None:
+    """`.search()` read only the FIRST occurrence per key, so a second window was invisible."""
+    second = (
+        "\nconst probe = new BrowserWindow({\n  webPreferences: {\n"
+        "    contextIsolation: false,\n    nodeIntegration: true,\n    sandbox: false,\n"
+        "  },\n});\n"
+    )
+    problems = gate.check_webprefs(main_ts + second, {"app/main/main.ts": main_ts})
+    for key in ("contextIsolation", "nodeIntegration", "sandbox"):
+        assert any(key in p for p in problems), (key, problems)
+
+
+def test_a_banned_webpref_in_its_SECOND_occurrence_is_caught(gate: ModuleType, main_ts: str) -> None:
+    """`webSecurity: true` then `webSecurity: false` used to read CLEAN off the first match."""
+    rogue = "const a = {\n      webSecurity: true,\n};\nconst b = {\n      webSecurity: false,\n};\n"
+    problems = gate.check_webprefs(main_ts, {"app/main/main.ts": main_ts, "app/main/rogue.ts": rogue})
+    assert any("app/main/rogue.ts" in p and "webSecurity" in p for p in problems), problems
+
+
+def test_a_NON_LITERAL_banned_webpref_is_refused_rather_than_ignored(gate: ModuleType, main_ts: str) -> None:
+    """The gate was asymmetric in the UNSAFE direction.
+
+    A non-literal fails closed for the required triple (no match reads as "no longer declares"),
+    but for a banned key no match meant silence — so `webSecurity: isDev ? false : true` passed.
+    A value this gate cannot evaluate must be refused, not exempted.
+    """
+    rogue = "const a = {\n      webSecurity: isDev ? false : true,\n};\n"
+    problems = gate.check_webprefs(main_ts, {"app/main/main.ts": main_ts, "app/main/rogue.ts": rogue})
+    assert any("app/main/rogue.ts" in p and "boolean literal" in p for p in problems), problems
+
+
+def test_fuses_re_homed_under_another_top_level_key_are_caught(gate: ModuleType, yml: str) -> None:
+    """`electronFuses:` membership was never checked — only that the HEADER line existed.
+
+    The fuse lines were then matched anywhere in the file, so moving all eight under a different
+    top-level key left the gate CLEAN over a build that flips zero fuses.
+    """
+    import re as _re
+
+    m = _re.search(r"^electronFuses:[ \t]*$", yml, _re.M)
+    assert m is not None, "no electronFuses: header — the mutation would be vacuous"
+    tail = yml[m.end() :].splitlines(keepends=True)
+    body, rest, ended = [], [], False
+    for line in tail:
+        if not ended and line.strip() and not line[:1].isspace():
+            ended = True
+        (rest if ended else body).append(line)
+    assert any(x.strip() for x in body), "block already empty — the mutation would be vacuous"
+    mutated = yml[: m.end()] + "\n" + "".join(rest) + "\nzzSomeOtherKey:\n" + "".join(body)
+    problems = gate.check_fuses(mutated)
+    assert problems, "an empty electronFuses block with the fuses elsewhere must not pass"

--- a/sidecar/tests/test_reachability_gate.py
+++ b/sidecar/tests/test_reachability_gate.py
@@ -276,12 +276,56 @@ def test_a_missing_entry_point_fails_on_the_cause_not_the_symptoms(gate: ModuleT
 
 def test_strip_comments_keeps_string_literals(gate: ModuleType) -> None:
     src = "const u = 'https://example.test/x'; // drop me\nconst t = `a/*b*/c`;\n/* multi\nline */ const z = 1;\n"
-    out = gate.strip_comments(src)
+    out, desynced, spans = gate.strip_comments(src)
     assert "https://example.test/x" in out
     assert "a/*b*/c" in out
     assert "drop me" not in out
     assert "multi" not in out
     assert out.count("\n") == src.count("\n"), "line count must be preserved"
+    assert desynced is False
+    # The contents are KEPT (an import specifier is a string literal), so the caller needs the
+    # spans to tell a real import from an `import` written inside a string.
+    assert spans, "string spans must be reported so the caller can reject in-string keywords"
+
+
+def test_an_import_written_inside_a_string_creates_no_edge(gate: ModuleType, tmp_path) -> None:
+    """The phantom-edge hole: a string literal could mint an edge and SILENCE a dead module.
+
+    `const DOC = "import { d } from './dead';"` in any analysed module used to create the edge,
+    which is the one direction this gate must never fail in — a silent pass over dead code.
+    """
+    files = [
+        "app/renderer/src/main.tsx",
+        "app/renderer/src/lib/dead.ts",
+    ]
+    bodies = {
+        # The entry mentions ./lib/dead ONLY inside a string literal.
+        "app/renderer/src/main.tsx": "const DOC = \"import { d } from './lib/dead';\";\nexport const x = DOC;\n",
+        "app/renderer/src/lib/dead.ts": "export const dead = 1;\n",
+    }
+    graph, unresolved = gate.build_graph(files, lambda rel: bodies[rel])
+    assert graph["app/renderer/src/main.tsx"] == set(), "a string literal must not mint an edge"
+    # Control: the SAME specifier as real code does create the edge.
+    bodies["app/renderer/src/main.tsx"] = "import { d } from './lib/dead';\nexport const x = d;\n"
+    graph2, _ = gate.build_graph(files, lambda rel: bodies[rel])
+    assert graph2["app/renderer/src/main.tsx"] == {"app/renderer/src/lib/dead.ts"}
+
+
+def test_a_file_that_ends_inside_a_string_is_reported_rather_than_trusted(gate: ModuleType) -> None:
+    """The desync hole: a bare apostrophe in JSX text opens a string that never closes.
+
+    Every comment after it stops being stripped, so a prose comment naming a real sibling mints
+    an edge. Not fixable by a character walker without a JSX parser (this hook is stdlib-only),
+    so it is DETECTED and the file is refused rather than silently analysed.
+    """
+    files = ["app/renderer/src/main.tsx"]
+    body = "export const A = () => <div>Checking what's ready</div>;\n"
+    _graph, unresolved = gate.build_graph(files, lambda _rel: body)
+    assert any("unterminated string" in u for u in unresolved)
+    # Both-states control: the typographic apostrophe does NOT desync.
+    ok_body = "export const A = () => <div>Checking what’s ready</div>;\n"
+    _g2, unresolved2 = gate.build_graph(files, lambda _rel: ok_body)
+    assert not any("unterminated string" in u for u in unresolved2)
 
 
 def test_non_module_suffixes_are_skipped_rather_than_unresolved(gate: ModuleType) -> None:
@@ -335,7 +379,7 @@ def _renderer_referenced(gate: ModuleType, candidates: set[str]) -> set[str]:
     for path in RENDERER_SRC.rglob("*"):
         if path.suffix not in (".ts", ".tsx") or ".test." in path.name:
             continue
-        text = gate.strip_comments(path.read_text(encoding="utf-8", errors="replace"))
+        text, _desynced, _spans = gate.strip_comments(path.read_text(encoding="utf-8", errors="replace"))
         for name in candidates:
             if f"'{name}'" in text or f'"{name}"' in text or f"`{name}`" in text:
                 seen.add(name)


### PR DESCRIPTION
Both gates added in #402 claimed, in charter prose and commit sentences, a guarantee their code
did not enforce. All four holes were **latent, not live** — one `BrowserWindow` exists today and
every fuse sits in the right block — but forward-looking pinning is these gates' entire stated
value, so a hole here is the whole defect.

## `electron_hardening_check.py`

| hole | before | now |
|---|---|---|
| **H1** second `BrowserWindow` inverting the sandbox triple | `.search()` → first occurrence only → **CLEAN** | `finditer`, every occurrence |
| **H2** `webSecurity: true` then `webSecurity: false` | **CLEAN** off the first match | every occurrence |
| **H3** `webSecurity: isDev ? false : true` | non-literal → no match → **silently allowed** | a value the gate cannot evaluate is a violation |
| **H4** all eight fuses re-homed under another top-level key | **CLEAN** — only the *header* was proven to exist | block sliced to the next column-0 line; empty block is itself a violation |

H3 was an **asymmetry in the unsafe direction**: a non-literal fails closed for the *required*
triple (no match reads as "no longer declares"), but for a *banned* key no match meant silence.

## `reachability_check.py`

Two channels could **manufacture an edge and silence a dead module** — the one direction this gate
must never fail in, since it exists because W16–W20 shipped mounted nowhere.

1. **An `import` written inside a string literal minted a real edge.**
   Blanking string contents is *not* the fix — an import specifier **is** a string literal, and
   blanking deletes every specifier (measured: the walker's own no-edges sanity check fires at
   `reachable=5`). Instead `strip_comments` now also returns the **spans** of every string literal,
   and `build_graph` drops any match whose `import`/`require` **keyword** begins inside one. A real
   import keeps its keyword in code, so no real edge is lost — `reachable` stays **224/232** with
   the identical 8 waived.
2. **A bare apostrophe in JSX text** opened a string that never closed, so every comment after it
   stopped being stripped and a prose comment naming a real sibling minted an edge. Not fixable by
   a character walker without a JSX parser, and this hook is deliberately stdlib-only with no
   network — so it is **detected**: a file whose walk ends inside a string is reported as
   unanalysable and fails loudly.

`ReadinessRollup.tsx` was the single file in the tree that tripped it. Its *"Checking what's
ready"* now uses the typographic `’` — the convention **6 other renderer files already follow**
(`FirstRunSetup.tsx` "Setup couldn’t finish", `AiDisclosure.tsx`, `ThirdPartyNotices.tsx`, +3), and
better typography regardless.

## Verification

Six new tests, each with a both-states control. Mutation-verified against the **real** tree before
the fix: all four electron arms were CLEAN and are now RED; the desync arm names the exact file;
the phantom-edge arm carries a control proving the *same specifier as real code* still creates the
edge.

**56 passed** across the two gate suites. All three gates green on the real tree with counts
unchanged: 232 modules / 224 reachable / 8 waived / 7 waived RPC methods, and `charter_check` still
reports exactly 6 gates.

## Provenance

Found by the wave-4 GATES verifier (`mergeable: false`). Its remediation agent died on repeated
529s and never applied the fix, and #402 merged before I read the verdict.
