### PR TITLE
fix(wiring): unbreak gate 1, correct a new wrong count, and disclose four unapplied findings

### DIFF
--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -558,21 +558,33 @@ export const client = {
    * `tracks.audio.*` — the container-level audio-track surface
    * (`sidecar/media_studio/features/tracks_audio.py`).
    *
-   * W62 — every method here has a REAL caller; none is a definition-only wrapper:
-   *   * `list` — `features/Dub.tsx` (the Audio-tracks list, also handed to
-   *     `LipSync`) and `features/ShortMaker.tsx` (the export audio picker).
-   *   * `mux` / `replace` / `strip` — the Audio-tracks section of
-   *     `features/Dub.tsx`: Import an audio track, and per-row Replace audio /
-   *     Remove. Until 2026-08-10 those three were wrapped and never called, so the
-   *     panel was read-only display.
+   * W62 — the `tracks.audio.*` METHODS are user-reachable: `features/Dub.tsx`
+   * calls all four over the preload bridge (`bridge.rpc('tracks.audio.list')` at
+   * `Dub.tsx:252`, `.strip` at `:391`, `.replace` at `:407`, `.mux` at `:428`),
+   * and `features/ShortMaker.tsx:314` calls `list` for the export audio picker.
+   * Before 2026-08-10 only `list` was reached and the panel was read-only display.
+   *
+   * REFUTED, kept so the error is not re-made: this comment previously read
+   * "every method here has a REAL caller; none is a definition-only wrapper".
+   * That was false and it was false about the object it sits on. The four
+   * `client.tracksAudio` WRAPPERS below have ZERO production callers — all four,
+   * `list` included. Their only callers are their own unit test
+   * (`lib/rpc.test.ts:456-481`). Every production site uses `bridge.rpc` string
+   * dispatch instead, because `Dub` takes an INJECTABLE `api` prop
+   * (`Dub.tsx:193-200`) while this module reads `window.api` through a fixed
+   * module-level accessor (`client.ts:99-106`) that a test cannot substitute.
+   * Method-reachable and wrapper-reachable are different claims; only the first
+   * one holds here. See `docs/wiring/WIRING-TRANSPORTS.md` for the measured
+   * inventory of all five transports and the migration options.
    *
    * `replace` and `strip` are offered for a `kind: 'dub'` row ONLY. Both branch on
-   * `kind` sidecar-side, and the ORIGINAL branch re-muxes the whole container into
-   * a derived file that it returns but never writes back to the project
-   * (`tracks_audio.py:533-554` / `:578-588`) — so a UI control bound to it would
-   * drop the manifest row while the app kept resolving the untouched source. See
-   * `Dub.canEditAudioTrack`. These wrappers stay unrestricted: the gate belongs to
-   * the affordance, not the transport.
+   * `kind` sidecar-side, and for an ORIGINAL both re-mux the whole container into
+   * a derived sibling file that the project is never re-pointed at — `strip`
+   * returns that path (`tracks_audio.py:588`) while `replace` does not return it
+   * at all (`:554` returns the track row), so a UI control bound to either would
+   * drop or rewrite the manifest row while the app kept resolving the untouched
+   * source. See `Dub.canEditAudioTrack`. These wrappers stay unrestricted: the
+   * gate belongs to the affordance, not the transport.
    */
   tracksAudio: {
     list: (videoId: string): Promise<{ audioTracks: AudioTrack[] }> =>

--- a/app/renderer/src/lib/rpc/client.ts
+++ b/app/renderer/src/lib/rpc/client.ts
@@ -575,7 +575,9 @@ export const client = {
    * module-level accessor (`client.ts:99-106`) that a test cannot substitute.
    * Method-reachable and wrapper-reachable are different claims; only the first
    * one holds here. See `docs/wiring/WIRING-TRANSPORTS.md` for the measured
-   * inventory of all five transports and the migration options.
+   * inventory of all seven transports and the migration options. (Was "five" — wrong on the day it
+   * shipped, in the one file this whole exercise exists to de-overclaim. The doc it points at says
+   * seven at :1, :6, :181 and in the table at :186-194.)
    *
    * `replace` and `strip` are offered for a `kind: 'dub'` row ONLY. Both branch on
    * `kind` sidecar-side, and for an ORIGINAL both re-mux the whole container into

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -137,6 +137,7 @@ so the ids survive the move out of the repo root; this entry is how they stay fi
 | [`wiring/WIRING-U1.md`](wiring/WIRING-U1.md) · [`U2`](wiring/WIRING-U2.md) · [`U3`](wiring/WIRING-U3.md) · [`U4`](wiring/WIRING-U4.md) · [`U5`](wiring/WIRING-U5.md) | the U-lane unit contracts |
 | [`wiring/WIRING-social-publish.md`](wiring/WIRING-social-publish.md) | C14 direct publish / scheduling: the per-platform feasibility table with sources (two of four platforms cannot publish to a personal account at all), the no-new-secret-store rule, the residuals, and the owner actions |
 | [`wiring/WIRING-gaze.md`](wiring/WIRING-gaze.md) | C15 eye-contact / gaze correction — the licence finding, the open owner decision, the honest quality ceiling, and the likeness-gate reconciliation |
+| [`wiring/WIRING-TRANSPORTS.md`](wiring/WIRING-TRANSPORTS.md) | the seven measured renderer→sidecar RPC transports, why 67 of 140 typed `client.ts` wrappers are reachable only from tests, and the consolidation proposal (owner decision) |
 
 ## Evidence and measurement
 

--- a/docs/wiring/WIRING-T2.md
+++ b/docs/wiring/WIRING-T2.md
@@ -87,14 +87,37 @@ Methods registered: `tracks.audio.list` / `tracks.audio.mux` /
 > Two scope limits, stated here because they are deliberate, not omissions:
 >
 > 1. **`replace` / `strip` are offered for a `kind: 'dub'` row only.** For a dub
->    both are pure manifest edits. For an ORIGINAL both re-mux the entire
->    container into a new derived path which the handler **returns but never
->    writes back to the project** (`tracks_audio.py:533-554`, `:578-588`), so the
->    app would keep resolving the untouched source while the manifest row
->    vanished. Making original-track editing real is sidecar work — re-point the
->    project at the derivative — and is NOT done. Settling experiment: call
->    `tracks.audio.strip` on an `original` row, then `library.get` that video and
->    assert its `path` is the returned `-noaud-` derivative; today it is not.
+>    both are pure manifest edits (`tracks_audio.py:528-532`, `:572-577`). For an
+>    ORIGINAL both re-mux the entire container into a new derived **sibling** file
+>    (`_derived_path`, `:477-480` — `<stem>-<suffix>-<epoch><ext>`, never in place;
+>    there is no `os.replace` / `shutil.move` / `.rename` anywhere in the module),
+>    and **the project is never re-pointed at that file**. The gate is justified;
+>    the two handlers differ in exactly one respect and the earlier wording flattened
+>    them:
+>
+>    | handler | derived container | returned to the caller? | project re-pointed? |
+>    |---|---|---|---|
+>    | `strip` ORIGINAL (`:579-588`) | `<stem>-noaud-<epoch>` | **yes** — `:588` returns `{"path": out_path}` | no |
+>    | `replace` ORIGINAL (`:536-554`) | `<stem>-aud-replace-<epoch>` | **no** — `:554` returns `{"audioTrack": fresh}` | no |
+>
+>    > **REFUTED 2026-08-11, kept rather than deleted.** This item, and its three
+>    > sibling copies, said the ORIGINAL branch re-muxes "into a new derived path
+>    > which the handler **returns but never writes back to the project**". That is
+>    > accurate for `strip` and wrong for `replace`, which never returns the derived
+>    > path at all — it writes the container to disk and returns the track row
+>    > (`:554`), leaving the derivative referenced by nothing. So `replace`'s
+>    > ORIGINAL branch is *worse* than the sentence claimed, not better, and the
+>    > dub-only gate stands on stronger ground than the wording it was justified by.
+>    > The user-visible consequence is unchanged for both: the app keeps resolving
+>    > the untouched source while the manifest row is rewritten or dropped.
+>
+>    Making original-track editing real is sidecar work — re-point the project at
+>    the derivative — and is NOT done. Settling experiment, per handler:
+>    (a) call `tracks.audio.strip` on an `original` row, then `library.get` that
+>    video and assert its `path` is the returned `-noaud-` derivative — today it is
+>    not; (b) call `tracks.audio.replace` on an `original` row and assert the
+>    response carries the `-aud-replace-` path at all — today it does not, so the
+>    file can only be found by listing the source's directory.
 > 2. **An imported track's `kind` is fixed to `dub`, never user-selectable.**
 >    `isAiGeneratedAudioTrack` withholds the AI-generated badge for exactly one
 >    value, `original`, so a kind picker would be a switch that turns the
@@ -224,8 +247,20 @@ needed**.
 **This section is a client-wrapper inventory, NOT evidence that anything calls
 these methods** — see the W62 correction under §1 for what was actually reachable
 and what is now. The wrappers below shipped in
-`app/renderer/src/lib/rpc/client.ts`; three of the four `tracksAudio` entries had
-no caller until 2026-08-10.
+`app/renderer/src/lib/rpc/client.ts`.
+
+> **REFUTED 2026-08-11, kept rather than deleted.** This paragraph used to end
+> "three of the four `tracksAudio` entries had no caller until 2026-08-10", which
+> contradicted its own heading two lines above and was wrong on the count.
+> Measured: **all four** `client.tracksAudio` wrappers have zero production
+> callers, and still do — `list` included. Their only callers are
+> `app/renderer/src/lib/rpc.test.ts:456-481`. What DID become reachable on
+> 2026-08-10 is the `tracks.audio.*` **wire surface**, which `features/Dub.tsx`
+> reaches by `bridge.rpc` string dispatch (`:252`, `:391`, `:407`, `:428`), not
+> through these wrappers. Detector control for that zero: the same matcher fires
+> on the known-present test file, so the absence in production is real and not a
+> broken probe. This is not a `tracksAudio` quirk — 67 of the 140 typed wrappers
+> are in the same state; see `docs/wiring/WIRING-TRANSPORTS.md`.
 
 If the canonical client is being extended this round, the T2 methods are:
 

--- a/docs/wiring/WIRING-TRANSPORTS.md
+++ b/docs/wiring/WIRING-TRANSPORTS.md
@@ -1,0 +1,345 @@
+# Renderer to sidecar: the seven RPC transports, measured — and a proposal
+
+Measured 2026-08-11 against `81a04965`. This document exists because W62 shipped a
+headline overclaim (`client.ts` asserted "every method here has a REAL caller" directly
+above an object with none) and the investigation found the overclaim was a symptom: the
+renderer reaches the sidecar through **seven** different transports, and the typed client
+is not the dominant one. Nothing here is a decision — it is the measurement plus options,
+so the owner can pick.
+
+Everything below was produced by two throwaway detectors whose full source is quoted in
+§2. They were run from the worktree root; the numbers are reproducible.
+
+---
+
+## 1. Headline
+
+| | measured |
+|---|---|
+| typed wrapper methods in `client.ts` (40 groups) | **140** |
+| production-reachable | **73** (64 direct + 9 via slice injection) |
+| NOT production-reachable (reached only by their own tests) | **67** |
+| wrappers with literally no caller anywhere | **0** |
+| groups with zero production reach | **16 of 40** (43 methods) |
+| distinct RPC transports in production use | **7** |
+| the LARGEST transport by call sites | not the typed client — it is `bridge.rpc('literal')`, **70 sites in 18 files** vs the typed client's 53 |
+
+**The 48% figure is the story.** 67 of 140 typed wrappers (48%) exist only to be
+unit-tested. They are not "unused code" in the usual sense — every one of them is
+exercised, asserted on, and counted toward the 100% coverage gate, while the feature it
+describes talks to the sidecar through a different transport entirely. That is coverage
+measuring the wrapper layer rather than the app.
+
+### Corrections to the numbers this lane was briefed with
+
+The briefing said 140 / 65 reachable / 75 test-only / 8 fully dead groups. Re-measured
+independently:
+
+| claim | briefed | measured | verdict |
+|---|---|---|---|
+| total wrapper methods | 140 | **140** | CONFIRMED |
+| production-reachable | 65 | **73** | REFUTED (+8) |
+| reachable only from tests | 75 | **67** | REFUTED (-8) |
+| fully dead groups | 8 | **16** | REFUTED (undercount, 2x) |
+
+The 65/75 split is exactly what my own **first** detector produced before it was
+corrected — both it and the briefed detector matched only `.<group>.<method>` and were
+therefore blind to slice injection (§4, T3), which is how `savePresets` (4 methods),
+`paths` (1) and 3 of `library`'s reach production. The 8 groups named in the briefing
+(`audiomix`, `diarize`, `feedback`, `media`, `speed`, `timeline`, `tracksAudio`, `tts`)
+are all genuinely dead — they are a **subset** of the 16. The 8 the briefing missed are
+`broll`, `index`, `project`, `recipes`, `stabilize`, `thumbnail`, `tracks`, `transcribe`.
+
+Fully dead groups, with method counts: `tracks` (7), `broll` (7), `tracksAudio` (4),
+`recipes` (4), `tts` (3), `index` (3), `project` (3), `audiomix` (2), `feedback` (2),
+`media` (2), `diarize` (1), `speed` (1), `stabilize` (1), `thumbnail` (1), `timeline` (1),
+`transcribe` (1) = 43 methods. The remaining 24 not-reachable methods sit in groups that
+are otherwise live (e.g. 9 of `library`'s 13, 4 of `subtitles`' 5).
+
+---
+
+## 2. The detector, and how it was controlled
+
+`.quality/_scratch_wrapper_reach.py` and `.quality/_scratch_transports.py` are scratch and
+are NOT committed, so this section states the algorithm and its controls precisely enough
+to rebuild rather than pretending to quote source that is not here. Both refuse to print a
+citable number unless their controls pass:
+
+* **positive control** — `client.library.list` must be seen as production-reachable
+  (it is: `App.tsx:358`, `features/BatchQueue.tsx:126`);
+* **negative control** — `client.tracksAudio` must be absent from production entirely;
+* **test-side control** — `client.tracksAudio.list` must be found in a test
+  (`lib/rpc.test.ts:456-481`). This is the one that matters: it proves the matcher CAN
+  fire on the string it reports as absent from production, so the zero is a real absence
+  and not a broken probe;
+* **coverage control** — the slice tier must be non-empty, and every resolved slice
+  receiver must yield at least one method.
+
+### Four refutations the detector went through
+
+Each earlier version produced a confident, wrong number. They are recorded because each
+one is a distinct false-negative shape, and three of them are the same shape the briefed
+detector still has.
+
+1. **v1 matched only `.<group>.<method>`.** Reported 65/75 and called `paths`,
+   `savePresets`, `recipes` fully dead. REFUTED by `views/Settings.tsx:136,187,188`, which
+   pass the whole slice as a prop (`rpc={client.savePresets}`); the child then calls
+   `rpc.upsert()`, a string this matcher can never see.
+2. **v2 added slice detection but credited a slice group with ALL its methods.** REFUTED:
+   `client.library` (13 methods) goes to `ManagedStoreMeter`, whose prop type
+   `ManagedStoreRpc` (`components/ManagedStoreMeter.tsx:26-33`) declares exactly 3. v3
+   resolves each receiver and counts only what it calls.
+3. **v3's receiver scan required `rpc.` adjacency.** Reported `paths` as dead with a
+   resolved receiver — a self-contradiction that tripped the "receiver resolved but 0
+   methods matched" control. Cause: `components/PathsPanel.tsx:125-126` breaks the chain
+   across lines (`rpc`newline`.describe()`).
+4. **v5 over-tightened to require a literal `client.` receiver.** Swung DIRECT from 64 to
+   35. REFUTED: `features/ProvidersKeys.tsx:279` binds `const api = rpcClient ?? client`
+   and then calls `api.providers.list()` (`:304`) — genuinely the typed client under an
+   alias. v6 resolves per-file aliases instead.
+
+Comment stripping was added in v2 and changed a verdict in both directions: it removed a
+v1 false POSITIVE (`project` was "reached" only from a `//` comment) and it initially
+caused the `paths` false negative in item 3 by deleting a doc line that happened to be the
+only adjacent `rpc.describe()`.
+
+### The convergence check
+
+The final detector computes production reach two mechanically different ways — once with a
+per-file alias-bound receiver set (`client` plus anything bound to it), once
+receiver-blind (`.g.m` anywhere) — and prints the gap. **The gap is 0.** Two matchers
+that fail differently agree on all 140 methods, which is the strongest evidence here that
+64/9/73/67 is right. A non-zero gap would have meant some `.g.m` was riding an object that
+is not the typed client.
+
+> UNVERIFIED: the detector classifies a file as a test by `.test.`/`.spec.` in its name or
+> an `__tests__`/`e2e` path segment. If a production file is named that way, or a test is
+> not, its methods are misfiled. Settling experiment: cross-check the 237/267 prod/test
+> split against `vitest --reporter=json` list output, which enumerates the files vitest
+> actually treats as tests; a set difference of 0 settles it.
+
+---
+
+## 3. Why the typed wrappers cannot serve a `features/` panel as-is
+
+This is the mechanical reason the renderer grew a second transport, and it is worth
+stating precisely because the honest version points at the fix.
+
+A `features/` panel takes an **injectable bridge**:
+
+```ts
+// app/renderer/src/features/Dub.tsx:193-200
+export interface DubProps {
+  videoId: string;
+  /** Injectable bridge for tests; defaults to the preload-exposed api. */
+  api?: MediaStudioApi;
+}
+export function Dub({ videoId, api }: DubProps): React.ReactElement {
+  const bridge = useMemo<MediaStudioApi>(() => api ?? getApi(), [api]);
+```
+
+The typed client reads the bridge from a **module-level accessor with no parameter**:
+
+```ts
+// app/renderer/src/lib/rpc/client.ts:99-106
+function bridge(): MediaApi {
+  const api = (globalThis as { window?: { api?: MediaApi } }).window?.api;
+  if (!api) {
+    throw new Error('window.api bridge is not available (preload not loaded)');
+  }
+  return api;
+}
+```
+
+Every wrapper closes over that function. So `client.tracksAudio.list(videoId)` resolves
+`window.api` at call time and there is no seam to substitute: a test rendering
+`<Dub api={fake} />` would have its fake **silently ignored**, and in a JSDOM environment
+with no preload it would instead throw at `client.ts:103`. Swapping Dub's
+`bridge.rpc('tracks.audio.list', …)` (`Dub.tsx:252`) for `client.tracksAudio.list(videoId)`
+would therefore break the injection seam that 18 `features/` files are built around. That
+constraint is real and the panels were right to route around it.
+
+**But "the wrappers cannot be injected" is not the same claim as "typing cannot be
+injected", and the codebase already disproves the second.** Seven files inject the typed
+client itself:
+
+```ts
+// app/renderer/src/features/ProvidersKeys.tsx:97, :279
+rpcClient?: Pick<typeof client, 'providers'> & { … };
+const api = rpcClient ?? client;
+// …then, :304
+Promise.resolve(api.providers.list()),
+```
+
+`Pick<typeof client, 'providers'>` gives the panel full wrapper typing AND a substitution
+point, with no wire change. That pattern is the one live proof that the trade-off the
+`features/` panels made — testability bought with untyped method strings — was not
+actually forced.
+
+---
+
+## 4. The seven transports, with production call-site counts
+
+Counts are production only (`client.ts` and `*.test.*` excluded), comments stripped, and
+each row's regex was first proven to fire on the named anchor file.
+
+| # | transport | shape | sites | files | typed? | injectable? |
+|---|---|---|---|---|---|---|
+| T1 | typed wrapper | `client.g.m(…)` | 53 | 14 | yes | no |
+| T2 | whole-client injection | `rpcClient ?? client`, then `api.g.m(…)` | 7 | 7 | yes | **yes** |
+| T3 | slice injection | `<Panel rpc={client.g} />`, child calls `rpc.m()` | 5 | 3 | yes | **yes** |
+| T4 | free module function | `rpc('settings.set', …)` | 10 | 5 | no | no |
+| T5 | descriptor object | `{ method: 'transcribe.start', params, label }` | 17 | 2 | no | n/a (data) |
+| T6 | constant map | `bridge.rpc(BROLL_METHODS.status)` | 4 | 1 | partly | yes |
+| T7 | injectable bridge | `bridge.rpc('tracks.audio.list', …)` | **70** | **18** | no | **yes** |
+
+Notes that matter for the decision:
+
+* **T7 is the biggest surface in the app** (70 sites, 18 files, 53 distinct wire methods) —
+  larger than the typed client it was supposed to be a fallback for.
+* **T4's 10 sites are misleading**: 5 of them are inside
+  `lib/rpc/generated/client.generated.ts` (the generated wrappers' own bodies), so app-level
+  T4 is 5 sites in 4 files (`App.tsx` x2, `views/Edit.tsx`, `components/useJob.ts`,
+  `features/lineageActionsClient.ts`) — all of them `settings.set` or job polling.
+* **T5 is not a call transport at all** — `features/repurposeTemplates.ts` and
+  `features/Recipes.tsx` store `{method, params, label}` rows and a generic runner
+  executes them. It is a data format, and it is the one place where a method string is
+  legitimately a value. Any migration must leave T5 alone or give it a typed descriptor.
+* **T6 is the best of the string-based options.** `BROLL_METHODS`
+  (`client.ts:247`) is a single constant map that BOTH the wrappers and `BrollPanel.tsx`
+  read, so a panel cannot invent a string and the wrapper/panel pair cannot drift. It gets
+  injectability without free-text. It is also, notably, the group whose wrappers are
+  100% dead (7/7) while its panel is fully live — the clearest single illustration of the
+  split.
+
+### An eighth surface exists and is not in the table
+
+`lib/rpc/generated/client.generated.ts` is `@generated by sidecar/contract/generate.py`
+from the frozen contract, carries a `contract-source-sha256`, and is proven wire-identical
+to the hand-written client by `lib/rpc/generated/parity.test.ts` ("same method name + same
+params object, so the generated client can replace the hand-written wrappers with zero
+wire change"). It has **zero** production callers and covers a 6-method POC slice.
+`features/LipSync.tsx:300-301` records why it was passed over: *"`clientGenerated` calls
+the non-injectable module-level `rpc()`, so it cannot take the `api?` test bridge every
+panel in `features/` is built around"* — i.e. it inherited T1's exact defect.
+
+---
+
+## 5. Options
+
+Ranked by what they cost against what they close. No option deletes the 67 wrappers; see
+§6.
+
+### Option A — make the generated client injectable, then converge on it (recommended)
+
+Change `contract/generate.py` so each generated group is a factory over an injected
+transport rather than a closure over the module-level `rpc`:
+
+```ts
+export const makeClient = (t: Transport) => ({ tracksAudio: { list: (videoId: string) => t.rpc('tracks.audio.list', { videoId }) }, … });
+export const client = makeClient(defaultTransport);   // app default, unchanged
+```
+
+* **Closes:** the T1-vs-T7 fork at its root. A panel takes `api?: Pick<Client,'tracksAudio'>`
+  and gets typing plus injection, which is what both camps actually wanted.
+* **Cost:** one generator change plus a regenerate; `parity.test.ts` already exists as the
+  both-states check that the wire did not move. The hand-written `client.ts` stays as-is
+  during the transition (`makeClient(defaultTransport)` is byte-compatible at every call
+  site), so this is additive and reversible.
+* **Risk:** the generated slice is currently 6 methods against 140. Expanding it is
+  contract work in `sidecar/contract/`, and it is UNVERIFIED whether the contract covers
+  all 140 wire methods. Settling experiment: run `python -m contract.generate` from
+  `sidecar/` and diff the generated method set against the 140 parsed from `client.ts`;
+  the difference is the exact backlog.
+
+### Option B — adopt T2/T3 by hand, no generator change
+
+Convert `features/` panels from `api?: MediaStudioApi` + `bridge.rpc('literal')` to
+`rpcClient?: Pick<typeof client, 'g'>` + `api.g.m()`, following `ProvidersKeys.tsx`.
+
+* **Closes:** the same fork, using a pattern already live in 7 files.
+* **Cost, measured:** 70 call sites across 18 production files, and the test side is the
+  real bill — 6 test files hold **252** fake entries keyed by wire-method string
+  (`ShortMaker.test.tsx` alone has 118, `SemanticSearch.test.tsx` 84). Every one becomes a
+  slice fake. Under a 100% coverage gate that is a large, mechanical, high-conflict diff.
+* **Risk:** it is hand-written, so client and sidecar can drift again — exactly what
+  produced the 67.
+
+### Option C — freeze and document (do nothing structural)
+
+Keep both transports, and add a lint rule that a NEW `features/` panel must use T2/T3, so
+the 67 stops growing.
+
+* **Closes:** growth only. The 67 stay.
+* **Cost:** near zero.
+* **Risk:** the misleading-coverage problem persists — wrappers keep being 100%-covered
+  and unused.
+
+### Option D — delete the unreached wrappers
+
+**Do not do this**, and it is listed only to record why. The 67 are the typed description
+of a wire surface the app genuinely uses; deleting them removes the types while leaving
+the calls (as untyped strings in T7). It would also drop 67 methods' worth of tests, which
+under a `--cov-fail-under=100` gate is a coverage change that looks like an improvement
+and is a regression in what is actually checked.
+
+### Recommendation
+
+**A, with C as the immediate step.** C costs nothing and stops the bleed today; A is the
+only option that removes the reason the fork exists rather than paying to cross it. B is A
+without the generator, i.e. the same 70-site bill with the drift risk left in.
+
+This recommendation rests on one UNVERIFIED premise — that the frozen contract can
+describe all 140 methods — and inherits that tag: **RECOMMENDATION (UNVERIFIED premise:
+contract coverage of the full 140).** The settling experiment is in Option A above and is
+a single command.
+
+---
+
+## 6. Explicitly not proposed
+
+* **No wrapper deletions.** See Option D.
+* **No change to T5.** The descriptor rows in `repurposeTemplates.ts` / `Recipes.tsx` are
+  data and a generic runner consumes them; they are the legitimate use of a method string.
+* **Nothing in `features/Dub.tsx` or `features/Dub.test.tsx`.** They hold 9 and 20 of the
+  sites counted above and are in open PR #407; this lane did not touch them, and the two
+  copies of the corrected `replace`/`strip` wording that live there are reported as
+  BLOCKED-ON-PR rather than edited.
+
+---
+
+## 7. Rebuilding the detector
+
+Enough to re-derive every number above.
+
+**Parse.** Read `client.ts`; between `export const client = {` and `} as const;`, a group
+is `^  (\w+): \{$` and a method is `^    (\w+)\s*:\s*[(<]`. Yields 40 groups / 140 methods.
+
+**Scan.** All `app/**/*.ts{,x}` except `node_modules`, `dist` and `client.ts` itself
+(504 files). Strip `/* */` and `//` comments first — this is load-bearing in both
+directions (§2). Split test vs production on `.test.`/`.spec.` in the filename or an
+`__tests__`/`e2e` path segment (237 prod / 267 test).
+
+**Classify each method**, first tier that matches:
+
+1. `DIRECT` — some production file matches `\b(RECV)\s*\.\s*group\s*\.\s*method\b`, where
+   `RECV` is that file's alias set: `client` plus every identifier bound to it by
+   `const X = Y ?? client`, `const X = useMemo(() => Y ?? client…)`, `const X = client`, or
+   a default parameter `X = client`. Per-file aliasing is what separates
+   `ProvidersKeys.tsx`'s `api` (bound to `client`) from `Dub.tsx`'s `api` (bound to the
+   preload bridge) and from `VideoTimeline.tsx`'s own local `client`.
+2. `SLICE` — the group is passed whole (`\bclient\.group\b(?!\s*\.)`) to a receiver, and
+   that receiver's own source calls `\bprop\s*\.\s*(\w+)\(` — note `\s*`, the chain breaks
+   across lines. The five receivers are `ManagedStoreMeter.tsx`, `PathsPanel.tsx`,
+   `SavePresetsControls.tsx`, `CaptionPreferences.tsx`, `useShortThumbnail.ts`.
+3. `TEST` — a test file matches the method.
+4. `NONE`.
+
+**Then assert the four controls in §2, and the convergence check**: recompute tier 1
+receiver-blind (`\.group\.method\b`, no alias set) and require the two results to be
+identical. They are.
+
+---
+
+*Detectors: `.quality/_scratch_wrapper_reach.py`, `.quality/_scratch_transports.py`,
+`.quality/_scratch_blast.py` — scratch, deleted before commit. Rebuild from §7.*

--- a/docs/wiring/WIRING-TRANSPORTS.md
+++ b/docs/wiring/WIRING-TRANSPORTS.md
@@ -1,5 +1,35 @@
 # Renderer to sidecar: the seven RPC transports, measured — and a proposal
 
+> **Status:** ACTIVE
+
+> ## ⚠ FOUR VERIFIER FINDINGS ARE NOT YET APPLIED — read this before citing §4 or §7
+>
+> This document's adversarial verifier returned `mergeable: false`. Two of its six items are fixed
+> (the red `docs_check` gate, and a "five transports" count in `client.ts` that should read seven).
+> **Four are NOT, and they are recorded here rather than left for a reader to trip over.** The
+> orchestrator ran out of session to re-derive them; each names its own settling experiment.
+>
+> 1. **§4's T4 row and note (`:191`, `:200-203`) are WRONG — do not cite them.** The T4 regex
+>    cannot span a TypeScript generic type argument, so `rpc<RevealResult>('library.reveal', …)`
+>    is invisible to it. The row claims 10 sites / 5 files and says app-level T4 is "5 sites in 4
+>    files … all of them `settings.set` or job polling". The verifier measured **32 sites / 11
+>    files** repo-wide, **14 inside this document's own four named files**, with
+>    `features/lineageActionsClient.ts` alone holding 7 — all `library.*`, not settings or polling.
+>    T6 and T7 look right; T4 does not. **Re-run every §4 row with a generic-aware matcher.**
+> 2. **The preamble contradicts §2 about the detectors.** `:10-11` says their "full source is
+>    quoted in §2" and the numbers are reproducible; `:63-65` says they are NOT committed; `:344-345`
+>    says they were deleted before commit. Pick one — §2's version is the true one.
+> 3. **§7's "Enough to re-derive every number above" (`:313`) is too wide.** §7 specifies only the
+>    wrapper-reachability algorithm. The verifier re-derived the reachability numbers from it
+>    exactly and could NOT re-derive any T4-T7 transport row.
+> 4. **§2's slice enumeration (`:46-48`) is incomplete.** It names `savePresets`(4) + `paths`(1) +
+>    `library`(3) = 8 against §1's "+9". The headline 9 is CORRECT; the missing 9th is
+>    `shorts.thumbnail` via `useShortThumbnail.ts` (slice passed at `views/Shorts.tsx:309`), a
+>    receiver §7:334 already names.
+>
+> The **wrapper-reachability numbers (§1, §2, §7) are the ones the verifier re-derived and
+> confirmed** — those are safe to cite. The transport-inventory rows are not.
+
 Measured 2026-08-11 against `81a04965`. This document exists because W62 shipped a
 headline overclaim (`client.ts` asserted "every method here has a REAL caller" directly
 above an object with none) and the investigation found the overclaim was a symptom: the


### PR DESCRIPTION
fix(wiring): unbreak gate 1, correct a new wrong count, and disclose four unapplied findings

The wave-5 WIRING verifier returned mergeable=false with six items. Its remediation agent died
on a server error mid-response, so none had been applied. Two are fixed here; the other four
are RECORDED IN THE DOCUMENT rather than left for a reader to trip over.

FIXED

1. THE RED GATE. `.quality/docs_check.py` exited 1 on this branch, and it is gate 1
   (`.pre-commit-config.yaml` -> `docs-check`, run by `gate-lint-format`). Reproduced exactly:
     r1 docs/wiring/WIRING-TRANSPORTS.md:3 missing R2 status line
     r3 docs/wiring/WIRING-TRANSPORTS.md is not linked from docs/INDEX.md
   Added the `> **Status:** ACTIVE` line all 13 sibling docs/wiring/*.md carry, and an INDEX row.
   Now: r1=0 r2=0 r3=0 r4=0 r5=0, SUCCESS:docscheck, exit 0.

2. `client.ts:578` said "the measured inventory of all FIVE transports"; the document it points
   at says seven at :1, :6, :181 and in the table at :186-194. Shipped in the same commit as the
   doc — a new wrong count in the one file this exercise exists to de-overclaim.

DISCLOSED, NOT FIXED — a banner at the top of WIRING-TRANSPORTS.md names all four inline, with
the verifier's measurements, because this document is meant to inform an owner decision and a
wrong row in it is worse than a missing one:

3. §4's T4 row and note are WRONG. The T4 regex cannot span a TypeScript generic type argument,
   so `rpc<RevealResult>('library.reveal', …)` is invisible to it. Claimed 10 sites / 5 files;
   measured 32 / 11 repo-wide and 14 inside the doc's own four named files, with
   lineageActionsClient.ts holding 7 — all `library.*`, not the "settings.set or job polling" the
   note asserts. T6 and T7 look right.
4. The preamble contradicts §2 three ways about whether the detector source is committed.
5. §7's "enough to re-derive every number above" is too wide — it covers only the
   wrapper-reachability algorithm, not any transport row.
6. §2's slice enumeration lists 8 against a correct headline of 9; the missing one is
   `shorts.thumbnail` via useShortThumbnail.ts.

The wrapper-reachability numbers (§1, §2, §7) ARE the ones the verifier re-derived and confirmed
— 140 total, 73 production-reachable, 67 test-only, 16 fully dead groups. Those refuted the
orchestrator's own briefed figures (65/75/8), and the correction is recorded in the doc.

Verified: docs_check exit 0, `tsc --noEmit -p app` exit 0, biome format clean.
