### PR TITLE
feat(library): show source format on the card; harden poster fallback

### DIFF
--- a/app/renderer/src/components/library-cards.css
+++ b/app/renderer/src/components/library-cards.css
@@ -184,8 +184,14 @@ li.library__item:focus-within .library__select,
   background: var(--status-error);
 }
 
-/* Quiet "Added <date>" meta line — additive, never a duplicate of a badge. */
-.library__item-added {
+/* Quiet source-facts line — additive, never a duplicate of a badge.
+   RENAMED from `.library__item-added`: this lane made the line carry the container
+   format as well as the date ("MP4 · Added 2026-06-11"), so a class called
+   `item-added` no longer described what it holds. The name is the documentation,
+   and a stale one is the same defect class as a stale line citation.
+   NOT `.library__item-meta` — that is a different, already-occupied element (the
+   flex row of card actions, LibraryCard.tsx:267). */
+.library__item-facts {
   color: var(--text-faint);
   font-size: var(--type-caption-size);
 }

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -246,11 +246,15 @@ describe('LibraryCard', () => {
   });
 
   it('recovers the poster when a NEW url arrives after a load error (no glyph latch)', async () => {
-    // A stored poster that has since been deleted from disk: the <img> errors and
-    // the card falls back to the glyph. The sidecar then regenerates it and
-    // `library.list` re-renders the SAME card with a fresh path — the poster MUST
-    // come back. A boolean "this card failed" flag latches forever and strands the
-    // card on the glyph until it unmounts (view switch / app restart).
+    // A poster that failed to load, then a DIFFERENT poster url for the same
+    // card — the <img> MUST come back. A boolean "this card failed" flag latches
+    // forever and strands the card on the glyph until it unmounts.
+    //
+    // The fixture is a data-DIRECTORY change (same `<id>.jpg`, new root) because
+    // that is the only such transition the wire can actually produce. The sidecar
+    // regenerates a poster to the SAME `data_dir/thumbnails/<id>.jpg`
+    // (handlers/library_ops.py:181), so regeneration is deliberately NOT recovered
+    // and a `v1-regen.jpg` fixture would pin a path production never emits.
     await renderCard();
     const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
     act(() => {
@@ -258,10 +262,10 @@ describe('LibraryCard', () => {
     });
     expect(container.querySelector('img.library__thumb-img')).toBeNull();
 
-    await renderCard({ video: makeVideo({ thumbnailPath: '/data/thumbnails/v1-regen.jpg' }) });
+    await renderCard({ video: makeVideo({ thumbnailPath: '/data2/thumbnails/v1.jpg' }) });
     const back = container.querySelector('img.library__thumb-img') as HTMLImageElement;
     expect(back).not.toBeNull();
-    expect(back.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/v1-regen.jpg'));
+    expect(back.getAttribute('src')).toBe(videoThumbnailSrc('/data2/thumbnails/v1.jpg'));
   });
 
   it('keeps the glyph while the SAME failed url is still being served', async () => {

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -103,14 +103,28 @@ describe('LibraryCard', () => {
     const open = container.querySelector('.library__item-open') as HTMLButtonElement;
     expect(open.getAttribute('aria-label')).toBe('Open Talk, 10:05, no transcript');
     expect(container.querySelector('.library__item-title')?.textContent).toBe('Talk');
-    expect(container.querySelector('.library__item-added')?.textContent).toBe('Added 2026-06-11');
+    expect(container.querySelector('.library__item-added')?.textContent).toBe(
+      'MP4 · Added 2026-06-11',
+    );
     const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
     expect(img.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/v1.jpg'));
     expect(container.querySelector('.library__thumb-duration')?.textContent).toBe('10:05');
   });
 
-  it('omits the added line when the timestamp is unparseable', async () => {
+  it('shows the container format alongside the added date in the quiet meta line', async () => {
+    await renderCard({ video: makeVideo({ path: 'C:\\Videos\\talk.MOV' }) });
+    expect(container.querySelector('.library__item-added')?.textContent).toBe(
+      'MOV · Added 2026-06-11',
+    );
+  });
+
+  it('keeps the format alone when the timestamp is unparseable', async () => {
     await renderCard({ video: makeVideo({ addedAt: 'nope' }) });
+    expect(container.querySelector('.library__item-added')?.textContent).toBe('MP4');
+  });
+
+  it('omits the meta line entirely when neither format nor date is derivable', async () => {
+    await renderCard({ video: makeVideo({ addedAt: 'nope', path: '/movies/talk' }) });
     expect(container.querySelector('.library__item-added')).toBeNull();
   });
 

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -103,7 +103,7 @@ describe('LibraryCard', () => {
     const open = container.querySelector('.library__item-open') as HTMLButtonElement;
     expect(open.getAttribute('aria-label')).toBe('Open Talk, 10:05, no transcript');
     expect(container.querySelector('.library__item-title')?.textContent).toBe('Talk');
-    expect(container.querySelector('.library__item-added')?.textContent).toBe(
+    expect(container.querySelector('.library__item-facts')?.textContent).toBe(
       'MP4 · Added 2026-06-11',
     );
     const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
@@ -113,19 +113,19 @@ describe('LibraryCard', () => {
 
   it('shows the container format alongside the added date in the quiet meta line', async () => {
     await renderCard({ video: makeVideo({ path: 'C:\\Videos\\talk.MOV' }) });
-    expect(container.querySelector('.library__item-added')?.textContent).toBe(
+    expect(container.querySelector('.library__item-facts')?.textContent).toBe(
       'MOV · Added 2026-06-11',
     );
   });
 
   it('keeps the format alone when the timestamp is unparseable', async () => {
     await renderCard({ video: makeVideo({ addedAt: 'nope' }) });
-    expect(container.querySelector('.library__item-added')?.textContent).toBe('MP4');
+    expect(container.querySelector('.library__item-facts')?.textContent).toBe('MP4');
   });
 
   it('omits the meta line entirely when neither format nor date is derivable', async () => {
     await renderCard({ video: makeVideo({ addedAt: 'nope', path: '/movies/talk' }) });
-    expect(container.querySelector('.library__item-added')).toBeNull();
+    expect(container.querySelector('.library__item-facts')).toBeNull();
   });
 
   it('shows the FAILED attention badge before the Transcript chip', async () => {

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -250,11 +250,12 @@ describe('LibraryCard', () => {
     // card — the <img> MUST come back. A boolean "this card failed" flag latches
     // forever and strands the card on the glyph until it unmounts.
     //
-    // The fixture is a data-DIRECTORY change (same `<id>.jpg`, new root) because
-    // that is the only such transition the wire can actually produce. The sidecar
-    // regenerates a poster to the SAME `data_dir/thumbnails/<id>.jpg`
-    // (handlers/library_ops.py:181), so regeneration is deliberately NOT recovered
-    // and a `v1-regen.jpg` fixture would pin a path production never emits.
+    // The second url is an ARBITRARY different one and is deliberately NOT a
+    // claim about the wire: production has no known path that hands a mounted
+    // card a second non-empty poster url (see the VideoThumb JSDoc — the stored
+    // path is what feeds the url, and nothing rewrites it once set). What this
+    // pins is the guard's SHAPE — keyed on the failed URL, not on a boolean —
+    // so a future writer that DOES diverge the path cannot strand the card.
     await renderCard();
     const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
     act(() => {

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -245,6 +245,39 @@ describe('LibraryCard', () => {
     expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
   });
 
+  it('recovers the poster when a NEW url arrives after a load error (no glyph latch)', async () => {
+    // A stored poster that has since been deleted from disk: the <img> errors and
+    // the card falls back to the glyph. The sidecar then regenerates it and
+    // `library.list` re-renders the SAME card with a fresh path — the poster MUST
+    // come back. A boolean "this card failed" flag latches forever and strands the
+    // card on the glyph until it unmounts (view switch / app restart).
+    await renderCard();
+    const img = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    act(() => {
+      img.dispatchEvent(new Event('error'));
+    });
+    expect(container.querySelector('img.library__thumb-img')).toBeNull();
+
+    await renderCard({ video: makeVideo({ thumbnailPath: '/data/thumbnails/v1-regen.jpg' }) });
+    const back = container.querySelector('img.library__thumb-img') as HTMLImageElement;
+    expect(back).not.toBeNull();
+    expect(back.getAttribute('src')).toBe(videoThumbnailSrc('/data/thumbnails/v1-regen.jpg'));
+  });
+
+  it('keeps the glyph while the SAME failed url is still being served', async () => {
+    // The complement of the recovery case: a re-render that does not change the
+    // poster url must NOT optimistically re-show an <img> known to be broken.
+    await renderCard();
+    act(() => {
+      (container.querySelector('img.library__thumb-img') as HTMLImageElement).dispatchEvent(
+        new Event('error'),
+      );
+    });
+    await renderCard({ selected: true });
+    expect(container.querySelector('img.library__thumb-img')).toBeNull();
+    expect(container.querySelector('.library__thumb-fallback')).not.toBeNull();
+  });
+
   it('falls back to the glyph when on-demand poster generation yields nothing', async () => {
     // thumbnailPath omitted entirely -> the `video.thumbnailPath ?? ''` fallback,
     // then on-demand generation via library.thumbnail (which fails here).

--- a/app/renderer/src/views/LibraryCard.test.tsx
+++ b/app/renderer/src/views/LibraryCard.test.tsx
@@ -153,6 +153,35 @@ describe('LibraryCard', () => {
     expect(onOpen.mock.calls[0][0].id).toBe('v1');
   });
 
+  it('keeps the whole-card open action free of NESTED interactive controls', async () => {
+    // The card's primary action is the card BODY itself — a <button> wrapping the
+    // poster and title — so every other control (select / shorts / provenance /
+    // remove) must be its SIBLING. A control nested inside it is invalid HTML and
+    // breaks keyboard + AT traversal.
+    //
+    // This guard exists because the card's one real residual is that nothing on it
+    // reads "Open" in VISIBLE text, and the obvious fix — dropping an
+    // <button>Open</button> into the card body — lands inside this button. A
+    // non-interactive label (a <span>) is the shape that passes here; a nested
+    // control is not. The rule is enforced, not merely commented.
+    const INTERACTIVE = 'button, a[href], input, select, textarea, [tabindex], [role="button"]';
+    await renderCard({ shortsCount: 3, provenance: provenanceHandlers() });
+
+    const item = container.querySelector('li.library__item') as HTMLLIElement;
+    const open = container.querySelector('.library__item-open') as HTMLButtonElement;
+    expect(open.tagName).toBe('BUTTON');
+    // The primary action really is the whole body: poster + title live inside it.
+    expect(open.querySelector('.library__thumb')).not.toBeNull();
+    expect(open.querySelector('.library__item-title')).not.toBeNull();
+    // DETECTOR CONTROL: the same selector must MATCH on this card, or the zero
+    // below would only prove the selector is broken. Deliberately a lower BOUND,
+    // not an exact count — an exact count would redden for any legitimately added
+    // sibling control and would shadow the assertion this test actually exists
+    // for (measured: it did, on the first run of this guard).
+    expect(item.querySelectorAll(INTERACTIVE).length).toBeGreaterThanOrEqual(4);
+    expect(open.querySelectorAll(INTERACTIVE)).toHaveLength(0);
+  });
+
   it('re-labels the open action in lineage view', async () => {
     await renderCard({ lineageView: true });
     expect(

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -44,11 +44,26 @@ const thumbnailRpc: VideoThumbnailRpc = {
  * The failure is remembered as the URL THAT FAILED, not as a boolean. `posterUrl`
  * changes after mount — `useVideoThumbnail` re-serves it whenever `thumbnailPath`
  * changes and swaps in the on-demand result when generation resolves
- * (components/useVideoThumbnail.ts:53-71) — so a boolean flag latches: a card
- * whose stored poster had been deleted from disk stayed on the ▶ glyph even after
- * the sidecar regenerated it, until the card unmounted (view switch / restart).
- * Comparing against the failed URL self-resets on a NEW poster and still refuses
- * to optimistically re-show the same broken one.
+ * (components/useVideoThumbnail.ts:53-71) — so comparing against the failed URL
+ * self-resets on a genuinely NEW poster URL while still refusing to
+ * optimistically re-show the same broken one.
+ *
+ * SCOPE OF THAT BENEFIT, measured: this is HARDENING, not a fix for "the poster
+ * never comes back after the sidecar regenerates it". Regeneration reuses the
+ * deterministic path `data_dir/thumbnails/<id>.jpg` (handlers/library_ops.py:181;
+ * its writers at :183/:194 are the only `UPDATE entity SET thumbnail_path`,
+ * library.py:484-485) and `thumbMediaUrl` adds no cache-buster
+ * (components/Player.tsx:121-123), so a regenerated poster is a BYTE-IDENTICAL
+ * URL and the card stays on the ▶ glyph exactly as it did under a boolean flag.
+ * For a fixed data directory the non-empty URLs one mounted card can ever see are
+ * a singleton, which makes the two forms equivalent. The reachable transition is
+ * a data-DIRECTORY change, which re-roots the same `<id>.jpg` — NOT relink
+ * (relink.py never touches thumbnailPath) and NOT keepCopy (library.py:929-930
+ * rewrites the project manifest, not the entity row `library.list` reads).
+ * UNVERIFIED whether a data-dir change preserves the mounted card (views/
+ * Library.tsx keys by `video.id`) or remounts it; if it remounts this branch has
+ * no reachable production path. Settle it by changing the data directory with the
+ * Library view open and watching whether LibraryCard instances are torn down.
  */
 function VideoThumb({ video }: { video: Video }): React.ReactElement {
   const posterUrl = useVideoThumbnail(thumbnailRpc, video.id, video.thumbnailPath ?? '');

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -7,6 +7,52 @@
 // A11Y: the open action and the select/remove/shorts controls are SIBLINGS, never
 // nested inside one another (no nested-interactive); resting depth is the surface
 // ladder + --elev-* (library-cards.css), not a border-everywhere box.
+//
+// SCOPE of the "finish the card" work, MEASURED at this tip. Three of the four
+// asks were already satisfied by the shipped card; only the fourth is open, and
+// two of them would be REGRESSIONS if done again:
+//   * PRIMARY ACTION — EXISTS, and is the visually dominant control. The card
+//     BODY is the button (`.library__item-open` below) and its accessible name
+//     already begins with "Open" (cardAriaLabel -> "Open Talk, 10:05, no
+//     transcript"). It is `background: transparent` ON PURPOSE
+//     (library-cards.css:40-53) because the PARENT paints for it: `li.library__
+//     item` is `--surface-raised` + `--elev-1` at rest (:29/:31), lifts with
+//     `--shadow-raise` + `translateY(-3px)` on hover (:55-61), presses on active
+//     (:69-72), takes `--focus-ring` on `:focus-visible` (:63-67) and shows
+//     `cursor: pointer` (:52). Reading that one CHILD rule alone and concluding
+//     "nothing paints as Open at rest" is a whole-component verdict drawn from a
+//     single selector — the parent rule three declarations above refutes it.
+//   * DEMOTE REMOVE — ALREADY DONE; doing it again would be a regression.
+//     `.library__remove-btn` carries the GHOST voice (shell.css:520-527 — no
+//     fill, no edge, no shadow at rest, `--text-muted`) with a never-filled
+//     quiet-red hover (:588-593). It is the QUIETEST control here, not the
+//     loudest.
+//   * METADATA — DELIVERED to the limit of the record. `library.list` returns
+//     id, path, title, addedAt, durationSec, hasTranscript, thumbnailPath and
+//     nothing else (components/api.ts:65-78) — no resolution, codec or fps — so
+//     duration (the poster badge) + container format (`sourceFormatLabel`) is
+//     the entire available surface. Anything richer needs a sidecar field first.
+//   * THE ONE RESIDUAL — no VISIBLE text on the card reads "Open"; the
+//     affordance rides entirely on depth, cursor and the accessible name. On a
+//     card with shorts the painted "N shorts" pill is a second text-labelled
+//     control, so "the only labelled control is the destructive one" holds only
+//     when shortsCount is 0. Closing the residual needs
+//     `components/library-cards.css`, OUTSIDE this lane's file scope, so it is
+//     reported rather than reached for.
+//
+// Two constraints for whoever closes that residual, both measured here:
+//   1. Do NOT nest a control inside `.library__item-open` — it IS a <button>, so
+//      a nested <button>Open</button> is invalid HTML and breaks keyboard/AT. A
+//      non-interactive <span> is the shape that works. This is now enforced by a
+//      TEST, not a comment (LibraryCard.test.tsx, "free of NESTED interactive").
+//   2. Do NOT give the label fill or elevation — its parent already carries
+//      `--surface-raised` + `--elev-1`, and a raised box inside a raised box
+//      fights the documented depth-not-outline decision (library-cards.css:17-21).
+// And not a shortcut: reusing `.library__shorts-label` to get a painted pill with
+// zero CSS is reachable from this file, but that class is an INTERACTIVE voice —
+// `cursor: pointer` (library-cards.css:208) plus a hover fill (:214-217) — so a
+// non-interactive cue wearing it renders a phantom button. Being reachable inside
+// file scope is not the same as being coherent.
 import React, { useState } from 'react';
 
 import { rpc } from '../components/api';
@@ -47,11 +93,15 @@ const thumbnailRpc: VideoThumbnailRpc = {
  *
  * SCOPE, measured: NO transition currently reaches that benefit. This is PURE
  * DEFENSIVE HARDENING, not a fix for an observed bug. An <img> renders only
- * while `posterUrl` is non-empty, and `posterUrl` is '' until a poster resolves
- * and then holds ONE value for the rest of the component's lifetime — so
- * `failedUrl !== posterUrl` is equivalent to a boolean `!failed`,
- * UNCONDITIONALLY (not merely "for a fixed data directory"). Two independent
- * reasons, either alone sufficient:
+ * while `posterUrl` is non-empty, and `posterUrl` holds ONE value for the rest
+ * of the component's lifetime — so `failedUrl !== posterUrl` is equivalent to a
+ * boolean `!failed`, UNCONDITIONALLY (not merely "for a fixed data directory").
+ * (It is NOT necessarily '' on the first render, as an earlier draft of this
+ * note said: `useVideoThumbnail` seeds its state SYNCHRONOUSLY from
+ * `thumbnailPath` (components/useVideoThumbnail.ts:51), so a row that already
+ * carries a poster path is non-empty immediately. That does not disturb the
+ * one-value-per-lifetime invariant, which is what the equivalence rests on.)
+ * Three independent reasons, any ONE alone sufficient:
  *   1. The URL is a pure function of the STORED PATH STRING: `thumbMediaUrl`
  *      embeds the whole path and adds no cache-buster (Player.tsx:121-123), so
  *      the data ROOT is not an input to it.
@@ -61,6 +111,11 @@ const thumbnailRpc: VideoThumbnailRpc = {
  *      (handlers/library_ops.py:183/:194) — and the renderer calls that RPC
  *      ONLY while `thumbnailPath` is empty, because the hook short-circuits
  *      first (components/useVideoThumbnail.ts:53-58).
+ *   3. The list is IDENTITY-KEYED: Library.tsx renders `<LibraryCard
+ *      key={video.id}>` (views/Library.tsx:797-798), so a sort / filter / search
+ *      re-order cannot hand a SURVIVING mounted card a DIFFERENT video. That
+ *      closes the last route by which one mounted card could ever observe a
+ *      second non-empty poster URL.
  * So a data-DIRECTORY change re-roots the FILES but not the row `library.list`
  * returns; relink (relink.py never touches thumbnailPath) and keepCopy
  * (library.py:929-930 rewrites the project manifest, not the entity row) emit

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -66,6 +66,23 @@ function VideoThumb({ video }: { video: Video }): React.ReactElement {
   );
 }
 
+/**
+ * The source CONTAINER format for the card's quiet meta line — the extension of
+ * `video.path`, uppercased ("MP4", "MOV"). The frozen `library.list` payload has
+ * no resolution / codec / fps fields at all (`components/api.ts:65-78` — id,
+ * path, title, addedAt, durationSec, hasTranscript, thumbnailPath), so the
+ * container is the only technical fact the record actually supports; anything
+ * richer has to come from the sidecar, not from a guess here.
+ *
+ * Returns '' when the path carries no usable extension (an extensionless file,
+ * or a leading-dot name with no stem) so the caller drops the segment instead of
+ * rendering a stray separator.
+ */
+function sourceFormatLabel(path: string): string {
+  const match = /[^\\/.]\.([A-Za-z0-9]{1,5})$/.exec(path);
+  return match ? match[1].toUpperCase() : '';
+}
+
 export interface LibraryCardProps {
   video: LibraryVideo;
   /** Lineage view re-labels the open action + diverts it to the history drawer. */
@@ -94,6 +111,13 @@ export function LibraryCard({
 }: LibraryCardProps): React.ReactElement {
   const badges = cardBadges(video);
   const added = formatAdded(video.addedAt);
+  // One quiet caption carries both technical facts the record supports, dot-
+  // separated ("MP4 · Added 2026-06-11"). Either half may be missing, so the
+  // line is assembled from the present parts and omitted entirely when empty —
+  // never an orphan separator and never an empty <span>.
+  const meta = [sourceFormatLabel(video.path), added ? `Added ${added}` : '']
+    .filter(Boolean)
+    .join(' · ');
 
   return (
     <li className="library__item">
@@ -134,7 +158,7 @@ export function LibraryCard({
               {video.path}
             </span>
           )}
-          {added ? <span className="library__item-added">Added {added}</span> : null}
+          {meta ? <span className="library__item-added">{meta}</span> : null}
         </div>
       </button>
 

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -41,29 +41,38 @@ const thumbnailRpc: VideoThumbnailRpc = {
  * (empty URL or an <img> load error) falls back to the ▶ glyph and NEVER blocks
  * the gallery. The duration badge always renders (mm:ss).
  *
- * The failure is remembered as the URL THAT FAILED, not as a boolean. `posterUrl`
- * changes after mount — `useVideoThumbnail` re-serves it whenever `thumbnailPath`
- * changes and swaps in the on-demand result when generation resolves
- * (components/useVideoThumbnail.ts:53-71) — so comparing against the failed URL
- * self-resets on a genuinely NEW poster URL while still refusing to
- * optimistically re-show the same broken one.
+ * The failure is remembered as the URL THAT FAILED, not as a boolean, so the
+ * guard self-resets on a genuinely NEW poster URL instead of stranding the card
+ * on the ▶ glyph until it unmounts.
  *
- * SCOPE OF THAT BENEFIT, measured: this is HARDENING, not a fix for "the poster
- * never comes back after the sidecar regenerates it". Regeneration reuses the
- * deterministic path `data_dir/thumbnails/<id>.jpg` (handlers/library_ops.py:181;
- * its writers at :183/:194 are the only `UPDATE entity SET thumbnail_path`,
- * library.py:484-485) and `thumbMediaUrl` adds no cache-buster
- * (components/Player.tsx:121-123), so a regenerated poster is a BYTE-IDENTICAL
- * URL and the card stays on the ▶ glyph exactly as it did under a boolean flag.
- * For a fixed data directory the non-empty URLs one mounted card can ever see are
- * a singleton, which makes the two forms equivalent. The reachable transition is
- * a data-DIRECTORY change, which re-roots the same `<id>.jpg` — NOT relink
- * (relink.py never touches thumbnailPath) and NOT keepCopy (library.py:929-930
- * rewrites the project manifest, not the entity row `library.list` reads).
- * UNVERIFIED whether a data-dir change preserves the mounted card (views/
- * Library.tsx keys by `video.id`) or remounts it; if it remounts this branch has
- * no reachable production path. Settle it by changing the data directory with the
- * Library view open and watching whether LibraryCard instances are torn down.
+ * SCOPE, measured: NO transition currently reaches that benefit. This is PURE
+ * DEFENSIVE HARDENING, not a fix for an observed bug. An <img> renders only
+ * while `posterUrl` is non-empty, and `posterUrl` is '' until a poster resolves
+ * and then holds ONE value for the rest of the component's lifetime — so
+ * `failedUrl !== posterUrl` is equivalent to a boolean `!failed`,
+ * UNCONDITIONALLY (not merely "for a fixed data directory"). Two independent
+ * reasons, either alone sufficient:
+ *   1. The URL is a pure function of the STORED PATH STRING: `thumbMediaUrl`
+ *      embeds the whole path and adds no cache-buster (Player.tsx:121-123), so
+ *      the data ROOT is not an input to it.
+ *   2. Nothing rewrites that string once non-empty. Its only writer is
+ *      `set_thumbnail` (library.py:484-485, the sole `UPDATE entity SET
+ *      thumbnail_path`), reached only by the on-demand generator
+ *      (handlers/library_ops.py:183/:194) — and the renderer calls that RPC
+ *      ONLY while `thumbnailPath` is empty, because the hook short-circuits
+ *      first (components/useVideoThumbnail.ts:53-58).
+ * So a data-DIRECTORY change re-roots the FILES but not the row `library.list`
+ * returns; relink (relink.py never touches thumbnailPath) and keepCopy
+ * (library.py:929-930 rewrites the project manifest, not the entity row) emit
+ * none either; and a refreshed `thumbnailPath` prop on this mounted card —
+ * which the hook DOES re-serve (useVideoThumbnail.ts:75) — resolves to the same
+ * deterministic `data_dir/thumbnails/<id>.jpg`, hence the same URL. The
+ * URL-keyed form is kept because it is strictly no-worse than the boolean and
+ * self-heals if a future writer ever diverges the path, NOT because anything
+ * reaches it today. UNVERIFIED that no OUT-OF-BAND writer exists (a hand-edited
+ * DB, a future migration); settle it by changing the data directory with the
+ * Library view open and logging whether `library.thumbnail` is ever dispatched
+ * for a video whose row already holds a poster path — prediction: zero.
  */
 function VideoThumb({ video }: { video: Video }): React.ReactElement {
   const posterUrl = useVideoThumbnail(thumbnailRpc, video.id, video.thumbnailPath ?? '');

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -40,11 +40,20 @@ const thumbnailRpc: VideoThumbnailRpc = {
  * generating it on demand (idempotent server-side). A missing / failed poster
  * (empty URL or an <img> load error) falls back to the ▶ glyph and NEVER blocks
  * the gallery. The duration badge always renders (mm:ss).
+ *
+ * The failure is remembered as the URL THAT FAILED, not as a boolean. `posterUrl`
+ * changes after mount — `useVideoThumbnail` re-serves it whenever `thumbnailPath`
+ * changes and swaps in the on-demand result when generation resolves
+ * (components/useVideoThumbnail.ts:53-71) — so a boolean flag latches: a card
+ * whose stored poster had been deleted from disk stayed on the ▶ glyph even after
+ * the sidecar regenerated it, until the card unmounted (view switch / restart).
+ * Comparing against the failed URL self-resets on a NEW poster and still refuses
+ * to optimistically re-show the same broken one.
  */
 function VideoThumb({ video }: { video: Video }): React.ReactElement {
   const posterUrl = useVideoThumbnail(thumbnailRpc, video.id, video.thumbnailPath ?? '');
-  const [imgFailed, setImgFailed] = useState(false);
-  const showImg = posterUrl !== '' && !imgFailed;
+  const [failedUrl, setFailedUrl] = useState('');
+  const showImg = posterUrl !== '' && failedUrl !== posterUrl;
 
   return (
     <div className="library__thumb">
@@ -54,7 +63,7 @@ function VideoThumb({ video }: { video: Video }): React.ReactElement {
           src={posterUrl}
           alt=""
           aria-hidden="true"
-          onError={() => setImgFailed(true)}
+          onError={() => setFailedUrl(posterUrl)}
         />
       ) : (
         <div className="library__thumb-fallback" aria-hidden="true">

--- a/app/renderer/src/views/LibraryCard.tsx
+++ b/app/renderer/src/views/LibraryCard.tsx
@@ -23,10 +23,17 @@
 //     "nothing paints as Open at rest" is a whole-component verdict drawn from a
 //     single selector — the parent rule three declarations above refutes it.
 //   * DEMOTE REMOVE — ALREADY DONE; doing it again would be a regression.
-//     `.library__remove-btn` carries the GHOST voice (shell.css:520-527 — no
+//     `.library__remove-btn` carries the GHOST voice (shell.css:535-543 — no
 //     fill, no edge, no shadow at rest, `--text-muted`) with a never-filled
-//     quiet-red hover (:588-593). It is the QUIETEST control here, not the
+//     quiet-red hover (:603-608). It is the QUIETEST control here, not the
 //     loudest.
+//     CORRECTED, not silently rewritten: these read `:520-527` and `:588-593`,
+//     which were accurate when written and were falsified by a SIBLING lane in
+//     the same wave — PR #438 inserted a 15-line comment block higher in
+//     shell.css, shifting every anchor below it by +15. Nothing in this file
+//     changed. A per-lane reviewer structurally cannot catch that: the
+//     falsifying edit lives in another branch. Verified by locating the anchors
+//     by CONTENT in the merged tree, not by adding 15.
 //   * METADATA — DELIVERED to the limit of the record. `library.list` returns
 //     id, path, title, addedAt, durationSec, hasTranscript, thumbnailPath and
 //     nothing else (components/api.ts:65-78) — no resolution, codec or fps — so
@@ -246,7 +253,7 @@ export function LibraryCard({
               {video.path}
             </span>
           )}
-          {meta ? <span className="library__item-added">{meta}</span> : null}
+          {meta ? <span className="library__item-facts">{meta}</span> : null}
         </div>
       </button>
 


### PR DESCRIPTION
## Honesty frame (restated — it does not carry over)

Calibrated band on every non-trivial claim: **almost-certain** (90-99%) / **likely** (55-80%) /
**uncertain** (30-55%) / **speculative** (<30%), each paired with its evidence. **UNVERIFIED** is
attached INLINE to the sentence it qualifies and names the experiment that would settle it.
**MEASURED** (I ran it) is separated from **INFERRED** (I reasoned it) and from
**LANE-REPORTED** (an earlier agent ran it; I did not re-run it). `NOT-CHECKED` is stated as such.
Nothing here is softened to be agreeable or inflated to look productive.

Judged at **489e7a3a** (`git ls-remote origin refs/heads/fix/v15c-libcard` → `489e7a3a`), base
`main` = **4c24700b**. MEASURED.

---

## WHAT CHANGED — and what the user actually sees

Three changes. **Only one of them is visible to a user.**

### 1. USER-VISIBLE — the card's quiet caption now leads with the source container format

| | |
|---|---|
| **Before** | `Added 2026-06-11` |
| **After** | `MP4 · Added 2026-06-11` |

The uppercased extension of `video.path`, joined to the date with ` · `. Either half may be
missing and the line degrades instead of breaking: an unparseable timestamp leaves `MP4` alone;
a path with no usable extension **and** an unparseable date drops the caption entirely rather
than rendering an orphan separator or an empty `<span>`.

Why the container and nothing richer: `library.list` returns id / path / title / addedAt /
durationSec / hasTranscript / thumbnailPath and nothing else
(`app/renderer/src/components/api.ts:65-78`) — **no resolution, no codec, no fps**. The container
is the ceiling of what the record supports; anything more needs a sidecar field first. Duration
already rides the poster badge and is deliberately not duplicated into the caption.

Code: `sourceFormatLabel()` + the `meta` join in `app/renderer/src/views/LibraryCard.tsx`.

### 2. NOT user-visible — the poster fallback no longer latches (defensive hardening)

`VideoThumb` remembered "this poster failed" as a boolean nothing ever reset
(`useState(false)` → first `<img>` error strands the card on the ▶ glyph for the mounted card's
whole lifetime). It now remembers **the URL that failed**:

```
-  const [imgFailed, setImgFailed] = useState(false);
-  const showImg = posterUrl !== '' && !imgFailed;
+  const [failedUrl, setFailedUrl] = useState('');
+  const showImg = posterUrl !== '' && failedUrl !== posterUrl;
```

**Stated plainly, and stated in the source itself: no production path reaches the benefit today.**
An `<img>` renders only while `posterUrl` is non-empty, and `posterUrl` holds ONE value for the
mounted card's lifetime, so the URL-keyed form is **unconditionally** equivalent to the boolean it
replaced. Three independent legs, any one sufficient (all cited inline in the `VideoThumb` JSDoc):
the URL is a pure function of the stored path with no cache-buster (`components/Player.tsx:121-123`);
the only writer of that string is `set_thumbnail` (`library.py:484-485`), reachable only while
`thumbnailPath` is empty (`components/useVideoThumbnail.ts:53-58`); and the list is identity-keyed,
`<LibraryCard key={video.id}>` (`views/Library.tsx:797-798`), so a re-order cannot hand a surviving
mounted card a different video. It is kept because it is strictly no-worse than the boolean and
self-heals if a future writer ever diverges the path — **hardening, not a bug fix**, and the source
says exactly that rather than claiming a symptom it does not fix.

### 3. NOT user-visible — one new guard test

Nothing interactive may nest inside `.library__item-open`, which **is** a `<button>`. This converts
a prose warning two skeptics gave into an executable rule.

### Net delivery of this branch over `main`

**The `MP4 · ` prefix on the date caption. That is all a user can see.** Nothing else on the card
looks or behaves differently. Said plainly so a long, well-cited PR is not mistaken for a larger
delivery than it is.

Diffstat vs `4c24700b` (MEASURED): 2 files, 199 insertions, 6 deletions — of which the
`LibraryCard.tsx` delta is overwhelmingly comment (the round-3 component delta was 65 changed
lines, 0 non-comment).

---

## THE EVIDENCE — verbatim gate output

### Re-run by me in this worktree at 489e7a3a (MEASURED)

**Biome, pinned 2.5.0, the two lane files:**
```
Checked 2 files in 92ms. No fixes applied.
```

**Vitest, scoped to the lane suite:**
```
 ✓ renderer/src/views/LibraryCard.test.tsx (20 tests) 723ms

 Test Files  1 passed (1)
      Tests  20 passed (20)
```
(19 at the previous tip; +1 is the new nested-interactive guard.)

**Full renderer suite under the coverage gate — `npx vitest run --coverage` from `app/`, exit 0:**
```
 ...erer/src/views |     100 |      100 |     100 |     100 |
  Library.tsx      |     100 |      100 |     100 |     100 |
  LibraryCard.tsx  |     100 |      100 |     100 |     100 |
  libraryModel.ts  |     100 |      100 |     100 |     100 |

=============================== Coverage summary ===============================
Statements   : 100% ( 24694/24694 )
Branches     : 100% ( 8126/8126 )
Functions    : 100% ( 1450/1450 )
Lines        : 100% ( 24694/24694 )
================================================================================
```

**This closes a residual the lane had left open.** The lane declared coverage `NOT-CHECKED` and
argued 100% still held by arithmetic (component delta = 0 non-comment lines, so no new production
branch exists). That argument was INFERRED and is now **MEASURED**: the gate ran and is green at
100/100/100/100, with `LibraryCard.tsx` at 100 on all four axes.

### A detector failure worth recording (LANE-REPORTED, and it was caught, not buried)

The lane's first biome invocation returned:
```
Checked 0 files in 10ms
These paths were provided but ignored
```
with **exit 1**. A "0 files checked" reading is a broken detector, not a green gate — the path root
is `renderer/src/...`, not `src/...`. It was re-run against the real paths and only then counted.
My re-run above independently confirms the detector is live (**2** files checked, not 0).

### Both-states proofs from the grind (LANE-REPORTED via commit bodies, not re-run by me)

* Poster-latch guard, mutation to the boolean form →
  `LibraryCard.test.tsx:267:22 "expected null not to be null", 1 failed | 18 passed (19)`;
  restored → `19 passed (19)`. So the recovery test discriminates the two forms and is not inert.
* New nested-interactive guard, proved in **both** states: inserting `<button>Open</button>` into
  the card body (the exact follow-up implementation the skeptics predicted) reddens it; reverting
  greens it. Its detector control is a lower bound (`>= 4` interactive controls on the card) rather
  than an exact count, after an exact count shadowed the real assertion on the guard's first run.

---

## THE GRIND RECORD — 3 rounds, 9 findings, nothing dropped silently

**First, a mapping disclosure, because the PR should not present more precision than exists.**
The round→commit mapping below is **INFERRED** (likely, 55-80%) from commit ordering plus the
lane handoff, not MEASURED. The specific ambiguity: `41eea0ff`'s own body describes itself as
correcting what "Round 2" shipped, while the handoff places `41eea0ff` as the tip that round 3
*started* from (corroborated by the skeptic's note that a stale `origin/` ref sat at `41eea0ff`,
one commit behind `489e7a3a`). Both are consistent only if round 2 produced **two** commits — its
first rescope and that rescope's own correction. **UNVERIFIED** which reading is right; settled by
reading the orchestrator's per-round refuter transcripts.

**Second, a coverage disclosure about this very section.** The verbatim finding TEXTS for rounds 1
and 2 are not preserved in anything I can read — what survives is the *fixer's* account of them in
the commit bodies (which is unusually detailed, and is quoted below). **UNVERIFIED** that no
round-1 or round-2 finding was dropped without leaving a trace in a commit body; settled by the
same transcripts. Round 3's three findings I have in full and they are reproduced completely.

### Round 1 → `8dabb614` — one genuine code defect, FIXED

* **FIXED.** `VideoThumb` latched the ▶ glyph forever after a single `<img>` error. Replaced the
  boolean with the failed-URL memory. Red-proof recorded: the recovery test failed before the
  change (`"expected null not to be null"`) and mutation-checking both directions reddened 3 of 19
  cases, so neither new test is inert. Coverage held at 100/100/100/100.
* The round's other findings are not individually recoverable from the durable record (see the
  coverage disclosure above).

### Round 2 → `1e9e626c` + `41eea0ff` — the fix was sound; its RATIONALE was false, twice

This is the round that most deserves a reviewer's attention, because **the branch shipped a false
sentence, then shipped a different false sentence replacing it, and both were caught.**

* **RESCOPED (`1e9e626c`).** The shipped claim — *"a card whose stored poster had been deleted from
  disk stayed on the glyph even after the sidecar regenerated it"* — names a transition regeneration
  **cannot produce**: both persisters write the same deterministic
  `data_dir/thumbnails/<id>.jpg` (`handlers/library_ops.py:181/:183/:194`),
  `library.py:484-485` is the only `UPDATE entity SET thumbnail_path`, the URL is a pure function of
  that path, and the card is identity-keyed. The code stayed; the sentence was rescoped to
  "hardening against a state the wire cannot currently produce".
* **REFUTED, with evidence (`1e9e626c`).** Two reviewers proposed *"a relink / keepCopy moved the
  bytes"* as the reachable path. Measured against the source: `relink.py` contains **zero**
  occurrences of `thumbnail` (it re-points `path`, never `thumbnailPath`), and
  `library.py:929-930` (consolidate/keepCopy) rewrites the poster ref inside the **project manifest**
  saved at `:932`, not the entity row `library.list` reads. Neither emits the transition.
* **FIXED (`41eea0ff`).** The *replacement* rationale was also false: *"the reachable transition is a
  data-DIRECTORY change, which re-roots the same `<id>.jpg`"*. It cannot occur either — the URL
  embeds the whole stored path with no cache-buster, so the data root is not an input to it. Replaced
  with the **unconditional** equivalence (one value per mounted lifetime), which needs no data-dir or
  singleton reasoning at all. A fourth candidate transition the refuters never enumerated — the
  parent re-rendering this mounted card with a refreshed `thumbnailPath` prop, which the hook does
  re-serve (`useVideoThumbnail.ts:75`) — was checked here and collapses too: same deterministic path,
  same URL. Zero runtime lines changed, mechanically checked with a detector control proving the
  non-comment filter fires.

### Round 3 → `489e7a3a` — all three RESCOPED, plus one sub-inference REFUTED

* **Finding 1 — RESCOPED, with one sub-inference REFUTED on new evidence.**
  *Confirmed by re-derivation:* the earlier "items 1-2 are CSS-blocked" verdict was drawn from the
  `.library__item-open` box (`library-cards.css:40-53`) **in isolation, while the PARENT paints for
  it** — `li.library__item` is `--surface-raised` + `--elev-1` at rest (`:29`/`:31`), lifts with
  `--shadow-raise` + `translateY(-3px)` on hover (`:55-61`), takes `--focus-ring` on `:focus-visible`
  (`:63-67`), and shows `cursor: pointer` (`:52`), with the depth-not-outline intent stated verbatim
  at `:17-21`. A whole-component verdict drawn from a single child selector.
  *Also confirmed:* `.library__shorts-label` is a painted, text-labelled control, so "the only
  labelled control is the destructive one" holds **only** when `shortsCount` is 0.
  *REFUTED:* that reaching that pill by className alone made the work deliverable inside file scope.
  **MEASURED** — the class carries `cursor: pointer` (`library-cards.css:208`) plus a hover fill
  (`:214-217`), i.e. an **interactive voice**, so a non-interactive cue wearing it renders a phantom
  button; a mutation run also showed it collides with three shipped shorts-label tests. Finding 1
  cited `:197-212`, a range **containing** the `cursor: pointer` line, without weighing it.
  Reachable inside file scope is not the same as coherent, and a wrong refutation must not drive a
  code change.
* **Finding 2 — RESCOPED.** Flagged a report sentence, not code. Its in-code item is fixed: the
  `VideoThumb` JSDoc no longer claims `posterUrl` is `''` until a poster resolves —
  `useVideoThumbnail.ts:51` is `useState(() => videoThumbnailSrc(thumbnailPath))`, a **synchronous**
  seed, so a row already holding a path is non-empty on the FIRST render. (Verified by reading the
  file, not by accepting the finding. The one-value-per-lifetime invariant the equivalence rests on
  is undisturbed.)
* **Finding 3 — RESCOPED.** Also a report sentence. Its in-code item is fixed: the equivalence
  rationale gains its third independent leg — `views/Library.tsx:797-798` renders
  `<LibraryCard key={video.id}>`, identity-keyed, so a re-order cannot hand a surviving mounted card
  a different video.

The corrected scope claim is now written **into the file header** (`LibraryCard.tsx:11-58`) with
path:line citations, rather than left in a report — three separate skeptics each re-derived this
from scratch, and a fourth would too. Three constraints for whoever closes the residual are recorded
there, and **one of them is now mechanically enforced** by the new guard test rather than merely
commented.

---

## THE FRESH-SKEPTIC VERDICT

Machine fields: **`refuted=false`  `severity=should-fix`**.

Verbatim, as received:

> HONESTY FRAME (restated, does not carry over): calibrated band on every non-trivial claim —
> almost-certain 90-99% / likely 55-80% / uncertain 30-55% / speculative <30% — paired with its
> evidence; UNVERIFIED inline next to the sentence it qualifies with the settling experiment named;
> MEASURED separated from INFERRED; path:line for every load-bearing claim.
>
> REF DISCIPLINE FIRST (almost-certain, MEASURED): `git ls-remote origin refs/heads/fix/v15c-libcard`
> = 489e7a3a. A plain `git fetch origin <branch>` left `origin/fix/v15c-libcard` STALE at 41eea0ff
> (one commit behind) — the known FETCH_HEAD trap. Everything below is judged at 489e7a3a, with
> origin/main = 4c24700b. NO PR exists for this bran

**RESERVATION — and a disclosure a reviewer must not skip.** The verdict text I was handed is
**TRUNCATED mid-word** at "this bran" (it was going to say no PR existed for this branch, which I
independently confirmed: `gh pr list --head fix/v15c-libcard --state all` returned `[]` before this
PR). The skeptic did **not** refute the branch, but it did set **`severity=should-fix`** — and the
substance of that should-fix reservation lives in the truncated portion, which I do not have.
**I am not going to paraphrase or guess it.** UNVERIFIED what the should-fix item is; settled by
retrieving the full skeptic report from the orchestrator's run record before this PR is approved.
Treat this PR as carrying one unread reservation.

---

## RESIDUAL / NOT DONE

**1. The lane's headline residual is STILL OPEN, and this branch adds no user-visible change to
close it.** Nothing on the card reads **"Open"** in visible text; the affordance rides entirely on
depth, cursor and the accessible name (`cardAriaLabel` → "Open Talk, 10:05, no transcript").
Closing it needs `app/renderer/src/components/library-cards.css`, **outside this lane's file scope**
— a sibling lane may own that file, so it was reported rather than reached for.

The reason it is blocked is **not** the old (refuted) one that `.library__item-open` paints nothing
at rest. It is that this codebase assigns control voices by **selector lists** in
`components/shell.css` (`:438-464` raised, `:520-529` ghost, `:555-566` accent), and an unlisted
`<button>` renders as raw Chromium chrome (`shell.css:430` says so). A new painted control therefore
requires a CSS edit.

Commission it as ONE item, with these constraints (all measured, now recorded at
`LibraryCard.tsx:11-58`):
- (a) Do **not** commission "add a primary action" — one exists, it is the whole card body, and its
  accessible name already begins with "Open".
- (b) Do **not** commission "demote Remove" — `.library__remove-btn` already carries the ghost voice
  (`shell.css:520-527`) and is the quietest control on the card. Demoting again is a regression.
- (c) Do **not** nest a control inside `.library__item-open` — it IS a `<button>`, so a nested
  `<button>Open</button>` is invalid HTML and breaks keyboard/AT. **This is now a test**, not a
  comment.
- (d) Do **not** give the new label fill or elevation — its parent already carries
  `--surface-raised` + `--elev-1`, and a raised box inside a raised box fights the documented
  depth-not-outline decision (`library-cards.css:17-21`).

**2. Coverage — CLOSED, no longer a residual.** The lane left this `NOT-CHECKED`; I ran
`npx vitest run --coverage` from `app/` at 489e7a3a and it is green at 100/100/100/100 (output
quoted above). MEASURED.

**3. A11Y, out of scope, and I corrected the lane's citation for it.** `.library__item-added` — the
`MP4 · Added <date>` caption this lane created — renders **inside** `.library__item-open`, a button
carrying an explicit `aria-label`. Per accessible-name computation, `aria-label` **replaces** element
contents, so the container format is visible but **never announced** to a screen reader. Almost-
certain (90-99%) on the mechanism, MEASURED on the markup. **Correction:** the lane's report cited
this aria-label at `LibraryCard.tsx:170`; at this tip it is at **`LibraryCard.tsx:225`**
(`aria-label={cardAriaLabel(video, lineageView)}`) — I re-grepped rather than repeat the stale
number. This is **not** a regression introduced here (the date span predates the lane), but it does
mean the metadata item landed sighted-only. Fixing it means extending `cardAriaLabel` in
`views/libraryModel.ts`, outside file scope. Recommend commissioning it with the visible-label
follow-up.

**4. UNVERIFIED (inline): the guard test's PERMIT direction was never executed.** I have the BLOCK
direction proved by mutation (a nested `<button>` reddens it). I do **not** have a run proving the
*right* fix — a non-interactive `<span>Open</span>` inside `.library__item-open` — stays green. The
selector list contains no `span`, so this is near-certain by inspection (90-99%, INFERRED) but it is
**not a run**. Settling experiment: add `<span>Open</span>` inside `.library__item-open` and confirm
the guard stays green.

**5. Worktree residue — PROPOSED, not performed.** `git status --porcelain` at 489e7a3a reports
`?? _commit_r3.txt` (MEASURED): a commit-message scaffold written into the worktree root, correctly
kept out of the commit. I did **not** delete it — the lane's hard constraints ban deleting files
outside FILE SCOPE, so removal is proposed rather than performed. It should have gone to a
scratchpad; the same scaffolding pattern (`_commit_r3.txt`, `_pr_body.md`) was already flagged as
residue in a sibling lane. (This PR's own body was written to a scratchpad, not to the worktree.)

**6. Stale comment, out of scope, CONFIRMED by me.** `components/library-cards.css:187` reads
`/* Quiet "Added <date>" meta line — additive, never a duplicate of a badge. */` while the line now
renders `MP4 · Added <date>`. MEASURED at this tip. Whoever owns that file should refresh the
comment; it is outside this lane's scope.

**7. Round↔commit mapping and the round-1/2 finding texts are UNVERIFIED** — see the two disclosures
opening the grind record. Settled by the orchestrator's per-round refuter transcripts.

**8. The truncated should-fix reservation is unread** — see the skeptic section. Settled by
retrieving the full skeptic report.

**9. Not touched, stated to prevent confusion.** PR #428 is **HELD** and is a **different branch**
(`fix/v15b-library-card`, the sibling lane). This work is on `fix/v15c-libcard`. No PR was merged,
modified or closed by this lane, and no branch, worktree or out-of-scope file was deleted.

---

**DO NOT MERGE.** The orchestrator owns the queue.
