### PR TITLE
docs: re-verify the W71/W75-W79 claims against the tree

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -49,13 +49,23 @@ per-file authority table for that corpus; this section is the tree-wide statemen
 | r4 | no `.gitignore`-matched path is cited by tracked source | `ssot-allow:` on the same line |
 | r5 | no tracked doc that lives in a SUBDIRECTORY is cited by bare basename | `ssot-allow:` on the same line |
 
-**r5 was missing from this table until 2026-08-11, and the omission was the exact defect
-r5 exists to catch.** `docs_check.py`'s own header says r5 was added "because r1-r4 could not
-see the drift this gate's own commit created"; the gate has printed `r1=0 r2=0 r3=0 r4=0 r5=0`
-on every run since, so a reader comparing this table against the gate's output would have
-found a fifth counter the map did not mention. Measured at `81a04965`: `python
-.quality/docs_check.py` exits 0 and prints `authority-docs=93 citing-files-scanned=1122
-waivers-applied=9 ambiguous-bare=10 r1=0 r2=0 r3=0 r4=0 r5=0`.
+**r5 was missing from this table until 2026-08-11.** `docs_check.py`'s own header says r5 was
+added "because r1-r4 could not see the drift this gate's own commit created"; the gate has
+printed `r1=0 r2=0 r3=0 r4=0 r5=0` on every run since, so a reader comparing this table against
+the gate's output would have found a fifth counter the map did not mention. Measured at
+`81a04965`: `python .quality/docs_check.py` exits 0 and prints `authority-docs=93
+citing-files-scanned=1122 waivers-applied=9 ambiguous-bare=10 r1=0 r2=0 r3=0 r4=0 r5=0`.
+
+> **REFUTED, kept rather than deleted: this paragraph first called the omission "the exact
+> defect r5 exists to catch".** It is not, and r5 itself is the disproof. r5's rule — the one
+> in the row above, and in `docs_check.py`'s rule list — is *"No tracked doc that lives in a
+> SUBDIRECTORY is cited by bare basename"*; a missing markdown table row is not a citation at
+> all. Run at `81a04965`, where this table stopped at r4, the gate reports `r5=0` and `EXIT=0`
+> (output quoted above, measured in a detached worktree at that rev): the omission was
+> invisible to r5, so r5 cannot be the rule that catches it. What is true is the weaker,
+> META statement the header actually makes — this is the same *class* r5 was born from, a
+> gate's own commit creating drift its rules cannot see — and that class is why the omission
+> is worth recording, not because any counter would have gone red.
 
 A waiver must state its reason on the same line and is greppable
 (`git grep "ssot-allow:"`), matching the charter's rule-4 suppression idiom.
@@ -82,7 +92,7 @@ re-copy this number.)
 | gate composition + tool pins | [`QUALITY-CHARTER.md`](../QUALITY-CHARTER.md) | `.quality/charter_check.py` |
 | provider catalog + free tiers | `sidecar/media_studio/models/catalog.py` | [`providers/`](providers/SETUP.md) is a human mirror, never the source |
 | model URLs, commits, sha256 pins | `sidecar/media_studio/assets/manifest.py` | — |
-| the chatterbox env pin list | `sidecar/media_studio/features/tts/chatterbox.py` :: `CHATTERBOX_REQUIREMENTS` | `assets/manager.py:617` compares against the tuple; the `.txt` mirrors IT |
+| the chatterbox env pin list | `sidecar/media_studio/features/tts/chatterbox.py` :: `CHATTERBOX_REQUIREMENTS` | `sidecar/tests/test_runtime_setup.py` :: `TestShippedRequirementFiles::test_chatterbox_requirements_file_mirrors_the_code_tuple_exactly` asserts the `.txt` and the tuple are identical lists; the `.txt` mirrors the tuple. (**REFUTED, kept: this cell cited `assets/manager.py:617` as the comparison site.** Wrong on line, file and mechanism — at `81a04965` that line is `def installed_path(...)`, and `CHATTERBOX_REQUIREMENTS` does not occur anywhere in `assets/manager.py`. Absence controlled: in the same read `installed_path` fires 4× and case-insensitive `chatterbox` 15×, so the walk was alive. This is a SECOND live instance of the rot class the row above was fixed for, in the same table — the re-verification pass that fixed that one disclosed only one surviving instance, which was narrower than its own evidence.) |
 
 ## Repo root
 
@@ -147,7 +157,15 @@ the ids survive the move out of the repo root; this entry is how they stay finda
 
 > **REFUTED: this line read "28 tracked source files".** No probe yields 28 — not the bare-id
 > form (11), not the path form (26), not the union (36), not any mention (38). The literal was
-> already wrong when it was written in `6ae972c1`, where the same three probes read 11 / 30 / 30.
+> already wrong when it was written in `6ae972c1`, where the same three probes — run in the same
+> tracked non-`docs/`, non-`reports/` scope that yields the `11` above — read 11 / **18** / 30.
+> (**REFUTED, kept: this sentence first said `11 / 30 / 30`.** The middle figure was wrong by 12
+> and carried no UNVERIFIED tag while the three figures one line above did. `30` is a real
+> number, but off the wrong revision *and* the wrong scope: measured, it is the path-form count
+> at `81a04965` over ALL tracked files, `docs/` included. That it reached this sentence by being
+> copied from that adjacent cell is an inference, **likely (55-80%)** — the measurement is the
+> `30`/`18` mismatch, not the copy. The verdict is untouched: at `6ae972c1` no probe yields 28
+> either — 11 / 18 / 30, union 29.)
 > The detector used here is controlled BOTH ways: it fires on this entry's own example string
 > `// ---- WIRING-T5 §2`, and it does **not** fire on `docs/wiring/WIRING-T5.md §2`, so the
 > bare-id and path forms cannot contaminate each other. **UNVERIFIED and unpinned:** nothing
@@ -187,7 +205,7 @@ the ids survive the move out of the repo root; this entry is how they stay finda
 | [`build/RUN-CHECKLIST.md`](build/RUN-CHECKLIST.md) | the only run procedure. **DRAFT** — its pins are stale against `sidecar/pyproject.toml`; rewrite pending. |
 | [`build/COMPLETENESS-REPORT.md`](build/COMPLETENESS-REPORT.md) | superseded and wrong at the headline, kept because `HIGH-1` / `HIGH-3` finding ids are cited by five live source files. |
 | [`build/INTEGRATION-REPORT.md`](build/INTEGRATION-REPORT.md) | same — header, do not delete. |
-| [`build/DESIGN-DIRECTION.md`](build/DESIGN-DIRECTION.md) | superseded by [`design-system.md`](design-system.md); **8** of its 14 palette values contradict `tokens.css`. **REFUTED: this cell said 9 of 14.** The `14` is right (6 surface + 4 text + 1 accent + 3 status named in `## Palette (exact values)`); the `9` is not. Compared BY TOKEN NAME at `81a04965`, the 8 that disagree are the six `--surface-*` plus `--text-muted` and `--text-faint`; `--text-primary`, `--text-secondary` and the three `--status-*` agree, and the accent is written with no token name so it can only be matched by value (`#f2a33c`, which `tokens.css` does carry). A by-VALUE probe on the same file reports 7, not 8, because `#50555f` occurs in `tokens.css` somewhere other than a `--token:` declaration — two of my own probes disagreed, and the by-NAME reading is the one that answers "contradicts". Merge-and-archive is tracked as phase-2 item 2.7, not done. |
+| [`build/DESIGN-DIRECTION.md`](build/DESIGN-DIRECTION.md) | superseded by [`design-system.md`](design-system.md); **9** of the **16** palette values it states contradict `tokens.css`. **DOUBLY REFUTED, both wordings kept.** (1) The cell originally read *"9 of its 14"*. (2) A re-verification pass then rewrote it to *"**8** of its 14 … **REFUTED: this cell said 9 of 14.** The `14` is right (6 surface + 4 text + 1 accent + 3 status); the `9` is not"* — **that correction was inverted and is itself REFUTED: the `9` was right and the `14` was wrong.** Measured by TOKEN NAME at `81a04965` against the stored blobs, `## Palette (exact values)` names **15** tokens carrying an exact value, plus the accent written with no token name (`#f2a33c`, which `tokens.css` carries as `--accent`) = 16 values. Nine disagree: the six `--surface-*`, **`--edge`** (`rgba(255,255,255,0.07)` vs `rgba(255, 255, 255, 0.09)`), `--text-muted` and `--text-faint`. Six agree: `--edge-strong`, `--text-primary`, `--text-secondary`, the three `--status-*`. The "14" is reached only by dropping `--edge` and `--edge-strong`, which are named with exact values in the prose two lines under the surface table rather than in it — and `--edge` is the ninth disagreement, so dropping it is what turned 9 into 8. Enumeration basis, stated so the `16` can be checked rather than trusted: one value per named token plus the accent, the same basis the original `14` used. The section also prints three further accent shades and two washes, which no reading here counted; on the widest basis it states 21 colour values. Detector note, because the first pass here was a detector failure and not a finding: my initial pairer emitted a bogus `---` token from the table separator and silently dropped `--surface-deep`; the reading above comes from a line-oriented pairer that refuses to print a tally unless it first finds every hand-checked token. Merge-and-archive is tracked as phase-2 item 2.7, not done. |
 
 ## Archive
 

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -47,6 +47,15 @@ per-file authority table for that corpus; this section is the tree-wide statemen
 | r2 | every `docs/**` / `reports/**` path cited by tracked source resolves | `ssot-allow:` on the same line |
 | r3 | every live authority doc is linked from this file | no |
 | r4 | no `.gitignore`-matched path is cited by tracked source | `ssot-allow:` on the same line |
+| r5 | no tracked doc that lives in a SUBDIRECTORY is cited by bare basename | `ssot-allow:` on the same line |
+
+**r5 was missing from this table until 2026-08-11, and the omission was the exact defect
+r5 exists to catch.** `docs_check.py`'s own header says r5 was added "because r1-r4 could not
+see the drift this gate's own commit created"; the gate has printed `r1=0 r2=0 r3=0 r4=0 r5=0`
+on every run since, so a reader comparing this table against the gate's output would have
+found a fifth counter the map did not mention. Measured at `81a04965`: `python
+.quality/docs_check.py` exits 0 and prints `authority-docs=93 citing-files-scanned=1122
+waivers-applied=9 ambiguous-bare=10 r1=0 r2=0 r3=0 r4=0 r5=0`.
 
 A waiver must state its reason on the same line and is greppable
 (`git grep "ssot-allow:"`), matching the charter's rule-4 suppression idiom.
@@ -59,13 +68,16 @@ and reverts. Run it after any change to `docs_check.py`.
 
 ## The SSOT pointers
 
-The five facts that get contradicted most often, and the one place each is decided.
+The eight facts that get contradicted most often, and the one place each is decided.
+(**REFUTED wording, kept so the correction is visible:** this line read *"The five facts"*
+while the table below it carried eight rows. Counted at `81a04965`; re-count the rows, do not
+re-copy this number.)
 
 | subject | the ONLY source | enforcer |
 |---|---|---|
 | coverage numbers | [`.coverage-thresholds.json`](../.coverage-thresholds.json) — 100% lines/branches/functions/statements on both sides | `.github/workflows/quality.yml` gate:3 + `app/vitest.config.ts`. The JSON is the **declaration**; those two are the **enforcement**. |
 | the app version | `app/package.json` | `electron-builder.yml` derives the artifact name from it |
-| the RPC wire contract | `sidecar/contract/spec.py` (machine) + [`rpc-contract-v2.md`](rpc-contract-v2.md) (doctrine) | `register_all` at `sidecar/media_studio/handlers/composition.py:71` |
+| the RPC wire contract | `sidecar/contract/spec.py` (machine) + [`rpc-contract-v2.md`](rpc-contract-v2.md) (doctrine) | `sidecar/media_studio/handlers/composition.py` :: `register_all` |
 | design-token VALUES | `app/renderer/src/styles/tokens.css` | `tokens.conformance.test.ts`; [`design-system.md`](design-system.md) is the portable human spec |
 | gate composition + tool pins | [`QUALITY-CHARTER.md`](../QUALITY-CHARTER.md) | `.quality/charter_check.py` |
 | provider catalog + free tiers | `sidecar/media_studio/models/catalog.py` | [`providers/`](providers/SETUP.md) is a human mirror, never the source |
@@ -127,8 +139,21 @@ The five facts that get contradicted most often, and the one place each is decid
 
 ## Wiring — `§`-numbered unit contracts
 
-28 tracked source files cite these by bare `§` id (e.g. `app/main/main.ts` `// ---- WIRING-T5 §2`),
-so the ids survive the move out of the repo root; this entry is how they stay findable.
+Tracked source cites these by bare `§` id (e.g. `app/main/main.ts` `// ---- WIRING-T5 §2`), so
+the ids survive the move out of the repo root; this entry is how they stay findable. Measured at
+`81a04965` over every tracked non-`docs/`, non-`reports/` file: **11** carry a bare
+`WIRING-<id> §` citation, **26** cite a `docs/wiring/…md` path instead, and **38** mention a
+`WIRING-` id in any form.
+
+> **REFUTED: this line read "28 tracked source files".** No probe yields 28 — not the bare-id
+> form (11), not the path form (26), not the union (36), not any mention (38). The literal was
+> already wrong when it was written in `6ae972c1`, where the same three probes read 11 / 30 / 30.
+> The detector used here is controlled BOTH ways: it fires on this entry's own example string
+> `// ---- WIRING-T5 §2`, and it does **not** fire on `docs/wiring/WIRING-T5.md §2`, so the
+> bare-id and path forms cannot contaminate each other. **UNVERIFIED and unpinned:** nothing
+> recomputes these three counts, so they rot exactly the way `28` did — settling experiment:
+> re-run that pair of matchers, or extend `sidecar/tests/test_contract_parity.py`'s
+> derive-the-number pattern to this entry.
 
 | file | unit |
 |---|---|
@@ -143,7 +168,7 @@ so the ids survive the move out of the repo root; this entry is how they stay fi
 | file | charter |
 |---|---|
 | [`validation/v15-audit-ledger.md`](validation/v15-audit-ledger.md) | the only audit SSOT: 225 findings actually checked (131 CONFIRMED + 94 REFUTED). Its headline lesson is *volume is not evidence*. |
-| `validation/v15-audit-ledger-unverified.md.gz` | the only home of the 2348 unchecked findings. Kept separate on purpose: merging them makes a claim and a verified finding look alike. |
+| `validation/v15-audit-ledger-unverified.md.gz` | the only home of the FULL recovered finding set — **2618** deduped findings (its own provenance block: `critical 56 / high 831 / medium 1219 / low 512`, which sums to 2618), of which only the 225 above carry a verdict. Kept separate on purpose: merging them makes a claim and a verified finding look alike. **REFUTED: this cell read "the 2348 unchecked findings"** — wrong twice. The string `2348` does not occur anywhere in the archive, and the archive is not the *unchecked* subset: it is the whole deduped set. Second signal: the decompressed file carries 2648 `###` headings; the 30-heading excess over 2618 is UNVERIFIED (settling experiment: classify those headings — the prose-artifact sections at the tail also use `###`). |
 | `validation/tools/` | the only regeneration recipe for the above (`extract_ledger.py`, `join_verdicts.py`, `join_by_agentid.py`), plus `verify_ssot_claims.py` (the drift verifier) and `probe_dependency_pin.py`. |
 | [`../reports/PHASE8-SOTA-MANIFEST.md`](../reports/PHASE8-SOTA-MANIFEST.md) | the only source of the 15-component SOTA table that `features/system_advisor.py:86-88` mirrors. **Unguarded mirror** — R3 wants a conformance test here. |
 
@@ -162,7 +187,7 @@ so the ids survive the move out of the repo root; this entry is how they stay fi
 | [`build/RUN-CHECKLIST.md`](build/RUN-CHECKLIST.md) | the only run procedure. **DRAFT** — its pins are stale against `sidecar/pyproject.toml`; rewrite pending. |
 | [`build/COMPLETENESS-REPORT.md`](build/COMPLETENESS-REPORT.md) | superseded and wrong at the headline, kept because `HIGH-1` / `HIGH-3` finding ids are cited by five live source files. |
 | [`build/INTEGRATION-REPORT.md`](build/INTEGRATION-REPORT.md) | same — header, do not delete. |
-| [`build/DESIGN-DIRECTION.md`](build/DESIGN-DIRECTION.md) | superseded by `design-system.md`; 9 of its 14 palette values contradict `tokens.css`. Merge-and-archive is tracked as phase-2 item 2.7, not done. |
+| [`build/DESIGN-DIRECTION.md`](build/DESIGN-DIRECTION.md) | superseded by [`design-system.md`](design-system.md); **8** of its 14 palette values contradict `tokens.css`. **REFUTED: this cell said 9 of 14.** The `14` is right (6 surface + 4 text + 1 accent + 3 status named in `## Palette (exact values)`); the `9` is not. Compared BY TOKEN NAME at `81a04965`, the 8 that disagree are the six `--surface-*` plus `--text-muted` and `--text-faint`; `--text-primary`, `--text-secondary` and the three `--status-*` agree, and the accent is written with no token name so it can only be matched by value (`#f2a33c`, which `tokens.css` does carry). A by-VALUE probe on the same file reports 7, not 8, because `#50555f` occurs in `tokens.css` somewhere other than a `--token:` declaration — two of my own probes disagreed, and the by-NAME reading is the one that answers "contradicts". Merge-and-archive is tracked as phase-2 item 2.7, not done. |
 
 ## Archive
 

--- a/docs/plans/v1.5/uiux-qol-audit-2026-08.md
+++ b/docs/plans/v1.5/uiux-qol-audit-2026-08.md
@@ -202,7 +202,15 @@ caption-style presets with visual `Aa` previews.
 > **The control this paragraph carried before was fabricated, and is REFUTED:** it paired
 > `BrowserWindow` **25×** with **11** alternation hits, and *no single scope yields both* — 25 requires
 > tests EXCLUDED (with tests the same matcher counts 41), while 11 requires them INCLUDED (without
-> tests it is 3). 8 of those 11 sit in `appMenu.test.ts`, and its `accelerator` matches assert the
+> tests it is 3). 9 of those 11 sit in `appMenu.test.ts` — **REFUTED, this said 8**: re-measured at
+> `81a04965` the with-tests reading is 11 matching LINES (12 occurrences), of which the two
+> non-test lines are `appMenu.ts` and `main.ts` and the remaining **nine** are all in
+> `appMenu.test.ts` (`:6 :11 :84 :85 :88 :90 :93 :145 :146`); the last two are the
+> `expect(src).toMatch(/Menu\.setApplicationMenu\(/)` pair, which an `accelerator`-only reading
+> misses. The correction does not move the verdict — it makes the arithmetic close. Note the two
+> units in this sentence are not the same: `3` counts OCCURRENCES (on 2 lines) and `11` counts
+> LINES. The refutation stands under either unit, because the 25-scope yields 3/2 and never 11.
+> Its `accelerator` matches assert the
 > attribute's ABSENCE (`:93 expect(item.accelerator).toBeUndefined()`) — cited as evidence of a
 > non-empty production reading while asserting the opposite. A pair stitched from two scopes is a
 > detector failure, not a control. Consequences below: **C2 and H1 are fixed** (no `Edit` menu at all — the items are
@@ -211,6 +219,16 @@ caption-style presets with visual `Aa` previews.
 > `accelerator` on any item (an explicit one overrides the role's per-platform default), so the app
 > still adds no `Ctrl+O`/`Ctrl+,`/`Ctrl+E` of its own. The observation is preserved rather than
 > rewritten: this is an audit of a dated build, and the finding is what triggered the fix.
+>
+> **Re-verified independently at `81a04965`.** The replacement control reproduces exactly. The
+> scope that yields the stated pair is the literal one written above — every tracked `.ts`/`.tsx`
+> under `app/` with `.test.` excluded, which keeps `app/e2e/*.spec.ts` and `app/vitest.config.ts`
+> in. Enumerated glob-free (`git ls-tree -r` + `git cat-file --batch`, filtering in code) rather
+> than by pathspec, because `git grep -- 'app/**/*.ts'` silently misses `app/vitest.config.ts` and
+> reads 21 instead of 25 — a glob artifact that would have looked like a doc defect. Measured:
+> matcher 0 / 3 / 3 occurrences and `BrowserWindow` 25 / 25 / 25 across `5d99bd2e^` / `5d99bd2e` /
+> HEAD. The both-states property therefore holds, and the known-present control is flat across all
+> three revisions, which is the property that proves the file walk did not change under it.
 
 Two independent signals: (a) `app/main/main.ts:13` imports `app, BrowserWindow, ipcMain, net,
 safeStorage, session, shell` — **no `Menu`**, and no `setApplicationMenu`/`buildFromTemplate`/`accelerator`
@@ -311,6 +329,22 @@ actionable, and its Download button sits at the far right edge where the Jobs sl
 > The three stale line numbers are a *class*, not three typos: a line number in prose rots on the next
 > edit above it, and nothing checks it. The same four confirm-site comments in the source carry the same
 > stale anchors — see the residual list in this unit's report; they are outside this lane's file scope.
+>
+> **Re-verified independently at `81a04965`, and this is the sharper of the two controls.** Every
+> figure reproduces: naive matcher `0 / 0` at `a44ba906`'s parent and at HEAD (it measures nothing,
+> as claimed); cast-aware matcher **6 → 0**, the six being `features/ExportPresetsPanel.tsx` ×2,
+> `features/Tracks.tsx`, `features/useShortsGallery.ts`, `views/Library.tsx`, `views/Shorts.tsx` —
+> six sites across the same five files as the five production imports, so the two figures do
+> reconcile; `useConfirm` raw occurrences 17 across 7 files; import statements 6, of which 5
+> production. A `useState` control reads 530 / 532 / 597 across the three revisions, so the file
+> walk was alive in the broken state too — without that, a `0` pre-fix could not be told from an
+> empty walk. And a caution earned the hard way in the re-verification: the cast-aware matcher must
+> be built from the ACTUAL pre-fix bytes. My first attempt used `[^)]{0,80}` between `globalThis`
+> and `.confirm`, which cannot cross the parens inside the cast type
+> `{ confirm?: (m: string) => boolean }`, so it read **0 pre-fix** and briefly looked like a
+> refutation of this paragraph. It was a broken matcher of mine — the same failure class this
+> paragraph documents, reproduced while checking it. The matcher that works is the plain
+> `\.confirm\?\.\(`.
 
 Confirmations exist. `app/renderer/src/views/Library.tsx:470-483` calls `globalThis.confirm(...)` before
 `shorts.delete`, and its comment records that this surface was *the* unguarded one because "four separate

--- a/docs/plans/v1.5/uiux-qol-audit-2026-08.md
+++ b/docs/plans/v1.5/uiux-qol-audit-2026-08.md
@@ -224,8 +224,16 @@ caption-style presets with visual `Aa` previews.
 > scope that yields the stated pair is the literal one written above — every tracked `.ts`/`.tsx`
 > under `app/` with `.test.` excluded, which keeps `app/e2e/*.spec.ts` and `app/vitest.config.ts`
 > in. Enumerated glob-free (`git ls-tree -r` + `git cat-file --batch`, filtering in code) rather
-> than by pathspec, because `git grep -- 'app/**/*.ts'` silently misses `app/vitest.config.ts` and
-> reads 21 instead of 25 — a glob artifact that would have looked like a doc defect. Measured:
+> than by pathspec, because `git grep -- 'app/**/*.ts'` silently drops `app/vitest.config.ts` and
+> reads **23** instead of 25 — git pathspec needs `:(glob)` magic for `**`, and
+> `:(glob)app/**/*.ts` does read 25. (**REFUTED, kept: this sentence first said "reads 21".** It
+> paired a one-file cause with a three-file number — 21 comes only from `app/main/*.ts`, which
+> additionally drops `app/e2e/preview.spec.ts` and `app/e2e/visual/_visualSetup.ts`, two files
+> the scope sentence above explicitly keeps IN. `app/vitest.config.ts` holds 2 occurrences, so
+> the route it does drop reads 25 − 2 = 23. That is verbatim the failure this paragraph refutes
+> above — "a pair stitched from two scopes is a detector failure, not a control" — committed
+> inside the sentence certifying that the fix for it reproduces. The verdict figures are
+> untouched: 0 / 3 / 3 and 25 / 25 / 25 both reproduce.) Measured:
 > matcher 0 / 3 / 3 occurrences and `BrowserWindow` 25 / 25 / 25 across `5d99bd2e^` / `5d99bd2e` /
 > HEAD. The both-states property therefore holds, and the known-present control is flat across all
 > three revisions, which is the property that proves the file walk did not change under it.

--- a/docs/rpc-contract-v2.md
+++ b/docs/rpc-contract-v2.md
@@ -95,6 +95,33 @@ remember to edit in lock-step. That is the definition of drift-prone.
 >   divergence runs — behind vs. ahead of main; only blob inequality was measured.)
 >   So this residual is real, and nothing under `docs/**` guards it. Settling
 >   experiment: re-run that detector after those branches land.
+> - **Independently re-measured at `81a04965` by a second pass that did not write the
+>   numbers above, because the pass that did write them lost its verifier before it
+>   returned a verdict.** Every figure in the table reproduced. Method, so the reading can
+>   be reproduced or refuted rather than trusted: each probe was run against the STORED
+>   BLOB (`git cat-file -p <rev>:<path>`), never the working tree, so a CRLF working copy
+>   cannot move a line count; and each was given a known-present control that had to fire
+>   before a count was believed. Row 4 was taken four mechanically different ways — `\n`
+>   bytes in the blob, `splitlines()` on the decoded blob, `splitlines()` on the working
+>   tree, and `git diff --numstat` against the empty blob — all four agree on `1521`, and
+>   the blob holds zero `CR` bytes. Row 3 was taken three ways (raw substring membership,
+>   backtick-opened span, word boundary) and all three agree on `45`. Row 1's split is
+>   `134` inline literals plus seven names reachable only through `BROLL_METHODS`. Row 5's
+>   two entry lists were counted by regex and again by a line walk between the fences.
+>   Row 2's registrations are all distinct — no name is registered twice.
+> - **The `1235` a refuting reader still sees is not live.** At `fde9d61b` the row-4 cell
+>   did read `1235`, and the paragraph that then claimed "every count above is measured"
+>   left it as unchanged context — a real defect, and the refutation was correct against
+>   that commit. `200de40d` replaced the cell. At `81a04965` the only surviving occurrence
+>   of that literal in this file is inside the REFUTED record two bullets above, which is
+>   where a retired figure is supposed to live.
+> - **The residual detector re-run, with its control.** The `~?\d{3}`-modifying-
+>   `methods?`/`handlers` matcher was rebuilt from this bullet's own description, confirmed
+>   to fire on the known-present `123-method` string, and run over `docs/**` at
+>   `81a04965`: **six** hits, and the split is exactly the one claimed — four quotations
+>   (`plans/v1.5/PROGRAM.md`, `plans/v1.5/flagship-transcript-editing.md`, and the two in
+>   this bullet) and two live disagreements (`plans/v1.5/competitor-matrix-2026-08.md`,
+>   `plans/v1.5/flagship-auto-broll.md`). The residual is real and unchanged.
 > - **The pin's cost, disclosed because it lands on other branches:** registering one
 >   new method changes the live count, so any branch that adds a `reg(...)` / `@method`
 >   must also update ONE line here and one in the migration plan, or its own `gate:3`

--- a/docs/rpc-contract-v2.md
+++ b/docs/rpc-contract-v2.md
@@ -113,15 +113,50 @@ remember to edit in lock-step. That is the definition of drift-prone.
 >   did read `1235`, and the paragraph that then claimed "every count above is measured"
 >   left it as unchanged context — a real defect, and the refutation was correct against
 >   that commit. `200de40d` replaced the cell. At `81a04965` the only surviving occurrence
->   of that literal in this file is inside the REFUTED record two bullets above, which is
->   where a retired figure is supposed to live.
-> - **The residual detector re-run, with its control.** The `~?\d{3}`-modifying-
->   `methods?`/`handlers` matcher was rebuilt from this bullet's own description, confirmed
->   to fire on the known-present `123-method` string, and run over `docs/**` at
->   `81a04965`: **six** hits, and the split is exactly the one claimed — four quotations
->   (`plans/v1.5/PROGRAM.md`, `plans/v1.5/flagship-transcript-editing.md`, and the two in
->   this bullet) and two live disagreements (`plans/v1.5/competitor-matrix-2026-08.md`,
->   `plans/v1.5/flagship-auto-broll.md`). The residual is real and unchanged.
+>   of that literal in this file was inside the REFUTED record that opens *"Two numbers in
+>   the table above were REFUTED by this re-measurement"*, which is where a retired figure
+>   is supposed to live. **REFUTED, and the refuted wording is kept rather than deleted:
+>   this bullet first placed that record "two bullets above" and stated the containment as
+>   if it were current.** Both were wrong on arrival. Counting `^> - ` bullet starts, this
+>   claim is the 8th and the REFUTED record is the 4th — FOUR above, not two — and the very
+>   commit making the claim is what inserted the bullets that pushed it there, so a reader
+>   following the pointer landed on the wrong bullet. It is located by quoting its opening
+>   words now, because a quotation does not move when a line above it does; a position is
+>   exactly the rot this file names as *"a line number in prose rots on the next edit above
+>   it and nothing checks it"*. The containment sentence breaks itself the same way: writing
+>   this bullet takes that literal from one standalone occurrence in the file to three.
+>   Correctly scoped, the fact that holds at every revision is narrower — no LIVE table cell
+>   carries it, and every occurrence sits in prose whose purpose is to retire it.
+> - **The residual detector re-run, and its earlier reading REFUTED — refuted wording kept.**
+>   This bullet first reported that the matcher "was rebuilt from this bullet's own
+>   description" and read **six** hits over `docs/**` at `81a04965` with "exactly the claimed
+>   split — four quotations … and the two in this bullet", closing "the residual is real and
+>   unchanged". Three things in that are wrong. **(a) The prose does not determine a
+>   matcher.** Rebuilding `~?\d{3}` modifying `methods?`/`handlers` and sweeping the allowed
+>   gap yields 0 / 3 / 5 / 7 / 8 / 13 hits at gaps 0 / 1 / 4 / 8 / 12 / 20, and the claimed
+>   membership appears at **no** width: the narrowest gap that reaches
+>   `plans/v1.5/competitor-matrix-2026-08.md` (whose `~150` has two words of separation) also
+>   reaches `rpc-contract-v2-migration.md` and `validation/v15-audit-ledger.md`, which the
+>   split never names. The earlier `10`-before / `6`-after figures are therefore not
+>   reproducible from their own description — and a reading that cannot be reproduced cannot
+>   be refuted either, which is the defect, not the count. **(b) "the two in this bullet" was
+>   false when written** — the two it means live in the bullet quoted above, not in the one
+>   asserting it. **(c) "unchanged" was self-breaking**, because that sentence quoted the
+>   detector's own control string and so added a hit while certifying the total; the older
+>   bullet above disclosed exactly this reflexivity and the re-verification replaced the
+>   disclosure with a denial of it. **Correctly scoped, and pinned so it is reproducible:**
+>   with the exact matcher `(?<![:\d])~?\d{3}(?![\d])[^.\n]{0,8}?(?:methods?|handlers)\b` over
+>   `docs/**` — controlled to fire on all three known-present quotations and to stay silent on
+>   a `path.py:507`-style line citation and on `1521 lines` — `81a04965` reads **seven** hits
+>   across six files, and this commit reads seven as well, because this bullet deliberately
+>   names no counted string. Both LIVE disagreements are still there — but they are NOT both
+>   inside that seven, and that gap IS point (a): `plans/v1.5/flagship-auto-broll.md`'s DRAFT
+>   handler figure is one of the seven at both revisions, while
+>   `plans/v1.5/competitor-matrix-2026-08.md`'s audit-yield figure carries two words of
+>   separation and is only reached once the gap is widened to 12 — a width at which the total
+>   becomes eight and pulls in two files the claimed split never named. **UNVERIFIED that any
+>   of this survives a later edit** — nothing recomputes it; settling experiment: pin this
+>   matcher in `sidecar/tests/test_contract_parity.py`, or stop quoting a count no test owns.
 > - **The pin's cost, disclosed because it lands on other branches:** registering one
 >   new method changes the live count, so any branch that adds a `reg(...)` / `@method`
 >   must also update ONE line here and one in the migration plan, or its own `gate:3`


### PR DESCRIPTION
Wave-5 DOCS lane. Verifier returned **mergeable: true**, no overclaims remaining.

Wave 4's docs work shipped a presence-only pin (it asserted a figure *existed*, not that it was
right) and, by its own later admission, two **fabricated detector controls** — which convert an
unmeasured claim into an apparently-verified one. That work merged in #404 without its verifier
ever returning, so this lane re-verified it and fixed what it found.

Re-measures the surviving numeric claims in `docs/rpc-contract-v2.md` and `docs/INDEX.md` with
controlled detectors.

## Worth reading in the verifier's report

It suspected that *"the gate has printed `r1=0 r2=0 r3=0 r4=0 r5=0` on every run since"* was wider
than its evidence, and tried to falsify it properly: it ran `.quality/docs_check.py` at **all 69
commit-states** from `6ae972c1` (where r5 landed) through `81a04965`, in a detached worktree.
Result 69/69 all-zero, exit 0, zero refuting revisions — so it revised its own suspicion because
the experiment refuted it, not because of an argument.

## Left un-done, deliberately

Two precision nits, both **under-counts rather than overclaims**, so neither blocks:

* `docs/INDEX.md:208` — the palette cell says "= 16 values" then partitions only 15 (nine disagree
  + six agree). The 16th, the unnamed accent `#f2a33c`, is never classified, though it does agree
  with `tokens.css`.
* `docs/INDEX.md:53-54` — a wording nit around `docs_check_mutations.py`, which deliberately
  drives the gate red.

## Base

Branch base is `81a04965`; `origin/main` has since advanced. The verifier proved the merge rather
than assuming it: `git merge --no-commit --no-ff` reports "Automatic merge went well" and
`--diff-filter=U` is empty. Zero file overlap — main advanced only in the #407/#408/#409 paths,
and this lane touches only `docs/INDEX.md`, `docs/rpc-contract-v2.md` and
`docs/plans/v1.5/uiux-qol-audit-2026-08.md`.
