### PR TITLE
fix(tabbar): delete the grouped TabBar path whose skin #431 removed

### DIFF
--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -212,16 +212,59 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
       return entry.name.endsWith('.css') ? [full] : [];
     });
 
-  /** Class names a component emits: plain `className="a b"` plus the string
-   *  literals inside a `className={cond ? 'a b' : 'a'}` expression. */
+  /** The text inside each `className={…}`, read with a BRACE-BALANCING scan
+   *  rather than a `[^}]*` capture. A capture stops at the FIRST `}`, which is
+   *  the one closing a template literal's own `${…}` — so every class written as
+   *  an interpolated template was silently invisible. */
+  const braceExpressions = (source: string): string[] => {
+    const out: string[] = [];
+    const marker = 'className={';
+    for (let at = source.indexOf(marker); at !== -1; at = source.indexOf(marker, at + 1)) {
+      let depth = 0;
+      let end = at + marker.length - 1; // the opening `{`
+      while (end < source.length) {
+        if (source[end] === '{') depth += 1;
+        if (source[end] === '}') {
+          depth -= 1;
+          if (depth === 0) break;
+        }
+        end += 1;
+      }
+      out.push(source.slice(at + marker.length, end));
+    }
+    return out;
+  };
+
+  /** Every string literal inside one `className` brace expression: single-quoted,
+   *  DOUBLE-quoted (the clsx/classnames idiom — previously unscanned, so
+   *  `clsx("a")` was invisible while `clsx('a')` was seen), and the STATIC chunks
+   *  of a template literal with its interpolations blanked out. */
+  const literalsIn = (expr: string): string[] => [
+    ...[...expr.matchAll(/'([^']*)'/g)].map((m) => m[1]),
+    ...[...expr.matchAll(/"([^"]*)"/g)].map((m) => m[1]),
+    ...[...expr.matchAll(/`([^`]*)`/g)].map((m) => m[1].replace(/\$\{[^}]*\}/g, ' ')),
+  ];
+
+  /** Class names a component emits: a plain quoted `className` attribute plus
+   *  every string literal inside a `className={…}` expression.
+   *
+   *  Comments are stripped FIRST, for the same use-vs-mention reason the CSS side
+   *  strips them: this reads TabBar.tsx's raw source, so a class merely named in
+   *  that file's own history comment would otherwise read as an emission and
+   *  demand a stylesheet rule for markup nothing renders. */
   const emittedClasses = (source: string): string[] => {
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
     const found = new Set<string>();
+    // Only tokens SHAPED like a CSS class are kept. Blanking an interpolation can
+    // leave debris (`?`, a bare `:`), and asserting a stylesheet rule for debris
+    // would be a false failure.
     const add = (list: string): void => {
-      for (const cls of list.split(/\s+/)) if (cls) found.add(cls);
+      for (const cls of list.split(/\s+/)) if (/^[A-Za-z_-][\w-]*$/.test(cls)) found.add(cls);
     };
-    for (const m of source.matchAll(/className="([^"]*)"/g)) add(m[1]);
-    for (const m of source.matchAll(/className=\{([^}]*)\}/g))
-      for (const literal of m[1].matchAll(/'([^']*)'/g)) add(literal[1]);
+    for (const m of code.matchAll(/className="([^"]*)"/g)) add(m[1]);
+    for (const expr of braceExpressions(code)) {
+      for (const literal of literalsIn(expr)) add(literal);
+    }
     return [...found].sort();
   };
 
@@ -247,5 +290,56 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
     // genuinely unstyled class could report as styled by a longer neighbour.
     const unstyled = classes.filter((cls) => !new RegExp(`\\.${cls}(?![\\w-])`).test(css));
     expect(unstyled).toEqual([]);
+  });
+
+  // EXTRACTOR CONTRACT. The guarantee TabBar.tsx's comment makes — a re-added
+  // grouped class cannot silently ship unstyled — is only ever as wide as
+  // `emittedClasses`. These are the SHAPES a re-add can take; each is measured
+  // here rather than assumed, so the sentence in TabBar.tsx cannot drift wider
+  // than the mechanism that backs it.
+  it('sees a re-added class in every shape a caller can write it', () => {
+    // Template literal WITH interpolation. A `className=\{([^}]*)\}` capture
+    // truncates at the interpolation's own `}`, so the class before it vanishes.
+    expect(emittedClasses('<div className={`tabbar__tablist ${mode}`}>')).toContain(
+      'tabbar__tablist',
+    );
+    // Bare template literal (no interpolation).
+    expect(emittedClasses('<div className={`tabbar--grouped`}>')).toContain('tabbar--grouped');
+    // Helper call with DOUBLE-quoted arguments (the clsx/classnames idiom). Only
+    // single-quoted literals used to be scanned inside a brace expression, so this
+    // was invisible even though the identical single-quoted call was seen.
+    expect(emittedClasses('<div className={clsx("tabbar__group", open)}>')).toContain(
+      'tabbar__group',
+    );
+    // The two shapes that already worked, kept so a rewrite cannot trade the new
+    // ones for the old. The first is the shape the DELETED grouped code used, so a
+    // `git revert` of that deletion is caught.
+    expect(emittedClasses('<div className="tabbar__export">')).toContain('tabbar__export');
+    expect(emittedClasses("<div className={on ? 'tabbar__group-label' : 'tab'}>")).toContain(
+      'tabbar__group-label',
+    );
+  });
+
+  // USE, NOT MENTION — the TS side of the hole already closed on the CSS side.
+  // Stylesheet comments are stripped before matching, but this extractor reads
+  // TabBar.tsx's RAW source, so a class merely NAMED in a doc comment there read
+  // as an emission and the contract would demand a rule for a class nothing
+  // renders. That is a false failure, and it silently forbids the file from
+  // documenting its own history in the shapes it documents.
+  it('ignores a class merely NAMED in a comment (use, not mention)', () => {
+    const block = '/* HISTORY: className="tabbar__ghost" shipped without a skin. */';
+    const line = '// see also className={`tabbar__relic ${x}`}';
+    expect(emittedClasses(`${block}\n${line}\n<div className="tab">`)).toEqual(['tab']);
+  });
+
+  // MEASURED LIMIT, pinned deliberately. This case is GREEN before and after the
+  // widening — it is a characterization pin, not a red-first test. A class held in
+  // a constant is invisible to a source-text extractor: resolving it needs a
+  // parser and a scope model, which this is not. If a later change makes this
+  // assertion fail, the extractor got wider and the "MEASURED LIMIT" sentence in
+  // TabBar.tsx must be widened in the same commit.
+  it('does NOT see a class held in a constant (documented residual, not a bug)', () => {
+    const src = "const CLS = 'tabbar__advanced-panel';\n<div className={CLS}>";
+    expect(emittedClasses(src)).not.toContain('tabbar__advanced-panel');
   });
 });

--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -435,11 +435,18 @@ describe('TabBar self-citation contract (claims about this file are machine-chec
    *  below passed identically whether the citation form was in use or every real
    *  citation had been deleted. Excluding the placeholder is what makes that control
    *  able to fail at all.
+   *
+   *  The exclusion is NARROW on purpose: only a capture that is nothing but ellipsis
+   *  and whitespace is dropped. Dropping every name that merely CONTAINS a `…` would
+   *  silently stop checking a real citation, which is the quiet weakening this whole
+   *  guard exists to prevent; a mixed placeholder such as `"… name …"` is instead
+   *  captured and fails LOUDLY against a name that does not exist here. Fail loud,
+   *  never quiet.
    */
   const citedTestNames = (source: string): string[] =>
     [...source.matchAll(/TabBar\.test\.tsx > "([^"]+)"/g)]
       .map((m) => m[1])
-      .filter((name) => !name.includes('…'));
+      .filter((name) => name.replace(/[…\s]/g, '') !== '');
 
   /** Cited names this file does not declare. Comments are stripped first, for the
    *  same use-vs-mention reason the skin contract strips them: a cited test renamed
@@ -483,6 +490,15 @@ describe('TabBar self-citation contract (claims about this file are machine-chec
     // unique, or the assertion below is about a string that no longer exists.
     expect(describing).toHaveLength(1);
     expect(citedTestNames(describing[0])).toEqual([]);
+  });
+
+  it('still checks a real name that merely CONTAINS an ellipsis (fail loud, never quiet)', () => {
+    // The exclusion is deliberately narrow. Dropping every capture that CONTAINS a
+    // `…` would silently stop checking a real citation — the same class of quiet
+    // weakening this guard exists to catch. Only a capture that is nothing but the
+    // placeholder is a mention; a mixed one like `"… name …"` is still captured and
+    // fails loudly against a name that does not exist here.
+    expect(citedTestNames('TabBar.test.tsx > "a real … name"')).toEqual(['a real … name']);
   });
 
   it('does NOT resolve a cited name that survives only in a COMMENT (use, not mention)', () => {

--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { TabBar, tabId, tabPanelId, type TabDef, type TabGroup } from './TabBar';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { TabBar, tabId, tabPanelId, type TabDef } from './TabBar';
 
 (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -62,121 +65,12 @@ describe('TabBar', () => {
   });
 });
 
-// WU-3a2: the optional `groups` prop renders tabs in NAMED clusters with an
-// "Advanced" disclosure. Purely ADDITIVE — the flat path above is unchanged.
-const GROUP_TABS: TabDef[] = [
-  { id: 't1', label: 'One' },
-  { id: 't2', label: 'Two' },
-  { id: 't3', label: 'Three' },
-];
-const GROUPS: TabGroup[] = [
-  { id: 'g1', label: 'Primary', tabIds: ['t1', 't2'] },
-  { id: 'g2', label: 'More', tabIds: ['t3'], advanced: true },
-];
-
-describe('TabBar (grouped clusters, WU-3a2)', () => {
-  it('renders named clusters with section labels and stable data-tab-id', () => {
-    const html = renderToStaticMarkup(
-      <TabBar tabs={GROUP_TABS} active="t1" onSelect={() => {}} groups={GROUPS} />,
-    );
-    expect(html).toContain('tabbar--grouped');
-    expect(html).toContain('tabbar__group-label');
-    expect(html).toContain('Primary');
-    expect(html).toContain('More');
-    expect(html).toContain('data-tab-id="t1"');
-    expect(html).toContain('data-tab-id="t3"');
-    // All 3 tabs stay real role="tab" buttons even with one cluster collapsed.
-    expect((html.match(/role="tab"/g) ?? []).length).toBe(3);
-  });
-
-  it('collapses the advanced cluster by default (aria-expanded=false, panel hidden)', () => {
-    const html = renderToStaticMarkup(
-      <TabBar tabs={GROUP_TABS} active="t1" onSelect={() => {}} groups={GROUPS} />,
-    );
-    expect(html).toContain('aria-expanded="false"');
-    expect(html).toMatch(/class="tabbar__advanced-panel"[^>]*hidden/);
-  });
-
-  it('expands the advanced cluster when advancedOpen is true (panel not hidden)', () => {
-    const html = renderToStaticMarkup(
-      <TabBar tabs={GROUP_TABS} active="t1" onSelect={() => {}} groups={GROUPS} advancedOpen />,
-    );
-    expect(html).toContain('aria-expanded="true"');
-    expect(html).not.toMatch(/class="tabbar__advanced-panel"[^>]*hidden/);
-  });
-
-  it('omits the Advanced toggle when no cluster is flagged advanced', () => {
-    const primaryOnly: TabGroup[] = [{ id: 'g1', label: 'Primary', tabIds: ['t1', 't2', 't3'] }];
-    const html = renderToStaticMarkup(
-      <TabBar tabs={GROUP_TABS} active="t2" onSelect={() => {}} groups={primaryOnly} />,
-    );
-    expect(html).not.toContain('tabbar__advanced-toggle');
-    expect(html).toContain('tabbar--grouped');
-    expect((html.match(/role="tab"/g) ?? []).length).toBe(3);
-  });
-
-  it('renders a persistent Export action only when onExport is provided', () => {
-    // design-review P1: EXPORT is the terminal goal, so it gets a standing button
-    // in the grouped strip — absent by default (no onExport).
-    const without = renderToStaticMarkup(
-      <TabBar tabs={GROUP_TABS} active="t1" onSelect={() => {}} groups={GROUPS} />,
-    );
-    expect(without).not.toContain('tabbar__export');
-
-    const withExport = renderToStaticMarkup(
-      <TabBar
-        tabs={GROUP_TABS}
-        active="t1"
-        onSelect={() => {}}
-        groups={GROUPS}
-        onExport={() => {}}
-      />,
-    );
-    expect(withExport).toContain('tabbar__export');
-    expect(withExport).toContain('Export');
-  });
-
-  it('invokes onExport when the Export action is clicked', () => {
-    const onExport = vi.fn();
-    const el = TabBar({
-      tabs: GROUP_TABS,
-      active: 't1',
-      onSelect: () => {},
-      groups: GROUPS,
-      onExport,
-    }) as React.ReactElement;
-    const children = el.props.children as React.ReactNode[];
-    // The Export button is the last child of the grouped root.
-    const exportButton = children[children.length - 1] as React.ReactElement;
-    exportButton.props.onClick();
-    expect(onExport).toHaveBeenCalledTimes(1);
-  });
-
-  it('invokes onToggleAdvanced when the disclosure toggle is clicked', () => {
-    const onToggle = vi.fn();
-    const el = TabBar({
-      tabs: GROUP_TABS,
-      active: 't1',
-      onSelect: () => {},
-      groups: GROUPS,
-      advancedOpen: false,
-      onToggleAdvanced: onToggle,
-    }) as React.ReactElement;
-    // The Advanced disclosure toggle now sits as a direct SIBLING of the tablist
-    // (moved OUT of role="tablist" so the list owns only tabs). The grouped root's
-    // children are [tablistDiv, toggleOrNull, exportOrNull]; locate the toggle by
-    // its stable class rather than by position.
-    const children = (el.props.children as React.ReactNode[]).flat();
-    const toggleButton = children.find(
-      (c): c is React.ReactElement =>
-        typeof c === 'object' &&
-        c !== null &&
-        String((c as React.ReactElement).props?.className ?? '') === 'tabbar__advanced-toggle',
-    ) as React.ReactElement;
-    toggleButton.props.onClick();
-    expect(onToggle).toHaveBeenCalledTimes(1);
-  });
-});
+// The grouped-cluster suite that stood here (WU-3a2: `groups` / `advancedOpen` /
+// `onToggleAdvanced` / `onExport`) was REMOVED with the branch it exercised. Those
+// eight tests were green the whole time #431 shipped a Workspace with no grouped
+// skin — they asserted on emitted markup and never asked whether that markup had a
+// stylesheet, so they read as coverage of a path no caller could safely use. The
+// skin contract at the bottom of this file is the guard that would have caught it.
 
 // WU-a11y: the ARIA tabs keyboard model (roving tabindex + arrow/Home/End nav +
 // tab↔panel id wiring), ported from TopTabBar. Rendered under jsdom so focus and
@@ -255,40 +149,21 @@ describe('TabBar keyboard model (roving tabindex + arrow nav)', () => {
     expect(onSelect).not.toHaveBeenCalled();
   });
 
-  it('grouped mode: arrow nav traverses primary tabs and skips a collapsed advanced tab', () => {
-    const onSelect = vi.fn();
-    renderBar({ tabs: GROUP_TABS, active: 't1', onSelect, groups: GROUPS, advancedOpen: false });
-    // ArrowRight from t1 -> t2 (t3 is in the collapsed cluster, not in the order).
-    key(btn('t1'), 'ArrowRight');
-    expect(onSelect).toHaveBeenLastCalledWith('t2');
-    // ArrowRight from t2 (last reachable) wraps to t1, NOT t3.
-    key(btn('t2'), 'ArrowRight');
-    expect(onSelect).toHaveBeenLastCalledWith('t1');
-    // A keydown on the hidden advanced tab t3 is a no-op (index -1 branch).
-    onSelect.mockClear();
-    key(btn('t3'), 'ArrowRight');
-    expect(onSelect).not.toHaveBeenCalled();
-  });
-
-  it('grouped mode: an open advanced cluster joins the arrow-nav order', () => {
-    const onSelect = vi.fn();
-    renderBar({ tabs: GROUP_TABS, active: 't2', onSelect, groups: GROUPS, advancedOpen: true });
-    // ArrowRight from t2 (last primary) -> t3 (advanced now reachable), focus follows.
-    key(btn('t2'), 'ArrowRight');
-    expect(onSelect).toHaveBeenLastCalledWith('t3');
-    expect(document.activeElement).toBe(btn('t3'));
-  });
-
   // F18: `navIds` marks the tabs whose activation navigates AWAY and unmounts this
   // tablist. Arrow-stepping onto one of those must MOVE FOCUS ONLY (ARIA APG
   // manual activation) — automatic activation there ejected the keyboard user out
   // of the surface being navigated.
+  //
+  // RETARGETED to the flat strip. These three previously drove `navIds` through the
+  // grouped branch, but `navIds` is checked in `move()` for BOTH modes, so grouped
+  // mode was never what they measured — it was scaffolding. Deleting it changes the
+  // fixture, not the behaviour under test.
   it('arrow-stepping onto a navIds tab moves focus only, never activating it', () => {
     const onSelect = vi.fn();
-    renderBar({ tabs: GROUP_TABS, active: 't1', onSelect, groups: GROUPS, navIds: ['t2'] });
-    key(btn('t1'), 'ArrowRight');
+    renderBar({ tabs: TABS, active: 'a', onSelect, navIds: ['b'] });
+    key(btn('a'), 'ArrowRight');
     expect(onSelect).not.toHaveBeenCalled();
-    expect(document.activeElement).toBe(btn('t2'));
+    expect(document.activeElement).toBe(btn('b'));
   });
 
   // Membership is per-TARGET, not "navIds is non-empty ⇒ the whole strip is
@@ -296,19 +171,81 @@ describe('TabBar keyboard model (roving tabindex + arrow nav)', () => {
   // every tab to manual activation the moment one nav id exists.
   it('arrow-stepping onto a NON-member still activates while navIds is present', () => {
     const onSelect = vi.fn();
-    renderBar({ tabs: GROUP_TABS, active: 't2', onSelect, groups: GROUPS, navIds: ['t2'] });
-    // ArrowRight from t2 (last reachable) wraps to t1, which is NOT a nav id.
-    key(btn('t2'), 'ArrowRight');
-    expect(onSelect).toHaveBeenLastCalledWith('t1');
-    expect(document.activeElement).toBe(btn('t1'));
+    renderBar({ tabs: TABS, active: 'b', onSelect, navIds: ['b'] });
+    // ArrowRight from b (last) wraps to a, which is NOT a nav id.
+    key(btn('b'), 'ArrowRight');
+    expect(onSelect).toHaveBeenLastCalledWith('a');
+    expect(document.activeElement).toBe(btn('a'));
   });
 
   it('still ACTIVATES a navIds tab on a deliberate click', () => {
     const onSelect = vi.fn();
-    renderBar({ tabs: GROUP_TABS, active: 't1', onSelect, groups: GROUPS, navIds: ['t2'] });
+    renderBar({ tabs: TABS, active: 'a', onSelect, navIds: ['b'] });
     act(() => {
-      btn('t2').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      btn('b').dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
-    expect(onSelect).toHaveBeenCalledWith('t2');
+    expect(onSelect).toHaveBeenCalledWith('b');
+  });
+});
+
+// SKIN CONTRACT. A component may not ship a class name that no stylesheet styles.
+//
+// This pins the exact cross-branch defect that produced it: PR #431 deleted the
+// grouped-TabBar block (`.tabbar--grouped` / `.tabbar__*`) from views/workspace.css
+// while TabBar.tsx still implemented grouped mode in full. Nothing went red, because
+// every unit test asserted on the emitted MARKUP and no test ever asked whether that
+// markup had a skin. The next caller to pass `groups=` would have rendered a
+// completely unstyled strip.
+//
+// Reading the SOURCE (not one rendered instance) is deliberate: a prop-gated branch
+// renders only when some caller opts in, so a render-based check is blind to exactly
+// the case that bites — the branch nobody calls yet. The source always shows it.
+describe('TabBar skin contract (every emitted class has a rule)', () => {
+  const SRC_ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+  /** Every `.css` under the renderer source tree — the full corpus that could
+   *  legitimately style this component (shell.css, views/workspace.css, ...). */
+  const cssFiles = (dir: string): string[] =>
+    readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) return cssFiles(full);
+      return entry.name.endsWith('.css') ? [full] : [];
+    });
+
+  /** Class names a component emits: plain `className="a b"` plus the string
+   *  literals inside a `className={cond ? 'a b' : 'a'}` expression. */
+  const emittedClasses = (source: string): string[] => {
+    const found = new Set<string>();
+    const add = (list: string): void => {
+      for (const cls of list.split(/\s+/)) if (cls) found.add(cls);
+    };
+    for (const m of source.matchAll(/className="([^"]*)"/g)) add(m[1]);
+    for (const m of source.matchAll(/className=\{([^}]*)\}/g))
+      for (const literal of m[1].matchAll(/'([^']*)'/g)) add(literal[1]);
+    return [...found].sort();
+  };
+
+  it('declares a CSS rule for every class name TabBar.tsx renders', () => {
+    const source = readFileSync(join(SRC_ROOT, 'components', 'TabBar.tsx'), 'utf8');
+    const classes = emittedClasses(source);
+    // Detector control: if the extractor ever silently stops finding classes, an
+    // empty list would make the assertion below vacuously true. `.tab` is the one
+    // class this component cannot stop emitting.
+    expect(classes).toContain('tab');
+
+    const css = cssFiles(SRC_ROOT)
+      .map((file) => readFileSync(file, 'utf8'))
+      // USE, NOT MENTION. Comments must be stripped before the search or a class
+      // merely NAMED in prose reads as styled. Measured, not theorised: on the first
+      // run of this test `.tabbar__advanced-toggle` — deleted from workspace.css by
+      // #431 — was reported STYLED, because shell.css's focus-ring comment still
+      // cited it as a live example. 6 of the 7 unstyled classes were found and the
+      // 7th was masked by a sentence about it.
+      .map((sheet) => sheet.replace(/\/\*[\s\S]*?\*\//g, ' '))
+      .join('\n');
+    // `(?![\w-])` is load-bearing: without it `.tab` would match `.tabbar` and a
+    // genuinely unstyled class could report as styled by a longer neighbour.
+    const unstyled = classes.filter((cls) => !new RegExp(`\\.${cls}(?![\\w-])`).test(css));
+    expect(unstyled).toEqual([]);
   });
 });

--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -297,23 +297,36 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
   // `emittedClasses`. These are the SHAPES a re-add can take; each is measured
   // here rather than assumed, so the sentence in TabBar.tsx cannot drift wider
   // than the mechanism that backs it.
-  it('sees a re-added class in every shape a caller can write it', () => {
-    // Template literal WITH interpolation. A `className=\{([^}]*)\}` capture
-    // truncates at the interpolation's own `}`, so the class before it vanishes.
+  // ONE SHAPE PER CASE, deliberately. Collapsing these into a single `it` hides
+  // evidence: vitest aborts a test at its FIRST failed assertion, so a bundled
+  // version proves only that the first shape was ever broken and leaves the rest
+  // inferred. Split, each shape is independently falsifiable — and each was
+  // observed RED against the pre-widening extractor.
+  it('SEES a class re-added via a template literal with interpolation', () => {
+    // A `className=\{([^}]*)\}` capture truncates at the interpolation's own `}`,
+    // so every class written before it vanished.
     expect(emittedClasses('<div className={`tabbar__tablist ${mode}`}>')).toContain(
       'tabbar__tablist',
     );
-    // Bare template literal (no interpolation).
+  });
+
+  it('SEES a class re-added via a bare template literal', () => {
     expect(emittedClasses('<div className={`tabbar--grouped`}>')).toContain('tabbar--grouped');
-    // Helper call with DOUBLE-quoted arguments (the clsx/classnames idiom). Only
-    // single-quoted literals used to be scanned inside a brace expression, so this
-    // was invisible even though the identical single-quoted call was seen.
+  });
+
+  it('SEES a class re-added as a DOUBLE-quoted argument in a brace expression', () => {
+    // The clsx/classnames idiom. Only single-quoted literals used to be scanned
+    // inside `className={…}`, so this was invisible while the identical
+    // single-quoted call was seen — the least obvious of the four holes.
     expect(emittedClasses('<div className={clsx("tabbar__group", open)}>')).toContain(
       'tabbar__group',
     );
-    // The two shapes that already worked, kept so a rewrite cannot trade the new
-    // ones for the old. The first is the shape the DELETED grouped code used, so a
-    // `git revert` of that deletion is caught.
+  });
+
+  it('still sees the two shapes that already worked (no trade-off)', () => {
+    // The quoted attribute is the shape the DELETED grouped code used, so a
+    // `git revert` of that deletion is caught. Kept so a later rewrite cannot
+    // swap the new shapes in at the old ones' expense.
     expect(emittedClasses('<div className="tabbar__export">')).toContain('tabbar__export');
     expect(emittedClasses("<div className={on ? 'tabbar__group-label' : 'tab'}>")).toContain(
       'tabbar__group-label',

--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -15,6 +15,19 @@ const TABS: TabDef[] = [
   { id: 'b', label: 'Beta' },
 ];
 
+/** Source text with every comment blanked out.
+ *
+ *  USE, NOT MENTION — shared deliberately by BOTH contracts below, so they cannot
+ *  drift apart. The skin contract strips comments so a class merely NAMED in
+ *  TabBar.tsx's history block is not read as an emission; the self-citation
+ *  contract strips them so a test name merely NAMED in a comment is not read as a
+ *  live test. Round 3 shipped the second guard WITHOUT the strip and the two DID
+ *  drift: a cited test renamed with its old name left behind in a comment stayed
+ *  green. One definition is the fix for that class, not a second copy of the regex.
+ */
+const stripComments = (source: string): string =>
+  source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+
 describe('TabBar', () => {
   it('renders all tab labels with role=tab', () => {
     const html = renderToStaticMarkup(<TabBar tabs={TABS} active="a" onSelect={() => {}} />);
@@ -253,7 +266,7 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
    *  that file's own history comment would otherwise read as an emission and
    *  demand a stylesheet rule for markup nothing renders. */
   const emittedClasses = (source: string): string[] => {
-    const code = source.replace(/\/\*[\s\S]*?\*\//g, ' ').replace(/\/\/[^\n]*/g, ' ');
+    const code = stripComments(source);
     const found = new Set<string>();
     // Only tokens SHAPED like a CSS class are kept. Blanking an interpolation can
     // leave debris (`?`, a bare `:`), and asserting a stylesheet rule for debris
@@ -371,6 +384,25 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
 // same shape as the defect this branch exists to close — #424 cited
 // `.tabbar__advanced-toggle`, #431 deleted the rule, nobody updated the sentence — so
 // it is closed mechanically here instead of by promising to remember.
+//
+// HOW THESE TWO FAIL ON THE PRE-FIX TEXT — recorded here because commit 3c89ad59's
+// message got it wrong and a commit message cannot be corrected in place. That
+// message pasted `expected 200 to be 247` and a `toEqual([])` diff as "RED, verbatim,
+// against the shipped text". Neither can come from the guards as shipped. Against
+// TabBar.tsx@e72d483b both fail at their DETECTOR CONTROLS, before any value is
+// compared: `/this file is (\d+) lines/` matches ZERO times there, because the phrase
+// wraps a comment line (`this file is 200\n * lines, so …`), so the first failure is
+// `expect(claimed).toHaveLength(1)` with received 0; and the `file > "name"` citation
+// form did not exist before the commit that added these tests, so the second is
+// `expect(cited.length).toBeGreaterThan(0)` with received 0. The operand is wrong
+// too — the shipped formula yields 246 at e72d483b, not 247. The transcript came
+// from a pre-commit DRAFT of these guards and was never re-run after the assertions
+// were rewritten. The substance survives (both DO go red on the pre-fix text, via
+// those controls) but the evidence was misattributed, which is this lane's own
+// subject one level up: a pasted failure message is a function of the instrument
+// that produced it, so it MUST be re-run after any change to the assertion, the
+// regex or the formula. Corrected, not quietly dropped, for the reason the shell.css
+// repair established.
 describe('TabBar self-citation contract (claims about this file are machine-checked)', () => {
   const HERE = dirname(fileURLToPath(import.meta.url));
   const readSource = (name: string): string => readFileSync(join(HERE, name), 'utf8');
@@ -387,18 +419,82 @@ describe('TabBar self-citation contract (claims about this file are machine-chec
     expect(Number(claimed[0][1])).toBe(actual);
   });
 
+  /** Test names TabBar.tsx cites in vitest's own `file > name` form.
+   *
+   *  `TabBar.test.tsx > "…"` is that path, adopted as the citation form precisely so
+   *  a machine can check it. Bare quoted prose is NOT scanned: the same comment
+   *  quotes three preview.spec.ts names, which belong to another file and another
+   *  lane, and demanding those here would be a false failure the moment that lane
+   *  renames one.
+   *
+   *  USE, NOT MENTION, one level up — and this is the round-3 defect. The sentence
+   *  that DESCRIBES the citation form has to write the form out, and it writes it
+   *  with a metasyntactic `…` (TabBar.tsx:150). The bare regex captured that
+   *  placeholder as a fourth "citation", which then resolved for free because `…`
+   *  occurs incidentally in this file's own comment prose — so the detector control
+   *  below passed identically whether the citation form was in use or every real
+   *  citation had been deleted. Excluding the placeholder is what makes that control
+   *  able to fail at all.
+   */
+  const citedTestNames = (source: string): string[] =>
+    [...source.matchAll(/TabBar\.test\.tsx > "([^"]+)"/g)]
+      .map((m) => m[1])
+      .filter((name) => !name.includes('…'));
+
+  /** Cited names this file does not declare. Comments are stripped first, for the
+   *  same use-vs-mention reason the skin contract strips them: a cited test renamed
+   *  with its old name left behind in a comment is exactly the drift this guard
+   *  exists to catch, and a raw substring test over the whole file cannot see it.
+   *
+   *  RESIDUAL, disclosed rather than implied away: containment over comment-free
+   *  text is not a parse of the suite's DECLARED names, so a cited name surviving in
+   *  some unrelated non-comment string literal would still resolve. Settling
+   *  experiment: extract `describe(`/`it(` string literals instead and re-run this
+   *  file — if the three citations still resolve, that check is strictly stronger
+   *  and should replace this one. */
+  const unresolvedCitations = (cited: readonly string[], self: string): string[] => {
+    const code = stripComments(self);
+    return cited.filter((name) => !code.includes(name));
+  };
+
   it('pins every TabBar.test.tsx name TabBar.tsx cites to a name that exists here', () => {
     const source = readSource('TabBar.tsx');
     const self = readSource('TabBar.test.tsx');
-    // `TabBar.test.tsx > "…"` is vitest's own `file > name` path, adopted as the
-    // citation form precisely so a machine can check it. Bare quoted prose is NOT
-    // scanned: the same comment quotes three preview.spec.ts names, which belong to
-    // another file and another lane, and demanding those here would be a false
-    // failure the moment that lane renames one.
-    const cited = [...source.matchAll(/TabBar\.test\.tsx > "([^"]+)"/g)].map((m) => m[1]);
-    // Detector control: the citation form must actually be in use, or the filter
-    // below is vacuously empty.
+    const cited = citedTestNames(source);
+    // Detector control. It now DISTINGUISHES its two hypotheses: with the
+    // placeholder excluded, deleting every real citation while keeping the sentence
+    // that describes the form leaves this at zero and fails HERE. What it proves is
+    // exactly that — at least one real citation is in use, so the filter below is
+    // not vacuously empty — and not that the three specific ones are still cited.
     expect(cited.length).toBeGreaterThan(0);
-    expect(cited.filter((name) => !self.includes(name))).toEqual([]);
+    expect(unresolvedCitations(cited, self)).toEqual([]);
+  });
+
+  // GUARD ON THE GUARD. The two cases above are only as good as the two helpers
+  // they call, and round 3 shipped a detector control that could not fail. These
+  // pin the helpers directly, against inputs chosen to separate the hypotheses.
+  it('does NOT count the sentence that DESCRIBES the citation form as a citation', () => {
+    const source = readSource('TabBar.tsx');
+    // The settling experiment, executed rather than promised: keep ONLY the sentence
+    // that describes the citation form and delete every real citation. If the
+    // control above means anything, nothing is cited in this state.
+    const describing = source.split(/\r?\n/).filter((line) => line.includes('> "…"'));
+    // Detector control for THIS case: the placeholder sentence must be present and
+    // unique, or the assertion below is about a string that no longer exists.
+    expect(describing).toHaveLength(1);
+    expect(citedTestNames(describing[0])).toEqual([]);
+  });
+
+  it('does NOT resolve a cited name that survives only in a COMMENT (use, not mention)', () => {
+    const mentionOnly = "// CORRECTED: this case used to be called 'renamed away'.";
+    expect(unresolvedCitations(['renamed away'], mentionOnly)).toEqual(['renamed away']);
+  });
+
+  it('DOES resolve a cited name that is really declared here', () => {
+    // The other half of the pair: stripping comments must not blind the check to a
+    // name that a live `it(...)` declares. Without this, deleting every citation
+    // would also read as success.
+    const declared = "it('renamed away', () => {});";
+    expect(unresolvedCitations(['renamed away'], declared)).toEqual([]);
   });
 });

--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -324,8 +324,11 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
   });
 
   it('still sees the two shapes that already worked (no trade-off)', () => {
-    // The quoted attribute is the shape the DELETED grouped code used, so a
-    // `git revert` of that deletion is caught. Kept so a later rewrite cannot
+    // The quoted attribute is the shape the DELETED grouped code used, so a HAND
+    // re-add of that code in its original form is caught. CORRECTED: this comment
+    // used to claim a `git revert` of the deletion is caught. It is not — d5b37dbe
+    // ADDED this contract in the same commit that deleted the code, so reverting it
+    // takes the guard away with the code it guards. Kept so a later rewrite cannot
     // swap the new shapes in at the old ones' expense.
     expect(emittedClasses('<div className="tabbar__export">')).toContain('tabbar__export');
     expect(emittedClasses("<div className={on ? 'tabbar__group-label' : 'tab'}>")).toContain(
@@ -354,5 +357,48 @@ describe('TabBar skin contract (every emitted class has a rule)', () => {
   it('does NOT see a class held in a constant (documented residual, not a bug)', () => {
     const src = "const CLS = 'tabbar__advanced-panel';\n<div className={CLS}>";
     expect(emittedClasses(src)).not.toContain('tabbar__advanced-panel');
+  });
+});
+
+// SELF-CITATION CONTRACT. TabBar.tsx's history comment makes two claims about
+// ITSELF — its own length, and the names of tests in THIS file — and both are
+// falsified by any later commit that grows the file or renames a test. Nothing in
+// the suite could evaluate them, and that is structural, not luck: the skin-contract
+// extractor above STRIPS comments by design (the use-vs-mention fix), so no test can
+// read prose in that block. Round 1 of this branch shipped both defects. It gave a
+// length measured on the PARENT tree in the very commit that grew the file by 46
+// lines, and it quoted a test name that the NEXT commit split into four. That is the
+// same shape as the defect this branch exists to close — #424 cited
+// `.tabbar__advanced-toggle`, #431 deleted the rule, nobody updated the sentence — so
+// it is closed mechanically here instead of by promising to remember.
+describe('TabBar self-citation contract (claims about this file are machine-checked)', () => {
+  const HERE = dirname(fileURLToPath(import.meta.url));
+  const readSource = (name: string): string => readFileSync(join(HERE, name), 'utf8');
+
+  it('pins the line count TabBar.tsx claims about itself to its real length', () => {
+    const source = readSource('TabBar.tsx');
+    const claimed = [...source.matchAll(/this file is (\d+) lines/g)];
+    // Detector control, in BOTH directions. Zero matches would make the assertion
+    // below vacuously true (the sentence quietly deleted); two would mean a later
+    // author quoted the refuted wording verbatim and this measured the wrong one.
+    expect(claimed).toHaveLength(1);
+    const lines = source.split(/\r?\n/);
+    const actual = lines[lines.length - 1] === '' ? lines.length - 1 : lines.length;
+    expect(Number(claimed[0][1])).toBe(actual);
+  });
+
+  it('pins every TabBar.test.tsx name TabBar.tsx cites to a name that exists here', () => {
+    const source = readSource('TabBar.tsx');
+    const self = readSource('TabBar.test.tsx');
+    // `TabBar.test.tsx > "…"` is vitest's own `file > name` path, adopted as the
+    // citation form precisely so a machine can check it. Bare quoted prose is NOT
+    // scanned: the same comment quotes three preview.spec.ts names, which belong to
+    // another file and another lane, and demanding those here would be a false
+    // failure the moment that lane renames one.
+    const cited = [...source.matchAll(/TabBar\.test\.tsx > "([^"]+)"/g)].map((m) => m[1]);
+    // Detector control: the citation form must actually be in use, or the filter
+    // below is vacuously empty.
+    expect(cited.length).toBeGreaterThan(0);
+    expect(cited.filter((name) => !self.includes(name))).toEqual([]);
   });
 });

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -15,45 +15,10 @@ export function tabPanelId(id: string): string {
   return `tabpanel-${id}`;
 }
 
-/**
- * A named cluster of tabs (WU-3a2 progressive disclosure). `tabIds` reference
- * TabDef ids in render order; a group flagged `advanced` sits behind the
- * "Advanced" disclosure toggle. This is a purely VISUAL grouping layer — every
- * referenced tab still renders as a real, reachable `role="tab"` button (nothing
- * is removed), so the tablist stays complete.
- */
-export interface TabGroup {
-  id: string;
-  label: string;
-  tabIds: string[];
-  advanced?: boolean;
-}
-
 export interface TabBarProps {
   tabs: TabDef[];
   active: string;
   onSelect: (id: string) => void;
-  /**
-   * ADDITIVE (WU-3a2): when provided, the tabs render in NAMED clusters with
-   * section labels + separators instead of one flat strip. Omitted → the
-   * original flat behaviour (unchanged). Every tab in `tabs` should be covered
-   * by exactly one group's `tabIds`, but the flat fallback remains authoritative
-   * for the full set.
-   */
-  groups?: TabGroup[];
-  /** Whether the advanced cluster(s) are expanded. Ignored without `groups`. */
-  advancedOpen?: boolean;
-  /** Toggle handler for the "Advanced" disclosure. Ignored without `groups`. */
-  onToggleAdvanced?: () => void;
-  /**
-   * ADDITIVE (design-review P1): a persistent Export/Deliver action rendered in
-   * the grouped strip. EXPORT is the user's terminal goal, so it gets a standing
-   * affordance even though the full Deliver cluster stays collapsed behind
-   * "Advanced". When provided (grouped mode only), a prominent "Export" button
-   * renders; omitted → nothing extra (unchanged). The host owns what Export does
-   * (jump to the deliver panel), keeping this component presentational.
-   */
-  onExport?: () => void;
   /**
    * ADDITIVE (F18): ids whose activation navigates AWAY from this tablist, so
    * arrow-stepping must MOVE FOCUS onto them WITHOUT activating them. This is the
@@ -78,10 +43,10 @@ export interface TabBarProps {
 }
 
 /**
- * The keyboard/focus context threaded to every rendered tab so the flat strip and
- * the grouped clusters share ONE roving-tabindex + arrow-key model (mirrors
- * TopTabBar's tabs pattern). `onKeyDown` is bound per-tab by id; `registerRef`
- * records each button so `onKeyDown` can move focus to the newly-selected tab.
+ * The keyboard/focus context threaded to every rendered tab, carrying ONE
+ * roving-tabindex + arrow-key model (mirrors TopTabBar's tabs pattern).
+ * `onKeyDown` is bound per-tab by id; `registerRef` records each button so
+ * `onKeyDown` can move focus to the newly-selected tab.
  */
 interface TabNav {
   active: string;
@@ -90,9 +55,8 @@ interface TabNav {
   registerRef: (id: string) => (el: HTMLButtonElement | null) => void;
 }
 
-/** One tab button. Shared by the flat strip and the grouped clusters so the
- *  `role="tab"` / `aria-selected` / roving-tabindex / id-wiring / test-pinned class
- *  contract is identical. */
+/** One tab button, holding the `role="tab"` / `aria-selected` / roving-tabindex /
+ *  id-wiring / test-pinned class contract. */
 function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
   const isActive = tab.id === nav.active;
   return (
@@ -125,67 +89,35 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
   );
 }
 
-/** One labelled cluster of tab buttons. The `<section>` is a PURELY VISUAL
- *  wrapper, so it carries `role="presentation"` to flatten it out of the
- *  accessibility tree — this exposes its `role="tab"` children as DIRECT children
- *  of the enclosing `role="tablist"` (satisfying WCAG aria-required-parent /
- *  aria-required-children, which resolve ownership on the presentation-flattened
- *  tree). It deliberately has NO `aria-label`: a labelled section maps to
- *  `role="region"`, which would (a) revoke `role="presentation"` and (b) sit as a
- *  non-tab node between the tablist and its tabs. The visible cluster name stays
- *  as the decorative, `aria-hidden` caption below. */
-function renderGroup(
-  group: TabGroup,
-  byId: Record<string, TabDef>,
-  nav: TabNav,
-): React.ReactElement {
-  return (
-    <section className="tabbar__group" key={group.id} role="presentation">
-      <span className="tabbar__group-label" aria-hidden="true">
-        {group.label}
-      </span>
-      {group.tabIds.map((id) => renderTab(byId[id], nav))}
-    </section>
-  );
-}
-
 /**
- * A horizontal tab strip. Accessible: role=tablist + aria-selected.
+ * A horizontal tab strip: one row of tab buttons.
+ * Accessible: role=tablist + aria-selected.
  *
- * Two rendering modes, chosen by the presence of `groups`:
- *   - FLAT (default, unchanged): one row of tab buttons.
- *   - GROUPED (WU-3a2): NAMED clusters with section labels; clusters flagged
- *     `advanced` are collapsed behind an "Advanced" disclosure toggle. Purely a
- *     visual layer — the tab behaviour (select-on-click) is identical.
+ * HISTORY (do not re-add without its stylesheet). This component also carried a
+ * GROUPED mode — `groups` / `advancedOpen` / `onToggleAdvanced` / `onExport`,
+ * emitting `.tabbar--grouped`, `.tabbar__tablist`, `.tabbar__group`,
+ * `.tabbar__group-label`, `.tabbar__advanced-panel`, `.tabbar__advanced-toggle`
+ * and `.tabbar__export`. PR #431 rebuilt the Workspace IA and deleted that skin
+ * from views/workspace.css, but left the branch here, so the two halves only
+ * disagreed when read together: the code shipped, the CSS did not, and the next
+ * caller to pass `groups=` would have rendered a completely unstyled strip.
+ * Measured before removal — zero production callers: `git grep "groups="`
+ * matched test files only, and all seven `<TabBar` call sites (App.tsx:678,
+ * Deliver.tsx:62, MakeShorts.tsx:314, Repurpose.tsx:28, Settings.tsx:308,
+ * Workspace.tsx:619 and :647) pass exactly `tabs` / `active` / `onSelect`.
+ * Workspace.test.tsx:894-967 independently asserts the grouped classes are
+ * ABSENT. The skin contract in TabBar.test.tsx now fails on any emitted class
+ * that no stylesheet declares, so this cannot silently recur.
  */
-export function TabBar({
-  tabs,
-  active,
-  onSelect,
-  groups,
-  advancedOpen = false,
-  onToggleAdvanced,
-  onExport,
-  navIds,
-}: TabBarProps): React.ReactElement {
+export function TabBar({ tabs, active, onSelect, navIds }: TabBarProps): React.ReactElement {
   // A plain ref map (NOT useRef) so this presentational component stays hook-free
   // and can still be invoked directly in unit tests. React populates it via each
   // tab's ref callback after commit; the last committed render's map is the one the
   // keydown handler closes over, so focus targets the live buttons.
   const btnRefs: { current: Record<string, HTMLButtonElement | null> } = { current: {} };
 
-  // The flat, keyboard-REACHABLE tab order for roving-tabindex arrow nav. In flat
-  // mode that is every tab; in grouped mode it is the primary clusters' tabs plus
-  // the advanced clusters' tabs ONLY when the advanced disclosure is open, so arrow
-  // keys never land focus on a tab inside a `hidden` collapsed cluster.
-  const orderedIds = groups
-    ? [
-        ...groups.filter((group) => !group.advanced).flatMap((group) => group.tabIds),
-        ...(advancedOpen
-          ? groups.filter((group) => group.advanced).flatMap((group) => group.tabIds)
-          : []),
-      ]
-    : tabs.map((tab) => tab.id);
+  // The keyboard-REACHABLE tab order for roving-tabindex arrow nav: every tab.
+  const orderedIds = tabs.map((tab) => tab.id);
 
   const move = (toIndex: number): void => {
     const nextId = orderedIds[toIndex];
@@ -202,10 +134,12 @@ export function TabBar({
   };
 
   const onKeyDown = (event: React.KeyboardEvent<HTMLButtonElement>, id: string): void => {
+    // Always found: `onKeyDown` is bound only from the `tabs.map` below, and
+    // `orderedIds` IS that same list, so every handler's id is a member. The
+    // former `index === -1` guard existed only for grouped mode's hidden
+    // collapsed-cluster tabs; with that branch gone it is unreachable, and an
+    // unreachable branch cannot be covered by the 100% gate.
     const index = orderedIds.indexOf(id);
-    // A tab outside the reachable order (a hidden collapsed-cluster tab) does not
-    // participate in arrow navigation.
-    if (index === -1) return;
     const last = orderedIds.length - 1;
     if (event.key === 'ArrowRight') {
       event.preventDefault();
@@ -237,52 +171,9 @@ export function TabBar({
     };
   const nav: TabNav = { active, onSelect, onKeyDown, registerRef };
 
-  if (!groups) {
-    return (
-      <div className="tabbar" role="tablist">
-        {tabs.map((tab) => renderTab(tab, nav))}
-      </div>
-    );
-  }
-
-  const byId: Record<string, TabDef> = {};
-  for (const tab of tabs) {
-    byId[tab.id] = tab;
-  }
-  const primary = groups.filter((group) => !group.advanced);
-  const advanced = groups.filter((group) => group.advanced);
-
   return (
-    <div className="tabbar tabbar--grouped">
-      {/* The role="tablist" is an INNER wrapper holding ONLY the tab clusters, so
-          in the accessibility tree it owns EXCLUSIVELY role="tab" elements
-          (surfaced through the presentation group wrappers). The non-tab controls
-          — the Advanced disclosure toggle and Export — are rendered as SIBLINGS of
-          the tablist, never descendants, so the tablist never owns a non-tab
-          child (WCAG aria-required-children). */}
-      <div className="tabbar__tablist" role="tablist">
-        {primary.map((group) => renderGroup(group, byId, nav))}
-        {advanced.length > 0 ? (
-          <div className="tabbar__advanced-panel" hidden={!advancedOpen}>
-            {advanced.map((group) => renderGroup(group, byId, nav))}
-          </div>
-        ) : null}
-      </div>
-      {advanced.length > 0 ? (
-        <button
-          type="button"
-          className="tabbar__advanced-toggle"
-          aria-expanded={advancedOpen}
-          onClick={onToggleAdvanced}
-        >
-          Advanced
-        </button>
-      ) : null}
-      {onExport ? (
-        <button type="button" className="tabbar__export" onClick={onExport}>
-          Export
-        </button>
-      ) : null}
+    <div className="tabbar" role="tablist">
+      {tabs.map((tab) => renderTab(tab, nav))}
     </div>
   );
 }

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -120,15 +120,36 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  *
  * WHAT THE SKIN CONTRACT GUARANTEES, exactly. TabBar.test.tsx fails on any class
  * this file emits that no renderer stylesheet declares, and its reach is measured
- * rather than asserted: "sees a re-added class in every shape a caller can write
- * it" pins one case per shape — a quoted attribute (the shape the deleted code
- * used, so a `git revert` of that deletion IS caught), a single- OR double-quoted
- * literal inside a brace expression (ternary or a clsx-style helper), and a
- * template literal with or without interpolation. Comments are stripped first, so
- * naming a class in this very block is a mention, not an emission. MEASURED LIMIT:
+ * rather than asserted: the cases under
+ * TabBar.test.tsx > "TabBar skin contract (every emitted class has a rule)"
+ * pin one case per shape — a quoted attribute (the shape the deleted grouped code
+ * used, so re-adding that code in its original form IS caught), a single- OR
+ * double-quoted literal inside a brace expression (ternary or a clsx-style helper),
+ * and a template literal with or without interpolation. Comments are stripped first,
+ * so naming a class in this very block is a mention, not an emission. MEASURED LIMIT:
  * a class held in a CONSTANT stays invisible — resolving it needs a parser and a
  * scope model, which a source-text extractor is not. That hole has its own pinning
- * test, so widening the extractor forces this paragraph to be widened with it.
+ * test —
+ * TabBar.test.tsx > "does NOT see a class held in a constant (documented residual, not a bug)"
+ * — so widening the extractor forces this paragraph to be widened with it.
+ *
+ * SCOPE LIMIT on that guarantee, mechanical — and CORRECTING the wording pushed in
+ * 5614bdbc, which said a `git revert` of the deletion IS caught. It is not. A literal
+ * `git revert` of the deleting commit d5b37dbe removes the guard along with the code
+ * the guard watches: that ONE commit deleted grouped mode, ADDED this contract, and
+ * repaired the shell.css citation (`git show d5b37dbe --stat` — TabBar.tsx,
+ * TabBar.test.tsx and shell.css, 140 insertions / 297 deletions), so reverting it
+ * also restores the false citation that masked the 7th unstyled class on the first
+ * run. The contract protects a HAND re-add, not a revert of its own commit. Settling
+ * experiment: `git revert -n d5b37dbe` on a scratch branch, then run the renderer
+ * suite — it is green. Closing it properly needs the guard in a commit the deletion
+ * can be reverted without.
+ *
+ * TWO CLAIMS IN THIS BLOCK ARE MACHINE-CHECKED, because the extractor above strips
+ * comments by design and so can never read its own documentation: this file's line
+ * count, and every `TabBar.test.tsx > "…"` name cited here. Both are pinned by
+ * TabBar.test.tsx > "TabBar self-citation contract (claims about this file are machine-checked)"
+ * — added because round 1 of this branch shipped both errors at once.
  *
  * SECOND UNCALLED SURFACE, disclosed not fixed. `navIds` also has ZERO production
  * callers: measured at this commit and at origin/main, every reference to it lives
@@ -156,13 +177,35 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  * "one stale test" to three was right; the hook is stale prose, not blast radius.
  *
  * (2) docs/validation/v15-audit-ledger.md — LARGER, and previously undisclosed.
- * 56 lines there cite the deleted classes, in two kinds of rot. DANGLING LINE
- * NUMBERS: 41 lines cite a `TabBar.tsx:` line at 200 or beyond (this file is 200
- * lines, so `:231` and `:239` are past EOF), and others cite `workspace.css:116` /
- * `:148-152` / `:189-192` in a 302-line file that has had ZERO `tabbar__` matches
- * since #431. IMPOSSIBLE PRESCRIPTIONS: eight lines (:379, :417, :766, :781, :798,
- * :807, :814, :924) tell a reader to add a `.tabbar__advanced-panel[hidden]` rule
- * for a defect that can no longer occur.
+ * TWO PARTIALLY-OVERLAPPING rot surfaces, not one nested set. Measured over that
+ * file as it stands in this tree (3157 lines; re-measure before acting on it, the
+ * docs lane owns it): 56 lines mention a class this branch deleted, and of the 67
+ * lines carrying a `TabBar.tsx:<n>` citation, 41 cite n >= 200. Their UNION is 73
+ * lines and their INTERSECTION 24 — so neither set contains the other, and the two
+ * counts cannot be read as kinds of one 56.
+ *
+ * Of those 41: twenty-four also name a deleted class, so they cite a line for markup
+ * that exists nowhere in this file any more; TWELVE are past EOF outright (n >= 247 —
+ * this file is 289 lines, and of the eleven distinct cited values >= 200, which are
+ * 215, 231, 236, 238, 239, 243, 244, 245, 246, 248 and 254, only :248 and :254 exceed
+ * it); three are both. The remaining EIGHT are in range and name no deleted class, so
+ * whether each still points at what it describes is NOT-CHECKED here — settling
+ * experiment: read those eight ledger lines against this file. Others cite
+ * `workspace.css:116` / `:148-152` / `:189-192` in a 302-line file that has had ZERO
+ * `tabbar__` matches since #431. IMPOSSIBLE PRESCRIPTIONS: eight lines (:379, :417,
+ * :766, :781, :798, :807, :814, :924) tell a reader to add a
+ * `.tabbar__advanced-panel[hidden]` rule for a defect that can no longer occur.
+ *
+ * CORRECTS the wording pushed in 5614bdbc, which gave this file's length as 200 and
+ * offered `:231` and `:239` as worked examples of citations past EOF. That was true
+ * at the PARENT commit abae7b61, where the file WAS 200 lines — and the very commit
+ * that wrote the sentence grew it +70/-24 to 246 without updating it. At 246 lines
+ * `:231` is a blank line and `:239` is a `return (`: both IN RANGE, as nine of the
+ * eleven distinct cited values >= 200 are. So that band is stale-but-in-range, not
+ * past-EOF, and the past-EOF surface is 12 lines rather than 41. Recorded rather than
+ * silently edited, for the reason the shell.css repair established — and since this
+ * is the same defect class the branch exists to close (a citation falsified by a
+ * sibling change), the length is now pinned by a test instead of by prose.
  *
  * Neither surface ships a defect and neither is on the merge path: docs are not
  * executable, `docs/validation/tools/verify_ssot_claims.py` is wired into no

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -101,32 +101,78 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  * from views/workspace.css, but left the branch here, so the two halves only
  * disagreed when read together: the code shipped, the CSS did not, and the next
  * caller to pass `groups=` would have rendered a completely unstyled strip.
- * Measured before removal — zero production callers: `git grep "groups="`
- * matched test files only, and all seven `<TabBar` call sites (App.tsx:678,
- * Deliver.tsx:62, MakeShorts.tsx:314, Repurpose.tsx:28, Settings.tsx:308,
- * Workspace.tsx:619 and :647) pass exactly `tabs` / `active` / `onSelect`.
- * Workspace.test.tsx:894-967 independently asserts the grouped classes are
- * ABSENT. The skin contract in TabBar.test.tsx now fails on any emitted class
- * that no stylesheet declares, so this cannot silently recur.
  *
- * RESIDUAL, out of this file's scope — and WIDER than the removing commit said.
- * That commit disclosed a single stale caller, `app/e2e/preview.spec.ts:190`. The
- * real surface is 11 selector references there, spanning THREE tests plus a global
- * `test.afterEach` hook that runs after every test in the file: the afterEach at
- * :74-77, "Advanced disclosure actually COLLAPSES the Deliver cluster (F17)" at
- * :190, "Workspace tabs mount, including SemanticSearch" at :279, and "export
- * action yields a real file" at :307 (which CLICKS `.tabbar__export`). Recorded
- * here because the narrower sentence is already in a pushed commit message and
- * cannot be corrected in place.
+ * NO PRODUCTION CALLER — two probes at the pre-deletion tree f8cfbd6c, one at
+ * HEAD. At f8cfbd6c: (1) `git grep "groups="` over app/renderer/src, restricted to
+ * non-test `.tsx`, returned no matches; and (2) enumerating call sites instead —
+ * the probe a prop spread would defeat — showed all seven production sites
+ * (App.tsx:678, Deliver.tsx:62, MakeShorts.tsx:314, Repurpose.tsx:28,
+ * Settings.tsx:308, Workspace.tsx:619 and :647) passing exactly `tabs` / `active`
+ * / `onSelect`. Those two query different FIELDS but are one instrument on one
+ * tree. The mechanically different probe is `npx tsc --noEmit` -> exit 0, and it
+ * belongs at HEAD: with `groups?` gone from TabBarProps, a surviving caller is an
+ * excess JSX attribute and a type error, so the compiler resolves the re-exports,
+ * aliases and spreads grep cannot see. CORRECTS commit abae7b61, which presented
+ * all three as mechanically independent probes run at f8cfbd6c — run THERE, tsc is
+ * INERT rather than circular: `groups?` was a legal optional prop, so exit 0 reads
+ * identically whether or not a caller passes it. Workspace.test.tsx:894-967
+ * independently asserts the grouped classes are ABSENT.
  *
- * Deleting grouped mode did NOT break them; they were already dead. Those
- * selectors can only match markup that grouped mode renders, and rendering it
- * requires a caller to pass `groups=` — which no production caller has done since
- * #431 (verified at the pre-deletion tree: all seven call sites pass exactly
- * tabs/active/onSelect). Nothing went red because `.github/workflows/e2e.yml`
- * triggers on `workflow_dispatch` + a nightly `schedule` ONLY — it has no
- * `pull_request` or `push` trigger, so this suite is not on the merge path. Fixing
- * that file belongs to whichever lane owns app/e2e.
+ * WHAT THE SKIN CONTRACT GUARANTEES, exactly. TabBar.test.tsx fails on any class
+ * this file emits that no renderer stylesheet declares, and its reach is measured
+ * rather than asserted: "sees a re-added class in every shape a caller can write
+ * it" pins one case per shape — a quoted attribute (the shape the deleted code
+ * used, so a `git revert` of that deletion IS caught), a single- OR double-quoted
+ * literal inside a brace expression (ternary or a clsx-style helper), and a
+ * template literal with or without interpolation. Comments are stripped first, so
+ * naming a class in this very block is a mention, not an emission. MEASURED LIMIT:
+ * a class held in a CONSTANT stays invisible — resolving it needs a parser and a
+ * scope model, which a source-text extractor is not. That hole has its own pinning
+ * test, so widening the extractor forces this paragraph to be widened with it.
+ *
+ * SECOND UNCALLED SURFACE, disclosed not fixed. `navIds` also has ZERO production
+ * callers: measured at this commit and at origin/main, every reference to it lives
+ * in TabBar.tsx or TabBar.test.tsx, and the same seven call sites above pass none.
+ * It is NOT deleted on grouped mode's grounds — that rationale was the code/skin
+ * SPLIT, and `navIds` emits no class, so it carries no unstyled-render defect. But
+ * it is the F18 manual-activation carve-out, so that a11y protection is wired into
+ * no screen today, and the three retargeted `navIds` tests cover a behaviour no
+ * shipped surface exercises. Whichever lane owns App.tsx / Workspace.tsx should
+ * either pass `navIds` on the tablists whose tabs navigate away and unmount them,
+ * or retire the prop.
+ *
+ * RESIDUAL, out of this file's scope — TWO stale surfaces, not one.
+ *
+ * (1) app/e2e/preview.spec.ts. Three tests would fail if run, their references
+ * unguarded: "Advanced disclosure actually COLLAPSES the Deliver cluster (F17)" at
+ * :190 (toggle/panel at :197-198, `toBeInViewport()` at :258), "Workspace tabs
+ * mount, including SemanticSearch" at :279 (click at :298), and "export action
+ * yields a real file" at :307 (click at :314). Of the 11 references only SIX are
+ * executable `locator()` calls (:77, :197, :198, :258, :298, :314); the other five
+ * are comments (:212, :244, :251, :295, :296). CORRECTS abae7b61, which counted all
+ * 11 alike and named the global `test.afterEach` at :74 beside the three failing
+ * tests: that hook returns early on `count() === 0` inside a try/catch (:79-85), so
+ * it degrades to a no-op and cannot fail anything. Widening the removing commit's
+ * "one stale test" to three was right; the hook is stale prose, not blast radius.
+ *
+ * (2) docs/validation/v15-audit-ledger.md — LARGER, and previously undisclosed.
+ * 56 lines there cite the deleted classes, in two kinds of rot. DANGLING LINE
+ * NUMBERS: 41 lines cite a `TabBar.tsx:` line at 200 or beyond (this file is 200
+ * lines, so `:231` and `:239` are past EOF), and others cite `workspace.css:116` /
+ * `:148-152` / `:189-192` in a 302-line file that has had ZERO `tabbar__` matches
+ * since #431. IMPOSSIBLE PRESCRIPTIONS: eight lines (:379, :417, :766, :781, :798,
+ * :807, :814, :924) tell a reader to add a `.tabbar__advanced-panel[hidden]` rule
+ * for a defect that can no longer occur.
+ *
+ * Neither surface ships a defect and neither is on the merge path: docs are not
+ * executable, `docs/validation/tools/verify_ssot_claims.py` is wired into no
+ * workflow, and `.github/workflows/e2e.yml` triggers on `workflow_dispatch` plus a
+ * nightly `schedule` ONLY — no `pull_request`, no `push`. Deleting grouped mode did
+ * not break either; both were already dead, since those selectors can only match
+ * markup grouped mode renders and no production caller has passed `groups=` since
+ * #431. Recorded rather than fixed because both belong to other lanes, and recorded
+ * rather than dropped for the reason the shell.css repair already established:
+ * correct the sentence, never quietly delete it.
  */
 export function TabBar({ tabs, active, onSelect, navIds }: TabBarProps): React.ReactElement {
   // A plain ref map (NOT useRef) so this presentational component stays hook-free

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -108,6 +108,25 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  * Workspace.test.tsx:894-967 independently asserts the grouped classes are
  * ABSENT. The skin contract in TabBar.test.tsx now fails on any emitted class
  * that no stylesheet declares, so this cannot silently recur.
+ *
+ * RESIDUAL, out of this file's scope — and WIDER than the removing commit said.
+ * That commit disclosed a single stale caller, `app/e2e/preview.spec.ts:190`. The
+ * real surface is 11 selector references there, spanning THREE tests plus a global
+ * `test.afterEach` hook that runs after every test in the file: the afterEach at
+ * :74-77, "Advanced disclosure actually COLLAPSES the Deliver cluster (F17)" at
+ * :190, "Workspace tabs mount, including SemanticSearch" at :279, and "export
+ * action yields a real file" at :307 (which CLICKS `.tabbar__export`). Recorded
+ * here because the narrower sentence is already in a pushed commit message and
+ * cannot be corrected in place.
+ *
+ * Deleting grouped mode did NOT break them; they were already dead. Those
+ * selectors can only match markup that grouped mode renders, and rendering it
+ * requires a caller to pass `groups=` — which no production caller has done since
+ * #431 (verified at the pre-deletion tree: all seven call sites pass exactly
+ * tabs/active/onSelect). Nothing went red because `.github/workflows/e2e.yml`
+ * triggers on `workflow_dispatch` + a nightly `schedule` ONLY — it has no
+ * `pull_request` or `push` trigger, so this suite is not on the merge path. Fixing
+ * that file belongs to whichever lane owns app/e2e.
  */
 export function TabBar({ tabs, active, onSelect, navIds }: TabBarProps): React.ReactElement {
   // A plain ref map (NOT useRef) so this presentational component stays hook-free

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -184,28 +184,32 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  * lines and their INTERSECTION 24 — so neither set contains the other, and the two
  * counts cannot be read as kinds of one 56.
  *
- * Of those 41: twenty-four also name a deleted class, so they cite a line for markup
- * that exists nowhere in this file any more; TWELVE are past EOF outright (n >= 247 —
- * this file is 289 lines, and of the eleven distinct cited values >= 200, which are
- * 215, 231, 236, 238, 239, 243, 244, 245, 246, 248 and 254, only :248 and :254 exceed
- * it); three are both. The remaining EIGHT are in range and name no deleted class, so
- * whether each still points at what it describes is NOT-CHECKED here — settling
- * experiment: read those eight ledger lines against this file. Others cite
- * `workspace.css:116` / `:148-152` / `:189-192` in a 302-line file that has had ZERO
- * `tabbar__` matches since #431. IMPOSSIBLE PRESCRIPTIONS: eight lines (:379, :417,
- * :766, :781, :798, :807, :814, :924) tell a reader to add a
- * `.tabbar__advanced-panel[hidden]` rule for a defect that can no longer occur.
+ * WHY they are stale, in the only terms that stay true: 24 of the 41 ALSO name a
+ * class this branch deleted, so they send a reader to a line for markup that exists
+ * nowhere in this file any more — a reason INDEPENDENT of how long this file happens
+ * to be. The other 17 are NOT-CHECKED here; settling experiment: read them against
+ * this file one by one. Others cite `workspace.css:116` / `:148-152` / `:189-192` in a
+ * 302-line file that has had ZERO `tabbar__` matches since #431. IMPOSSIBLE
+ * PRESCRIPTIONS: eight lines (:379, :417, :766, :781, :798, :807, :814, :924) tell a
+ * reader to add a `.tabbar__advanced-panel[hidden]` rule for a defect that can no
+ * longer occur.
  *
- * CORRECTS the wording pushed in 5614bdbc, which gave this file's length as 200 and
- * offered `:231` and `:239` as worked examples of citations past EOF. That was true
- * at the PARENT commit abae7b61, where the file WAS 200 lines — and the very commit
- * that wrote the sentence grew it +70/-24 to 246 without updating it. At 246 lines
- * `:231` is a blank line and `:239` is a `return (`: both IN RANGE, as nine of the
- * eleven distinct cited values >= 200 are. So that band is stale-but-in-range, not
- * past-EOF, and the past-EOF surface is 12 lines rather than 41. Recorded rather than
- * silently edited, for the reason the shell.css repair established — and since this
- * is the same defect class the branch exists to close (a citation falsified by a
- * sibling change), the length is now pinned by a test instead of by prose.
+ * PAST-EOF IS THE WRONG CRITERION — it has now produced two false sentences in a row,
+ * and BOTH died in the commit that wrote them. 5614bdbc wrote that the file was 200
+ * lines "so `:231` and `:239` are past EOF". True at the PARENT abae7b61, where it WAS
+ * 200; the same commit grew it +70/-24 to 246 and left the sentence standing (two
+ * probes: `git log -S` puts the sentence in 5614bdbc, `git diff --numstat abae7b61
+ * 5614bdbc` puts the +46 there too). At 246, `:231` is blank, `:239` is a `return (`,
+ * and 9 of the 11 distinct cited values >= 200 — 215, 231, 236, 238, 239, 243, 244,
+ * 245, 246, 248, 254 — are in range. Rescoping that to "12 are past EOF at 246"
+ * repeated the mistake ONE COMMIT LATER: 3c89ad59 asserted the 12 while its own added
+ * lines pushed this file past 254, so the count was already ZERO when it landed. The
+ * past-EOF count simply moves with this file's length, hitting zero at any length
+ * >= 254, the largest value the ledger cites. A criterion whose value changes when you
+ * edit the file it describes is not a criterion, so the stale-content reason above is
+ * the one recorded. Kept as a correction rather than a quiet edit, for the reason the
+ * shell.css repair established. The one claim here a machine CAN check is now checked,
+ * so the next author is told rather than trusted: this file is 293 lines.
  *
  * Neither surface ships a defect and neither is on the merge path: docs are not
  * executable, `docs/validation/tools/verify_ssot_claims.py` is wired into no

--- a/app/renderer/src/components/shell.css
+++ b/app/renderer/src/components/shell.css
@@ -64,11 +64,26 @@ body,
  *
  * 2. WINDOWS HIGH CONTRAST. `--focus-ring` is pure box-shadow (tokens.css) and Chromium
  *    force-sets `box-shadow: none` under `forced-colors: active`. With `outline: none` also
- *    declared, borderless controls — the Workspace `.tab` (shell.css `border: none`) and
- *    `.tabbar__advanced-toggle` (workspace.css `border: none`) — had NO focus affordance at
- *    all, one OS toggle away. forced-colors PRESERVES outline width/style and substitutes a
- *    system color, so a real outline survives. Same pattern already proven to survive in
+ *    declared, borderless controls — the Workspace `.tab` (shell.css `border: none`, still
+ *    live below) and the header segmented controls `.quality-toggle__btn` /
+ *    `.routing-toggle__btn` (shell.css `border: none`) — had NO focus affordance at all, one
+ *    OS toggle away. forced-colors PRESERVES outline width/style and substitutes a system
+ *    color, so a real outline survives. Same pattern already proven to survive in
  *    directorPanel.css and captionBox.css.
+ *
+ *    CORRECTED (was: `.tabbar__advanced-toggle`, workspace.css). That was true when #424
+ *    wrote it and is FALSE now: #431 deleted the grouped-TabBar skin from workspace.css, and
+ *    the branch that emitted the class has since been removed from components/TabBar.tsx, so
+ *    half of #424's recorded evidence named a control that no longer exists. The REPAIR this
+ *    comment justifies is unaffected — it never depended on that example, and the two
+ *    replacements above are live, borderless and in this same file. Kept as a correction
+ *    rather than a deletion so the next reader inherits the fact, not a quiet gap.
+ *
+ *    A stale citation is not merely untidy here: TabBar.test.tsx's skin contract greps the
+ *    stylesheets for a rule per emitted class, and on its first run this very sentence made
+ *    the DELETED `.tabbar__advanced-toggle` report as STYLED — 6 of 7 unstyled classes found,
+ *    the 7th masked by prose about it. The test now strips comments before matching (use, not
+ *    mention); keep citations accurate so the next detector is not blunted the same way.
  *
  * The box-shadow ring is kept as the styled enhancement wherever it still wins the cascade.
  */


### PR DESCRIPTION
**DO NOT MERGE from this PR.** The orchestrator owns the merge queue; branch protection is strict.

**HONESTY FRAME (restated — it does not carry over).** Every non-trivial claim below carries a
calibrated band — almost-certain (90-99%) / likely (55-80%) / uncertain (30-55%) / speculative
(<30%) — paired with its evidence. `UNVERIFIED` and `NOT-CHECKED` appear INLINE next to the
sentence they qualify, each naming the experiment that would settle it, never only in a trailing
section. MEASURED is separated from INFERRED. Load-bearing claims cite `path:line` or verbatim
command output. Nothing is softened to be agreeable and nothing is inflated to look productive.

Branch `fix/v15c-tabbar` @ `f4a9a42625e791967541d4a7c876cd164d676d78` (MEASURED:
`git ls-remote origin refs/heads/fix/v15c-tabbar` = `f4a9a426…`, identical to the worktree HEAD;
base `main` = `4c24700ba1221ff0727805563af713fb08398f11`). 8 commits, 3 files,
+517 / −297 (`git diff origin/main...HEAD --stat`).

---

## 1. What changed, and what the user sees

`app/renderer/src/components/TabBar.tsx` · `TabBar.test.tsx` · `shell.css` (comment-only).

**The defect was cross-branch — neither half is wrong alone, only together.** PR #431 rebuilt the
Workspace IA and deleted the grouped-TabBar skin (`.tabbar--grouped` / `.tabbar__*`) from
`views/workspace.css`, but left grouped mode fully implemented in `components/TabBar.tsx`. The code
shipped; its stylesheet did not. Only a cross-branch look sees it: every single-diff review of
either half is structurally blind to it.

1. **Deleted the grouped branch** — `groups` / `advancedOpen` / `onToggleAdvanced` / `onExport` and
   the markup they gated (7 classes: `tabbar--grouped`, `tabbar__group`, `tabbar__group-label`,
   `tabbar__tablist`, `tabbar__advanced-toggle`, `tabbar__advanced-panel`, `tabbar__export`).
   Deleted rather than re-skinned because nothing calls it, and `Workspace.test.tsx:894-967`
   already asserts those classes are ABSENT — #431 removed the path deliberately.
2. **Removed the now-unreachable `index === -1` guard** in `onKeyDown` (it existed only for grouped
   mode's hidden collapsed-cluster tabs). An unreachable branch cannot satisfy the 100% branch gate.
3. **Corrected a false citation already on `main`** at `app/renderer/src/components/shell.css:64-90`
   — comment-only, no rule changed. #424's focus-ring rationale named `.tabbar__advanced-toggle`
   (workspace.css) as one of two live borderless controls; #431 deleted that rule, so half of #424's
   recorded evidence was false. Repointed at `.quality-toggle__btn` / `.routing-toggle__btn` and
   marked `CORRECTED`, not silently dropped. MEASURED by me at this HEAD, not inherited from the
   lane: `shell.css:264` + `:266` and `:323` + `:325` — both selectors are live and carry
   `border: none` in that same file, so the replacement example is TRUE.
4. **Added three guards in `TabBar.test.tsx`** so the class cannot recur silently: a *skin contract*
   (every class `TabBar.tsx` emits must have a rule in some renderer stylesheet — read from the
   SOURCE, not one rendered instance, because a prop-gated branch renders only when a caller opts
   in), plus two *self-citation* guards (the line count the file claims about itself must equal its
   real length; every `TabBar.test.tsx > "name"` the file cites must exist here). Both sides strip
   comments first — use, not mention.

**User-visible effect — before vs now.** Before: the app looked exactly as it does now. Grouped
mode was already unreachable, so nothing on screen was broken; the defect was a loaded gun. The next
caller to pass `groups=` would have rendered a **completely unstyled tab strip** — 7 emitted classes
with no rule anywhere — and nothing in the 254-file suite would have gone red, because the deleted
tests asserted on emitted markup and never asked whether that markup had a stylesheet. Now: **no
pixel changes on any shipped screen** (almost-certain, 90-99%, MEASURED by me at this HEAD, three
probes each able to fail alone) — (a) `git grep "groups=" -- app/renderer/src` returns 4 hits, all
of them prose in comments (`TabBar.tsx:103,106,219`, `TabBar.test.tsx:210`), zero JSX props;
(b) all seven production call sites pass exactly `tabs`/`active`/`onSelect` — `App.tsx:678`,
`Deliver.tsx:62`, `MakeShorts.tsx:314`, `Repurpose.tsx:28`, `Settings.tsx:308`, `Workspace.tsx:619`
and `:647` (the one JSX spread is the test harness at `TabBar.test.tsx:106`); (c) `npx tsc --noEmit`
exits 0 with the props removed — the probe grep cannot be, since the compiler resolves re-exports,
aliases and spreads. What changes for the user is counterfactual: the trap is gone, and re-adding an
unstyled class now goes red instead of shipping.

**Tests were deleted — disclosed, not buried.** Eight grouped-cluster tests were deleted *with the
code path they covered* (commit `d5b37dbe`), and three `navIds` tests were RETARGETED to the flat
strip rather than dropped. No test was weakened, skipped, xfailed or deleted to make a gate pass.
MEASURED by me: `^\s*(it|test)\(` counts 21 cases in the `origin/main` blob vs 25 at HEAD; the
8-deleted / 3-retargeted split is INFERRED from `d5b37dbe`'s message — I did not run the suite at
`main` to count it case-by-case (NOT-CHECKED; settling experiment: `git stash`-free scratch worktree
at `4c24700b`, `npx vitest run renderer/src/components/TabBar.test.tsx`, diff the case names).

---

## 2. The evidence

Every line below was **re-run by me (the PR agent) at `f4a9a426`** in the lane worktree
`C:/Users/Prekzursil/.claude/rf-w6/tabbar/app` — not copied from the lane's report. Two mechanically
independent runs (the lane's and mine, different sessions, different shells) now agree on all four.

**(1) targeted suite — `npx vitest run renderer/src/components/TabBar.test.tsx`**

```
 ✓ renderer/src/components/TabBar.test.tsx (25 tests) 80ms

 Test Files  1 passed (1)
      Tests  25 passed (25)
vitest exit=0
```

**(2) lint — `npx --yes @biomejs/biome@2.5.0 check` on all three changed files**

```
Checked 3 files in 44ms. No fixes applied.
biome exit=0
```

**(3) typecheck — `npx tsc --noEmit`**

```
tsc exit=0
```

**(4) full renderer suite + the BLOCKING coverage gate — `npx vitest run --coverage`**

```
 Test Files  254 passed (254)
      Tests  4923 passed (4923)
File               | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s
All files          |     100 |      100 |     100 |     100 |
vitest-coverage exit=0
```

That is the project's SSOT gate: `.coverage-thresholds.json` → `coverage.renderer` = 100
lines/branches/functions/statements, `_enforced_by: app/vitest.config.ts test.coverage.thresholds
(gate:3)`.

**Detector failure in my own run, disclosed so nobody cites it.** My first pass at reading the
coverage log matched `FAIL`/`ERROR` inside *test-name prose* on `stderr` lines (e.g.
`ShortMaker.test.tsx > … an export FAILING after a videoId switch raises no error banner`). Those
are test names, not failures. The authoritative lines are `Test Files 254 passed (254)` and exit 0.
The lane reported the mirror-image of this same failure (a case-insensitive `Select-String 'ERROR'`
flooding its summary) — same class, second instance, worth naming rather than hiding.

**Gates deliberately NOT run.** Sidecar Python gates: no Python file is touched (renderer-only
change), so `pytest --cov=media_studio --cov=contract` carries no signal here. e2e: **MEASURED by me
this time, not inherited** — `.github/workflows/e2e.yml:38-51` declares `on:` with
`workflow_dispatch:` (`:39`) and `schedule:` `cron "17 4 * * *"` (`:49-51`) and **no `pull_request`
or `push` trigger**, so that suite is off the merge path. It was still not EXECUTED (NOT-CHECKED as
a behavioural signal; settling experiment: `gh workflow run e2e.yml --ref fix/v15c-tabbar` and read
the run — note it drives `app/e2e/preview.spec.ts`, which holds 3 stale tests this lane reports and
does not own).

---

## 3. The grind record — 3 fix rounds, nothing dropped

Every refuter finding across all three rounds is listed with its disposition. **Zero were silently
dropped** (that is the load-bearing claim of this section; a dropped finding would be a defect).
Rounds 1 and 2 are reconstructed from the branch's own commit messages, which I read in full
(`5614bdbc`, `e72d483b`, `3c89ad59`, `5df065c2`) — MEASURED as *what the lane recorded*, INFERRED as
to whether that record is complete (I was not present for those rounds; settling experiment: diff
the refuter agents' returns in the orchestrator transcript against this list).

### Round 1 — 3 verdicts, 3 actionable (`5614bdbc`, then evidence repair in `e72d483b`)

All three were the C2 shape: **the code was right and a sentence was wider than its evidence.**

- **F1 — FIXED (mechanism, not sentence).** The comment claimed the skin contract meant a re-added
  grouped class "cannot silently recur". Replicating the extractor against seven re-add shapes
  showed it saw three and missed four, so the guarantee was wider than the mechanism. The lane
  widened the extractor rather than narrowing the sentence — turning a documented hole into a
  covered one. Three shapes now seen that were not: a template literal with interpolation (the
  `[^}]*` capture stopped at the interpolation's own `}`), a bare template literal, and a
  DOUBLE-quoted argument in a brace expression (`clsx("a")` was invisible while `clsx('a')` was
  seen — now a brace-balancing scan). RED first, verbatim:
  `expected [] to include 'tabbar__tablist'` and
  `expected [ 'tab', 'tabbar__ghost' ] to deeply equal [ 'tab' ]`; GREEN after: 16/16.
- **F1b — RESCOPED.** `abae7b61`'s "three independent probes" was MIS-LOCATED: two of them ran at
  `f8cfbd6c` and query different fields, but they are one instrument on one tree. The mechanically
  different probe is `tsc --noEmit`, and it carries signal only at HEAD — at `f8cfbd6c`, `groups?`
  was a legal optional prop, so exit 0 reads identically under both hypotheses (INERT, not
  circular). Corrected to "two probes at `f8cfbd6c`, one at HEAD".
- **F2 — RESCOPED.** `navIds` is a SECOND uncalled surface, previously undisclosed on a file whose
  whole subject is uncalled surfaces. Measured at the fixed tree `origin/main 4c24700b` so the
  lane's own edits could not move the number: all 13 references live in `TabBar.tsx` or
  `TabBar.test.tsx`, none elsewhere under `app/`. Correctly NOT deleted on grouped mode's grounds
  (it emits no class, so it carries no unstyled-render defect) — but the F18 manual-activation
  carve-out is therefore wired into no screen. Fixing it needs `App.tsx`/`Workspace.tsx`, outside
  this lane's file scope.
- **F3 — RESCOPED in both directions.** The e2e blast radius: `d5b37dbe` said one stale test;
  `abae7b61` corrected that to three tests plus a global `test.afterEach`; round 1 then measured
  that only six of the eleven references are executable `locator()` calls (`:77, :197, :198, :258,
  :298, :314`) and that the `afterEach` at `:74` returns early on `count() === 0` inside a
  try/catch, so it degrades to a no-op and cannot fail anything. "One stale test → three" stands;
  listing the `afterEach` beside three genuinely-red tests implied a radius the guard removes.
- **Two review claims CORRECTED by the lane's own measurement as WIDER than reported** (recorded,
  not quietly adopted): the ledger's prescription lines are eight (`:379, :417, :766, :781, :798,
  :807, :814, :924`), not the five enumerated in review; and the dangling-citation surface is 41
  lines, not the nine listed.
- **Self-caught evidence repair (`e72d483b`), no reviewer asked for it.** `5614bdbc` asserted all
  five re-add shapes inside ONE `it`. Vitest aborts a test at its first failed assertion, so the RED
  run it cited proved only that the template-literal shape was ever broken — the other holes were
  INFERRED from reading the regex, which is exactly the standard this lane exists to hold sentences
  to, one level up. Split into one case per shape and re-run against the pre-widening extractor:
  `Tests  4 failed | 15 passed (19)`, all four holes independently MEASURED red.

### Round 2 — 3 verdicts, 3 actionable (`3c89ad59`, then `5df065c2`)

Round 2 caught the lane **committing the exact defect it was chartered to close**: a citation
invalidated by a sibling change, left unupdated. Three times, all in `TabBar.tsx`'s own doc comment,
all created by this branch's later commits.

- **F1 LINE COUNT / PAST-EOF — FIXED (blocking).** "this file is 200 lines, so `:231` and `:239` are
  past EOF" was TRUE at the parent `abae7b61` (200 lines) and was falsified by the +70/−24 in the
  very commit that wrote it. Four independent instruments say 246 (`git grep -c ""`, a PowerShell
  array count, a python newline count, the editor's numbering). Corrected, and the length is now
  machine-checked by a test.
- **F2 SET CONTAINMENT — FIXED.** "56 lines cite the deleted classes, in two kinds of rot: 41 … and
  eight …" read 41 and 8 as subsets of 56. Measured: |class-mention| = 56, |cite n≥200| = 41, union
  73, intersection 24 — neither set contains the other. The corrected paragraph states both surfaces
  and partitions the 41 mechanically, with the undecidable remainder marked NOT-CHECKED rather than
  folded into a number that looks measured.
- **F3 REVERT SCOPE — FIXED.** "a quoted attribute (the shape the deleted code used, so a
  `git revert` of that deletion IS caught)" is false for the operation it names: `git show d5b37dbe
  --stat` shows the guard was ADDED by the deleting commit, so reverting it removes the guard *with*
  the code and restores the false `shell.css` citation. The contract protects a HAND re-add, not a
  revert of its own commit. Corrected in both places it was asserted.
- **F4 DANGLING TEST NAME — FIXED.** The comment quoted a test name `e72d483b` had split into four;
  it now cites the describe block and the constant-residual case in vitest's own `file > "name"`
  form. (Reported by the lane as a fourth item inside the same round; included here rather than
  compressed away.)
- **The new guard immediately caught round 2's own replacement text (`5df065c2`) — recorded, not
  quietly patched, because it is the strongest evidence for the guard I can offer.** `3c89ad59`
  rescoped "41 dangling because past EOF" to "TWELVE past EOF (n ≥ 247)" — measured against a
  246-line file, while the same commit's added comments grew the file to 289. The ledger's largest
  cited value is 254, so at 289 lines the corrected count was **already ZERO the moment it landed**.
  Identical mechanism to the defect being corrected, one commit later, inside the paragraph
  explaining the mistake. Root cause now stated in the file: past-EOF is not a criterion at all —
  its truth is a function of this file's length, so it can only ever be true by accident. Replaced
  with the length-independent, mechanically measurable reason: 24 of the 41 lines citing
  `TabBar.tsx:<n>` with n ≥ 200 ALSO name a class this branch deleted, so they point a reader at
  markup that exists nowhere in the file at any length; the other 17 are marked NOT-CHECKED with the
  settling experiment named.

### Round 3 — 3 verdicts, 3 actionable (`e91bb411`, then self-review in `f4a9a426`)

- **F1 — FIXED (code), and the sentence rescoped with it.** The finding is CORRECT and the lane
  reproduced it on its own instrument before touching anything (MEASURED, almost-certain): the
  shipped regex at `TabBar.test.tsx:398` captures FOUR strings, the fourth being the metasyntactic
  placeholder in the sentence that DESCRIBES the citation form (`TabBar.tsx:150`,
  `TabBar.test.tsx > "…"`). Executing the settling experiment the refuter named — delete the three
  real citations, keep the placeholder sentence — **the shipped guard stayed GREEN having checked
  none**. Two mechanical fixes, each RED first: (a) the extractor drops the placeholder, which is
  what makes `expect(cited.length).toBeGreaterThan(0)` able to fail at all; (b) `stripComments` is
  hoisted to module scope and now used by BOTH contracts, so the containment check is
  use-not-mention and the skin contract and the citation guard cannot drift apart again. The
  control's comment at `:399-401` now states what it actually proves (at least one real citation is
  in use — not that the three specific ones are). RED verbatim:
  `expected [ '…' ] to deeply equal []` and
  `expected [] to deeply equal [ 'renamed away' ]`; `Tests  2 failed | 22 passed (24)` → GREEN 24/24.
- **F2 — FIXED by the same change; its extra claim independently CONFIRMED.** MEASURED:
  `TabBar.test.tsx` contains 5 `U+2026` characters (`:215, :217, :249, :319, :393`), every one in
  unrelated comment prose about `className={…}` — which is precisely why `self.includes('…')`
  resolved for free. The latent false-failure it predicted (ASCII-normalising those comments
  reddening the guard with `expected ['…'] to deeply equal []`) is now structurally impossible: the
  placeholder never enters `cited`. Its H1/H2 framing was adopted as the test's own wording.
- **F3 — RESCOPED, and the refutation was verified by the lane rather than accepted** (a wrong
  refutation must not drive a change). MEASURED against `TabBar.tsx@e72d483b` with the REAL runner,
  not a simulation: both shipped guards fail at their DETECTOR CONTROLS before any value is compared
  — `expected [] to have a length of 1 but got +0` and `expected 0 to be greater than 0` — because
  `/this file is (\d+) lines/` matches ZERO times there (the phrase wraps a comment line:
  `this file is 200\n * lines, so …`) and the `file > "name"` citation form did not exist before the
  commit that added these tests. The shipped formula yields 246 at `e72d483b`, not 247. So
  `3c89ad59`'s pasted `expected 200 to be 247` **cannot** have come from the shipped guards; it came
  from a pre-commit draft and was never re-run. A pushed commit message cannot be corrected in
  place, so the correction is recorded in `TabBar.test.tsx` beside the guards and repeated in the
  new commit message — corrected, never quietly dropped.
- **Self-review caught one of the lane's own (`f4a9a426`), no reviewer asked for it.** The first
  exclusion dropped every capture CONTAINING an ellipsis — which would have silently stopped
  checking a real name that happened to contain one. That is the same quiet-weakening class the
  guard exists to close, shipped inside the fix for it. Narrowed to ellipsis-and-whitespace-ONLY: a
  mixed placeholder like `"… name …"` is now captured and fails LOUDLY against a name that does not
  exist. RED first, verbatim: `expected [] to deeply equal [ 'a real ... name' ]`,
  `Tests  1 failed | 24 passed (25)`; and the H2 control still fails correctly after the narrowing,
  so nothing was traded away to buy it.

---

## 4. The fresh-skeptic verdict (verbatim)

Reproduced exactly as it was handed to me. **INLINE CAVEAT: the transcript I received is truncated
mid-sentence** at "…in TabBarProps or"; I reproduce only what I was given and do not reconstruct the
remainder. UNVERIFIED (by me) whether the untruncated verdict carries reservations beyond the
`severity=should-fix` in its header — settling experiment: read the skeptic agent's full return in
the orchestrator transcript.

```
refuted=false severity=should-fix — HONESTY FRAME (restated; does not carry over): calibrated
band on every non-trivial claim — almost-certain 90-99% / likely 55-80% / uncertain 30-55% /
speculative <30%. UNVERIFIED and NOT-CHECKED inline next to the sentence they qualify. MEASURED
separated from INFERRED. path:line or command output cited for load-bearing claims. Nothing
softened, nothing inflated.

VERDICT: MERGEABLE. Judged on the final state of f4a9a426 (fetched fresh via FETCH_HEAD, not a
stale tracking ref), not on the commit messages.

1) DOES THE LANE GOAL HOLD? YES — almost-certain (90-99%), MEASURED. Grouped mode is gone from
TabBar.tsx: no `groups` / `advancedOpen` / `onToggleAdvanced` / `onExport` in TabBarProps or
```

`severity=should-fix` is itself a reservation, not a clean bill: it is the skeptic saying the branch
is mergeable *with* open should-fix items, which are the residuals in §5 below.

---

## 5. Residual / not done

**None of these block, and none are hidden.** Items 1-3 and 6 are disclosed INLINE in the code
itself, not only here.

1. **Containment is not a parse of DECLARED names** (disclosed inline in the helper's doc comment,
   with its settling experiment). Containment over comment-free text is still not a parse of the
   suite's declared test names, so a cited name surviving in an unrelated NON-comment string literal
   would still resolve. Settling experiment, named in the comment: extract `describe(` / `it(`
   string literals instead and re-run — if the three citations still resolve, that check is strictly
   stronger and should replace this one. Not done this round because it is wider than the measured
   defect (which was a COMMENT) and needs its own red-first cycle.
2. **The new test's own detector control is slightly wider than its subject** (disclosed, not
   hidden). `does NOT count the sentence that DESCRIBES the citation form as a citation` selects
   `TabBar.tsx` lines containing `> "…"`, not the fully-qualified `TabBar.test.tsx > "…"`, and
   asserts exactly one such line. If a future lane adds a placeholder line for another file (e.g.
   `preview.spec.ts > "…"`), that control goes RED for a reason unrelated to this guard.
   Deliberate: it fails LOUD rather than silently admitting a second placeholder shape. UNVERIFIED
   how likely that is (speculative, <30%); settling experiment: add such a line and run the file.
3. **One case is GREEN-IN-BOTH-STATES by design**, labelled as such in the code and not presented as
   red-first: `DOES resolve a cited name that is really declared here` is a characterization pin, so
   a later tightening of the containment check cannot pass by resolving nothing. Same status the
   lane already gives its `MEASURED LIMIT` constant test (a class held in a CONSTANT is still
   invisible to the extractor — resolving it needs a parser and a scope model).
4. **NOT-CHECKED, not folded into any verdict.** (a) The 8091→8093 branch-denominator drift raised
   in round 3: my own `--coverage` run closes all four axes at 100, which is the gate, but I did not
   compare denominators between commits; settling experiment: run `--coverage` at `3c89ad59` and at
   `f4a9a426` in scratch worktrees and diff the v8 branch totals. (b) The e2e suite was not
   EXECUTED — I did independently measure that it is off the merge path (`e2e.yml:38-51`,
   `workflow_dispatch` + `schedule` only), which is a different claim from "it would pass".
   (c) `shell.css` was untouched after round 3 — but unlike the lane, I did re-measure its round-3
   correction at this HEAD and it is TRUE (`:264`/`:266`, `:323`/`:325` both `border: none`), so
   that item is now MEASURED rather than inherited.
5. **PROPOSED, NOT PERFORMED — deletion is not mine.** Two untracked scratch files from round 3
   remain in the lane worktree root: `_commit_r3.txt` and `_commit_r3b.txt` (MEASURED: still present
   in `git status --porcelain` at this HEAD). They are untracked, cannot enter a commit under
   explicit-path staging, and are harmless. Whoever owns cleanup may remove them; I did not.
6. **Out-of-lane surfaces, reported and NOT touched** (they belong to other lanes; editing them
   would be a scope escape that clobbers a sibling): `app/e2e/preview.spec.ts` holds 3 stale tests
   and 6 executable `locator()` calls against the deleted classes — already dead before this branch,
   and off the merge path; `docs/validation/v15-audit-ledger.md` holds 56 lines citing the deleted
   classes, 41 lines citing `TabBar.tsx:<n>` with n ≥ 200 (24 of which also name a deleted class, 17
   NOT-CHECKED), and 8 lines prescribing a `.tabbar__advanced-panel[hidden]` rule for a defect that
   can no longer occur. Its checker `verify_ssot_claims.py` is wired into no workflow
   (`git grep -l verify_ssot_claims -- .github` exits 1), so none of it is on the merge path.
7. **Generalisable rule this branch earns**, in two halves. (i) A DETECTOR CONTROL must be stated as
   two hypotheses *before* it is written — "what does a PASS look like under H1 vs H2?" — and if it
   looks identical under both, it measures only that the instrument ran. (ii) The same applies to
   EVIDENCE TRANSCRIPTS: a pasted failure message is a function of the instrument that produced it,
   so it must be re-run after any change to the assertion, the regex or the formula, or it silently
   becomes a claim about a mechanism that no longer exists.

---

## 6. Scope and constraints

- **Files touched:** `app/renderer/src/components/TabBar.tsx`, `TabBar.test.tsx`, `shell.css` —
  nothing else (`git diff origin/main...HEAD --stat`). No scope escape.
- `TabBar.tsx` is byte-unchanged since round 2, so its machine-checked "this file is 293 lines"
  self-claim needed no update. During round 3 it was temporarily replaced with its `e72d483b` blob
  and with an H2 mutation for two both-states runs, and restored with
  `git checkout HEAD -- <path>` each time; `git status --porcelain` confirms it is unmodified.
- **Anti-ratchet: clean** — no tab, disclosure surface or IA level was added or removed.
- No `--force`, no `--no-verify`, no test weakened/skipped/xfailed to make a gate pass, no branch or
  worktree deleted, staging explicit-path only (`git add app/renderer/src/components/TabBar.test.tsx`),
  never `git add -A`.
