### PR TITLE
fix(e2e): one shared cold-start budget, applied to the launch AND to packaged.spec

### DIFF
--- a/app/e2e/fixtures.ts
+++ b/app/e2e/fixtures.ts
@@ -87,6 +87,27 @@ export const DIST_DIR = join(REPO_ROOT, 'dist');
 export const APP_EXE_ENV = 'RF_E2E_APP_EXE';
 
 /**
+ * How long a COLD first run may take before the app is expected to answer.
+ *
+ * Default 15 minutes. The documented estimate is ~3 minutes
+ * (`FirstRunSetup.SETUP_ESTIMATE_MIN`) but that is a warm-network figure for a developer box.
+ * A non-numeric or non-positive value falls back to the default rather than silently becoming
+ * 0 — a 0 would make every wait vacuous and the tests meaningless.
+ *
+ * LIVES HERE, not in a spec, because BOTH `installed-app.spec.ts` and `packaged.spec.ts` launch
+ * a real package whose first run does the bootstrap, and they were drifting: the value was
+ * defined in one spec while the other silently used Playwright's defaults. Duplicating a value
+ * across N places is the shape that produced the get-pip pin/artifact mismatch (#406), where a
+ * rotation updated two of the three places a comment said to keep in sync.
+ *
+ * Tunable via `RF_E2E_COLD_TIMEOUT_MS`; `e2e.yml:687` passes 1200000 for the installed leg.
+ */
+export const COLD_TIMEOUT_MS = ((): number => {
+  const parsed = Number(process.env.RF_E2E_COLD_TIMEOUT_MS ?? '');
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 900_000;
+})();
+
+/**
  * What the launched app boots: the args + (for a real package) the executable
  * path, plus whether we are pointing at a PACKAGED artifact or the dev build.
  */

--- a/app/e2e/installed-app.spec.ts
+++ b/app/e2e/installed-app.spec.ts
@@ -102,6 +102,7 @@ import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import {
   APP_EXE_ENV,
+  COLD_TIMEOUT_MS,
   DIST_DIR,
   REPO_ROOT,
   SIDECAR_DIR,
@@ -116,19 +117,10 @@ import {
 /** The installed app to drive; empty means "skip this whole suite". */
 const INSTALLED = process.env[APP_EXE_ENV]?.trim() ?? '';
 
-/**
- * How long the COLD first-run bootstrap may take before the pipeline is expected
- * to answer. Default 15 minutes: the documented estimate is ~3 minutes
- * (`FirstRunSetup.SETUP_ESTIMATE_MIN`) but that is a warm-network figure for a
- * developer box, and this window has never been measured on a CI runner —
- * UNVERIFIED, which is exactly why it is env-tunable rather than hardcoded. A
- * non-numeric or non-positive value falls back to the default rather than
- * silently becoming 0 (a 0 would make the wait vacuous and the test meaningless).
- */
-const COLD_TIMEOUT_MS = ((): number => {
-  const parsed = Number(process.env.RF_E2E_COLD_TIMEOUT_MS ?? '');
-  return Number.isFinite(parsed) && parsed > 0 ? parsed : 900_000;
-})();
+// COLD_TIMEOUT_MS moved to fixtures.ts (2026-08-11) so packaged.spec.ts shares one value: it
+// launches a real package too and was silently using Playwright's defaults. Still env-tunable
+// via RF_E2E_COLD_TIMEOUT_MS. The window remains UNVERIFIED on a CI runner — the settling
+// experiment is a dispatch that gets all the way through a cold first run.
 
 const SKIP_REASON =
   `${APP_EXE_ENV} is not set, so there is no installed app to drive. Set it to the ` +
@@ -254,10 +246,19 @@ test.describe('INSTALLED build — first run to working pipeline (W-A + W41)', (
       'exactly one MEDIA_STUDIO_* key may reach the installed app: the seeded data root',
     ).toEqual(['MEDIA_STUDIO_CONFIG_DIR']);
 
+    // THE THIRD TIMEOUT ON THIS PATH, and each one only became visible after the previous was
+    // removed. `electron.launch` has its OWN budget, separate from the test timeout and from the
+    // beforeAll hook timeout above; at its default it aborted with `electron.launch: Timeout
+    // 180000ms exceeded` while the app was still bootstrapping. MEASURED on Actions run
+    // 31455388644: the captured stderr shows `[bootstrap] adopted the installer's default
+    // profile` and the asset manifest registering assets — i.e. the run was PROGRESSING, and
+    // there was no sha256 mismatch, so #406 held. A cold first run genuinely exceeds 3 minutes
+    // because it builds the env and installs packages.
     app = await electron.launch({
       args: [built.main, '--autoplay-policy=no-user-gesture-required', '--no-sandbox'],
       ...(built.executablePath ? { executablePath: built.executablePath } : {}),
       env: appEnv,
+      timeout: COLD_TIMEOUT_MS,
     });
     const proc = app.process();
     proc.stdout?.on('data', (d: Buffer) => mainLog.push(d.toString()));

--- a/app/e2e/packaged.spec.ts
+++ b/app/e2e/packaged.spec.ts
@@ -21,6 +21,7 @@ import { test, expect, _electron as electron, type ElectronApplication } from '@
 import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import {
+  COLD_TIMEOUT_MS,
   SIDECAR_DIR,
   bundledFfmpegPath,
   findBuiltApp,
@@ -50,6 +51,15 @@ test.describe('packaged (shipped binary) E2E', () => {
   const mainLog: string[] = [];
 
   test.beforeAll(async () => {
+    // Same cold-start budget as installed-app.spec.ts, and for the same reason: this hook
+    // launches a REAL package, whose FIRST run does the full bootstrap. It began failing the
+    // moment that bootstrap started genuinely working — before #406 it died fast on a get-pip
+    // sha256 mismatch, so the 120 s default was never reached. MEASURED on Actions run
+    // 31455388644: `"beforeAll" hook timeout of 120000ms exceeded` at packaged.spec.ts:52, with
+    // 20 passed / 1 failed / 4 did not run. `test.setTimeout()` inside beforeAll sets the HOOK
+    // timeout; `electron.launch` needs its own, which is a separate budget again.
+    test.setTimeout(COLD_TIMEOUT_MS + 120_000);
+
     // HARD requirement: a real package must exist (no dev fallback here). Set the
     // flag ONLY around our own resolution and restore it immediately, so it can
     // never leak into preview.spec (same single-worker process) and force IT to
@@ -70,6 +80,7 @@ test.describe('packaged (shipped binary) E2E', () => {
       args: [built.main, '--autoplay-policy=no-user-gesture-required', '--no-sandbox'],
       ...(built.executablePath ? { executablePath: built.executablePath } : {}),
       env: seeded.appEnv,
+      timeout: COLD_TIMEOUT_MS,
     });
     const proc = app.process();
     proc.stdout?.on('data', (d: Buffer) => mainLog.push(d.toString()));


### PR DESCRIPTION
fix(e2e): one shared cold-start budget, applied to the launch AND to packaged.spec

THREE timeouts sit on the cold-first-run path and each only became visible once the previous
was removed. This closes the remaining two and stops the value being defined in one spec
while the other silently used Playwright's defaults.

1. `electron.launch` has its OWN budget, separate from the test timeout and from the
   beforeAll hook timeout fixed in #410. At its default the installed leg aborted with
   `electron.launch: Timeout 180000ms exceeded`.
2. `packaged.spec.ts` had no hook timeout at all and began failing the moment the bootstrap
   started genuinely working: before #406 it died fast on a get-pip sha256 mismatch, so the
   120 s default was never reached.

MEASURED on Actions run 31455388644, driving a real silent NSIS install:
* step 22 `"beforeAll" hook timeout of 120000ms exceeded` at packaged.spec.ts:52 —
  20 passed, 1 failed, 4 did not run;
* step 28 `electron.launch: Timeout 180000ms exceeded`, and the captured stderr shows
  `[bootstrap] adopted the installer's default profile` plus the asset manifest registering
  assets, with NO sha256 mismatch. So the bootstrap was PROGRESSING and #406 held — a cold
  first run simply exceeds 3 minutes because it builds the env and installs packages.

Same run also CONFIRMS #408: steps 25 (speech -> transcript -> caption) and 26 (the W40
"Add videos" gate) both SUCCEEDED while steps 22 and 23 were red. Both reported `skipped`
before the cascade fix, so the guards are doing exactly what they were added for.

COLD_TIMEOUT_MS moves to fixtures.ts and both specs import it. It was defined in
installed-app.spec.ts while packaged.spec.ts — which also launches a real package whose
first run bootstraps — used the defaults. Duplicating a value across N places is the shape
that produced the get-pip pin/artifact mismatch, where a rotation updated two of the three
places a comment said to keep in sync. Still env-tunable via RF_E2E_COLD_TIMEOUT_MS, which
e2e.yml:687 already sets to 1200000 for the installed leg.

Verified: `npm run typecheck:e2e` exit 0, and both specs still enumerate (10 tests in 2
files). Whether a cold first run then SUCCEEDS remains UNVERIFIED — no run has yet got past
the launch. Settling experiment: another e2e.yml dispatch on main with
drive_installed_build checked, after this merges.
