### PR TITLE
fix(ssot): derive the rail from App.tsx instead of pinning the pre-L5 eight

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,23 +77,33 @@ bundles — **prompt-driven editing (Director)**, **repurpose**, **intelligence*
 **editing-refine**, and **UX quality-of-life** — all plug into this one substrate, so there
 is exactly one place to manage keys, cost, and privacy.
 
-### The tabs
+### The rail
 
-The app organises everything into **eight** top-level sections (an ARIA tablist; the
-active section is derived from the route, so the strip can never desync). The list below
-is derived from `app/renderer/src/App.tsx` — it previously said "five" and named only
-five, omitting Caption, Export and Deliver:
+The app organises everything into **four destinations plus Settings** (an ARIA tablist; the
+active destination is derived from the route, so the rail can never desync). The list below is
+derived from the `tabs` array in `app/renderer/src/App.tsx`, which that file declares to be the
+SSOT for the rail.
 
-| Tab | What it's for |
-|-----|---------------|
-| **Library** | Your video library home. Add videos; open one to drill into the **Edit** section for that video. |
-| **Make Shorts** | The novice front door / short-maker: AI moment-pick **and** manual-interval shorts → boundary-snap → cut → vertical 9:16 reframe → caption editor → export, plus the single produced-Shorts gallery and batch / template repurposing (it carries the interrupted-batch resume badge). |
-| **Edit** | The per-video manual surface — trim / cut / join, reframe, the caption position & style editor, audio mix / duck / loudnorm, stabilize, transcribe, export — hosted in the per-video Workspace. |
-| **Caption** | The caption stage on its own rail: the draggable / resizable caption box over a real frame, cue editing, and the burn-in vs soft-mux choice. |
-| **Export** | The guarded export stage — pick a platform preset, review what will be written, then commit; determinate progress with a cancel. |
-| **Deliver** | Post-export delivery: where finished files go, and the produced-clip hand-off. |
-| **Director** | Prompt-driven AI video editing: describe an edit, review the storyboard / diff and its cost, then apply real ffmpeg op-engines (reframe, zoom/pan, retime, overlay, lower-third, remove fillers, translate captions, export). |
-| **Settings** | Sub-navigated into **eight** panels (from `views/Settings.tsx`): **Models & System** (pick / download models, hardware tiers, paths), **Setup**, **Providers & Keys** (add / redact API keys, per-key usage bars, consent toggles, **monthly spend cap**), **Storage**, **Caption defaults**, **System Health** diagnostics, **Licenses**, and **Export presets**. |
+**This section previously described EIGHT tabs** — Library / Make Shorts / Edit / Caption / Export /
+Deliver / Director / Settings — and was invalidated by the L5 navigation rebuild (`69665321`).
+**Nothing was removed from the product:** four of those eight had two answers in two places
+("where do I make a short?", "where do I finish?"), so each old destination became a **mode** of the
+destination that owns its job, reached by a small sub-navigation inside it. The mapping is given
+below so a reader arriving from the old docs can find what they knew.
+
+| Destination | What it's for | Modes (former top-level tabs) |
+|-----|---------------|---------------|
+| **Library** | Your video library home. Add videos; opening one routes into **Refine**. | — |
+| **Produce** | Both AI paths in one place, because they are the same job — AI proposes, you review. | **Make Shorts** (candidate-driven: AI moment-pick **and** manual-interval shorts → boundary-snap → cut → vertical 9:16 reframe → caption editor → export, plus the produced-Shorts gallery and batch / template repurposing, carrying the interrupted-batch resume badge) · **Director** (prompt-driven: describe an edit, review the storyboard / diff and its cost, then apply real ffmpeg op-engines) |
+| **Refine** | The editor for one video. | **Editor** (trim / cut / join, reframe, audio mix / duck / loudnorm, stabilize, transcribe — a preview with a docked timeline and a selection-driven inspector) · **Caption design** (the draggable / resizable caption box over a real frame, cue editing, burn-in vs soft-mux) |
+| **Deliver** | Getting files out. | **Finish** (the guarded per-video commit — pick a platform preset, review what will be written, then commit, with determinate progress and a cancel) · **Publish** (cross-video / batch, platform presets, and the pro EDL/CSV hand-off) |
+| **Settings** | A sub-tabbed area. `SETTINGS_SECTIONS` in `views/Settings.tsx` is the SSOT for which sub-sections exist — deliberately not re-listed here, because the duplicated list is exactly what rotted last time. | — |
+
+> **Reading `Refine` accurately:** "Editor" does not open on the Workspace directly. `views/Edit.tsx`
+> opens on its Task Hub and mounts the Workspace — preview, docked timeline, selection-driven
+> inspector — only after a card is picked, or immediately when a remembered hub choice resumes there.
+> So the L5 "timeline with zero navigation actions" invariant holds **from the Workspace mount**, not
+> from a first open of this destination. That gap is real and tracked as a follow-up.
 
 **Providers & Keys + spend cap.** Keys live **only on your machine** — never transmitted
 anywhere but the owning provider, never logged. A persisted, month-keyed **cumulative spend

--- a/app/renderer/src/App.tsx
+++ b/app/renderer/src/App.tsx
@@ -25,10 +25,28 @@
 //                exactly the two choices `resumeFor` maps to `{kind:'workspace'}`
 //                (lib/taskHub.ts:109 'subtitles', :111 'advanced'). So the L5
 //                "timeline with zero navigation actions" invariant holds from the
-//                Workspace mount, NOT from a first open of this destination. That
-//                gap is REAL and is not this lane's to close: Edit.tsx is outside
-//                its file scope and byte-unchanged on this branch. Follow-up in
-//                the PR residuals.
+//                Workspace mount, NOT from a first open of this destination.
+//
+//                THAT GAP IS REAL AND UNOWNED — and the reason previously given for
+//                deferring it is now FALSE. This block used to close with "Edit.tsx
+//                is outside its file scope and byte-unchanged on this branch",
+//                which was true when the L5 lane wrote it and was invalidated two
+//                commits later: #427 (a4dbec7c) adopted the shared EmptyState in
+//                views/Edit.tsx, so `git diff --name-status 1fa9a69f a4dbec7c --
+//                app` lists `M app/renderer/src/views/Edit.tsx`. The deferral was
+//                therefore resting on a premise that no longer holds, with no lane
+//                owning the fix — which is how a locked acceptance invariant stays
+//                broken indefinitely while every individual PR looks reasonable.
+//                (#427 changed only the no-video empty state, so it did NOT make
+//                the invariant worse. The defect is the orphaned ownership.)
+//
+//                OWNER DECISION REQUIRED, deliberately not taken here: closing it
+//                means flipping Edit.tsx:70 `useState<'hub'|'workspace'>('hub')` to
+//                land on 'workspace' when a video is already open. That is a
+//                PRODUCT change — it demotes the Task Hub from the default landing
+//                surface — not a mechanical repair, so it is surfaced rather than
+//                applied. Until it is taken, G-7 invariant 2 does not hold and no
+//                doc, comment or PR body may claim otherwise.
 //   * Deliver  — getting files out: "Finish" (Phase-5 guarded commit for ONE
 //                video, views/Export.tsx) and "Publish" (cross-video / batch
 //                publish + platform presets + the pro EDL/CSV handoff),

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -98,7 +98,7 @@ re-copy this number.)
 
 | file | charter |
 |---|---|
-| [`README.md`](../README.md) | the only user-facing description of WHAT SHIPS: the 8 rails, the 8 Settings sections, install + run. |
+| [`README.md`](../README.md) | the only user-facing description of WHAT SHIPS: the rail destinations, the 8 Settings sections, install + run. |
 | [`CHANGELOG.md`](../CHANGELOG.md) | the only release history; every version in `app/package.json` has a heading. |
 | [`QUALITY-CHARTER.md`](../QUALITY-CHARTER.md) | the only place gate COMPOSITION and tool VERSION PINS are declared. |
 | [`SECURITY.md`](../SECURITY.md) | the only vuln-reporting policy. |

--- a/docs/plans/v1.5/README.md
+++ b/docs/plans/v1.5/README.md
@@ -81,7 +81,13 @@ They are at `docs/_archive/2026-07/` because they are superseded, and one is
 **actively wrong** in a way worth remembering:
 
 - `docs/_archive/2026-07/reframe-visual-audit.md` — its P0 ("16+ horizontal top-level tabs") is refuted by
-  `App.tsx`, which renders 8 vertical rails.
+  `App.tsx`, which renders a vertical rail. **Re-measured 2026-08-13: the rail is FIVE destinations**
+  (Library / Produce / Refine / Deliver / Settings), derived from the `tabs` array `App.tsx` declares to be
+  its SSOT. This line previously said "8 vertical rails", which was true when written and was invalidated by
+  the L5 navigation rebuild (`69665321`, PR #431) that cut the rail from eight destinations to four +
+  Settings. The refutation of the archived P0 still stands — vertical, not 16 horizontal tabs — only the
+  count moved. Do not re-pin a raw count here: `P2.10a` in `docs/validation/tools/verify_ssot_claims.py`
+  now DERIVES the rail from that array and is the machine-checked authority.
 - `docs/_archive/2026-07/reframe-reconcile-audit.md` — asserts *"there is NO 'YuNet' anywhere in the repo
   (zero matches)"*. YuNet is referenced throughout the tree — hundreds of occurrences across
   dozens of files, and the detector it

--- a/docs/validation/tools/verify_ssot_claims.py
+++ b/docs/validation/tools/verify_ssot_claims.py
@@ -364,9 +364,34 @@ check(
 check("P2.9b", True, seed_right, f"docs/plans/_archive/provider-hub/CATALOG-SEED.md present={seed_right}")
 
 appt = read("app/renderer/src/App.tsx") or ""
-RAILS = ["library", "makeshorts", "edit", "caption", "export", "deliver", "director", "settings"]
-rails_found = [r for r in RAILS if f"'{r}'" in appt or f'"{r}"' in appt]
-check("P2.10a", True, len(rails_found) == 8, f"App.tsx names {len(rails_found)}/8 rails: {rails_found}")
+# P2.10a — the top-level rail.
+#
+# DERIVED from App.tsx's own `tabs` array, which that file declares to BE the SSOT for the
+# rail ("The `tabs` array below is the SSOT for the rail", App.tsx:3). Compared against the
+# owner-locked L5 destination list, which is a product decision and therefore legitimately
+# pinned here — unlike a version string, it does not drift on its own.
+#
+# THIS CHECK WAS ITSELF THE DRIFT (2026-08-13). It hardcoded the pre-L5 eight
+# ["library","makeshorts","edit","caption","export","deliver","director","settings"] and
+# substring-matched them anywhere in App.tsx. When #431 cut the rail to four + Settings the
+# check went red — and reported a MEANINGLESS "5/8", because "caption" and "director" still
+# matched as MODE ids elsewhere in the file while the three genuinely-removed destinations
+# did not. So the number it printed was neither the old rail nor the new one. That is the
+# same failure the version checks above already recorded ("the checker itself was the
+# drift"): a probe that hardcodes a value the product is allowed to change.
+#
+# Parsing the array instead of substring-matching the file also closes the use-vs-mention
+# hole: a mode id, a comment, or a route literal can no longer satisfy a rail assertion.
+_tabs = re.search(r"const tabs: TopTab\[\] = useMemo\(\s*\(\)\s*=>\s*\[(.*?)\n\s*\],", appt, re.S)
+rails_found = re.findall(r"\{\s*id:\s*['\"]([a-zA-Z]+)['\"]", _tabs.group(1)) if _tabs else []
+RAIL_LOCKED = ["library", "produce", "refine", "deliver", "settings"]
+check(
+    "P2.10a",
+    True,
+    rails_found == RAIL_LOCKED,
+    f"App.tsx `tabs` declares the rail as {rails_found} (L5-locked: {RAIL_LOCKED})"
+    + ("" if _tabs else " -- PARSE FAILED: the `tabs` array shape changed, so this measured nothing"),
+)
 setts = read("app/renderer/src/views/Settings.tsx") or ""
 SUBTABS = ["models", "setup", "providers", "storage", "preferences", "health", "licenses", "presets"]
 subs_found = [s for s in SUBTABS if f"'{s}'" in setts or f'"{s}"' in setts]


### PR DESCRIPTION
**`main` is currently RED on its own SSOT gate, and merging #431 is what broke it.**

```
MISS P2.10a [INV] BROKEN :: App.tsx names 5/8 rails:
    ['library', 'caption', 'deliver', 'director', 'settings']
total=40  as-predicted=39  mismatched=1
FAILED:ssot-verify — exit 1
```

## Why it broke, and why `8 → 5` would have been the wrong fix

`P2.10a` hardcoded the pre-L5 destinations and substring-matched them anywhere in `App.tsx`:

```python
RAILS = ["library","makeshorts","edit","caption","export","deliver","director","settings"]
rails_found = [r for r in RAILS if f"'{r}'" in appt or f'"{r}"' in appt]
check("P2.10a", True, len(rails_found) == 8, ...)
```

The L5 rebuild (`69665321`, #431) cut the rail to four destinations + Settings, so the check went red.
Worse, **the number it printed was meaningless**: `caption` and `director` still matched as *mode* ids
elsewhere in the file, while the three genuinely-removed destinations did not — so "5/8" described
neither the old rail nor the new one.

The file already records this exact lesson, two checks below:

> *"Both this check and P2.12 below hardcoded '1.4.2', so a legitimate bump made two SSOT probes report a
> false failure — **the checker itself was the drift**."*

A probe that pins a value the product is allowed to change becomes the drift it exists to catch.
Changing `8` to `5` rebuilds the same trap.

## The fix

`P2.10a` now **parses** the `tabs` array that `App.tsx:3` declares to *be* the rail's SSOT, and compares
the ids to the owner-locked L5 list. That list is a product decision, not an incidental value — it does
not drift on its own, and a change to it is precisely what the check should catch.

Parsing also closes a use-vs-mention hole: a mode id, a comment or a route literal can no longer satisfy
a rail assertion. A parse failure is now reported *as* a parse failure rather than silently measuring
nothing.

### Both-states control — executed, not assumed

| state | result |
|---|---|
| clean | `P2.10a OK`, `total=40 as-predicted=40`, exit 0 |
| rail id `refine`→`repurpose` | `P2.10a MISS :: declares the rail as [… 'repurpose' …] (L5-locked: [… 'refine' …])`, exit 1 |

The red message now names what changed and what was expected, where the old one printed `5/8`.

## Docs reconciled in the same pass — the code is the authority, the docs were the bug

* **`README.md` "The tabs" → "The rail".** It described the eight-tab structure and is the only
  user-facing description of what ships. Rewritten as four destinations + Settings **with a mode
  mapping**, so a reader arriving from the old docs can still find what they knew. Nothing was removed
  from the product — each old destination became a *mode* of the destination that owns its job. It also
  now records the honest caveat from `App.tsx`: "Editor" opens on its Task Hub, so the *"timeline with
  zero navigation actions"* invariant holds from the **Workspace mount**, not from a first open of the
  destination.
* **`docs/plans/v1.5/README.md:84`** said "8 vertical rails". Re-measured and marked **CORRECTED** rather
  than silently edited — the archived P0 it refutes ("16+ horizontal top-level tabs") still stands, only
  the count moved — and it now points at `P2.10a` as the machine-checked authority instead of re-pinning
  a raw number.
* **`docs/INDEX.md:101`** charter line: "the 8 rails" → "the rail destinations". The count was **deleted**
  rather than changed to 5, because a bare count in a charter line will rot again for the same reason.

The Settings "8 sub-tabs" figures are untouched — `P2.10b` still measures 8 and passes.

## Gates

* `verify_ssot_claims.py` → `total=40 as-predicted=40 mismatched=0`, `SUCCESS:ssot-verify`, exit 0
* `docs_check.py` → `authority-docs=95 citing-files-scanned=1130 r1..r5=0`, `SUCCESS:docscheck`, exit 0

## Disclosed

* **This verifier is not wired into CI** — `git grep verify_ssot_claims -- .github` returns nothing,
  which is exactly why `quality` passed on #431 while main's own SSOT gate was red. Wiring it is a
  separate decision: `QUALITY-CHARTER.md` declares the blocking gate set CLOSED with one-in/one-out, so
  adding a seventh gate is an owner call, not a drive-by.
* Branch named `fix/ssot-rail-derive`, not `fix/v15b-ssot-rails`. The latter was rejected by GitHub with
  `Internal Server Error` on three separate attempts; pushing the identical commit under the new name
  succeeded immediately. **I first concluded the ref name was the cause — that is UNVERIFIED and probably
  wrong.** Minutes later `gh pr update-branch` on an unrelated PR returned `502 Bad Gateway`, so GitHub
  was intermittently degraded and the successful push most likely just landed in a good window. The
  content is identical either way; only the ref name differs. Settling experiment: push the original name
  again once GitHub is stable — if it succeeds, the name was never the cause.
