### PR TITLE
docs(reframe): anchor two drifting citations and close the half-disclosed residual

### DIFF
--- a/sidecar/media_studio/features/reframe_analyze.py
+++ b/sidecar/media_studio/features/reframe_analyze.py
@@ -57,6 +57,19 @@ golden run on real footage.
   ``test_omitting_the_flags_can_report_an_unedited_shot``, a name that greps to ZERO
   hits — and it re-asserted, in the citation itself, the very "omitting the flags"
   precondition the line above had just narrowed away from.
+  COMPLETED 2026-08-11 — this bullet disclosed only the OVER-report direction ("names a
+  shot the caller did not edit"). The symmetric UNDER-report — ``affected`` MISSING a shot
+  the caller did edit, reachable the same way when the fallback lands on a bundle whose
+  plan already carries the caller's edit — went undisclosed, so a reader could take the
+  set as a lower bound. It is not; it is neither bound. The "never wrong pixels" half
+  holds in BOTH directions, and that is measured rather than argued: after ``affected`` is
+  computed in :meth:`ReframeAnalyzeService.render` it is referenced at exactly two sites —
+  a progress STRING (``f"re-rendering {len(affected)} changed shot(s)"``) and the reported
+  METADATA (``{"affected": list(affected)}``). The engine call receives ``affected_only``,
+  a **bool**, never the set, so :meth:`MultiSpeakerReframeEngine.render_shot_plan` cannot
+  be steered by a wrong set in either direction; it decides reuse from the on-disk
+  manifest. So both directions cost a wrong count and a wrong reported field, never wrong
+  output — a completeness gap in this disclosure, not an overclaim in the code.
 * ``reframe.render`` runs NO availability / offline gate. Reviewed 2026-08-10 and
   kept: it loads no model and reaches no network, so neither gate has anything to
   check — the reasoning and the settling experiment are on :meth:`ReframeAnalyzeService.render`.
@@ -629,9 +642,20 @@ class ReframeAnalyzeService:
         wraps ANY runner exception in :class:`~media_studio.features.reframe_multispeaker.MultiSpeakerRenderError`,
         which the job layer surfaces as a failed job rather than a crash. (Cited by
         SYMBOL: this sentence carried ``reframe_multispeaker.py:2204-2211``, correct at
-        ``origin/main`` and INVALIDATED by the ~140-line insertion the same commit made
+        ``fe4b0a8b`` and INVALIDATED by the ~140-line insertion the same commit made
         earlier in that file — the range now lands in unrelated code. A same-file line
-        range is the one citation form this programme has already broken twice.)
+        range is the one citation form this programme has already broken twice.
+        CORRECTED 2026-08-11 — this parenthetical anchored that claim to ``origin/main``,
+        a MOVING ref, so the sentence warning against a fragile citation form used one
+        itself. A ref that advances cannot preserve a statement about a fixed past state,
+        and it had already stopped being true. Re-measured from the STORED BLOB at four
+        revisions (``git cat-file -p <rev>:<path>``, never the worktree), the enclosing
+        symbol at :2204 is ``_run_pass`` at ``fe4b0a8b`` — the intended target, and the
+        lines there are exactly the ``raise MultiSpeakerRenderError`` wrapping this
+        sentence describes — but ``_write_shot_manifest`` at ``origin/main`` and
+        ``render_shot_plan`` at both ``654f049d`` and HEAD. Three different wrong symbols
+        across four revisions: the range has been wrong in four distinct ways, which is
+        the measured EVIDENCE for citing by symbol rather than a restatement of it.)
         UNVERIFIED at the UX level — whether that message names ffmpeg clearly enough
         for a user to act on is not measured here; the settling experiment is a render
         with ffmpeg renamed away, asserting on the job's error text.

--- a/sidecar/media_studio/features/reframe_multispeaker.py
+++ b/sidecar/media_studio/features/reframe_multispeaker.py
@@ -1656,9 +1656,21 @@ def segment_is_reusable(
     most surprising assertion in this docstring was the one thing no test could redden,
     while the lane's own standard (cite a live test, not a deleted probe) was applied
     elsewhere. Measured over the sidecar suite AS IT STOOD BEFORE that test existed, by
-    wrapping this function and counting every call it received: 75 calls, 8 distinct
+    wrapping this function and counting every call it received — **at ``654f049d``**, by the
+    lane that wrote this line: 75 calls, 8 distinct
     ``(recorded, measured, result)`` triples, and exactly ONE granting triple —
-    ``(4096, 4096, True)``, nine times. ZERO granting triples had ``recorded == 0``, so
+    ``(4096, 4096, True)``, nine times.
+    ANCHORED 2026-08-11 — the figures above previously named no commit, which made them
+    unreproducible in the one way that matters: a reader at HEAD re-runs the enumeration,
+    gets different numbers (this lane's own new test adds calls to the very function being
+    counted), and reasonably concludes the docstring is lying. It is not; it was measured
+    against a different tree. The commit is now named, so the measurement can be re-derived
+    where it was taken — check out ``654f049d`` and wrap this function across
+    ``test_reframe_analyze.py`` + ``test_reframe_multispeaker.py``, the two modules that
+    reach it. Stated as ATTRIBUTED rather than re-verified: the anchoring commit was
+    confirmed to exist and to be the scope-three-docstrings change, but the enumeration
+    itself has not been re-run here, and a figure that drifts by design should not be
+    quoted as if it were re-measured today. ZERO granting triples had ``recorded == 0``, so
     mutating the return to ``recorded > 0 and ...`` was provably indistinguishable on
     every call that suite made — a GREEN mutant by enumeration, not by sampling. That
     same enumeration is the detector control: the nine ``4096`` grants are exactly what


### PR DESCRIPTION
Closes the three items wave 5 shipped as honest **disclosures** rather than fixes. Each was
re-measured here rather than carried forward on the earlier lane's report.

Docstrings only — no behaviour change.

### 1. A fixed-commit claim was anchored to a MOVING ref

`reframe_analyze.py` said the citation `reframe_multispeaker.py:2204-2211` was *"correct at
`origin/main`"*. `origin/main` advances, so it cannot preserve a statement about a fixed past
state — and it had already stopped being true. The sentence warning that a same-file line range
*"is the one citation form this programme has already broken twice"* had itself used a fragile
citation form one clause later.

Re-measured from the **stored blob** at four revisions (`git cat-file -p <rev>:<path>`, never the
worktree — the working tree is CRLF here and would not be what CI reads):

| rev | enclosing symbol at `:2204` | |
|---|---|---|
| `fe4b0a8b` | `_run_pass` | ✅ the intended target — the lines there are exactly the `raise MultiSpeakerRenderError` the sentence describes |
| `origin/main` | `_write_shot_manifest` | ❌ |
| `654f049d` | `render_shot_plan` | ❌ |
| `HEAD` | `render_shot_plan` (different content again) | ❌ |

Three different wrong symbols across four revisions. Anchor is now `fe4b0a8b`, and the four-way
measurement is recorded as the **evidence** for citing by symbol — not as a restatement of the rule.

### 2. A measurement with no commit anchor

*"75 calls, 8 distinct triples, exactly ONE granting triple"* named no commit. A reader at `HEAD`
re-runs the enumeration, gets different numbers — this lane's own new test adds calls to the
function being counted — and reasonably concludes the docstring lies. It does not; it was measured
against a different tree.

Now anchored at `654f049d` with the re-derivation recipe.

**Scoped honestly:** stated as ATTRIBUTED, *not* re-verified. The commit was confirmed to exist and
to be the scope-three-docstrings change, but the enumeration itself was **not** re-run here — it
needs a checkout plus a full sidecar suite run with a call wrapper. A figure that drifts by design
must not be quoted as if it were re-measured today.

### 3. The `find()` residual disclosed only ONE direction

The bullet disclosed the OVER-report (*"names a shot the caller did not edit"*). The symmetric
**under-report** — `affected` *missing* a shot the caller did edit — went undisclosed, so a reader
could take the set as a lower bound. It is neither bound.

The "never wrong pixels" half holds in **both** directions, and that is now measured rather than
asserted. After `affected` is computed in `render()` it is referenced at exactly two sites:

* a progress **string** — `f"re-rendering {len(affected)} changed shot(s)"`
* the reported **metadata** — `{"affected": list(affected)}`

The engine call receives `affected_only`, a **bool**, never the set. So `render_shot_plan` cannot
be steered by a wrong set in either direction; it decides reuse from the on-disk manifest. Both
directions cost a wrong count and a wrong reported field, never wrong output — a **completeness gap
in the disclosure**, not an overclaim in the code.

### Verification

* `298 passed` across `test_reframe_analyze.py` + `test_reframe_multispeaker.py` (the two modules
  that reach this code)
* `ruff 0.15.17 format --check` → *2 files already formatted*; `ruff check` → *All checks passed!*
  (pinned to CI's version — the ambient ruff is a different release and formats differently)
