### PR TITLE
fix(e2e): give the installed-build beforeAll the cold timeout the spec already defines

### DIFF
--- a/app/e2e/installed-app.spec.ts
+++ b/app/e2e/installed-app.spec.ts
@@ -216,6 +216,21 @@ test.describe('INSTALLED build — first run to working pipeline (W-A + W41)', (
   test.skip(INSTALLED === '', SKIP_REASON);
 
   test.beforeAll(async () => {
+    // THE HOOK'S OWN TIMEOUT, not the test's. Without this the suite could never go green on a
+    // COLD install: this file defines COLD_TIMEOUT_MS (default 900 s, and e2e.yml passes
+    // RF_E2E_COLD_TIMEOUT_MS=1200000) for exactly this wait, but Playwright bounds a beforeAll
+    // hook at its own 120 s default and that fires FIRST. `test.setTimeout()` inside beforeAll
+    // sets the HOOK timeout.
+    //
+    // MEASURED, not guessed: Actions run 31451957732 step 28, on `main`, with the installed
+    // build. The hook aborted at 02:33:32 -> 02:35:33 with `"beforeAll" hook timeout of
+    // 120000ms exceeded`, and all FOUR real tests below reported `-` (skipped). That is why the
+    // installed-build arm had never been observed green — the launch never got to run.
+    //
+    // The slack is for the launch + firstWindow() round trip on top of the bootstrap wait; the
+    // cold budget itself stays env-tunable so a slow runner is a config change, not an edit.
+    test.setTimeout(COLD_TIMEOUT_MS + 120_000);
+
     built = findBuiltApp();
     // findBuiltApp fails loud on a bad path, so reaching here means the tree
     // parsed. Re-assert the two properties the rest of the suite depends on.


### PR DESCRIPTION
fix(e2e): give the installed-build beforeAll the cold timeout the spec already defines

The installed-build arm could never go green on a COLD install. The spec defines
COLD_TIMEOUT_MS for exactly this wait (default 900 s, and e2e.yml passes
RF_E2E_COLD_TIMEOUT_MS=1200000), but Playwright bounds a `beforeAll` hook at its own 120 s
default and that fires FIRST. The hook launches the installed Electron app and awaits
firstWindow(), which on a cold first run is the long path by construction.

MEASURED on `main`, not inferred: Actions run 31451957732 step 28, driving a real silent
NSIS install. The hook aborted 02:33:32 -> 02:35:33 with `"beforeAll" hook timeout of
120000ms exceeded`, and all FOUR real tests reported `-` (skipped). So the arm reported a
failure that was never about the product.

`test.setTimeout()` inside beforeAll sets the HOOK timeout, which is the one that was
biting. The cold budget itself stays env-tunable, so a slower runner is a config change
rather than an edit; the extra slack covers launch + firstWindow() on top of the bootstrap.

CONTEXT — this is the SECOND gate on that path, and the first one was real. Before
81a04965 the same step failed with `FAILED:bootstrap get-pip.py sha256 mismatch`, a genuine
release-blocking defect (a stale vendored artifact) fixed in #406. Clearing it revealed
this one. Whether the cold first run then SUCCEEDS is still UNVERIFIED — no run has yet got
past the launch — and the settling experiment is one dispatch of e2e.yml on main with
drive_installed_build checked after this merges.
