### PR TITLE
fix(library): give the Library card a visible primary action, and return focus on overflow select

### DIFF
--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -270,7 +270,12 @@ describe('LibraryCard', () => {
   // ---- v1.5b: the card's PRIMARY action is visible, and Remove stops being the
   // only labelled verb on the card (the "no primary action" finding).
 
-  it('paints a visible Open call-to-action inside the primary button', async () => {
+  // NAME SCOPED IN ROUND 2. This was titled "paints a visible Open call-to-action";
+  // it asserts textContent, aria-hidden, ancestry and tagName and nothing about
+  // paint, while `.library__item-cta` has ZERO rules in any stylesheet — so the old
+  // name printed a green claim the product does not satisfy. Paint is the declared
+  // scope-escape into components/library-cards.css.
+  it('renders the CTA verb inside the primary button', async () => {
     await renderCard();
     const cta = container.querySelector('.library__item-cta');
     expect(cta?.textContent).toBe('Open');
@@ -288,14 +293,31 @@ describe('LibraryCard', () => {
     expect(container.querySelector('.library__item-cta')?.textContent).toBe('Show history');
   });
 
-  it('demotes Remove to an icon-only control so it is not the primary action peer', async () => {
+  it('keeps Remove LEGIBLE — a visible word, never an unlabelled glyph', async () => {
     await renderCard();
     const remove = container.querySelector('.library__remove-btn') as HTMLButtonElement;
-    // No visible verb: the glyph carries no text label, the name is on aria-label.
-    expect(remove.textContent).toBe('×');
+    // Round 2 REVERSAL, pinned so it cannot silently regress. An earlier draft of
+    // this lane demoted Remove to an icon-only `×` + `title="Remove"`. That was the
+    // wrong lever, on three measured grounds:
+    //   1. `.library__remove-btn` has NO resting box to fall back on — shell.css
+    //      :520-529 gives it the GHOST voice (`background: transparent;
+    //      border-color: transparent; box-shadow: none`), same 0-1-0 specificity as
+    //      the raised base at :438-447 but later in source order. Its WORD was the
+    //      only thing that read as a control at rest.
+    //   2. views/Library.tsx:386-419 fires `library.remove` with NO confirm and NO
+    //      undo (`useConfirm` is wired, but only around `deleteShort` at :505),
+    //      against the repo standard at features/KeepCopyControl.tsx:21 — "never a
+    //      silent one-click destructive action".
+    //   3. `title` is not an equivalent substitute: it surfaces on mouse-hover dwell
+    //      and not on keyboard focus, so a keyboard user got an unnamed glyph on an
+    //      irreversible action.
+    // Remove stops being the primary-action peer by the CTA gaining WEIGHT (the
+    // library-cards.css scope-escape), not by the destructive control losing its name.
+    expect(remove.textContent).toBe('Remove');
     expect(remove.getAttribute('aria-label')).toBe('Remove Talk');
-    expect(remove.getAttribute('title')).toBe('Remove');
-    expect(remove.querySelector('[aria-hidden="true"]')).not.toBeNull();
+    // No decorative glyph, and no tooltip standing in for a visible label.
+    expect(remove.querySelector('[aria-hidden="true"]')).toBeNull();
+    expect(remove.hasAttribute('title')).toBe(false);
   });
 
   // ---- v1.5b: the overflow menu — Deliver deep-links, never a second converter.

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -10,7 +10,7 @@ vi.mock('../components/api', () => ({
   hasApi: () => true,
 }));
 
-import { LibraryCard } from './LibraryCard';
+import { LibraryCard, type DeliverMenu } from './LibraryCard';
 import type { LibraryVideo } from './libraryModel';
 import { videoThumbnailSrc } from '../components/useVideoThumbnail';
 
@@ -74,6 +74,7 @@ interface Over {
   shortsCount?: number;
   onOpenShorts?: (v: LibraryVideo) => void;
   provenance?: ReturnType<typeof provenanceHandlers>;
+  deliver?: DeliverMenu;
 }
 
 async function renderCard(over: Over = {}): Promise<void> {
@@ -90,6 +91,7 @@ async function renderCard(over: Over = {}): Promise<void> {
           shortsCount={over.shortsCount ?? 0}
           onOpenShorts={over.onOpenShorts ?? (() => {})}
           provenance={over.provenance}
+          deliver={over.deliver}
         />
       </ul>,
     );
@@ -103,14 +105,38 @@ describe('LibraryCard', () => {
     const open = container.querySelector('.library__item-open') as HTMLButtonElement;
     expect(open.getAttribute('aria-label')).toBe('Open Talk, 10:05, no transcript');
     expect(container.querySelector('.library__item-title')?.textContent).toBe('Talk');
-    expect(container.querySelector('.library__item-added')?.textContent).toBe('Added 2026-06-11');
+    // The quiet meta line now leads with the source container (derived from the
+    // path extension — the ONLY format signal the frozen Video contract carries).
+    expect(container.querySelector('.library__item-added')?.textContent).toBe(
+      'MP4 · Added 2026-06-11',
+    );
     const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
     expect(img.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/v1.jpg'));
     expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
   });
 
-  it('omits the added line when the timestamp is unparseable', async () => {
+  it('keeps the format on the meta line when the timestamp is unparseable', async () => {
     await renderCard({ video: makeVideo({ addedAt: 'nope' }) });
+    expect(container.querySelector('.library__item-added')?.textContent).toBe('MP4');
+  });
+
+  it('shows the date alone when the path carries no usable extension', async () => {
+    await renderCard({ video: makeVideo({ path: '/movies/talk' }) });
+    expect(container.querySelector('.library__item-added')?.textContent).toBe('Added 2026-06-11');
+  });
+
+  it('omits the meta line entirely when neither format nor date is known', async () => {
+    await renderCard({ video: makeVideo({ path: '/movies/talk', addedAt: 'nope' }) });
+    expect(container.querySelector('.library__item-added')).toBeNull();
+  });
+
+  it('ignores a dot that is not a real extension (dotted directory, no basename dot)', async () => {
+    await renderCard({ video: makeVideo({ path: 'C:\\my.videos\\talk', addedAt: 'nope' }) });
+    expect(container.querySelector('.library__item-added')).toBeNull();
+  });
+
+  it('ignores an implausibly long extension rather than shouting it', async () => {
+    await renderCard({ video: makeVideo({ path: '/movies/talk.backupcopy', addedAt: 'nope' }) });
     expect(container.querySelector('.library__item-added')).toBeNull();
   });
 
@@ -239,5 +265,123 @@ describe('LibraryCard', () => {
     expect(rpcMock).toHaveBeenCalledWith('library.thumbnail', { id: 'v1' });
     expect(container.querySelector('img.library__thumb-img')).toBeNull();
     expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
+  });
+
+  // ---- v1.5b: the card's PRIMARY action is visible, and Remove stops being the
+  // only labelled verb on the card (the "no primary action" finding).
+
+  it('paints a visible Open call-to-action inside the primary button', async () => {
+    await renderCard();
+    const cta = container.querySelector('.library__item-cta');
+    expect(cta?.textContent).toBe('Open');
+    // The CTA is DECORATION for the button that already owns the accessible name,
+    // so it must not be announced a second time...
+    expect(cta?.getAttribute('aria-hidden')).toBe('true');
+    // ...and it must live INSIDE the open button (never a sibling control, which
+    // would add a second tab stop to every card).
+    expect(container.querySelector('.library__item-open .library__item-cta')).not.toBeNull();
+    expect(cta?.tagName).toBe('SPAN');
+  });
+
+  it('matches the visible CTA verb to the action in lineage view', async () => {
+    await renderCard({ lineageView: true });
+    expect(container.querySelector('.library__item-cta')?.textContent).toBe('Show history');
+  });
+
+  it('demotes Remove to an icon-only control so it is not the primary action peer', async () => {
+    await renderCard();
+    const remove = container.querySelector('.library__remove-btn') as HTMLButtonElement;
+    // No visible verb: the glyph carries no text label, the name is on aria-label.
+    expect(remove.textContent).toBe('×');
+    expect(remove.getAttribute('aria-label')).toBe('Remove Talk');
+    expect(remove.getAttribute('title')).toBe('Remove');
+    expect(remove.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  // ---- v1.5b: the overflow menu — Deliver deep-links, never a second converter.
+
+  it('renders no overflow menu when no Deliver shortcuts are wired', async () => {
+    await renderCard();
+    expect(container.querySelector('.library__card-menu')).toBeNull();
+  });
+
+  it('renders no overflow menu when the shortcut list is empty', async () => {
+    await renderCard({ deliver: { shortcuts: [], onSelect: vi.fn() } });
+    expect(container.querySelector('.library__card-menu')).toBeNull();
+  });
+
+  it('keeps the overflow panel mounted-but-hidden at rest so aria-controls resolves', async () => {
+    await renderCard({
+      deliver: { shortcuts: [{ id: 'convert', label: 'Convert…' }], onSelect: vi.fn() },
+    });
+    const trigger = container.querySelector('.library__card-menu-trigger') as HTMLButtonElement;
+    const panel = container.querySelector('.library__card-menu-panel') as HTMLDivElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger.getAttribute('aria-haspopup')).toBe('true');
+    expect(trigger.getAttribute('aria-label')).toBe('More actions for Talk');
+    expect(panel).not.toBeNull();
+    expect(panel.hidden).toBe(true);
+    expect(trigger.getAttribute('aria-controls')).toBe(panel.id);
+    expect(panel.id).not.toBe('');
+  });
+
+  it('opens the overflow menu and deep-links a shortcut into Deliver pre-filled', async () => {
+    const onSelect = vi.fn();
+    await renderCard({
+      deliver: {
+        shortcuts: [
+          { id: 'convert', label: 'Convert…' },
+          { id: 'nle', label: 'Send to editor…' },
+        ],
+        onSelect,
+      },
+    });
+    const trigger = container.querySelector('.library__card-menu-trigger') as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const panel = container.querySelector('.library__card-menu-panel') as HTMLDivElement;
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(panel.hidden).toBe(false);
+
+    const items = [...container.querySelectorAll('.library__card-menu-item')];
+    expect(items.map((i) => i.textContent)).toEqual(['Convert…', 'Send to editor…']);
+
+    act(() => {
+      (items[1] as HTMLButtonElement).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    // The card hands Deliver the WHOLE source video + which preset to pre-fill; it
+    // never converts anything itself.
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    expect(onSelect.mock.calls[0][0].id).toBe('v1');
+    expect(onSelect.mock.calls[0][1]).toBe('nle');
+    // Choosing an item closes the menu (a shortcut, not a sticky panel).
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect((container.querySelector('.library__card-menu-panel') as HTMLDivElement).hidden).toBe(
+      true,
+    );
+  });
+
+  it('closes the overflow menu when the trigger is pressed again', async () => {
+    await renderCard({
+      deliver: { shortcuts: [{ id: 'convert', label: 'Convert…' }], onSelect: vi.fn() },
+    });
+    const trigger = container.querySelector('.library__card-menu-trigger') as HTMLButtonElement;
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    act(() => {
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('keeps the overflow trigger a SIBLING of the open button (no nested interactive)', async () => {
+    await renderCard({
+      deliver: { shortcuts: [{ id: 'convert', label: 'Convert…' }], onSelect: vi.fn() },
+    });
+    expect(container.querySelector('.library__item-open .library__card-menu')).toBeNull();
+    expect(container.querySelector('.library__item-open button')).toBeNull();
   });
 });

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -415,6 +415,54 @@ describe('LibraryCard', () => {
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
   });
 
+  it('returns focus to the overflow trigger when a shortcut is chosen', async () => {
+    // ROUND-3 DEFECT, found by the did-it-break reviewer. The row that closes the
+    // menu lives INSIDE the panel the close then `hidden`s, so a keyboard user who
+    // activated the row was left focused on a hidden element — browsers drop that
+    // focus to <body>, i.e. back to the top of the document, on every shortcut use.
+    //
+    // The docblock previously defended this as "exactly the contract
+    // CardProvenanceDisclosure uses … and nothing more". That equivalence is FALSE on
+    // this axis: that disclosure is closed only from its toggle, which sits OUTSIDE
+    // the panel (CardProvenanceDisclosure.tsx:42-53 vs the panel at :57-59), and its
+    // body is `{open ? <LibraryProvenance/> : null}` — so it has nothing focusable
+    // inside to blur. The house pattern for focus-RETURN is JobQueue.tsx:109-126
+    // ("disclosure focus-return contract"), which this now follows.
+    //
+    // The pre-existing selection test cannot catch this: it asserts `panel.hidden`
+    // and the onSelect payload, never `document.activeElement`, and it clicks via
+    // dispatchEvent (which does not focus), so focus is on <body> before AND after.
+    // This test focuses the row first, which is what makes it discriminating.
+    const onSelect = vi.fn();
+    await renderCard({
+      deliver: { shortcuts: [{ id: 'convert', label: 'Convert…' }], onSelect },
+    });
+    const trigger = container.querySelector('.library__card-menu-trigger') as HTMLButtonElement;
+    act(() => {
+      trigger.focus();
+      trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    const row = container.querySelector('.library__card-menu-item') as HTMLButtonElement;
+    act(() => {
+      row.focus();
+    });
+    // Control: the row really holds focus before activation, so a pass below cannot
+    // come from focus never having moved off the trigger in the first place.
+    expect(document.activeElement).toBe(row);
+
+    act(() => {
+      row.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    // The panel really did collapse (so the focused row really is hidden now)...
+    expect((container.querySelector('.library__card-menu-panel') as HTMLDivElement).hidden).toBe(
+      true,
+    );
+    // ...and focus is back on the control that opened the menu, never stranded on
+    // the hidden row and never dumped on <body>.
+    expect(document.activeElement).toBe(trigger);
+  });
+
   it('keeps the overflow trigger a SIBLING of the open button (no nested interactive)', async () => {
     await renderCard({
       deliver: { shortcuts: [{ id: 'convert', label: 'Convert…' }], onSelect: vi.fn() },

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -317,12 +317,28 @@ describe('LibraryCard', () => {
     const trigger = container.querySelector('.library__card-menu-trigger') as HTMLButtonElement;
     const panel = container.querySelector('.library__card-menu-panel') as HTMLDivElement;
     expect(trigger.getAttribute('aria-expanded')).toBe('false');
-    expect(trigger.getAttribute('aria-haspopup')).toBe('true');
     expect(trigger.getAttribute('aria-label')).toBe('More actions for Talk');
     expect(panel).not.toBeNull();
     expect(panel.hidden).toBe(true);
     expect(trigger.getAttribute('aria-controls')).toBe(panel.id);
     expect(panel.id).not.toBe('');
+  });
+
+  it('advertises a disclosure, not a menu widget, on the overflow trigger', async () => {
+    await renderCard({
+      deliver: { shortcuts: [{ id: 'convert', label: 'Convert…' }], onSelect: vi.fn() },
+    });
+    const trigger = container.querySelector('.library__card-menu-trigger') as HTMLButtonElement;
+    // ARIA 1.2 makes aria-haspopup="true" a SYNONYM for "menu", so setting it would
+    // announce a menu button over a popup that keeps none of the APG menu contract
+    // (no role=menu/menuitem, no roving tabindex, no arrow keys, no Escape, no focus
+    // return). The house disclosure — CardProvenanceDisclosure:42-57 — sets
+    // aria-expanded + aria-controls and NOTHING else; this trigger must match it, and
+    // no axe rule catches a haspopup/role mismatch, so the assertion is the only gate.
+    expect(trigger.hasAttribute('aria-haspopup')).toBe(false);
+    // The panel is always mounted, so this also covers the item rows while closed.
+    expect(container.querySelector('[role="menu"]')).toBeNull();
+    expect(container.querySelector('[role="menuitem"]')).toBeNull();
   });
 
   it('opens the overflow menu and deep-links a shortcut into Deliver pre-filled', async () => {

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -12,9 +12,13 @@
 // call to action. Three changes, all inside this file:
 //   1. a VISIBLE CTA ("Open" / "Show history") painted inside the open button as a
 //      non-interactive <span>, so the primary action finally has a label;
-//   2. Remove demoted to an icon-only ghost control (accessible name kept on
-//      aria-label + title) so the destructive action is no longer the peer — let
-//      alone the only member — of the labelled-action set;
+//   2. Remove stops being the only member of the labelled-action set — because the
+//      set GAINED a member (item 1), not because Remove lost its name. A round-2
+//      draft did demote it to an icon-only `×` + `title="Remove"`; that shipped a
+//      no-confirm, no-undo delete with no visible label while the compensating CTA
+//      paint stayed a scope-escape, and it was REVERSED. See the comment on the
+//      button itself for the three measurements. Ceasing to be the visual PEER of
+//      the primary action is a WEIGHT problem, and weight lives in CSS: SCOPE-ESCAPE 2;
 //   3. an overflow menu that deep-links into Deliver PRE-FILLED (L5-NAV G-3): the
 //      card hands over `(video, shortcutId)` and nothing else. It never implements
 //      conversion — a second converter here would be the tab-strip ratchet in a new
@@ -47,10 +51,30 @@
 //      the tree, and `.library__item-open` is `padding:0; border:none;
 //      background:transparent; font:inherit` (library-cards.css:40-53) inside a plain
 //      flex column, so at HEAD the CTA paints as an ordinary body-text line under the
-//      meta line — a primary action in the DOM, a stray word on the pixels — while
-//      `.library__remove-btn` keeps its whole box and merely loses its word. Net:
-//      Remove is still the only element on the card that reads as a control. That CSS
-//      must land in the SAME release or the card is worse than before, not better.
+//      meta line — a primary action in the DOM, a stray word on the pixels.
+//
+//      CORRECTION, round 2 — an earlier draft of this paragraph claimed
+//      "`.library__remove-btn` keeps its whole box and merely loses its word. Net:
+//      Remove is still the only element on the card that reads as a control." That
+//      was FALSE and it understated the regression it was documenting. Remove is in
+//      the raised-voice list (shell.css:438-447) but shell.css:520-529 then applies
+//      the GHOST voice to it — `background: transparent; border-color: transparent;
+//      box-shadow: none; color: var(--text-muted)` — at the same 0-1-0 specificity
+//      and LATER in source order, so the ghost wins at rest and the only thing the
+//      raised base still contributes is the invisible `--control-pad-btn` hit-box.
+//      A second, independent source agrees: docs/validation/v15-audit-ledger.md:104
+//      records the same transparent/borderless `--text-muted` reading. Surface, edge
+//      and shadow appear only on `:hover` (shell.css:589). So Remove NEVER had a
+//      painted box; it read as a control because of its WORD — which is exactly why
+//      the icon-only draft was reversed rather than shipped.
+//
+//      Correctly scoped, then: after the reversal NEITHER control is painted at rest,
+//      but BOTH are legible — "Open" and "Remove" both render as words. That is
+//      strictly no worse than origin/main (which had "Remove" alone) and one visible
+//      verb better. The CSS is still owed, and owes paint to BOTH: button weight for
+//      `.library__item-cta`, and a resting affordance for `.library__remove-btn` that
+//      does not make it the primary's peer. Treating Remove as already-solved would
+//      ship a boxless destructive control beside a newly-painted CTA.
 //
 // TWO TRAPS THE CSS LANE INHERITS, measured here so it does not rediscover them:
 //   * `[hidden]` vs `display`. The panel is hidden ONLY by the UA `[hidden] {
@@ -60,10 +84,18 @@
 //     stays green, because they assert `panel.hidden === true`, never computed
 //     display. Scope it: `.library__card-menu-panel:not([hidden]) { display: … }`.
 //   * TARGET SIZE (WCAG 2.5.8) — SPLIT by measurement, not carried as one blanket
-//     risk. `.library__remove-btn` IS named in shell.css:395-401's raised-voice list,
-//     so it takes `--control-pad-btn` = 6px 14px (tokens.css:199) at
-//     `--type-control-size` 12px (:159) plus 1px borders => >=26px tall and ~37px
-//     wide against `--size-target-min` 24px (:192): MET at AA (AAA 44x44 still fails).
+//     risk. `.library__remove-btn` IS named in the raised-voice list, which is TEN
+//     selectors at shell.css:438-447 on current origin/main (an earlier draft of this
+//     header cited seven at :395-401; #424 added `.vtl__bar button`,
+//     `.vtl__laneHead button` and `.caption-prefs__actions button`, so only the anchor
+//     drifted — the membership and therefore the arithmetic are unchanged). It takes
+//     `--control-pad-btn` = 6px 14px (styles/tokens.css:199) at `--type-control-size`
+//     12px (:159) plus 1px borders => >=26px tall against `--size-target-min` 24px
+//     (:192), the min-HEIGHT axis that token governs: MET at AA (AAA 44x44 still
+//     fails). The ghost override at :520-529 does not weaken this — it zeroes
+//     `border-color`, never `border-width`, and never touches `padding`. Width is
+//     text-driven now that the visible verb is back, so it is no longer the binding
+//     axis (the reverted glyph draft was the ~37px case).
 //     The "⋯" trigger is NOT in that list and the Library view has no `.feature-panel`
 //     ancestor (that list is explicit classes, not a bare `button` selector), so it
 //     alone falls through to raw Chromium UA chrome and is the control genuinely at
@@ -144,8 +176,17 @@ function VideoThumb({ video }: { video: Video }): React.ReactElement {
  *
  * Returns '' (meaning "say nothing") unless the BASENAME has a trailing dot
  * followed by 1-5 alphanumerics — so `C:\my.videos\talk` (dotted directory),
- * `.env` (leading dot, no name) and `talk.backupcopy` (not an extension) all
- * stay quiet instead of shouting a wrong format at the user.
+ * `.env` (leading dot, no name) and `talk.backupcopy` (>5 chars, so not read as an
+ * extension) all stay quiet.
+ *
+ * SCOPED in round 2: that is a SHAPE guard, not a container check, and it rejects
+ * exactly those three shapes — not the class. Any alphanumeric suffix of five
+ * characters or fewer is still upper-cased into the format slot, so `talk.final`
+ * prints "FINAL", `render.v2` prints "V2" and `clip.2024` prints "2024". An earlier
+ * draft of this docblock implied the guard prevented shouting a wrong format
+ * generally; it does not. Settle it, if it matters, with a container allow-list
+ * (mp4/mov/mkv/webm/m4v/avi/…) rather than a wider regex — and note an allow-list
+ * trades this false-positive for silence on an unlisted-but-real container.
  */
 export function formatContainer(path: string): string {
   const base = path.slice(Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\')) + 1);

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -19,30 +19,60 @@
 //      card hands over `(video, shortcutId)` and nothing else. It never implements
 //      conversion — a second converter here would be the tab-strip ratchet in a new
 //      costume. Opt-in via the `deliver` prop, so a host that has not wired the
-//      Deliver route yet renders exactly what it renders today.
+//      Deliver route yet renders exactly what it renders today — which, at HEAD, is
+//      EVERY host: see SCOPE-ESCAPE 1. Item 3 is a contract, not a shipped feature.
 //
 // A11Y: the open action and the select/remove/shorts/overflow controls are SIBLINGS,
 // never nested inside one another (no nested-interactive); resting depth is the
 // surface ladder + --elev-* (library-cards.css), not a border-everywhere box. The
 // overflow panel is ALWAYS mounted and merely toggles `hidden` (the WAI-ARIA
 // disclosure rule CardProvenanceDisclosure already follows) so `aria-controls` is
-// never a dangling IDREF.
+// never a dangling IDREF. The visible CTA tracks `cardAriaLabel`'s verb, so the
+// accessible name still STARTS with the visible string (WCAG 2.5.3 Label in Name).
 //
-// STILL OWED, and deliberately NOT faked here — this lane's file scope is this file
-// alone, so it ships the structure and leaves the paint to a `library-cards.css`
-// follow-up. Three rules that file must add:
-//   * `.library__item-cta` has NO style yet, so the visible CTA currently renders as
-//     inherited body text. It is the hook; it is not yet the button-weight the card
-//     deserves.
-//   * `.library__card-menu-trigger` / `-panel` / `-item` are likewise unstyled. The
-//     panel is a plain absolute-less <div>; it needs positioning + a surface.
-//   * TARGET SIZE (WCAG 2.5.8): the now icon-only `.library__remove-btn` and the "⋯"
-//     trigger inherit only shell.css's `--control-pad-btn`. That is UNVERIFIED as
-//     >=24x24 — and library-cards.css:236 explicitly sets `min-height:
-//     var(--size-target-min)` on `.card-provenance__toggle`, which is evidence the
-//     base padding alone was NOT judged sufficient. Settle it by measuring the two
-//     controls' rendered box in the running app (the ui-audit tap-target gate), or
-//     pre-empt it by adding the same `min-height` rule to both.
+// SCOPE-ESCAPE — declared, not deferred. This lane's file scope is this file alone,
+// so two of the three items above cannot LAND here. They are reported up rather than
+// described as shipped; a residual reads as optional polish, and these are not.
+//
+//   1. WI-3 IS STRUCTURE ONLY AND RENDERS IN ZERO PIXELS. `deliver` is optional and
+//      the sole production mount — views/Library.tsx — never passes it
+//      (`git grep -c deliver -- app/renderer/src/views/Library.tsx` returns 0 at
+//      origin/main). PR #423 owns Library.tsx, so the wiring is a SCOPE-ESCAPE into
+//      that file, not a residual of this one. Until it lands, CardOverflowMenu and
+//      its tests describe a contract the app never instantiates.
+//
+//   2. WI-1/WI-2 SHIP THE SEMANTIC HALF; THE PAINT IS A SCOPE-ESCAPE INTO
+//      components/library-cards.css. `.library__item-cta` and
+//      `.library__card-menu-trigger` / `-panel` / `-item` have ZERO rules anywhere in
+//      the tree, and `.library__item-open` is `padding:0; border:none;
+//      background:transparent; font:inherit` (library-cards.css:40-53) inside a plain
+//      flex column, so at HEAD the CTA paints as an ordinary body-text line under the
+//      meta line — a primary action in the DOM, a stray word on the pixels — while
+//      `.library__remove-btn` keeps its whole box and merely loses its word. Net:
+//      Remove is still the only element on the card that reads as a control. That CSS
+//      must land in the SAME release or the card is worse than before, not better.
+//
+// TWO TRAPS THE CSS LANE INHERITS, measured here so it does not rediscover them:
+//   * `[hidden]` vs `display`. The panel is hidden ONLY by the UA `[hidden] {
+//     display: none }` rule. `.library__card-menu-panel` and `[hidden]` are both
+//     specificity 0-1-0, so ANY `display:` declaration added to that class wins on
+//     source order and silently un-hides the closed panel — while every overflow test
+//     stays green, because they assert `panel.hidden === true`, never computed
+//     display. Scope it: `.library__card-menu-panel:not([hidden]) { display: … }`.
+//   * TARGET SIZE (WCAG 2.5.8) — SPLIT by measurement, not carried as one blanket
+//     risk. `.library__remove-btn` IS named in shell.css:395-401's raised-voice list,
+//     so it takes `--control-pad-btn` = 6px 14px (tokens.css:199) at
+//     `--type-control-size` 12px (:159) plus 1px borders => >=26px tall and ~37px
+//     wide against `--size-target-min` 24px (:192): MET at AA (AAA 44x44 still fails).
+//     The "⋯" trigger is NOT in that list and the Library view has no `.feature-panel`
+//     ancestor (that list is explicit classes, not a bare `button` selector), so it
+//     alone falls through to raw Chromium UA chrome and is the control genuinely at
+//     risk. CORRECTION: an earlier draft of this header cited library-cards.css:236 as
+//     evidence the base padding was judged insufficient — that was a MISREAD.
+//     `.card-provenance__toggle` uses `--space-1 --space-2` + the caption font, not
+//     `--control-pad-btn`, which is precisely why it needed its own min-height; it is
+//     silent about the raised voice. Settle the trigger with the ui-audit tap-target
+//     gate, or pre-empt it with a `min-height: var(--size-target-min)` rule.
 import React, { useId, useState } from 'react';
 
 import { rpc } from '../components/api';
@@ -169,9 +199,22 @@ export interface DeliverMenu {
 }
 
 /**
- * The trailing "⋯" overflow: a disclosure (not an ARIA menu widget) matching the
- * house pattern in `CardProvenanceDisclosure`. Choosing a row closes it, because a
- * shortcut that leaves its own menu open reads as a settings panel.
+ * The trailing "⋯" overflow: a DISCLOSURE, not an ARIA menu widget — exactly the
+ * contract `CardProvenanceDisclosure` (:42-57) uses, `aria-expanded` +
+ * `aria-controls` + an always-mounted `hidden` panel, and nothing more.
+ *
+ * It deliberately does NOT set `aria-haspopup`. ARIA 1.2 makes
+ * `aria-haspopup="true"` a synonym for `"menu"`, so it would announce a menu
+ * button over a popup that keeps none of the APG menu-button contract: no
+ * `role="menu"`/`"menuitem"`, no roving tabindex, no arrow keys, no Escape, no
+ * focus return to the trigger. No axe rule flags a haspopup/role mismatch, so
+ * nothing but the pinned assertion in LibraryCard.test.tsx guards it. A later
+ * lane wanting real menu semantics must add the WHOLE contract, not the
+ * attribute — and once library-cards.css turns the panel into a positioned
+ * overlay, outside-click dismissal becomes genuinely owed too.
+ *
+ * Choosing a row closes it, because a shortcut that leaves its own menu open
+ * reads as a settings panel.
  */
 function CardOverflowMenu({
   video,
@@ -189,7 +232,6 @@ function CardOverflowMenu({
         type="button"
         className="library__card-menu-trigger"
         aria-label={`More actions for ${video.title}`}
-        aria-haspopup="true"
         aria-expanded={open}
         aria-controls={panelId}
         onClick={() => setOpen((v) => !v)}

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -365,18 +365,22 @@ export function LibraryCard({
         {deliver && deliver.shortcuts.length > 0 ? (
           <CardOverflowMenu video={video} deliver={deliver} />
         ) : null}
-        {/* Destructive, and therefore ICON-ONLY: the word "Remove" was the card's
-            only visible verb, which made deletion look like the primary action.
-            The accessible name is unchanged (aria-label), and `title` gives sighted
-            users the same word on hover. */}
+        {/* Destructive, and therefore LABELLED. Round 2 reversed an earlier draft
+            that demoted this to an icon-only `×` + `title="Remove"`: this control
+            has no resting box to fall back on (the GHOST voice at shell.css:520-529
+            zeroes its background, border-colour and shadow), it deletes with NO
+            confirm and NO undo (views/Library.tsx:386-419), and `title` surfaces on
+            mouse-hover dwell but not on keyboard focus — so the glyph left a
+            keyboard user an unnamed control on an irreversible action. Remove stops
+            being the primary-action PEER by the CTA gaining weight, not by the
+            destructive verb losing its name. */}
         <button
           type="button"
           className="library__remove-btn"
           aria-label={`Remove ${video.title}`}
-          title="Remove"
           onClick={(event) => onRemove(video.id, event)}
         >
-          <span aria-hidden="true">×</span>
+          Remove
         </button>
       </div>
     </li>

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -9,7 +9,8 @@
 // — library-cards.css:40-53 strips its chrome (`border:none; background:transparent;
 // padding:0`) and its only name is an aria-label. So on the rendered pixels the sole
 // action VERB was the destructive "Remove", which made deletion read as the card's
-// call to action. Three changes, all inside this file:
+// call to action. Three INTENDED changes, all attempted inside this file — read the
+// WHAT-A-USER-ACTUALLY-GETS block below before treating any of them as shipped:
 //   1. a VISIBLE CTA ("Open" / "Show history") painted inside the open button as a
 //      non-interactive <span>, so the primary action finally has a label;
 //   2. Remove stops being the only member of the labelled-action set — because the
@@ -26,12 +27,30 @@
 //      Deliver route yet renders exactly what it renders today — which, at HEAD, is
 //      EVERY host: see SCOPE-ESCAPE 1. Item 3 is a contract, not a shipped feature.
 //
+// WHAT A USER ACTUALLY GETS FROM THIS BRANCH — stated up front, because three rounds
+// of reviewers read the list above as three shipped features and it is not. Over the
+// whole diff the MEASURED user-visible delta is exactly two things:
+//   (a) the quiet meta line gains a filename-derived container token
+//       ("MP4 · Added 2026-06-11"), and
+//   (b) one `aria-hidden` word ("Open" / "Show history") renders as the last line
+//       INSIDE the card's already-wired open button.
+// (b) is a real affordance rather than a dead label — the enclosing button's onClick
+// is `onOpen(video)`, which Library.tsx routes to `openVideo` (or the lineage drawer)
+// — and the visible verb is a PREFIX of the accessible name in both modes
+// (libraryModel.ts:118-126), so WCAG 2.5.3 holds. But WI-2 ships NO change of its own
+// (the Remove button is byte-identical to origin/main; only comments around it moved)
+// and WI-3 ships as code no host instantiates. This lane is therefore PARTIAL —
+// WI-1's semantic half, blocked on two declared scope-escapes — not done.
+//
 // A11Y: the open action and the select/remove/shorts/overflow controls are SIBLINGS,
 // never nested inside one another (no nested-interactive); resting depth is the
 // surface ladder + --elev-* (library-cards.css), not a border-everywhere box. The
 // overflow panel is ALWAYS mounted and merely toggles `hidden` (the WAI-ARIA
 // disclosure rule CardProvenanceDisclosure already follows) so `aria-controls` is
-// never a dangling IDREF. The visible CTA tracks `cardAriaLabel`'s verb, so the
+// never a dangling IDREF. Choosing a row ALSO returns focus to the "⋯" trigger:
+// unlike that provenance disclosure, this panel contains the controls that close it,
+// so without the return a keyboard user is left focused on a hidden element — see the
+// CardOverflowMenu docblock. The visible CTA tracks `cardAriaLabel`'s verb, so the
 // accessible name still STARTS with the visible string (WCAG 2.5.3 Label in Name).
 //
 // SCOPE-ESCAPE — declared, not deferred. This lane's file scope is this file alone,
@@ -41,17 +60,42 @@
 //   1. WI-3 IS STRUCTURE ONLY AND RENDERS IN ZERO PIXELS. `deliver` is optional and
 //      the sole production mount — views/Library.tsx — never passes it
 //      (`git grep -c deliver -- app/renderer/src/views/Library.tsx` returns 0 at
-//      origin/main). PR #423 owns Library.tsx, so the wiring is a SCOPE-ESCAPE into
-//      that file, not a residual of this one. Until it lands, CardOverflowMenu and
-//      its tests describe a contract the app never instantiates.
+//      origin/main). The wiring is a SCOPE-ESCAPE purely because THIS lane's file
+//      scope is this one file; until someone lands it, CardOverflowMenu and its
+//      tests describe a contract the app never instantiates.
+//      CORRECTION, round 3 — an earlier draft parked this behind "PR #423 owns
+//      Library.tsx". That was FALSE at the very SHA this header cites: #423 merged
+//      as b26948a7, which `git merge-base --is-ancestor b26948a7 origin/main`
+//      confirms is an ancestor of origin/main (78c415c9). Library.tsx is therefore
+//      UNOWNED and both this wiring and the Library.tsx confirm-gate (item 2 of the
+//      Remove comment below) are available to the NEXT lane immediately — not
+//      blocked on an in-flight PR. The scope-escape verdict is unchanged; only its
+//      stated cause was wrong, and the wrong cause misdirects whoever reads it.
 //
 //   2. WI-1/WI-2 SHIP THE SEMANTIC HALF; THE PAINT IS A SCOPE-ESCAPE INTO
 //      components/library-cards.css. `.library__item-cta` and
 //      `.library__card-menu-trigger` / `-panel` / `-item` have ZERO rules anywhere in
 //      the tree, and `.library__item-open` is `padding:0; border:none;
 //      background:transparent; font:inherit` (library-cards.css:40-53) inside a plain
-//      flex column, so at HEAD the CTA paints as an ordinary body-text line under the
-//      meta line — a primary action in the DOM, a stray word on the pixels.
+//      flex column, so at HEAD the CTA renders as an ordinary body-text line under the
+//      meta line: a primary action in the DOM, an unstyled word on the pixels.
+//
+//      SCOPED, round 3 — an earlier draft called that "a stray word on the pixels"
+//      and treated it as self-evidently worse. That is INFERRED from the cascade and
+//      the token table, never MEASURED, and the pessimistic reading may be wrong:
+//      NOTHING on this card is painted at rest. The card button is
+//      `border:none; background:transparent` (library-cards.css:40-53), Remove is
+//      ghost-voiced (shell.css:520-529), and `.card-provenance__toggle` is
+//      `background:transparent; border:none; color:var(--text-faint)`
+//      (library-cards.css:229-249). So the CTA, inheriting the button's `font:inherit`
+//      body voice, is not anomalous here and may ALREADY out-weigh Remove's
+//      `--type-control-size` 12px `--text-muted` and the meta line's 11px
+//      `--text-faint`. UNVERIFIED either way — nobody has measured the rendered card
+//      across three rounds. Settle it with a computed-style read of
+//      `.library__item-cta` vs `.library__remove-btn`, or with the Library-tab
+//      screenshot in app/e2e/visual/library.visual.spec.ts, BEFORE asserting either
+//      "stray word" or "primary action delivered". The CSS is still owed regardless:
+//      an explicit resting weight for the CTA beats an inherited accident.
 //
 //      CORRECTION, round 2 — an earlier draft of this paragraph claimed
 //      "`.library__remove-btn` keeps its whole box and merely loses its word. Net:
@@ -77,18 +121,32 @@
 //      ship a boxless destructive control beside a newly-painted CTA.
 //
 // TWO TRAPS THE CSS LANE INHERITS, measured here so it does not rediscover them:
-//   * `[hidden]` vs `display`. The panel is hidden ONLY by the UA `[hidden] {
-//     display: none }` rule. `.library__card-menu-panel` and `[hidden]` are both
-//     specificity 0-1-0, so ANY `display:` declaration added to that class wins on
-//     source order and silently un-hides the closed panel — while every overflow test
-//     stays green, because they assert `panel.hidden === true`, never computed
-//     display. Scope it: `.library__card-menu-panel:not([hidden]) { display: … }`.
+//   * `[hidden]` vs `display`. The panel is hidden ONLY by the UA
+//     `[hidden] { display: none }` rule, and ANY author-origin `display:`
+//     declaration outranks it by CASCADE ORIGIN. So adding an unscoped
+//     `display:` to `.library__card-menu-panel` silently un-hides the closed
+//     panel — while every overflow test stays green, because they assert
+//     `panel.hidden === true`, never computed display. Scope it:
+//     `.library__card-menu-panel:not([hidden]) { display: … }`.
+//     CORRECTION, round 3 — an earlier draft of this bullet gave the WRONG REASON
+//     for the right prescription: "both specificity 0-1-0, so ANY `display:` wins
+//     on source order". Specificity and source order do not arbitrate ACROSS
+//     cascade origins; author beats UA whatever its specificity and wherever it
+//     sits. Under the old model an author could believe that moving the rule
+//     earlier, or lowering its specificity, preserved the hiding. It does not —
+//     `:not([hidden])` is mandatory, not defensive. The repo already states and
+//     ships exactly this at views/workspace.css:195-200 (same UA rule, same
+//     `hidden={!open}` panel, same `:not([hidden])` fix), so this bullet was
+//     contradicting the codebase's own prior art on the identical trap.
 //   * TARGET SIZE (WCAG 2.5.8) — SPLIT by measurement, not carried as one blanket
 //     risk. `.library__remove-btn` IS named in the raised-voice list, which is TEN
 //     selectors at shell.css:438-447 on current origin/main (an earlier draft of this
 //     header cited seven at :395-401; #424 added `.vtl__bar button`,
 //     `.vtl__laneHead button` and `.caption-prefs__actions button`, so only the anchor
-//     drifted — the membership and therefore the arithmetic are unchanged). It takes
+//     drifted — `.library__remove-btn`'s OWN membership, and therefore the arithmetic
+//     below, are unchanged. Round 3: the LIST's membership demonstrably did change,
+//     7 -> 10; the earlier wording said "the membership … unchanged" one sentence
+//     after enumerating three additions, which reads as a claim about the list). It takes
 //     `--control-pad-btn` = 6px 14px (styles/tokens.css:199) at `--type-control-size`
 //     12px (:159) plus 1px borders => >=26px tall against `--size-target-min` 24px
 //     (:192), the min-HEIGHT axis that token governs: MET at AA (AAA 44x44 still
@@ -105,7 +163,7 @@
 //     `--control-pad-btn`, which is precisely why it needed its own min-height; it is
 //     silent about the raised voice. Settle the trigger with the ui-audit tap-target
 //     gate, or pre-empt it with a `min-height: var(--size-target-min)` rule.
-import React, { useId, useState } from 'react';
+import React, { useId, useRef, useState } from 'react';
 
 import { rpc } from '../components/api';
 import type { Video } from '../components/api';
@@ -240,9 +298,20 @@ export interface DeliverMenu {
 }
 
 /**
- * The trailing "⋯" overflow: a DISCLOSURE, not an ARIA menu widget — exactly the
- * contract `CardProvenanceDisclosure` (:42-57) uses, `aria-expanded` +
- * `aria-controls` + an always-mounted `hidden` panel, and nothing more.
+ * The trailing "⋯" overflow: a DISCLOSURE, not an ARIA menu widget — it borrows
+ * `CardProvenanceDisclosure`'s ATTRIBUTE contract (:42-57), `aria-expanded` +
+ * `aria-controls` + an always-mounted `hidden` panel.
+ *
+ * CORRECTION, round 3 — that used to read "exactly the contract
+ * CardProvenanceDisclosure uses … and nothing more", and the "nothing more" was a
+ * real defect, not just a wide sentence. That disclosure is closed ONLY from its
+ * toggle, which sits OUTSIDE its panel (:42-53 vs the panel at :57-59), and its body
+ * is `{open ? <LibraryProvenance/> : null}` — so it has nothing focusable inside to
+ * blur and structurally CANNOT lose focus. This menu's rows live INSIDE the panel
+ * that closing `hidden`s, so copying only the attributes stranded focus on an
+ * invisible control (measured: `document.activeElement` stayed on the hidden row).
+ * Hence the explicit focus return below; the house pattern for it is
+ * JobQueue.tsx:109-126, the "disclosure focus-return contract".
  *
  * It deliberately does NOT set `aria-haspopup`. ARIA 1.2 makes
  * `aria-haspopup="true"` a synonym for `"menu"`, so it would announce a menu
@@ -266,10 +335,12 @@ function CardOverflowMenu({
 }): React.ReactElement {
   const [open, setOpen] = useState(false);
   const panelId = useId();
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   return (
     <div className="library__card-menu">
       <button
+        ref={triggerRef}
         type="button"
         className="library__card-menu-trigger"
         aria-label={`More actions for ${video.title}`}
@@ -287,6 +358,13 @@ function CardOverflowMenu({
             type="button"
             className="library__card-menu-item"
             onClick={() => {
+              // Focus FIRST, before the close and before the hand-off, so the
+              // restoration is not contingent on either. The trigger is rendered
+              // unconditionally in this same component and a row is only clickable
+              // while that component is mounted, so the ref is always populated
+              // here — the same guarantee, and the same cast idiom, as
+              // JobQueue.tsx:117-124.
+              (triggerRef.current as HTMLButtonElement).focus();
               setOpen(false);
               deliver.onSelect(video, shortcut.id);
             }}

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -1,13 +1,49 @@
 // LibraryCard.tsx — one content-first Library card (v1.5 §4). A re-skin of the
 // shipped card: a real focusable OPEN button (aria-label = title + duration +
-// status), a poster-frame thumb, additive meta (date + a FAILED attention badge +
-// the quiet Transcript chip), the multi-select checkbox, and the "N shorts" label
-// that opens the produced-shorts gallery (the P0 one-to-many affordance).
+// status), a poster-frame thumb, additive meta (format + date + a FAILED attention
+// badge + the quiet Transcript chip), the multi-select checkbox, and the "N shorts"
+// label that opens the produced-shorts gallery (the P0 one-to-many affordance).
 //
-// A11Y: the open action and the select/remove/shorts controls are SIBLINGS, never
-// nested inside one another (no nested-interactive); resting depth is the surface
-// ladder + --elev-* (library-cards.css), not a border-everywhere box.
-import React, { useState } from 'react';
+// v1.5b — "the card has no primary action". Precisely: the open affordance EXISTED
+// (this `.library__item-open` button, keyboard- and SR-reachable) but was invisible
+// — library-cards.css:40-53 strips its chrome (`border:none; background:transparent;
+// padding:0`) and its only name is an aria-label. So on the rendered pixels the sole
+// action VERB was the destructive "Remove", which made deletion read as the card's
+// call to action. Three changes, all inside this file:
+//   1. a VISIBLE CTA ("Open" / "Show history") painted inside the open button as a
+//      non-interactive <span>, so the primary action finally has a label;
+//   2. Remove demoted to an icon-only ghost control (accessible name kept on
+//      aria-label + title) so the destructive action is no longer the peer — let
+//      alone the only member — of the labelled-action set;
+//   3. an overflow menu that deep-links into Deliver PRE-FILLED (L5-NAV G-3): the
+//      card hands over `(video, shortcutId)` and nothing else. It never implements
+//      conversion — a second converter here would be the tab-strip ratchet in a new
+//      costume. Opt-in via the `deliver` prop, so a host that has not wired the
+//      Deliver route yet renders exactly what it renders today.
+//
+// A11Y: the open action and the select/remove/shorts/overflow controls are SIBLINGS,
+// never nested inside one another (no nested-interactive); resting depth is the
+// surface ladder + --elev-* (library-cards.css), not a border-everywhere box. The
+// overflow panel is ALWAYS mounted and merely toggles `hidden` (the WAI-ARIA
+// disclosure rule CardProvenanceDisclosure already follows) so `aria-controls` is
+// never a dangling IDREF.
+//
+// STILL OWED, and deliberately NOT faked here — this lane's file scope is this file
+// alone, so it ships the structure and leaves the paint to a `library-cards.css`
+// follow-up. Three rules that file must add:
+//   * `.library__item-cta` has NO style yet, so the visible CTA currently renders as
+//     inherited body text. It is the hook; it is not yet the button-weight the card
+//     deserves.
+//   * `.library__card-menu-trigger` / `-panel` / `-item` are likewise unstyled. The
+//     panel is a plain absolute-less <div>; it needs positioning + a surface.
+//   * TARGET SIZE (WCAG 2.5.8): the now icon-only `.library__remove-btn` and the "⋯"
+//     trigger inherit only shell.css's `--control-pad-btn`. That is UNVERIFIED as
+//     >=24x24 — and library-cards.css:236 explicitly sets `min-height:
+//     var(--size-target-min)` on `.card-provenance__toggle`, which is evidence the
+//     base padding alone was NOT judged sufficient. Settle it by measuring the two
+//     controls' rendered box in the running app (the ui-audit tap-target gate), or
+//     pre-empt it by adding the same `min-height` rule to both.
+import React, { useId, useState } from 'react';
 
 import { rpc } from '../components/api';
 import type { Video } from '../components/api';
@@ -66,6 +102,120 @@ function VideoThumb({ video }: { video: Video }): React.ReactElement {
   );
 }
 
+/**
+ * The source container shown on the card's meta line, derived from the file
+ * extension of `path`.
+ *
+ * That extension is the ONLY format signal available: the FROZEN library payload
+ * (`sidecar/contract/spec.py` `Video` → `components/api.ts:65`) carries exactly
+ * `id/path/title/addedAt/durationSec/hasTranscript/thumbnailPath?` — there is no
+ * container, codec or RESOLUTION field, so a "1080p" chip cannot be rendered
+ * honestly here and is deliberately absent rather than guessed.
+ *
+ * Returns '' (meaning "say nothing") unless the BASENAME has a trailing dot
+ * followed by 1-5 alphanumerics — so `C:\my.videos\talk` (dotted directory),
+ * `.env` (leading dot, no name) and `talk.backupcopy` (not an extension) all
+ * stay quiet instead of shouting a wrong format at the user.
+ */
+export function formatContainer(path: string): string {
+  const base = path.slice(Math.max(path.lastIndexOf('/'), path.lastIndexOf('\\')) + 1);
+  const dot = base.lastIndexOf('.');
+  if (dot <= 0) return '';
+  const ext = base.slice(dot + 1);
+  return /^[a-z0-9]{1,5}$/i.test(ext) ? ext.toUpperCase() : '';
+}
+
+/**
+ * The card's ONE quiet meta line — "MP4 · Added 2026-06-11". Either half may be
+ * unknown (see `formatContainer`; `formatAdded` returns '' for an unparseable
+ * timestamp), and '' means the line is omitted entirely rather than rendered as a
+ * stray separator. Duration is NOT repeated here: it already rides the poster as
+ * the timecode badge (the editing-room convention), and printing it twice on one
+ * card is noise, not information.
+ */
+export function cardMetaLine(video: LibraryVideo): string {
+  const parts: string[] = [];
+  const container = formatContainer(video.path);
+  if (container) parts.push(container);
+  const added = formatAdded(video.addedAt);
+  if (added) parts.push(`Added ${added}`);
+  return parts.join(' · ');
+}
+
+/**
+ * The VISIBLE primary-action label. It must track `cardAriaLabel`'s verb, or the
+ * card would show "Open" while activating the history drawer.
+ */
+export function cardActionLabel(lineageView: boolean): string {
+  return lineageView ? 'Show history' : 'Open';
+}
+
+/** One pre-filled Deliver preset offered in the card's overflow menu. */
+export interface DeliverShortcut {
+  /** Which Deliver preset to pre-fill (e.g. 'convert' | 'nle' | 'tracks'). */
+  id: string;
+  /** The menu row's visible text. */
+  label: string;
+}
+
+/**
+ * The card's overflow-menu contract. The card owns NO catalogue and NO conversion
+ * logic: the host supplies the shortcut list and receives `(video, shortcutId)` to
+ * route into the Deliver form with the source pre-filled.
+ */
+export interface DeliverMenu {
+  shortcuts: readonly DeliverShortcut[];
+  onSelect: (video: LibraryVideo, shortcutId: string) => void;
+}
+
+/**
+ * The trailing "⋯" overflow: a disclosure (not an ARIA menu widget) matching the
+ * house pattern in `CardProvenanceDisclosure`. Choosing a row closes it, because a
+ * shortcut that leaves its own menu open reads as a settings panel.
+ */
+function CardOverflowMenu({
+  video,
+  deliver,
+}: {
+  video: LibraryVideo;
+  deliver: DeliverMenu;
+}): React.ReactElement {
+  const [open, setOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <div className="library__card-menu">
+      <button
+        type="button"
+        className="library__card-menu-trigger"
+        aria-label={`More actions for ${video.title}`}
+        aria-haspopup="true"
+        aria-expanded={open}
+        aria-controls={panelId}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span aria-hidden="true">⋯</span>
+      </button>
+
+      <div id={panelId} className="library__card-menu-panel" hidden={!open}>
+        {deliver.shortcuts.map((shortcut) => (
+          <button
+            key={shortcut.id}
+            type="button"
+            className="library__card-menu-item"
+            onClick={() => {
+              setOpen(false);
+              deliver.onSelect(video, shortcut.id);
+            }}
+          >
+            {shortcut.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export interface LibraryCardProps {
   video: LibraryVideo;
   /** Lineage view re-labels the open action + diverts it to the history drawer. */
@@ -79,6 +229,12 @@ export interface LibraryCardProps {
   onOpenShorts: (video: LibraryVideo) => void;
   /** L5 provenance handlers; when present the card shows its source-file row. */
   provenance?: ProvenanceHandlers;
+  /**
+   * Deliver deep-link shortcuts. OPTIONAL and additive: with no shortcuts wired
+   * the card renders no overflow control at all, so a host that has not adopted
+   * the Deliver route is unchanged.
+   */
+  deliver?: DeliverMenu;
 }
 
 export function LibraryCard({
@@ -91,9 +247,10 @@ export function LibraryCard({
   shortsCount,
   onOpenShorts,
   provenance,
+  deliver,
 }: LibraryCardProps): React.ReactElement {
   const badges = cardBadges(video);
-  const added = formatAdded(video.addedAt);
+  const meta = cardMetaLine(video);
 
   return (
     <li className="library__item">
@@ -134,7 +291,14 @@ export function LibraryCard({
               {video.path}
             </span>
           )}
-          {added ? <span className="library__item-added">Added {added}</span> : null}
+          {meta ? <span className="library__item-added">{meta}</span> : null}
+          {/* The visible primary action. A <span>, never a nested <button>: the
+              enclosing .library__item-open already IS the control and owns the
+              accessible name, so this is decoration and is hidden from AT to
+              avoid announcing the verb twice. */}
+          <span className="library__item-cta" aria-hidden="true">
+            {cardActionLabel(lineageView)}
+          </span>
         </div>
       </button>
 
@@ -156,13 +320,21 @@ export function LibraryCard({
             {shortsCountLabel(shortsCount)}
           </button>
         ) : null}
+        {deliver && deliver.shortcuts.length > 0 ? (
+          <CardOverflowMenu video={video} deliver={deliver} />
+        ) : null}
+        {/* Destructive, and therefore ICON-ONLY: the word "Remove" was the card's
+            only visible verb, which made deletion look like the primary action.
+            The accessible name is unchanged (aria-label), and `title` gives sighted
+            users the same word on hover. */}
         <button
           type="button"
           className="library__remove-btn"
           aria-label={`Remove ${video.title}`}
+          title="Remove"
           onClick={(event) => onRemove(video.id, event)}
         >
-          Remove
+          <span aria-hidden="true">×</span>
         </button>
       </div>
     </li>


### PR DESCRIPTION
> **HONESTY CONTRACT** (restated here because it does not carry over between agents): every
> non-trivial claim below carries a calibrated band paired with its evidence; **MEASURED** is
> separated from **INFERRED**; `UNVERIFIED` sits **inline** next to the claim it qualifies and
> names the experiment that would settle it; `NOT-CHECKED` is stated, never folded into a pass.
>
> Two provenance labels are used throughout. **[MINE]** = measured in this PR-opening pass on
> 2026-08-13, worktree `C:/Users/Prekzursil/.claude/rf-w5/library-card`, `HEAD = 5bfbc336`,
> `origin/main = 78c415c9` (both re-confirmed by `git ls-remote`, the authoritative source, because
> the lane itself hit a stale remote-tracking-ref detector failure on exactly this). **[LANE]** /
> **[REVIEWER]** = inherited from the implementing lane or a round reviewer and *not* re-measured
> by me; those are cited as claims, not as my receipts.

---

# 1. WHAT CHANGED — and what the user actually sees

**Terminal state: PARTIAL, not done.** The branch is 2 files, +579/-12 ([MINE] `git diff
origin/main...HEAD --numstat` = `233/3` `LibraryCard.test.tsx` + `346/9` `LibraryCard.tsx`; that
sums to exactly the `additions 579 / deletions 12` GitHub reports for this PR, so the diff surface
is what I think it is).

### Before

On the rendered card the **only action verb was the destructive one**. The open affordance already
existed as the `.library__item-open` button, but `library-cards.css:40-53` strips its chrome
([MINE] that block is `.library__item-open` with `padding: 0` at `:46`, `border: none` at `:47`,
`background: transparent` at `:48`, `font: inherit` at `:50`) and its only name was an
`aria-label` — so a sighted user saw a poster, a title, two faint caption lines, and the word
**"Remove"**. Deletion read as the call to action. That is the defect this lane exists to fix.

### Now — the MEASURED user-visible delta, all of it

Exactly two things reach the pixels:

1. **The quiet meta line gains a filename-derived container token.** `<span
   className="library__item-added">Added 2026-06-11</span>` becomes `MP4 · Added 2026-06-11`
   (`LibraryCard.tsx:249-272` `formatContainer`/`cardMetaLine`, rendered at `:455`).
2. **One `aria-hidden` word renders as the last line *inside* the already-wired open button** —
   `Open`, or `Show history` in lineage view (`LibraryCard.tsx:456-462`).

(2) is a real affordance, not a dead label: the enclosing `.library__item-open` button's `onClick`
is `onOpen(video)`, which `Library.tsx` routes to `handleItemClick` and on to `App.tsx` `openVideo`,
or to `setLineageAsset` → `<LineagePanel>` in lineage mode. The visible verb is a **prefix** of the
accessible name in both modes (`libraryModel.ts` `cardAriaLabel` returns `"Open {title}, …"` /
`"Show history of {title}, …"`), so WCAG 2.5.3 Label-in-Name holds. [LANE, re-derived by the round-3
reviewer]

Plus one real **defect fix** shipped in round 3 (§3), and one behaviour that exists as code but
reaches **zero pixels** today (§5, ESCAPE 2).

### What did NOT change, stated plainly because the first commit's subject claims otherwise

Commit `924cbf01` is titled "give the Library card a visible primary action **and demote Remove**".
The second half is **false for the shipped result**, and this PR title drops it. The Remove
`<button>` is byte-identical to `origin/main` — same `type`/`className`/`aria-label`/`onClick`/text;
only a comment above it moved — and `li.library__item .library__item-meta { justify-content:
flex-end }` still leaves it the sole control in the footer action lane ([MINE] `library-cards.css`
`:74-78`, the declaration at `:77`, under a comment reading "the meta strip is the footer action
lane, so the Remove control seats to the trailing edge" — note this corrects a `:71-75` anchor I
first wrote from the lane's report and then re-derived; `:71` is the tail of
`li.library__item:active`).
The weight lever is `.library__item-cta`, which has **zero CSS rules anywhere on the branch**
([MINE] `git grep "library__item-cta" -- app/renderer/src` returns 8 hits, all in `LibraryCard.tsx`
or `LibraryCard.test.tsx`, none in any stylesheet) (§5, ESCAPE 1). Round 2 deliberately *reversed* an earlier icon-only Remove demotion rather than
ship it; `1b686eb1` is that reversal, so a log reader sees the correction in history.

**Is "Open" now visually heavier than "Remove"?** `UNVERIFIED` (uncertain, 30-55%) — nobody has
measured the rendered card in three rounds. It is not simply "a stray word", because nothing on this
card is painted at rest (the card button, Remove's ghost voice at `shell.css:520-529`, and
`.card-provenance__toggle` at `library-cards.css:229-249` are all transparent and borderless), so
the CTA inheriting the button's `font: inherit` body voice may already out-weigh Remove's 12px
`--text-muted`. **Settle it with:** a computed-style read of `.library__item-cta` vs
`.library__remove-btn`, or `app/e2e/visual/library.visual.spec.ts`.

---

# 2. THE EVIDENCE — verbatim gate output

All five blocks below are **[MINE]**, re-run in this pass at `HEAD = 5bfbc336`. Command, then the
literal bytes it printed, then its exit code.

### 2.1 Biome (`.pre-commit-config.yaml` hook: `biome-format`)

```console
$ npx --yes @biomejs/biome@2.5.0 check renderer/src/views/LibraryCard.tsx renderer/src/views/LibraryCard.test.tsx
Checked 2 files in 96ms. No fixes applied.
BIOME_EXIT=0
```

### 2.2 oxlint — the ACTUAL JS/TS linter in `.pre-commit-config.yaml:45-51`

```console
$ npx --yes oxlint@1.69.0 --config app/.oxlintrc.json --deny-warnings app/renderer/src/views/LibraryCard.tsx app/renderer/src/views/LibraryCard.test.tsx
OXLINT_EXIT=0
```

It printed **nothing**, and a silent probe is not evidence — so per the both-states rule I ran a
known-bad control with the same binary and the same config before trusting that silence:

```console
$ npx --yes oxlint@1.69.0 --config <repo>/app/.oxlintrc.json --deny-warnings _oxctl/_ctl.tsx
_oxctl/_ctl.tsx:2:3: error eslint(no-debugger): `debugger` statement is not allowed help: Remove the debugger statement
_oxctl/_ctl.tsx:3:9: error eslint(no-unused-vars): Variable 'unusedThing' is declared but never used. Unused variables should start with a '_'. help: Consider removing this declaration.
CONTROL_EXIT=1
```

The detector **fires**, so the exit-0 above is a real pass and not an inert probe. Disclosed
limitation, inline: my control file lives **outside** the repo tree (so it could not contaminate a
sibling lane's worktree), which means it does not also prove the *path pattern* is in scope; the
lane ran the equivalent control at an in-repo `app/renderer/src/views/_oxctl.tsx` and reported the
same two errors / exit 1 [LANE].

### 2.3 Typecheck (`quality.yml` `gate-types tsc app`)

```console
$ npx tsc --noEmit
TSC_EXIT=0
```

tsc emits no diagnostics on success; the empty output *is* the pass. This is the gate whose output
was truncated in the lane's own handoff, so it is now closed by first-hand measurement.

### 2.4 The FULL renderer suite with coverage — the BLOCKING gate, not a subset

This is the command `quality.yml` actually runs (`app/package.json` `test:coverage`), and it was the
lane's largest `NOT-CHECKED`. It is now **MEASURED [MINE]**:

```console
$ npx vitest run --coverage

 Test Files  249 passed (249)
      Tests  4872 passed (4872)
   Start at  02:08:12
   Duration  278.19s (transform 303.91s, setup 0ms, collect 740.47s, tests 407.06s, environment 1360.47s, prepare 455.99s)

=============================== Coverage summary ===============================
Statements   : 100% ( 24807/24807 )
Branches     : 100% ( 8164/8164 )
Functions    : 100% ( 1451/1451 )
Lines        : 100% ( 24807/24807 )
================================================================================
VITEST_FULL_EXIT=0
```

Zero lines in the 25,636-line log match `\d+ failed`. The four thresholds are real and enforced, not
decorative: `app/vitest.config.ts:77-81` declares `thresholds: { lines: 100, branches: 100,
functions: 100, statements: 100 }`, which `.coverage-thresholds.json` names as the enforcement point
for the renderer.

Per-view rows include `LibraryCard.tsx | 100 | 100 | 100 | 100` and `Library.tsx | 100 | 100 | 100 |
100`.

**Consistency control that passed:** a round-3 reviewer measured `249 files / 4871 tests` at
`c1679856` [REVIEWER]; I measure `249 files / 4872 tests` at `5bfbc336`, and round 3 added **exactly
one** test (the focus-return case). `4871 + 1 = 4872` reconciles across two independent runs by two
agents at two commits.

**Caveat, inline:** this green is measured on the **branch** tree. The branch is BEHIND main
(`merge-base = 1fa9a69f`, `origin/main = 78c415c9`, both [MINE] via `git merge-base` /
`git ls-remote`), so `UNVERIFIED` that the identical green holds at the **merge result**. GitHub's
own server-side verdict is `mergeable: MERGEABLE` (a mechanically independent second signal), and
`mergeStateStatus: BEHIND` is a staleness state, not a conflict. **Settle it with:** update the
branch and let `quality.yml` run — I deliberately did **not** update it, because the orchestrator
owns the queue.

### 2.5 Scope and cleanliness

```console
$ git diff origin/main...HEAD --numstat
233     3       app/renderer/src/views/LibraryCard.test.tsx
346     9       app/renderer/src/views/LibraryCard.tsx

$ git status --porcelain
<empty>
```

FILE SCOPE held: `LibraryCard.tsx` and its co-located test, nothing else. `git status --porcelain`
was empty before my runs and empty after them, and `app/coverage/` does not exist — so no artifact
of mine can be swept into anyone's commit.

---

# 3. THE GRIND RECORD — 3 rounds, every reviewer finding, nothing dropped

`GRIND HISTORY: [{round 1: 3 verdicts, 3 actionable}, {round 2: 3, 3}, {round 3: 3, 3}]`.

Provenance note stated up front: **round 3's handoff numbers its findings (1/2/3) and I map them
1:1. The round-1 and round-2 commit bodies do NOT number theirs, so the item→finding mapping for
those two rounds is INFERRED from the commit text (`git log origin/main..HEAD`), not measured.** No
item is omitted; where the mapping is uncertain the item is still listed with its verdict.

### Round 1 — commit `18f2bc71`

| # | Finding | Verdict |
|---|---|---|
| R1-a | The overflow trigger set `aria-haspopup="true"` while its own docblock claimed to be "a disclosure (not an ARIA menu widget)". ARIA 1.2 makes `aria-haspopup="true"` a synonym for `"menu"`, so it announced a menu button over a plain `<div>` of `<button>`s with no `role=menu`/`menuitem`, no roving tabindex, no arrow keys, no Escape, no focus return. No axe rule catches a haspopup/role mismatch, and the lane's own test pinned the mismatch in place. | **FIXED** (red first). Attribute dropped — the honest-disclosure option — rather than bolting on the whole APG menu-button contract. New test asserts the attribute is ABSENT and that no `role=menu`/`menuitem` exists; it fails against the previous code. |
| R1-b | Two items were described as "residuals", which reads as optional polish. | **RESCOPED** to declared **SCOPE-ESCAPES** in the file header: (1) WI-3 renders in zero pixels because the sole production mount never passes `deliver`; (2) WI-1/WI-2 ship the SEMANTIC half only, because `.library__item-cta` and `.library__card-menu-*` have zero CSS rules. |
| R1-c | The header's own WCAG 2.5.8 residual. | **REFUTED — by the lane against itself**, with evidence: `.library__remove-btn` **is** named in the raised-voice list, so it takes `--control-pad-btn` (6px 14px at 12px font) and is **met at AA**; only the `⋯` trigger falls through to UA chrome. The cited `library-cards.css:236` was a misread — `.card-provenance__toggle` uses `--space-1`/`--space-2` + the caption font, which is why it needed its own min-height, and says nothing about the raised voice. The residual was overstated *and* mis-cited; the corrected, narrower version ships. |
| R1-new | Not a finding — newly documented: the `[hidden]` vs `display` trap the CSS lane inherits (see R3-b, which corrected its stated mechanism two rounds later). | documented |

### Round 2 — commits `1b686eb1` (code) and `c1679856` (comments only)

| # | Finding | Verdict |
|---|---|---|
| R2-a | **Blocking.** The only user-visible delta the branch shipped was **de-labelling the destructive control**: the text node "Remove" replaced by an `aria-hidden` `×` glyph + `title="Remove"`. The compensating primary-action paint does not land with this branch (declared CSS scope-escape), so on merge the net effect was a no-confirm/no-undo delete losing its only visible name while nothing gained weight in its place. Three measured grounds: (1) `.library__remove-btn` has no resting box to fall back on — the GHOST voice at `shell.css:520-529` wins at rest over the raised-voice base; (2) the action is irreversible and unguarded — `library.remove` fires straight after an optimistic filter while `useConfirm` is wired only around `deleteShort`; (3) `title` surfaces on mouse-hover dwell but not on keyboard focus, so a keyboard-only user was left an unnamed glyph on a no-undo action. | **FIXED** (red first: `expected 'x' to be 'Remove'`). The icon-only demotion is reversed; Remove keeps its word. WI-2 is served by the CTA gaining **weight**, not by the destructive verb losing its **name** — and the weight is the CSS escape. Also renamed a test that read "**paints** a visible Open call-to-action": it asserts `textContent`, `aria-hidden`, ancestry and `tagName` and nothing about paint, while the class it names has zero CSS rules — a green claim the product does not satisfy. |
| R2-b | **An OVERCLAIM, found independently by two reviewers.** SCOPE-ESCAPE 2 asserted "`.library__remove-btn` keeps its whole box and merely loses its word. Net: Remove is still the only element on the card that reads as a control." FALSE on the measured stylesheet — and wrong in the direction that makes the disclosed regression look *smaller* than it is. | **RESCOPED** (the code was fine; the sentence was wider than its evidence). The class is in the raised-voice base list, but the GHOST voice at `shell.css:520-529` — `background: transparent; border-color: transparent; box-shadow: none; color: var(--text-muted)`, under a comment reading "truly quiet — no fill, no edge, no shadow at rest" — applies at the same 0-1-0 specificity and later source order, so the ghost wins at rest. Only the invisible `--control-pad-btn` hit-box survives; surface/edge/shadow appear only on `:hover`. A mechanically independent second source records the same reading: `docs/validation/v15-audit-ledger.md:104`. Root cause of the miss, disclosed: an earlier draft had read that very ghost rule and checked it only for a *height* declaration, so the box-paint override went unseen while the line was cited as evidence. |
| R2-c | Three drifted / too-wide anchors. | **RESCOPED**, each re-derived: the raised-voice list is **ten** selectors at `shell.css:438-447` on current `origin/main`, not seven at `:395-401` (#424 added three) — membership and the ≥26px MET-at-AA arithmetic are unchanged, only the anchor drifted; `tokens.css` is at `styles/tokens.css` and `--size-target-min` governs min-**height**, the axis actually checked; and `formatContainer`'s docblock implied its guard stops the *class* of wrong formats when it stops three **shapes** — `talk.final` → "FINAL", `render.v2` → "V2", `clip.2024` → "2024" still print, with a container allow-list named as the settling change. |

### Round 3 — commit `5bfbc336` (the round this PR opens on)

**FINDING 2 → FIXED — the one real defect. `CardOverflowMenu` destroyed keyboard focus on every
shortcut use.** A menu row's `onClick` set `open=false` while that row — which lives **inside** the
panel the close then `hidden`s — held focus. MEASURED in the fail-first run: `document.activeElement`
stayed on the now-hidden `.library__card-menu-item`; a real browser drops that to `<body>`, i.e. the
top of the document, on every use.

The docblock had defended this as "exactly the contract `CardProvenanceDisclosure` uses … and
nothing more". That equivalence is **false on the only axis that mattered**, and the refuter's core
argument was independently confirmed: `CardProvenanceDisclosure.tsx:42-53` puts its toggle *outside*
the panel (`:57-59`) and renders the body as `{open ? <LibraryProvenance/> : null}`, so it has
nothing focusable inside to blur and **structurally cannot** lose focus. Copying the attributes
copied none of that safety.

Fixed at `LibraryCard.tsx:360-370` by returning focus to the trigger **before** the close and
**before** the hand-off, so restoration is not contingent on either — following the repo's own house
pattern at `JobQueue.tsx:109-126` (which literally names the "disclosure focus-return contract") and
its zero-branch cast idiom at `:117-124`. **Zero new branches, so the 100% gate is unmoved** (§2.4).

- **RED:** `expected the trigger, received <button class="library__card-menu-item">`
- **GREEN:** part of the `4872 passed (4872)` in §2.4 [MINE].

The pre-existing selection test could not have caught it: it asserts `panel.hidden` and the
`onSelect` payload, never `document.activeElement`, and it clicks via `dispatchEvent` (which does not
focus), so focus sits on `<body>` before *and* after. The new test focuses the row first — that is
what makes it discriminating.

Severity held at **should-fix, not upgraded**, and honestly: `deliver` is never passed by any host,
so this renders in zero pixels today. **Latent, not shipping.**

**FINDING 3 → RESCOPED** (both wrong-reason sentences, plus two nits):

- **(a) The `[hidden]` trap gave the wrong MECHANISM for the right fix.** The bullet said
  `.library__card-menu-panel` and `[hidden]` are "both specificity 0-1-0, so ANY `display:` wins on
  source order". Specificity and source order do not arbitrate across cascade **origins**: `[hidden]
  { display: none }` is a **UA** rule and any author-origin `display:` outranks it regardless of
  specificity or position — so `:not([hidden])` is **mandatory**, not defensive. Under the old model
  an author could move the rule earlier or lower its specificity and believe the hiding survived; it
  does not. The prior art was re-derived independently: `git grep "\[hidden\]" origin/main --
  "*.css"` returns **only** `views/workspace.css:195/197/200`, and `:197` reads verbatim
  "author-origin `display` outranks the UA `[hidden] { display: none }` rule" with the
  `:not([hidden])` fix shipped at `:200`. The branch had been contradicting the codebase on the
  identical trap.
- **(b) "PR #423 owns `Library.tsx`" was FALSE at the very SHA the header cites.** #423 merged as
  `b26948a7`; `git merge-base --is-ancestor b26948a7 origin/main` exits 0 against `origin/main =
  78c415c9`. Restated on this lane's file-scope grant alone — because the wrong cause misdirects the
  next lane: the `deliver` wiring and the `Library.tsx` confirm-gate are **unowned and available
  now**, not parked behind an in-flight PR.
- **(c) nit:** the raised-voice **list**'s membership did change 7 → 10; only `.library__remove-btn`'s
  *own* membership is unchanged, which is what the arithmetic needs. **(d) nit:** the
  `KeepCopyControl.tsx:21` citation count is **six** other renderer sites, not four.

**FINDING 1 → RESCOPED — the completion sentence, not the code.** Added a WHAT-A-USER-ACTUALLY-GETS
block naming the MEASURED two-item delta (§1), stating that WI-2 ships **no change of its own** and
WI-3 ships as **code no host instantiates**, and declaring the lane **PARTIAL**. "Three changes"
became "three **INTENDED** changes" at its source, since that sentence is what generated the same
misreading three rounds running, and `924cbf01`'s "and demote Remove" was dropped from the PR title.
The reviewers' converging correction was also adopted in the **optimistic** direction, not only the
pessimistic one: "a stray word on the pixels" was INFERRED, never measured, and is plausibly wrong —
so it is now tagged `UNVERIFIED` inline with its settling experiment named (§1), rather than asserted
either way.

**The WORK ITEM's own premise stays REFUTED, re-derived:** WI-1 said "duration, resolution, format
are available". `components/api.ts:65-77` and `sidecar/contract/spec.py:47-56` carry
`id/path/title/addedAt/durationSec/hasTranscript/thumbnailPath?` — **no** container, codec or
resolution field — and the only library-side probe seam is `ffprobe_duration`
(`sidecar/media_studio/handlers/_services.py:48`). A `1080p` chip needs a **new sidecar RPC**.
Refusing to render it was correct, not under-delivery (almost-certain, 90-99%). Duration already
rides the poster as the timecode badge.

**A detector failure the lane disclosed on itself**, reproduced here because it is the kind of thing
that silently produces a false claim: its first `git merge-tree --write-tree origin/main
origin/fix/v15b-library-card` returned a tree SHA **byte-identical** to the one reviewers had
measured *before* round 3's commit existed. That coincidence was the tell — `git ls-remote`
(authoritative) said the remote branch was at `5bfbc336` while the worktree's remote-tracking ref was
**stale** at `c1679856` despite a preceding `git fetch origin`. Recomputed after an explicit-refspec
fetch, the branch merges CLEAN. I re-confirmed both SHAs with `git ls-remote` myself before writing
this body, for exactly that reason.

---

# 4. THE FRESH-SKEPTIC VERDICT — verbatim, including every reservation

Recovered verbatim from the skeptic agent's own transcript record (6,508 chars, reproduced whole and
unedited; its `refuted=true severity=should-fix` header is preserved above it). It measured the tree
at `5bfbc336`. Where it and I disagree on a number, the disagreement is called out **after** the
quote, not inside it.

```text
refuted=true severity=should-fix

HONESTY CONTRACT (restated; it does not carry over): every claim below carries a calibrated band paired with its evidence; MEASURED is separated from INFERRED; UNVERIFIED sits inline next to the claim it qualifies and names the settling experiment; NOT-CHECKED is stated, not guessed.

VERDICT: NOT mergeable as the lane's fix — but the failure mode is INCOMPLETENESS + DEAD CODE, not breakage. I found no correctness defect. The branch is also unusually honest: its own header says "This lane is therefore PARTIAL … not done" (LibraryCard.tsx:42-43), so I am not refuting an overclaim in the code — I am refuting that the lane goal holds in the final state.

Q1 — DOES THE STATED GOAL HOLD? No (almost-certain, 90-99%). MEASURED, the ENTIRE non-comment delta over origin/main is three things:
* `formatContainer` + `cardMetaLine` turn the pre-existing `.library__item-added` span from "Added 2026-06-11" into "MP4 · Added 2026-06-11" (LibraryCard.tsx:249-272, :455);
* a new `<span className="library__item-cta" aria-hidden="true">Open|Show history</span>` as the LAST child inside the ALREADY-EXISTING `.library__item-open` button (:456-462);
* `CardOverflowMenu` + `DeliverShortcut`/`DeliverMenu` + an optional `deliver` prop (:282-378, :484-486).
Against the four work items: WI-1 HALF — a visible verb exists, but `.library__item-cta` has ZERO CSS rules anywhere in app/renderer/src (git grep: hits only in LibraryCard.tsx and its test), and its parent button is `padding:0; border:none; background:transparent; font:inherit` (library-cards.css:40-53), so the "primary action" paints as an ordinary body-text line, last in the card body under two faint caption lines. The clickable button and the mm:ss poster badge both PRE-DATE this branch. WI-2 NOT DELIVERED — the Remove button is byte-identical to origin/main (only surrounding comments moved); the chosen mechanism ("the CTA gains weight") lives in CSS this lane cannot touch. WI-3 NOT DELIVERED TO USERS (see Q2). WI-4 scope HELD — exactly 2 files, +579/-12.

Q2 — HALF-DONE / MOUNTED NOWHERE? Yes, self-admitted and independently MEASURED. No production host passes `deliver`: `git grep deliver -- app/renderer/src/views/Library.tsx` on the branch returns nothing; the only `<LibraryCard` mounts are Library.tsx:702 and LibraryCard.test.tsx:84. So ~50 lines of component, two exported interfaces and the prop are reachable only from tests. All four of its classes (`library__card-menu`, `-trigger`, `-panel`, `-item`) also have ZERO CSS rules, so even once wired the "panel" would be an unstyled in-flow block, not a popup. The branch itself proves Library.tsx is UNOWNED right now (#423 merged and is an ancestor of origin/main), i.e. the wiring was available and was not done.

Q3 — DO COMMENTS/COMMITS OVERCLAIM? Not materially (likely, 55-80%). Commit 924cbf01's subject says "demote Remove", which the final state does not do — but 1b686eb1 explicitly reverses it in the same history, so a log reader sees the correction. Spot-checks of the header's load-bearing anchors CONFIRM rather than refute: `.library__remove-btn` is in the raised-voice base list at shell.css:439 and takes the GHOST override (`background:transparent; border-color:transparent; box-shadow:none; color:var(--text-muted)`) at :523 — later, same 0-1-0 specificity — on CURRENT origin/main, exactly as claimed; `cardAriaLabel` returns "Open {title}, …" / "Show history of {title}, …", so the visible verb really is a prefix of the accessible name (WCAG 2.5.3 holds). My first probe read the BRANCH's shell.css (:396/:443) and looked like a bad citation; a second probe against origin/main refuted my own finding — the header says it re-anchored to origin/main deliberately. The real hygiene cost is 165 comment lines (34% of the file) before the first import, much of it a meta-narrative of review rounds ("CORRECTION, round 3 — an earlier draft of this bullet gave the WRONG REASON…"), which is process history leaking into the product.

Q4 — WOULD A USER NOTICE? Barely, and possibly not as an improvement (uncertain, 30-55%). They see one extra faint token ("MP4 · ") and the word "Open" as a plain unstyled line at the bottom of the card body. Remove keeps its `--control-pad-btn` hit-box and its word. Whether "Open" out-weighs "Remove" is UNVERIFIED — the branch says so itself and nobody has measured the rendered card in three rounds. Settle it with a computed-style read of `.library__item-cta` vs `.library__remove-btn`, or the Library visual screenshot. So the finding this lane exists to fix — "the destructive action is the most prominent control" — is not demonstrably fixed.

Q5 — WAVE-1 INVARIANTS: hold trivially (almost-certain). The 2-file scope touches no nav, rail, tab list or panel registry, so no 1280px overflow risk, no rail-count change, no panel-reachability change. The anti-ratchet rule is untouched.

WHAT IS GOOD (do not discard): tests 30/30 on LibraryCard.test.tsx and 418/418 across all 23 renderer/src/views test files, `npx tsc --noEmit` exit 0 — all MEASURED in the clean lane worktree at 5bfbc336. The overflow focus-return fix is real and its test carries a discriminating control assertion (`expect(document.activeElement).toBe(row)` before activation). Test names were correctly rescoped ("renders the CTA verb inside the primary button", not "paints"). The branch correctly REFUTES the brief's premise that resolution is available: `Video` (api.ts:65-78) carries no container/codec/resolution field, so a "1080p" chip would have been fabrication.

NOT-CHECKED (stated, not guessed): the full ~3,910-test suite, the sidecar suite, lint, and coverage thresholds; I ran views + typecheck only. I did not render the app, so the CTA-vs-Remove visual weight stays UNVERIFIED. `app/e2e/visual/library.visual.spec.ts` pins `library-win32.png` against a SEEDED card (asserts `.library__item-title` == 'sample'), and this branch changes that card's text without refreshing the baseline — non-blocking, because e2e.yml's own header states it "NEVER gates a normal PR" and quality.yml (the PR gate) has no visual step (MEASURED).

WHY should-fix AND NOT blocking: nothing regresses, nothing is broken, and the increment is strictly additive. The objection is that merging closes a lane whose headline defect is untouched while adding a zero-pixel Deliver contract, a rule-less CSS class, and a 165-line review-history header — another individually-defensible increment of exactly the kind the anti-ratchet note warns produces incoherence.
```

### Two reconciliations, stated outside the quote so the verdict stays verbatim

1. **Its `Library.tsx:702` vs this body's `:797-808`.** Both are right about different trees. `:702`
   is the mount's line number on the *branch* (which is BEHIND main, `merge-base = 1fa9a69f`); on
   current `origin/main = 78c415c9` the mount is at `:797-808`. Same defect, two line numbers — this
   is the ordinary consequence of reading a stale tree, not a contradiction.
2. **Its "full ~3,910-test suite … NOT-CHECKED" is now CLOSED.** The skeptic ran views + typecheck
   only, so its NOT-CHECKED was honest at the time. §2.4 above is that measurement: `249 files /
   4872 tests` and 100% on all four coverage axes, exit 0 [MINE]. Its other NOT-CHECKED items
   (rendered pixels, sidecar suite) remain open and are carried into §5 rather than quietly dropped.

The skeptic's verdict — **NOT mergeable as the lane's *fix*, should-fix, not blocking** — is left
standing. Nothing in it was refuted; the argument is that WI-2 is undelivered and WI-3 is
unmounted, and both of those are true in the final state and are stated as such in §1 and §5.

---

# 5. RESIDUAL / NOT DONE

Not "none". Ordered by what a reader most needs to know.

1. **No rendered-pixel evidence of any kind** — no Electron build, no Playwright, no axe, no
   screenshot. `UNVERIFIED` (uncertain, 30-55%): whether `.library__item-cta` actually out-weighs
   `.library__remove-btn` on screen. Every pixel statement in this branch is CSS-cascade plus token
   arithmetic, which is exactly why the paint claim is tagged inline in the source rather than
   asserted. **Settle it with:** a computed-style read of `.library__item-cta` vs
   `.library__remove-btn`, or `app/e2e/visual/library.visual.spec.ts`. **After three rounds nobody
   has measured the rendered card — this is the single biggest open item on the lane.**
2. **The visual baseline will need refreshing, and it is NOT a merge blocker.** [MINE]
   `app/e2e/visual/library.visual.spec.ts:31` asserts `toHaveScreenshot('library.png', …)` against
   an on-disk baseline `library.visual.spec.ts-snapshots/library-win32.png` (63,097 bytes), on a
   seeded card whose title the spec pins to `'sample'` at `:30`. This branch changes that card's
   rendered text, so the baseline will differ until refreshed
   (`npm run test:e2e:visual:update`). Non-blocking, MEASURED two ways: `.github/workflows/e2e.yml:3`
   states verbatim "This NEVER gates a normal PR", and `git grep -i "visual\|playwright" --
   .github/workflows/quality.yml` returns exactly one hit, a *comment* about `tsconfig.json`
   excluding `e2e/**` — the blocking gate has no visual step.
3. **WI-2's visual demotion is UNDELIVERED and cannot be delivered from `LibraryCard.tsx`.** A
   judgement call, stated rather than hidden: I did **not** reach for an inline style or borrow an
   unrelated painted class to fake it — that trades a declared scope-escape for an undeclared design
   regression and a token-conformance risk. See ESCAPE 1.
4. **7 of the 30 `LibraryCard.test.tsx` tests drive the `deliver` prop that no host passes**, so the
   100% coverage figure includes unreachable code in its denominator. Banked here in the open rather
   than quietly.
5. **Remaining `pre-commit run --all-files` hooks: `NOT-CHECKED` by me** — `docs_check`,
   `reachability_check`, `electron-hardening`, `gitleaks`, `ruff`. I ran the two JS/TS gates
   (oxlint, biome), tsc, and the full renderer suite with coverage. [REVIEWER] separately established
   that `reachability_check.py` is MODULE-level, so the never-mounted `CardOverflowMenu` does not
   trip it, and that main's `shell.buttonVoice.conformance.test.ts` reads only `shell.css` /
   `CaptionPreferences` / `VideoTimeline`, so a TSX-only diff cannot move it — re-derived by them,
   not by me. The **sidecar** pytest suite is also `NOT-CHECKED`; a TSX-only diff touching no Python
   cannot plausibly move it (INFERRED, likely 55-80%), which is not the same as measured.
6. **The claim that the `aria-hidden` CTA span trips no axe rule is INFERRED** from
   `aria-hidden-focus` / `nested-interactive` / `button-name` semantics — not measured. **Settle it
   with:** an axe run against the rendered Library tab.
7. **The threshold gate was not mutation-tested.** Coverage came back 100/100/100/100 with
   thresholds declared at `app/vitest.config.ts:77-81`, so exit 0 means met-and-enforced — but I did
   not prove the *threshold* mechanism would fail closed. `NOT-CHECKED`. **Settle it with:** delete
   one assertion, re-run `npx vitest run --coverage`, and require it to go red.
8. **The green is measured on the branch tree, not the merged tree** (§2.4 caveat). `mergeable:
   MERGEABLE` + `mergeStateStatus: BEHIND`. I did not update the branch — the orchestrator owns the
   queue.
9. **Inherited anchors I did not personally re-derive this pass**, flagged so no reader treats them
   as my receipts: `shell.css:438-447` (ten selectors), `:520-529`, `:589`,
   `styles/tokens.css:159/192/199`, `library-cards.css:229-249`,
   `views/workspace.css:195-200`, `Library.tsx:386-419`/`:505`/`:797-808`,
   `libraryModel.ts` `cardAriaLabel`, `docs/validation/v15-audit-ledger.md:104`. Three prior
   reviewers each re-derived these against the same `origin/main = 78c415c9` and agreed, so they are
   likely-correct inherited evidence (55-80%), not measurement of mine. The SHAs, the diff surface,
   the gate outputs, the workflow-gating facts and the visual-baseline facts in this body **are**
   mine.

---

# Scope escapes — REPORTED, not performed

FILE SCOPE held strictly (§2.5). Two escapes are declared for other lanes; nothing outside
`LibraryCard.tsx` + its test was touched, and no branch, worktree or out-of-scope file was deleted.

**ESCAPE 1 — `app/renderer/src/components/library-cards.css`** (WI-2's paint, and the CTA's resting
weight). `.library__item-cta` and `.library__card-menu-trigger` / `-panel` / `-item` have **zero
rules anywhere in the tree**. Without them WI-2 ships nothing. The CSS lane owes: (a) an explicit
resting weight for `.library__item-cta` — an *inherited* body voice is an accident, not a design
decision (zero-rule status [MINE]: `git grep "library__card-menu" -- "app/renderer/src/**/*.css"`
returns **no matches at all**, and `library__item-cta` appears only in `LibraryCard.tsx` and its
test); (b) a resting affordance for `.library__remove-btn` that does not make it the primary's
peer; and (c) `.library__card-menu-panel:not([hidden]) { display: … }`, where the `:not([hidden])`
is **mandatory** for the cascade-origin reason now documented in the source (author-origin `display:`
outranks the UA `[hidden] { display: none }` rule, so moving the rule or lowering its specificity
does **not** preserve the hiding), with shipped prior art at `views/workspace.css:195-200`.

**ESCAPE 2 — `app/renderer/src/views/Library.tsx`** (WI-3's wiring, plus a destructive-action gap).
`Library.tsx:797-808` is the only production mount and omits `deliver`, so `CardOverflowMenu` renders
in zero pixels. Also open there: `handleRemove` (`:386-419`) fires `library.remove` with **no confirm
and no undo**, while `confirm({` exists at `:505` for `deleteShort` only — against the repo standard
defined at `features/KeepCopyControl.tsx:21` ("never a silent one-click destructive action") and
cited at **six other renderer sites** ([MINE] `git grep "never a silent one-click destructive action"
-- app/renderer/src` = 7 hits: the definition plus `ExportPresetsPanel.tsx:246`,
`ExportPresetsPanel.test.tsx:377`, `Tracks.tsx:124`, `Tracks.test.tsx:219`, `Library.tsx:481`,
`Library.test.tsx:1641`. Detector note, because the count is exactly the kind of nit this branch was
pilloried for: grepping the literal citation string `KeepCopyControl.tsx:21` instead yields 5 other
files plus this lane's own test — same standard, two defensible counts; round 3's "six" is right
under the phrase measure).

**Correction to the standing attribution, because it changes who can act:** both escapes were
previously parked behind "PR #423 owns `Library.tsx`". That is **FALSE** — #423 merged as `b26948a7`
and `git merge-base --is-ancestor b26948a7 origin/main` exits 0 against `origin/main = 78c415c9`
(MEASURED, almost-certain 90-99%). `Library.tsx` is **unowned**, and both items are available to the
next lane immediately.
