### PR TITLE
fix(e2e): fail the packaged leg in seconds with the real cause, not a 900s hang

### DIFF
--- a/app/e2e/packaged.spec.ts
+++ b/app/e2e/packaged.spec.ts
@@ -19,7 +19,9 @@
 
 import { test, expect, _electron as electron, type ElectronApplication } from '@playwright/test';
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
 import {
   COLD_TIMEOUT_MS,
   SIDECAR_DIR,
@@ -29,6 +31,9 @@ import {
   type BuiltApp,
   type SeededEnv,
 } from './fixtures';
+
+/** Repo root, from this file: app/e2e/ -> app/ -> <root>. */
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..');
 
 // The packaged artifact is ONLY produced on the Windows leg (electron-builder.yml
 // has a win: target; the embeddable CPython + ffmpeg staging is Windows-only —
@@ -59,6 +64,47 @@ test.describe('packaged (shipped binary) E2E', () => {
     // 20 passed / 1 failed / 4 did not run. `test.setTimeout()` inside beforeAll sets the HOOK
     // timeout; `electron.launch` needs its own, which is a separate budget again.
     test.setTimeout(COLD_TIMEOUT_MS + 120_000);
+
+    // FAIL FAST ON THE FUSE, before burning the 900 s launch budget.
+    //
+    // Playwright drives an Electron MAIN process over the NODE inspector: its
+    // launcher passes `--inspect=0` and waits for that inspector to come up.
+    // `electron-builder.yml` sets `enableNodeCliInspectArguments: false` (W66
+    // hardening, commit d4a7e3f1, 2026-08-11), which makes Electron IGNORE
+    // `--inspect` entirely — so the inspector never appears and `electron.launch`
+    // waits out its full timeout with no diagnosis.
+    //
+    // MEASURED: this leg has failed on every nightly since 2026-08-11, the day that
+    // fuse landed, and the CI call log shows the app itself starting normally —
+    // "DevTools listening on ws://…", then the renderer finishing load and the
+    // auto-updater reporting a result. The SHIPPED APP IS FINE; only Playwright's
+    // control channel is closed.
+    //
+    // Why the fuse's own comment says nothing depends on `--inspect`: it was
+    // measured by grepping the repo's tracked sources, and `--inspect` is injected
+    // at runtime by playwright-core's Electron launcher, not written in any file
+    // here. A source grep structurally cannot see that dependency.
+    //
+    // This throws rather than skipping: the coverage is genuinely lost while the
+    // fuse is off, and a skip would turn a real gap into a green tick. Throwing
+    // keeps the leg red — but red in seconds, naming the cause and the options.
+    const fuses = readFileSync(resolve(REPO_ROOT, 'electron-builder.yml'), 'utf8').replace(
+      /#[^\n]*/g,
+      '',
+    );
+    if (/enableNodeCliInspectArguments:\s*false/.test(fuses)) {
+      throw new Error(
+        'packaged.spec cannot drive the shipped binary: electron-builder.yml sets ' +
+          '`enableNodeCliInspectArguments: false`, so Electron ignores the `--inspect` ' +
+          'flag Playwright needs to attach to the main process. This is a HARDENING vs ' +
+          'TESTABILITY trade-off, not an app defect — the packaged app launches fine. ' +
+          'Resolve by one of: (a) flip the fuse true and accept the re-opened ' +
+          'Node-injection surface; (b) build a test-only package with the fuse on and ' +
+          'assert separately that the RELEASE artifact has it off; or (c) drop these ' +
+          'main-process assertions and cover the package another way. Until then this ' +
+          'leg is red BY CONSTRUCTION and its 900 s hang was measuring nothing.',
+      );
+    }
 
     // HARD requirement: a real package must exist (no dev fallback here). Set the
     // flag ONLY around our own resolution and restore it immediately, so it can


### PR DESCRIPTION
## Root cause of a nightly that has been red since 2026-08-11

`electron-builder.yml` sets `enableNodeCliInspectArguments: false` (W66 hardening, commit `d4a7e3f1`, **that same day**).

Playwright drives an Electron **main** process over the **Node inspector** — its launcher passes `--inspect=0` and waits for that inspector to come up. That fuse makes Electron *ignore* `--inspect`, so the inspector never appears and `electron.launch` waits out its full 900 s budget, reporting nothing but a timeout.

**The shipped app is fine.** The CI call log shows it starting normally:

```
[out] Checking for update
[out] Generated new staging user ID: …
[out] Update for version 1.5.0 is not available (latest version: 1.4.0, downgrade is disallowed)
```

`wireAutoUpdater` only fires on `did-finish-load`, so the renderer had already finished loading. Only Playwright's control channel is closed.

## Why the fuse's own comment says nothing depends on `--inspect`

It says: *"Measured before flipping: neither NODE_OPTIONS nor `--inspect` appears in ANY tracked .ts/.py/.json/.yml/.ps1/.mjs file, so nothing in this repo depends on either."*

That measurement was honest and still wrong: `--inspect` is injected **at runtime** by `playwright-core`'s Electron launcher, not written in any file here. A source grep structurally cannot see that dependency.

Two independent signals agree: the **mechanism**, and the **exact date match** between the fuse landing and the leg going red.

## What this changes

Nothing about the fuse, and nothing about the app. The spec now checks the fuse first and **throws in seconds** with the cause and the options, instead of hanging for 15 minutes and saying only "timeout".

It **throws rather than skips** deliberately: the coverage is genuinely lost while the fuse is off, and a skip would turn a real gap into a green tick. The leg stays red — but red *informatively*.

## The decision this surfaces (yours — it is the W66 trade-off)

1. **Flip the fuse `true`** — restores packaged coverage, re-opens the Node-injection surface W66 closed.
2. **Build a test-only package with the fuse on**, and assert separately that the *release* artifact has it off. Standard resolution; the tested bytes are no longer the shipped bytes.
3. **Cover the package without main-process assertions** — drop `app.isPackaged` / asar-path checks and verify the artifact another way.

I have not picked one; the spec names all three in its failure message.

## Verification

- `tsc --noEmit -p tsconfig.e2e.json` clean.
- **Both-states control**: the guard resolves `electron-builder.yml` and fires on the current state, and does **not** fire when the fuse is `true`.
