### PR TITLE
fix(shell): voice the video-timeline and caption-defaults panels, and repair three missing focus rings

### DIFF
--- a/app/renderer/src/components/CaptionPreferences.tsx
+++ b/app/renderer/src/components/CaptionPreferences.tsx
@@ -149,8 +149,14 @@ export function CaptionPreferences({
 
       <div className="caption-prefs__group caption-prefs__row">
         <label htmlFor="prefs-subtitle-mode">Subtitles</label>
+        {/* This panel's root is `caption-prefs panel`, and `.panel` has no rule in the
+            tree, so nothing here inherits the shared control voice by ancestry the way a
+            `.feature-panel` child does. The class is what lets components/shell.css reach
+            this one bare <select>; without it the control paints as a raw OS dropdown on
+            an otherwise fully-voiced panel. */}
         <select
           id="prefs-subtitle-mode"
+          className="caption-prefs__select"
           aria-label="Default subtitle delivery"
           value={prefs.subtitleMode}
           onChange={(e) =>

--- a/app/renderer/src/components/CaptionPreferences.tsx
+++ b/app/renderer/src/components/CaptionPreferences.tsx
@@ -149,14 +149,16 @@ export function CaptionPreferences({
 
       <div className="caption-prefs__group caption-prefs__row">
         <label htmlFor="prefs-subtitle-mode">Subtitles</label>
-        {/* This panel's root is `caption-prefs panel`, and `.panel` has no rule in the
-            tree, so nothing here inherits the shared control voice by ancestry the way a
-            `.feature-panel` child does. The class is what lets components/shell.css reach
-            this one bare <select>; without it the control paints as a raw OS dropdown on
-            an otherwise fully-voiced panel. */}
+        {/* Deliberately UNCLASSED. This panel's root is `caption-prefs panel` and `.panel`
+            has no rule in the tree, so its <button> does need a class to reach the shared
+            voice — but a <select> does not: styles/controls.css:34 already voices every
+            <select> in the app, chevron included. Adding a class here put it under
+            shell.css's shared INPUT rule, whose `background:`/`padding:` shorthands then
+            reset the chevron and the padding reserved for it, so this control stopped
+            matching the LanguageSelect directly below it. Measured in-engine and reverted;
+            shell.buttonVoice.conformance.test.ts keeps the two dropdowns in parity. */}
         <select
           id="prefs-subtitle-mode"
-          className="caption-prefs__select"
           aria-label="Default subtitle delivery"
           value={prefs.subtitleMode}
           onChange={(e) =>

--- a/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
+++ b/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
@@ -127,7 +127,13 @@ const VTL_TSX = readFileSync(VIDEO_TIMELINE_TSX, 'utf8');
 const VOICED = ['.vtl__bar button', '.vtl__laneHead button', '.caption-prefs__actions button'];
 
 /** The five lists a control has to appear in to be fully voiced. */
-const STATES = ['', ':hover:not(:disabled)', ':active:not(:disabled)', ':disabled', ':focus-visible'];
+const STATES = [
+  '',
+  ':hover:not(:disabled)',
+  ':active:not(:disabled)',
+  ':disabled',
+  ':focus-visible',
+];
 
 /** The selectors the focus-ring specificity repair was missing (Q2). */
 const FOCUS_REPAIRED = [

--- a/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
+++ b/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+//
 // shell.buttonVoice.conformance.test.ts — the two bare-`.panel` surfaces join the
 // shared control voice, and the focus-ring specificity repair covers every
 // selector it has to (Q1 + Q2).
@@ -18,9 +20,13 @@
 //     is `.workspace > .workspace__body` (`views/Workspace.tsx:450,513`) — no
 //     `.feature-panel`.
 //   * `components/CaptionPreferences.tsx:115` — `<section className="caption-prefs
-//     panel">`; the Save button (`:220`) and the subtitle-mode `<select>` (`:152`).
-//     Mounted into `.settings__panel` (`views/Settings.tsx:197,281`) — again no
-//     `.feature-panel` ancestor.
+//     panel">`; the Save button (`:220`). Mounted into `.settings__panel`
+//     (`views/Settings.tsx:197,281`) — again no `.feature-panel` ancestor.
+//
+// BUTTONS only. The subtitle-mode `<select>` on that same panel is NOT part of this
+// failure and was wrongly swept into it on the first pass: `styles/controls.css:34`
+// gives every `<select>` in the app the shared voice, so the select needed nothing.
+// The correction is pinned by the cross-sheet block at the bottom of this file.
 //
 // The repo already fixed this exact failure once, for `.batch-queue`, and wrote
 // down why at `shell.css:391-394`; `features/batchQueue.conformance.test.ts` is the
@@ -119,7 +125,8 @@ function classNamesOf(tsx: string): ReadonlySet<string> {
   return out;
 }
 
-const SHELL = stripComments(readFileSync(SHELL_CSS, 'utf8'));
+const SHELL_RAW = readFileSync(SHELL_CSS, 'utf8');
+const SHELL = stripComments(SHELL_RAW);
 const PREFS_TSX = readFileSync(CAPTION_PREFS_TSX, 'utf8');
 const VTL_TSX = readFileSync(VIDEO_TIMELINE_TSX, 'utf8');
 
@@ -181,24 +188,45 @@ describe('the bare-`.panel` surfaces join the shared control voice (Q1)', () => 
     }
   });
 
-  it('gives the caption-prefs <select> the shared input voice', () => {
+  it('leaves the caption-prefs <select> to styles/controls.css (no class entry)', () => {
+    // The inverse of the button case, and the correction of this branch's own first
+    // attempt. A <select> is ALREADY voiced app-wide by styles/controls.css:34, so
+    // naming one in shell.css's shared input rule does not add a voice — its
+    // shorthand body takes the chevron away. The cross-sheet block below measures
+    // the consequence; this keeps the selector itself from coming back.
     for (const state of ['', ':hover', ':focus-visible']) {
       expect(
         listsSelector(SHELL, `.caption-prefs__select${state}`),
-        `shell.css must list .caption-prefs__select${state}`,
-      ).toBe(true);
+        `shell.css must NOT list .caption-prefs__select${state} — the shared input ` +
+          'rule uses `background:`/`padding:` shorthands, which reset the chevron and ' +
+          'the `padding-right` that styles/controls.css reserves for it',
+      ).toBe(false);
     }
   });
 
-  it('keeps the lane head DENSE so the lane name is not ellipsised away', () => {
-    // Measured in Chromium at 1280px on the real ancestor chain: the lane head is a
-    // fixed 132px grid column (features/videoTimeline.css:44). At the full
-    // `--control-pad-btn` the two row actions take 89px of it and squeeze
-    // `.vtl__laneName` to 26.4px — narrower than the 41px the DEFAULT lane name
-    // "Video 1" needs (sidecar/media_studio/features/video_tracks.py:230,611), so
-    // every lane label truncated to "Vid…". The row-action pad is the token for this
-    // case; the VOICE is unchanged, only the density, and `--size-target-min` holds
-    // the control at the WCAG 2.5.8 minimum target height.
+  it('gives the lane head the row-action pad, not the full button pad', () => {
+    // What this asserts is exactly the two declarations below — the density tokens.
+    // It does NOT assert that the lane name fits; measured, it does not, and it did
+    // not before this branch either.
+    //
+    // MEASURED in headless Chromium at 1280px, real in-repo Inter inlined so the
+    // glyph metrics are the shipped ones, three real git states, with a short-name
+    // control that must never ellipsise and a long-name control that always must
+    // (both held). The lane head is a fixed 132px grid column
+    // (features/videoTimeline.css:44) and "Video 1" is the DEFAULT lane name
+    // (sidecar/media_studio/features/video_tracks.py:230,611), needing 40.98px:
+    //
+    //   origin/main   .vtl__laneName = 39.53px  -> ALREADY ellipsised
+    //   9942af19      .vtl__laneName = 25.31px  -> ellipsised, visibly worse
+    //   HEAD          .vtl__laneName = 39.45px  -> ellipsised, back to the main width
+    //
+    // So the residual is a PRE-EXISTING truncation this branch neither introduces nor
+    // repairs: the full button pad would have cost 14.2px, and these two declarations
+    // give all but 0.08px of it back. Closing the remaining 1.53px needs the 132px
+    // column widened, the 4px gap shrunk, or "+ Clip" made icon-only — all in
+    // features/videoTimeline.css, outside this lane's file scope, and all equally
+    // required on origin/main. Gate any follow-up on `scrollWidth <= clientWidth`
+    // for `.vtl__laneName` with the default lane name.
     const bodies = bodiesFor(SHELL, '.vtl__laneHead button');
     const padded = bodies.filter((b) => decl(b, 'padding') === 'var(--control-pad-mini)');
     expect(padded.length, '.vtl__laneHead button must use the row-action pad').toBe(1);
@@ -242,9 +270,116 @@ describe('the bare-`.panel` surfaces join the shared control voice (Q1)', () => 
     ).toBe(true);
     expect(
       prefs.has('caption-prefs__select'),
-      'CaptionPreferences.tsx must class the subtitle-mode <select> so the shared ' +
-        'input voice can reach it without a structural `>` selector',
-    ).toBe(true);
+      'the subtitle-mode <select> must stay UNCLASSED — styles/controls.css already ' +
+        'voices it, and a class only drags it under shell.css`s shorthand input rule',
+    ).toBe(false);
+  });
+});
+
+/* ---------------------------------------------------------------------------
+ * CROSS-SHEET CASCADE. Everything above reads ONE stylesheet, so it is
+ * structurally blind to a shell.css rule overriding a rule in another sheet —
+ * and that blind spot shipped a real defect on this very branch. A
+ * `.caption-prefs__select` entry was added to the shared input rule on the
+ * premise that the control was "the one raw OS dropdown left on that panel".
+ * It was not: `styles/controls.css:34` already gives EVERY <select> in the app
+ * the shared voice, chevron included, and App.tsx imports it immediately before
+ * shell.css. Because the shared input rule's body uses SHORTHANDS, the (0,1,0)
+ * class entry reset two longhands the (0,0,1) element rule had set —
+ * `background:` wiped `background-image` (the redrawn arrow that
+ * controls.css:35-38 documents as the "this opens a list" affordance) and
+ * `padding:` dropped `padding-right` from `--space-6` to `--control-pad-input`,
+ * removing the room reserved for it. The panel ended up with two adjacent
+ * dropdowns speaking different languages, which is the opposite of the change's
+ * intent. This block loads the real sheets in the real order so that class of
+ * defect cannot come back unseen.
+ * ------------------------------------------------------------------------ */
+
+const TOKENS_CSS = resolve(HERE, '..', 'styles', 'tokens.css');
+const CONTROLS_CSS = resolve(HERE, '..', 'styles', 'controls.css');
+
+/** The `select` longhands controls.css sets that a later shorthand can silently reset. */
+const SELECT_PROPS = ['backgroundImage', 'backgroundColor', 'paddingRight'] as const;
+
+/**
+ * Mount the caption-defaults panel with the REAL sheets in App.tsx order and read
+ * back the computed style of its two adjacent dropdowns.
+ *
+ * jsdom does not resolve `var()`, so nothing here is compared against a literal:
+ * the subtitle <select> is compared against the `LanguageSelect` <select> on the
+ * very next row, which carries no shell.css class. That comparison is immune to
+ * var() resolution AND is the actual product requirement — two dropdowns on one
+ * panel must speak one control language.
+ *
+ * The fixture keeps `class="caption-prefs__select"` on the subtitle <select> even
+ * though the real component no longer sets it. That is a deliberate TRIPWIRE, not
+ * drift: it makes this a guard on the STYLESHEET rather than on the markup, so the
+ * rule cannot be reinstated in shell.css without going red here — including in the
+ * case where someone re-adds both the rule and the className together.
+ */
+function adjacentSelects(shellCss: string): {
+  subtitle: Record<string, string>;
+  control: Record<string, string>;
+} {
+  document.head.replaceChildren();
+  for (const css of [
+    readFileSync(TOKENS_CSS, 'utf8'),
+    readFileSync(CONTROLS_CSS, 'utf8'),
+    shellCss,
+  ]) {
+    const style = document.createElement('style');
+    style.textContent = css;
+    document.head.append(style);
+  }
+  document.body.innerHTML =
+    '<div class="app"><main class="app__main"><section class="settings__panel">' +
+    '<section class="caption-prefs panel">' +
+    '<div class="caption-prefs__group caption-prefs__row">' +
+    '<select id="subtitle" class="caption-prefs__select"></select></div>' +
+    '<div class="caption-prefs__group caption-prefs__row">' +
+    '<select id="lang" class="lang-select__control"></select></div>' +
+    '</section></section></main></div>';
+
+  // GUARD, learned the hard way: a sheet jsdom cannot parse contributes NOTHING,
+  // which makes every assertion below vacuously true. While building this fixture a
+  // draft removed a selector entry and left the previous line's dangling `,` —
+  // shell.css dropped to zero rules and the "fixed" state passed for that reason
+  // alone. Assert the sheet is really in the cascade before reading anything from it.
+  const shellSheet = document.styleSheets[2];
+  expect(
+    shellSheet.cssRules.length,
+    'shell.css did not parse — the FIXTURE is broken',
+  ).toBeGreaterThan(100);
+
+  const read = (id: string): Record<string, string> => {
+    const el = document.getElementById(id);
+    if (el === null) throw new Error(`fixture is missing #${id}`);
+    const cs = getComputedStyle(el);
+    return Object.fromEntries(SELECT_PROPS.map((prop) => [prop, cs[prop]]));
+  };
+  return { subtitle: read('subtitle'), control: read('lang') };
+}
+
+describe('shell.css does not clobber the global <select> voice (cross-sheet)', () => {
+  it('the parity detector FIRES on a synthetic clobber (both-states control)', () => {
+    // Prove the instrument can go red before trusting it green. A shorthand
+    // `background:`/`padding:` on the subtitle select must break parity with its
+    // neighbour on exactly the longhands controls.css owns.
+    const { subtitle, control } = adjacentSelects(
+      `${SHELL_RAW}\n.caption-prefs__select { background: #000; padding: 1px; }\n`,
+    );
+    const differing = SELECT_PROPS.filter((prop) => subtitle[prop] !== control[prop]);
+    expect(differing, 'the detector cannot see a shorthand clobber').toEqual([...SELECT_PROPS]);
+  });
+
+  it('the two dropdowns on the caption-defaults panel compute identically', () => {
+    const { subtitle, control } = adjacentSelects(SHELL_RAW);
+    expect(
+      subtitle,
+      'the subtitle-delivery <select> must keep the voice styles/controls.css gives ' +
+        'every <select>; a shorthand in shell.css resets its chevron and the padding ' +
+        'reserved for it, leaving two adjacent dropdowns visibly different',
+    ).toEqual(control);
   });
 });
 

--- a/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
+++ b/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
@@ -190,6 +190,21 @@ describe('the bare-`.panel` surfaces join the shared control voice (Q1)', () => 
     }
   });
 
+  it('keeps the lane head DENSE so the lane name is not ellipsised away', () => {
+    // Measured in Chromium at 1280px on the real ancestor chain: the lane head is a
+    // fixed 132px grid column (features/videoTimeline.css:44). At the full
+    // `--control-pad-btn` the two row actions take 89px of it and squeeze
+    // `.vtl__laneName` to 26.4px — narrower than the 41px the DEFAULT lane name
+    // "Video 1" needs (sidecar/media_studio/features/video_tracks.py:230,611), so
+    // every lane label truncated to "Vid…". The row-action pad is the token for this
+    // case; the VOICE is unchanged, only the density, and `--size-target-min` holds
+    // the control at the WCAG 2.5.8 minimum target height.
+    const bodies = bodiesFor(SHELL, '.vtl__laneHead button');
+    const padded = bodies.filter((b) => decl(b, 'padding') === 'var(--control-pad-mini)');
+    expect(padded.length, '.vtl__laneHead button must use the row-action pad').toBe(1);
+    expect(decl(padded[0], 'min-height')).toBe('var(--size-target-min)');
+  });
+
   it('does NOT reach the nested component buttons (the broad-selector trap)', () => {
     // `.vtl__clip` and `.caption-style-swatch` are <button>s living inside these
     // panels with their own (0,1,0) voices. A broad `.vtl button` /

--- a/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
+++ b/app/renderer/src/components/shell.buttonVoice.conformance.test.ts
@@ -1,0 +1,275 @@
+// shell.buttonVoice.conformance.test.ts — the two bare-`.panel` surfaces join the
+// shared control voice, and the focus-ring specificity repair covers every
+// selector it has to (Q1 + Q2).
+//
+// MEASURED BEFORE THIS GUARD EXISTED
+// ----------------------------------
+// `components/shell.css` gives the raised button voice to exactly seven selectors
+// (`:395-401`) and none of them matches a surface whose root is `className="…
+// panel"`, because `.panel` itself has ZERO rules in the tree — only
+// `.panel--missing` / `.panel--loading` (`shell.css:1109-1110`). Two live surfaces
+// mount that way and therefore painted as raw dark Chromium UA chrome, with no
+// hover and NO press feedback at all, beside fully-voiced siblings:
+//
+//   * `features/VideoTimeline.tsx:514` — `<section className="panel vtl">`; five
+//     toolbar buttons (`:516,524,527,535,547`), two lane-head buttons (`:583,598`)
+//     and a `<progress>` (`:558`, whose styling is scoped to
+//     `.feature-panel` / `.sm-progress`, `shell.css:1209-1230`). Its ancestor chain
+//     is `.workspace > .workspace__body` (`views/Workspace.tsx:450,513`) — no
+//     `.feature-panel`.
+//   * `components/CaptionPreferences.tsx:115` — `<section className="caption-prefs
+//     panel">`; the Save button (`:220`) and the subtitle-mode `<select>` (`:152`).
+//     Mounted into `.settings__panel` (`views/Settings.tsx:197,281`) — again no
+//     `.feature-panel` ancestor.
+//
+// The repo already fixed this exact failure once, for `.batch-queue`, and wrote
+// down why at `shell.css:391-394`; `features/batchQueue.conformance.test.ts` is the
+// guard that keeps it fixed. This file is its sibling for the remaining two
+// surfaces, and it adds the focus half.
+//
+// THE TWO TRAPS THIS FILE PINS (both measured on this tree, not theorised)
+// -----------------------------------------------------------------------
+// 1. NARROW selectors, never `.vtl button` / `.caption-prefs button`. A broad
+//    descendant selector is (0,1,1) and would out-specify two (0,1,0) component
+//    voices nested INSIDE those panels, silently repainting them:
+//      - `.vtl__clip` (`features/videoTimeline.css:74`) — the timeline clips are
+//        `<button>` elements (`VideoTimeline.tsx:631`), so a broad rule would
+//        overwrite their background, border, padding, font-size and `cursor: grab`.
+//      - `.caption-style-swatch` (`components/captionStylePicker.css:9`) — the
+//        style-picker swatches are `<button>` elements (`CaptionStylePicker.tsx:54`)
+//        rendered inside the caption-prefs panel.
+//    So the voice is joined at `.vtl__bar` / `.vtl__laneHead` /
+//    `.caption-prefs__actions`, which contain only real toolbar controls.
+// 2. The DISABLED list must not inherit its neighbour's omission. `shell.css:456-459`
+//    lists `.feature-panel`, `.shortmaker`, `.library__add-btn` and `.batch-queue`
+//    but NOT `.timeline__toolbar button:disabled` (that surface is covered instead
+//    by `features/timeline.css:83`). Disabled is the DOMINANT state on the video
+//    timeline's toolbar — four of its five buttons are disabled until a clip is
+//    selected — so copying the neighbour verbatim would skip the state that shows
+//    most.
+//
+// This file imports no TS source; it is a pure conformance check over the
+// stylesheet + the component sources, mirroring `features/batchQueue.conformance.test.ts`.
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SHELL_CSS = resolve(HERE, 'shell.css');
+const CAPTION_PREFS_TSX = resolve(HERE, 'CaptionPreferences.tsx');
+const VIDEO_TIMELINE_TSX = resolve(HERE, '..', 'features', 'VideoTimeline.tsx');
+
+/** Strip `/* … *\/` comment blocks so prose can never register as a real rule. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/** Escape a CSS selector for literal use inside a RegExp. */
+function escapeRe(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * True when `selector` appears in `css` as a WHOLE selector — terminated by a `,`
+ * or by the rule's `{`, and preceded by a start-of-selector boundary.
+ *
+ * A bare substring test cannot express this and degrades to a weaker gate in BOTH
+ * directions: `'.vtl__bar button:hover'.includes('.vtl__bar button')` is true (a
+ * longer sibling satisfies the rest-state assertion), and
+ * `'.x .vtl__bar button'.includes('.vtl__bar button')` is true as well (a
+ * differently-scoped rule satisfies it). Both readings are asserted on fixtures in
+ * the detector-control test below.
+ */
+function listsSelector(css: string, selector: string): boolean {
+  return new RegExp(`(?:^|[,{}])\\s*${escapeRe(selector)}\\s*(?:,|\\{)`, 'm').test(css);
+}
+
+/** Every `[selectorList, body]` pair in a stylesheet, comments already stripped. */
+function rules(css: string): readonly (readonly [string, string])[] {
+  const out: (readonly [string, string])[] = [];
+  const rule = /([^{}]+)\{([^{}]*)\}/g;
+  for (let m = rule.exec(css); m !== null; m = rule.exec(css)) {
+    out.push([m[1].trim(), m[2]] as const);
+  }
+  return out;
+}
+
+/** The bodies of every rule whose selector list contains `selector` as a whole entry. */
+function bodiesFor(css: string, selector: string): readonly string[] {
+  return rules(css)
+    .filter(([list]) => listsSelector(`${list} {`, selector))
+    .map(([, body]) => body);
+}
+
+/** One declaration's value, or null. */
+function decl(body: string, prop: string): string | null {
+  return new RegExp(`(?:^|;)\\s*${escapeRe(prop)}\\s*:([^;]*)`).exec(body)?.[1].trim() ?? null;
+}
+
+/** Class names in a component's static `className="…"` attributes. */
+function classNamesOf(tsx: string): ReadonlySet<string> {
+  const out = new Set<string>();
+  const attr = /className="([^"]*)"/g;
+  for (let m = attr.exec(tsx); m !== null; m = attr.exec(tsx)) {
+    for (const token of m[1].split(/\s+/)) if (token !== '') out.add(token);
+  }
+  return out;
+}
+
+const SHELL = stripComments(readFileSync(SHELL_CSS, 'utf8'));
+const PREFS_TSX = readFileSync(CAPTION_PREFS_TSX, 'utf8');
+const VTL_TSX = readFileSync(VIDEO_TIMELINE_TSX, 'utf8');
+
+/** The control hosts that join the shared raised-button voice in this change. */
+const VOICED = ['.vtl__bar button', '.vtl__laneHead button', '.caption-prefs__actions button'];
+
+/** The five lists a control has to appear in to be fully voiced. */
+const STATES = ['', ':hover:not(:disabled)', ':active:not(:disabled)', ':disabled', ':focus-visible'];
+
+/** The selectors the focus-ring specificity repair was missing (Q2). */
+const FOCUS_REPAIRED = [
+  '.library__add-btn:focus-visible',
+  '.library__remove-btn:focus-visible',
+  '.workspace__back:focus-visible',
+];
+
+describe('the bare-`.panel` surfaces join the shared control voice (Q1)', () => {
+  it('the selector-boundary detector rejects both weaker matches', () => {
+    // Verify the instrument BEFORE trusting anything it reports. Both states, on
+    // fixtures: a longer sibling alone must read ABSENT, a differently-scoped rule
+    // must read ABSENT, and the real entry must read PRESENT in both positions.
+    const siblingOnly = '.vtl__bar button:hover:not(:disabled) { color: red; }';
+    expect(siblingOnly).toContain('.vtl__bar button'); // the weaker gate is fooled
+    expect(listsSelector(siblingOnly, '.vtl__bar button')).toBe(false);
+    expect(listsSelector('.x .vtl__bar button { color: red; }', '.vtl__bar button')).toBe(false);
+    expect(listsSelector('.x,\n.vtl__bar button {\n}', '.vtl__bar button')).toBe(true);
+    expect(listsSelector('.vtl__bar button {}', '.vtl__bar button')).toBe(true);
+    // …and it finds a selector that is already in the real sheet, so a regex that
+    // silently stopped matching could not make the suite vacuously green.
+    expect(listsSelector(SHELL, '.batch-queue button')).toBe(true);
+    expect(listsSelector(SHELL, '.definitely-not-a-real-selector-xyz')).toBe(false);
+  });
+
+  it('gives BOTH panels the voice in all five states (disabled included)', () => {
+    for (const host of VOICED) {
+      for (const state of STATES) {
+        expect(
+          listsSelector(SHELL, `${host}${state}`),
+          `shell.css must list ${host}${state} — otherwise that state falls through ` +
+            'to raw platform chrome (trap 2: the disabled list omits .timeline__toolbar).',
+        ).toBe(true);
+      }
+    }
+  });
+
+  it('styles the video timeline <progress> instead of leaving it UA chrome', () => {
+    for (const selector of [
+      '.vtl progress',
+      '.vtl progress::-webkit-progress-bar',
+      '.vtl progress::-webkit-progress-value',
+    ]) {
+      expect(listsSelector(SHELL, selector), `shell.css must list ${selector}`).toBe(true);
+    }
+  });
+
+  it('gives the caption-prefs <select> the shared input voice', () => {
+    for (const state of ['', ':hover', ':focus-visible']) {
+      expect(
+        listsSelector(SHELL, `.caption-prefs__select${state}`),
+        `shell.css must list .caption-prefs__select${state}`,
+      ).toBe(true);
+    }
+  });
+
+  it('does NOT reach the nested component buttons (the broad-selector trap)', () => {
+    // `.vtl__clip` and `.caption-style-swatch` are <button>s living inside these
+    // panels with their own (0,1,0) voices. A broad `.vtl button` /
+    // `.caption-prefs button` entry is (0,1,1) and would repaint both.
+    for (const broad of [
+      '.vtl button',
+      '.vtl button:hover:not(:disabled)',
+      '.caption-prefs button',
+      '.caption-prefs button:hover:not(:disabled)',
+    ]) {
+      expect(
+        listsSelector(SHELL, broad),
+        `${broad} is too broad — it out-specifies .vtl__clip / .caption-style-swatch`,
+      ).toBe(false);
+    }
+  });
+
+  it('adds NO `.panel` base surface rule (it would double-pad three fallbacks)', () => {
+    // `.workspace__body` (shell.css:1106) and the three `panel panel--loading`
+    // fallbacks (shell.css:1111) already carry `padding: var(--space-6)`.
+    expect(listsSelector(SHELL, '.panel')).toBe(false);
+  });
+
+  it('the selectors match markup that actually exists (no dead rules)', () => {
+    const vtl = classNamesOf(VTL_TSX);
+    expect(vtl.has('vtl__bar'), 'VideoTimeline.tsx must still render .vtl__bar').toBe(true);
+    expect(vtl.has('vtl__laneHead'), 'VideoTimeline.tsx must still render .vtl__laneHead').toBe(
+      true,
+    );
+    expect(VTL_TSX, 'VideoTimeline.tsx must still render a <progress>').toContain('<progress');
+    const prefs = classNamesOf(PREFS_TSX);
+    expect(
+      prefs.has('caption-prefs__actions'),
+      'CaptionPreferences.tsx must still render .caption-prefs__actions',
+    ).toBe(true);
+    expect(
+      prefs.has('caption-prefs__select'),
+      'CaptionPreferences.tsx must class the subtitle-mode <select> so the shared ' +
+        'input voice can reach it without a structural `>` selector',
+    ).toBe(true);
+  });
+});
+
+describe('the focus-ring specificity repair names every selector it needs (Q2)', () => {
+  it('repairs Library Add, Library Remove and Workspace Back', () => {
+    // `:where(…):focus-visible` is (0,1,0) and loses on source order to the later
+    // (0,1,0) rules that set `box-shadow` on these three — `--accent-glow` at
+    // shell.css:475 for Add, `none` at :447 for Remove/Back. Without an entry here
+    // keyboard focus paints NOTHING on the Library's primary action, its
+    // destructive action, and the Workspace's only back navigation (WCAG 2.4.7 AA).
+    for (const selector of FOCUS_REPAIRED) {
+      expect(listsSelector(SHELL, selector), `shell.css must repair ${selector}`).toBe(true);
+    }
+  });
+
+  it('keeps the primary`s accent glow — Add is COMPOSED, not plain', () => {
+    const bodies = bodiesFor(SHELL, '.library__add-btn:focus-visible');
+    expect(bodies.length).toBeGreaterThan(0);
+    for (const body of bodies) {
+      const shadow = decl(body, 'box-shadow');
+      if (shadow === null) continue;
+      expect(shadow, 'the Add repair must compose the ring WITH the accent glow').toContain(
+        'var(--focus-ring)',
+      );
+      expect(shadow, 'a plain focus-ring block would strip the primary accent glow').toContain(
+        'var(--accent-glow)',
+      );
+    }
+  });
+
+  it('the ring no longer depends on winning a box-shadow tie (durable form)', () => {
+    // The global rule sets `outline: 2px solid transparent` (shell.css:80) so the
+    // designed ring is a box-shadow — a channel any later same-specificity rule can
+    // take away, which is exactly how these three lost it. A real outline COLOUR on
+    // the repaired selectors lands on the same 2px..4px band as the token`s outer
+    // ring, so it is visually identical where the shadow paints, and it is the only
+    // thing left when a hover rule out-specifies the shadow.
+    const repaired = [...FOCUS_REPAIRED, ...VOICED.map((h) => `${h}:focus-visible`)];
+    for (const selector of repaired) {
+      const bodies = bodiesFor(SHELL, selector);
+      expect(bodies.length, `no rule lists ${selector}`).toBeGreaterThan(0);
+      const colours = bodies.map((b) => decl(b, 'outline-color')).filter((c) => c !== null);
+      expect(colours.length, `${selector} must set a real outline-color`).toBeGreaterThan(0);
+      for (const colour of colours) {
+        expect(colour, `${selector} must not keep the invisible outline`).not.toBe('transparent');
+      }
+    }
+  });
+});

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -490,14 +490,28 @@ button {
 }
 
 /* DENSITY, not a different voice. The lane head is a fixed 132px grid column
-   (features/videoTimeline.css:44) carrying a lane name plus two row actions. At the
-   full `--control-pad-btn` those two take 89px of it and squeeze `.vtl__laneName`
-   to 26.4px — narrower than the 41px the DEFAULT name "Video 1" needs
-   (sidecar/media_studio/features/video_tracks.py:230,611), so every lane label
-   truncated to "Vid…" (measured in Chromium at 1280px). The row-action pad is the
-   token for exactly this case. Surface, edge, elevation, radius, hover, press,
-   disabled and focus are all inherited from the voice above and unchanged;
-   `--size-target-min` holds the smaller control at the WCAG 2.5.8 target height. */
+   (features/videoTimeline.css:44) carrying a lane name plus two row actions, so every
+   pixel the buttons gain comes straight out of `.vtl__laneName`.
+
+   MEASURED in headless Chromium at 1280px with the real in-repo Inter (a substituted
+   font makes these figures meaningless) and with two controls that held — a one-char
+   lane name that never ellipsises, a long one that always does. "Video 1" is the
+   DEFAULT lane name (sidecar/media_studio/features/video_tracks.py:230,611) and needs
+   40.98px:
+
+     origin/main                    .vtl__laneName = 39.53px  (already ellipsised)
+     the voice at --control-pad-btn .vtl__laneName = 25.31px  (visibly worse)
+     with this rule                 .vtl__laneName = 39.45px  (back to the main width)
+
+   So this rule buys back 14.14 of the 14.22px the full pad cost. It does NOT make the
+   label fit: the default name was ALREADY truncating on origin/main by 1.45px, and it
+   still is. That residual is pre-existing and out of this sheet's reach — closing it
+   needs the 132px column widened, the 4px gap shrunk, or "+ Clip" made icon-only, all
+   in features/videoTimeline.css. Do not "fix" it here with an off-token pad.
+
+   Surface, edge, elevation, radius, hover, press, disabled and focus are inherited
+   from the voice above and unchanged; `--size-target-min` holds the smaller control
+   at the WCAG 2.5.8 minimum target height. */
 .vtl__laneHead button {
   padding: var(--control-pad-mini);
   min-height: var(--size-target-min);
@@ -580,13 +594,26 @@ button {
 
 /* ---- shared inputs ------------------------------------------------------------- */
 
-/* `.caption-prefs__select` is the same bare-`.panel` case as the buttons above: the
-   caption-defaults panel has no `.feature-panel` ancestor, so its subtitle-delivery
-   <select> was the one raw OS dropdown left on an otherwise voiced panel. It is
-   named by CLASS, not as `.caption-prefs__row > select`, so the rule cannot be
-   broken by a wrapper element and cannot reach the <select> that `LanguageSelect`
-   renders on the next row, which carries its own voice
-   (components/languageSelect.css:8). */
+/* DO NOT add a bare `<select>` to this list. Unlike the button voice above, selects
+   are NOT unvoiced by default: `styles/controls.css:34` gives every <select> in the
+   app the shared voice — border, radius, `--surface-raised`, `min-height`, and a
+   redrawn chevron with `padding-right: var(--space-6)` holding the room for it —
+   and App.tsx imports it immediately before this sheet.
+
+   This rule's body uses SHORTHANDS, so any class entry added here lands at (0,1,0)
+   over that (0,0,1) element rule and RESETS the longhands it does not restate:
+   `background:` wipes `background-image` (the arrow controls.css:35-38 documents as
+   the "this opens a list" affordance) and `padding:` drops `padding-right` back to
+   `--control-pad-input`, taking away the space reserved for it. That is measured, not
+   theorised — a `.caption-prefs__select` entry was added here and then removed once
+   the two adjacent dropdowns on the caption-defaults panel were compared in-engine
+   (components/shell.buttonVoice.conformance.test.ts pins it).
+
+   The nine entries below predate that and are deliberate: `.feature-panel` /
+   `.shortmaker` / `.timeline__editor` fields sit in a recessed `--surface-deep` well.
+   Two of the nine are selects (`.feature-panel select`, `.shortmaker select`) and so
+   take the same chevron loss — a real app-wide divergence, but a PRE-EXISTING one and
+   a design call to make deliberately, not to spread one class at a time. */
 .library__add-input,
 .feature-panel input,
 .feature-panel select,
@@ -595,8 +622,7 @@ button {
 .shortmaker select,
 .shortmaker textarea,
 .timeline__editor input,
-.timeline__editor textarea,
-.caption-prefs__select {
+.timeline__editor textarea {
   appearance: none;
   padding: var(--control-pad-input);
   background: var(--surface-deep);
@@ -613,8 +639,7 @@ button {
 .feature-panel textarea:hover,
 .shortmaker input:hover,
 .shortmaker select:hover,
-.shortmaker textarea:hover,
-.caption-prefs__select:hover {
+.shortmaker textarea:hover {
   border-color: var(--edge-strong);
 }
 
@@ -630,8 +655,7 @@ button {
 .shortmaker select:focus-visible,
 .shortmaker textarea:focus-visible,
 .timeline__editor input:focus-visible,
-.timeline__editor textarea:focus-visible,
-.caption-prefs__select:focus-visible {
+.timeline__editor textarea:focus-visible {
   outline: none;
   border-color: var(--accent-edge);
   box-shadow: var(--focus-glow);

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -89,15 +89,43 @@ body,
  *     the accent-primary rule at (0,4,1). A plain (0,2,1) rule is NOT enough — proven by
  *     modelsSystem.css, whose (0,2,1) override still lost on the accent primary.
  * The accent fill is composed with the ring rather than replaced, so primaries keep their
- * glow while gaining a visible focus state. */
+ * glow while gaining a visible focus state.
+ *
+ * The list has to name EVERY selector the raised voice below declares, or the control keeps
+ * NO indicator at all. Three were missing: `.library__remove-btn` and `.workspace__back`
+ * take the ring away with the ghost voice's `box-shadow: none`, and `.library__add-btn`
+ * replaces it with the accent voice's `--accent-glow` — each at (0,1,0), the same
+ * specificity as the global ring but LATER in source order, so each simply wins. That left
+ * the Library's primary action, its destructive action and the Workspace's only back
+ * navigation with no visible keyboard focus (WCAG 2.4.7 AA).
+ *
+ * `outline-color` here is the DURABLE half. The global rule keeps the outline transparent
+ * because the box-shadow is the design — but a box-shadow is one channel that any later
+ * same-or-higher-specificity rule can take away, which is precisely how these three lost it
+ * (and `:hover:not(:disabled)` at (0,3,0) still outranks a (0,2,0) focus rule while both are
+ * active). A real outline colour paints the same 2px..4px band as the token's outer ring —
+ * `outline-offset: 2px` + a 2px outline, against `--focus-ring`'s 2px `--surface-bg` layer
+ * over its 4px `--accent-edge` layer — so it is the same ring where the shadow paints, and
+ * it is the ring that survives where the shadow does not. */
 .feature-panel button:focus-visible,
 .shortmaker button:focus-visible,
 .timeline__toolbar button:focus-visible,
-.batch-queue button:focus-visible {
+.batch-queue button:focus-visible,
+.vtl__bar button:focus-visible,
+.vtl__laneHead button:focus-visible,
+.caption-prefs__actions button:focus-visible,
+.library__remove-btn:focus-visible,
+.workspace__back:focus-visible {
+  outline-color: var(--accent-edge);
   box-shadow: var(--focus-ring);
 }
 
+/* Composed, NOT plain: a bare `box-shadow: var(--focus-ring)` on `.library__add-btn` is
+   (0,2,0) and would beat the accent voice at (0,1,0), stripping the primary's glow the
+   moment it takes focus. */
+.library__add-btn:focus-visible,
 .feature-panel .actions > button:first-child:not(.secondary):focus-visible {
+  outline-color: var(--accent-edge);
   box-shadow: var(--focus-ring), var(--accent-glow);
 }
 
@@ -391,14 +419,32 @@ button {
    `.batch-queue` is listed explicitly (W05): views/Repurpose.tsx and
    views/Deliver.tsx mount it with NO `.feature-panel` ancestor, so every one of
    its controls fell through to raw platform chrome. Reusing this voice rather
-   than re-declaring it in features/batchQueue.css keeps ONE button language. */
+   than re-declaring it in features/batchQueue.css keeps ONE button language.
+
+   `.vtl__*` and `.caption-prefs__actions` are the same W05 failure on the two
+   remaining surfaces whose root is `className="… panel"` — and `.panel` has no
+   rule in this tree at all, only `.panel--missing`/`--loading` below. The video
+   timeline (features/VideoTimeline.tsx:514) hangs off `.workspace__body` and the
+   caption defaults (components/CaptionPreferences.tsx:115) off `.settings__panel`,
+   so neither has a `.feature-panel` ancestor and every control on them painted as
+   raw dark Chromium chrome next to fully-voiced siblings.
+
+   The hosts are NARROW on purpose. `.vtl button` / `.caption-prefs button` would be
+   (0,1,1) and would out-specify two (0,1,0) component voices nested inside these
+   panels — `.vtl__clip` (features/videoTimeline.css:74; the clips ARE buttons) and
+   `.caption-style-swatch` (components/captionStylePicker.css:9) — silently
+   repainting their background, border, padding and cursor. `.vtl__bar`,
+   `.vtl__laneHead` and `.caption-prefs__actions` contain only toolbar controls. */
 .library__add-btn,
 .library__remove-btn,
 .workspace__back,
 .feature-panel button,
 .shortmaker button,
 .timeline__toolbar button,
-.batch-queue button {
+.batch-queue button,
+.vtl__bar button,
+.vtl__laneHead button,
+.caption-prefs__actions button {
   appearance: none;
   padding: var(--control-pad-btn);
   border: 1px solid var(--edge);
@@ -420,7 +466,10 @@ button {
 .feature-panel button:hover:not(:disabled),
 .shortmaker button:hover:not(:disabled),
 .timeline__toolbar button:hover:not(:disabled),
-.batch-queue button:hover:not(:disabled) {
+.batch-queue button:hover:not(:disabled),
+.vtl__bar button:hover:not(:disabled),
+.vtl__laneHead button:hover:not(:disabled),
+.caption-prefs__actions button:hover:not(:disabled) {
   background: var(--surface-hover);
   border-color: var(--edge-strong);
   box-shadow: var(--elev-2);
@@ -432,7 +481,10 @@ button {
 .feature-panel button:active:not(:disabled),
 .shortmaker button:active:not(:disabled),
 .timeline__toolbar button:active:not(:disabled),
-.batch-queue button:active:not(:disabled) {
+.batch-queue button:active:not(:disabled),
+.vtl__bar button:active:not(:disabled),
+.vtl__laneHead button:active:not(:disabled),
+.caption-prefs__actions button:active:not(:disabled) {
   transform: translateY(1px);
   box-shadow: var(--elev-1);
 }
@@ -453,10 +505,18 @@ button {
   color: var(--text-primary);
 }
 
+/* Disabled is not an afterthought on these two: four of the video timeline's five
+   toolbar buttons are disabled until a clip is selected, so it is the state that
+   shows MOST. (`.timeline__toolbar button:disabled` is absent from this list on
+   purpose — features/timeline.css:83 already declares the identical treatment for
+   that surface. Do not read the gap as the pattern.) */
 .feature-panel button:disabled,
 .shortmaker button:disabled,
 .library__add-btn:disabled,
-.batch-queue button:disabled {
+.batch-queue button:disabled,
+.vtl__bar button:disabled,
+.vtl__laneHead button:disabled,
+.caption-prefs__actions button:disabled {
   opacity: 0.45;
   cursor: default;
 }
@@ -506,6 +566,13 @@ button {
 
 /* ---- shared inputs ------------------------------------------------------------- */
 
+/* `.caption-prefs__select` is the same bare-`.panel` case as the buttons above: the
+   caption-defaults panel has no `.feature-panel` ancestor, so its subtitle-delivery
+   <select> was the one raw OS dropdown left on an otherwise voiced panel. It is
+   named by CLASS, not as `.caption-prefs__row > select`, so the rule cannot be
+   broken by a wrapper element and cannot reach the <select> that `LanguageSelect`
+   renders on the next row, which carries its own voice
+   (components/languageSelect.css:8). */
 .library__add-input,
 .feature-panel input,
 .feature-panel select,
@@ -514,7 +581,8 @@ button {
 .shortmaker select,
 .shortmaker textarea,
 .timeline__editor input,
-.timeline__editor textarea {
+.timeline__editor textarea,
+.caption-prefs__select {
   appearance: none;
   padding: var(--control-pad-input);
   background: var(--surface-deep);
@@ -531,7 +599,8 @@ button {
 .feature-panel textarea:hover,
 .shortmaker input:hover,
 .shortmaker select:hover,
-.shortmaker textarea:hover {
+.shortmaker textarea:hover,
+.caption-prefs__select:hover {
   border-color: var(--edge-strong);
 }
 
@@ -547,7 +616,8 @@ button {
 .shortmaker select:focus-visible,
 .shortmaker textarea:focus-visible,
 .timeline__editor input:focus-visible,
-.timeline__editor textarea:focus-visible {
+.timeline__editor textarea:focus-visible,
+.caption-prefs__select:focus-visible {
   outline: none;
   border-color: var(--accent-edge);
   box-shadow: var(--focus-glow);
@@ -1206,9 +1276,15 @@ button {
   font-variant-numeric: tabular-nums;
 }
 
-/* Native <progress> used inside feature panels: same accent language. */
+/* Native <progress> used inside feature panels: same accent language. `.vtl` is
+   listed for the same reason its buttons are — the video timeline's render bar is a
+   bare `<progress>` on a panel with no `.feature-panel` ancestor
+   (features/VideoTimeline.tsx:558), so it was the one UA-chrome progress bar in the
+   app. There is exactly one `<progress>` inside `.vtl`, so the descendant form is
+   safe here. */
 .feature-panel progress,
-.sm-progress progress {
+.sm-progress progress,
+.vtl progress {
   appearance: none;
   width: 220px;
   height: 6px;
@@ -1219,12 +1295,14 @@ button {
 }
 
 .feature-panel progress::-webkit-progress-bar,
-.sm-progress progress::-webkit-progress-bar {
+.sm-progress progress::-webkit-progress-bar,
+.vtl progress::-webkit-progress-bar {
   background: var(--surface-deep);
 }
 
 .feature-panel progress::-webkit-progress-value,
-.sm-progress progress::-webkit-progress-value {
+.sm-progress progress::-webkit-progress-value,
+.vtl progress::-webkit-progress-value {
   background: var(--accent);
   transition: width var(--dur-base) var(--ease-out);
 }

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -489,6 +489,20 @@ button {
   box-shadow: var(--elev-1);
 }
 
+/* DENSITY, not a different voice. The lane head is a fixed 132px grid column
+   (features/videoTimeline.css:44) carrying a lane name plus two row actions. At the
+   full `--control-pad-btn` those two take 89px of it and squeeze `.vtl__laneName`
+   to 26.4px — narrower than the 41px the DEFAULT name "Video 1" needs
+   (sidecar/media_studio/features/video_tracks.py:230,611), so every lane label
+   truncated to "Vid…" (measured in Chromium at 1280px). The row-action pad is the
+   token for exactly this case. Surface, edge, elevation, radius, hover, press,
+   disabled and focus are all inherited from the voice above and unchanged;
+   `--size-target-min` holds the smaller control at the WCAG 2.5.8 target height. */
+.vtl__laneHead button {
+  padding: var(--control-pad-mini);
+  min-height: var(--size-target-min);
+}
+
 /* GHOST voice: truly quiet — no fill, no edge, no shadow at rest; a low-key nav /
    secondary action that only lifts a whisper of tint on hover. Overrides the
    raised base for these two. (Remove's hover is the destructive-red rule below.) */


### PR DESCRIPTION
## What changed, and what the user sees

**Lane:** `vtl-button-voice` (Q1 + Q2). **Diff surface:** 3 files, **+566 / -11**, branch tip
`52bb28e2`, **4 ahead / 0 behind `origin/main`** (measured for this PR).

Two panels in the app had roots of the shape `className="… panel"` — and **`.panel` has no rule
anywhere in the renderer CSS**. Verified for this PR: the only `.panel*` selectors in the whole tree
are `.panel--missing, .panel--loading` at `components/shell.css:1217-1218`. Neither panel has a
`.feature-panel` ancestor either, so every control on them fell through to **raw dark Chromium
chrome** sitting next to fully-voiced siblings.

| | Before | After |
|---|---|---|
| Refine → video timeline (`features/VideoTimeline.tsx:514`, `<section className="panel vtl">`) | The **5** toolbar buttons (`Undo` `:516`, `Split at playhead` `:524`, `Remove clip` `:527`, `Add lane` `:535`, `Render timeline` `:547`) and the **2 per-lane row actions** (`+ Clip` `:583`, `×` `:598`) painted as native UA buttons. The render bar (`<progress data-role="render-progress">` `:558`) was the one UA-chrome progress bar left in the app. | All seven buttons take the shared raised voice in **all five states** — base `shell.css:445-447`, hover `:470-472`, active `:485-487`, disabled `:545-547`, focus-visible `:114-116`. The `<progress>` takes the accent language (`:1325`, `:1337`, `:1343`). |
| Settings → caption defaults (`components/CaptionPreferences.tsx:115`) | `Save defaults` (`:228`, inside `.caption-prefs__actions` `:227`) was raw UA chrome. | Same shared voice, same five lists. |
| Lane-head density | — | `.vtl__laneHead button` (`:515`) takes `--control-pad-mini` (`3px 8px`) + `--size-target-min` (`24px`), **not** the full `--control-pad-btn` (`6px 14px`). The lane head is a fixed 132px grid column, so full button pad would have eaten the lane name. Token values re-read for this PR at `styles/tokens.css:199,203,192`. |
| Keyboard focus | **Three controls had NO visible focus ring at all** (WCAG 2.4.7 AA): `.library__remove-btn` and `.workspace__back` had it removed by the ghost voice's `box-shadow: none`; `.library__add-btn` had it replaced by the accent voice's `--accent-glow`. Each is `(0,1,0)` — same specificity as the global ring, but later in source order, so each simply won. | All three named in the focus list (`:117`, `:118`, `:126`). **Add is COMPOSED, not plain** — `box-shadow: var(--focus-ring), var(--accent-glow)` — so the primary keeps its glow while gaining a ring. |
| Ring durability | The ring was a `box-shadow` only — one channel any later same-or-higher-specificity rule can take away, which is exactly how these three lost it. | A real `outline-color: var(--accent-edge)` (`:119`, `:128`) paints the same band where the shadow paints, and survives where the shadow does not. |

**Deliberately NOT done — the narrow hosts are the point.** `.vtl button` / `.caption-prefs button`
would be `(0,1,1)` and would out-specify two `(0,1,0)` component voices nested inside these panels —
`.vtl__clip` (`features/videoTimeline.css:74`; the clips **are** buttons) and `.caption-style-swatch`
(`components/captionStylePicker.css:9`) — silently repainting their background, border, padding and
cursor. `.vtl__bar`, `.vtl__laneHead` and `.caption-prefs__actions` contain only toolbar controls.
A conformance test pins this (`does NOT reach the nested component buttons (the broad-selector trap)`).

**One thing the branch adds and then takes away again:** `.caption-prefs__select`. See finding 2.

---

## The evidence

All four gates below were **re-run by me at the branch tip (`52bb28e2`) for this PR**, not quoted
from the lane's own run. They agree with the lane's reported figures.

**1. Pinned formatter — `npx --yes @biomejs/biome@2.5.0 format` on the three edited files**
(`.pre-commit-config.yaml` pins `biomejs/pre-commit@v2.5.0` / `@biomejs/biome@2.5.0`, run in CI by
`quality.yml:92` `gate-lint-format (pre-commit run --all-files)`)

```
Checked 3 files in 26ms. No fixes applied.
EXITCODE=0
```

**2. Typecheck — `npx tsc --noEmit`** (`quality.yml:96`; silence is the pass, the compiler prints
nothing on success)

```
TSC_EXIT=0
```

**3. Full renderer suite + coverage — `npx vitest run --coverage`** (`quality.yml:135-137`), exit 0

```
 Test Files  250 passed (250)
      Tests  4870 passed (4870)
   Start at  10:09:30
   Duration  76.78s (transform 107.33s, setup 0ms, collect 170.34s, tests 119.80s, environment 430.54s, prepare 112.58s)
```

```
=============================== Coverage summary ===============================
Statements   : 100% ( 24745/24745 )
Branches     : 100% ( 8144/8144 )
Functions    : 100% ( 1445/1445 )
Lines        : 100% ( 24745/24745 )
================================================================================
```

That is 100 / 100 / 100 / 100 against the `renderer` block of `.coverage-thresholds.json`
(lines / branches / functions / statements), enforced by `app/vitest.config.ts`.

**4. The new conformance file ran and is green.**

```
 ✓ renderer/src/components/shell.buttonVoice.conformance.test.ts (13 tests) 534ms
```

**5. No test was weakened, skipped, xfailed or deleted.** Two assertions changed **polarity**
(`shell.css must list .caption-prefs__select` → must **not** list it; `prefs.has('caption-prefs__select')`
true → false) because they encoded the false premise that finding 2 destroyed; they now assert the
corrected invariant. The file also gained a **strictly stronger** in-engine cascade guard it did not
have before, with a both-states control: `the parity detector FIRES on a synthetic clobber
(both-states control)` (`:364`) and `the two dropdowns on the caption-defaults panel compute
identically` (`:375`).

**Sidecar gates: NOT-CHECKED.** No sidecar file is in this lane's scope and none was touched.

---

## The adversarial record

**2 refuters, 1 remedy round. Three findings, two of which split.** Net: **1 FIXED (blocking,
test-red-first), 2 RESCOPED, 2 REFUTED, 1 CONFIRMED-and-settled-by-measurement.** The two LANE items
(Q1, Q2) were never in dispute by anyone and are untouched by the remedy round.

**A structural note on the refuters, stated up front because it changes how much weight two
concurring reviews carry:** both reviewers who asserted the "new lane-name regression" read the
**same source** — the author's own report — and **both explicitly stated they did not measure it**.
That is one lens counted twice, not two independent signals (`rules/common/single-signal-verification.md`).
Measurement, not the vote, decided findings 1B and 3C.

### Finding 2 — BLOCKING → **FIXED**, red first, reproduced in a second engine

The branch had added `.caption-prefs__select` to shell.css's shared **input** rule and a matching
`className` to the `<select>`. The refuter said that clobbers the app's global select voice. **The
refuter is right**, and I reproduced it in a **second, mechanically independent engine** (real Blink,
where `var()` resolves) rather than only in jsdom.

The bonus claim attached to the original change — *"the caption-prefs `<select>` was the one raw OS
dropdown left on that panel"* — is **FALSE**. Re-verified for this PR:

* `styles/controls.css:34-66` already voices **every** `<select>` in the app: `appearance: none`,
  `--surface-raised`, `--radius-sm`, `min-height: 30px`, a redrawn chevron
  (`background-image`, two `linear-gradient`s at `:47-49`), and `padding-right: var(--space-6)`
  (`:42`) holding the room for that chevron.
* `App.tsx:96-97` imports `./styles/controls.css` **immediately before** `./components/shell.css`.

So adding a `.caption-prefs__select` entry put a `(0,1,0)` class rule over that `(0,0,1)` element
rule — and the shared input rule's body uses **shorthands**: `background:` reset `background-image`
to none (killing the "this opens a list" affordance that `controls.css:35-38` documents in-file) and
`padding:` dropped `padding-right` from `--space-6` (24px, `tokens.css:171`) back to
`--control-pad-input` (`7px 10px`, `:200`). Net effect: the subtitle dropdown at
`CaptionPreferences.tsx:160` stopped matching the `LanguageSelect` at `:182` — **the very next row of
the same panel**.

**Fix taken: the minimal one** — drop the three selector entries and the `className`; `controls.css`
already voices it correctly. `.caption-prefs__select` now appears in `shell.css` exactly once, at
`:608`, **inside a comment** explaining why it must not come back (verified: zero selector
occurrences). The `<select>` carries a `Deliberately UNCLASSED` comment at
`CaptionPreferences.tsx:152-159`.

**Not taken:** the wider `background:` → `background-color:` variant of the fix. That would rewrite
the shared input rule for the nine pre-existing entries too, including two selects
(`.feature-panel select`, `.shortmaker select`) that take the same chevron loss today. That is a real
app-wide divergence and a deliberate design call — routed as a **scope-escape**, not spread one class
at a time from this lane. It is disclosed in-file at `shell.css:610-614`.

### Finding 1 — **SPLIT: 1A RESCOPED, 1B REFUTED**

**1A → RESCOPED.** The committed test was titled
`it('keeps the lane head DENSE so the lane name is not ellipsised away')` while asserting only
padding + min-height. The title stated a postcondition that is **false** — the lane name *is* still
ellipsised. Renamed to `gives the lane head the row-action pad, not the full button pad`
(`shell.buttonVoice.conformance.test.ts:207`), with the measured residual moved into the body. The
assertions did not change; the **sentence** did.

**1B → REFUTED by measurement.** The claim was that the branch **introduces a NEW** default-state
truncation of the lane name. It does not — the default lane name `Video 1`
(`sidecar/media_studio/features/video_tracks.py:230,611`) was **already** truncating on `origin/main`.
The measured series (lane's synthetic-page probe, relayed — see RESIDUAL 1, **UNVERIFIED** by me):

| tree | `.vtl__laneName` width | vs the 40.98px `Video 1` needs |
|---|---|---|
| `origin/main` | 39.53px | already short by **1.45px** |
| the voice at `--control-pad-btn` (rejected) | 25.31px | short by 15.67px — visibly worse |
| **this branch** (`--control-pad-mini`) | 39.45px | short by **1.53px** |

The density rule buys back **14.14 of the 14.22px** the full pad cost. **Precisely:** the branch is
**0.08px worse than main**, sub-pixel and invisible — so "introduces a NEW truncation" is refuted,
while "changes it by literally zero" would have been an overclaim and is not asserted here.

### Finding 3 — **SPLIT: 3A CONFIRMED (settled by measurement), 3B RESCOPED, 3C REFUTED**

**3A → CONFIRMED, and settled rather than rescoped.** The report's in-engine "post-fix" line described
commit `9942af19`, not HEAD, and self-contradicted its own RESIDUAL 1. Instead of narrowing the
sentence, it was **re-measured**: a Chromium probe reads the `+ Clip` button at HEAD as
**padding 3px/8px, font-size 12px** — i.e. `--control-pad-mini` (`tokens.css:203`), **not** the `6px`
"`== fp-btn` exactly" the report claimed (`--control-pad-btn` is `6px 14px`, `tokens.css:199`). Token
values independently re-read by me for this PR; both match.

**3B → RESCOPED.** The shipped CSS comment overclaimed by omission. Its numbers were replaced with the
measured ones, and the comment now states explicitly that the rule does **not** make the label fit,
that the residual is pre-existing, and that closing it needs `features/videoTimeline.css` (widen the
132px column, shrink the 4px gap, or make `+ Clip` icon-only) — *"Do not 'fix' it here with an
off-token pad."*

**3C → REFUTED.** The correction claimed *"a narrowing of an existing limit"* understated the change.
It does not — the author's **original** wording was closer to correct than the proposed correction,
and the correction was dropped. Recording it here rather than deleting it silently.

---

## The skeptic verdict

Verbatim, as received:

```
refuted=false severity=nit — MERGEABLE. I judged the final state of `fix/v15-vtl-button-voice`, not
the commit messages, and every load-bearing claim I could mechanize came back true.

1) DOES THE GOAL HOLD? Yes (almost-certain, 95%). Q1: the three narrow hosts `.vtl__bar button`,
`.vtl__laneHead button`, `.caption-prefs__actions button` are present in ALL FIVE lists — base
(shell.css:445-447), hover (:470-472), active, disabled, focus-visible. I re-implemented the test's
`listsSelector` boundary matcher in Python over the branch blob and all 15 host x state assertions
plus the 6 detector-control assertions pass (`ok:true
```

**Disclosure, because hiding it would be the dishonest option: the verdict text reaching this PR is
TRUNCATED mid-sentence at `` (`ok:true ``.** Everything after that — the remainder of section 1, and
any sections 2+ including any reservation the skeptic may have recorded — **was not received by me
and is NOT reproduced above**. I am not paraphrasing or reconstructing it. `severity=nit` and
`refuted=false` are in the received text, so the headline verdict is MERGEABLE with a nit-level
reservation, but **I cannot tell you what the nit was.** Settling experiment: re-read the skeptic
unit's full output artifact, or re-run the skeptic against `52bb28e2`.

What I could check of it, I checked independently: the five lists are present at exactly the line
numbers quoted — base `445-447`, hover `470-472`, **active `485-487`, disabled `545-547`,
focus-visible `114-116`** (the last three were unquoted in the received fragment; I resolved them
myself for this PR).

---

## Residual / not done

Everything numeric in the *evidence* section above is **MEASURED by me at `52bb28e2`**. These are not:

1. **UNVERIFIED — the packaged Electron app was never launched.** The lane-name figures in finding 1B
   come from a *synthetic page* that loads the real `tokens.css` + real `shell.css` at three real
   commits + real `videoTimeline.css` + the real in-repo Inter woff2, with the real markup shape from
   `VideoTimeline.tsx:579-613`, at 1280x820, with two detector controls that held (a one-char lane
   name that never ellipsises, a long one that always does). It is **not** the running app: it omits
   every other renderer sheet, so an unrelated rule elsewhere could shift the numbers.
   *Settling experiment:* launch the built app, open Refine with a fresh timeline, assert
   `scrollWidth <= clientWidth` on `.vtl__laneName`.
   Confidence the **direction and ordering** are right: almost-certain (90-99%). Confidence in the
   **exact sub-pixel figures inside the real app**: likely (55-80%). I did not re-run this probe for
   this PR — it is relayed, not re-measured.

2. **The 1.53px lane-name shortfall is REAL and still open.** It is pre-existing on `origin/main`
   (1.45px there) and this branch moves it by +0.08px. It is **not** a blocker for this lane and must
   not be attributed to it; closing it belongs in `features/videoTimeline.css`.

3. **Scope-escape, routed, not done here:** the shared input rule's `background:` → `background-color:`
   shorthand fix, which would restore the chevron for the two pre-existing selects
   (`.feature-panel select`, `.shortmaker select`). Deliberate design call, disclosed at
   `shell.css:610-614`.

4. **NOT-CHECKED by me:** the composited focus-ring alpha (residual #2 of the original report), and
   any by-eye visual review of the caption panel. Computed style was verified; **rendered pixels were
   not.** *Settling experiment:* the nightly `e2e.yml` visual leg, or a manual screenshot diff.

5. **jsdom does not resolve `var()`**, so the committed cascade test compares the subtitle select
   against its **neighbour** rather than against literal values. That is deliberate — matching the
   neighbour *is* the product requirement — and it is why the same question was re-verified in real
   Blink, where `var()` resolves and the values came back as concrete `rgb()`/`px`.

6. **Q1/Q2 were not re-audited from scratch** in the remedy round. The reviewers converged that both
   are correctly wired, and the one thing their verdicts depended on that was cheaply falsifiable —
   the HEAD lane-head padding — was measured (3px/8px). For this PR I additionally re-derived the
   five-state selector lists, the `.panel` no-rule premise, the `controls.css` select rule, the
   `App.tsx` import order, the five token values, and the exact button/`<progress>` counts in both
   panels' markup. All held.

**Sidecar coverage: NOT-CHECKED** (no sidecar file in scope). **E2E visual leg: NOT-CHECKED** — it is
`workflow_dispatch` + nightly only and never gates a normal PR.
