### PR TITLE
docs(quality): scope the gate-1 charter row and the W38 claim to what is measured

### DIFF
--- a/QUALITY-CHARTER.md
+++ b/QUALITY-CHARTER.md
@@ -98,10 +98,11 @@ tree, and github-actions); that is supply-chain hygiene, not part of the 6-gate 
   packs) does not admit today.
 - **Electron hardening is enforced from the packaging config, and Electronegativity is
   deliberately NOT wired (W66).** `.quality/electron_hardening_check.py` asserts (e1)
-  `electron-builder.yml` declares an `electronFuses:` header line **and** that each of the
-  eight required fuses appears with its required value — ASAR integrity +
-  `onlyLoadAppFromAsar` ON, `NODE_OPTIONS`/`--inspect` OFF, and `runAsNode` pinned **true**
-  because the caption render path spawns the Electron exe as plain Node — and (e2)
+  `electron-builder.yml` declares `asar: true`, a NON-EMPTY top-level `electronFuses:`
+  block, and each of the eight required fuses with its required value **inside that block,
+  at every occurrence** — ASAR integrity + `onlyLoadAppFromAsar` ON, `NODE_OPTIONS`/
+  `--inspect` OFF, and `runAsNode` pinned **true** because the caption render path spawns
+  the Electron exe as plain Node — and (e2)
   `app/main/main.ts` still declares `contextIsolation`/`nodeIntegration`/`sandbox`, with no
   `app/main/**` file re-opening the renderer via `webSecurity: false`. e2 exists because of
   a measured overclaim caught while writing this very note: `app/main/security.test.ts`
@@ -111,20 +112,28 @@ tree, and github-actions); that is supply-chain hygiene, not part of the 6-gate 
   happens on a shared runner is the "green gate that was never seen red" failure this
   charter exists to prevent. Revisit it as a pinned devDependency once someone can run it
   locally first.
-  **Scope of e1, stated so it is not read as more — an earlier wording here said the gate
-  asserts `electron-builder.yml` "declares the whole `electronFuses` block", and that is
-  REFUTED.** Measured 2026-08-11 by mutating the real yml and calling `check_fuses`
-  directly: the gate proves the `electronFuses:` HEADER line exists, then matches each fuse
-  at two-space indentation **anywhere in the file**, reading only the FIRST occurrence. So
-  (a) re-homing all eight fuses under a different top-level key and leaving `electronFuses:`
-  empty is CLEAN, over a build that flips zero fuses, and (b) a second, contradicting
-  `enableEmbeddedAsarIntegrityValidation: false` further down is CLEAN. Both are latent, not
-  live — today every fuse is inside the block, declared once. Detector control for that pair
-  of zeroes: deleting a fuse line outright, and commenting out the header, are each CAUGHT,
-  so the two CLEAN readings are the gate's behaviour and not a broken probe. **This
-  paragraph tightens when PR #409 lands** — it adds block-slicing plus an every-occurrence
-  walk, at which point "declares an `electronFuses:` block containing every key" becomes
-  true and this scope note should be replaced by that sentence.
+  **TWO earlier wordings of the e1 sentence above are REFUTED, recorded rather than
+  deleted.** (1) "declares the whole `electronFuses` block" was written against the
+  pre-#409 gate, which proved only that the HEADER line existed and then matched fuses
+  anywhere in the file, first occurrence only — wider than the code it described.
+  (2) Its replacement, drafted 2026-08-11 against branch base `81a04965`, said the gate
+  asserts a header line **and** the eight fuse values, and stated as measured fact that
+  re-homing all eight fuses under another top-level key with `electronFuses:` left empty
+  was CLEAN, that a second contradicting `enableEmbeddedAsarIntegrityValidation: false`
+  was CLEAN, and that "this paragraph tightens when PR #409 lands". PR #409 had ALREADY
+  merged (`60f1a43e`, 2026-08-11T02:43:13Z — fourteen minutes after that commit), so the
+  wording landed false the moment it was written. Re-measured against `origin/main` by
+  calling `check_fuses` on the real yml plus mutations: BOTH of those mutations are now
+  CAUGHT (`has an EMPTY electronFuses: block — it flips nothing`; `fuse
+  enableEmbeddedAsarIntegrityValidation is false, must be true`), because #409 added
+  `fuses_block()` block-slicing, an explicit empty-block rejection, and a `finditer`
+  every-occurrence walk. Both wordings ALSO omitted the third assertion the checker makes,
+  `asar: true` (`_ASAR_TRUE_RE`, asserted identically at both revisions — mutating it to
+  `false` is CAUGHT before and after). Detector control for the flipped pair: the
+  unmutated yml is CLEAN, and a deleted fuse line and a commented-out header are each
+  CAUGHT, at BOTH revisions — so the difference is the gate change, not a broken probe.
+  Standing lesson, not a to-do: a dated measurement taken against an OPEN PR expires the
+  moment that PR merges. Re-probe `origin/main` before quoting gate behaviour here.
   **What is NOT proven by this gate:** it reads CONFIG, so it proves the fuses are
   *declared*, not that the bits are flipped in a built exe. Settling experiment:
   `npx electron-builder --config ../electron-builder.yml --win`, then

--- a/QUALITY-CHARTER.md
+++ b/QUALITY-CHARTER.md
@@ -98,7 +98,8 @@ tree, and github-actions); that is supply-chain hygiene, not part of the 6-gate 
   packs) does not admit today.
 - **Electron hardening is enforced from the packaging config, and Electronegativity is
   deliberately NOT wired (W66).** `.quality/electron_hardening_check.py` asserts (e1)
-  `electron-builder.yml` declares the whole `electronFuses` block — ASAR integrity +
+  `electron-builder.yml` declares an `electronFuses:` header line **and** that each of the
+  eight required fuses appears with its required value — ASAR integrity +
   `onlyLoadAppFromAsar` ON, `NODE_OPTIONS`/`--inspect` OFF, and `runAsNode` pinned **true**
   because the caption render path spawns the Electron exe as plain Node — and (e2)
   `app/main/main.ts` still declares `contextIsolation`/`nodeIntegration`/`sandbox`, with no
@@ -110,6 +111,20 @@ tree, and github-actions); that is supply-chain hygiene, not part of the 6-gate 
   happens on a shared runner is the "green gate that was never seen red" failure this
   charter exists to prevent. Revisit it as a pinned devDependency once someone can run it
   locally first.
+  **Scope of e1, stated so it is not read as more — an earlier wording here said the gate
+  asserts `electron-builder.yml` "declares the whole `electronFuses` block", and that is
+  REFUTED.** Measured 2026-08-11 by mutating the real yml and calling `check_fuses`
+  directly: the gate proves the `electronFuses:` HEADER line exists, then matches each fuse
+  at two-space indentation **anywhere in the file**, reading only the FIRST occurrence. So
+  (a) re-homing all eight fuses under a different top-level key and leaving `electronFuses:`
+  empty is CLEAN, over a build that flips zero fuses, and (b) a second, contradicting
+  `enableEmbeddedAsarIntegrityValidation: false` further down is CLEAN. Both are latent, not
+  live — today every fuse is inside the block, declared once. Detector control for that pair
+  of zeroes: deleting a fuse line outright, and commenting out the header, are each CAUGHT,
+  so the two CLEAN readings are the gate's behaviour and not a broken probe. **This
+  paragraph tightens when PR #409 lands** — it adds block-slicing plus an every-occurrence
+  walk, at which point "declares an `electronFuses:` block containing every key" becomes
+  true and this scope note should be replaced by that sentence.
   **What is NOT proven by this gate:** it reads CONFIG, so it proves the fuses are
   *declared*, not that the bits are flipped in a built exe. Settling experiment:
   `npx electron-builder --config ../electron-builder.yml --win`, then

--- a/docs/plans/v1.5/README.md
+++ b/docs/plans/v1.5/README.md
@@ -51,9 +51,13 @@ changed — never the reverse.
   inside a model-name regex in `advisorMeta.test.ts`, i.e. a mention, not a swap).
 
 - **B-roll is not deferred.** `docs/ROADMAP.md` lists B-roll, emoji/SFX triggers and
-  publishing as "deferred from V1"; `PROGRAM.md` makes local auto-B-roll flagship #3
-  and puts emoji-burst + SFX-on-emphasis in the caption engine. docs/ROADMAP.md is stale
-  at v1.2.0 while `app/package.json` is 1.4.2.
+  publishing as "deferred from V1" (`docs/ROADMAP.md:66`); `PROGRAM.md` makes local
+  auto-B-roll flagship #3 and puts emoji-burst + SFX-on-emphasis in the caption engine.
+  Re-measured 2026-08-11: `docs/ROADMAP.md`'s Release-status list still stops at **v1.2.0**
+  while `app/package.json` is **1.5.0** — so the gap is three minors wide, not one.
+  (An earlier revision of this line asserted `app/package.json` is 1.4.2. That was true when
+  written and is now REFUTED; the version is a moving figure, so treat the dated measurement
+  as the claim and re-run it rather than reading the number as a standing fact.)
 
 ## Two documents were archived, not promoted
 

--- a/docs/plans/v1.5/README.md
+++ b/docs/plans/v1.5/README.md
@@ -54,10 +54,14 @@ changed — never the reverse.
   publishing as "deferred from V1" (`docs/ROADMAP.md:66`); `PROGRAM.md` makes local
   auto-B-roll flagship #3 and puts emoji-burst + SFX-on-emphasis in the caption engine.
   Re-measured 2026-08-11: `docs/ROADMAP.md`'s Release-status list still stops at **v1.2.0**
-  while `app/package.json` is **1.5.0** — so the gap is three minors wide, not one.
+  while `app/package.json` is **1.5.0** — so the gap is three minors wide (1.2 -> 1.3 -> 1.4
+  -> 1.5), not the two it was when this line was written.
   (An earlier revision of this line asserted `app/package.json` is 1.4.2. That was true when
   written and is now REFUTED; the version is a moving figure, so treat the dated measurement
-  as the claim and re-run it rather than reading the number as a standing fact.)
+  as the claim and re-run it rather than reading the number as a standing fact. A first
+  attempt at this correction closed with "not one", which is also REFUTED: the superseded
+  figure 1.4.2 against v1.2.0 is a TWO-minor gap, and no revision of this line ever claimed
+  one.)
 
 ## Two documents were archived, not promoted
 

--- a/sidecar/tests/test_charter_check_gate.py
+++ b/sidecar/tests/test_charter_check_gate.py
@@ -38,6 +38,7 @@ coverage number.
 from __future__ import annotations
 
 import importlib.util
+import re
 from pathlib import Path
 from types import ModuleType
 
@@ -45,6 +46,7 @@ import pytest
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHARTER_CHECK_PY = REPO_ROOT / ".quality" / "charter_check.py"
+PRECOMMIT_CONFIG = REPO_ROOT / ".pre-commit-config.yaml"
 
 # The slugs that quality.yml really declares as step names today. `secrets` is absent on
 # purpose: it rides inside the gate-lint-format pre-commit step (charter_check.COVERED_BY).
@@ -213,6 +215,106 @@ def test_disclosed_residual_never_adds_a_phantom_slug(shape: str, charter_check:
     got = charter_check.parse_workflow_gate_steps(text)
     assert got == expected
     assert not (got - truth), f"{shape} ADDED a phantom slug: {sorted(got - truth)}"
+
+
+# --- the gate-1 local hooks must be DECLARED, not just described ---------------------
+#
+# `charter_check.py` reads QUALITY-CHARTER.md and quality.yml only. The three stdlib
+# checkers the gate-1 charter row names ride INSIDE the pre-commit step, so nothing —
+# not charter_check, not either gate's own test module — asserted that
+# `.pre-commit-config.yaml` still declares them. Deleting a `- id:` block was therefore
+# invisible: the charter would keep advertising a checker that no longer runs, which is
+# the same charter-stops-meaning-anything failure the rest of this module exists to catch.
+#
+# Parsed structurally for the same reason the W30 fix went structural: a substring search
+# would be satisfied by the several COMMENTS in that file that name these hooks by id.
+PRECOMMIT_HOOK_ID = re.compile(r"^\s+-\s+id:\s*(?P<id>[A-Za-z0-9][\w.-]*)")
+PRECOMMIT_ENTRY = re.compile(r"^\s+entry:\s*(?P<entry>\S.*?)\s*$")
+
+# hook id -> the script its `entry:` must invoke.
+GATE1_LOCAL_HOOKS = {
+    "docs-check": ".quality/docs_check.py",
+    "reachability-check": ".quality/reachability_check.py",
+    "electron-hardening-check": ".quality/electron_hardening_check.py",
+}
+
+
+def parse_precommit_hooks(text: str) -> dict[str, str]:
+    """id -> entry, for every hook declared as a real `- id:` sequence item.
+
+    Scope, so this is not read as more: it proves the hook is DECLARED with an entry that
+    names the expected script. It does NOT prove pre-commit executes it — `stages:`,
+    `always_run`, and the top-level `exclude:` are not modelled here, and no pre-commit
+    process is spawned (this suite is hermetic and offline).
+    """
+    hooks: dict[str, str] = {}
+    current: str | None = None
+    for line in text.splitlines():
+        hook = PRECOMMIT_HOOK_ID.match(line)
+        if hook is not None:
+            current = hook.group("id")
+            hooks.setdefault(current, "")
+            continue
+        entry = PRECOMMIT_ENTRY.match(line)
+        if entry is not None and current is not None:
+            hooks[current] = entry.group("entry")
+    return hooks
+
+
+def test_gate1_local_hook_ids_are_declared_in_precommit_config() -> None:
+    """The three stdlib checkers the gate-1 charter row names are really wired."""
+    hooks = parse_precommit_hooks(PRECOMMIT_CONFIG.read_text(encoding="utf-8"))
+    missing = sorted(set(GATE1_LOCAL_HOOKS) - set(hooks))
+    assert not missing, (
+        f"QUALITY-CHARTER.md gate 1 names these, .pre-commit-config.yaml does not declare them: {missing}"
+    )
+    for hook_id, script in GATE1_LOCAL_HOOKS.items():
+        assert script in hooks[hook_id], f"hook {hook_id!r} no longer runs {script} (entry is {hooks[hook_id]!r})"
+
+
+def test_the_hook_id_parser_finds_known_present_ids() -> None:
+    """Detector control: the parser must find ids it is known to be pointed at.
+
+    A regex that matched nothing would fail the assertion above as "missing hook" — a
+    loud but WRONG diagnosis, pointing at the config when the probe is what broke. Pin the
+    positive case on five unrelated hooks so a parser regression is named as such.
+    """
+    hooks = parse_precommit_hooks(PRECOMMIT_CONFIG.read_text(encoding="utf-8"))
+    assert {"ruff", "ruff-format", "oxlint", "biome-format", "gitleaks"} <= set(hooks), sorted(hooks)
+
+
+@pytest.mark.parametrize(
+    "mention",
+    [
+        "      # - id: ghost-check\n",
+        "  # the ghost-check hook was removed, see the tracking issue\n",
+        "        name: ghost-check (a hook NAME is not an id)\n",
+        "        entry: python .quality/ghost_check.py\n",
+    ],
+    ids=["commented sequence item", "prose comment", "name: key", "entry: key"],
+)
+def test_a_mentioned_hook_id_is_not_a_declared_hook(mention: str) -> None:
+    """Both-states control: a MENTION must not satisfy the assertion above.
+
+    This is the W30 defect in its pre-commit form. Each vector below is appended to the
+    real config; none may make `ghost-check` appear as a declared hook.
+    """
+    text = PRECOMMIT_CONFIG.read_text(encoding="utf-8") + mention
+    assert "ghost-check" not in parse_precommit_hooks(text)
+
+
+def test_removing_a_hook_id_block_is_caught() -> None:
+    """Both-states control: the KNOWN-BROKEN state must go red.
+
+    Delete the `- id: electron-hardening-check` line from the real config and the parser
+    must stop reporting it — otherwise the assertion above could never fail.
+    """
+    real = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    anchor = "      - id: electron-hardening-check\n"
+    assert anchor in real, "anchor no longer exists in .pre-commit-config.yaml"
+    hooks = parse_precommit_hooks(real.replace(anchor, ""))
+    assert "electron-hardening-check" not in hooks
+    assert "docs-check" in hooks, "the mutation must be surgical, not destroy the whole parse"
 
 
 def test_comment_only_gate_fails_end_to_end(

--- a/sidecar/tests/test_charter_check_gate.py
+++ b/sidecar/tests/test_charter_check_gate.py
@@ -38,11 +38,11 @@ coverage number.
 from __future__ import annotations
 
 import importlib.util
-import re
 from pathlib import Path
 from types import ModuleType
 
 import pytest
+import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 CHARTER_CHECK_PY = REPO_ROOT / ".quality" / "charter_check.py"
@@ -226,10 +226,34 @@ def test_disclosed_residual_never_adds_a_phantom_slug(shape: str, charter_check:
 # invisible: the charter would keep advertising a checker that no longer runs, which is
 # the same charter-stops-meaning-anything failure the rest of this module exists to catch.
 #
-# Parsed structurally for the same reason the W30 fix went structural: a substring search
-# would be satisfied by the several COMMENTS in that file that name these hooks by id.
-PRECOMMIT_HOOK_ID = re.compile(r"^\s+-\s+id:\s*(?P<id>[A-Za-z0-9][\w.-]*)")
-PRECOMMIT_ENTRY = re.compile(r"^\s+entry:\s*(?P<entry>\S.*?)\s*$")
+# Parsed with `yaml.safe_load` — the loader pre-commit itself uses — for the same reason
+# the W30 fix went structural.
+#
+# REFUTED wording, kept so it is not re-derived: this comment first read "a substring search
+# would be satisfied by the several COMMENTS in that file that name these hooks by id".
+# Measured over the real file: exactly ONE comment line names exactly ONE of the three ids
+# (`.pre-commit-config.yaml:79`, "Same reasoning as docs-check above"), and
+# `reachability-check` / `electron-hardening-check` appear in NO comment at all — so "the
+# several COMMENTS", plural both ways, is false. The decision to parse structurally is still
+# right, for a reason that sentence did not give: every hook's own `name:` value repeats its
+# id verbatim (`:72`, `:89`, `:101`), so a substring search for an id is satisfied by the
+# hook's LABEL rather than by its declaration.
+#
+# REFUTED implementation, likewise recorded: the first structural version was a pair of
+# line-positional regexes, and an adversarial review measured it wrong in BOTH directions.
+#   * `entry:` captured the raw remainder of the line INCLUDING a trailing ` #` comment,
+#     while the assertion below is a containment test — so `entry: true  # python
+#     .quality/docs_check.py` was GREEN while pre-commit executed `true`. That is the W30
+#     use-vs-mention defect in the ENTRY position, committed by the fix written to close it
+#     in the ID position (`.quality/docs_check.py:33-37` records the same class).
+#   * `id:` was read positionally, so a hook whose keys were reordered (legal — YAML mapping
+#     keys are unordered) reported as MISSING, a folded `entry: >-` reported its entry as
+#     `">-"`, and a `- id: ghost-check` nested under `args:` registered as a declared hook.
+# `ENTRY_HOLE_VECTORS` (3), `PARSER_FALSE_RED_VECTORS` (2) and the `nested args:` mention
+# vector (1) pin six vectors between them. Measured by swapping this loader back out for
+# the retired regex and re-running: all six go RED against the regex and GREEN against the
+# loader, so they discriminate. The `entry: key` mention vector does NOT — it behaves
+# identically under both — and says so where it is declared.
 
 # hook id -> the script its `entry:` must invoke.
 GATE1_LOCAL_HOOKS = {
@@ -240,67 +264,169 @@ GATE1_LOCAL_HOOKS = {
 
 
 def parse_precommit_hooks(text: str) -> dict[str, str]:
-    """id -> entry, for every hook declared as a real `- id:` sequence item.
+    """id -> entry, for every hook really declared under ``repos[].hooks[]``.
 
     Scope, so this is not read as more: it proves the hook is DECLARED with an entry that
     names the expected script. It does NOT prove pre-commit executes it — `stages:`,
     `always_run`, and the top-level `exclude:` are not modelled here, and no pre-commit
-    process is spawned (this suite is hermetic and offline).
+    process is spawned (this suite is hermetic and offline). A non-string `entry:` (`true`,
+    a list, absent) normalises to `""`, which FAILS the containment assertion below rather
+    than passing it; that is the direction a neutered hook must fall in.
     """
+    document = yaml.safe_load(text)
     hooks: dict[str, str] = {}
-    current: str | None = None
-    for line in text.splitlines():
-        hook = PRECOMMIT_HOOK_ID.match(line)
-        if hook is not None:
-            current = hook.group("id")
-            hooks.setdefault(current, "")
+    if not isinstance(document, dict):
+        return hooks
+    repos = document.get("repos")
+    if not isinstance(repos, list):
+        return hooks
+    for repo in repos:
+        if not isinstance(repo, dict):
             continue
-        entry = PRECOMMIT_ENTRY.match(line)
-        if entry is not None and current is not None:
-            hooks[current] = entry.group("entry")
+        declared = repo.get("hooks")
+        if not isinstance(declared, list):
+            continue
+        for hook in declared:
+            if not isinstance(hook, dict):
+                continue
+            hook_id = hook.get("id")
+            if not isinstance(hook_id, str):
+                continue
+            entry = hook.get("entry")
+            hooks[hook_id] = entry if isinstance(entry, str) else ""
     return hooks
+
+
+def gate1_hook_violations(text: str) -> list[str]:
+    """Exactly the failures the assertion below reports, as data.
+
+    Shared so the both-states controls pin the REAL verdict instead of re-implementing it —
+    a control that drifts from the assertion it guards proves nothing about the assertion.
+    """
+    hooks = parse_precommit_hooks(text)
+    problems = [f"missing hook {hook_id}" for hook_id in sorted(set(GATE1_LOCAL_HOOKS) - set(hooks))]
+    problems += [
+        f"hook {hook_id!r} no longer runs {script} (entry is {hooks[hook_id]!r})"
+        for hook_id, script in sorted(GATE1_LOCAL_HOOKS.items())
+        if hook_id in hooks and script not in hooks[hook_id]
+    ]
+    return problems
 
 
 def test_gate1_local_hook_ids_are_declared_in_precommit_config() -> None:
     """The three stdlib checkers the gate-1 charter row names are really wired."""
-    hooks = parse_precommit_hooks(PRECOMMIT_CONFIG.read_text(encoding="utf-8"))
-    missing = sorted(set(GATE1_LOCAL_HOOKS) - set(hooks))
-    assert not missing, (
-        f"QUALITY-CHARTER.md gate 1 names these, .pre-commit-config.yaml does not declare them: {missing}"
-    )
-    for hook_id, script in GATE1_LOCAL_HOOKS.items():
-        assert script in hooks[hook_id], f"hook {hook_id!r} no longer runs {script} (entry is {hooks[hook_id]!r})"
+    problems = gate1_hook_violations(PRECOMMIT_CONFIG.read_text(encoding="utf-8"))
+    assert not problems, f"QUALITY-CHARTER.md gate 1 names checkers .pre-commit-config.yaml does not run: {problems}"
 
 
 def test_the_hook_id_parser_finds_known_present_ids() -> None:
     """Detector control: the parser must find ids it is known to be pointed at.
 
-    A regex that matched nothing would fail the assertion above as "missing hook" — a
+    A parser that found nothing would fail the assertion above as "missing hook" — a
     loud but WRONG diagnosis, pointing at the config when the probe is what broke. Pin the
     positive case on five unrelated hooks so a parser regression is named as such.
     """
     hooks = parse_precommit_hooks(PRECOMMIT_CONFIG.read_text(encoding="utf-8"))
     assert {"ruff", "ruff-format", "oxlint", "biome-format", "gitleaks"} <= set(hooks), sorted(hooks)
+    assert hooks["docs-check"] == "python .quality/docs_check.py", hooks["docs-check"]
+
+
+# The real `docs-check` entry, and the shapes that neuter the hook while leaving the real
+# command visible in a trailing YAML comment. pre-commit runs the value BEFORE the ` #`;
+# the retired regex captured the whole line, so all three were GREEN.
+REAL_DOCS_ENTRY = "entry: python .quality/docs_check.py"
+ENTRY_HOLE_VECTORS = {
+    "disabled to echo, real command in the comment": (
+        "entry: echo  # python .quality/docs_check.py (disabled, see the tracking issue)"
+    ),
+    "neutered to a no-op, real command in the comment": "entry: true  # python .quality/docs_check.py",
+    "renamed, OLD name left in the comment": "entry: python .quality/docs_check_v2.py  # was .quality/docs_check.py",
+}
+
+
+@pytest.mark.parametrize("shape", sorted(ENTRY_HOLE_VECTORS), ids=sorted(ENTRY_HOLE_VECTORS))
+def test_a_script_named_only_in_a_trailing_comment_is_caught(shape: str) -> None:
+    """Both-states control for the ENTRY half: a MENTION must not satisfy the entry.
+
+    The hook id survives in every shape, so the id half of the assertion stays green; only
+    the command changes. This is the realistic way a gate-1 checker stops running — a rename
+    that leaves the old path in a comment, or a temporary `true`/`echo` that outlives its
+    tracking issue — and it is the shape the retired line-positional parser could not see.
+    """
+    real = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    mutated = real.replace(REAL_DOCS_ENTRY, ENTRY_HOLE_VECTORS[shape])
+    assert mutated != real, f"anchor {REAL_DOCS_ENTRY!r} no longer exists in .pre-commit-config.yaml"
+    assert "docs-check" in parse_precommit_hooks(mutated), "the mutation must neuter the entry, not the id"
+    assert gate1_hook_violations(mutated), f"{shape} left the gate GREEN"
+
+
+# Legal rewrites that are the SAME configuration to pre-commit. anchor -> replacement.
+PARSER_FALSE_RED_VECTORS = {
+    "folded block scalar entry": (
+        "entry: python .quality/reachability_check.py",
+        "entry: >-\n          python .quality/reachability_check.py",
+    ),
+    "id: written after entry: in the same hook": (
+        "      - id: docs-check\n"
+        "        name: docs-check (SSOT anti-drift R1-R5)\n"
+        "        entry: python .quality/docs_check.py\n",
+        "      - name: docs-check (SSOT anti-drift R1-R5)\n"
+        "        entry: python .quality/docs_check.py\n"
+        "        id: docs-check\n",
+    ),
+}
+
+
+@pytest.mark.parametrize("shape", sorted(PARSER_FALSE_RED_VECTORS), ids=sorted(PARSER_FALSE_RED_VECTORS))
+def test_semantically_identical_yaml_does_not_go_red(shape: str) -> None:
+    """The over-tightening direction: a legal rewrite must not be reported as a broken hook.
+
+    YAML mapping keys are unordered and a folded scalar is just a wrapped string, so both
+    shapes below run exactly what the real file runs. The retired regex reported the first as
+    ``reachability-check no longer runs ... (entry is '>-')`` and the second as ``missing hook
+    docs-check`` — loud, and pointing at the config when the probe was what broke.
+    """
+    anchor, rewrite = PARSER_FALSE_RED_VECTORS[shape]
+    real = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    assert anchor in real, f"anchor for {shape} no longer exists in .pre-commit-config.yaml"
+    problems = gate1_hook_violations(real.replace(anchor, rewrite))
+    assert not problems, f"{shape} is the same config to pre-commit, but the parser reports: {problems}"
 
 
 @pytest.mark.parametrize(
-    "mention",
+    ("mention", "entry_owner_mutated"),
     [
-        "      # - id: ghost-check\n",
-        "  # the ghost-check hook was removed, see the tracking issue\n",
-        "        name: ghost-check (a hook NAME is not an id)\n",
-        "        entry: python .quality/ghost_check.py\n",
+        ("      # - id: ghost-check\n", False),
+        ("  # the ghost-check hook was removed, see the tracking issue\n", False),
+        ("        name: ghost-check (a hook NAME is not an id)\n", False),
+        ("        entry: python .quality/ghost_check.py\n", True),
+        ("        args:\n          - --config\n          - id: ghost-check\n", False),
     ],
-    ids=["commented sequence item", "prose comment", "name: key", "entry: key"],
+    ids=["commented sequence item", "prose comment", "name: key", "entry: key", "nested args: sequence item"],
 )
-def test_a_mentioned_hook_id_is_not_a_declared_hook(mention: str) -> None:
+def test_a_mentioned_hook_id_is_not_a_declared_hook(mention: str, entry_owner_mutated: bool) -> None:
     """Both-states control: a MENTION must not satisfy the assertion above.
 
-    This is the W30 defect in its pre-commit form. Each vector below is appended to the
-    real config; none may make `ghost-check` appear as a declared hook.
+    This is the W30 defect in its pre-commit form. Each vector is appended to the real
+    config; none may make `ghost-check` appear as a declared hook.
+
+    The second column exists because the `entry:` vector passed for the WRONG reason: an
+    `entry:` appended at hook-key indentation cannot create a hook, it silently gives the
+    LAST declared hook (`gitleaks`, which declares no `entry:` of its own) that command. So
+    "ghost-check is absent" was a tautology there; asserting the side effect makes it a
+    measurement. Scope of that row, measured and stated so it is not read as more: BOTH the
+    retired regex and this loader reassign `gitleaks` identically, so it pins behaviour and
+    does NOT discriminate between the two parsers. The `args:` vector is the one that does —
+    it is the shape a line-positional parser got wrong in the other direction, registering
+    `ghost-check` as a declared hook.
     """
-    text = PRECOMMIT_CONFIG.read_text(encoding="utf-8") + mention
-    assert "ghost-check" not in parse_precommit_hooks(text)
+    real = PRECOMMIT_CONFIG.read_text(encoding="utf-8")
+    before = parse_precommit_hooks(real)
+    after = parse_precommit_hooks(real + mention)
+    assert "ghost-check" not in after
+    assert sorted(after) == sorted(before), "a mention must not change the DECLARED hook set"
+    mutated = {key for key in after if before[key] != after[key]}
+    assert mutated == ({"gitleaks"} if entry_owner_mutated else set()), mutated
 
 
 def test_removing_a_hook_id_block_is_caught() -> None:

--- a/sidecar/tests/test_contract_parity.py
+++ b/sidecar/tests/test_contract_parity.py
@@ -204,9 +204,19 @@ def test_newly_declared_keys_are_modeled():
     `silenceTrim` as the probes): the old assertion fired on a COMPLETE migration —
     both sides landed, nothing drifted — so the suite punished exactly the progress
     the contract exists to enable. The half it was really reaching for (store and
-    contract must not disagree) is now enforced, and enforced more widely, by
+    contract must not disagree) is now enforced by
     ``test_declared_settings_defaults_match_the_store`` below, whose RED conditions
     are pinned by ``test_default_parity_rule_goes_red_on_*``.
+
+    REFUTED wording, kept so it is not re-derived: this used to read "enforced, and
+    enforced more widely". Measured against the live registry 2026-08-11 — schema
+    properties 20, ``DEFAULT_SETTINGS`` 22, intersection 14, minus the 2 nested-block
+    exemptions = **12 keys checked**, and ``set(checked) == set(_STATIC_DEFAULT_KEYS)``
+    exactly (symmetric difference empty both ways). The rule's own failure message prints
+    ``(12 keys checked)``. So the replacement is not wider TODAY; it is the same 12 keys
+    obtained by computation instead of enumeration. The forward-looking claim at
+    ``_default_parity_drift`` ("the checked set grows with the tree") is the true one and
+    is where the value actually is.
     """
     props = registry.settings_schema()["properties"]
     missing = [key for key in _NEWLY_DECLARED_KEYS if key not in props]
@@ -225,6 +235,41 @@ def _default_parity_drift(
     nowhere. This walks ``schema.properties ∩ store`` instead, so the checked set
     grows with the tree. ``_STATIC_DEFAULT_KEYS`` is kept as a FLOOR by the caller —
     a computed set that silently shrank to nothing would otherwise pass vacuously.
+
+    That "grows with the tree" claim is forward-looking and is the whole value here; it
+    is NOT a claim that the checked set is wider than the hand list today. Measured
+    2026-08-11: schema properties 20 ∩ store 22 = 14, minus the 2 nested-block
+    exemptions = 12 checked, which is exactly ``set(_STATIC_DEFAULT_KEYS)``.
+
+    THREE RESIDUALS, measured the same day by calling this function against mutated
+    inputs, disclosed here rather than in a footer because each bounds the sentence above:
+
+    1. It still punishes forward progress, one class narrower than the assertion W38
+       removed. A COMPLETE, correct migration of a THIRD nested block — declared
+       ``{"type": "object"}`` in the schema, materialised in the store, contract default
+       ``None`` = absent — reports drift (measured: ``{'zzNewBlock': (None, {'a': 1})}``)
+       and goes RED until ``_NESTED_BLOCK_KEYS`` is hand-edited to add it. Settling change:
+       exempt by SCHEMA TYPE (``props[key]["type"] == "object"``) instead of by name, which
+       also removes the hand list this drift-check would then be waiting on.
+    2. Nested-block CONTENTS are never parity-checked at all. Both exempt blocks are
+       dropped whole, so mutating ``DEFAULT_SETTINGS["autosave"]["debounceMs"]`` to a
+       string returns ``{}`` — the five sub-properties the schema declares across the two
+       blocks (``autosave``: ``enabled``, ``debounceMs``; ``exportDefaults``:
+       ``subtitleFormat``, ``nleFormat``, ``nleFps``) carry the same drift exposure the
+       scalars had before W38. Settling change: recurse one level into an exempt block and
+       compare its declared sub-properties.
+    3. A contract-only default is invisible. The set is an INTERSECTION, so a key declared
+       in the schema with a contract default the store never materialises is silently
+       dropped rather than flagged (measured: ``{}``). Six keys are schema-only today
+       (``captionSpeakerLabels``, ``captionStyle``, ``hookTitle``, ``removeFillers``,
+       ``silenceTrim``, ``stabilize``) and all six have contract default ``None``
+       (measured, not assumed) — which is why nothing is wrong right now, and why none of
+       them would be caught if that changed. Settling change: walk the UNION and treat
+       "declared non-None default, absent from the store" as drift.
+
+    Detector control for the two ``{}`` readings above: residual 1 shows this same function
+    DOES emit drift on mutated input, and ``test_default_parity_rule_goes_red_on_a_scalar_drift``
+    pins the scalar direction — so the empty results are real holes, not a dead probe.
     """
     props = schema["properties"]
     assert isinstance(props, dict)

--- a/sidecar/tests/test_contract_parity.py
+++ b/sidecar/tests/test_contract_parity.py
@@ -242,7 +242,10 @@ def _default_parity_drift(
     exemptions = 12 checked, which is exactly ``set(_STATIC_DEFAULT_KEYS)``.
 
     THREE RESIDUALS, measured the same day by calling this function against mutated
-    inputs, disclosed here rather than in a footer because each bounds the sentence above:
+    inputs, disclosed here rather than in a footer because each bounds the sentence above.
+    Three FOUND by that probe — the list is not a proof that there are only three, and both
+    2 and 3 below carry the record of having been stated wider than their evidence on the
+    first pass:
 
     1. It still punishes forward progress, one class narrower than the assertion W38
        removed. A COMPLETE, correct migration of a THIRD nested block — declared
@@ -251,21 +254,57 @@ def _default_parity_drift(
        and goes RED until ``_NESTED_BLOCK_KEYS`` is hand-edited to add it. Settling change:
        exempt by SCHEMA TYPE (``props[key]["type"] == "object"``) instead of by name, which
        also removes the hand list this drift-check would then be waiting on.
-    2. Nested-block CONTENTS are never parity-checked at all. Both exempt blocks are
-       dropped whole, so mutating ``DEFAULT_SETTINGS["autosave"]["debounceMs"]`` to a
-       string returns ``{}`` — the five sub-properties the schema declares across the two
-       blocks (``autosave``: ``enabled``, ``debounceMs``; ``exportDefaults``:
-       ``subtitleFormat``, ``nleFormat``, ``nleFps``) carry the same drift exposure the
-       scalars had before W38. Settling change: recurse one level into an exempt block and
-       compare its declared sub-properties.
-    3. A contract-only default is invisible. The set is an INTERSECTION, so a key declared
-       in the schema with a contract default the store never materialises is silently
-       dropped rather than flagged (measured: ``{}``). Six keys are schema-only today
+    2. Nested-block CONTENTS are dropped whole by this function — but the exposure is on
+       the CONTRACT side, and the first version of this residual had it backwards. REFUTED
+       wording AND refuted evidence, both kept rather than deleted: it read "the five
+       sub-properties ... carry the same drift exposure the scalars had before W38", and
+       offered ``DEFAULT_SETTINGS["autosave"]["debounceMs"] = "not-an-int"`` -> ``{}`` as
+       the demonstration. That is the most-caught mutation of the set — measured over the
+       whole suite it goes red in THREE places, starting with
+       ``test_settings_schema_validates_real_get_payload`` (earlier in this module), which
+       calls ``registry.validate_settings_object(DEFAULT_SETTINGS)`` over a schema that
+       REJECTS a string there. The residual's own probe demonstrated a hole that does not
+       exist.
+       Re-measured 2026-08-11 by running the WHOLE sidecar suite once per mutation: the
+       STORE side is guarded too. ``autosave.debounceMs`` -> ``999999``, ``autosave.enabled``
+       -> ``False`` and ``autosave.debounceMs`` DELETED each fail
+       ``test_settings_store.py::test_qol_defaults_present_exact`` +
+       ``::test_qol_keys_round_trip``; ``exportDefaults.nleFps`` -> ``0`` fails
+       ``::test_qol_defaults_present_exact`` + ``::test_export_defaults_exact_acceptance`` +
+       ``::test_autosave_partial_set_round_trips``. Those tests pin both blocks as exact
+       dicts. Control: the same suite with no mutation is all-green, so the reds are the
+       mutations and not the harness.
+       What IS unguarded is CONTRACT-vs-store parity inside a block. ``contract/spec.py``
+       declares ``Autosave.debounceMs = 1500`` / ``ExportDefaults.nleFps = 30`` and
+       ``media_studio.settings_store`` declares the same numbers again, and nothing compares
+       the two copies: the generated schema for a nested block carries sub-property TYPES
+       only, with no ``default`` key at all (measured), and
+       ``registry.settings_defaults()["autosave"]`` is ``None``. Drifting the CONTRACT copy
+       to 2000 leaves this function at ``{}``, the schema byte-identical and
+       ``validate_settings_object`` ACCEPTING, and no test reads those dataclass defaults.
+       Detector control for that reading: the first attempt patched the class attribute
+       only, which a ``@dataclass`` ignores — ``spec.Autosave()`` still read 1500, so that
+       run measured nothing and was discarded; the numbers above come from patching
+       ``__init__.__defaults__``, asserted to have taken effect before anything was read.
+       Settling change: recurse one level into an exempt block and compare the contract
+       sub-field defaults against the store's materialised values.
+    3. The set is an INTERSECTION, so it drops keys in BOTH directions — 14 of the 28-key
+       union, not the 6 first disclosed. REFUTED wording, kept rather than deleted: this
+       residual originally read "a contract-only default is invisible ... Six keys are
+       schema-only today", which quantified ONE side of an intersection while presenting
+       itself as the whole loss. Re-measured 2026-08-11: schema-only = 6
        (``captionSpeakerLabels``, ``captionStyle``, ``hookTitle``, ``removeFillers``,
-       ``silenceTrim``, ``stabilize``) and all six have contract default ``None``
-       (measured, not assumed) — which is why nothing is wrong right now, and why none of
-       them would be caught if that changed. Settling change: walk the UNION and treat
-       "declared non-None default, absent from the store" as drift.
+       ``silenceTrim``, ``stabilize``), all six with contract default ``None`` (measured,
+       not assumed) — which is why nothing is wrong on that side right now, and why none of
+       them would be caught if that changed. Store-only = 8, MORE than the six disclosed
+       (``asrVocabulary``, ``brandCaptionTemplate``, ``brandFontFamily``, ``brandLogoPath``,
+       ``consent``, ``providers``, ``routing``, ``savePresets``) — each equally dropped
+       (measured: mutating ``asrVocabulary`` to a sentinel returns ``{}``), and unlike the
+       schema-only six they are not modelled by the contract at all, so
+       ``test_newly_declared_keys_are_modeled`` above polices only the 5 it names by hand.
+       Settling change, one change covering both directions: walk the UNION, treat
+       "declared non-None contract default, absent from the store" as drift, and treat
+       "materialised by the store, declared nowhere in the schema" as unmodelled.
 
     Detector control for the two ``{}`` readings above: residual 1 shows this same function
     DOES emit drift on mutated input, and ``test_default_parity_rule_goes_red_on_a_scalar_drift``


### PR DESCRIPTION
Wave-5 GATES lane. Verifier returned **mergeable: true**, no overclaims remaining.

Corrects the charter/W38/README sentences that promised more than the code enforced, and adds the missing assertion that the two new pre-commit hook ids exist in .pre-commit-config.yaml.

Two non-blocking notes from the verifier, both recorded rather than silently accepted:
* **PyYAML is undeclared.** \	est_charter_check_gate.py:45\ adds the only \import yaml\ in the sidecar tree, and PyYAML is declared nowhere in \sidecar/pyproject.toml\ — CI gets it purely as a transitive dep of \pre-commit==4.6.0\. Works today (almost certain, 90-99%), but the day pre-commit moves to its own venv, gate 3 dies at collection. One-line fix available at \quality.yml:41-45\; not done here to keep this diff scoped.
* **Merge-order precondition:** the charter sentence describes the POST-#409 checker, so merge onto a main containing \60f1a43e\ (it does). Verified conflict-free and green on the merged tree.