### PR TITLE
fix(a11y): the vertical inspector tablist now announces and keys as vertical

### DIFF
--- a/app/renderer/src/components/TabBar.test.tsx
+++ b/app/renderer/src/components/TabBar.test.tsx
@@ -199,6 +199,64 @@ describe('TabBar keyboard model (roving tabindex + arrow nav)', () => {
     });
     expect(onSelect).toHaveBeenCalledWith('b');
   });
+
+  // ── VERTICAL ORIENTATION (the inspector tablist) ─────────────────────────
+  //
+  // THE DEFECT: views/workspace.css:260-263 renders
+  // `.workspace .workspace__inspector .tabbar` with `flex-direction: column`, so that
+  // tab list is VERTICAL on screen. TabBar declared no `aria-orientation` (which
+  // DEFAULTS to horizontal per WAI-ARIA) and moved focus only on ArrowLeft/ArrowRight.
+  //
+  // So a keyboard user facing a visibly vertical list pressed Down and nothing
+  // happened, while Right — which points across the list rather than along it — was
+  // the only key that worked; a screen reader announced a horizontal list that is not.
+  // WAI-ARIA APG: a vertical tablist declares aria-orientation="vertical" and moves
+  // with Up/Down. The strip is mounted twice inside `.workspace`, so this is the most
+  // exposed tab list in the app, not an edge case.
+  it('declares aria-orientation="vertical" when asked for a vertical strip', () => {
+    renderBar({ tabs: TABS, active: 'a', onSelect: () => {}, orientation: 'vertical' });
+    expect(container.querySelector('[role="tablist"]')?.getAttribute('aria-orientation')).toBe(
+      'vertical',
+    );
+  });
+
+  it('still declares horizontal by DEFAULT, so no existing call site changes', () => {
+    // DETECTOR CONTROL for the case above: a hardcoded attribute would pass that test
+    // while telling us nothing. Every other call site relies on this default.
+    renderBar({ tabs: TABS, active: 'a', onSelect: () => {} });
+    expect(container.querySelector('[role="tablist"]')?.getAttribute('aria-orientation')).toBe(
+      'horizontal',
+    );
+  });
+
+  it('ArrowDown / ArrowUp move selection and focus when vertical, wrapping', () => {
+    const onSelect = vi.fn();
+    renderBar({ tabs: TABS, active: 'a', onSelect, orientation: 'vertical' });
+    key(btn('a'), 'ArrowDown');
+    expect(onSelect).toHaveBeenLastCalledWith('b');
+    expect(document.activeElement).toBe(btn('b'));
+    // wraps forward off the end...
+    key(btn('b'), 'ArrowDown');
+    expect(onSelect).toHaveBeenLastCalledWith('a');
+    // ...and backward off the start.
+    key(btn('a'), 'ArrowUp');
+    expect(onSelect).toHaveBeenLastCalledWith('b');
+  });
+
+  it('a vertical strip ignores ArrowRight, and a horizontal one ignores ArrowDown', () => {
+    // Keeps the two models DISTINCT. Handling every arrow everywhere would satisfy the
+    // cases above while violating the APG in the other direction, so both halves are
+    // pinned here rather than assumed.
+    const onSelect = vi.fn();
+    renderBar({ tabs: TABS, active: 'a', onSelect, orientation: 'vertical' });
+    key(btn('a'), 'ArrowRight');
+    expect(onSelect).not.toHaveBeenCalled();
+
+    const onSelectH = vi.fn();
+    renderBar({ tabs: TABS, active: 'a', onSelect: onSelectH });
+    key(btn('a'), 'ArrowDown');
+    expect(onSelectH).not.toHaveBeenCalled();
+  });
 });
 
 // SKIN CONTRACT. A component may not ship a class name that no stylesheet styles.

--- a/app/renderer/src/components/TabBar.tsx
+++ b/app/renderer/src/components/TabBar.tsx
@@ -40,6 +40,24 @@ export interface TabBarProps {
    *      above, but non-obvious — hence documented here, at the prop.
    */
   navIds?: string[];
+  /**
+   * Which way this strip is LAID OUT, which decides both the announced
+   * `aria-orientation` and which arrow keys walk it. Default `'horizontal'`.
+   *
+   * Not cosmetic. `views/workspace.css:260-263` renders
+   * `.workspace .workspace__inspector .tabbar` with `flex-direction: column`, so
+   * that strip is vertical on screen — while this component declared no
+   * `aria-orientation` (WAI-ARIA DEFAULTS it to horizontal) and moved focus only on
+   * ArrowLeft/ArrowRight. A keyboard user facing a visibly vertical list pressed
+   * Down and nothing happened; Right, which points ACROSS the list rather than
+   * along it, was the only key that worked, and a screen reader announced a
+   * horizontal list that is not one.
+   *
+   * The two key models are kept DISTINCT rather than accepting every arrow
+   * everywhere: the APG specifies Left/Right for horizontal and Up/Down for
+   * vertical, and answering both would violate it in the other direction.
+   */
+  orientation?: 'horizontal' | 'vertical';
 }
 
 /**
@@ -209,7 +227,7 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  * edit the file it describes is not a criterion, so the stale-content reason above is
  * the one recorded. Kept as a correction rather than a quiet edit, for the reason the
  * shell.css repair established. The one claim here a machine CAN check is now checked,
- * so the next author is told rather than trusted: this file is 293 lines.
+ * so the next author is told rather than trusted: this file is 323 lines.
  *
  * Neither surface ships a defect and neither is on the merge path: docs are not
  * executable, `docs/validation/tools/verify_ssot_claims.py` is wired into no
@@ -221,7 +239,13 @@ function renderTab(tab: TabDef, nav: TabNav): React.ReactElement {
  * rather than dropped for the reason the shell.css repair already established:
  * correct the sentence, never quietly delete it.
  */
-export function TabBar({ tabs, active, onSelect, navIds }: TabBarProps): React.ReactElement {
+export function TabBar({
+  tabs,
+  active,
+  onSelect,
+  navIds,
+  orientation = 'horizontal',
+}: TabBarProps): React.ReactElement {
   // A plain ref map (NOT useRef) so this presentational component stays hook-free
   // and can still be invoked directly in unit tests. React populates it via each
   // tab's ref callback after commit; the last committed render's map is the one the
@@ -253,12 +277,18 @@ export function TabBar({ tabs, active, onSelect, navIds }: TabBarProps): React.R
     // unreachable branch cannot be covered by the 100% gate.
     const index = orderedIds.indexOf(id);
     const last = orderedIds.length - 1;
-    if (event.key === 'ArrowRight') {
+    // The APG pairs the walking keys to the ORIENTATION: Left/Right along a
+    // horizontal strip, Up/Down along a vertical one. Answering both everywhere
+    // would satisfy each case while violating the spec in the other direction, so
+    // the off-axis key is deliberately ignored (pinned by test).
+    const forward = orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight';
+    const backward = orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft';
+    if (event.key === forward) {
       event.preventDefault();
       move(index === last ? 0 : index + 1);
       return;
     }
-    if (event.key === 'ArrowLeft') {
+    if (event.key === backward) {
       event.preventDefault();
       move(index === 0 ? last : index - 1);
       return;
@@ -284,7 +314,7 @@ export function TabBar({ tabs, active, onSelect, navIds }: TabBarProps): React.R
   const nav: TabNav = { active, onSelect, onKeyDown, registerRef };
 
   return (
-    <div className="tabbar" role="tablist">
+    <div className="tabbar" role="tablist" aria-orientation={orientation}>
       {tabs.map((tab) => renderTab(tab, nav))}
     </div>
   );

--- a/app/renderer/src/views/Workspace.tsx
+++ b/app/renderer/src/views/Workspace.tsx
@@ -644,7 +644,15 @@ export function Workspace({
           <p className="workspace__inspector-context" data-role="selection">
             {INSPECTOR_CONTEXT_LABEL[context]}
           </p>
-          <TabBar tabs={sectionTabs} active={active} onSelect={selectSection} />
+          {/* VERTICAL: workspace.css:260-263 lays this strip out `flex-direction:
+              column`, so it must announce that and walk with Up/Down. Without the
+              prop it announced (and keyed as) horizontal while rendering vertical. */}
+          <TabBar
+            tabs={sectionTabs}
+            active={active}
+            onSelect={selectSection}
+            orientation="vertical"
+          />
           <div
             className="workspace__body"
             role="tabpanel"


### PR DESCRIPTION
Closes the wave clean-audit's HIGH finding: *the inspector tab list renders VERTICALLY but TabBar ships a horizontal-only keyboard model and no aria-orientation*.

## The defect, measured

- `views/workspace.css:260-263` renders `.workspace .workspace__inspector .tabbar` with `flex-direction: column` — the strip is **vertical on screen**.
- `TabBar.tsx` declared **no `aria-orientation`** (WAI-ARIA defaults it to horizontal) and handled only `ArrowRight` / `ArrowLeft`.

A keyboard user facing a visibly vertical list pressed Down and nothing happened; Right — which points *across* the list rather than along it — was the only key that worked. A screen reader announced a horizontal list that is not one.

This is the most exposed tab list in the app: the inspector strip mounts **twice** inside `.workspace`.

## The fix

An `orientation` prop (default `'horizontal'`, so none of the other call sites change) drives both `aria-orientation` and which arrows walk the strip; `Workspace.tsx` passes `"vertical"`.

The two key models are kept **distinct** rather than accepting every arrow everywhere — the APG specifies Left/Right for horizontal and Up/Down for vertical, and answering both would violate it in the other direction. The off-axis key is deliberately ignored, and that is pinned by a test.

## Verification

- **TDD, both states**: the 4 new cases were RED before the change, with the 25 existing cases still passing in that same red run — so the failure was specific, not collateral.
- **106/106 green** afterwards across `TabBar.test.tsx` and `Workspace.test.tsx`; `tsc --noEmit` and biome clean.
- One case is a **detector control** asserting the horizontal default, so a hardcoded attribute cannot satisfy the vertical case vacuously.
- The repo's own self-citation contract caught the edit (`TabBar.tsx` states its own line count, machine-checked: 293 → 323). Updated, not suppressed.
