### PR TITLE
fix(sast): ship an explicit gate-4 scan set (272 files were unscanned)

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,67 @@
+# opengrep / semgrep ignore — gate 4 (SAST). Adopted from quality-zero-platform
+# docs/lean-gate/semgrepignore.template.
+#
+# ── WHY THIS FILE EXISTS ────────────────────────────────────────────────────
+#
+# With NO `.semgrepignore` in the scanned root, opengrep falls back to a
+# BUILT-IN ignore template that drops test code. Measured 2026-08-11 on the
+# PINNED CI engine (opengrep v1.22.0 CLI on Linux, the exact build gate 4
+# installs), controlled detector, one variable changed at a time:
+#
+#   src/inline.go    db.Query(fmt.Sprintf(...))        -> FIRES
+#   tests/inline.go  byte-identical to the line above  -> SILENT
+#
+# and `paths.skipped` reported `none` while it happened, so NOTHING in the gate
+# output revealed it. Pointing the scanner directly at `tests/` returns
+# `paths.scanned: []`, so an explicit path argument does not override it either.
+#
+# The dropped set, enumerated with one identical vulnerable file per candidate
+# path: `*_test.go` at ANY depth, plus the `test/` and `tests/` directories.
+# (Python/TS test FILENAMES — `test_app.py`, `app_test.py`, `conftest.py`,
+# `app.test.ts`, `app.spec.ts`, `__tests__/` — are NOT dropped; only the two
+# directories are.) The engine abandons the built-in template as soon as ANY
+# `.semgrepignore` exists, so shipping this file restores the test tree and
+# makes the scanned set a DELIBERATE choice.
+#
+# Effect measured on THIS repo, using its own gate-4 scan paths (app sidecar):
+# 803 files scanned before, 1075 after (+272 newly visible), and
+# 0 findings either way — so adoption is finding-neutral.
+#
+# ── EDITING RULES ───────────────────────────────────────────────────────────
+#
+# 1. NEVER add `*_test.go`, `test/`, `tests/`, `spec/` or `__tests__/`.
+#    First-party test code is first-party code — it handles credentials, builds
+#    queries and shells out. Re-excluding it restores the exact hole this file
+#    closes.
+# 2. Every directory entry ships BOTH the root-anchored and the nested form: a
+#    bare `**/x/` does NOT match a root-level `x/`, and it fails open with no
+#    warning. Measured with a positive control — `**/vendor/` left a root-level
+#    `vendor/pkg/b.go` scanned while `vendor/` excluded both trees.
+# 3. An exclusion is a statement about SCOPE ("this is not our source"), never
+#    about severity. Do not use this file to make a finding go away.
+
+.git/
+
+# Vendored third-party source. Not ours to fix, and upstream style trips
+# first-party rules. Secrets in these trees stay covered by gitleaks (gate 5),
+# which scans independently of this file.
+vendor/
+**/vendor/
+vendor_src/
+**/vendor_src/
+node_modules/
+**/node_modules/
+
+# Installed dependencies (virtualenvs) — third-party bytes, not source.
+.venv/
+**/.venv/
+venv/
+**/venv/
+
+# Build output, generated from source that gate 4 already scans.
+dist/
+**/dist/
+build/
+**/build/
+out/
+**/out/


### PR DESCRIPTION
## What this is

Gate 4 (SAST) has been scanning a file set it **inherited from a vendor default**, not one this repo chose — and the difference is invisible in the gate output. This ships an explicit `.semgrepignore` so the scanned set becomes a deliberate, reviewable decision.

Measured on the **pinned CI engine** — opengrep v1.22.0 CLI on Linux, exactly the build `reusable-quality.yml` installs — with a controlled detector and one variable changed at a time. Confidence: almost certain (90-99%).

## The hole

| file | content | result |
|---|---|---|
| `src/inline.go` | `db.Query(fmt.Sprintf(...))` | **FIRES** |
| `tests/inline.go` | byte-identical to the file above | **SILENT** |

`paths.scanned` listed 3 of 4 files and **`paths.skipped` reported `none`** — nothing in the gate output says a test tree was dropped. Pointing the scanner *directly* at `tests/` returns `paths.scanned: []`, so an explicit path argument does not override it either.

Enumerated precisely, the built-in template drops **`*_test.go` at any depth, plus the `test/` and `tests/` directories**. Python/TS test *filenames* (`test_app.py`, `app_test.py`, `conftest.py`, `app.test.ts`, `app.spec.ts`, `__tests__/`) are **not** dropped — only the two directories. The engine abandons the built-in template as soon as any `.semgrepignore` exists, so shipping this file is the whole fix.

## Effect on this repo, using its own gate-4 scan paths (`app sidecar`)

| | before | after |
|---|---|---|
| files scanned | 803 | **1075** (+272) |
| findings | 0 | 0 |

**+272 files become visible to the gate, and the finding count does not move** — so adoption is finding-neutral and green stays reachable.

## Both-states proof, against this repo's own curated ruleset

The same `eval()` file placed in `src/` and under `tests/`:

```
with this .semgrepignore      -> BOTH fire,  gate exit 1
with it removed (control)     -> src/ fires, tests/ INVISIBLE
clean ast.literal_eval file   -> silent,     gate exit 0
```

The **control** is the load-bearing half: a probe that is silent in the broken state measures nothing, so the hole is demonstrated rather than asserted.

## Scope discipline

- **No exclusion was added to make a finding go away.** The finding count is unchanged.
- Every directory entry ships **both** the root-anchored and the nested form, because a bare `**/x/` does **not** match a root-level `x/` and fails open with no warning — measured with a positive control (`**/vendor/` left a root-level `vendor/pkg/b.go` scanned; `vendor/` excluded both trees).
- The file carries its own editing rules, including "never add `test/`/`tests/`", so the hole cannot be quietly reopened.

## Related

Control-plane companion — the copyable template plus a non-blocking gate-4 warning for any caller with no explicit scan set: Prekzursil/quality-zero-platform#289. That PR also records, in `known-issues/QZ-SAST-001.yml`, a **second** measured gate-4 gap: the curated rules match SQL-injection *syntax* only, so the same bug written through a local variable escapes them. The obvious `mode: taint` fix was withdrawn after it produced 58 false positives across momentstudio and Reframe; the entry carries the evidence and the settling experiment.
