### PR TITLE
feat(editor): give CropPlan a real crop rect + a preview-facing selector (no preview yet)

### DIFF
--- a/app/renderer/src/lib/editorState.test.ts
+++ b/app/renderer/src/lib/editorState.test.ts
@@ -259,3 +259,45 @@ describe('crop framing carried by the editor state', () => {
     expect(cropViewport(base({ cropPlan: { engine: 'verthor' } }))).toBeNull();
   });
 });
+
+// The THIRD door. `initialEditorState` and the `setCropPlan` reducer case both
+// normalise, but an `EditorState` assembled directly does not pass through
+// either — and that is not a hypothetical shape: it is the shape `base()` uses
+// on every line above. `cropViewport` therefore validates the numbers it is
+// about to divide by instead of trusting an invariant it cannot enforce, so a
+// state built outside this module can never push Infinity or NaN into a preview.
+describe('cropViewport on a hand-built state', () => {
+  it('returns null for a framing whose source frame is not positive and finite', () => {
+    expect(
+      cropViewport(base({ cropPlan: { framing: { ...FRAMING, sourceWidth: 0 } } })),
+    ).toBeNull();
+    expect(
+      cropViewport(base({ cropPlan: { framing: { ...FRAMING, sourceHeight: Number.NaN } } })),
+    ).toBeNull();
+  });
+
+  it('returns null for a framing whose rect is degenerate or not finite', () => {
+    expect(
+      cropViewport(base({ cropPlan: { framing: { ...FRAMING, crop: [0, 0, 0, 1080] } } })),
+    ).toBeNull();
+    expect(
+      cropViewport(
+        base({ cropPlan: { framing: { ...FRAMING, crop: [0, Number.NaN, 600, 1080] } } }),
+      ),
+    ).toBeNull();
+  });
+
+  it('pulls an off-frame hand-built rect inside the frame instead of reporting it out of bounds', () => {
+    const framing: CropFraming = {
+      crop: [-400, -400, 600, 1080],
+      sourceWidth: 1920,
+      sourceHeight: 1080,
+    };
+    expect(cropViewport(base({ cropPlan: { framing } }))).toEqual({
+      x: 0,
+      y: 0,
+      width: 600 / 1920,
+      height: 1,
+    });
+  });
+});

--- a/app/renderer/src/lib/editorState.test.ts
+++ b/app/renderer/src/lib/editorState.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import {
   type CropFraming,
   type EditorAction,
@@ -299,5 +302,29 @@ describe('cropViewport on a hand-built state', () => {
       width: 600 / 1920,
       height: 1,
     });
+  });
+});
+
+// ANCHOR-ROT GUARD. This module's docstrings are its actual deliverable: the
+// crop container is dead in production, so what ships is the map telling the
+// next author where the adoption blockers live. A cross-file `path:line` pin is
+// the one citation form this repo has watched rot repeatedly, and NOTHING
+// validates these: `C13-code-anchor` in `docs/validation/tools/`
+// only matches citations whose TARGET is a `docs/**.md` file, and its own
+// comment says the scan covers "docs->docs only" while citations from
+// application source into other source are "covered by nothing". Six of the
+// files this module cites are surfaces concurrent lanes are editing right now,
+// so a line pin here is stale on someone else's next commit and no gate says so.
+// Symbols move with their code; line numbers do not. This test is that gate.
+describe('editorState docstrings (anchor-rot guard)', () => {
+  it('cites symbols, never a bare cross-file source line number', () => {
+    const source = readFileSync(
+      resolve(dirname(fileURLToPath(import.meta.url)), 'editorState.ts'),
+      'utf8',
+    );
+    // e.g. `views/Caption.tsx:110` or `lib/directorHandoff.ts:109` — a pin that
+    // silently retargets the moment the cited file gains or loses a line above.
+    const linePins = source.match(/[A-Za-z0-9_/.-]+\.tsx?:\d+/g) ?? [];
+    expect(linePins).toEqual([]);
   });
 });

--- a/app/renderer/src/lib/editorState.test.ts
+++ b/app/renderer/src/lib/editorState.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+  type CropFraming,
   type EditorAction,
   type EditorState,
   clampSelection,
+  cropFraming,
+  cropViewport,
   editorReducer,
   initialEditorState,
   transcriptReady,
@@ -159,5 +162,100 @@ describe('editorReducer', () => {
     const prev = base();
     const next = editorReducer(prev, { type: 'bogus' } as unknown as EditorAction);
     expect(next).toBe(prev);
+  });
+});
+
+// The crop rect the REFRAME phase computes, expressed in the SAME shape the
+// per-shot override layer and the sidecar already use (`Crop = [x, y, w, h]` in
+// source pixels, reframeOverride.ts). These tests pin the two doors into state
+// (seed + `setCropPlan`) and the one read a preview needs (`cropViewport`), so a
+// removed normalisation or a removed selector goes red here.
+const FRAMING: CropFraming = { crop: [100, 0, 600, 1080], sourceWidth: 1920, sourceHeight: 1080 };
+
+describe('cropFraming', () => {
+  it('rejects a source frame that is not a positive finite size', () => {
+    expect(cropFraming([0, 0, 10, 10], 0, 100)).toBeNull();
+    expect(cropFraming([0, 0, 10, 10], 100, 0)).toBeNull();
+    expect(cropFraming([0, 0, 10, 10], Number.NaN, 100)).toBeNull();
+    expect(cropFraming([0, 0, 10, 10], 100, Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it('rejects a rect that is degenerate or not finite', () => {
+    expect(cropFraming([Number.NaN, 0, 10, 10], 100, 100)).toBeNull();
+    expect(cropFraming([0, Number.NaN, 10, 10], 100, 100)).toBeNull();
+    expect(cropFraming([0, 0, 0, 10], 100, 100)).toBeNull();
+    expect(cropFraming([0, 0, 10, 0], 100, 100)).toBeNull();
+  });
+
+  it('keeps an in-frame rect and records the frame it is measured against', () => {
+    expect(cropFraming([100, 0, 600, 1080], 1920, 1080)).toEqual(FRAMING);
+  });
+
+  it('pulls an off-frame rect fully inside the source frame', () => {
+    expect(cropFraming([-50, -50, 4000, 4000], 1920, 1080)?.crop).toEqual([0, 0, 1920, 1080]);
+  });
+});
+
+describe('crop framing carried by the editor state', () => {
+  it('seeds a usable framing through initialEditorState', () => {
+    const state = initialEditorState({
+      video: { videoId: 'v1', window: WINDOW },
+      cropPlan: { engine: 'reframe_multispeaker', framing: FRAMING },
+    });
+    expect(state.cropPlan?.framing).toEqual(FRAMING);
+    expect(cropViewport(state)).toEqual({ x: 100 / 1920, y: 0, width: 600 / 1920, height: 1 });
+  });
+
+  it('seeds a plan whose framing is unusable WITHOUT the framing', () => {
+    const state = initialEditorState({
+      video: { videoId: 'v1', window: WINDOW },
+      cropPlan: { engine: 'verthor', framing: { ...FRAMING, sourceWidth: 0 } },
+    });
+    expect(state.cropPlan?.engine).toBe('verthor');
+    expect(state.cropPlan?.framing).toBeUndefined();
+    expect(cropViewport(state)).toBeNull();
+  });
+
+  it('setCropPlan stores a framing a preview can read back as fractions', () => {
+    const next = editorReducer(base(), {
+      type: 'setCropPlan',
+      cropPlan: { engine: 'reframe_multispeaker', framing: FRAMING },
+    });
+    expect(cropViewport(next)).toEqual({ x: 100 / 1920, y: 0, width: 600 / 1920, height: 1 });
+  });
+
+  it('setCropPlan clamps an off-frame rect instead of storing it raw', () => {
+    const next = editorReducer(base(), {
+      type: 'setCropPlan',
+      cropPlan: {
+        framing: { crop: [-400, -400, 600, 1080], sourceWidth: 1920, sourceHeight: 1080 },
+      },
+    });
+    expect(next.cropPlan?.framing?.crop).toEqual([0, 0, 600, 1080]);
+  });
+
+  it('setCropPlan drops an unusable framing rather than storing a NaN preview', () => {
+    const next = editorReducer(base(), {
+      type: 'setCropPlan',
+      cropPlan: { engine: 'verthor', framing: { ...FRAMING, crop: [0, 0, 0, 1080] } },
+    });
+    expect(next.cropPlan?.engine).toBe('verthor');
+    expect(next.cropPlan?.framing).toBeUndefined();
+    expect(cropViewport(next)).toBeNull();
+  });
+
+  it('setCropPlan keeps the very same plan object when nothing needs normalising', () => {
+    const plan = { engine: 'verthor', framing: FRAMING };
+    expect(editorReducer(base(), { type: 'setCropPlan', cropPlan: plan }).cropPlan).toBe(plan);
+  });
+
+  it('setCropPlan clears the plan back to null', () => {
+    const seeded = base({ cropPlan: { engine: 'verthor', framing: FRAMING } });
+    expect(editorReducer(seeded, { type: 'setCropPlan', cropPlan: null }).cropPlan).toBeNull();
+  });
+
+  it('cropViewport is null with no plan at all and with a plan that has no rect', () => {
+    expect(cropViewport(base())).toBeNull();
+    expect(cropViewport(base({ cropPlan: { engine: 'verthor' } }))).toBeNull();
   });
 });

--- a/app/renderer/src/lib/editorState.ts
+++ b/app/renderer/src/lib/editorState.ts
@@ -12,9 +12,17 @@
 // Reusability note: the Caption phase is the pilot, so `design` is a
 // `CaptionDesign` today. The OTHER four redesigned phases reuse THIS same state
 // container (that is the whole point of extracting it) — a Reframe phase edits
-// `cropPlan`, an Edit phase reads `cues`/`playhead`, etc. `cropPlan` is therefore
-// carried here as an opaque cross-phase value the Caption phase never mutates, so
-// the shared context is already reusable by that phase without a second store.
+// `cropPlan`, an Edit phase reads `cues`/`playhead`, etc. The Caption phase still
+// never mutates `cropPlan`; it only carries it, so the shared context is reusable
+// by the Reframe phase without a second store.
+//
+// `cropPlan` USED to be fully opaque ("the Reframe phase will refine the shape
+// when it adopts this container"). It now carries a real, previewable rect —
+// `CropFraming` — reusing the `Crop = [x, y, w, h]` source-pixel type the per-shot
+// override layer and the sidecar `reframe_override` contract already agree on
+// (`reframeOverride.ts`), so there is ONE crop model rather than two. Only the
+// per-engine `keyframes` stay loose; the rect does not, because the rect is the
+// one field a crop preview must be able to read.
 //
 // Everything here is IMMUTABLE — every action returns a NEW state object.
 
@@ -22,6 +30,7 @@ import type { Cue } from './rpc';
 import { type CaptionDesign, DEFAULT_CAPTION_DESIGN } from './captionDesign';
 import type { CaptionOverride } from './captionOverride';
 import type { CaptionBox } from './captionPosition';
+import { type Crop, clampCrop } from './reframeOverride';
 
 /** A source-absolute preview window (structurally a Player `PlayerWindow`). */
 export interface EditorWindow {
@@ -30,14 +39,46 @@ export interface EditorWindow {
 }
 
 /**
- * Opaque cross-phase crop plan. Owned/edited by the REFRAME phase; the Caption
- * pilot only carries it (never mutates it) so the shared editor state is already
- * reusable by that phase without introducing a second store. Kept intentionally
- * loose — the Reframe phase will refine the shape when it adopts this container.
+ * A crop rect PLUS the source frame it is measured against. Both halves are
+ * required to be previewable at all: `[x, y, w, h]` in source pixels says
+ * nothing about where it lands on screen until you know the frame it is a
+ * fraction of. `Crop` is the SAME type the per-shot override layer and the
+ * sidecar `reframe_override` contract already use, so a plan built here is
+ * byte-compatible with the shot decisions the Reframe engine emits.
+ */
+export interface CropFraming {
+  /** `[x, y, w, h]` in SOURCE pixels (matches the R0 ReframeTrace crop). */
+  readonly crop: Crop;
+  /** Source frame width the rect is expressed against (positive, finite). */
+  readonly sourceWidth: number;
+  /** Source frame height the rect is expressed against (positive, finite). */
+  readonly sourceHeight: number;
+}
+
+/**
+ * The crop as 0..1 fractions of the source frame — the form a preview overlay
+ * consumes, because it scales to whatever size a stage happens to render at.
+ */
+export interface CropViewport {
+  readonly x: number;
+  readonly y: number;
+  readonly width: number;
+  readonly height: number;
+}
+
+/**
+ * Cross-phase crop plan. Owned/edited by the REFRAME phase; the Caption pilot
+ * only carries it (never mutates it) so the shared editor state is already
+ * reusable by that phase without introducing a second store.
+ *
+ * `framing` is the rect the plan resolves to — the field a crop preview reads.
+ * `engine` and `keyframes` stay loose on purpose: the per-engine keyframe shape
+ * is still the producer's business, and nothing in the app reads it yet.
  */
 export interface CropPlan {
   readonly engine?: string;
   readonly keyframes?: readonly unknown[];
+  readonly framing?: CropFraming;
 }
 
 /** The media the editor is working on. */
@@ -75,6 +116,49 @@ export interface EditorSeed {
   design?: CaptionDesign;
 }
 
+/** True for a real, positive, finite measurement — a size safe to divide by. */
+function isPositiveSize(n: number): boolean {
+  return Number.isFinite(n) && n > 0;
+}
+
+/**
+ * Build a previewable framing from a raw rect and its source frame, or null
+ * when those numbers cannot describe one. Loud-vs-quiet is deliberate:
+ * `clampCrop` THROWS on a degenerate rect because a renderer has nothing to
+ * draw from it, but this is the STATE boundary, so it mirrors `clampSelection`
+ * instead and resolves an unusable input to "no framing". A malformed or stale
+ * plan can therefore never push NaN into a preview.
+ */
+export function cropFraming(
+  crop: Crop,
+  sourceWidth: number,
+  sourceHeight: number,
+): CropFraming | null {
+  if (!isPositiveSize(sourceWidth) || !isPositiveSize(sourceHeight)) return null;
+  const [x, y, w, h] = crop;
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return null;
+  if (!isPositiveSize(w) || !isPositiveSize(h)) return null;
+  return { crop: clampCrop(crop, sourceWidth, sourceHeight), sourceWidth, sourceHeight };
+}
+
+/**
+ * Normalise a plan on its way INTO state — the single funnel both doors (seed
+ * and `setCropPlan`) run through, so an invariant holds for every consumer: a
+ * stored `framing` is always previewable. An unusable rect is DROPPED while the
+ * plan itself survives (the "is there a crop plan" consumers keep working); an
+ * off-frame rect is pulled inside; an already-valid plan is returned BY
+ * REFERENCE so merely carrying a plan stays allocation-free.
+ */
+function normalizeCropPlan(plan: CropPlan | null): CropPlan | null {
+  if (plan === null) return null;
+  const { framing } = plan;
+  if (framing === undefined) return plan;
+  const usable = cropFraming(framing.crop, framing.sourceWidth, framing.sourceHeight);
+  if (usable === null) return { ...plan, framing: undefined };
+  if (usable.crop.every((v, i) => v === framing.crop[i])) return plan;
+  return { ...plan, framing: usable };
+}
+
 /**
  * Build the initial editor state from a seed. The playhead starts at the window
  * in-point; nothing is selected; the caption design defaults to the shipped
@@ -84,7 +168,7 @@ export function initialEditorState(seed: EditorSeed): EditorState {
   return {
     video: seed.video,
     cues: seed.cues ?? [],
-    cropPlan: seed.cropPlan ?? null,
+    cropPlan: normalizeCropPlan(seed.cropPlan ?? null),
     design: seed.design ?? DEFAULT_CAPTION_DESIGN,
     playhead: seed.video.window.start,
     selection: null,
@@ -106,6 +190,25 @@ export type EditorAction =
 /** True once at least one caption cue exists — the transcript-present gate. */
 export function transcriptReady(state: EditorState): boolean {
   return state.cues.length > 0;
+}
+
+/**
+ * The stored crop as 0..1 fractions of the source frame, or null when this
+ * state holds no rect to show. This is the read a crop PREVIEW makes: multiply
+ * by the rendered stage size to get the overlay box. Division is safe by
+ * construction — every door into `cropPlan` runs `normalizeCropPlan`, so a
+ * stored framing always carries a positive finite source frame.
+ */
+export function cropViewport(state: EditorState): CropViewport | null {
+  const framing = state.cropPlan?.framing;
+  if (framing === undefined) return null;
+  const [x, y, w, h] = framing.crop;
+  return {
+    x: x / framing.sourceWidth,
+    y: y / framing.sourceHeight,
+    width: w / framing.sourceWidth,
+    height: h / framing.sourceHeight,
+  };
 }
 
 /**
@@ -148,7 +251,7 @@ export function editorReducer(state: EditorState, action: EditorAction): EditorS
     case 'selectCue':
       return { ...state, selection: clampSelection(action.index, state.cues.length) };
     case 'setCropPlan':
-      return { ...state, cropPlan: action.cropPlan };
+      return { ...state, cropPlan: normalizeCropPlan(action.cropPlan) };
     default:
       return state;
   }

--- a/app/renderer/src/lib/editorState.ts
+++ b/app/renderer/src/lib/editorState.ts
@@ -77,8 +77,9 @@ export interface CropViewport {
  *
  * NOT LIVE YET — read this before assuming a crop can reach a screen. BOTH doors
  * into `cropPlan` are dead in production: nothing dispatches `setCropPlan`, and
- * all three production `EditorSeed` literals pass only `video`
- * (`views/Caption.tsx:110`, `views/Director.tsx:112`, `views/Export.tsx:287`).
+ * all three production `EditorSeed` literals pass only `video` — the `EditorSeed`
+ * that each of `views/Caption.tsx`, `views/Director.tsx` and `views/Export.tsx`
+ * builds for its provider.
  * `state.cropPlan` is therefore permanently `null` in the shipped app, so
  * `cropViewport` never returns a rect, `exportModel.framingSummary` can only
  * render "Original framing", and `directorHandoff`'s `hasCrop` can only be
@@ -88,10 +89,12 @@ export interface CropViewport {
  * holds the exact `(crop, sourceWidth, sourceHeight)` triple `cropFraming`
  * consumes, but it does not call `useEditor`, its host `features/ReframeCorrect`
  * does not either, and neither sits under an `EditorProvider`: the provider is
- * mounted at exactly three sibling destinations (`views/Caption.tsx:119`,
- * `views/Director.tsx:121`, `views/Export.tsx:296`) while that panel reaches the
- * tree through `views/Edit.tsx:156` -> `views/Workspace.tsx:483`, and
- * `useEditor()` throws outside a provider (`features/EditorContext.tsx:46`).
+ * mounted at exactly three sibling destinations (the `<EditorProvider>` in each
+ * of `views/Caption.tsx`, `views/Director.tsx` and `views/Export.tsx`) while that
+ * panel reaches the tree down a different spine — the `<Workspace>` element in
+ * `views/Edit.tsx`, then the `reframeFix` arm of that view's panel switch, which
+ * renders `<ReframeCorrect>` — and `useEditor` (`features/EditorContext.tsx`)
+ * throws outside a provider.
  * Wrapping the Workspace in its own provider does not fix it either — the
  * provider is UNCONTROLLED and seeds once, and those destinations render
  * exclusively, so it would be a fourth instance that unmounts on a destination
@@ -177,10 +180,10 @@ export function cropFraming(
  * An unusable rect is DROPPED while the plan itself SURVIVES, which deliberately
  * DECOUPLES "has a crop plan" from "has something to preview". Whoever adopts
  * this container owns that decision, because BOTH of today's consumers key on
- * presence alone and neither looks at the rect: `directorHandoff.landingZones`
- * (`lib/directorHandoff.ts:109,125-128`) reports the Reframe zone `ready` with
- * "Crop plan in place — framing nudges land on it.", and
- * `exportModel.framingSummary` (`features/export/exportModel.ts:383`) renders
+ * presence alone and neither looks at the rect: `landingZones`
+ * (`lib/directorHandoff.ts`) reports the Reframe zone `ready` with "Crop plan in
+ * place — framing nudges land on it.", and `framingSummary`
+ * (`features/export/exportModel.ts`) renders
  * "Reframed". For a plan whose rect was dropped, both would say yes while
  * `cropViewport` returns null — the status text promising nudges land on a rect
  * that does not exist. Switching those reads to `cropViewport(state) !== null`

--- a/app/renderer/src/lib/editorState.ts
+++ b/app/renderer/src/lib/editorState.ts
@@ -74,6 +74,29 @@ export interface CropViewport {
  * `framing` is the rect the plan resolves to — the field a crop preview reads.
  * `engine` and `keyframes` stay loose on purpose: the per-engine keyframe shape
  * is still the producer's business, and nothing in the app reads it yet.
+ *
+ * NOT LIVE YET — read this before assuming a crop can reach a screen. BOTH doors
+ * into `cropPlan` are dead in production: nothing dispatches `setCropPlan`, and
+ * all three production `EditorSeed` literals pass only `video`
+ * (`views/Caption.tsx:110`, `views/Director.tsx:112`, `views/Export.tsx:287`).
+ * `state.cropPlan` is therefore permanently `null` in the shipped app, so
+ * `cropViewport` never returns a rect, `exportModel.framingSummary` can only
+ * render "Original framing", and `directorHandoff`'s `hasCrop` can only be
+ * false. That is PRE-EXISTING and is not something this container broke.
+ *
+ * Adopting it is NOT a one-line dispatch. `panels/ReframeOverridePanel` already
+ * holds the exact `(crop, sourceWidth, sourceHeight)` triple `cropFraming`
+ * consumes, but it does not call `useEditor`, its host `features/ReframeCorrect`
+ * does not either, and neither sits under an `EditorProvider`: the provider is
+ * mounted at exactly three sibling destinations (`views/Caption.tsx:119`,
+ * `views/Director.tsx:121`, `views/Export.tsx:296`) while that panel reaches the
+ * tree through `views/Edit.tsx:156` -> `views/Workspace.tsx:483`, and
+ * `useEditor()` throws outside a provider (`features/EditorContext.tsx:46`).
+ * Wrapping the Workspace in its own provider does not fix it either — the
+ * provider is UNCONTROLLED and seeds once, and those destinations render
+ * exclusively, so it would be a fourth instance that unmounts on a destination
+ * switch and could never be read by Export or the Director handoff. Deciding who
+ * OWNS the crop plan across destinations is the real prerequisite.
  */
 export interface CropPlan {
   readonly engine?: string;
@@ -142,9 +165,11 @@ export function cropFraming(
 }
 
 /**
- * Normalise a plan on its way INTO state — the single funnel both doors (seed
- * and `setCropPlan`) run through, so an invariant holds for every consumer: a
- * stored `framing` is always previewable. An unusable rect is DROPPED while the
+ * Normalise a plan on its way INTO state — the single funnel both CODE paths in
+ * (seed and `setCropPlan`) run through, so an invariant holds for every
+ * consumer: a stored `framing` is always previewable. That is a correctness
+ * property of this module, NOT evidence that either path is live — both are
+ * currently dead in production (see `CropPlan`). An unusable rect is DROPPED while the
  * plan itself survives (the "is there a crop plan" consumers keep working); an
  * off-frame rect is pulled inside; an already-valid plan is returned BY
  * REFERENCE so merely carrying a plan stays allocation-free.

--- a/app/renderer/src/lib/editorState.ts
+++ b/app/renderer/src/lib/editorState.ts
@@ -165,14 +165,26 @@ export function cropFraming(
 }
 
 /**
- * Normalise a plan on its way INTO state — the single funnel both CODE paths in
- * (seed and `setCropPlan`) run through, so an invariant holds for every
- * consumer: a stored `framing` is always previewable. That is a correctness
- * property of this module, NOT evidence that either path is live — both are
- * currently dead in production (see `CropPlan`). An unusable rect is DROPPED while the
- * plan itself survives (the "is there a crop plan" consumers keep working); an
- * off-frame rect is pulled inside; an already-valid plan is returned BY
+ * Normalise a plan on its way INTO state — the funnel both of this module's CODE
+ * paths in (seed and `setCropPlan`) run through, so a stored `framing` is always
+ * previewable. That is a correctness property of this module, NOT evidence that
+ * either path is live — both are currently dead in production (see `CropPlan`) —
+ * and it is not a whole-program guarantee either, because a hand-built
+ * `EditorState` reaches no funnel at all (which is why `cropViewport` re-checks).
+ * An off-frame rect is pulled inside; an already-valid plan is returned BY
  * REFERENCE so merely carrying a plan stays allocation-free.
+ *
+ * An unusable rect is DROPPED while the plan itself SURVIVES, which deliberately
+ * DECOUPLES "has a crop plan" from "has something to preview". Whoever adopts
+ * this container owns that decision, because BOTH of today's consumers key on
+ * presence alone and neither looks at the rect: `directorHandoff.landingZones`
+ * (`lib/directorHandoff.ts:109,125-128`) reports the Reframe zone `ready` with
+ * "Crop plan in place — framing nudges land on it.", and
+ * `exportModel.framingSummary` (`features/export/exportModel.ts:383`) renders
+ * "Reframed". For a plan whose rect was dropped, both would say yes while
+ * `cropViewport` returns null — the status text promising nudges land on a rect
+ * that does not exist. Switching those reads to `cropViewport(state) !== null`
+ * is the open decision; it is not this module's to make unilaterally.
  */
 function normalizeCropPlan(plan: CropPlan | null): CropPlan | null {
   if (plan === null) return null;
@@ -220,19 +232,30 @@ export function transcriptReady(state: EditorState): boolean {
 /**
  * The stored crop as 0..1 fractions of the source frame, or null when this
  * state holds no rect to show. This is the read a crop PREVIEW makes: multiply
- * by the rendered stage size to get the overlay box. Division is safe by
- * construction — every door into `cropPlan` runs `normalizeCropPlan`, so a
- * stored framing always carries a positive finite source frame.
+ * by the rendered stage size to get the overlay box.
+ *
+ * It re-validates through `cropFraming` instead of trusting `normalizeCropPlan`,
+ * because normalisation owns only TWO of the three ways an `EditorState` comes
+ * to exist: `initialEditorState` and the `setCropPlan` case both funnel through
+ * it, but a state object assembled DIRECTLY does not — and that is not a
+ * hypothetical, it is the shape this module's own tests build. TypeScript cannot
+ * express "positive and finite", so the compiler cannot stop one either, and
+ * marking a field `readonly` would NOT help: `readonly` forbids a later
+ * mutation, not an object literal that carries a degenerate frame from birth.
+ * So this selector validates its own denominator and resolves an unusable rect
+ * to null exactly as `cropFraming` does — it can never emit Infinity or NaN.
  */
 export function cropViewport(state: EditorState): CropViewport | null {
   const framing = state.cropPlan?.framing;
   if (framing === undefined) return null;
-  const [x, y, w, h] = framing.crop;
+  const usable = cropFraming(framing.crop, framing.sourceWidth, framing.sourceHeight);
+  if (usable === null) return null;
+  const [x, y, w, h] = usable.crop;
   return {
-    x: x / framing.sourceWidth,
-    y: y / framing.sourceHeight,
-    width: w / framing.sourceWidth,
-    height: h / framing.sourceHeight,
+    x: x / usable.sourceWidth,
+    y: y / usable.sourceHeight,
+    width: w / usable.sourceWidth,
+    height: h / usable.sourceHeight,
   };
 }
 


### PR DESCRIPTION
# CropPlan gets a real crop rect + a preview-facing selector — **no preview yet**

> **Honesty frame** (restated here because it does not carry over between agents): every
> non-trivial claim below carries a calibrated band — almost-certain 90-99% / likely 55-80% /
> uncertain 30-55% / speculative <30% — paired with its evidence. **MEASURED** = a probe was
> run and its output read. **INFERRED** = derived from something measured. `UNVERIFIED` /
> `NOT-CHECKED` sit **inline** next to the sentence they qualify and name the experiment that
> would settle them. Nothing here was softened to be agreeable or inflated to look productive.

## WHAT CHANGED, and what the user sees

**Before this PR:** the user opens the Reframe correction panel, nudges and zooms the crop of a
shot, and the only feedback is four integers rendered as text (`[100, 0, 600, 1080]`). No crop
preview is drawn anywhere in Reframe. `CropPlan` was `{ engine?: string; keyframes?: readonly
unknown[] }` — structurally incapable of *holding* a crop rect — so even a component that wanted
to draw one had nothing to read.

**After this PR:** **exactly the same.** The user still sees four integers and no preview.

This PR changes the **shape of editor state only**, in one file plus its test. It makes the
container able to hold a crop (`CropPlan.framing?: CropFraming`), adds the validating builder a
producer would call (`cropFraming`), and adds the read a preview overlay would make
(`cropViewport`, returning 0..1 fractions of the source frame). Nothing dispatches into it and
nothing reads it, so `state.cropPlan` is **permanently `null` in the shipped app**. Do not read
this PR as "the crop is now previewable" — it is the *first* of at least three steps, and the
real blocker (step 0: no `EditorProvider` above the panel) is documented below and is **outside
this lane's file scope**.

Diff surface, MEASURED by the PR agent (mechanically independent of the fix agent's own report —
and it **corrects** that report, which listed only the test file):

```
$ git diff --name-only origin/main...HEAD
app/renderer/src/lib/editorState.test.ts
app/renderer/src/lib/editorState.ts

$ git diff --stat origin/main...HEAD
 app/renderer/src/lib/editorState.test.ts | 167 ++++++++++++++++++++++++++++++
 app/renderer/src/lib/editorState.ts      | 172 +++++++++++++++++++++++++++++--
 2 files changed, 330 insertions(+), 9 deletions(-)
```

Both files are inside the lane's declared scope, so this is **not** a scope escape — the round-4
report's `SCOPE + HYGIENE` line was simply incomplete. Almost-certain (90-99%), MEASURED at
`54469efc`.

## THE EVIDENCE — verbatim gate output

All gates below were run by the round-4 fix agent from
`.../rf-w6/croppreview/app`, at the **pinned versions CI uses** (commands taken from
`.github/workflows/quality.yml`, not from memory), at `54469efc`:

```
$ npx --yes @biomejs/biome@2.5.0 check renderer/src/lib/editorState.ts renderer/src/lib/editorState.test.ts
Checked 2 files in 50ms. No fixes applied.

$ npx tsc --noEmit
exit=0

$ npx tsc --noEmit -p tsconfig.e2e.json
exit=0

$ npx vitest run renderer/src/lib/editorState.test.ts
Test Files  1 passed (1)
     Tests  35 passed (35)

$ npx vitest run renderer/src/lib/editorState.test.ts --coverage --coverage.include=renderer/src/lib/editorState.ts
Statements   : 100% ( 84/84 )
Branches     : 100% ( 51/51 )
Functions    : 100% ( 8/8 )
Lines        : 100% ( 84/84 )

$ npx vitest run <editorState + directorHandoff + exportModel + EditorContext + features/caption>
Test Files  9 passed (9)
     Tests  150 passed (150)

$ git status --porcelain
(clean)
```

The **file count in the biome line is the control**: a wrong path reports `Checked 0 files` and
passes vacuously, so `Checked 2 files` is what makes that green mean something.

### Second, mechanically independent signal — CI on Linux at the exact head SHA

The gates above ran on a Windows box. CI ran the same gates on Linux, and I pinned the run to
the head commit rather than trusting a green badge (the stale-SHA-gate failure class). MEASURED
by the PR agent:

```
$ gh api repos/Prekzursil/Reframe/actions/runs/31801489787 --jq '{name,head_sha,conclusion}'
{"conclusion":"success","head_sha":"54469efc4e695eeb85667e70ea71f1c24ce6ee70","name":"quality"}

$ gh api repos/Prekzursil/Reframe/actions/runs/31801489724 --jq '{name,head_sha,conclusion}'
{"conclusion":"success","head_sha":"54469efc4e695eeb85667e70ea71f1c24ce6ee70","name":"mutation-incremental"}

$ gh pr checks 433
Analyze (actions)                       pass    40s
Analyze (javascript-typescript)         pass    1m20s
Analyze (python)                        pass    1m19s
CodeQL                                  pass    3s
Seer Code Review                        pass    1m59s
mutmut-incremental (sidecar)            pass    16s
quality                                 pass    5m56s
stryker-incremental (renderer)          pass    26s
fanout-kill-tasks (survivors → Codex)   skipping 0
```

That is **8 pass + 1 skipping, not "9 green"**. `fanout-kill-tasks` is the benign no-survivors
path — it only runs when stryker reports survivors. A skipped job is not a success and is not
counted as one here.

### Third signal — counts re-derived by the PR agent, not inherited

```
$ (git show HEAD:app/renderer/src/lib/editorState.test.ts | Select-String '^\s*it\(' -AllMatches).Count
35
$ (git show origin/main:app/renderer/src/lib/editorState.test.ts | Select-String '^\s*it\(' -AllMatches).Count
19
$ (git show HEAD:app/renderer/src/lib/editorState.ts | Select-String '[A-Za-z0-9_/.-]+\.tsx?:[0-9]+' -AllMatches).Count
0
```

19 → 35 (delta **16**) corroborates the vitest `35 passed`, by a different mechanism (source-text
count vs runner output). The `0` corroborates that the round-3 anchor-rot fix actually landed:
no `path:line` pin survives in the shipped source. Almost-certain (90-99%), MEASURED.

## THE GRIND RECORD — 3 fix rounds, every refuter finding accounted for

Counts from the lane's grind history: round 1 → 3 verdicts / 3 actionable; round 2 → 3 verdicts /
2 actionable; round 3 → 3 verdicts / 2 actionable. **Nothing was silently dropped.** Across all
three rounds, **not one reviewer found a defect in committed behaviour that shipped wrong** —
the recurring shape was *the code is right and a sentence was wider than its evidence*, which is
exactly the overclaim class, and it is reported as such rather than dressed up as bug-fixing.

| # | Round | Refuter finding | Verdict | Evidence / what was done |
|---|---|---|---|---|
| 1 | 1 | "The reducer case is still dead" understates it | **FIXED** (prose) | **Both** doors are dead. All three production `EditorSeed` literals were read directly (not inferred from an absence grep) and none passes `cropPlan`. Consequence now stated loudly: `framingSummary` can only render "Original framing" and `hasCrop` can only be `false`. |
| 2 | 1 | "which makes that dispatch a one-liner" | **FIXED** (prose) | Deleted, and replaced by **step 0**: there is no `EditorProvider` above `ReframeOverridePanel` at all, and `useEditor()` throws outside one — so adding the call today crashes that panel during render. A Workspace-scoped provider does not rescue it (it would be a fourth instance that unmounts on a destination switch). |
| 3 | 1 | "10 new cases, all exercising the wiring through `editorReducer`" | **FIXED** (count) | Actually **12** at that round: 4 direct on the builder + 8 through the doors. Branch total is now 16. |
| 4 | 1 | minor: "`clampCrop` is at `:60`, not `:62`" | **REFUTED** | Both numbers are right about **different things**: `:60` is the function declaration, `:62` is the `cw <= 0 \|\| ch <= 0` throw the sentence actually cites. The original text was correct; it is now disambiguated in place so the mis-correction cannot recur. |
| 5 | 2 | The doc claim *"Division is safe by construction"* is false | **FIXED** (code, test RED first) | Executably false — a state object assembled **directly** (the shape this module's own tests build) never runs `normalizeCropPlan`. RED before the fix: `AssertionError: expected { x: Infinity, y: +0, …(2) } to be null`. Remedy is a guard, not a narrower sentence: `cropViewport` re-validates through the **same** `cropFraming` validator the write path uses, so there is one definition of "usable", and it can no longer emit `Infinity`/`NaN`. |
| 5b | 2 | …the reviewer's proposed **mechanism** (`readonly` on `EditorState.cropPlan`) | **REFUTED** while accepting the finding | `readonly` forbids a later *mutation*, not an object literal that is degenerate from birth — adding it would not have closed this. The real cause is that TypeScript cannot express "positive and finite". The doc now says exactly that, so the next owner does not reach for `readonly`. |
| 6 | 2 | The plan-presence sentence presents a trade-off as benign | **RESCOPED** (no code change) | Correct, and the finding **undercounted**: it said one presence-keyed consumer, there are **two** (`landingZones` in `directorHandoff`, `framingSummary` in `exportModel`). Dropping a rect decouples plan-presence from previewability, so both would say "yes" while `cropViewport` returns `null`. **Latent, not shipping** (nothing dispatches). Both files are **outside this lane's file scope**, so the hazard is documented and handed off, not edited. |
| 7 | 3 | 11 cross-file `path:line` anchors in `editorState.ts` are validated by **nothing** | **FIXED** (code + a new gate) | Correct, and load-bearing because this lane's deliverable *is* documentation. Confirmed at `origin/main` (`4c24700b`): `_CITE_RE = re.compile(r"(docs/[A-Za-z0-9_./-]+\.md):(\d+)")` in `docs/validation/tools/verify_ssot_claims.py` matches only `docs/**.md` **targets**, and that file's own comment says source→source citations are "covered by nothing". All 11 pins were **accurate**; the defect is durability — six cited files sit on surfaces sibling lanes are editing. Every pin is now a **symbol** citation, and a new anchor-rot guard reads this module's own source and fails on any `path:line` pin. |
| 8 | 3 | The **Tests** section still asserts round-2 counts as current, tagged "MEASURED" | **RESCOPED** (body edit) | Correct and self-contradicting: one document asserted both 31 and 34 as fact. Per single-signal-verification, a self-contradicting output is a **detector failure, not a finding**. The section is now labelled a superseded `444f340b` snapshot, the "MEASURED" tag is off the stale pair, counts are re-measured mechanically at HEAD, and the dead control row (`Control: restored → 31 passed`) is flagged as no longer reproducing. |
| 9 | 3 | "`cropViewport` allocates one extra small object per call" undercounts | **RESCOPED** (sentence) | It allocates **two**: `clampCrop` returns a fresh `[x, y, w, h]` and `cropFraming` wraps it in a fresh `CropFraming`. Verified by reading `cropViewport` at HEAD against its pre-round-3 form at `0404553d`, which divided `framing.crop` directly with no call. Cost is nil because the path is dead; the shared-validator route was still the right call. |

### The round-3 fix was TDD with a mutation control

| step | result |
|---|---|
| Guard written **first**, run against the real docstrings | **RED** — listed all 11 pins, `1 failed \| 34 passed (35)` |
| After rewriting the 11 pins to symbols | **GREEN** — `35 passed (35)` |
| Mutation control: re-introduce **one** pin | **RED** — `1 failed \| 34 passed (35)`; restored → 0 pins |

The mutation control is the part that matters: without it, a guard that passes proves only that
it ran, not that it can catch a single re-introduction.

### A measurement trap that was hit and resolved (reported, not hidden)

`git grep _CITE_RE` returns **nothing** at the branch HEAD, which looked like the round-3 refuter
citing evidence that does not exist. It is not: `_CITE_RE` lives at `origin/main`, which is 1
commit ahead of this branch's merge-base (the gate landed in #430 *after* the fork). The detector
was fine (control: a known-present token matched in the same file); the **revision** differed.
Two hypotheses were stated first — "the refuter fabricated the quote" vs "I probed the wrong
revision" — and re-probing at `origin/main` distinguished them. The second is true.

## THE FRESH-SKEPTIC VERDICT — verbatim

`refuted=false severity=should-fix`

> HONESTY FRAME (restated, does not carry over): every non-trivial claim below carries a
> calibrated band — almost-certain 90-99% / likely 55-80% / uncertain 30-55% / speculative <30% —
> paired with its evidence. MEASURED = I ran the command or read the file myself at `54469efc`.
> INFERRED is labelled. UNVERIFIED/NOT-CHECKED sits inline in the sentence it qualifies and names
> the settling experiment. I did not write this code and did not review the diff; I judged the
> FINAL STATE.
>
> IDENTITY RE-VERIFIED BEFORE ANY WRITE (MEASURED): `git -C
> C:/Users/Prekzursil/.claude/rf-w6/croppreview remote get-url origin` =
> `https://github.com/Prekzursil/Reframe.git`; `rev-parse --abbrev-ref HEAD` = `fix/v15c-crop`

> ⚠️ **UNVERIFIED — the skeptic's text reached the PR agent truncated at exactly that point**
> (mid-token, `fix/v15c-crop`), so **the body of the reservation behind `severity=should-fix` is
> not reproduced here, because the PR agent never received it and will not invent it.** What is
> known is only the header: `refuted=false`, `severity=should-fix`. Settling experiment: re-read
> the skeptic agent's full transcript (or re-run the skeptic against `54469efc`) and paste the
> remainder into this section. Until then, treat this branch as carrying **at least one
> unreproduced should-fix reservation**, not as skeptic-clean. Reviewers: this is the single
> weakest link in this PR's evidence chain, and it is stated here rather than buried.

## RESIDUAL / NOT DONE

1. **NO CROP PREVIEW EXISTS.** Almost-certain (90-99%), MEASURED. This is the lane's headline
   gap and it is **not closed**. Zero production dispatch sites for `setCropPlan`; all three
   production `EditorSeed` literals omit `cropPlan`; `state.cropPlan` is permanently `null` in
   the shipped app. The live production dispatch is **not reachable inside this file scope** —
   it needs an owner for the crop plan across four mutually exclusive destinations, which is a
   cross-file decision (step 0 above).
2. **The new anchor-rot guard is file-scoped, not repo-wide.** MEASURED. It reads only
   `editorState.ts`. Other source files still carry source→source `path:line` citations that no
   gate validates; **NOT-CHECKED** how many. Settling experiment:
   `git grep -nE "[A-Za-z0-9_/.-]+\.tsx?:[0-9]+" -- app/renderer/src` and count files.
3. **A repo-wide gate hole is reported, not fixed — it is outside this lane's file scope.**
   `docs/validation/tools/verify_ssot_claims.py` at `4c24700b` validates only citations whose
   *target* is a `docs/**.md` file, so **every** source→source `path:line` citation in this repo
   is unvalidated. Widening `_CITE_RE` (or adding a repo-wide anchor lint) requires editing that
   file, which belongs to whoever owns the validation tooling.
4. **This PR body still contains historical `path:line` readings.** MEASURED. Each is pinned to
   the SHA it was measured at (`444f340b` / `6e77814c` / `0404553d`). A PR body is a frozen
   record, so SHA-labelling was judged correct rather than rewriting past measurements — which
   would destroy the record of what was actually claimed. The **shipped source** contains none
   (measured: 0).
5. **`mergeStateStatus` is `BEHIND`** — `origin/main` (`4c24700b`) is 1 commit ahead of the
   merge-base. The branch was deliberately **not** merged or updated: the orchestrator owns the
   queue. That 1 commit is #430, docs-only, so no renderer file drifted underneath. MEASURED.
6. **NOT-CHECKED, explicit: the app was never launched.** The claim "a user sees nothing new" is
   derived from zero-dispatch / zero-consumer greps plus the comment-only nature of the round-3
   source edit — **not** from observing a screen. Likewise the step-0 claim that `useEditor()`
   would throw is derived from render topology, not observed. Settling experiment: add
   `useEditor()` to `ReframeOverridePanel` and render `Workspace.test.tsx`'s `reframeFix` case.
   Also **NOT-CHECKED**: the `stryker-incremental (renderer)` job log was not read, so it is
   unconfirmed that it genuinely mutated `editorState.ts`; it ships shadow/observe-only, so it
   could not have blocked either way.
7. **`UNVERIFIED`: the guard's regex `[A-Za-z0-9_/.-]+\.tsx?:\d+` does not catch every citation
   form** — e.g. "line 110 of Caption.tsx", or a `.py`/`.css` target. It closes the form that
   actually rotted here, not every conceivable form. Settling experiment: add a `.py` pin to a
   docstring and confirm the guard stays green — it will, and that is a disclosed limit, not a
   completeness claim.
8. **`UNVERIFIED`: whether the right temporal key for a moving crop is shot index or frame
   number.** A plan today carries ONE STATIC RECT, and Reframe's differentiator is a **tracked**
   crop, which a single rect structurally cannot express. Settling experiment: read how
   `reframe_override.py` maps a decision onto output frames (renderer-side is already settled:
   the override layer keys by shot index; frames are presentational).

### Provenance of this document

This PR was **not created by this pass** — it already existed as #433 and `gh pr create` refused
a duplicate (`a pull request for branch "fix/v15c-croppreview" into branch "main" already
exists`). This body was **updated in place**. Sections above the horizontal rule that are tagged
"MEASURED by the PR agent" were re-derived independently in this pass (diff surface, `it(` counts,
pin count, CI head-SHA pinning); the gate transcript is quoted from the round-4 fix agent's report
and was corroborated — not replaced — by the CI run pinned to the same SHA. Everything below the
rule is the accumulated round-by-round record and is preserved unedited.

---

## What a user can see after this PR

**Nothing new.** This is editor-state plumbing only. There is still no crop preview
anywhere in Reframe: no pixels moved, no overlay is drawn, and no component reads the
new selector yet. Do not read this PR as "the crop is now previewable".

## What was actually wrong

`CropPlan` was `{ engine?: string; keyframes?: readonly unknown[] }` — structurally
incapable of carrying a crop rect — and `setCropPlan` had **zero** production dispatch
sites.

MEASURED (`grep setCropPlan app/` → 4 matches, repo-wide, at `f8cfbd6c`): the action
declaration `editorState.ts:104`, the reducer case `editorState.ts:150`, and two test
lines. Its only production consumers read it as a **boolean**:

* `lib/directorHandoff.ts:109` — `const hasCrop = state.cropPlan !== null;`
* `features/export/exportModel.ts:383` — `state.cropPlan ? 'Reframed' : 'Original framing'`

This was never a bug. The docstring said so: *"Kept intentionally loose — the Reframe
phase will refine the shape when it adopts this container."* The container was built
speculatively and the consumer never arrived. This PR performs that adoption **for the
shape only**.

## The rect is not invented — it already existed

`lib/reframeOverride.ts:18` already defines the production crop type:
`Crop = readonly [x, y, w, h]` in **source pixels**. Two independent probes confirm it
is the real wire shape, not just a renderer convention:

1. `reframeOverride.ts:11,17-18` — the TS type and its docstring ("crop is `[x, y, w, h]`
   in source pixels, matching the R0 ReframeTrace").
2. The **producer itself**, `sidecar/media_studio/features/reframe_override.py:96`
   ("`crop` — the crop rectangle `(x, y, w, h)` in source pixels") and its parser at
   `:247` (`raise OverrideError("crop must be [x, y, w, h]")`).

So `CropPlan` now reuses `Crop` rather than defining a second, divergent crop model.
Confidence: almost-certain (90-99%), MEASURED at both ends of the wire.

## What this PR adds (all in `lib/editorState.ts`)

| Export | Role |
| --- | --- |
| `CropFraming { crop, sourceWidth, sourceHeight }` | A rect **plus** the frame it is measured against — a rect alone cannot be drawn. Field names mirror `ShotPlan`'s `sourceWidth`/`sourceHeight`. |
| `CropPlan.framing?: CropFraming` | The rect. Additive and optional. |
| `cropFraming(crop, w, h)` | Validating builder a producer calls. Returns `null` when the numbers cannot describe a rect; clamps an off-frame rect inside via the existing `clampCrop`. |
| `cropViewport(state)` | The read a preview overlay makes — the rect as 0..1 fractions of the source frame. `null` when there is nothing to show. |
| `normalizeCropPlan` (internal) | The single funnel **both code paths into state** run through. |

**Widening breaks no caller** (verified, not assumed): `framing` is optional, so every
existing construction still type-checks, and both boolean consumers above are
null-checks that this PR never changes. The pre-existing identity assertions
(`expect(state.cropPlan).toBe(cropPlan)` at `editorState.test.ts:55` and `:155`) still
pass because `normalizeCropPlan` returns the plan **by reference** when nothing needs
normalising.

### The invariant that makes the selector safe

Both code paths — the `initialEditorState` seed and the `setCropPlan` reducer case — run
`normalizeCropPlan`, so *a stored `framing` is always previewable*. An unusable rect is
dropped (the plan itself survives, so `hasCrop`/`framingSummary` keep working) and an
off-frame rect is pulled inside. That is why `cropViewport` can divide without guarding
against a zero or NaN source frame. The state layer deliberately resolves bad input to
"no framing" — mirroring `clampSelection` — rather than throwing the way `clampCrop`
does, because a reducer that throws takes the React tree with it.

Note this is a **correctness property of the module**, not evidence that either path is
live. Both are currently dead in production — see the next section.

## What is still missing — do not claim this is done

**BOTH doors into `cropPlan` are dead in production, not just the reducer.** MEASURED at
`444f340b`:

* No production `dispatch({ type: 'setCropPlan', ... })` exists anywhere. An exact-token
  grep over `app` + `sidecar` + `docs` returns only the action union
  (`editorState.ts:188`), the reducer case (`:253`), a doc line, and tests.
* **No production seed sets it either.** All three `EditorSeed` literals pass only
  `video`: `views/Caption.tsx:110`, `views/Director.tsx:112`, `views/Export.tsx:287`
  (read directly, not inferred from an absence grep).

So `state.cropPlan` is provably **permanently `null`** in the shipped app. Every line
added here past `normalizeCropPlan`'s `plan === null` early return is 100% test-covered
and 0% production-exercised. The consequence is worth stating separately and loudly,
because it is user-visible: the two pre-existing consumers are pinned to their no-crop
branch, so `exportModel.framingSummary` can only ever render **"Original framing"** and
`directorHandoff`'s `hasCrop` can only ever be **false**. *"Reframed"* is unreachable UI
copy today — the shipped UI permanently tells the user the flagship reframing did not
happen. That is **pre-existing**, is NOT introduced by this PR, and is not fixable
inside this PR's declared file scope (`lib/editorState.ts` only).

### Remaining work, in order — step 0 is new and is the real blocker

0. **Give the crop plan an app-level owner.** This was previously described as making
   the dispatch "a one-liner". That was wrong, and so was the weaker correction that the
   panel merely "does not currently call `useEditor`". The actual blocker is that
   **there is no `EditorProvider` above that panel at all.** `ReframeOverridePanel`
   reaches the tree only through `views/Edit.tsx:156` → `views/Workspace.tsx:79,483` →
   `features/ReframeCorrect.tsx:243`, and none of those four files references
   `EditorContext` / `useEditor` / `EditorProvider`. The provider is mounted at exactly
   three **sibling** destinations (`views/Caption.tsx:119`, `views/Director.tsx:121`,
   `views/Export.tsx:296`), and `useEditor()` throws outside one
   (`features/EditorContext.tsx:46`) — so adding the call today crashes that panel
   during render.
   Wrapping the Workspace in its own provider does **not** rescue it either.
   `EditorProvider` is explicitly UNCONTROLLED and seeds once
   (`EditorContext.tsx:9-11,37`), and `App.tsx` returns Refine▸Editor (`:604`),
   Refine▸Caption (`:599`), Produce▸Director (`:590`) and Deliver▸Export (`:620`) as
   mutually exclusive destinations. A Workspace-scoped provider would therefore be a
   **fourth independent instance that unmounts on a destination switch**, and a crop
   dispatched into it could never be read by Export's `framingSummary` or the Director
   handoff. Deciding who owns the crop plan across those four destinations (lifted state
   or persistence) is a separate, larger work item.
   MEASURED, almost-certain (90-99%): `<Workspace` occurs in production at exactly one
   site, `views/Edit.tsx:156`, and is never a child of the three provider views — this
   settles the experiment an earlier review pass left open. NOT-CHECKED: the app was not
   launched, so the throw and the unmount are derived from the render topology, not
   observed on screen; settling experiment = add `useEditor()` to
   `ReframeOverridePanel` and render `Workspace.test.tsx`'s `reframeFix` case.
1. **Then** connect the panel and dispatch
   `setCropPlan({ framing: cropFraming(shot.crop, plan.sourceWidth, plan.sourceHeight) })`
   on nudge (`ReframeOverridePanel.tsx:120`) / zoom (`:126`). The panel already holds the
   exact `(crop, sourceWidth, sourceHeight)` triple `cropFraming()` consumes.
2. **Then** draw the overlay from `cropViewport(state)` in a Stage component. **Until
   this exists, no user can see a crop.**
3. Type `keyframes` for a crop that MOVES. A plan today carries ONE STATIC RECT, and
   Reframe's differentiator is a TRACKED crop, which a single rect structurally cannot
   express. Step 1 is done only for a static rect.
   UNVERIFIED: whether the right temporal key is shot index or frame number — settled by
   reading how `ShotDecision.startFrame`/`endFrame` are consumed by the R1 engine.

## Tests

> **SUPERSEDED ROUND-2 SNAPSHOT — measured at `444f340b`, not at HEAD.** Round 3 review
> caught this section still asserting round-2 counts as current fact, and asserting them
> with a "MEASURED" tag, while a table further down said something different. Both the
> counts and the tag are corrected here rather than deleted, so the record shows what was
> actually claimed. **Current counts live in [Gates](#gates-pinned-versions-re-run-at-54469efc)
> at the bottom.** In particular the control row below (`Control: restored → 31 passed`)
> no longer reproduces at HEAD — do not re-run it expecting 31.

**12 new cases in round 2** (superseded — the branch now carries **16** new cases in
total): 4 unit-test the exported `cropFraming` builder directly, and 8 exercise the wiring
**through** `editorReducer` / `initialEditorState` rather than calling the internal
normaliser — so deleting the normalisation from either door turns them red. They pin: the
builder's rejection classes and its clamping, both doors into state, drop-vs-clamp,
reference preservation, and the selector's two null paths.

Count as re-measured at `54469efc` (mechanically, not by eye —
`(git show <rev>:…editorState.test.ts | Select-String '^\s*it\(' -AllMatches).Count`):
`it(` blocks go **19 → 35** against `origin/main` (`4c24700b`), delta **16**, and vitest
reports `Tests 35 passed (35)`. The round-2 figures were 19 → 31 / `31 passed`; the
round-3 guard added 3 and the round-4 anchor guard added 1.

TDD evidence (round 2, at `444f340b`): the new tests were run before the implementation
and failed (`10 failed | 21 passed (31)`, `TypeError: (0 , cropViewport) is not a
function`), then passed after (`31 passed (31)`). Ten of the twelve fail with the
implementation absent; the two that do not are the reference-preservation and
clear-to-null cases, which hold under the old shape too. That red-proof is genuine and is
NOT superseded — only the totals moved.

---

## Independent verification pass (second agent, fresh context)

A second lane agent re-ran this branch from scratch and tried to break the claims above
rather than trust them. Everything below is MEASURED by that agent, not inherited.

**Gates re-run at `444f340b`** (pinned versions, as CI uses):

| Gate | Result |
| --- | --- |
| `npx vitest run src/lib/editorState.test.ts` | `Tests 31 passed (31)` |
| coverage, scoped to `editorState.ts` | `100 / 100 / 100 / 100` (stmts/branch/funcs/lines) |
| `npx --yes @biomejs/biome@2.5.0 check` (both files) | `Checked 2 files. No fixes applied.` |

**The "deleting the normalisation turns them red" claim was not taken on trust — it was
executed.** Both doors were mutated in turn and the suite re-run (a both-states probe: a
test that stays green under mutation is not protecting the behaviour):

| Probe | Result |
| --- | --- |
| Reducer door: `normalizeCropPlan(action.cropPlan)` → `action.cropPlan` | **RED** — `Tests 2 failed \| 29 passed` (off-frame rect stored raw; unusable framing stored) |
| Seed door: `normalizeCropPlan(seed.cropPlan ?? null)` → `seed.cropPlan ?? null` | **RED** — `Tests 1 failed \| 30 passed` |
| Control: restored | **GREEN** — `Tests 31 passed (31)` |

Both mutations were reverted; the working tree was confirmed clean afterwards. CONFIRMED,
almost-certain (90-99%): the tests are load-bearing on both doors, not decorative.

> **Round-4 note on the three rows above:** every number in this block is a `444f340b`
> reading and none reproduces at HEAD (the totals are now 35). The *verdict* — both doors
> are load-bearing — still holds, because a mutation that took 2 tests red at 31 takes the
> same 2 red at 35. Re-running the control at HEAD yields `35 passed (35)`, not `31`.

**"Widening breaks no caller" re-measured by a different grep** (`cropPlan`, lower-case,
production files only — the pattern in the section above would not have matched these two
call sites, so this is a mechanically independent probe). Exactly two production consumers
exist outside `editorState.ts`, both bare null-checks, neither touched:
`lib/directorHandoff.ts:109` and `features/export/exportModel.ts:383`. CONFIRMED.

**`clampCrop` cannot throw through this path.** `reframeOverride.ts:62` — the guard
inside `clampCrop`, which is *declared* at `:60` — throws only on `cw <= 0 || ch <= 0`;
`cropFraming` rejects on `Number.isFinite(w) && w > 0` first, which is strictly stronger
(it also rejects `NaN`, which would slip past `cw <= 0` and produce a NaN rect). So the
"the state layer resolves bad input instead of throwing" claim holds — the reducer cannot
take the React tree down. CONFIRMED, MEASURED at `editorState.ts:120,140`.

### The gap is more concrete than "no preview exists"

`panels/ReframeOverridePanel.tsx` already holds a real `ShotPlan` (`:75`) and already lets
the user **nudge** (`:120`) and **zoom** (`:126`) the crop of any shot. What it renders back
is `cropText(shot.crop)` — the four numbers as a string, `[100, 0, 600, 1080]` (`:69`, `:275`).

So Reframe today ships an **interactive crop editor whose only feedback is a text readout of
four integers.** That is the user-facing shape of this gap, and it is worth stating plainly
in whatever issue tracks the follow-up. The panel is genuinely reachable —
`Workspace.tsx:483` → `ReframeCorrect.tsx:243`, fed by the trace-free
`reframe.shotPlanFor` door (`client.ts:1112`, called at `ReframeCorrect.tsx:130`) — so this
is a live surface, not a theoretical one.

That panel is also the precise landing site for step 1 of the remaining work: it is the one
production component that already has the exact `(crop, sourceWidth, sourceHeight)` triple
`cropFraming()` consumes (`plan.sourceWidth` / `plan.sourceHeight` are already passed to
`nudgeCrop`/`zoomCrop` on those same lines). What it still lacks is an editor context to
dispatch into — see step 0 above, which is the blocker.

### Refinement of the UNVERIFIED above ("shot index or frame number?")

Partially settled, renderer-side, MEASURED: `startFrame`/`endFrame` are consumed in the
renderer at exactly one place, `ReframeOverridePanel.tsx:211`, and only as a **display
label** (`frames {shot.startFrame}–{shot.endFrame}`). The override layer keys by **shot
index**, not by frame — `ShotOverride.index`, resolved through a `Map<number, ShotOverride>`
in `applyShotOverrides` (`reframeOverride.ts:135-146`). So within the renderer the temporal
key is the shot index and frames are presentational.

NOT-CHECKED: the sidecar R1 engine was not read, so this does not settle what the *engine*
keys on. Settling experiment: read how `reframe_override.py` maps a decision onto output
frames. Until then, treat "shot index" as renderer-local (likely, 55-80%), not as the
cross-wire answer.

---

## Round-1 grind (third pass, three independent reviewers)

Three reviewers attacked this branch on different angles (does-it-work, did-it-break, and
a claim audit). **None found a code defect** — all four falsification probes against the
committed code failed to break it. Every finding was the same shape: the code is right and
a sentence was wider than its evidence. So this round changed **no behaviour**; it corrected
sentences, and moved the load-bearing correction into `editorState.ts`'s own doc comment
(commit `0404553d`), because the module is where the next owner looks and a PR body is not.

Corrected in place, not appended (the body previously carried both "a one-liner" and "not a
one-liner" five sections apart):

1. "The reducer case is still dead" → **both doors are dead**, with the seed-side evidence
   and the user-visible "Original framing" consequence now stated.
2. "which makes that dispatch a one-liner" → **deleted**, replaced by step 0: there is no
   `EditorProvider` above the panel, and adding one at the Workspace does not connect the
   handoff either.
3. "10 new cases, all exercising the wiring through `editorReducer`" → **12 new cases**,
   4 direct + 8 through the doors. (Round-2 figure; the branch total is now **16**.)

One reviewer minor was **refuted rather than applied**: a claim that `clampCrop` is "at
`:60`, not `:62`". Both line numbers are right about different things — `:60` is the
function declaration, `:62` is the `cw <= 0 || ch <= 0` throw the sentence actually cites.
The original text was correct; it is now disambiguated in place so the mis-correction does
not recur.

**CI status is 8 checks pass + 1 skipped**, not "9 SUCCESS": `fanout-kill-tasks
(survivors → Codex)` reports `skipping`, which is the benign no-survivors path (it only
runs when stryker finds survivors, and `stryker-incremental` passed). A skipped job is not
a success and should not be counted as one.

Gates re-run after the doc change **at `444f340b`**, at the pinned versions CI uses: biome
2.5.0 `Checked 2 files`, `Tests 31 passed (31)` (a round-2 total — `35` at HEAD), coverage
`100 / 100 / 100 / 100` on `editorState.ts`, and `npx tsc --noEmit` exit 0 (the typecheck
neither vitest nor biome can substitute for).

**A user can still see NOTHING new. No crop preview exists.**



---

## Round 3 — `6e77814c` — one overclaim FIXED in code, one RESCOPED

Two grind findings, both against sentences in `editorState.ts`. They got different
treatments because only one had an in-scope code remedy.

### FIXED: `cropViewport` now guards its own division

The doc claimed *"Division is safe by construction — every door into `cropPlan` runs
`normalizeCropPlan`"*. That was **executably false**, and this is the RED that proved it
before the fix:

```
AssertionError: expected { x: Infinity, y: +0, …(2) } to be null
```

Normalisation owns only **two** of the three ways an `EditorState` comes to exist.
`initialEditorState` and the `setCropPlan` reducer case funnel through it; a state object
assembled **directly** does not — and that is not hypothetical, it is the shape this
module's own tests build via `base({ cropPlan: … })` (`editorState.test.ts:26`).

The remedy is the guard, not a narrower sentence: `cropViewport` re-validates through
`cropFraming` — the **same** validator the write path uses, so there is one definition of
"usable" rather than two — and resolves an unusable rect to `null`. It can no longer emit
`Infinity` or `NaN` from any input. This also brings the read side in line with the
module's own stated design (`cropFraming`'s doc: *"this is the STATE boundary … a
malformed or stale plan can therefore never push NaN into a preview"*); previously only
the write side honoured that.

**Correcting the reviewer's mechanism while accepting the finding:** the hole is NOT that
`EditorState.cropPlan` lacks `readonly`. `readonly` forbids a later *mutation*, not an
object literal that carries a degenerate frame from birth — adding it would not have
closed this. The real cause is that TypeScript cannot express "positive and finite". The
doc now says exactly that, so the next owner does not reach for `readonly` as the fix.

### RESCOPED: the plan-presence sentence (no code change — the code is out of scope)

`normalizeCropPlan`'s doc said an unusable rect is dropped *"while the plan itself
survives (the 'is there a crop plan' consumers keep working)"*. That presents a trade-off
as unambiguously benign; measured against the consumers, it is not. The doc now states
that dropping the rect **decouples plan-presence from previewability**, names both
consumers that key on presence alone, and names the open decision.

Both consumers, confirmed by a repo-wide grep of `cropPlan` (the finding said there was
exactly **one**; there are **two**):

* `landingZones` in `lib/directorHandoff.ts` — reports the Reframe zone `ready` with
  "Crop plan in place — framing nudges land on it."
* `framingSummary` in `features/export/exportModel.ts` — renders "Reframed"

For a plan whose rect was dropped, both would say yes while `cropViewport` returns `null`
— the status text promising nudges land on a rect that does not exist. Switching those
reads to `cropViewport(state) !== null` is the open decision. **Latent, not shipping:**
unreachable today because nothing dispatches `setCropPlan`. Those two files are **outside
this lane's file scope**, so the hazard is documented and handed off, not edited.

## Round 4 — the anchor-rot defect, and two corrected sentences

Round-3 review returned two findings, both `should-fix`, neither blocking. One was a real
defect in the deliverable; two were over-wide sentences. All three are addressed here.

### FIXED (code + new gate): 11 unvalidated cross-file `path:line` anchors

This lane's actual deliverable is **documentation** — a deliberately dead crop container
plus a map of the adoption blockers. Round 3 pinned that map with 11 hardcoded cross-file
`path:line` anchors in `editorState.ts` docstrings, and **nothing validates them.**

Measured at **`origin/main` = `4c24700b`**, not at the branch tip — the gate landed in
#430 *after* this branch's merge-base (`f8cfbd6c`), which is why it does not appear at
`6e77814c`. `git grep _CITE_RE` returns nothing at HEAD and three hits at `origin/main`:

* `docs/validation/tools/verify_ssot_claims.py` — `_CITE_RE = re.compile(r"(docs/[A-Za-z0-9_./-]+\.md):(\d+)")`
  feeding `check("C13-code-anchor", …)`. It matches only citations whose **target** is a
  `docs/**.md` file, so `views/Caption.tsx:110` matches nothing.
* the same file's own comment: the citing-side scan `ROOT.glob("docs/**/*.md")` "covers
  docs->docs only", and citations from application source into other source are
  "covered by nothing".
* `docs/plans/v1.5/uiux-qol-audit-2026-08.md` already records the rule — *"Cite the
  SYMBOL, not the line"* — because a bare line range "has now rotted here repeatedly".

**All 11 anchors were accurate — none was false at merge time.** The defect is durability:
six of the cited files sit on surfaces concurrent lanes are editing right now, so the pins
rot on someone else's next commit and no gate would say so.

Every pin is now a symbol citation (the `EditorSeed` each view builds, the three
`<EditorProvider>` mounts, the `<Workspace>` element in `views/Edit.tsx`, the `reframeFix`
arm rendering `<ReframeCorrect>`, `useEditor`, `landingZones`, `framingSummary`), and a
new **anchor-rot guard** test reads this module's own source and fails on any `path:line`
pin — so the gate that was missing now exists for this file.

TDD, both-states:

| step | result |
|---|---|
| Guard written first, run against the real docstrings | **RED** — listed all 11 pins, `1 failed \| 34 passed (35)` |
| After rewriting the 11 pins to symbols | **GREEN** — `35 passed (35)` |
| Mutation control: re-introduce **one** pin (`features/EditorContext.tsx:46`) | **RED** — `1 failed \| 34 passed (35)`; restored → 0 pins |

The mutation control matters: without it, a guard that passes proves only that it ran.

### RESCOPED (no code change): the stale Tests section

The round-3 report claimed the PR body was verified. It verified the ends and missed the
middle: the **Tests** section still carried round-2 counts, tagged "MEASURED two ways",
while a table lower down said `34 passed`. One document asserted both 31 and 34 as fact.
Per single-signal-verification, a self-contradicting output is a **detector failure, not a
finding**. Corrected above: the section is labelled a superseded `444f340b` snapshot, the
"MEASURED" tag no longer sits on the stale pair, current counts are re-measured
mechanically at HEAD, and the dead control row (`Control: restored → 31 passed`) is
flagged as not reproducing.

### RESCOPED (no code change): the allocation count undercounted by one

Round 3 said `cropViewport` "allocates one extra small object per call". It allocates
**two**: `clampCrop` returns a fresh `[x, y, w, h]` array (`reframeOverride.ts`, `return
[x, y, w, h];`) and `cropFraming` wraps it in a fresh `CropFraming` — on top of the
`CropViewport` literal it already allocated before round 3. Verified by reading
`cropViewport` at HEAD against its pre-round-3 form at `0404553d`, which divided
`framing.crop` directly with no call. Cost is nil in production because the path is dead;
the shared-validator route was still the right call, so that the read and the write can
never disagree about what "usable" means.

### Gates (pinned versions, re-run at `54469efc`)

| gate | result |
|---|---|
| `biome@2.5.0 check` | `Checked 2 files`, no fixes — the file **count** is the control; a wrong path reports `Checked 0 files` and passes vacuously |
| `tsc --noEmit` | exit 0 |
| `tsc --noEmit -p tsconfig.e2e.json` | exit 0 |
| `editorState.test.ts` | **35 passed (35)** |
| 9 suites touching the changed surface | **150 passed** |
| coverage of `editorState.ts` | **100%** — 84/84 stmts, 51/51 branches, 8/8 funcs |

Round 3's coverage counts (82 → 84 statements, 49 → 51 branches) are unchanged by round 4,
because the round-4 source edit is **comment-only** — no new production branch exists to
cover. The one new test is a source-text guard, not a behavioural path.

### Citation discipline in this PR body

Every remaining `path:line` in this document is a **historical** reading pinned to the SHA
stated beside it (`444f340b`, `6e77814c`, `0404553d`). The shipped source no longer
contains any. Where a citation is load-bearing for the handoff, it is by symbol.

### Unchanged by rounds 3 and 4

Nothing dispatches `setCropPlan`; all three production `EditorSeed` literals still omit
`cropPlan`; `state.cropPlan` is permanently `null` in the shipped app. Work item 2 (a live
production dispatch) remains **not done and not reachable inside this file scope** — it
needs an owner for the crop plan across destinations, which is a cross-file decision.

**A user can still see NOTHING new. No crop preview exists.**



